### PR TITLE
Apply `mTicksPerSecond` when importing the animations

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -60,3 +60,6 @@ exclude_patterns:
   - "*_autogen*"
   - src/dependencies/*
   - src/CMakeFiles/*
+  - "_deps/*"
+  - "moc_*"
+  - "media/*"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -71,3 +71,4 @@ exclude_patterns:
   - "*.in"
   - "*.yml"
   - "*.cmake"
+  - "makefile"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -59,7 +59,15 @@ exclude_patterns:
   - src/OgreXML/*
   - "*_autogen*"
   - src/dependencies/*
+  - CMakeFiles/*
   - src/CMakeFiles/*
   - "_deps/*"
   - "moc_*"
   - "media/*"
+  - "lib/*"
+  - "bin/*"
+  - "cfg/*"
+  - "*.md"
+  - "*.in"
+  - "*.yml"
+  - "*.cmake"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -56,17 +56,17 @@ plugins:
       standard: "cpp17"
       library: googletest
 exclude_patterns:
-  - src/OgreXML/*
+  - "src/OgreXML/"
   - "*_autogen*"
-  - src/dependencies/*
-  - CMakeFiles/*
-  - src/CMakeFiles/*
-  - "_deps/*"
+  - "src/dependencies/"
+  - "CMakeFiles/"
+  - "src/CMakeFiles/"
+  - "_deps/"
   - "moc_*"
-  - "media/*"
-  - "lib/*"
-  - "bin/*"
-  - "cfg/*"
+  - "media/"
+  - "lib/"
+  - "bin/"
+  - "cfg/"
   - "*.md"
   - "*.in"
   - "*.yml"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 1.8.0 LANGUAGES CXX)
+project(QtMeshEditor VERSION 1.8.4 LANGUAGES CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/src/Assimp/AnimationProcessor.h
+++ b/src/Assimp/AnimationProcessor.h
@@ -11,7 +11,7 @@ public:
 
 private:
     void processAnimation(aiAnimation* animation, const aiScene* scene);
-    void processAnimationChannel(aiNodeAnim* nodeAnim, Ogre::Animation* animation, const aiScene* scene, unsigned int channelIndex);
+    void processAnimationChannel(aiNodeAnim* nodeAnim, Ogre::Animation* animation, const aiScene* scene, unsigned int channelIndex, Ogre::Real mTicksPerSecond);
     Ogre::SkeletonPtr skeleton;
 };
 


### PR DESCRIPTION
# Summary
<!-- Please include a high-level summary of your solution. Screenshots are helpful! -->
Improves the Assimp importer by applying the `mTicksPerSecond`

# Technical Details
<!-- Include bullets of the general areas of technical change in the PR. This can be helpful to list as they don't always track 1:1 with the number of commits/commit messages -->
Apply the `mTicksPerSecond` to the animation processor and improve the test coverage config.

### :sparkles: Features
* Apply `mTicksPerSecond` when importing the animations

### :bug: Bugfixes
* none
