### PR TITLE
Add CI job to auto-update Homebrew cask on release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1343,3 +1343,77 @@ jobs:
           update_latest_release: true
           overwrite: false
           verbose: true
+
+####################################################################
+# Update Homebrew Cask after macOS release
+####################################################################
+
+ update-homebrew-cask:
+    needs: build-macos
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+    - name: Wait for DMG to be available
+      run: |
+        echo "Waiting for DMG to be uploaded to release..."
+        sleep 30
+
+    - name: Download DMG from release
+      run: |
+        VERSION="${{ github.ref_name }}"
+        DMG_URL="https://github.com/fernandotonon/QtMeshEditor/releases/download/${VERSION}/QtMeshEditor-${VERSION}-MacOS.dmg"
+        echo "Downloading DMG from: $DMG_URL"
+
+        # Retry download up to 5 times with increasing delays
+        for i in 1 2 3 4 5; do
+          if curl -L -f -o QtMeshEditor.dmg "$DMG_URL"; then
+            echo "Download successful"
+            break
+          else
+            echo "Download attempt $i failed, waiting..."
+            sleep $((i * 30))
+          fi
+        done
+
+        if [ ! -f QtMeshEditor.dmg ]; then
+          echo "Failed to download DMG after all retries"
+          exit 1
+        fi
+
+    - name: Calculate SHA256
+      id: sha256
+      run: |
+        SHA256=$(shasum -a 256 QtMeshEditor.dmg | awk '{print $1}')
+        echo "SHA256: $SHA256"
+        echo "sha256=$SHA256" >> $GITHUB_OUTPUT
+
+    - name: Clone Homebrew tap repository
+      run: |
+        git clone https://x-access-token:${{ secrets.HOMEBREW_TAP_TOKEN }}@github.com/fernandotonon/homebrew-qtmesheditor.git
+        cd homebrew-qtmesheditor
+        git config user.name "GitHub Actions Bot"
+        git config user.email "actions@github.com"
+
+    - name: Update Cask file
+      run: |
+        VERSION="${{ github.ref_name }}"
+        SHA256="${{ steps.sha256.outputs.sha256 }}"
+        CASK_FILE="homebrew-qtmesheditor/Casks/qtmesheditor.rb"
+
+        echo "Updating cask to version $VERSION with SHA256 $SHA256"
+
+        # Update version
+        sed -i "s/version \".*\"/version \"$VERSION\"/" "$CASK_FILE"
+
+        # Update sha256
+        sed -i "s/sha256 \".*\"/sha256 \"$SHA256\"/" "$CASK_FILE"
+
+        echo "Updated cask file:"
+        cat "$CASK_FILE"
+
+    - name: Commit and push changes
+      run: |
+        cd homebrew-qtmesheditor
+        git add Casks/qtmesheditor.rb
+        git commit -m "Update QtMeshEditor to ${{ github.ref_name }}" || echo "No changes to commit"
+        git push


### PR DESCRIPTION
## Summary
- Add `update-homebrew-cask` job to the deploy workflow
- Automatically updates the Homebrew cask after macOS DMG is uploaded to a release
- Downloads the DMG, calculates SHA256, and updates the cask file in homebrew-qtmesheditor repo

## How it works
1. Runs after `build-macos` job completes (only on release publish)
2. Downloads the DMG from the GitHub release
3. Calculates the SHA256 hash
4. Clones the homebrew-qtmesheditor repo
5. Updates version and sha256 in `Casks/qtmesheditor.rb`
6. Commits and pushes the changes

## Setup Required
Create a GitHub secret named `HOMEBREW_TAP_TOKEN`:
1. Go to Settings → Secrets and variables → Actions
2. Create a new secret with a GitHub PAT that has `repo` scope
3. The PAT needs write access to `fernandotonon/homebrew-qtmesheditor`

## Test plan
- [ ] Create a test release to verify the workflow runs correctly
- [ ] Verify the Homebrew cask is updated with correct version and SHA256

🤖 Generated with [Claude Code](https://claude.com/claude-code)