### PR TITLE
fixes crashing when renaming animation

### DIFF
--- a/src/AnimationWidget.cpp
+++ b/src/AnimationWidget.cpp
@@ -222,18 +222,18 @@ void AnimationWidget::on_animTable_cellDoubleClicked(int row, int column)
             return;
         }
 
-        if(Manager::getSingleton()->hasAnimationName(newName))
-        {
-            QMessageBox::warning(this,tr("Error when renaming the animation"),tr("This name already exists."),QMessageBox::Ok);
-            return;
-        }
-
         Ogre::Entity* entity = 0;
         entity = (Ogre::Entity*)ui->animTable->model()->data(ui->animTable->model()->index(row,0), ENTITY_DATA).value<void *>();
 
         disableAllSkeletonDebug();
         if(entity)
         {
+            if(Manager::getSingleton()->hasAnimationName(entity, newName))
+            {
+                QMessageBox::warning(this,tr("Error when renaming the animation"),tr("This name already exists."),QMessageBox::Ok);
+                return;
+            }
+
             if(SkeletonTransform::renameAnimation(entity,oldName,newName))
             {
                 updateAnimationTable();

--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -303,20 +303,13 @@ bool Manager::isForbidenNodeName(const QString &_name)
             ||_name.startsWith("Unnamed_")); //TODO find what is this <- Done, it's the cameras's nodes
 }
 
-bool Manager::hasAnimationName(const QString &_name)
+bool Manager::hasAnimationName(Ogre::Entity *entity, const QString &_name)
 {
-    foreach(Ogre::Entity* entity, getEntities())
-    {
-        Ogre::AnimationStateSet* set = entity->getAllAnimationStates();
-        if(set)
-        {
-            Ogre::AnimationStateIterator iter=set->getAnimationStateIterator();
-            while(iter.hasMoreElements())
-            {
-                Ogre::String str = iter.getNext()->getAnimationName();
-                if(_name==str.c_str())
-                    return true;
-            }
+    if(!entity->hasSkeleton()) return false;
+    auto animationStateSet = entity->getAllAnimationStates();
+    for (auto animState : animationStateSet->getAnimationStates()) {
+        if (_name.toStdString() == animState.second->getAnimationName()) {
+            return true;
         }
     }
     return false;

--- a/src/Manager.h
+++ b/src/Manager.h
@@ -67,7 +67,7 @@ public:
 
     bool                isForbidenNodeName(const QString &_name);
 
-    bool                hasAnimationName(const QString &_name);
+    bool                hasAnimationName(Ogre::Entity *entity, const QString &_name);
 
     bool                isValidFileExtention(QString &_uri);
     QString             getValidFileExtention();


### PR DESCRIPTION
# Summary
<!-- Please include a high-level summary of your solution. Screenshots are helpful! -->

It was crashing when renaming animation.

# Technical Details
<!-- Include bullets of the general areas of technical change in the PR. This can be helpful to list as they don't always track 1:1 with the number of commits/commit messages -->

For some reason, `set` was passing a null-check, but crashing when calling `set->getAnimationStates()`. So I changed it to only validate equal names on the entity it is renaming.

### :sparkles: Features

* none

### :bug: Bugfixes

* Crashing when renaming animations