### PR TITLE
add tests for mainwindow

### DIFF
--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -201,8 +201,7 @@ void Manager::destroySceneNode(Ogre::SceneNode* node)
     if(PrimitiveObject::isPrimitive(node))
     {
         PrimitiveObject* primitive = PrimitiveObject::getPrimitiveFromSceneNode(node);
-        //if (!(node->getUserObjectBindings().getUserAny().isEmpty()))
-            node->getUserObjectBindings().clear();
+        node->getUserObjectBindings().clear();
 
         delete primitive;
     }
@@ -225,6 +224,7 @@ void Manager::destroyAllAttachedMovableObjects(Ogre::SceneNode* node)
 
    for(auto attachedObject : attachedObjects)
       node->getCreator()->destroyMovableObject(attachedObject);
+
    /* TODO check to free up the meshmanager
    if(ent->getMesh().getPointer()->isManuallyLoaded())
    {

--- a/src/PrimitiveObject.cpp
+++ b/src/PrimitiveObject.cpp
@@ -47,6 +47,9 @@ PrimitiveObject::PrimitiveObject(const QString& name, PrimitiveType type) :
 PrimitiveObject::~PrimitiveObject()
 {
    //We don't destroy this scene node as it will be destroy by the Manager
+
+    Manager::getSingleton()->getSceneMgr()->destroyManualObject(mName.toStdString());
+    Ogre::MeshManager::getSingleton().remove(mName.toStdString());
 }
 
 void PrimitiveObject::setDefaultParams()

--- a/src/PrimitivesWidget_test.cpp
+++ b/src/PrimitivesWidget_test.cpp
@@ -5,6 +5,7 @@
 #include <QKeyEvent>
 #include <QInputDialog>
 #include "PrimitivesWidget.h"
+#include "Manager.h"
 
 // Test case for MaterialWidget
 class PrimitivesWidgetTest : public ::testing::Test
@@ -38,6 +39,26 @@ TEST_F(PrimitivesWidgetTest, CreateCube)
 
     QString primitiveType = primitiveTypeLineEdit->text();
     ASSERT_EQ(primitiveType, "Cube");
+}
+
+TEST_F(PrimitivesWidgetTest, RemoveAndRecreateCube) {
+    PrimitivesWidget widget;
+    QLineEdit* primitiveTypeLineEdit = widget.findChild<QLineEdit*>("edit_type");
+    ASSERT_TRUE(primitiveTypeLineEdit != nullptr);
+
+    PrimitiveObject::createCube("Cube");
+
+    auto countBefore = Manager::getSingleton()->getSceneNodes().count();
+
+    Manager::getSingleton()->destroySceneNode("Cube");
+
+    auto countAfter = Manager::getSingleton()->getSceneNodes().count();
+
+    ASSERT_EQ(countBefore-1,countAfter);
+
+    PrimitiveObject::createCube("Cube");
+    Manager::getSingleton()->destroySceneNode("Cube");
+    ASSERT_EQ(countBefore-1,countAfter);
 }
 
 TEST_F(PrimitivesWidgetTest, CreateSphere)

--- a/src/SelectionSet.cpp
+++ b/src/SelectionSet.cpp
@@ -1,29 +1,3 @@
-/*/////////////////////////////////////////////////////////////////////////////////
-/// A QtMeshEditor file
-///
-/// Copyright (c) HogPog Team (www.hogpog.com.br)
-///
-/// The MIT License
-///
-/// Permission is hereby granted, free of charge, to any person obtaining a copy
-/// of this software and associated documentation files (the "Software"), to deal
-/// in the Software without restriction, including without limitation the rights
-/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-/// copies of the Software, and to permit persons to whom the Software is
-/// furnished to do so, subject to the following conditions:
-///
-/// The above copyright notice and this permission notice shall be included in
-/// all copies or substantial portions of the Software.
-///
-/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-/// THE SOFTWARE.
-////////////////////////////////////////////////////////////////////////////////*/
-
 #include <QtDebug>
 
 #include <Ogre.h>
@@ -61,7 +35,7 @@ void SelectionSet::kill()
 // Constructor & Destructor
 
 SelectionSet::SelectionSet()
-    :QObject(0)
+    :QObject(nullptr)
 {
 
 }
@@ -218,11 +192,10 @@ void SelectionSet::setEntityScaleFactor(Ogre::Entity *obj, const Ogre::Vector3 &
     if(mEntityScaleFactor.count(obj))
     {
         mEntityScaleFactor[obj] = scaleFactor;
+        return;
     }
-    else
-    {
-        mEntityScaleFactor.insert(obj,scaleFactor);
-    }
+
+    mEntityScaleFactor.insert(obj,scaleFactor);
 }
 
 Ogre::Vector3 SelectionSet::getEntityScaleFactor(Ogre::Entity *obj)
