### PR TITLE
Fix 0% coverage: tests not running (Debug build path mismatch)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -641,26 +641,31 @@ jobs:
 
     - name: Add missing libraries
       run: |
-            # Create the bin directory since cmake builds to build/bin but we need ./bin for the tests
+            # Debug build puts executables in build/debug/, Release in build/bin/
             mkdir -p ./bin
             mkdir -p ./build/bin
-            
-            # Copy Qt ICU libraries to both locations
+            mkdir -p ./build/debug
+
+            # Copy Qt ICU libraries
             sudo cp -R /home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/gcc_64/lib/libicui18n.* ./bin
             sudo cp -R /home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/gcc_64/lib/libicuuc.* ./bin
             sudo cp -R /home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/gcc_64/lib/libicudata.* ./bin
-            
-            # Also copy to build/bin where cmake actually puts the executables
+
+            sudo cp -R /home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/gcc_64/lib/libicui18n.* ./build/debug/ || true
+            sudo cp -R /home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/gcc_64/lib/libicuuc.* ./build/debug/ || true
+            sudo cp -R /home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/gcc_64/lib/libicudata.* ./build/debug/ || true
+
             sudo cp -R /home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/gcc_64/lib/libicui18n.* ./build/bin/ || true
             sudo cp -R /home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/gcc_64/lib/libicuuc.* ./build/bin/ || true
             sudo cp -R /home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/gcc_64/lib/libicudata.* ./build/bin/ || true
-            
+
             # Copy libraries to system locations
             sudo cp -R ./bin/*.so* /lib/x86_64-linux-gnu || true
             sudo cp -R /usr/local/lib/OGRE/* /lib/x86_64-linux-gnu || true
             sudo cp -R /usr/local/lib/OGRE/* ./bin || true
             sudo cp -R /usr/local/lib/OGRE/* ./build/bin/ || true
-    
+            sudo cp -R /usr/local/lib/OGRE/* ./build/debug/ || true
+
     - name: Setup headless environment for Qt tests
       run: |
             sudo apt-get update
@@ -686,21 +691,25 @@ jobs:
             run_test() {
                 local test_name=$1
                 local output_file=$2
-                
-                if [ -f "./build/bin/$test_name" ]; then
+
+                if [ -f "./build/debug/$test_name" ]; then
+                    echo "Found $test_name in ./build/debug/"
+                    sudo -E ./build/debug/$test_name --gtest_output=xml:$output_file
+                elif [ -f "./build/bin/$test_name" ]; then
                     echo "Found $test_name in ./build/bin/"
                     sudo -E ./build/bin/$test_name --gtest_output=xml:$output_file
                 elif [ -f "./bin/$test_name" ]; then
                     echo "Found $test_name in ./bin/"
                     sudo -E ./bin/$test_name --gtest_output=xml:$output_file
                 else
-                    echo "$test_name not found in ./build/bin/ or ./bin/"
+                    echo "ERROR: $test_name not found in ./build/debug/, ./build/bin/, or ./bin/"
+                    find build -name "$test_name" -type f 2>/dev/null || true
                     return 1
                 fi
             }
             
             echo "Running UnitTests (Google Tests - includes Assimp and other unit tests)..."
-            run_test "UnitTests" "test-results-unittests.xml" || echo "UnitTests not found"
+            run_test "UnitTests" "test-results-unittests.xml"
             
             echo "Running MaterialEditorQML Unit Tests..."
             run_test "MaterialEditorQML_test" "test-results-materialeditor.xml" || echo "MaterialEditorQML_test not found"


### PR DESCRIPTION
## Summary
- Fix test executable search path to include `build/debug/` (where Debug builds put executables)
- Copy shared libraries to `build/debug/` alongside the test binaries
- Fail the build if `UnitTests` executable is not found (instead of silently continuing)

## Root Cause
`CMAKE_BUILD_TYPE=Debug` was set (for gcov coverage), which makes CMake put executables in `build/debug/` instead of `build/bin/`. But the test runner only searched `./build/bin/` and `./bin/`.

**The tests were never actually running.** CI logs confirmed:
```
Running UnitTests (Google Tests - includes Assimp and other unit tests)...
UnitTests not found in ./build/bin/ or ./bin/
UnitTests not found
```

The 520 .gcda files existed from compilation, but with 0 execution counts since no tests ran.

## Test plan
- [ ] CI finds and runs UnitTests from `build/debug/`
- [ ] gcovr generates `coverage.xml` with non-zero covered lines
- [ ] SonarCloud shows actual coverage percentage after merge to master

🤖 Generated with [Claude Code](https://claude.com/claude-code)