### PR TITLE
Fix SonarCloud 0% coverage: remove cfamily gcov override

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -744,16 +744,6 @@ jobs:
             exit 1
         fi
 
-        echo "=== Generating gcov files for CFamily sensor ==="
-        cd build
-        find . -path "./_deps" -prune -o -name "*.gcda" -print | while read gcda; do
-            dir=$(dirname "$gcda")
-            (cd "$dir" && gcov -p *.gcda 2>/dev/null || true)
-        done
-        cd ..
-        GCOV_COUNT=$(find build -name "*.gcov" -type f 2>/dev/null | wc -l)
-        echo "Generated $GCOV_COUNT .gcov files"
-
         echo "=== Generating SonarQube coverage XML via gcovr ==="
         gcovr --root . \
               --filter 'src/' \
@@ -772,11 +762,12 @@ jobs:
 
         echo "=== Validating coverage files ==="
         if [ -f coverage.xml ] && [ -s coverage.xml ]; then
-            echo "coverage.xml exists and has content ($(wc -l < coverage.xml) lines)"
+            echo "coverage.xml exists and has content ($(wc -c < coverage.xml) bytes)"
             echo "Files with coverage data:"
             grep -c '<file' coverage.xml || echo "0 files"
         else
-            echo "WARNING: coverage.xml is missing or empty - relying on cfamily gcov sensor"
+            echo "ERROR: coverage.xml is missing or empty!"
+            exit 1
         fi
 
     - name: Run sonar-scanner
@@ -806,9 +797,6 @@ jobs:
           echo "=== Coverage files ==="
           ls -la coverage.xml 2>/dev/null || echo "coverage.xml not found"
 
-          GCOV_COUNT=$(find build -name "*.gcov" -type f 2>/dev/null | wc -l)
-          echo "Found $GCOV_COUNT .gcov files in build directory"
-
           echo "=== Running SonarCloud analysis ==="
           sonar-scanner \
             -Dsonar.projectKey=fernandotonon_QtMeshEditor \
@@ -825,7 +813,6 @@ jobs:
             -Dsonar.cpp.file.suffixes=.cpp,.cc,.cxx,.c++,.hpp,.hh,.hxx,.h++,.h \
             -Dsonar.objc.file.suffixes=.m,.mm \
             -Dsonar.cfamily.build-wrapper-output=$BW_DIR \
-            -Dsonar.cfamily.gcov.reportsPath=build \
             -Dsonar.cfamily.cache.enabled=true \
             -Dsonar.cfamily.threads=4 \
             -Dsonar.verbose=true

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -26,9 +26,8 @@ sonar.coverage.exclusions=**/*_test.cpp,**/test_*.cpp,tests/**/*.cpp,tests/**/*.
 
 # Coverage settings for C++ projects
 # Generic coverage report (SonarQube XML format from gcovr)
+# Note: Do NOT use sonar.cfamily.gcov.reportsPath - it overrides generic coverage with incorrect data
 sonar.coverageReportPaths=coverage.xml
-# Native gcov reports for CFamily analyzer (required - CFamily overrides generic coverage)
-sonar.cfamily.gcov.reportsPath=build
 
 # Enable C++ file analysis with build-wrapper support
 # The build-wrapper provides compilation data for SonarCloud analysis


### PR DESCRIPTION
## Summary
- Remove `sonar.cfamily.gcov.reportsPath=build` which was causing the CFamily gcov sensor to **override** the working generic coverage data
- Remove the `.gcov` file generation step (no longer needed)
- Fail the build if `coverage.xml` is missing or empty (instead of silently continuing)

## Root Cause
CI logs showed:
1. **Generic Coverage Report** sensor: "Imported coverage data for 63 files" - **working correctly**
2. **CFamily gcov sensor** runs **after** and overwrites coverage for all C++ files with incorrect data → **0% coverage**

The [official SonarSource gcovr example](https://github.com/sonarsource-cfamily-examples/linux-cmake-gcovr-gh-actions-sc) uses only `sonar.coverageReportPaths` (generic coverage from gcovr) and does NOT use `sonar.cfamily.gcov.reportsPath`.

## Test plan
- [ ] CI passes (tests + SonarCloud analysis)
- [ ] SonarCloud shows non-zero coverage after merging to master
- [ ] Generic Coverage Report still shows "Imported coverage data for N files"
- [ ] CFamily gcov sensor no longer runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)