@@ -231,10 +204,8 @@ Ogre::Vector3 SelectionSet::getEntityScaleFactor(Ogre::Entity *obj)
     {
         return mEntityScaleFactor.value(obj);
     }
-    else
-    {
-        return Ogre::Vector3::UNIT_SCALE;
-    }
+
+    return Ogre::Vector3::UNIT_SCALE;
 }
 
 void SelectionSet::setEntityRotation(Ogre::Entity *obj, const Ogre::Vector3 &rotation)
@@ -242,11 +213,10 @@ void SelectionSet::setEntityRotation(Ogre::Entity *obj, const Ogre::Vector3 &rot
     if(mEntityRotation.count(obj))
     {
         mEntityRotation[obj] = rotation;
+        return;
     }
-    else
-    {
-        mEntityRotation.insert(obj,rotation);
-    }
+
+    mEntityRotation.insert(obj,rotation);
 }
 
 Ogre::Vector3 SelectionSet::getEntityRotation(Ogre::Entity *obj)
@@ -255,10 +225,8 @@ Ogre::Vector3 SelectionSet::getEntityRotation(Ogre::Entity *obj)
     {
         return mEntityRotation.value(obj);
     }
-    else
-    {
-        return Ogre::Vector3::ZERO;
-    }
+
+    return Ogre::Vector3::ZERO;
 }
 
 Ogre::SceneNode* const& SelectionSet::getSceneNode(int i) const

--- a/src/SelectionSet.cpp
+++ b/src/SelectionSet.cpp
@@ -337,7 +337,7 @@ const Ogre::Vector3 SelectionSet::getSelectionNodesCenter() const
 
 const Ogre::Vector3 SelectionSet::getSelectionScale(void)   const
 {
-    Ogre::Vector3 vResult = Ogre::Vector3::ZERO;
+    Ogre::Vector3 vResult = Ogre::Vector3::UNIT_SCALE;
 
     if(hasNodes())
     {
@@ -353,10 +353,6 @@ const Ogre::Vector3 SelectionSet::getSelectionScale(void)   const
             vResult += getSingleton()->getEntityScaleFactor(obj);
 
         vResult = vResult/getEntitiesCount();
-    }
-    else
-    {
-        vResult = Ogre::Vector3::UNIT_SCALE;
     }
 
     return (vResult);

--- a/src/SelectionSet.h
+++ b/src/SelectionSet.h
@@ -1,29 +1,3 @@
-/*/////////////////////////////////////////////////////////////////////////////////
-/// A QtMeshEditor file
-///
-/// Copyright (c) HogPog Team (www.hogpog.com.br)
-///
-/// The MIT License
-///
-/// Permission is hereby granted, free of charge, to any person obtaining a copy
-/// of this software and associated documentation files (the "Software"), to deal
-/// in the Software without restriction, including without limitation the rights
-/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-/// copies of the Software, and to permit persons to whom the Software is
-/// furnished to do so, subject to the following conditions:
-///
-/// The above copyright notice and this permission notice shall be included in
-/// all copies or substantial portions of the Software.
-///
-/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-/// THE SOFTWARE.
-////////////////////////////////////////////////////////////////////////////////*/
-
 #ifndef SELECTION_SET_H
 #define SELECTION_SET_H
 

--- a/src/SelectionSet_test.cpp
+++ b/src/SelectionSet_test.cpp
@@ -80,3 +80,34 @@ TEST(SelectionSetTests, ClearList)
     EXPECT_FALSE(selectionSet->contains(sceneNode));
     Manager::getSingleton()->destroySceneNode(sceneNode);
 }
+
+TEST(SelectionSetTests, GetSelectionNodesCenterEmpty)
+{
+    SelectionSet::getSingleton()->clear();
+    auto center = SelectionSet::getSingleton()->getSelectionNodesCenter();
+
+    EXPECT_EQ(center.x, 0.0f);
+    EXPECT_EQ(center.y, 0.0f);
+    EXPECT_EQ(center.z, 0.0f);
+}
+
+TEST(SelectionSetTests, GetSelectionNodesCenter)
+{
+    SelectionSet* selectionSet = SelectionSet::getSingleton();
+    auto sceneNode = Manager::getSingleton()->addSceneNode("test");
+    auto sceneNode2 = Manager::getSingleton()->addSceneNode("test2");
+
+    selectionSet->selectOne(sceneNode);
+    selectionSet->append(sceneNode2);
+
+    sceneNode2->translate(1.0,2.0,3.0);
+
+    auto center = selectionSet->getSelectionNodesCenter();
+
+    EXPECT_EQ(center.x, 0.5f);
+    EXPECT_EQ(center.y, 1.0f);
+    EXPECT_EQ(center.z, 1.5f);
+
+    Manager::getSingleton()->destroySceneNode(sceneNode);
+    Manager::getSingleton()->destroySceneNode(sceneNode2);
+}

