### PR TITLE
Fix crash-on-exit in SkeletonDebug and BoneWeightOverlay

### DIFF
--- a/src/BoneWeightOverlay.cpp
+++ b/src/BoneWeightOverlay.cpp
@@ -21,6 +21,7 @@ BoneWeightOverlay::BoneWeightOverlay(Ogre::Entity* entity, Ogre::SceneManager* s
 BoneWeightOverlay::~BoneWeightOverlay()
 {
     mUpdateTimer.stop();
+    mUpdateTimer.disconnect();
     destroyOverlay();
 
     if (mSoftwareAnimRequested && mEntity)

--- a/src/SkeletonDebug.cpp
+++ b/src/SkeletonDebug.cpp
@@ -3,8 +3,6 @@
 #include <array>
 #include <cassert>
 
-#include "Manager.h"
-
 SkeletonDebug::SkeletonDebug(Ogre::Entity* entity, Ogre::SceneManager *man, float boneSize, float scaleAxes)
     : mBoneSize(boneSize)
     , mEntity(entity)
@@ -59,20 +57,19 @@ SkeletonDebug::SkeletonDebug(Ogre::Entity* entity, Ogre::SceneManager *man, floa
 SkeletonDebug::~SkeletonDebug()
 {
     mTimer.stop();
-
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    mTimer.disconnect();
 
     for(auto* ent : mBoneEntities)
     {
         mEntity->detachObjectFromBone(ent);
-        sceneMgr->destroyEntity(ent);
+        mSceneMan->destroyEntity(ent);
     }
     mBoneEntities.clear();
 
     for(auto* ent : mAxisEntities)
     {
         mEntity->detachObjectFromBone(ent);
-        sceneMgr->destroyEntity(ent);
+        mSceneMan->destroyEntity(ent);
     }
     mAxisEntities.clear();
 }


### PR DESCRIPTION
## Summary
- **SkeletonDebug**: Added `mTimer.disconnect()` after `mTimer.stop()` in destructor to prevent queued timeout signals from firing after the timer is stopped. Replaced `Manager::getSingleton()->getSceneMgr()` with the already-stored `mSceneMan` member to avoid accessing a potentially-killed singleton during shutdown.
- **BoneWeightOverlay**: Added `mUpdateTimer.disconnect()` after `mUpdateTimer.stop()` in destructor to prevent queued timeout signals from invoking `updateOverlayPositions()` on destroyed Ogre objects.
- Removed unused `#include "Manager.h"` from SkeletonDebug.cpp.

## Root cause
`QTimer::stop()` prevents new timeout signals from being generated, but a signal may already be queued in the event loop. Without `disconnect()`, the slot fires during or after destruction, accessing destroyed Ogre objects and causing a crash reported in Sentry.

## Test plan
- [ ] Open app, load a mesh with skeleton, enable bone visualization
- [ ] Close the app — verify no crash in Sentry
- [ ] Repeat several times to confirm stability

🤖 Generated with [Claude Code](https://claude.com/claude-code)