### PR TITLE
Fix QML Material List on Linux and modal focus issue

### DIFF
--- a/qml/MaterialListModal.qml
+++ b/qml/MaterialListModal.qml
@@ -1,7 +1,6 @@
 import QtQuick 6.0
 import QtQuick.Controls 6.0
 import QtQuick.Layouts 6.0
-import QtQuick.Dialogs
 import MaterialEditorQML 1.0
 
 ApplicationWindow {
@@ -10,7 +9,6 @@ ApplicationWindow {
     width: 600
     height: 500
     visible: true
-    modality: Qt.ApplicationModal
     color: backgroundColor
     
     // Theme colors

--- a/qml/PassPropertiesPanel.qml
+++ b/qml/PassPropertiesPanel.qml
@@ -1,7 +1,6 @@
 import QtQuick 6.0
 import QtQuick.Controls 6.0
 import QtQuick.Layouts 6.0
-import QtQuick.Dialogs
 import MaterialEditorQML 1.0
 
 GroupBox {

--- a/qml/TexturePropertiesPanel.qml
+++ b/qml/TexturePropertiesPanel.qml
@@ -1,8 +1,6 @@
 import QtQuick 6.0
 import QtQuick.Controls 6.0
 import QtQuick.Layouts 6.0
-import QtQuick.Dialogs
-import Qt.labs.platform 1.1 as Labs
 import MaterialEditorQML 1.0
 
 GroupBox {


### PR DESCRIPTION
## Summary
- Remove unused `import QtQuick.Dialogs` from `MaterialListModal.qml`, `PassPropertiesPanel.qml`, and `TexturePropertiesPanel.qml` — this caused "QML Material List failed to load" on Linux when `Qt6QuickDialogs2` isn't available
- Also remove unused `import Qt.labs.platform` from `TexturePropertiesPanel.qml`
- Remove `modality: Qt.ApplicationModal` from Material List so the Material Editor can be used alongside it without being blocked

## Test plan
- [ ] Open Material List on Linux — loads without error
- [ ] Open Material List on macOS/Windows — still works
- [ ] Edit a material from Material List — Material Editor opens, both windows are interactive
- [ ] Verify no QML import warnings in console output

🤖 Generated with [Claude Code](https://claude.com/claude-code)