### PR TITLE
Fix SonarCloud coverage reporting for C/C++

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -905,15 +905,13 @@ jobs:
             echo "WARNING: Skipping build-wrapper output (not found). Analysis will proceed without compilation database."
           fi
           
-          # Only add coverage if file exists and is not empty
-          if [ -f coverage.lcov ] && [ -s coverage.lcov ]; then
-            echo "Using LCOV format for coverage"
-            SCANNER_CMD="$SCANNER_CMD -Dsonar.coverageReportPaths=coverage.lcov"
-          elif [ -f coverage.xml ] && [ -s coverage.xml ]; then
-            echo "Using XML format for coverage (LCOV not available)"
-            SCANNER_CMD="$SCANNER_CMD -Dsonar.coverageReportPaths=coverage.xml"
+          # Add gcov coverage reports path for C/C++ (native cfamily analyzer)
+          GCOV_COUNT=$(find build -name "*.gcov" -type f 2>/dev/null | wc -l)
+          if [ "$GCOV_COUNT" -gt 0 ]; then
+            echo "Found $GCOV_COUNT .gcov files in build directory"
+            SCANNER_CMD="$SCANNER_CMD -Dsonar.cfamily.gcov.reportsPath=build"
           else
-            echo "WARNING: No coverage file found! Skipping coverage reporting."
+            echo "WARNING: No .gcov files found in build directory! Skipping coverage reporting."
           fi
           
           # Execute scanner

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -25,7 +25,8 @@ sonar.exclusions=**/OgreXML/**,**/dependencies/**,**/*_autogen/**,**/CMakeFiles/
 sonar.coverage.exclusions=**/*_test.cpp,**/test_*.cpp,tests/**/*.cpp,tests/**/*.qml,**/*_autogen/**
 
 # Coverage settings for C++ projects
-# Note: Coverage path will be set dynamically in workflow to ensure file exists
+# Use gcov reports for C/C++ coverage (native cfamily analyzer integration)
+sonar.cfamily.gcov.reportsPath=build
 
 # Enable C++ file analysis with build-wrapper support
 # The build-wrapper provides compilation data for SonarCloud analysis


### PR DESCRIPTION
## Summary
- Switch from `sonar.coverageReportPaths` (Generic Coverage XML) to `sonar.cfamily.gcov.reportsPath=build` (native C/C++ gcov integration)
- The previous config tried to pass an LCOV file to `sonar.coverageReportPaths`, which only accepts Generic Coverage XML format, causing coverage to be silently ignored
- `.gcov` files are already generated in the `build/` directory by the CI workflow, so this uses them directly

## Test plan
- [ ] Verify the `unit-tests-linux` CI job passes
- [ ] Check SonarCloud dashboard shows coverage data: https://sonarcloud.io/project/overview?id=fernandotonon_QtMeshEditor

🤖 Generated with [Claude Code](https://claude.com/claude-code)