### PR TITLE
Fix black viewport on Linux .deb install and Wayland systems

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -512,13 +512,16 @@ jobs:
             cp ./bin/QtMeshEditor ./pack-deb/usr/share/qtmesheditor/qtmesheditor
 
             # Create proper launcher script
-            printf '#!/bin/sh\nexport LD_LIBRARY_PATH="/usr/lib/qtmesheditor:${LD_LIBRARY_PATH}"\nexport QML2_IMPORT_PATH="/usr/share/qtmesheditor/qml:${QML2_IMPORT_PATH}"\nexec /usr/share/qtmesheditor/qtmesheditor "$@"\n' > ./pack-deb/usr/bin/qtmesheditor
+            printf '#!/bin/sh\nexport LD_LIBRARY_PATH="/usr/lib/qtmesheditor:${LD_LIBRARY_PATH}"\nexport QML2_IMPORT_PATH="/usr/share/qtmesheditor/qml:${QML2_IMPORT_PATH}"\n# Ogre requires X11 window handles; force XCB under Wayland\nexport QT_QPA_PLATFORM="${QT_QPA_PLATFORM:-xcb}"\nexec /usr/share/qtmesheditor/qtmesheditor "$@"\n' > ./pack-deb/usr/bin/qtmesheditor
             chmod 755 ./pack-deb/usr/bin/qtmesheditor
 
             # Copy copyright file
             cp ./DEBIAN-copyright ./pack-deb/usr/share/doc/qtmesheditor/copyright
 
             cp -R ./bin/cfg/ ./pack-deb/usr/share/qtmesheditor/
+            # Fix OGRE plugin path: CI build hardcodes /usr/local/lib/OGRE but
+            # the .deb bundles plugins in /usr/lib/qtmesheditor/
+            sed -i 's|^PluginFolder=.*|PluginFolder=/usr/lib/qtmesheditor|' ./pack-deb/usr/share/qtmesheditor/cfg/plugins.cfg
             sudo chmod -R 755 ./pack-deb/usr/share/qtmesheditor/cfg
             cp -R ./bin/media/ ./pack-deb/usr/share/qtmesheditor/
             cp -R ./bin/platforms/ ./pack-deb/usr/share/qtmesheditor/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 2.7.3 LANGUAGES CXX)
+project(QtMeshEditor VERSION 2.7.4 LANGUAGES CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -506,12 +506,10 @@ void Manager::initRoot()
 
 void Manager::initRenderSystem()
 {
-    // setup a renderer
-    Ogre::RenderSystem *renderSystem = mRoot->getRenderSystemByName("OpenGL Rendering Subsystem"); //TODO: Add OpenGL 3+, and allow the user to select the render system.
+    Ogre::RenderSystem *renderSystem = mRoot->getRenderSystemByName("OpenGL Rendering Subsystem");
 
     if (!renderSystem)
     {
-        // Try GL3Plus as fallback
         renderSystem = mRoot->getRenderSystemByName("OpenGL 3+ Rendering Subsystem");
     }
 

--- a/src/OgreWidget.cpp
+++ b/src/OgreWidget.cpp
@@ -159,7 +159,6 @@ void OgreWidget::initOgreWindow(void)
 
     params["externalWindowHandle"] = winHandle;
 #ifdef Q_OS_MACOS
-    // code for Mac
     params["macAPI"] = "cocoa";
     params["macAPICocoaUseNSView"] = "true";
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,8 +23,24 @@
 #include <unistd.h>
 #endif
 
+#ifdef Q_OS_LINUX
+static void forceX11PlatformIfNeeded()
+{
+    if (!qEnvironmentVariableIsSet("QT_QPA_PLATFORM")) {
+        qputenv("QT_QPA_PLATFORM", "xcb");
+    }
+}
+#endif
+
 int main(int argc, char *argv[])
 {
+#ifdef Q_OS_LINUX
+    // Ogre's externalWindowHandle requires X11 window IDs.
+    // Under Wayland, Qt's winId() returns an incompatible surface handle,
+    // causing Ogre to render to the wrong target (black viewport).
+    forceX11PlatformIfNeeded();
+#endif
+
     // Check for MCP server mode before creating QApplication
     bool mcpOnlyMode = false;
     bool mcpWithGuiMode = false;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -103,7 +103,6 @@ MainWindow::MainWindow(QWidget *parent) :
     ///// Workaround, when using mRoot->startRendering() there's a flickering effect on the grid
     m_pTimer = new QTimer(this);
     connect(m_pTimer, &QTimer::timeout, this, [this](){
-        // Safely check if root and windows still exist before rendering
         if(m_pRoot && m_pRoot->getRenderSystem())
         {
             try {


### PR DESCRIPTION
## Summary

- **Fix .deb PluginFolder path**: The CI build hardcoded `/usr/local/lib/OGRE` in `plugins.cfg`, but the .deb installs plugins to `/usr/lib/qtmesheditor/`. Ogre couldn't load any render system, resulting in a black viewport.
- **Force XCB platform on Linux**: Ogre's `externalWindowHandle` requires X11 window IDs. Under Wayland, `winId()` returns an incompatible surface handle. Added `QT_QPA_PLATFORM=xcb` both in `main.cpp` and the .deb launcher script.
- **Bump version to 2.7.4**

## Root cause

The render timer in `MainWindow` calls `renderOneFrame()` and catches exceptions — when the render system fails to load (wrong plugin path) or materials fail (if GL3Plus is used without shaders), the exception handler silently stops the timer. The viewport stays black with no visible error.

## Test plan

- [x] Verified locally on Ubuntu with NVIDIA RTX 3060 (driver 580.x) — viewport renders the grid correctly
- [ ] CI builds .deb with corrected `plugins.cfg` path
- [ ] Install .deb on Ubuntu and confirm viewport renders


Made with [Cursor](https://cursor.com)