### PR TITLE
Fix macOS missing Codec_Assimp.dylib

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1203,6 +1203,28 @@ jobs:
             sudo install_name_tool -add_rpath @executable_path/../Frameworks ${{github.workspace}}/bin/QtMeshEditor.app/Contents/MacOS/QtMeshEditor
             sudo install_name_tool -add_rpath @loader_path/ ${{github.workspace}}/bin/QtMeshEditor.app/Contents/MacOS/QtMeshEditor
 
+            # Fix all dylibs in MacOS directory to use @rpath for their dependencies
+            echo "Fixing dylib install names and rpaths..."
+            for dylib in ${{github.workspace}}/bin/QtMeshEditor.app/Contents/MacOS/*.dylib; do
+                if [ -f "$dylib" ]; then
+                    dylib_name=$(basename "$dylib")
+                    echo "Processing $dylib_name"
+
+                    # Change the install name to use @rpath
+                    sudo install_name_tool -id "@rpath/$dylib_name" "$dylib" 2>/dev/null || true
+
+                    # Add rpath to find other dylibs in the same directory
+                    sudo install_name_tool -add_rpath @loader_path/ "$dylib" 2>/dev/null || true
+
+                    # Fix references to build machine paths
+                    otool -L "$dylib" 2>/dev/null | grep -E "runner|build|SDK" | awk '{print $1}' | while read -r dep; do
+                        dep_name=$(basename "$dep")
+                        echo "  Fixing dependency: $dep -> @rpath/$dep_name"
+                        sudo install_name_tool -change "$dep" "@rpath/$dep_name" "$dylib" 2>/dev/null || true
+                    done
+                fi
+            done
+
     - name: Code Sign Application (for Sequoia compatibility)
       run: |
             echo "=== Code Signing for macOS Sequoia Compatibility ==="

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -371,7 +371,7 @@ else()
     ENDIF()
     SET(OGRELIBLIST ${OGRELIBLIST}
         OgreMain
-        #Codec_Assimp
+        Codec_Assimp
         Codec_STBI
         RenderSystem_GL
         Plugin_OctreeSceneManager


### PR DESCRIPTION
## Summary
- Fix macOS app crashing with "Library not loaded: Codec_Assimp.14.4.dylib"
- The Codec_Assimp library was not being bundled with the app and had hardcoded build paths

## Changes
- Uncomment `Codec_Assimp` in `OGRELIBLIST` so it gets installed to the app bundle
- Add `install_name_tool` fixes to change hardcoded build machine paths to `@rpath`
- Fix all dylibs in MacOS directory to use relative paths for their dependencies

## Test plan
- [ ] Build macOS release via GitHub Actions
- [ ] Download and install the DMG on macOS
- [ ] Verify app launches without "Library not loaded" errors
- [ ] Test loading 3D models that use Assimp codec

🤖 Generated with [Claude Code](https://claude.com/claude-code)