### PR TITLE
Fix missing Qt6QuickControls2 library on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 2.1.1 LANGUAGES CXX)
+project(QtMeshEditor VERSION 2.1.2 LANGUAGES CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")
@@ -109,6 +109,8 @@ SET (QTLIBLIST
     Qt${QT_VERSION_MAJOR}Network
     Qt${QT_VERSION_MAJOR}OpenGL
     Qt${QT_VERSION_MAJOR}QmlMeta
+    Qt${QT_VERSION_MAJOR}QuickControls2
+    Qt${QT_VERSION_MAJOR}QuickTemplates2
 )
 FOREACH(qtlib ${QTLIBLIST})
         include_directories(${${qtlib}_INCLUDE_DIRS})


### PR DESCRIPTION
## Summary
Fixes the error "missing libQt6QuickControls2.so.6" when running QtMeshEditor on Ubuntu after installing from the .deb package.

## Changes
- Added `Qt6QuickControls2` to QTLIBLIST (required for Qt Quick Controls 2 styling)
- Added `Qt6QuickTemplates2` to QTLIBLIST (dependency of QuickControls2)
- Bumped version to 2.1.2

## Root Cause
The application uses Qt Quick Controls 2 for the UI (set via `QQuickStyle::setStyle("Basic")`), but the required library wasn't being included in the Linux deployment.

## Test Plan
- [ ] Build .deb package on Linux CI
- [ ] Install .deb on Ubuntu
- [ ] Verify QtMeshEditor launches without missing library errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)