--- a/src/SelectionSet_test.cpp
+++ b/src/SelectionSet_test.cpp
@@ -1,0 +1,82 @@
+#include <gtest/gtest.h>
+#include "Manager.h"
+#include <QMap>
+#include "SelectionSet.h"
+
+TEST(SelectionSetTests, AppendSceneNode)
+{
+    SelectionSet* selectionSet = SelectionSet::getSingleton();
+    auto sceneNode = Manager::getSingleton()->addSceneNode("test");
+
+    selectionSet->append(sceneNode);
+
+    EXPECT_EQ(selectionSet->getNodesCount(), 1);
+    EXPECT_TRUE(selectionSet->contains(sceneNode));
+
+    auto sceneNode2 = Manager::getSingleton()->addSceneNode("test2");
+    selectionSet->append(sceneNode);
+    selectionSet->append(sceneNode2);
+
+    EXPECT_EQ(selectionSet->getNodesCount(), 2);
+    EXPECT_TRUE(selectionSet->contains(sceneNode));
+    EXPECT_TRUE(selectionSet->contains(sceneNode2));
+
+    Manager::getSingleton()->destroySceneNode(sceneNode);
+    Manager::getSingleton()->destroySceneNode(sceneNode2);
+}
+
+TEST(SelectionSetTests, RemoveSceneNode)
+{
+    SelectionSet* selectionSet = SelectionSet::getSingleton();
+    auto sceneNode = Manager::getSingleton()->addSceneNode("test");
+
+    selectionSet->append(sceneNode);
+    bool removed = selectionSet->removeOne(sceneNode);
+
+    EXPECT_TRUE(removed);
+    EXPECT_EQ(selectionSet->getNodesCount(), 0);
+    EXPECT_FALSE(selectionSet->contains(sceneNode));
+
+    Manager::getSingleton()->destroySceneNode(sceneNode);
+    SelectionSet::kill();
+}
+
+TEST(SelectionSetTests, SelectSceneNode)
+{
+    SelectionSet* selectionSet = SelectionSet::getSingleton();
+    auto sceneNode = Manager::getSingleton()->addSceneNode("test");
+
+    selectionSet->selectOne(sceneNode);
+
+    EXPECT_EQ(selectionSet->getNodesCount(), 1);
+    EXPECT_TRUE(selectionSet->contains(sceneNode));
+
+    Manager::getSingleton()->destroySceneNode(sceneNode);
+}
+
+TEST(SelectionSetTests, Clear)
+{
+    SelectionSet* selectionSet = SelectionSet::getSingleton();
+    auto sceneNode = Manager::getSingleton()->addSceneNode("test");
+
+    selectionSet->append(sceneNode);
+    selectionSet->clear();
+
+    EXPECT_EQ(selectionSet->getNodesCount(), 0);
+    EXPECT_FALSE(selectionSet->contains(sceneNode));
+
+    Manager::getSingleton()->destroySceneNode(sceneNode);
+}
+
+TEST(SelectionSetTests, ClearList)
+{
+    SelectionSet* selectionSet = SelectionSet::getSingleton();
+    auto sceneNode = Manager::getSingleton()->addSceneNode("test");
+
+    selectionSet->append(sceneNode);
+    selectionSet->clearList();
+
+    EXPECT_EQ(selectionSet->getNodesCount(), 0);
+    EXPECT_FALSE(selectionSet->contains(sceneNode));
+    Manager::getSingleton()->destroySceneNode(sceneNode);
+}

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -145,9 +145,6 @@ void MainWindow::initToolBar()
     connect(ui->actionTranslate_Object, &QAction::triggered, this, [this]{setTransformState(TransformOperator::TS_TRANSLATE);});
     connect(ui->actionRotate_Object, &QAction::triggered, this, [this]{setTransformState(TransformOperator::TS_ROTATE);});
     connect(ui->actionRemove_Object, SIGNAL(triggered()), TransformOperator::getSingleton(), SLOT(removeSelected()));
