### PR TITLE
Animation Control Widget

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,7 @@
 #
 # - OGRE_HOME (C:\OgreSDK)
 # - CMAKE_PREFIX_PATH (to Qt <version>\<compiler>\lib\cmake folder)
-# - OgreProcedural_HOME (Ogre Procedural SDK Folder)
 #
-# TODO: Add ogre-procedural as dependency
 ##############################################################
 #  Versions
 ##############################################################
@@ -14,7 +12,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 1.5.2 LANGUAGES CXX)
+project(QtMeshEditor VERSION 1.6.0 LANGUAGES CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")
@@ -65,9 +63,9 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 ##############################################################
 #Find Qt Packages
 find_package(QT NAMES Qt6 Qt5)
-find_package(Qt6 REQUIRED COMPONENTS Core Widgets Gui)
+find_package(Qt6 REQUIRED COMPONENTS Core Widgets Gui QuickWidgets Quick)
 if (NOT Qt6_FOUND)
-    find_package(Qt5 5.15 REQUIRED COMPONENTS Core Widgets Gui)
+    find_package(Qt5 5.15 REQUIRED COMPONENTS Core Widgets Gui QuickWidgets Quick)
 endif()
 
 if(UNIX)
@@ -81,6 +79,8 @@ SET (QTLIBLIST
     Qt${QT_VERSION_MAJOR}Gui
     Qt${QT_VERSION_MAJOR}Core
     Qt${QT_VERSION_MAJOR}Widgets
+    Qt${QT_VERSION_MAJOR}QuickWidgets
+    Qt${QT_VERSION_MAJOR}Quick
 )
 FOREACH(qtlib ${QTLIBLIST})
         include_directories(${${qtlib}_INCLUDE_DIRS})
@@ -106,8 +106,6 @@ endif()
 ##############################################################
 #  Find Ogre
 ##############################################################
-# We provide a FindOgre.cmake as the one provided by Ogre has a bug on linux (version number in the default install path)
-
 find_package(OGRE REQUIRED)
 
 message("OGRE_INCLUDE_DIRS: ")
@@ -124,6 +122,17 @@ if(FIX_NEED_ZLIB)
         set(OGRE_LIBRARIES ${OGRE_LIBRARIES} ${ZLIB_LIBRARIES})
 endif()
 
+##############################################################
+#  Find Assimp
+##############################################################
+find_package(assimp REQUIRED)
+if (assimp_FOUND)
+    message("Assimp Found")
+    set(ASSIMP_LIBRARY "assimp")
+    add_library(${ASSIMP_LIBRARY} SHARED IMPORTED)
+    set_target_properties(${ASSIMP_LIBRARY} PROPERTIES IMPORTED_LOCATION "${ASSIMP_LIBRARY_DIRS}/libassimp.so")
+    include_directories(${ASSIMP_INCLUDE_DIRS})
+endif(assimp_FOUND)
 ##############################################################
 #  Adding ReadMe file
 ##############################################################

--- a/src/AnimationWidget.cpp
+++ b/src/AnimationWidget.cpp
@@ -75,35 +75,32 @@ void AnimationWidget::updateAnimationTable()
 
     bool hasAnimationEnable = false;
 
-    foreach(Ogre::Entity* entity, SelectionSet::getSingleton()->getEntitiesSelectionList())
+    for(Ogre::Entity* entity : SelectionSet::getSingleton()->getEntitiesSelectionList())
     {
         //Animation
         Ogre::AnimationStateSet* set = entity->getAllAnimationStates();
         if(set)
         {
-            Ogre::AnimationStateIterator iter=set->getAnimationStateIterator();
-            while(iter.hasMoreElements())
+            for (const auto &animationState:set->getAnimationStates())
             {
                 QTableWidgetItem *entityItem = new QTableWidgetItem;
                 entityItem->setText(entity->getName().data());
                 entityItem->setData(ENTITY_DATA,QVariant::fromValue((void *) entity));
                 entityItem->setFlags(entityItem->flags() & ~Qt::ItemIsEditable);
 
-                Ogre::AnimationState * animationState = iter.getNext();
-
-                QString animationName = animationState->getAnimationName().c_str();
+                QString animationName = animationState.second->getAnimationName().c_str();
 
                 QTableWidgetItem *animationItem = new QTableWidgetItem;
                 animationItem->setText(animationName);
                 animationItem->setFlags(animationItem->flags() & ~Qt::ItemIsEditable);
 
                 QTableWidgetItem* enabledCB = new QTableWidgetItem(0);
-                enabledCB->setCheckState(animationState->getEnabled()?Qt::Checked:Qt::Unchecked);
+                enabledCB->setCheckState(animationState.second->getEnabled()?Qt::Checked:Qt::Unchecked);
                 enabledCB->setFlags(enabledCB->flags() & ~Qt::ItemIsEditable);
-                hasAnimationEnable = hasAnimationEnable || animationState->getEnabled();
+                hasAnimationEnable = hasAnimationEnable || animationState.second->getEnabled();
 
                 QTableWidgetItem* loopCB = new QTableWidgetItem(0);
-                loopCB->setCheckState(animationState->getLoop()?Qt::Checked:Qt::Unchecked);
+                loopCB->setCheckState(animationState.second->getLoop()?Qt::Checked:Qt::Unchecked);
                 loopCB->setFlags(loopCB->flags() & ~Qt::ItemIsEditable);
 
                 ui->animTable->insertRow(0);
@@ -130,7 +127,7 @@ void AnimationWidget::updateSkeletonTable()
     if(!SelectionSet::getSingleton()->hasEntities())
         return;
 
-    foreach(Ogre::Entity* entity, SelectionSet::getSingleton()->getEntitiesSelectionList())
+    for(Ogre::Entity* entity : SelectionSet::getSingleton()->getEntitiesSelectionList())
     {
         QString str = entity->getName().data();
         QTableWidgetItem *entityItem = new QTableWidgetItem;
@@ -155,16 +152,11 @@ void AnimationWidget::on_PlayPauseButton_toggled(bool checked)
 
 void AnimationWidget::setAnimationState(bool playing)
 {
-    if(playing)
-    {
-        ui->PlayPauseButton->setIcon(QIcon(":/icones/pause.png"));
-        emit changeAnimationState(true);
-    }
-    else
-    {
-        ui->PlayPauseButton->setIcon(QIcon(":/icones/play.png"));
-        emit changeAnimationState(false);
-    }
+    auto icon = QIcon(playing?":/icones/pause.png":":/icones/play.png");
+
+    ui->PlayPauseButton->setIcon(icon);
+
+    emit changeAnimationState(playing);
 }
 
 void AnimationWidget::on_skeletonTable_clicked(const QModelIndex &index)
@@ -251,12 +243,9 @@ void AnimationWidget::disableEntityAnimations(Ogre::Entity* entity)
     Ogre::AnimationStateSet* set = entity->getAllAnimationStates();
     if(set)
     {
-        Ogre::AnimationStateIterator iter=set->getAnimationStateIterator();
-        while(iter.hasMoreElements())
+        for (const auto &animationState : set->getAnimationStates())
         {
-            Ogre::String str = iter.getNext()->getAnimationName();
-            Ogre::AnimationState* animationState = entity->getAnimationState(str);
-            animationState->setEnabled(false);
+            animationState.second->setEnabled(false);
         }
     }
     updateAnimationTable();
@@ -267,17 +256,14 @@ void AnimationWidget::disableAllSelectedAnimations()
     if(!SelectionSet::getSingleton()->hasEntities())
         return;
 
-    foreach(Ogre::Entity* entity, SelectionSet::getSingleton()->getEntitiesSelectionList())
+    for(Ogre::Entity* entity : SelectionSet::getSingleton()->getEntitiesSelectionList())
     {
         Ogre::AnimationStateSet* set = entity->getAllAnimationStates();
         if(set)
         {
-            Ogre::AnimationStateIterator iter=set->getAnimationStateIterator();
-            while(iter.hasMoreElements())
+            for (const auto &animationState : set->getAnimationStates())
             {
-                Ogre::String str = iter.getNext()->getAnimationName();
-                Ogre::AnimationState* animationState = entity->getAnimationState(str);
-                animationState->setEnabled(false);
+                animationState.second->setEnabled(false);
             }
         }
     }
@@ -286,7 +272,7 @@ void AnimationWidget::disableAllSelectedAnimations()
 
 void AnimationWidget::disableAllSkeletonDebug()
 {
-    foreach(SkeletonDebug *sd, mShowSkeleton.values())
+    for(SkeletonDebug *sd : mShowSkeleton.values())
     {
         sd->showAxes(false);
         sd->showBones(false);

--- a/src/Assimp/AssimpLoader.cpp
+++ b/src/Assimp/AssimpLoader.cpp
@@ -1,0 +1,1403 @@
+/*
+-----------------------------------------------------------------------------
+This source file is part of
+                                    _
+  ___   __ _ _ __ ___  __ _ ___ ___(_)_ __ ___  _ __
+ / _ \ / _` | '__/ _ \/ _` / __/ __| | '_ ` _ \| '_ \
+| (_) | (_| | | |  __/ (_| \__ \__ \ | | | | | | |_) |
+ \___/ \__, |_|  \___|\__,_|___/___/_|_| |_| |_| .__/
+       |___/                                   |_|
+
+Copyright (c) 2011 Jacob 'jacmoe' Moen
+
+Licensed under the MIT license:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-----------------------------------------------------------------------------
+*/
+#include "OgreAssimpLoader.h"
+
+#include <assimp/version.h>
+#include <assimp/scene.h>
+#include <assimp/postprocess.h>
+#include <assimp/Importer.hpp>
+#include <assimp/DefaultLogger.hpp>
+#include <assimp/IOStream.hpp>
+#include <assimp/IOSystem.hpp>
+#include <assimp/DefaultIOSystem.h>
+
+#include <Ogre.h>
+
+#include <OgreCodec.h>
+
+#include <OgreShaderGenerator.h>
+
+using namespace Ogre;
+
+namespace
+{
+struct OgreLogStream : public Assimp::LogStream
+{
+    LogMessageLevel _lml;
+    OgreLogStream(LogMessageLevel lml) : _lml(lml) {}
+
+    void write(const char* message) override
+    {
+        String msg(message);
+        StringUtil::trim(msg);
+        LogManager::getSingleton().logMessage("Assimp: " + msg, _lml);
+    }
+};
+
+struct OgreIOStream : public Assimp::IOStream
+{
+    DataStreamPtr stream;
+
+    OgreIOStream(DataStreamPtr _stream) : stream(_stream) {}
+
+    size_t Read(void* pvBuffer, size_t pSize, size_t pCount) override
+    {
+        size_t bytes = stream->read(pvBuffer, pSize * pCount);
+        return bytes / pSize;
+    }
+    size_t Tell() const override { return stream->tell(); }
+    size_t FileSize() const override { return stream->size(); }
+
+    size_t Write(const void* pvBuffer, size_t pSize, size_t pCount) override { return 0; }
+    aiReturn Seek(size_t pOffset, aiOrigin pOrigin) override
+    {
+        if (pOrigin != aiOrigin_SET)
+            return AI_FAILURE;
+
+        stream->seek(pOffset);
+        return AI_SUCCESS;
+    }
+    void Flush() override {}
+};
+
+struct OgreIOSystem : public Assimp::IOSystem
+{
+    DataStreamPtr source;
+    std::vector<OgreIOStream*> streams;
+    String _group;
+
+    OgreIOSystem(const DataStreamPtr& _source, const String& group) : source(_source), _group(group) {}
+
+    bool Exists(const char* pFile) const override
+    {
+        String file = StringUtil::normalizeFilePath(pFile, false);
+        if (file == source->getName())
+            return true;
+        return ResourceGroupManager::getSingleton().resourceExists(_group, file);
+    }
+    char getOsSeparator() const override { return '/'; }
+
+    Assimp::IOStream* Open(const char* pFile, const char* pMode) override
+    {
+        String file = StringUtil::normalizeFilePath(pFile, false);
+        DataStreamPtr res;
+        if (file == source->getName())
+        {
+            res = source;
+            // glTF2 importer wants to open files multiple times
+            // while this is not fully correct, this makes it happy
+            source->seek(0);
+        }
+        if (!res)
+            res = ResourceGroupManager::getSingleton().openResource(file, _group, NULL, false);
+
+        if (res)
+        {
+            streams.emplace_back(new OgreIOStream(res));
+            return streams.back();
+        }
+        return NULL;
+    }
+    void Close(Assimp::IOStream* pFile) override
+    {
+        auto it = std::find(streams.begin(), streams.end(), pFile);
+        if (it != streams.end())
+        {
+            delete pFile;
+            streams.erase(it);
+        }
+    }
+};
+
+/** translation, rotation, scale */
+typedef std::tuple<aiVectorKey*, aiQuatKey*, aiVectorKey*> KeyframeData;
+typedef std::map<Real, KeyframeData> KeyframesMap;
+
+template <int _i>
+void GetInterpolationIterators(KeyframesMap& keyframes, KeyframesMap::iterator it,
+                               KeyframesMap::reverse_iterator& front, KeyframesMap::iterator& back)
+{
+    front = KeyframesMap::reverse_iterator(it);
+
+    front++;
+    for (; front != keyframes.rend(); front++)
+    {
+        if (std::get<_i>(front->second) != NULL)
+        {
+            break;
+        }
+    }
+
+    back = it;
+    back++;
+    for (; back != keyframes.end(); back++)
+    {
+        if (std::get<_i>(back->second) != NULL)
+        {
+            break;
+        }
+    }
+}
+
+aiVector3D getTranslate(aiNodeAnim* node_anim, KeyframesMap& keyframes, KeyframesMap::iterator it,
+                        Real ticksPerSecond)
+{
+    aiVectorKey* translateKey = std::get<0>(it->second);
+    aiVector3D vect;
+    if (translateKey)
+    {
+        vect = translateKey->mValue;
+    }
+    else
+    {
+        KeyframesMap::reverse_iterator front;
+        KeyframesMap::iterator back;
+
+        GetInterpolationIterators<0>(keyframes, it, front, back);
+
+        KeyframesMap::reverse_iterator rend = keyframes.rend();
+        KeyframesMap::iterator end = keyframes.end();
+        aiVectorKey* frontKey = NULL;
+        aiVectorKey* backKey = NULL;
+
+        if (front != rend)
+            frontKey = std::get<0>(front->second);
+
+        if (back != end)
+            backKey = std::get<0>(back->second);
+
+        // got 2 keys can interpolate
+        if (frontKey && backKey)
+        {
+            float prop =
+                (float)(((double)it->first - frontKey->mTime) / (backKey->mTime - frontKey->mTime));
+            prop /= ticksPerSecond;
+            vect = Math::lerp(frontKey->mValue, backKey->mValue, prop);
+        }
+
+        else if (frontKey)
+        {
+            vect = frontKey->mValue;
+        }
+        else if (backKey)
+        {
+            vect = backKey->mValue;
+        }
+    }
+
+    return vect;
+}
+
+aiQuaternion getRotate(aiNodeAnim* node_anim, KeyframesMap& keyframes, KeyframesMap::iterator it,
+                       Real ticksPerSecond)
+{
+    aiQuatKey* rotationKey = std::get<1>(it->second);
+    aiQuaternion rot;
+    if (rotationKey)
+    {
+        rot = rotationKey->mValue;
+    }
+    else
+    {
+        KeyframesMap::reverse_iterator front;
+        KeyframesMap::iterator back;
+
+        GetInterpolationIterators<1>(keyframes, it, front, back);
+
+        KeyframesMap::reverse_iterator rend = keyframes.rend();
+        KeyframesMap::iterator end = keyframes.end();
+        aiQuatKey* frontKey = NULL;
+        aiQuatKey* backKey = NULL;
+
+        if (front != rend)
+            frontKey = std::get<1>(front->second);
+
+        if (back != end)
+            backKey = std::get<1>(back->second);
+
+        // got 2 keys can interpolate
+        if (frontKey && backKey)
+        {
+            float prop =
+                (float)(((double)it->first - frontKey->mTime) / (backKey->mTime - frontKey->mTime));
+            prop /= ticksPerSecond;
+            aiQuaternion::Interpolate(rot, frontKey->mValue, backKey->mValue, prop);
+        }
+
+        else if (frontKey)
+        {
+            rot = frontKey->mValue;
+        }
+        else if (backKey)
+        {
+            rot = backKey->mValue;
+        }
+    }
+
+    return rot;
+}
+
+aiVector3D getScale(aiNodeAnim* node_anim, KeyframesMap& keyframes, KeyframesMap::iterator it,
+                    Real ticksPerSecond)
+{
+    aiVectorKey* scaleKey = std::get<2>(it->second);
+    aiVector3D vect(1, 1, 1);
+    if (scaleKey)
+    {
+        vect = scaleKey->mValue;
+    }
+    else
+    {
+        KeyframesMap::reverse_iterator front;
+        KeyframesMap::iterator back;
+
+        GetInterpolationIterators<2>(keyframes, it, front, back);
+
+        KeyframesMap::reverse_iterator rend = keyframes.rend();
+        KeyframesMap::iterator end = keyframes.end();
+        aiVectorKey* frontKey = NULL;
+        aiVectorKey* backKey = NULL;
+
+        if (front != rend)
+            frontKey = std::get<2>(front->second);
+
+        if (back != end)
+            backKey = std::get<2>(back->second);
+
+        // got 2 keys can interpolate
+        if (frontKey && backKey)
+        {
+            float prop =
+                (float)(((double)it->first - frontKey->mTime) / (backKey->mTime - frontKey->mTime));
+            prop /= ticksPerSecond;
+            vect = Math::lerp(frontKey->mValue, backKey->mValue, prop);
+        }
+
+        else if (frontKey)
+        {
+            vect = frontKey->mValue;
+        }
+        else if (backKey)
+        {
+            vect = backKey->mValue;
+        }
+    }
+
+    return vect;
+}
+
+String ReplaceSpaces(const String& s)
+{
+    String res(s);
+    replace(res.begin(), res.end(), ' ', '_');
+
+    return res;
+}
+} // namespace
+
+int AssimpLoader::msBoneCount = 0;
+
+AssimpLoader::AssimpLoader()
+{
+    Assimp::DefaultLogger::create("");
+    Assimp::DefaultLogger::get()->attachStream(new OgreLogStream(LML_NORMAL), ~Assimp::DefaultLogger::Err);
+    Assimp::DefaultLogger::get()->attachStream(new OgreLogStream(LML_CRITICAL), Assimp::DefaultLogger::Err);
+}
+
+AssimpLoader::~AssimpLoader() {}
+
+bool AssimpLoader::load(const DataStreamPtr& source, Mesh* mesh, SkeletonPtr& skeletonPtr,
+                        const Options& options)
+{
+    Assimp::Importer importer;
+    importer.SetIOHandler(new OgreIOSystem(source, mesh->getGroup()));
+    _load(source->getName().c_str(), importer, mesh, skeletonPtr, options);
+    return true;
+}
+
+bool AssimpLoader::load(const String& source, Mesh* mesh, SkeletonPtr& skeletonPtr,
+                        const AssimpLoader::Options& options)
+{
+    Assimp::Importer importer;
+    _load(source.c_str(), importer, mesh, skeletonPtr, options);
+    return true;
+}
+
+bool AssimpLoader::_load(const char* name, Assimp::Importer& importer, Mesh* mesh, SkeletonPtr& skeletonPtr,
+                         const Options& options)
+{    
+    uint32 flags = aiProcessPreset_TargetRealtime_Fast | aiProcess_TransformUVCoords | aiProcess_FlipUVs;
+    flags &= ~(aiProcess_JoinIdenticalVertices | aiProcess_CalcTangentSpace); // optimize for fast loading
+
+    if(StringUtil::endsWith(name, ".gltf") || StringUtil::endsWith(name, ".glb"))
+        flags |= aiProcess_JoinIdenticalVertices;
+
+    flags |= options.postProcessSteps;
+
+    if((flags & (aiProcess_GenSmoothNormals | aiProcess_GenNormals)) != aiProcess_GenNormals)
+        flags &= ~aiProcess_GenNormals; // prefer smooth normals
+
+    importer.SetPropertyFloat("PP_GSN_MAX_SMOOTHING_ANGLE", options.maxEdgeAngle);
+    const aiScene* scene = importer.ReadFile(name, flags);
+
+    // If the import failed, report it
+    if (!scene)
+    {
+        LogManager::getSingleton().logError("Assimp failed - " + String(importer.GetErrorString()));
+        return false;
+    }
+
+    mAnimationSpeedModifier = options.animationSpeedModifier;
+    mLoaderParams = options.params;
+    mQuietMode = mLoaderParams & LP_QUIET_MODE;
+    mUseIndexBuffer = flags & aiProcess_JoinIdenticalVertices;
+    mCustomAnimationName = options.customAnimationName;
+    mNodeDerivedTransformByName.clear();
+
+    String basename, extension;
+    StringUtil::splitBaseFilename(mesh->getName(), basename, extension);
+
+    grabNodeNamesFromNode(scene, scene->mRootNode);
+    grabBoneNamesFromNode(scene, scene->mRootNode);
+
+    computeNodesDerivedTransform(scene, scene->mRootNode, scene->mRootNode->mTransformation);
+
+    if (mBonesByName.size())
+    {
+        mSkeleton = SkeletonManager::getSingleton().create(basename + ".skeleton", RGN_DEFAULT, true);
+
+        msBoneCount = 0;
+        createBonesFromNode(scene, scene->mRootNode);
+        msBoneCount = 0;
+        createBoneHiearchy(scene, scene->mRootNode);
+
+        if (scene->HasAnimations())
+        {
+            for (unsigned int i = 0; i < scene->mNumAnimations; ++i)
+            {
+                parseAnimation(scene, i, scene->mAnimations[i]);
+            }
+        }
+    }
+
+    // Create embedded textures
+    for (unsigned int i = 0; i < scene->mNumTextures; ++i)
+    {
+        const aiTexture* tex = scene->mTextures[i];
+        auto texname =
+            StringUtil::format("%s%s.%s", mesh->getName().c_str(), tex->mFilename.C_Str(), tex->achFormatHint);
+        if (TextureManager::getSingleton().resourceExists(texname, mesh->getGroup()))
+            continue;
+
+        Image img;
+        if(tex->mHeight == 0)
+        {
+            auto stream = std::make_shared<MemoryDataStream>(tex->pcData, tex->mWidth, false);
+            img.load(stream, tex->achFormatHint);
+        }
+        else
+        {
+            img.loadDynamicImage((uchar*)tex->pcData, tex->mWidth, tex->mHeight, PF_A8R8G8B8);
+        }
+
+        TextureManager::getSingleton().loadImage(texname, mesh->getGroup(), img);
+    }
+
+    loadDataFromNode(scene, scene->mRootNode, mesh);
+
+    Assimp::DefaultLogger::kill();
+
+    if (mSkeleton)
+    {
+
+        if (!mQuietMode)
+        {
+            LogManager::getSingleton().logMessage("Root bone: " + mSkeleton->getRootBones()[0]->getName());
+        }
+
+        skeletonPtr = mSkeleton;
+        mesh->setSkeletonName(mSkeleton->getName());
+    }
+
+    for (auto sm : mesh->getSubMeshes())
+    {
+        if (!sm->useSharedVertices)
+        {
+
+            VertexDeclaration* newDcl = sm->vertexData->vertexDeclaration->getAutoOrganisedDeclaration(
+                mesh->hasSkeleton(), mesh->hasVertexAnimation(), false);
+
+            if (*newDcl != *(sm->vertexData->vertexDeclaration))
+            {
+                sm->vertexData->reorganiseBuffers(newDcl);
+            }
+        }
+    }
+
+    // clean up
+    mBonesByName.clear();
+    mBoneNodesByName.clear();
+    boneMap.clear();
+    mSkeleton.reset();
+
+    mCustomAnimationName = "";
+
+    return true;
+}
+
+void AssimpLoader::parseAnimation(const aiScene* mScene, int index, aiAnimation* anim)
+{
+    // DefBonePose a matrix that represents the local bone transform (can build from Ogre bone components)
+    // PoseToKey a matrix representing the keyframe translation
+    // What assimp stores aiNodeAnim IS the decomposed form of the transform (DefBonePose * PoseToKey)
+    // To get PoseToKey which is what Ogre needs we'ed have to build the transform from components in
+    // aiNodeAnim and then DefBonePose.Inverse() * aiNodeAnim(generated transform) will be the right
+    // transform
+
+    String animName;
+    if (mCustomAnimationName != "")
+    {
+        animName = mCustomAnimationName;
+        if (index >= 1)
+        {
+            animName += StringConverter::toString(index);
+        }
+    }
+    else
+    {
+        animName = String(anim->mName.data);
+    }
+    if (animName.length() < 1)
+    {
+        animName = "Animation" + StringConverter::toString(index);
+    }
+
+    if (!mQuietMode)
+    {
+        LogManager::getSingleton().logMessage("Animation name = '" + animName + "'");
+        LogManager::getSingleton().logMessage("duration = " +
+                                              StringConverter::toString(Real(anim->mDuration)));
+        LogManager::getSingleton().logMessage("tick/sec = " +
+                                              StringConverter::toString(Real(anim->mTicksPerSecond)));
+        LogManager::getSingleton().logMessage("channels = " +
+                                              StringConverter::toString(anim->mNumChannels));
+    }
+    Animation* animation;
+    mTicksPerSecond = (Real)((0 == anim->mTicksPerSecond) ? 24 : anim->mTicksPerSecond);
+    mTicksPerSecond *= mAnimationSpeedModifier;
+
+    Real cutTime = 0.0;
+    if (mLoaderParams & LP_CUT_ANIMATION_WHERE_NO_FURTHER_CHANGE)
+    {
+        for (int i = 1; i < (int)anim->mNumChannels; i++)
+        {
+            aiNodeAnim* node_anim = anim->mChannels[i];
+
+            // times of the equality check
+            Real timePos = 0.0;
+            Real timeRot = 0.0;
+
+            for (unsigned int j = 1; j < node_anim->mNumPositionKeys; j++)
+            {
+                if (node_anim->mPositionKeys[j] != node_anim->mPositionKeys[j - 1])
+                {
+                    timePos = (Real)node_anim->mPositionKeys[j].mTime;
+                    timePos /= mTicksPerSecond;
+                }
+            }
+
+            for (unsigned int j = 1; j < node_anim->mNumRotationKeys; j++)
+            {
+                if (node_anim->mRotationKeys[j] != node_anim->mRotationKeys[j - 1])
+                {
+                    timeRot = (Real)node_anim->mRotationKeys[j].mTime;
+                    timeRot /= mTicksPerSecond;
+                }
+            }
+
+            if (timePos > cutTime)
+            {
+                cutTime = timePos;
+            }
+            if (timeRot > cutTime)
+            {
+                cutTime = timeRot;
+            }
+        }
+
+        animation = mSkeleton->createAnimation(String(animName), cutTime);
+    }
+    else
+    {
+        cutTime = Math::POS_INFINITY;
+        animation = mSkeleton->createAnimation(String(animName), Real(anim->mDuration / mTicksPerSecond));
+    }
+
+    animation->setInterpolationMode(Animation::IM_LINEAR); // FIXME: Is this always true?
+
+    if (!mQuietMode)
+    {
+        LogManager::getSingleton().logMessage("Cut Time " + StringConverter::toString(cutTime));
+    }
+
+    for (unsigned int i = 0; i < anim->mNumChannels; i++)
+    {
+        TransformKeyFrame* keyframe;
+
+        aiNodeAnim* node_anim = anim->mChannels[i];
+        if (!mQuietMode)
+        {
+            LogManager::getSingleton().logMessage("Channel " + StringConverter::toString(i));
+            LogManager::getSingleton().logMessage("affecting node: " + String(node_anim->mNodeName.data));
+            // LogManager::getSingleton().logMessage("position keys: " +
+            // StringConverter::toString(node_anim->mNumPositionKeys));
+            // LogManager::getSingleton().logMessage("rotation keys: " +
+            // StringConverter::toString(node_anim->mNumRotationKeys));
+            // LogManager::getSingleton().logMessage("scaling keys: " +
+            // StringConverter::toString(node_anim->mNumScalingKeys));
+        }
+
+        String boneName = String(node_anim->mNodeName.data);
+        if (mSkeleton->hasBone(boneName))
+        {
+            Bone* bone = mSkeleton->getBone(boneName);
+            Affine3 defBonePoseInv;
+            defBonePoseInv.makeInverseTransform(bone->getPosition(), bone->getScale(),
+                                                bone->getOrientation());
+
+            NodeAnimationTrack* track = animation->createNodeTrack(i, bone);
+
+            // Ogre needs translate rotate and scale for each keyframe in the track
+            KeyframesMap keyframes;
+
+            for (unsigned int j = 0; j < node_anim->mNumPositionKeys; j++)
+            {
+                KeyframesMap::iterator it =
+                    keyframes.find((Real)node_anim->mPositionKeys[j].mTime / mTicksPerSecond);
+                if (it != keyframes.end())
+                {
+                    std::get<0>(it->second) = &(node_anim->mPositionKeys[j]);
+                }
+                else
+                {
+                    keyframes[(Real)node_anim->mPositionKeys[j].mTime / mTicksPerSecond] =
+                        KeyframeData(&(node_anim->mPositionKeys[j]), NULL, NULL);
+                }
+
+            }
+
+            for (unsigned int j = 0; j < node_anim->mNumRotationKeys; j++)
+            {
+                KeyframesMap::iterator it =
+                    keyframes.find((Real)node_anim->mRotationKeys[j].mTime / mTicksPerSecond);
+                if (it != keyframes.end())
+                {
+                    std::get<1>(it->second) = &(node_anim->mRotationKeys[j]);
+                }
+                else
+                {
+                    keyframes[(Real)node_anim->mRotationKeys[j].mTime / mTicksPerSecond] =
+                        KeyframeData(NULL, &(node_anim->mRotationKeys[j]), NULL);
+                }
+            }
+
+            for (unsigned int j = 0; j < node_anim->mNumScalingKeys; j++)
+            {
+                KeyframesMap::iterator it =
+                    keyframes.find((Real)node_anim->mScalingKeys[j].mTime / mTicksPerSecond);
+                if (it != keyframes.end())
+                {
+                    std::get<2>(it->second) = &(node_anim->mScalingKeys[j]);
+                }
+                else
+                {
+                    keyframes[(Real)node_anim->mRotationKeys[j].mTime / mTicksPerSecond] =
+                        KeyframeData(NULL, NULL, &(node_anim->mScalingKeys[j]));
+                }
+            }
+
+            Ogre::LogManager::getSingleton().logMessage("Assimp Bone: "+bone->getName());
+
+            KeyframesMap::iterator it = keyframes.begin();
+            KeyframesMap::iterator it_end = keyframes.end();
+            for (; it != it_end; ++it)
+            {
+                if (it->first < cutTime) // or should it be <=
+                {
+                    aiVector3D aiTrans = getTranslate(node_anim, keyframes, it, mTicksPerSecond);
+
+                    Vector3 trans(aiTrans.x, aiTrans.y, aiTrans.z);
+
+                    aiQuaternion aiRot = getRotate(node_anim, keyframes, it, mTicksPerSecond);
+                    Quaternion rot(aiRot.w, aiRot.x, aiRot.y, aiRot.z);
+                    Ogre::LogManager::getSingleton().logMessage("Quaternion: "+Ogre::StringConverter::toString(rot));
+
+                    aiVector3D aiScale = getScale(node_anim, keyframes, it, mTicksPerSecond);
+                    Vector3 scale(aiScale.x, aiScale.y, aiScale.z);
+
+                    Vector3 transCopy = trans;
+
+                    Affine3 fullTransform;
+                    fullTransform.makeTransform(trans, scale, rot);
+
+                    Affine3 poseTokey = defBonePoseInv * fullTransform;
+                    poseTokey.decomposition(trans, scale, rot);
+
+                    keyframe = track->createNodeKeyFrame(Real(it->first));
+
+                    // weirdness with the root bone, But this seems to work
+                    if (mSkeleton->getRootBones()[0]->getName() == boneName)
+                    {
+                        trans = transCopy - bone->getPosition();
+                    }
+
+                    keyframe->setTranslate(trans);
+                    keyframe->setRotation(rot);
+                    keyframe->setScale(scale);
+                }
+            }
+
+        } // if bone exists
+
+    } // loop through channels
+
+    mSkeleton->optimiseAllAnimations();
+}
+
+void AssimpLoader::markAllChildNodesAsNeeded(const aiNode* pNode)
+{
+    flagNodeAsNeeded(pNode->mName.data);
+    // Traverse all child nodes of the current node instance
+    for (unsigned int childIdx = 0; childIdx < pNode->mNumChildren; ++childIdx)
+    {
+        const aiNode* pChildNode = pNode->mChildren[childIdx];
+        markAllChildNodesAsNeeded(pChildNode);
+    }
+}
+
+void AssimpLoader::grabNodeNamesFromNode(const aiScene* mScene, const aiNode* pNode)
+{
+    boneMap.emplace(String(pNode->mName.data), false);
+    mBoneNodesByName[pNode->mName.data] = pNode;
+    if (!mQuietMode)
+    {
+        LogManager::getSingleton().logMessage("Node " + String(pNode->mName.data) + " found.");
+    }
+
+    // Traverse all child nodes of the current node instance
+    for (unsigned int childIdx = 0; childIdx < pNode->mNumChildren; ++childIdx)
+    {
+        const aiNode* pChildNode = pNode->mChildren[childIdx];
+        grabNodeNamesFromNode(mScene, pChildNode);
+    }
+}
+
+void AssimpLoader::computeNodesDerivedTransform(const aiScene* mScene, const aiNode* pNode,
+                                                const aiMatrix4x4& accTransform)
+{
+    if (mNodeDerivedTransformByName.find(pNode->mName.data) == mNodeDerivedTransformByName.end())
+    {
+        mNodeDerivedTransformByName[pNode->mName.data] = Affine3(accTransform[0]);
+    }
+    for (unsigned int childIdx = 0; childIdx < pNode->mNumChildren; ++childIdx)
+    {
+        const aiNode* pChildNode = pNode->mChildren[childIdx];
+        computeNodesDerivedTransform(mScene, pChildNode, accTransform * pChildNode->mTransformation);
+    }
+}
+
+void AssimpLoader::createBonesFromNode(const aiScene* mScene, const aiNode* pNode)
+{
+    if (isNodeNeeded(pNode->mName.data))
+    {
+        Bone* bone = mSkeleton->createBone(String(pNode->mName.data), msBoneCount);
+
+        aiQuaternion rot;
+        aiVector3D pos;
+        aiVector3D scale;
+
+        const aiMatrix4x4& aiM = pNode->mTransformation;
+
+        if (!aiM.IsIdentity())
+        {
+            aiM.Decompose(scale, rot, pos);
+            bone->setPosition(pos.x, pos.y, pos.z);
+            bone->setOrientation(rot.w, rot.x, rot.y, rot.z);
+        }
+
+        if (!mQuietMode)
+        {
+            LogManager::getSingleton().logMessage(StringConverter::toString(msBoneCount) +
+                                                  ") Creating bone '" + String(pNode->mName.data) + "'");
+        }
+        msBoneCount++;
+    }
+    // Traverse all child nodes of the current node instance
+    for (unsigned int childIdx = 0; childIdx < pNode->mNumChildren; ++childIdx)
+    {
+        const aiNode* pChildNode = pNode->mChildren[childIdx];
+        createBonesFromNode(mScene, pChildNode);
+    }
+}
+
+void AssimpLoader::createBoneHiearchy(const aiScene* mScene, const aiNode* pNode)
+{
+    if (isNodeNeeded(pNode->mName.data))
+    {
+        Bone* parent = 0;
+        Bone* child = 0;
+        if (pNode->mParent)
+        {
+            if (mSkeleton->hasBone(pNode->mParent->mName.data))
+            {
+                parent = mSkeleton->getBone(pNode->mParent->mName.data);
+            }
+        }
+        if (mSkeleton->hasBone(pNode->mName.data))
+        {
+            child = mSkeleton->getBone(pNode->mName.data);
+        }
+        if (parent && child)
+        {
+            parent->addChild(child);
+        }
+    }
+    // Traverse all child nodes of the current node instance
+    for (unsigned int childIdx = 0; childIdx < pNode->mNumChildren; childIdx++)
+    {
+        const aiNode* pChildNode = pNode->mChildren[childIdx];
+        createBoneHiearchy(mScene, pChildNode);
+    }
+}
+
+void AssimpLoader::flagNodeAsNeeded(const char* name)
+{
+    boneMapType::iterator iter = boneMap.find(String(name));
+    if (iter != boneMap.end())
+    {
+        iter->second = true;
+    }
+}
+
+bool AssimpLoader::isNodeNeeded(const char* name)
+{
+    boneMapType::iterator iter = boneMap.find(String(name));
+    if (iter != boneMap.end())
+    {
+        return iter->second;
+    }
+    return false;
+}
+
+void AssimpLoader::grabBoneNamesFromNode(const aiScene* mScene, const aiNode* pNode)
+{
+    static int meshNum = 0;
+    meshNum++;
+    if (pNode->mNumMeshes > 0)
+    {
+        for (unsigned int idx = 0; idx < pNode->mNumMeshes; ++idx)
+        {
+            aiMesh* pAIMesh = mScene->mMeshes[pNode->mMeshes[idx]];
+
+            if (pAIMesh->HasBones())
+            {
+                for (uint32 i = 0; i < pAIMesh->mNumBones; ++i)
+                {
+                    aiBone* pAIBone = pAIMesh->mBones[i];
+                    if (NULL != pAIBone)
+                    {
+                        mBonesByName[pAIBone->mName.data] = pAIBone;
+
+                        if (!mQuietMode)
+                        {
+                            LogManager::getSingleton().logMessage(
+                                StringConverter::toString(i) +
+                                ") REAL BONE with name : " + String(pAIBone->mName.data));
+                        }
+
+                        // flag this node and all parents of this node as needed, until we reach the node
+                        // holding the mesh, or the parent.
+                        aiNode* node = mScene->mRootNode->FindNode(pAIBone->mName.data);
+                        while (node)
+                        {
+                            if (node->mName == pNode->mName)
+                            {
+                                flagNodeAsNeeded(node->mName.data);
+                                break;
+                            }
+                            if (node->mName == pNode->mParent->mName)
+                            {
+                                flagNodeAsNeeded(node->mName.data);
+                                break;
+                            }
+
+                            // Not a root node, flag this as needed and continue to the parent
+                            flagNodeAsNeeded(node->mName.data);
+                            node = node->mParent;
+                        }
+
+                        // Flag all children of this node as needed
+                        node = mScene->mRootNode->FindNode(pAIBone->mName.data);
+                        markAllChildNodesAsNeeded(node);
+
+                    } // if we have a valid bone
+                }     // loop over bones
+            }         // if this mesh has bones
+        }             // loop over meshes
+    }                 // if this node has meshes
+
+    // Traverse all child nodes of the current node instance
+    for (unsigned int childIdx = 0; childIdx < pNode->mNumChildren; childIdx++)
+    {
+        const aiNode* pChildNode = pNode->mChildren[childIdx];
+        grabBoneNamesFromNode(mScene, pChildNode);
+    }
+}
+
+static bool getTextureName(const aiMaterial* mat, aiTextureType type, const aiScene* scene, const String& meshName,
+                           String& basename)
+{
+    aiString path;
+    String outPath;
+    if (mat->GetTexture(type, 0, &path) == AI_SUCCESS)
+    {
+        const aiTexture* tex = scene->GetEmbeddedTexture(path.C_Str());
+        if(tex)
+        {
+            basename = StringUtil::format("%s%s.%.8s", meshName.c_str(), tex->mFilename.C_Str(), tex->achFormatHint);
+            return true;
+        }
+
+        StringUtil::splitFilename(String(path.data), basename, outPath);
+        return true;
+    }
+    return false;
+}
+
+static MaterialPtr createMaterial(const aiMaterial* mat, const Ogre::String &group, const String& meshName, const aiScene* scene, bool verbose)
+{
+    static int dummyMatCount = 0;
+
+    MaterialManager* omatMgr = MaterialManager::getSingletonPtr();
+    enum aiTextureType type = aiTextureType_DIFFUSE;
+    static aiString path;
+    unsigned int uvindex = 0; // the texture uv index channel
+
+    aiString szPath;
+    if (AI_SUCCESS == aiGetMaterialString(mat, AI_MATKEY_NAME, &szPath))
+    {
+        if (verbose)
+        {
+            LogManager::getSingleton().logMessage("Using aiGetMaterialString : Name " +
+                                                  String(szPath.data));
+        }
+    }
+
+    String matName = meshName;
+    if(szPath.length)
+    {
+        matName += String(szPath.data);
+        matName = ReplaceSpaces(matName);
+    }
+    else
+    {
+        matName += StringUtil::format("dummyMat%d", dummyMatCount++);
+    }
+
+    auto status = omatMgr->createOrRetrieve(matName, group);
+    auto omat = static_pointer_cast<Material>(status.first);
+
+    if (!status.second)
+        return omat;
+
+    if (verbose)
+    {
+        LogManager::getSingleton().logMessage("Creating " + matName);
+    }
+
+    // ambient
+    aiColor4D clr(1.0f, 1.0f, 1.0f, 1.0);
+    // Ambient is usually way too low! FIX ME!
+    if (mat->GetTexture(type, 0, &path) != AI_SUCCESS)
+        aiGetMaterialColor(mat, AI_MATKEY_COLOR_AMBIENT, &clr);
+    omat->setAmbient(clr.r, clr.g, clr.b);
+
+    // diffuse
+    clr = aiColor4D(1.0f, 1.0f, 1.0f, 1.0f);
+    if (AI_SUCCESS == aiGetMaterialColor(mat, AI_MATKEY_COLOR_DIFFUSE, &clr))
+    {
+        omat->setDiffuse(clr.r, clr.g, clr.b, clr.a);
+    }
+
+    // specular
+    clr = aiColor4D(1.0f, 1.0f, 1.0f, 1.0f);
+    if (AI_SUCCESS == aiGetMaterialColor(mat, AI_MATKEY_COLOR_SPECULAR, &clr))
+    {
+        omat->setSpecular(clr.r, clr.g, clr.b, clr.a);
+    }
+
+    // emissive
+    clr = aiColor4D(1.0f, 1.0f, 1.0f, 1.0f);
+    if (AI_SUCCESS == aiGetMaterialColor(mat, AI_MATKEY_COLOR_EMISSIVE, &clr))
+    {
+        omat->setSelfIllumination(clr.r, clr.g, clr.b);
+    }
+
+    float fShininess;
+    if (AI_SUCCESS == aiGetMaterialFloat(mat, AI_MATKEY_SHININESS, &fShininess))
+    {
+        omat->setShininess(Real(fShininess));
+    }
+
+    int shade = aiShadingMode_NoShading;
+    if (AI_SUCCESS == mat->Get(AI_MATKEY_SHADING_MODEL, shade) && shade != aiShadingMode_NoShading)
+    {
+        switch (shade)
+        {
+        case aiShadingMode_Phong: // Phong shading mode was added to opengl and directx years ago to be
+                                  // ready for gpus to support it (in fixed function pipeline), but no gpus
+                                  // ever did, so it has never done anything. From directx 10 onwards it was
+                                  // removed again.
+        case aiShadingMode_Gouraud:
+            omat->setShadingMode(SO_GOURAUD);
+            break;
+        case aiShadingMode_Flat:
+            omat->setShadingMode(SO_FLAT);
+            break;
+        default:
+            break;
+        }
+    }
+
+    String basename;
+    if (getTextureName(mat, type, scene, meshName, basename))
+    {
+        if (verbose)
+        {
+            LogManager::getSingleton().logMessage("Found texture " + basename + " for channel " +
+                                                  StringConverter::toString(uvindex));
+        }
+        omat->getTechnique(0)->getPass(0)->createTextureUnitState(basename);
+    }
+
+    if (getTextureName(mat, aiTextureType_EMISSIVE, scene, meshName, basename))
+    {
+        if (verbose)
+        {
+            LogManager::getSingleton().logMessage("Found emissive map: " + basename);
+        }
+        auto tus = omat->getTechnique(0)->getPass(0)->createTextureUnitState(basename);
+        tus->setColourOperation(LBO_ADD);
+        omat->setSelfIllumination(0, 0, 0); // assimp assumes emissive is modulated, whereas Ogre adds up
+    }
+
+#ifdef OGRE_BUILD_COMPONENT_RTSHADERSYSTEM
+    auto shaderGen = RTShader::ShaderGenerator::getSingletonPtr();
+
+    if(!shaderGen)
+        return omat;
+
+    if (getTextureName(mat, aiTextureType_NORMALS, scene, meshName, basename))
+    {
+        if (verbose)
+        {
+            LogManager::getSingleton().logMessage("Found normal map: " + basename);
+        }
+
+        shaderGen->createShaderBasedTechnique(omat->getTechnique(0), MSN_SHADERGEN);
+        auto rs = shaderGen->getRenderState(MSN_SHADERGEN, *omat, 0);
+        auto srs = shaderGen->createSubRenderState("NormalMap");
+
+        srs->setParameter("texture", basename);
+        rs->addTemplateSubRenderState(srs);
+    }
+
+    if (getTextureName(mat, aiTextureType_UNKNOWN, scene, meshName, basename))
+    {
+        if (verbose)
+        {
+            LogManager::getSingleton().logMessage("Found metal roughness map: " + basename);
+        }
+
+        shaderGen->createShaderBasedTechnique(omat->getTechnique(0), MSN_SHADERGEN);
+        auto rs = shaderGen->getRenderState(MSN_SHADERGEN, *omat, 0);
+        auto srs = shaderGen->createSubRenderState("CookTorranceLighting");
+
+        srs->setParameter("texture", basename);
+        rs->addTemplateSubRenderState(srs);
+
+        srs = shaderGen->createSubRenderState("FFP_Texturing");
+        srs->setParameter("late_add_blend", "true");
+        rs->addTemplateSubRenderState(srs);
+    }
+#endif
+
+    return omat;
+}
+
+bool AssimpLoader::createSubMesh(const String& name, int index, const aiNode* pNode, const aiMesh* mesh,
+                                 const MaterialPtr& matptr, Mesh* mMesh, AxisAlignedBox& mAAB)
+{
+    // if animated all submeshes must have bone weights
+    if (mBonesByName.size() && !mesh->HasBones())
+    {
+        if (!mQuietMode)
+        {
+            LogManager::getSingleton().logMessage("Skipping Mesh " + String(mesh->mName.data) +
+                                                  "with no bone weights");
+        }
+        return false;
+    }
+
+    // now begin the object definition
+    // We create a submesh per material
+    SubMesh* submesh = mMesh->createSubMesh(name + StringConverter::toString(index));
+
+    // prime pointers to vertex related data
+    aiVector3D* vec = mesh->mVertices;
+    aiVector3D* norm = mesh->mNormals;
+    aiVector3D* uv = mesh->mTextureCoords[0];
+    aiVector3D* tang = mesh->mTangents;
+    aiColor4D *col = mesh->mColors[0];
+
+    // We must create the vertex data, indicating how many vertices there will be
+    submesh->useSharedVertices = false;
+    submesh->vertexData = new VertexData();
+    submesh->vertexData->vertexStart = 0;
+    submesh->vertexData->vertexCount = mesh->mNumVertices;
+
+    switch(mesh->mPrimitiveTypes)
+    {
+    default:
+    case aiPrimitiveType_TRIANGLE:
+        submesh->operationType = RenderOperation::OT_TRIANGLE_LIST;
+        break;
+    case aiPrimitiveType_LINE:
+        submesh->operationType = RenderOperation::OT_LINE_LIST;
+        break;
+    case aiPrimitiveType_POINT:
+        submesh->operationType = RenderOperation::OT_POINT_LIST;
+        break;
+    }
+
+    // We must now declare what the vertex data contains
+    VertexDeclaration* declaration = submesh->vertexData->vertexDeclaration;
+    static const unsigned short source = 0;
+    size_t offset = 0;
+    offset += declaration->addElement(source, offset, VET_FLOAT3, VES_POSITION).getSize();
+
+    if (!mQuietMode)
+    {
+        LogManager::getSingleton().logMessage(StringUtil::format("%d vertices", mesh->mNumVertices));
+    }
+    if (norm)
+    {
+        if (!mQuietMode)
+        {
+            LogManager::getSingleton().logMessage(StringUtil::format("%d normals", mesh->mNumVertices));
+        }
+        offset += declaration->addElement(source, offset, VET_FLOAT3, VES_NORMAL).getSize();
+    }
+
+    if (uv)
+    {
+        if (!mQuietMode)
+        {
+            LogManager::getSingleton().logMessage(StringUtil::format("%d uvs", mesh->mNumVertices));
+        }
+        offset += declaration->addElement(source, offset, VET_FLOAT2, VES_TEXTURE_COORDINATES).getSize();
+    }
+
+    if (tang)
+    {
+        if (!mQuietMode)
+        {
+            LogManager::getSingleton().logMessage(StringUtil::format("%d tangents", mesh->mNumVertices));
+        }
+        offset += declaration->addElement(source, offset, VET_FLOAT3, VES_TANGENT).getSize();
+    }
+
+    if (col)
+    {
+        matptr->getTechnique(0)->getPass(0)->setVertexColourTracking(TVC_DIFFUSE);
+        if (!mQuietMode)
+        {
+            LogManager::getSingleton().logMessage(StringUtil::format("%d colours", mesh->mNumVertices));
+        }
+        offset += declaration->addElement(source, offset, VET_UBYTE4_NORM, VES_DIFFUSE).getSize();
+    }
+
+    // Finally we set a material to the submesh
+    submesh->setMaterial(matptr);
+
+    // We create the hardware vertex buffer
+    HardwareVertexBufferSharedPtr vbuffer = HardwareBufferManager::getSingleton().createVertexBuffer(
+        declaration->getVertexSize(source), // == offset
+        submesh->vertexData->vertexCount,   // == nbVertices
+        HardwareBuffer::HBU_STATIC_WRITE_ONLY);
+
+    Affine3 aiM = mNodeDerivedTransformByName.find(pNode->mName.data)->second;
+
+    Matrix3 normalMatrix = aiM.linear().inverse().transpose();
+
+    // Now we get access to the buffer to fill it.  During so we record the bounding box.
+    float* vdata = static_cast<float*>(vbuffer->lock(HardwareBuffer::HBL_DISCARD));
+    for (size_t i = 0; i < mesh->mNumVertices; ++i)
+    {
+        // Position
+        Vector3 vect(vec->x, vec->y, vec->z);
+        vect = aiM * vect;
+
+        /*
+        if(NULL != mSkeletonRootNode)
+        {
+            vect *= mSkeletonRootNode->mTransformation;
+        }
+        */
+
+        *vdata++ = vect.x;
+        *vdata++ = vect.y;
+        *vdata++ = vect.z;
+        mAAB.merge(vect);
+        vec++;
+
+        // Normal
+        if (norm)
+        {
+            vect = normalMatrix * Vector3(norm->x, norm->y, norm->z);
+            vect.normalise();
+
+            *vdata++ = vect.x;
+            *vdata++ = vect.y;
+            *vdata++ = vect.z;
+            norm++;
+        }
+
+        // uvs
+        if (uv)
+        {
+            *vdata++ = uv->x;
+            *vdata++ = uv->y;
+            uv++;
+        }
+
+        if(tang)
+        {
+            *vdata++ = tang->x;
+            *vdata++ = tang->y;
+            *vdata++ = tang->z;
+            tang++;
+        }
+
+        if (col)
+        {
+            PixelUtil::packColour(col->r, col->g, col->b, col->a, PF_BYTE_RGBA, vdata++);
+            col++;
+        }
+    }
+
+    vbuffer->unlock();
+    submesh->vertexData->vertexBufferBinding->setBinding(source, vbuffer);
+
+    // set bone weigths
+    if (mesh->HasBones())
+    {
+        for (uint32 i = 0; i < mesh->mNumBones; i++)
+        {
+            aiBone* pAIBone = mesh->mBones[i];
+            if (NULL != pAIBone)
+            {
+                String bname = pAIBone->mName.data;
+                for (uint32 weightIdx = 0; weightIdx < pAIBone->mNumWeights; weightIdx++)
+                {
+                    aiVertexWeight aiWeight = pAIBone->mWeights[weightIdx];
+
+                    VertexBoneAssignment vba;
+                    vba.vertexIndex = aiWeight.mVertexId;
+                    vba.boneIndex = mSkeleton->getBone(bname)->getHandle();
+                    vba.weight = aiWeight.mWeight;
+
+                    submesh->addBoneAssignment(vba);
+                }
+            }
+        }
+    } // if mesh has bones
+
+    if(mesh->mNumFaces == 0)
+        return true;
+
+    if (!mQuietMode)
+    {
+        LogManager::getSingleton().logMessage(StringConverter::toString(mesh->mNumFaces) + " faces");
+    }
+
+    if(!mUseIndexBuffer)
+        return true;
+
+    aiFace* faces = mesh->mFaces;
+    int faceSz = mesh->mPrimitiveTypes == aiPrimitiveType_LINE ? 2 : 3;
+
+    // Creates the index data
+    submesh->indexData->indexStart = 0;
+    submesh->indexData->indexCount = mesh->mNumFaces * faceSz;
+
+    if (mesh->mNumVertices >= 65536) // 32 bit index buffer
+    {
+        submesh->indexData->indexBuffer = HardwareBufferManager::getSingleton().createIndexBuffer(
+            HardwareIndexBuffer::IT_32BIT, submesh->indexData->indexCount,
+            HardwareBuffer::HBU_STATIC_WRITE_ONLY);
+
+        uint32* indexData =
+            static_cast<uint32*>(submesh->indexData->indexBuffer->lock(HardwareBuffer::HBL_DISCARD));
+
+        for (size_t i = 0; i < mesh->mNumFaces; ++i)
+        {
+            for(int j = 0; j < faceSz; j++)
+                *indexData++ = faces->mIndices[j];
+
+            faces++;
+        }
+    }
+    else // 16 bit index buffer
+    {
+        submesh->indexData->indexBuffer = HardwareBufferManager::getSingleton().createIndexBuffer(
+            HardwareIndexBuffer::IT_16BIT, submesh->indexData->indexCount,
+            HardwareBuffer::HBU_STATIC_WRITE_ONLY);
+
+        uint16* indexData =
+            static_cast<uint16*>(submesh->indexData->indexBuffer->lock(HardwareBuffer::HBL_DISCARD));
+
+        for (size_t i = 0; i < mesh->mNumFaces; ++i)
+        {
+            for(int j = 0; j < faceSz; j++)
+                *indexData++ = faces->mIndices[j];
+
+            faces++;
+        }
+    }
+
+    submesh->indexData->indexBuffer->unlock();
+
+    return true;
+}
+
+void AssimpLoader::loadDataFromNode(const aiScene* mScene, const aiNode* pNode, Mesh* mesh)
+{
+    if (pNode->mNumMeshes > 0)
+    {
+        AxisAlignedBox mAAB = mesh->getBounds();
+
+        for (unsigned int idx = 0; idx < pNode->mNumMeshes; ++idx)
+        {
+            aiMesh* pAIMesh = mScene->mMeshes[pNode->mMeshes[idx]];
+            if (!mQuietMode)
+            {
+                LogManager::getSingleton().logMessage("SubMesh " + StringConverter::toString(idx) +
+                                                      " for mesh '" + String(pNode->mName.data) + "'");
+            }
+
+            // Create a material instance for the mesh.
+            const aiMaterial* pAIMaterial = mScene->mMaterials[pAIMesh->mMaterialIndex];
+            MaterialPtr matptr = createMaterial(pAIMaterial, mesh->getGroup(), mesh->getName(), mScene, !mQuietMode);
+            createSubMesh(pNode->mName.data, idx, pNode, pAIMesh, matptr, mesh, mAAB);
+        }
+
+        // We must indicate the bounding box
+        mesh->_setBounds(mAAB);
+        mesh->_setBoundingSphereRadius((mAAB.getMaximum() - mAAB.getMinimum()).length() / 2);
+    }
+
+    // Traverse all child nodes of the current node instance
+    for (unsigned int childIdx = 0; childIdx < pNode->mNumChildren; childIdx++)
+    {
+        const aiNode* pChildNode = pNode->mChildren[childIdx];
+        loadDataFromNode(mScene, pChildNode, mesh);
+    }
+}
+
+static std::vector<std::unique_ptr<Codec> > registeredCodecs;
+struct AssimpCodec : public Codec
+{
+    String mType;
+
+    AssimpCodec(const String& type) : mType(type) {}
+
+    String magicNumberToFileExt(const char* magicNumberPtr, size_t maxbytes) const override { return ""; }
+    String getType() const override { return mType; }
+    void decode(const DataStreamPtr& input, const Any& output) const override
+    {
+        Mesh* dst = any_cast<Mesh*>(output);
+
+        AssimpLoader::Options opts;
+        opts.params = AssimpLoader::LP_QUIET_MODE;
+        SkeletonPtr skeleton;
+        AssimpLoader loader;
+        loader.load(input, dst, skeleton, opts);
+    }
+
+    static void startup()
+    {
+        String version = StringUtil::format("Assimp - %d.%d.%d - Open-Asset-Importer", aiGetVersionMajor(),
+                                            aiGetVersionMinor(), aiGetVersionRevision());
+        LogManager::getSingleton().logMessage(version);
+
+        String extensions;
+        Assimp::Importer tmp;
+        tmp.GetExtensionList(extensions);
+
+        String blacklist[] = {"mesh", "mesh.xml", "raw", "mdc", "bsp"};
+        auto stream = LogManager::getSingleton().stream();
+        stream << "Supported formats:";
+        // Register codecs
+        for (const auto& dotext : StringUtil::split(extensions, ";"))
+        {
+            String ext = dotext.substr(2);
+            if (std::find(begin(blacklist), std::end(blacklist), ext) != std::end(blacklist))
+                continue;
+
+            stream << " " << ext;
+            Codec* codec = new AssimpCodec(ext);
+            registeredCodecs.push_back(std::unique_ptr<Codec>(codec));
+            Codec::registerCodec(codec);
+        }
+
+        stream << "\n";
+    }
+    static void shutdown()
+    {
+        for (const auto& c : registeredCodecs)
+            Codec::unregisterCodec(c.get());
+        registeredCodecs.clear();
+    }
+};

--- a/src/Assimp/CMakeLists.txt
+++ b/src/Assimp/CMakeLists.txt
@@ -1,0 +1,15 @@
+##############################################################
+#  adding the files
+##############################################################
+
+set(SRC_FILES 
+${SRC_FILES}
+${CMAKE_CURRENT_SOURCE_DIR}/AssimpLoader.cpp
+PARENT_SCOPE
+)
+
+set(HEADER_FILES
+${HEADER_FILES}
+${CMAKE_CURRENT_SOURCE_DIR}/OgreAssimpLoader.h
+PARENT_SCOPE
+)

--- a/src/Assimp/OgreAssimpLoader.h
+++ b/src/Assimp/OgreAssimpLoader.h
@@ -1,0 +1,100 @@
+#ifndef __AssimpLoader_h__
+#define __AssimpLoader_h__
+
+#include <OgreMesh.h>
+#include <OgrePlugin.h>
+#include <OgreAssimpExports.h>
+
+struct aiScene;
+struct aiNode;
+struct aiBone;
+struct aiMesh;
+struct aiMaterial;
+struct aiAnimation;
+
+template <typename TReal> class aiMatrix4x4t;
+typedef aiMatrix4x4t<float> aiMatrix4x4;
+
+namespace Assimp
+{
+class Importer;
+}
+
+using namespace Ogre;
+
+class AssimpLoader
+{
+public:
+    enum LoaderParams
+    {
+        // 3ds max exports the animation over a longer time frame than the animation actually plays for
+        // this is a fix for that
+        LP_CUT_ANIMATION_WHERE_NO_FURTHER_CHANGE = 1 << 0,
+
+        // Quiet mode - don't output anything
+        LP_QUIET_MODE = 1 << 1
+    };
+
+    struct Options
+    {
+        float animationSpeedModifier;
+        int params;
+        int postProcessSteps;
+        String customAnimationName;
+        float maxEdgeAngle;
+
+        Options() : animationSpeedModifier(1), params(0), postProcessSteps(0), maxEdgeAngle(30) {}
+    };
+
+    AssimpLoader();
+    virtual ~AssimpLoader();
+
+    bool load(const String& source, Mesh* mesh, SkeletonPtr& skeletonPtr,
+              const Options& options = Options());
+
+    bool load(const DataStreamPtr& source, Mesh* mesh, SkeletonPtr& skeletonPtr,
+              const Options& options = Options());
+
+private:
+    bool _load(const char* name, Assimp::Importer& importer, Mesh* mesh, SkeletonPtr& skeletonPtr,
+               const Options& options);
+    bool createSubMesh(const String& name, int index, const aiNode* pNode, const aiMesh* mesh,
+                       const MaterialPtr& matptr, Mesh* mMesh, AxisAlignedBox& mAAB);
+    void grabNodeNamesFromNode(const aiScene* mScene, const aiNode* pNode);
+    void grabBoneNamesFromNode(const aiScene* mScene, const aiNode* pNode);
+    void computeNodesDerivedTransform(const aiScene* mScene, const aiNode* pNode,
+                                      const aiMatrix4x4& accTransform);
+    void createBonesFromNode(const aiScene* mScene, const aiNode* pNode);
+    void createBoneHiearchy(const aiScene* mScene, const aiNode* pNode);
+    void loadDataFromNode(const aiScene* mScene, const aiNode* pNode, Mesh* mesh);
+    void markAllChildNodesAsNeeded(const aiNode* pNode);
+    void flagNodeAsNeeded(const char* name);
+    bool isNodeNeeded(const char* name);
+    void parseAnimation(const aiScene* mScene, int index, aiAnimation* anim);
+    typedef std::map<String, bool> boneMapType;
+    boneMapType boneMap;
+    // aiNode* mSkeletonRootNode;
+    int mLoaderParams;
+
+    String mCustomAnimationName;
+
+    typedef std::map<String, const aiNode*> BoneNodeMap;
+    BoneNodeMap mBoneNodesByName;
+
+    typedef std::map<String, const aiBone*> BoneMap;
+    BoneMap mBonesByName;
+
+    typedef std::map<String, Affine3> NodeTransformMap;
+    NodeTransformMap mNodeDerivedTransformByName;
+
+    SkeletonPtr mSkeleton;
+
+    static int msBoneCount;
+
+    bool mQuietMode;
+    bool mUseIndexBuffer;
+    Real mTicksPerSecond;
+    Real mAnimationSpeedModifier;
+};
+
+#endif // __AssimpLoader_h__

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,8 @@
 
 set(SRC_FILES 
 about.cpp
+animationcontrolwidget.cpp
+animationcontrolslider.cpp
 main.cpp
 Manager.cpp
 material.cpp
@@ -34,6 +36,8 @@ MaterialHighlighter.cpp
 )
 
 set(HEADER_FILES
+animationcontrolwidget.h
+animationcontrolslider.h
 GlobalDefinitions.h
 Euler.h
 about.h
@@ -68,6 +72,7 @@ MaterialHighlighter.h
 )
 
 ADD_SUBDIRECTORY("${CMAKE_CURRENT_SOURCE_DIR}/OgreXML")
+ADD_SUBDIRECTORY("${CMAKE_CURRENT_SOURCE_DIR}/Assimp")
 
 
 #file(GLOB UI_FILES ./ui_files/*.ui)
@@ -224,9 +229,12 @@ endif()
 target_link_libraries(${CMAKE_PROJECT_NAME}
 ${OGRE_Codec_Assimp_LIBRARY_REL} #TODO: find a better way to link ogreassimp
 ${OGRE_LIBRARIES}
+${ASSIMP_LIBRARIES}
 Qt::Gui
 Qt::Core
 Qt::Widgets
+Qt::QuickWidgets
+Qt::Quick
 )
 
 ##############################################################

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -233,8 +233,6 @@ ${ASSIMP_LIBRARIES}
 Qt::Gui
 Qt::Core
 Qt::Widgets
-Qt::QuickWidgets
-Qt::Quick
 )
 
 ##############################################################

--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -68,7 +68,7 @@ Manager* Manager:: m_pSingleton = 0;
 
 QString Manager::mValidFileExtention = ".mesh .dae .blend .3ds .ase .obj .ifc .xgl .zgl .ply .dxf .lwo "\
         ".lws .lxo .stl .x .ac .ms3d .cob .scn .bvh .csm .xml .irrmesh .irr .mdl .md2 .md3 "\
-        ".pk3 .mdc .md5 .smd .vta .m3 .3d .b3d .q3d .q3s .nff .nff .off .raw .ter .mdl .hmp .ndo .fbx .glb .gltf";
+        ".pk3 .mdc .md5 .txt .smd .vta .m3 .3d .b3d .q3d .q3s .nff .nff .off .raw .ter .mdl .hmp .ndo .fbx .glb .gltf";
 
 ////////////////////////////////////////
 /// Static Member to build & destroy

--- a/src/PrimitivesWidget.cpp
+++ b/src/PrimitivesWidget.cpp
@@ -74,7 +74,7 @@ PrimitivesWidget::~PrimitivesWidget()
 
 void PrimitivesWidget::setUiEmpty()
 {
-    edit_type->setText(QString());
+    edit_type->setText("");
 
     gb_Geometry->hide();
     gb_Mesh->hide();

--- a/src/animationcontrolslider.cpp
+++ b/src/animationcontrolslider.cpp
@@ -1,0 +1,26 @@
+#include "animationcontrolslider.h"
+
+AnimationControlSlider::AnimationControlSlider(QWidget *parent)
+    : QSlider(parent)
+{
+
+}
+
+void AnimationControlSlider::addTick(int value, QColor color)
+{
+    m_ticks.push_back(std::make_pair(value, color));
+}
+
+void AnimationControlSlider::paintEvent(QPaintEvent *event)
+{
+    QSlider::paintEvent(event);
+
+    for(auto tick : m_ticks)
+    {
+        int x = style()->sliderPositionFromValue(minimum(), maximum(), tick.first, width());
+        QPainter painter(this);
+        painter.setPen(QPen(tick.second, 2));
+        painter.drawLine(x, 15, x, height());
+    }
+    
+}

--- a/src/animationcontrolslider.h
+++ b/src/animationcontrolslider.h
@@ -1,0 +1,23 @@
+#ifndef ANIMATIONCONTROLSLIDER_H
+#define ANIMATIONCONTROLSLIDER_H
+
+#include <QSlider>
+#include <QPainter>
+#include <QStyle>
+
+class AnimationControlSlider : public QSlider
+{
+    Q_OBJECT
+
+public:
+    explicit AnimationControlSlider(QWidget *parent = nullptr);
+    void addTick(int value, QColor color);
+
+protected:
+    void paintEvent(QPaintEvent *event);
+
+private:
+    std::vector<std::pair<int, QColor>> m_ticks;
+};
+
+#endif // ANIMATIONCONTROLSLIDER_H

--- a/src/animationcontrolwidget.cpp
+++ b/src/animationcontrolwidget.cpp
@@ -1,0 +1,142 @@
+#include "animationcontrolwidget.h"
+#include "ui_animationcontrolwidget.h"
+#include "SelectionSet.h"
+#include <QTreeWidgetItem>
+#include <QTimer>
+
+AnimationControlWidget::AnimationControlWidget(QWidget *parent) :
+    QDockWidget(parent),
+    ui(new Ui::AnimationControlWidget)
+{
+    ui->setupUi(this);
+    updateAnimationTree();
+
+    connect(SelectionSet::getSingleton(),SIGNAL(entitySelectionChanged()),this,SLOT(updateAnimationTree()));
+    connect(ui->treeWidget, &QTreeWidget::itemSelectionChanged, this, [=](){
+        ui->horizontalSlider->setValue(0);
+        ui->horizontalSlider->setEnabled(true);
+        if(ui->treeWidget->selectedItems().size() > 0)
+        {
+            QTreeWidgetItem* item = ui->treeWidget->selectedItems().at(0);
+            auto selected = item->text(0).toStdString();
+
+            m_selectedAnimation = selected.substr(6);
+            auto data = item->data(0,Qt::UserRole).value<std::tuple<Ogre::Entity*,Ogre::SkeletonInstance*,Ogre::AnimationState*>>();
+            m_selectedEntity = std::get<0>(data);
+            m_selectedSkeleton = std::get<1>(data);
+
+            Ogre::Animation* animation = m_selectedSkeleton->getAnimation(m_selectedAnimation);
+            if(animation)
+            {
+                ui->horizontalSlider->setMaximum(animation->getLength()*1000);
+                ui->maxSliderLabel->setText(QString::number(animation->getLength()));
+
+                ui->boneList->clear();
+                auto trackList = animation->_getNodeTrackList();
+                for(const auto &track:trackList)
+                {
+                    // add to bone list
+                    QListWidgetItem* boneItem = new QListWidgetItem(QString::fromStdString(track.second->getAssociatedNode()->getName()));
+                    boneItem->setData(Qt::UserRole,QVariant::fromValue(track.second));
+                    ui->boneList->addItem(boneItem);
+                }
+                if(trackList.size() > 0)
+                {
+                    m_selectedTrack = trackList.begin()->second;
+                    ui->boneList->setCurrentRow(0);
+                    //Add track marks to the slider
+                    for (int i = 0; i < m_selectedTrack->getNumKeyFrames(); i++)
+                    {
+                        Ogre::KeyFrame* keyFrame = m_selectedTrack->getKeyFrame(i);
+                        ui->horizontalSlider->addTick(keyFrame->getTime()*1000, QColor("yellow"));
+                    }
+                }
+            }
+        }
+    });
+    connect(ui->boneList, &QListWidget::itemSelectionChanged, this, [=](){
+        if(ui->boneList->selectedItems().size() > 0)
+        {
+            auto selected = ui->boneList->selectedItems().at(0);
+            m_selectedTrack = selected->data(Qt::UserRole).value<Ogre::NodeAnimationTrack*>();
+        }
+    });
+    connect(ui->horizontalSlider,SIGNAL(valueChanged(int)),this,SLOT(setAnimationFrame(int)));
+    QTimer *m_pTimer = new QTimer(this);
+    connect(m_pTimer, &QTimer::timeout, this, [this](){
+        if(m_selectedEntity)
+        {
+            // Updates the slider
+            Ogre::AnimationState* state = m_selectedEntity->getAnimationState(m_selectedAnimation);
+            ui->horizontalSlider->setValue(state->getTimePosition()*1000);
+        }
+    });
+    m_pTimer->start(0);
+}
+
+AnimationControlWidget::~AnimationControlWidget()
+{
+    delete ui;
+}
+
+void AnimationControlWidget::updateAnimationTree()
+{
+    ui->treeWidget->clear();
+    for(Ogre::Entity* entity : SelectionSet::getSingleton()->getEntitiesSelectionList())
+    {
+        // get skeleton
+        Ogre::SkeletonInstance* skeleton = entity->getSkeleton();
+        QTreeWidgetItem* item = new QTreeWidgetItem(ui->treeWidget);
+        // only allow expanding, not selecting
+        item->setFlags(item->flags() & ~Qt::ItemIsSelectable);
+        item->setText(0,QString::fromStdString("mesh: "+entity->getName()));
+        //Animation
+        Ogre::AnimationStateSet* set = entity->getAllAnimationStates();
+        if(set)
+        {
+            for (const auto &animationState:set->getAnimationStates())
+            {
+                QTreeWidgetItem* child = new QTreeWidgetItem(item);
+                child->setText(0,QString::fromStdString("anim: "+animationState.first));
+                //add skeleton and animation state to item data
+                child->setData(0,Qt::UserRole,QVariant::fromValue(std::make_tuple(entity,skeleton,animationState.second)));
+            }
+        }
+    }
+
+}
+
+void AnimationControlWidget::setAnimationFrame(int time)
+{
+    if (m_selectedEntity)
+    {
+        Ogre::AnimationState* state = m_selectedEntity->getAnimationState(m_selectedAnimation);
+        state->setTimePosition(time/1000.0f);
+
+        if(m_selectedTrack){
+            Ogre::KeyFrame* keyframe1;
+            Ogre::KeyFrame* keyframe2;
+            m_selectedTrack->getKeyFramesAtTime(time/1000.0f, &keyframe1, &keyframe2);
+            if(keyframe1)
+            {
+                Ogre::TransformKeyFrame* keyframe = static_cast<Ogre::TransformKeyFrame*>(keyframe1);
+
+                Ogre::Vector3 translation = keyframe->getTranslate();
+                Ogre::Quaternion rotation = keyframe->getRotation();
+                Ogre::Vector3 scale = keyframe->getScale();
+
+                ui->tableWidget->item(0,1)->setText(QString::number(translation.x));
+                ui->tableWidget->item(0,2)->setText(QString::number(translation.y));
+                ui->tableWidget->item(0,3)->setText(QString::number(translation.z));
+                ui->tableWidget->item(1,1)->setText(QString::number(scale.x));
+                ui->tableWidget->item(1,2)->setText(QString::number(scale.y));
+                ui->tableWidget->item(1,3)->setText(QString::number(scale.z));
+                ui->tableWidget->item(2,0)->setText(QString::number(rotation.w));
+                ui->tableWidget->item(2,1)->setText(QString::number(rotation.x));
+                ui->tableWidget->item(2,2)->setText(QString::number(rotation.y));
+                ui->tableWidget->item(2,3)->setText(QString::number(rotation.z));
+            }
+        }
+    }
+    
+}

--- a/src/animationcontrolwidget.h
+++ b/src/animationcontrolwidget.h
@@ -1,0 +1,37 @@
+#ifndef ANIMATIONCONTROLWIDGET_H
+#define ANIMATIONCONTROLWIDGET_H
+
+#include <QDockWidget>
+
+namespace Ui {
+class AnimationControlWidget;
+}
+
+namespace Ogre {
+    class Entity;
+    class NodeAnimationTrack;
+    class SkeletonInstance;
+}
+
+class AnimationControlWidget : public QDockWidget
+{
+    Q_OBJECT
+
+public:
+    explicit AnimationControlWidget(QWidget *parent = nullptr);
+    ~AnimationControlWidget();
+
+private slots:
+    void updateAnimationTree();
+    void setAnimationFrame(int time);
+
+private:
+    Ui::AnimationControlWidget *ui;
+    std::string m_selectedAnimation="";
+    Ogre::NodeAnimationTrack* m_selectedTrack=nullptr;
+    Ogre::SkeletonInstance* m_selectedSkeleton=nullptr;
+    Ogre::Entity* m_selectedEntity=nullptr;
+    float m_time = 0.0f;
+};
+
+#endif // ANIMATIONCONTROLWIDGET_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,11 +34,11 @@
 
 int main(int argc, char *argv[])
 {
+    QApplication a(argc, argv);
+
     QCoreApplication::setOrganizationName("QtMeshEditor");
     QCoreApplication::setOrganizationDomain("none");
     QCoreApplication::setApplicationName("QtMeshEditor");
-
-    QApplication a(argc, argv);
 
     a.setStyle(QStyleFactory::create("Fusion"));
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -76,7 +76,6 @@ private slots:
     void setTransformState(TransformOperator::TransformState newState);
     void createEditorViewport(void);
     void onWidgetClosing(EditorViewport* const& widget);
-    void ogreUpdate(void);
 
     void on_actionSingle_toggled(bool arg1);
 

--- a/ui_files/animationcontrolwidget.ui
+++ b/ui_files/animationcontrolwidget.ui
@@ -1,0 +1,355 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>AnimationControlWidget</class>
+ <widget class="QDockWidget" name="AnimationControlWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>963</width>
+    <height>200</height>
+   </rect>
+  </property>
+  <property name="floating">
+   <bool>false</bool>
+  </property>
+  <property name="windowTitle">
+   <string>Animation Control</string>
+  </property>
+  <widget class="QWidget" name="dockWidgetContents">
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
+   <layout class="QVBoxLayout" name="verticalLayout_3">
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayout_7">
+        <property name="rightMargin">
+         <number>10</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Select Animation</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QTreeWidget" name="treeWidget">
+          <property name="maximumSize">
+           <size>
+            <width>400</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="columnCount">
+           <number>2</number>
+          </property>
+          <attribute name="headerVisible">
+           <bool>false</bool>
+          </attribute>
+          <attribute name="headerDefaultSectionSize">
+           <number>400</number>
+          </attribute>
+          <column>
+           <property name="text">
+            <string notr="true">1</string>
+           </property>
+          </column>
+          <column>
+           <property name="text">
+            <string notr="true">2</string>
+           </property>
+          </column>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayout_6">
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Bones</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QListWidget" name="boneList">
+          <property name="modelColumn">
+           <number>0</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayout_4">
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="minSliderLabel">
+            <property name="text">
+             <string>0</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="AnimationControlSlider" name="horizontalSlider">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="tracking">
+             <bool>true</bool>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="invertedAppearance">
+             <bool>false</bool>
+            </property>
+            <property name="invertedControls">
+             <bool>false</bool>
+            </property>
+            <property name="tickPosition">
+             <enum>QSlider::TicksBelow</enum>
+            </property>
+            <property name="tickInterval">
+             <number>1</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="maxSliderLabel">
+            <property name="text">
+             <string>--</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
+          <item>
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QTableWidget" name="tableWidget">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>430</width>
+              <height>110</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>430</width>
+              <height>110</height>
+             </size>
+            </property>
+            <property name="verticalScrollBarPolicy">
+             <enum>Qt::ScrollBarAlwaysOff</enum>
+            </property>
+            <property name="horizontalScrollBarPolicy">
+             <enum>Qt::ScrollBarAlwaysOff</enum>
+            </property>
+            <property name="showDropIndicator" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="dragDropOverwriteMode">
+             <bool>false</bool>
+            </property>
+            <attribute name="horizontalHeaderDefaultSectionSize">
+             <number>90</number>
+            </attribute>
+            <row>
+             <property name="text">
+              <string>Translation</string>
+             </property>
+            </row>
+            <row>
+             <property name="text">
+              <string>Scale</string>
+             </property>
+            </row>
+            <row>
+             <property name="text">
+              <string>Rotation</string>
+             </property>
+            </row>
+            <column>
+             <property name="text">
+              <string>w</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>x</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>y</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>z</string>
+             </property>
+            </column>
+            <item row="0" column="0">
+             <property name="text">
+              <string>-</string>
+             </property>
+             <property name="flags">
+              <set>ItemIsSelectable|ItemIsDragEnabled|ItemIsDropEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
+             </property>
+            </item>
+            <item row="0" column="1">
+             <property name="text">
+              <string>0</string>
+             </property>
+             <property name="flags">
+              <set>ItemIsSelectable|ItemIsDragEnabled|ItemIsDropEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
+             </property>
+            </item>
+            <item row="0" column="2">
+             <property name="text">
+              <string>0</string>
+             </property>
+             <property name="flags">
+              <set>ItemIsSelectable|ItemIsDragEnabled|ItemIsDropEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
+             </property>
+            </item>
+            <item row="0" column="3">
+             <property name="text">
+              <string>0</string>
+             </property>
+             <property name="flags">
+              <set>ItemIsSelectable|ItemIsDragEnabled|ItemIsDropEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
+             </property>
+            </item>
+            <item row="1" column="0">
+             <property name="text">
+              <string>-</string>
+             </property>
+             <property name="flags">
+              <set>ItemIsSelectable|ItemIsDragEnabled|ItemIsDropEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
+             </property>
+            </item>
+            <item row="1" column="1">
+             <property name="text">
+              <string>0</string>
+             </property>
+             <property name="flags">
+              <set>ItemIsSelectable|ItemIsDragEnabled|ItemIsDropEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
+             </property>
+            </item>
+            <item row="1" column="2">
+             <property name="text">
+              <string>0</string>
+             </property>
+             <property name="flags">
+              <set>ItemIsSelectable|ItemIsDragEnabled|ItemIsDropEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
+             </property>
+            </item>
+            <item row="1" column="3">
+             <property name="text">
+              <string>0</string>
+             </property>
+             <property name="flags">
+              <set>ItemIsSelectable|ItemIsDragEnabled|ItemIsDropEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
+             </property>
+            </item>
+            <item row="2" column="0">
+             <property name="text">
+              <string>0</string>
+             </property>
+             <property name="flags">
+              <set>ItemIsSelectable|ItemIsDragEnabled|ItemIsDropEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
+             </property>
+            </item>
+            <item row="2" column="1">
+             <property name="text">
+              <string>0</string>
+             </property>
+             <property name="flags">
+              <set>ItemIsSelectable|ItemIsDragEnabled|ItemIsDropEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
+             </property>
+            </item>
+            <item row="2" column="2">
+             <property name="text">
+              <string>0</string>
+             </property>
+             <property name="flags">
+              <set>ItemIsSelectable|ItemIsDragEnabled|ItemIsDropEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
+             </property>
+            </item>
+            <item row="2" column="3">
+             <property name="text">
+              <string>0</string>
+             </property>
+             <property name="flags">
+              <set>ItemIsSelectable|ItemIsDragEnabled|ItemIsDropEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>AnimationControlSlider</class>
+   <extends>QSlider</extends>
+   <header>animationcontrolslider.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/ui_files/mainwindow.ui
+++ b/ui_files/mainwindow.ui
@@ -46,7 +46,7 @@
      <x>0</x>
      <y>0</y>
      <width>1010</width>
-     <height>22</height>
+     <height>24</height>
     </rect>
    </property>
    <property name="mouseTracking">
@@ -158,7 +158,7 @@
    </property>
    <property name="maximumSize">
     <size>
-     <width>300</width>
+     <width>350</width>
      <height>524287</height>
     </size>
    </property>


### PR DESCRIPTION
# Summary
<!-- Please include a high-level summary of your solution. Screenshots are helpful! -->
Improved the Assimp mesh importer configurations and created a new widget for handling animations.
For now it only allows reading the keyframe values, but in the future It should allow editing it.

Before|After
-|-
<img width="1001" alt="image" src="https://user-images.githubusercontent.com/996529/218763136-5369beba-a225-4e9c-a902-6fb27806f8cb.png">|<img width="1001" alt="image" src="https://user-images.githubusercontent.com/996529/218763335-360e7212-5b7e-4705-abcc-7621e9620dc1.png">


# Technical Details
<!-- Include bullets of the general areas of technical change in the PR. This can be helpful to list as they don't always track 1:1 with the number of commits/commit messages -->
The Assimp loader is now a separate implementation, not using the ogreassimp plugin.
There's now a new widget "AnimationControlWidget" and a custom implementation of QSlider for allowing adding the keyframes marks.

### :sparkles: Features

* The new Animation Control Widget allow to manually control the animation position and to see the values and position of each keyframe.

### :bug: Bugfixes

* Fixes importing meshs using Assimp
