### PR TITLE
Fix headless test failures to increase SonarCloud coverage

### DIFF
--- a/src/AnimationWidget_test.cpp
+++ b/src/AnimationWidget_test.cpp
@@ -6,35 +6,11 @@
 #include <QTableWidget>
 #include <QPushButton>
 #include <OgreException.h>
-#include <OgreMaterialManager.h>
-#include <OgreResourceGroupManager.h>
 #include "Manager.h"
 #include "SelectionSet.h"
 #include "MeshImporterExporter.h"
 #include "AnimationWidget.h"
-
-// Helper function to create required OGRE materials for tests
-static void createOGREMaterials()
-{
-    Ogre::MaterialPtr baseWhiteMat = Ogre::MaterialManager::getSingleton().getByName(
-        "BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    if (!baseWhiteMat) {
-        baseWhiteMat = Ogre::MaterialManager::getSingleton().create(
-            "BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setSelfIllumination(1, 1, 1);
-        baseWhiteMat->getTechnique(0)->setLightingEnabled(false);
-    }
-    Ogre::MaterialPtr baseWhiteMat2 = Ogre::MaterialManager::getSingleton().getByName(
-        "BaseWhite", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    if (!baseWhiteMat2) {
-        baseWhiteMat2 = Ogre::MaterialManager::getSingleton().create(
-            "BaseWhite", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        baseWhiteMat2->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
-        baseWhiteMat2->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1);
-    }
-}
+#include "TestHelpers.h"
 
 // ---------------------------------------------------------------------------
 // Base test fixture: Manager + Ogre initialized, no mesh loaded
@@ -53,7 +29,7 @@ protected:
         } catch (const Ogre::Exception& e) {
             GTEST_SKIP() << "Skipping: Ogre initialization failed (" << e.getFullDescription() << ")";
         }
-        createOGREMaterials();
+        createStandardOgreMaterials();
         // Start with a clean selection
         SelectionSet::getSingleton()->clear();
     }

--- a/src/MCPServer_test.cpp
+++ b/src/MCPServer_test.cpp
@@ -10,34 +10,7 @@
 #include "PrimitiveObject.h"
 #include "SelectionSet.h"
 #include <OgreException.h>
