### PR TITLE
Remove unused QtQuick.Dialogs from MaterialEditorWindow.qml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 2.7.1 LANGUAGES CXX)
+project(QtMeshEditor VERSION 2.7.2 LANGUAGES CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/qml/MaterialEditorWindow.qml
+++ b/qml/MaterialEditorWindow.qml
@@ -1,8 +1,6 @@
 import QtQuick 6.0
 import QtQuick.Controls 6.0
 import QtQuick.Layouts 6.0
-import QtQuick.Dialogs
-import Qt.labs.platform 1.1 as Labs
 import MaterialEditorQML 1.0
 
 ApplicationWindow {
@@ -1144,27 +1142,6 @@ ApplicationWindow {
                     }
                 }
             }
-        }
-    }
-
-    // Dialog components
-    FileDialog {
-        id: openMaterialDialog
-        title: "Open Material File"
-        nameFilters: ["Material files (*.material)", "All files (*)"]
-        onAccepted: {
-            console.log("Opening material file:", selectedFile)
-            // Handle material file opening
-        }
-    }
-
-    FileDialog {
-        id: exportMaterialDialog
-        title: "Export Material"
-        fileMode: FileDialog.SaveFile
-        nameFilters: ["Material files (*.material)", "All files (*)"]
-        onAccepted: {
-            MaterialEditorQML.exportMaterial(selectedFile.toString())
         }
     }
 

--- a/qml/qmldir
+++ b/qml/qmldir
@@ -2,6 +2,8 @@ module MaterialEditorQML
 MaterialEditorWindow 1.0 MaterialEditorWindow.qml
 PassPropertiesPanel 1.0 PassPropertiesPanel.qml
 TexturePropertiesPanel 1.0 TexturePropertiesPanel.qml
+AISettingsDialog 1.0 AISettingsDialog.qml
+MaterialListModal 1.0 MaterialListModal.qml
 ThemedButton 1.0 ThemedButton.qml
 ThemedComboBox 1.0 ThemedComboBox.qml
 ThemedSpinBox 1.0 ThemedSpinBox.qml

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -349,6 +349,7 @@ if(BUILD_TESTS)
     ${HEADER_FILES}
     ${TEST_SOURCES}
     ${RESOURCE_SRCS}
+    ${QML_RESOURCE_SRCS}
     ${CMAKE_CURRENT_SOURCE_DIR}/test_main.cpp
     )
 

--- a/src/MaterialEditorQML_qml_test.cpp
+++ b/src/MaterialEditorQML_qml_test.cpp
@@ -13,6 +13,9 @@
 #include <QTemporaryDir>
 #include <QDir>
 #include "MaterialEditorQML.h"
