### PR TITLE
Fix QML Material List Modal failing to load

### DIFF
--- a/qml/qmldir
+++ b/qml/qmldir
@@ -1,5 +1,4 @@
 module MaterialEditorQML
-singleton MaterialEditorQML 1.0 MaterialEditorQML.qml
 MaterialEditorWindow 1.0 MaterialEditorWindow.qml
 PassPropertiesPanel 1.0 PassPropertiesPanel.qml
 TexturePropertiesPanel 1.0 TexturePropertiesPanel.qml


### PR DESCRIPTION
## Summary
- Fix QML Material List Modal failing to load with error "QML Material List Modal failed to load. Please check the QML files and try again."

## Root Cause
The `qml/qmldir` file incorrectly referenced a non-existent `MaterialEditorQML.qml` file as a singleton:
```
singleton MaterialEditorQML 1.0 MaterialEditorQML.qml
```

The `MaterialEditorQML` singleton is actually registered from C++ via `qmlRegisterSingletonType` in `mainwindow.cpp`, not from a QML file. This incorrect qmldir entry caused the QML engine to fail when trying to load the module.

## Changes
- Removed the invalid `singleton MaterialEditorQML 1.0 MaterialEditorQML.qml` line from `qml/qmldir`

## Test plan
- [ ] Build macOS release via GitHub Actions
- [ ] Download and install the DMG on macOS
- [ ] Open the Material List from the menu
- [ ] Verify the QML modal loads correctly without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)