-    // TODO improve that : the first connection could not be done in the first call of createEditorViewport
-    // because m_pTransformOperator doesn't exist yet, but m_pTransformOperator need the ressources to be created...
-    //connect(mDockWidgetList.at(0)->getOgreWidget(), SIGNAL(focusOnWidget(OgreWidget*)), TransformOperator::getSingleton(), SLOT(setActiveWidget(OgreWidget*)));
 
     // Material tab
     m_pMaterialWidget = new MaterialWidget(this->ui->tabWidget);
@@ -158,25 +155,25 @@ void MainWindow::initToolBar()
     m_pPrimitivesWidget = new PrimitivesWidget(this->ui->tabWidget);
     ui->tabWidget->addTab(m_pPrimitivesWidget, tr("Edit"));
 
-    QToolButton* addPrimitiveButton=new QToolButton(ui->objectsToolbar);
+    auto addPrimitiveButton = new QToolButton(ui->objectsToolbar);
     addPrimitiveButton->setIcon(QIcon(":/icones/cube.png"));
     addPrimitiveButton->setToolTip(tr("Add Primitive"));
     addPrimitiveButton->setPopupMode(QToolButton::InstantPopup);
 
-    QMenu* addPrimitiveMenu=new QMenu(addPrimitiveButton);
+    auto addPrimitiveMenu = new QMenu(addPrimitiveButton);
 
-    QAction* pAddCube       = new QAction(QIcon(":/icones/cube.png"),tr("Cube"), addPrimitiveButton);
-    QAction* pAddSphere     = new QAction(QIcon(":/icones/sphere.png"),tr("Sphere"), addPrimitiveButton);
-    QAction* pAddPlane      = new QAction(QIcon(":/icones/square.png"),tr("Plane"), addPrimitiveButton);
-    QAction* pAddCylinder   = new QAction(QIcon(":/icones/cylinder.png"),tr("Cylinder"), addPrimitiveButton);
-    QAction* pAddCone       = new QAction(QIcon(":/icones/cone.png"),tr("Cone"), addPrimitiveButton);
-    QAction* pAddTorus      = new QAction(QIcon(":/icones/torus.png"),tr("Torus"), addPrimitiveButton);
+    auto pAddCube       = new QAction(QIcon(":/icones/cube.png"),tr("Cube"), addPrimitiveButton);
+    auto pAddSphere     = new QAction(QIcon(":/icones/sphere.png"),tr("Sphere"), addPrimitiveButton);
+    auto pAddPlane      = new QAction(QIcon(":/icones/square.png"),tr("Plane"), addPrimitiveButton);
+    auto pAddCylinder   = new QAction(QIcon(":/icones/cylinder.png"),tr("Cylinder"), addPrimitiveButton);
+    auto pAddCone       = new QAction(QIcon(":/icones/cone.png"),tr("Cone"), addPrimitiveButton);
+    auto pAddTorus      = new QAction(QIcon(":/icones/torus.png"),tr("Torus"), addPrimitiveButton);
     // TODO add correct icon for tube and polish the existing ones
-    QAction* pAddTube       = new QAction(QIcon(":/icones/torus.png"),tr("Tube"), addPrimitiveButton);
-    QAction* pAddCapsule    = new QAction(QIcon(":/icones/capsule.png"),tr("Capsule"), addPrimitiveButton);
-    QAction* pAddIcoSphere  = new QAction(QIcon(":/icones/sphere.png"),tr("IcoSphere"), addPrimitiveButton);
-    QAction* pAddRoundedBox = new QAction(QIcon(":/icones/roundedbox.png"),tr("Rounded Box"), addPrimitiveButton);
-    QAction* pAddSpring     = new QAction(QIcon(":/icones/spring.png"),tr("Spring"), addPrimitiveButton);
+    auto pAddTube       = new QAction(QIcon(":/icones/torus.png"),tr("Tube"), addPrimitiveButton);
+    auto pAddCapsule    = new QAction(QIcon(":/icones/capsule.png"),tr("Capsule"), addPrimitiveButton);
+    auto pAddIcoSphere  = new QAction(QIcon(":/icones/sphere.png"),tr("IcoSphere"), addPrimitiveButton);
+    auto pAddRoundedBox = new QAction(QIcon(":/icones/roundedbox.png"),tr("Rounded Box"), addPrimitiveButton);
+    auto pAddSpring     = new QAction(QIcon(":/icones/spring.png"),tr("Spring"), addPrimitiveButton);
 
     addPrimitiveMenu->addAction(pAddCube);
     addPrimitiveMenu->addAction(pAddSphere);