+#include "LLMManager.h"
+#include "ModelDownloader.h"
+#include "QMLMaterialHighlighter.h"
 
 class MaterialEditorQMLIntegrationTest : public ::testing::Test {
 protected:
@@ -158,7 +161,97 @@ TEST_F(QMLPropertyBindingTest, BasicPropertyBinding) {
     // QML object will be cleaned up automatically by engine destruction
 }
 
-// Note: Additional color binding tests are disabled due to MaterialEditorQML singleton 
+// --- QML Component Loading Tests ---
+// Verifies that QML files load without import errors (e.g. no stale QtQuick.Dialogs).
+// These tests only parse/compile the component; they do not instantiate it,
+// so the MaterialEditorQML singleton lifecycle issue does not apply.
+
+class QMLComponentLoadingTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        if (!QApplication::instance()) {
+            int argc = 0;
+            char* argv[] = { nullptr };
+            app = std::make_unique<QApplication>(argc, argv);
+        }
+
+        engine = std::make_unique<QQmlEngine>();
+
+        // Register all types that the MaterialEditorQML QML module expects
+        qmlRegisterSingletonType<MaterialEditorQML>("MaterialEditorQML", 1, 0, "MaterialEditorQML",
+            [](QQmlEngine *eng, QJSEngine *js) -> QObject * {
+                return MaterialEditorQML::qmlInstance(eng, js);
+            }
+        );
+        qmlRegisterSingletonType<LLMManager>("MaterialEditorQML", 1, 0, "LLMManager",
+            [](QQmlEngine *eng, QJSEngine *js) -> QObject * {
+                return LLMManager::qmlInstance(eng, js);
+            }
+        );
+        qmlRegisterSingletonType<ModelDownloader>("MaterialEditorQML", 1, 0, "ModelDownloader",
+            [](QQmlEngine *eng, QJSEngine *js) -> QObject * {
+                return ModelDownloader::qmlInstance(eng, js);
+            }
+        );
+        qmlRegisterType<QMLMaterialHighlighter>("MaterialEditorQML", 1, 0, "MaterialHighlighter");
+
+        // Let the engine find sub-components via the compiled-in qmldir
+        engine->addImportPath("qrc:/");
+    }
+
+    void TearDown() override {
+        engine.reset();
+        QCoreApplication::processEvents();
+    }
+
+    // Load a QML file from resources. Returns empty string on success,
+    // or a description of all QML errors on failure.
+    QString loadComponent(const QString &qrcPath) {
+        QQmlComponent component(engine.get(), QUrl(qrcPath));
+        if (component.isLoading()) {
+            QSignalSpy spy(&component, &QQmlComponent::statusChanged);
+            spy.wait(5000);
+        }
+        if (component.isError()) {
+            QStringList msgs;
+            for (const QQmlError &err : component.errors())
+                msgs << err.toString();
+            return msgs.join("\n");
+        }
+        return {};
+    }
+
+private:
+    std::unique_ptr<QApplication> app;
+    std::unique_ptr<QQmlEngine> engine;
+};
+
+TEST_F(QMLComponentLoadingTest, MaterialEditorWindowLoadsWithoutErrors) {
+    QString err = loadComponent("qrc:/MaterialEditorQML/MaterialEditorWindow.qml");
+    EXPECT_TRUE(err.isEmpty()) << err.toStdString();
+}
+
+TEST_F(QMLComponentLoadingTest, MaterialListModalLoadsWithoutErrors) {
+    QString err = loadComponent("qrc:/MaterialEditorQML/MaterialListModal.qml");
+    EXPECT_TRUE(err.isEmpty()) << err.toStdString();
+}
+
+TEST_F(QMLComponentLoadingTest, PassPropertiesPanelLoadsWithoutErrors) {
+    QString err = loadComponent("qrc:/MaterialEditorQML/PassPropertiesPanel.qml");
+    EXPECT_TRUE(err.isEmpty()) << err.toStdString();
+}
+
+TEST_F(QMLComponentLoadingTest, TexturePropertiesPanelLoadsWithoutErrors) {
+    QString err = loadComponent("qrc:/MaterialEditorQML/TexturePropertiesPanel.qml");
+    EXPECT_TRUE(err.isEmpty()) << err.toStdString();
+}
+
+TEST_F(QMLComponentLoadingTest, AISettingsDialogLoadsWithoutErrors) {
+    QString err = loadComponent("qrc:/MaterialEditorQML/AISettingsDialog.qml");
+    EXPECT_TRUE(err.isEmpty()) << err.toStdString();
+}
+
+// Note: Additional color binding tests are disabled due to MaterialEditorQML singleton
 // lifecycle issues in test environment. Direct C++ API testing covers color functionality.
 
 /*

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,6 +51,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/ModelDownloader.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/SentryReporter.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/BoneWeightOverlay.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/QMLMaterialHighlighter.cpp
     )
     
     set(TEST_HEADER_FILES


### PR DESCRIPTION
## Summary
- Remove dead-code `FileDialog` components and unused `QtQuick.Dialogs` / `Qt.labs.platform` imports from `MaterialEditorWindow.qml` — prevents load failures on deployed builds where `QtQuickDialogs2` isn't bundled
- Add 5 unit tests (`QMLComponentLoadingTest`) that verify all QML components (`MaterialEditorWindow`, `MaterialListModal`, `PassPropertiesPanel`, `TexturePropertiesPanel`, `AISettingsDialog`) load without import errors
- Complete the `qmldir` with missing `AISettingsDialog` and `MaterialListModal` entries
- Include QML resources (`${QML_RESOURCE_SRCS}`) in the `UnitTests` target so QML loading tests can find resource files
- Bump version to 2.7.2

## Test plan
- [x] All 5 new `QMLComponentLoadingTest` tests pass locally
- [x] Existing `QMLPropertyBindingTest.BasicPropertyBinding` still passes
- [x] `QtMeshEditor` app builds successfully
- [x] CI passes on all platforms (Windows, Linux, macOS)
- [ ] Open Material List and Material Editor in the app — both load without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)