### PR TITLE
Fix Homebrew cask update sed patterns for single quotes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1402,11 +1402,11 @@ jobs:
 
         echo "Updating cask to version $VERSION with SHA256 $SHA256"
 
-        # Update version
-        sed -i "s/version \".*\"/version \"$VERSION\"/" "$CASK_FILE"
+        # Update version (Homebrew cask uses single quotes)
+        sed -i "s/version '.*'/version '$VERSION'/" "$CASK_FILE"
 
-        # Update sha256
-        sed -i "s/sha256 \".*\"/sha256 \"$SHA256\"/" "$CASK_FILE"
+        # Update sha256 (Homebrew cask uses single quotes)
+        sed -i "s/sha256 '.*'/sha256 '$SHA256'/" "$CASK_FILE"
 
         echo "Updated cask file:"
         cat "$CASK_FILE"


### PR DESCRIPTION
## Summary
- Fixed the Homebrew cask auto-update job that wasn't updating the cask file
- The issue was that sed commands were looking for double quotes (`"`) but the Homebrew cask uses single quotes (`'`)
- Changed `version ".*"` to `version '.*'` and `sha256 ".*"` to `sha256 '.*'`

## Test plan
- [ ] Merge PR and create a new release
- [ ] Verify that the [homebrew-qtmesheditor cask](https://github.com/fernandotonon/homebrew-qtmesheditor/blob/main/Casks/qtmesheditor.rb) is updated with the new version and SHA256

🤖 Generated with [Claude Code](https://claude.com/claude-code)