-#include <OgreMaterialManager.h>
-#include <OgreResourceGroupManager.h>
-
-// Helper function to create required OGRE materials for tests
-static void createOGREMaterials()
-{
-    Ogre::MaterialPtr baseWhiteMat = Ogre::MaterialManager::getSingleton().getByName(
-        "BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    if (!baseWhiteMat)
-    {
-        baseWhiteMat = Ogre::MaterialManager::getSingleton().create(
-            "BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setSelfIllumination(1, 1, 1);
-        baseWhiteMat->getTechnique(0)->setLightingEnabled(false);
-    }
-
-    Ogre::MaterialPtr baseWhiteMat2 = Ogre::MaterialManager::getSingleton().getByName(
-        "BaseWhite", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    if (!baseWhiteMat2)
-    {
-        baseWhiteMat2 = Ogre::MaterialManager::getSingleton().create(
-            "BaseWhite", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        baseWhiteMat2->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
-        baseWhiteMat2->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1);
-    }
-}
+#include "TestHelpers.h"
 
 // Helper to extract the text from an MCP tool result
 static QString getResultText(const QJsonObject &result)
@@ -68,7 +41,7 @@ protected:
         } catch (const Ogre::Exception& e) {
             GTEST_SKIP() << "Skipping: Ogre initialization failed (" << e.getFullDescription() << ")";
         }
-        createOGREMaterials();
+        createStandardOgreMaterials();
 
         server = std::make_unique<MCPServer>();
         // No mainWindow set — tests that need it will test the error path

--- a/src/Manager_test.cpp
+++ b/src/Manager_test.cpp
@@ -6,39 +6,12 @@
 #include <QMap>
 #include "SelectionSet.h"
 #include <OgreException.h>
-#include <OgreMaterialManager.h>
-#include <OgreResourceGroupManager.h>
 #include <QApplication>
 #include <QCoreApplication>
 #include <QThread>
+#include "TestHelpers.h"
 
 using ::testing::Mock;
-
-// Helper function to create required OGRE materials for tests
-static void createOGREMaterials()
-{
-    Ogre::MaterialPtr baseWhiteMat = Ogre::MaterialManager::getSingleton().getByName(
-        "BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    if (!baseWhiteMat)
-    {
-        baseWhiteMat = Ogre::MaterialManager::getSingleton().create(
-            "BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setSelfIllumination(1, 1, 1);
-        baseWhiteMat->getTechnique(0)->setLightingEnabled(false);
-    }
-
-    Ogre::MaterialPtr baseWhiteMat2 = Ogre::MaterialManager::getSingleton().getByName(
-        "BaseWhite", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    if (!baseWhiteMat2)
-    {
-        baseWhiteMat2 = Ogre::MaterialManager::getSingleton().create(
-            "BaseWhite", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        baseWhiteMat2->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
-        baseWhiteMat2->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1);
-    }
-}
 
 // Test fixture for Manager tests with minimal setup (no Ogre initialization)
 class ManagerTest : public ::testing::Test {
@@ -71,7 +44,7 @@ protected:
         } catch (const Ogre::Exception& e) {
             GTEST_SKIP() << "Skipping: Ogre initialization failed (" << e.getFullDescription() << ")";
         }
-        createOGREMaterials();
+        createStandardOgreMaterials();
     }
 
     void TearDown() override {

--- a/src/MaterialEditorQML_test.cpp
+++ b/src/MaterialEditorQML_test.cpp
@@ -7,34 +7,7 @@
 #include "MaterialEditorQML.h"
 #include "Manager.h"
 #include <OgreException.h>
-#include <OgreMaterialManager.h>
-#include <OgreResourceGroupManager.h>
-
-// Helper function to create required OGRE materials for tests
-static void createOGREMaterials()
-{
-    Ogre::MaterialPtr baseWhiteMat = Ogre::MaterialManager::getSingleton().getByName(
-        "BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    if (!baseWhiteMat)
-    {
-        baseWhiteMat = Ogre::MaterialManager::getSingleton().create(
-            "BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setSelfIllumination(1, 1, 1);
-        baseWhiteMat->getTechnique(0)->setLightingEnabled(false);
-    }
-
-    Ogre::MaterialPtr baseWhiteMat2 = Ogre::MaterialManager::getSingleton().getByName(
-        "BaseWhite", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    if (!baseWhiteMat2)
-    {
-        baseWhiteMat2 = Ogre::MaterialManager::getSingleton().create(
-            "BaseWhite", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        baseWhiteMat2->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
-        baseWhiteMat2->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1);
-    }
-}
+#include "TestHelpers.h"
 
 // Ensure a QApplication exists for the process lifetime.
 // gtest_main does not create one, so we lazily create it here.
@@ -86,7 +59,7 @@ protected:
         } catch (const Ogre::Exception& e) {
             GTEST_SKIP() << "Skipping: Ogre initialization failed (" << e.getFullDescription() << ")";
         }
-        createOGREMaterials();
+        createStandardOgreMaterials();
 
         editor = std::make_unique<MaterialEditorQML>();
     }

--- a/src/MaterialHighlighter_test.cpp
+++ b/src/MaterialHighlighter_test.cpp
@@ -3,6 +3,7 @@
 #include <QTextDocument>
 #include <QTextEdit>
 #include <QApplication>
+#include <QPalette>
 #include <QRegularExpression>
 #include "MaterialHighlighter.h"
 
@@ -44,9 +45,13 @@ TEST(MaterialHighlighterTest, HighlightKeywordsDarkModeTest) {
 
     QString testText = "material MyMaterial { technique MyTechnique { pass MyPass { } } }";
 
+    // Determine expected color based on current palette (same logic as MaterialHighlighter)
+    QColor palette = QApplication::palette().color(QPalette::Text);
+    bool dark = qGray(palette.red(), palette.green(), palette.blue()) > 100;
+
     QTextCharFormat expectedFormat;
     expectedFormat.setFontWeight(QFont::Bold);
-    expectedFormat.setForeground(Qt::darkBlue);
+    expectedFormat.setForeground(dark ? QColor("mediumorchid") : Qt::darkBlue);
 
     std::vector<QTextCharFormat> capturedFormats;
 

--- a/src/MeshImporterExporter_test.cpp
+++ b/src/MeshImporterExporter_test.cpp
@@ -7,34 +7,7 @@
 #include "Manager.h"
 #include "MeshImporterExporter.h"
 #include <OgreException.h>
-#include <OgreMaterialManager.h>
-#include <OgreResourceGroupManager.h>
-
-// Helper function to create required OGRE materials for tests
-static void createOGREMaterials()
-{
-    Ogre::MaterialPtr baseWhiteMat = Ogre::MaterialManager::getSingleton().getByName(
-        "BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    if (!baseWhiteMat)
-    {
-        baseWhiteMat = Ogre::MaterialManager::getSingleton().create(
-            "BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setSelfIllumination(1, 1, 1);
-        baseWhiteMat->getTechnique(0)->setLightingEnabled(false);
-    }
-
-    Ogre::MaterialPtr baseWhiteMat2 = Ogre::MaterialManager::getSingleton().getByName(
-        "BaseWhite", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    if (!baseWhiteMat2)
-    {
-        baseWhiteMat2 = Ogre::MaterialManager::getSingleton().create(
-            "BaseWhite", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        baseWhiteMat2->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
-        baseWhiteMat2->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1);
-    }
-}
+#include "TestHelpers.h"
 
 class MeshImporterExporterTest : public ::testing::Test {
 protected:
@@ -52,7 +25,7 @@ protected:
         } catch (const Ogre::Exception& e) {
             GTEST_SKIP() << "Skipping: Ogre initialization failed (" << e.getFullDescription() << ")";
         }
-        createOGREMaterials();
+        createStandardOgreMaterials();
     }
 
     void TearDown() override {

--- a/src/MeshTransform_test.cpp
+++ b/src/MeshTransform_test.cpp
@@ -3,36 +3,10 @@
 #include <QCoreApplication>
 #include <QThread>
 #include <OgreException.h>
-#include <OgreMaterialManager.h>
-#include <OgreResourceGroupManager.h>
 #include "Manager.h"
 #include "MeshTransform.h"
 #include "PrimitiveObject.h"
-
-static void createOGREMaterials()
-{
-    Ogre::MaterialPtr baseWhiteMat = Ogre::MaterialManager::getSingleton().getByName(
-        "BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    if (!baseWhiteMat)
-    {
-        baseWhiteMat = Ogre::MaterialManager::getSingleton().create(
-            "BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setSelfIllumination(1, 1, 1);
-        baseWhiteMat->getTechnique(0)->setLightingEnabled(false);
-    }
-
-    Ogre::MaterialPtr baseWhiteMat2 = Ogre::MaterialManager::getSingleton().getByName(
-        "BaseWhite", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    if (!baseWhiteMat2)
-    {
-        baseWhiteMat2 = Ogre::MaterialManager::getSingleton().create(
-            "BaseWhite", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        baseWhiteMat2->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
-        baseWhiteMat2->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1);
-    }
-}
+#include "TestHelpers.h"
 
 // Helper to read vertex positions from a mesh for verification
 static std::vector<Ogre::Vector3> getVertexPositions(Ogre::Mesh* mesh)
@@ -87,7 +61,7 @@ protected:
         } catch (const Ogre::Exception& e) {
             GTEST_SKIP() << "Skipping: Ogre initialization failed (" << e.getFullDescription() << ")";
         }
-        createOGREMaterials();
+        createStandardOgreMaterials();
     }
     void TearDown() override {
         Manager::kill();

--- a/src/ObjectItemModel_test.cpp
+++ b/src/ObjectItemModel_test.cpp
@@ -7,30 +7,7 @@
 #include "SelectionSet.h"
 #include "PrimitiveObject.h"
 #include <OgreException.h>
-#include <OgreMaterialManager.h>
-#include <OgreResourceGroupManager.h>
-
-// Helper function to create required OGRE materials for tests
-static void createOGREMaterials()
-{
-    Ogre::MaterialPtr baseWhiteMat = Ogre::MaterialManager::getSingleton().getByName("BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    if (!baseWhiteMat)
-    {
-        baseWhiteMat = Ogre::MaterialManager::getSingleton().create("BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setSelfIllumination(1, 1, 1);
-        baseWhiteMat->getTechnique(0)->setLightingEnabled(false);
-    }
-
-    Ogre::MaterialPtr baseWhiteMat2 = Ogre::MaterialManager::getSingleton().getByName("BaseWhite", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    if (!baseWhiteMat2)
-    {
-        baseWhiteMat2 = Ogre::MaterialManager::getSingleton().create("BaseWhite", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        baseWhiteMat2->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
-        baseWhiteMat2->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1);
-    }
-}
+#include "TestHelpers.h"
 
 class ObjectItemModelTest : public ::testing::Test
 {
@@ -48,7 +25,7 @@ protected:
         } catch (const Ogre::Exception& e) {
             GTEST_SKIP() << "Skipping: Ogre initialization failed (" << e.getFullDescription() << ")";
         }
-        createOGREMaterials();
+        createStandardOgreMaterials();
     }
 
     void TearDown() override

--- a/src/PrimitiveObject_test.cpp
+++ b/src/PrimitiveObject_test.cpp
@@ -5,8 +5,7 @@
 #include <QCoreApplication>
 #include <QThread>
 #include <OgreException.h>
-#include <OgreMaterialManager.h>
-#include <OgreResourceGroupManager.h>
+#include "TestHelpers.h"
 
 // ---------- Existing standalone tests (no Manager needed) ----------
 
@@ -240,28 +239,6 @@ TEST(PrimitivesTest, PrimitiveTypeConstructor)
 
 // ---------- Fixture tests (need Manager / Ogre) ----------
 
-// Helper function to create required OGRE materials for tests
-static void createOGREMaterials()
-{
-    Ogre::MaterialPtr baseWhiteMat = Ogre::MaterialManager::getSingleton().getByName("BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    if (!baseWhiteMat)
-    {
-        baseWhiteMat = Ogre::MaterialManager::getSingleton().create("BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setSelfIllumination(1, 1, 1);
-        baseWhiteMat->getTechnique(0)->setLightingEnabled(false);
-    }
-
-    Ogre::MaterialPtr baseWhiteMat2 = Ogre::MaterialManager::getSingleton().getByName("BaseWhite", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    if (!baseWhiteMat2)
-    {
-        baseWhiteMat2 = Ogre::MaterialManager::getSingleton().create("BaseWhite", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        baseWhiteMat2->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
-        baseWhiteMat2->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1);
-    }
-}
-
 class PrimitiveObjectOgreTest : public ::testing::Test {
 protected:
     void SetUp() override {
@@ -274,7 +251,7 @@ protected:
         } catch (const Ogre::Exception& e) {
             GTEST_SKIP() << "Skipping: Ogre initialization failed (" << e.getFullDescription() << ")";
         }
-        createOGREMaterials();
+        createStandardOgreMaterials();
     }
     void TearDown() override {
         Manager::kill();

--- a/src/PrimitivesWidget_test.cpp
+++ b/src/PrimitivesWidget_test.cpp
@@ -8,30 +8,7 @@
 #include "PrimitivesWidget.h"
 #include "Manager.h"
 #include <OgreException.h>
-#include <OgreMaterialManager.h>
-#include <OgreResourceGroupManager.h>
-
-// Helper function to create required OGRE materials for tests
-static void createOGREMaterials()
-{
-    Ogre::MaterialPtr baseWhiteMat = Ogre::MaterialManager::getSingleton().getByName("BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    if (!baseWhiteMat)
-    {
-        baseWhiteMat = Ogre::MaterialManager::getSingleton().create("BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setSelfIllumination(1, 1, 1);
-        baseWhiteMat->getTechnique(0)->setLightingEnabled(false);
-    }
-
-    Ogre::MaterialPtr baseWhiteMat2 = Ogre::MaterialManager::getSingleton().getByName("BaseWhite", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    if (!baseWhiteMat2)
-    {
-        baseWhiteMat2 = Ogre::MaterialManager::getSingleton().create("BaseWhite", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        baseWhiteMat2->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
-        baseWhiteMat2->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1);
-    }
-}
+#include "TestHelpers.h"
 
 class PrimitivesWidgetTest : public ::testing::Test
 {
@@ -49,7 +26,7 @@ protected:
         } catch (const Ogre::Exception& e) {
             GTEST_SKIP() << "Skipping: Ogre initialization failed (" << e.getFullDescription() << ")";
         }
-        createOGREMaterials();
+        createStandardOgreMaterials();
     }
 
     void TearDown() override

--- a/src/RotationGizmo_test.cpp
+++ b/src/RotationGizmo_test.cpp
@@ -4,15 +4,15 @@
 #include "RotationGizmo.h"
 #include "Manager.h"
 #include <OgreException.h>
-#include <OgreMaterialManager.h>
-#include <OgreResourceGroupManager.h>
 #include <QApplication>
 #include <QCoreApplication>
 #include <QThread>
+#include "TestHelpers.h"
 
 // Helper function to create required OGRE materials for tests
 static void createOGREMaterials()
 {
+    ensureMaterialManagerInitialised();
     Ogre::MaterialPtr guiMat = Ogre::MaterialManager::getSingleton().getByName(GUI_MATERIAL_NAME, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
     if (!guiMat)
     {

--- a/src/SelectionSet_test.cpp
+++ b/src/SelectionSet_test.cpp
@@ -4,34 +4,7 @@
 #include "SelectionSet.h"
 #include "PrimitiveObject.h"
 #include <OgreException.h>
-#include <OgreMaterialManager.h>
-#include <OgreResourceGroupManager.h>
-
-// Helper function to create required OGRE materials for entity tests
-static void createOGREMaterials()
-{
-    Ogre::MaterialPtr baseWhiteMat = Ogre::MaterialManager::getSingleton().getByName(
-        "BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    if (!baseWhiteMat)
-    {
-        baseWhiteMat = Ogre::MaterialManager::getSingleton().create(
-            "BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setSelfIllumination(1, 1, 1);
-        baseWhiteMat->getTechnique(0)->setLightingEnabled(false);
-    }
-
-    Ogre::MaterialPtr baseWhiteMat2 = Ogre::MaterialManager::getSingleton().getByName(
-        "BaseWhite", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    if (!baseWhiteMat2)
-    {
-        baseWhiteMat2 = Ogre::MaterialManager::getSingleton().create(
-            "BaseWhite", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        baseWhiteMat2->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
-        baseWhiteMat2->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1);
-    }
-}
+#include "TestHelpers.h"
 
 TEST(SelectionSetTests, AppendSceneNode)
 {
@@ -221,7 +194,7 @@ TEST(SelectionSetTests, GetCount)
     EXPECT_EQ(selectionSet->getSubEntitiesCount(), 0);
 
     // Add an entity to verify count sums across types
-    createOGREMaterials();
+    createStandardOgreMaterials();
     auto cubeNode = PrimitiveObject::createCube("testGetCountCube");
     ASSERT_FALSE(Manager::getSingleton()->getEntities().isEmpty());
     Ogre::Entity* entity = Manager::getSingleton()->getEntities().last();
@@ -268,7 +241,7 @@ TEST(SelectionSetTests, EntitySelection)
     }
     SelectionSet* selectionSet = SelectionSet::getSingleton();
     selectionSet->clear();
-    createOGREMaterials();
+    createStandardOgreMaterials();
 
     // Create a cube primitive to get an entity
     auto cubeNode = PrimitiveObject::createCube("testEntitySelCube");
@@ -316,7 +289,7 @@ TEST(SelectionSetTests, EntityScaleRotationFactors)
     }
     SelectionSet* selectionSet = SelectionSet::getSingleton();
     selectionSet->clear();
-    createOGREMaterials();
+    createStandardOgreMaterials();
 
     auto cubeNode = PrimitiveObject::createCube("testScaleRotCube");
     ASSERT_FALSE(Manager::getSingleton()->getEntities().isEmpty());

--- a/src/SkeletonDebug_test.cpp
+++ b/src/SkeletonDebug_test.cpp
@@ -6,34 +6,7 @@
 #include "SkeletonDebug.h"
 #include "MeshImporterExporter.h"
 #include <OgreException.h>
-#include <OgreMaterialManager.h>
-#include <OgreResourceGroupManager.h>
-
-// Helper function to create required OGRE materials for tests
-static void createOGREMaterials()
-{
-    Ogre::MaterialPtr baseWhiteMat = Ogre::MaterialManager::getSingleton().getByName(
-        "BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    if (!baseWhiteMat)
-    {
-        baseWhiteMat = Ogre::MaterialManager::getSingleton().create(
-            "BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setSelfIllumination(1, 1, 1);
-        baseWhiteMat->getTechnique(0)->setLightingEnabled(false);
-    }
-
-    Ogre::MaterialPtr baseWhiteMat2 = Ogre::MaterialManager::getSingleton().getByName(
-        "BaseWhite", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    if (!baseWhiteMat2)
-    {
-        baseWhiteMat2 = Ogre::MaterialManager::getSingleton().create(
-            "BaseWhite", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        baseWhiteMat2->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
-        baseWhiteMat2->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1);
-    }
-}
+#include "TestHelpers.h"
 
 class SkeletonDebugTests : public ::testing::Test {
 protected:
@@ -52,7 +25,7 @@ protected:
         } catch (const Ogre::Exception& e) {
             GTEST_SKIP() << "Skipping: Ogre initialization failed (" << e.getFullDescription() << ")";
         }
-        createOGREMaterials();
+        createStandardOgreMaterials();
 
         // Import a mesh with skeleton
         QStringList validUri{"./media/models/robot.mesh"};

--- a/src/SkeletonTransform_test.cpp
+++ b/src/SkeletonTransform_test.cpp
@@ -3,37 +3,10 @@
 #include <QCoreApplication>
 #include <QThread>
 #include <OgreException.h>
-#include <OgreMaterialManager.h>
-#include <OgreResourceGroupManager.h>
 #include "Manager.h"
 #include "SkeletonTransform.h"
 #include "MeshImporterExporter.h"
-
-// Helper function to create required OGRE materials for tests
-static void createOGREMaterials()
-{
-    Ogre::MaterialPtr baseWhiteMat = Ogre::MaterialManager::getSingleton().getByName(
-        "BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    if (!baseWhiteMat)
-    {
-        baseWhiteMat = Ogre::MaterialManager::getSingleton().create(
-            "BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1);
-        baseWhiteMat->getTechnique(0)->getPass(0)->setSelfIllumination(1, 1, 1);
-        baseWhiteMat->getTechnique(0)->setLightingEnabled(false);
-    }
-
-    Ogre::MaterialPtr baseWhiteMat2 = Ogre::MaterialManager::getSingleton().getByName(
-        "BaseWhite", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    if (!baseWhiteMat2)
-    {
-        baseWhiteMat2 = Ogre::MaterialManager::getSingleton().create(
-            "BaseWhite", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        baseWhiteMat2->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
-        baseWhiteMat2->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1);
-    }
-}
+#include "TestHelpers.h"
 
 class SkeletonTransformTest : public ::testing::Test {
 protected:
@@ -52,7 +25,7 @@ protected:
         } catch (const Ogre::Exception& e) {
             GTEST_SKIP() << "Skipping: Ogre initialization failed (" << e.getFullDescription() << ")";
         }
-        createOGREMaterials();
+        createStandardOgreMaterials();
 
         // Import robot.mesh which has a skeleton with animations
         QStringList validUri{"./media/models/robot.mesh"};
@@ -548,7 +521,7 @@ protected:
         } catch (const Ogre::Exception& e) {
             GTEST_SKIP() << "Skipping: Ogre initialization failed (" << e.getFullDescription() << ")";
         }
-        createOGREMaterials();
+        createStandardOgreMaterials();
     }
 
     void TearDown() override {

--- a/src/TestHelpers.h
+++ b/src/TestHelpers.h
@@ -1,0 +1,63 @@
+#ifndef TEST_HELPERS_H
+#define TEST_HELPERS_H
+
+#include <OgreMaterialManager.h>
+#include <OgreResourceGroupManager.h>
+
+/**
+ * Ensures that Ogre's MaterialManager has been initialised.
+ *
+ * In normal application startup this happens inside
+ * Ogre::Root::oneTimePostWindowInit() -- which is only called after the
+ * first RenderWindow is created.  Headless unit tests never create a
+ * window, so the default material settings (and the built-in BaseWhite /
+ * BaseWhiteNoLighting materials) are missing.  Without them every
+ * Material::create() produces a material with an empty technique list and
+ * any call to getTechnique(0) throws std::out_of_range.
+ *
+ * Call this helper once before creating or querying Ogre materials in
+ * test fixtures.
+ */
+static inline void ensureMaterialManagerInitialised()
+{
+    if (!Ogre::MaterialManager::getSingleton().getDefaultSettings())
+    {
+        Ogre::MaterialManager::getSingleton().initialise();
+    }
+}
+
+/**
+ * Creates the BaseWhiteNoLighting and BaseWhite materials that many parts
+ * of QtMeshEditor expect to exist.
+ *
+ * Automatically calls ensureMaterialManagerInitialised() first so that
+ * newly created materials receive the default technique/pass.
+ */
+static inline void createStandardOgreMaterials()
+{
+    ensureMaterialManagerInitialised();
+
+    Ogre::MaterialPtr baseWhiteMat = Ogre::MaterialManager::getSingleton().getByName(
+        "BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+    if (!baseWhiteMat)
+    {
+        baseWhiteMat = Ogre::MaterialManager::getSingleton().create(
+            "BaseWhiteNoLighting", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+        baseWhiteMat->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
+        baseWhiteMat->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1);
+        baseWhiteMat->getTechnique(0)->getPass(0)->setSelfIllumination(1, 1, 1);
+        baseWhiteMat->getTechnique(0)->setLightingEnabled(false);
+    }
+
+    Ogre::MaterialPtr baseWhiteMat2 = Ogre::MaterialManager::getSingleton().getByName(
+        "BaseWhite", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+    if (!baseWhiteMat2)
+    {
+        baseWhiteMat2 = Ogre::MaterialManager::getSingleton().create(
+            "BaseWhite", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+        baseWhiteMat2->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
+        baseWhiteMat2->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1);
+    }
+}
+
+#endif // TEST_HELPERS_H

--- a/src/TransformOperator_test.cpp
+++ b/src/TransformOperator_test.cpp
@@ -7,12 +7,12 @@
 #include "TransformOperator.h"
 #include "Manager.h"
 #include "GlobalDefinitions.h"
-#include <OgreMaterialManager.h>
-#include <OgreResourceGroupManager.h>
+#include "TestHelpers.h"
 
 // Helper function to create required OGRE materials for tests
 static void createOGREMaterials()
 {
+    ensureMaterialManagerInitialised();
     Ogre::MaterialPtr guiMat = Ogre::MaterialManager::getSingleton().getByName(GUI_MATERIAL_NAME, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
     if (!guiMat)
     {

--- a/src/TranslationGizmo_test.cpp
+++ b/src/TranslationGizmo_test.cpp
@@ -4,15 +4,15 @@
 #include "TranslationGizmo.h"
 #include "Manager.h"
 #include <OgreException.h>
-#include <OgreMaterialManager.h>
-#include <OgreResourceGroupManager.h>
 #include <QApplication>
 #include <QCoreApplication>
 #include <QThread>
+#include "TestHelpers.h"
 
 // Helper function to create required OGRE materials for tests
 static void createOGREMaterials()
 {
+    ensureMaterialManagerInitialised();
     Ogre::MaterialPtr guiMat = Ogre::MaterialManager::getSingleton().getByName(GUI_MATERIAL_NAME, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
     if (!guiMat)
     {


### PR DESCRIPTION
## Summary
- Fix 200+ test failures in CI caused by `MaterialManager::initialise()` never being called in headless Ogre mode (no render window). Materials created without initialization have empty technique vectors, causing `getTechnique(0)` to throw `std::out_of_range`.
- Add shared `TestHelpers.h` with `ensureMaterialManagerInitialised()` and `createStandardOgreMaterials()`, replacing duplicated `createOGREMaterials()` across 15 test files.
- Fix `MaterialHighlighterTest.HighlightKeywordsDarkModeTest` to be theme-aware instead of hardcoded to light-mode color.

## Root Cause
When `Manager::getSingleton()` runs headless, `Root::initialise(false)` is called but `Root::oneTimePostWindowInit()` (which calls `MaterialManager::initialise()`) is skipped because no RenderWindow is created. This means `MaterialManager::getDefaultSettings()` returns null, newly created materials get no default technique/pass, and `mat->getTechnique(0)` throws `std::out_of_range` (not `Ogre::Exception`, so the existing `catch` + `GTEST_SKIP()` didn't catch it).

## Expected Coverage Impact
These 200+ tests were previously failing in CI, meaning their source code coverage was not counted. With this fix, coverage should increase significantly from the current 3.9%.

## Test plan
- [ ] CI `unit-tests-linux` job passes with 0 failures (previously 26+ failures)
- [ ] SonarCloud coverage increases substantially from 3.9%
- [ ] No tests are skipped due to MaterialManager issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)