### PR TITLE
Fix animation renaming

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 1.7.0 LANGUAGES CXX)
+project(QtMeshEditor VERSION 1.7.1 LANGUAGES CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")


### PR DESCRIPTION
# Summary
<!-- Please include a high-level summary of your solution. Screenshots are helpful! -->

When renaming, the animations were getting weird animation results.
Also, it had some issues regarding disk access 

<img width="546" alt="image" src="https://github.com/fernandotonon/QtMeshEditor/assets/996529/bd4ba9a6-e9ee-41dc-b6f9-7f4f315bc681">


# Technical Details
<!-- Include bullets of the general areas of technical change in the PR. This can be helpful to list as they don't always track 1:1 with the number of commits/commit messages -->

* The animations were getting renamed by exporting the skeleton as xml, replacing the name and reimporting the xml.
* Now it clones the animation and apply to the skeleton in the memory

### :sparkles: Features
* none

### :bug: Bugfixes
* Fixes renaming animation