@@ -318,7 +315,7 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
 {
     QtInputManager::getInstance().keyPressEvent(event);
 
-    switch(event->key ()){
+    switch(event->key()){
     case Qt::Key_R:
         setTransformState(TransformOperator::TS_ROTATE);
        break;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -34,6 +34,7 @@ public:
     explicit MainWindow(QWidget *parent = nullptr);
     virtual ~MainWindow();
     void importMeshs(const QStringList &_uriList);
+    void keyPressEvent(QKeyEvent *event);
     
 private slots:
     void on_actionImport_triggered();
@@ -94,7 +95,6 @@ protected:
     bool frameRenderingQueued(const Ogre::FrameEvent &evt);
     bool frameEnded(const Ogre::FrameEvent& evt);
 
-    void keyPressEvent(QKeyEvent *event);
     void keyReleaseEvent(QKeyEvent *event);
     void dropEvent(QDropEvent *event);
     void dragEnterEvent(QDragEnterEvent *event);

--- a/src/mainwindow_test.cpp
+++ b/src/mainwindow_test.cpp
@@ -321,6 +321,33 @@ TEST_F(MainWindowTest, RemoveSelectedSceneNodeShortcut) {
     }
 }
 
+TEST_F(MainWindowTest, RemoveAndRecreateSceneNode) {
+    auto actionRemove_Object = mainWindow->findChild<QAction*>("actionRemove_Object");
+    ASSERT_TRUE(actionRemove_Object != nullptr);
+
+    auto sceneNodeName = "TestSceneNode";
+    auto sceneNode = Manager::getSingleton()->addSceneNode(sceneNodeName);
+    auto countBefore = Manager::getSingleton()->getSceneNodes().count();
+
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->selectOne(sceneNode);
+
+    actionRemove_Object->trigger();
+
+    auto countAfter = Manager::getSingleton()->getSceneNodes().count();
+
+    ASSERT_EQ(countBefore-1,countAfter);
+
+    for (auto node : Manager::getSingleton()->getSceneNodes()) {
+        ASSERT_NE(node->getName(), sceneNodeName);
+    }
+
+    sceneNode = Manager::getSingleton()->addSceneNode(sceneNodeName);
+    SelectionSet::getSingleton()->selectOne(sceneNode);
+    actionRemove_Object->trigger();
+    ASSERT_EQ(countBefore-1,countAfter);
+}
+
 TEST_F(MainWindowTest, ShowHideObjectsToolbar) {
     mainWindow->setVisible(true);
     auto actionObjectsToolbar = mainWindow->findChild<QAction*>("actionObjects_Toolbar");

--- a/src/mainwindow_test.cpp
+++ b/src/mainwindow_test.cpp
@@ -279,28 +279,6 @@ TEST_F(MainWindowTest, RemoveEmptySelectionShortcut) {
     ASSERT_EQ(countBefore,countAfter);
 }
 
-TEST_F(MainWindowTest, RemoveSelectedSceneNode) {
-    auto actionRemove_Object = mainWindow->findChild<QAction*>("actionRemove_Object");
-    ASSERT_TRUE(actionRemove_Object != nullptr);
-
-    auto sceneNodeName = "TestSceneNode";
-    auto sceneNode = Manager::getSingleton()->addSceneNode(sceneNodeName);
-    auto countBefore = Manager::getSingleton()->getSceneNodes().count();
-
-    SelectionSet::getSingleton()->clear();
-    SelectionSet::getSingleton()->selectOne(sceneNode);
-
-    actionRemove_Object->trigger();
-
-    auto countAfter = Manager::getSingleton()->getSceneNodes().count();
-
-    ASSERT_EQ(countBefore-1,countAfter);
-    
-    for (auto node : Manager::getSingleton()->getSceneNodes()) {
-        ASSERT_NE(node->getName(), sceneNodeName);
-    }
-}
-
 TEST_F(MainWindowTest, RemoveSelectedSceneNodeShortcut) {
     auto sceneNodeName = "TestSceneNode";
     auto sceneNode = Manager::getSingleton()->addSceneNode(sceneNodeName);


### PR DESCRIPTION
# Summary
<!-- Please include a high-level summary of your solution. Screenshots are helpful! -->
Fixed a crashing issue when recreating primitives, and improved test coverage on mainwindow, primitives widget and selection set

# Technical Details
<!-- Include bullets of the general areas of technical change in the PR. This can be helpful to list as they don't always track 1:1 with the number of commits/commit messages -->
* included tests for selecting tools visibility
* it is now deleting the mesh in the primitive destructor
* included tests for the bugfix
* included tests for Selection Set

### :sparkles: Features
* none

### :bug: Bugfixes
* fixed crashing when recreating primitives
