### PR TITLE
Fix reimport of same file after deleting its node

### DIFF
--- a/src/Assimp/Importer.cpp
+++ b/src/Assimp/Importer.cpp
@@ -64,6 +64,12 @@ Ogre::MeshPtr AssimpToOgreImporter::loadModel(const std::string& path) {
     modelName = scene->mName.C_Str();
     if(modelName.empty()) modelName = path.substr(path.find_last_of("/\\") + 1);
 
+    // Remove stale resources from a previous import of the same file
+    if (auto oldMesh = Ogre::MeshManager::getSingleton().getByName(modelName))
+        Ogre::MeshManager::getSingleton().remove(oldMesh);
+    if (auto oldSkel = Ogre::SkeletonManager::getSingleton().getByName(modelName + ".skeleton"))
+        Ogre::SkeletonManager::getSingleton().remove(oldSkel);
+
     // Process materials
     materialProcessor.loadScene(scene);
 

--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -314,13 +314,27 @@ void Manager::destroyAllAttachedMovableObjects(Ogre::SceneNode* node)
        return;
    }
 
-   // Destroy all the attached objects
+   // Collect mesh/skeleton resource names before destroying entities
+   std::vector<Ogre::String> meshNames;
+   std::vector<Ogre::String> skeletonNames;
+
    try {
        auto attachedObjects = node->getAttachedObjects();
 
        for(auto attachedObject : attachedObjects)
        {
            try {
+               if (attachedObject->getMovableType() == "Entity")
+               {
+                   auto* entity = static_cast<Ogre::Entity*>(attachedObject);
+                   auto mesh = entity->getMesh();
+                   if (mesh)
+                   {
+                       meshNames.push_back(mesh->getName());
+                       if (!mesh->getSkeletonName().empty())
+                           skeletonNames.push_back(mesh->getSkeletonName());
+                   }
+               }
                node->getCreator()->destroyMovableObject(attachedObject);
            } catch (...) {
                // Ignore exceptions during cleanup
@@ -330,12 +344,24 @@ void Manager::destroyAllAttachedMovableObjects(Ogre::SceneNode* node)
        // Ignore exceptions during cleanup
    }
 
-   /* TODO check to free up the meshmanager
-   if(ent->getMesh().getPointer()->isManuallyLoaded())
+   // Remove mesh/skeleton resources no longer in use by any entity
+   for (const auto& name : meshNames)
    {
-       pSceneMgr->destroyManualObject(currentName);
-       Ogre::MeshManager::getSingleton().remove(currentName);
-   }*/
+       try {
+           auto mesh = Ogre::MeshManager::getSingleton().getByName(name);
+           // use_count == 2 means only MeshManager + this local variable hold it
+           if (mesh && mesh.use_count() <= 2)
+               Ogre::MeshManager::getSingleton().remove(mesh);
+       } catch (...) {}
+   }
+   for (const auto& name : skeletonNames)
+   {
+       try {
+           auto skel = Ogre::SkeletonManager::getSingleton().getByName(name);
+           if (skel && skel.use_count() <= 2)
+               Ogre::SkeletonManager::getSingleton().remove(skel);
+       } catch (...) {}
+   }
 
    // Recurse to child SceneNodes
    try {


### PR DESCRIPTION
## Summary
- When a node was deleted, only the Entity and SceneNode were destroyed — the underlying `Ogre::Mesh` and `Ogre::Skeleton` resources remained in their resource managers
- Reimporting the same file failed silently because `createManual()` throws on duplicate resource names
- Now cleans up unreferenced mesh/skeleton resources after entity destruction, using `use_count()` to avoid removing resources still shared by other entities

## Root cause
`Manager::destroyAllAttachedMovableObjects()` had a longstanding TODO comment acknowledging that mesh resources were never freed. The Assimp importer uses `MeshManager::createManual()` and `SkeletonManager::create()` which throw `ItemIdentityException` if a resource with the same name already exists.

## Test plan
- [ ] Import a file (e.g. .fbx or .mesh)
- [ ] Delete the node
- [ ] Import the same file again — should load successfully
- [ ] Import a file twice (without deleting) — second import should still work (gets unique node name)
- [ ] Import file A, import file B (sharing a material name), delete A, reimport A — should work

🤖 Generated with [Claude Code](https://claude.com/claude-code)