### PR TITLE
Upgrade dependencies: Qt 6.9.3, Assimp 6.0.4, Ogre 14.5.2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,10 +12,10 @@ env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
   AQT_VERSION: '==3.3.*'
-  QT_VERSION: '6.9.1'
-  ASSIMP_VERSION: '6.0.2'
+  QT_VERSION: '6.9.3'
+  ASSIMP_VERSION: '6.0.4'
   ASSIMP_DIR_VERSION: '6.0'
-  OGRE_VERSION: '14.4.1'
+  OGRE_VERSION: '14.5.2'
 
 jobs:
 #  send-slack-notification:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,9 +38,9 @@ If Xcode SDK is updated, clear CMake cache (`rm build_local/CMakeCache.txt`) and
 
 ## Dependencies
 
-- **Qt 6.9.1**: Core, Widgets, Gui, QuickWidgets, Quick, Qml, Network, QuickControls2, Test
-- **Ogre3D 14.x**: 3D rendering engine
-- **Assimp 6.0.2**: 3D model import/export
+- **Qt 6.9.3**: Core, Widgets, Gui, QuickWidgets, Quick, Qml, Network, QuickControls2, Test
+- **Ogre3D 14.5.x**: 3D rendering engine
+- **Assimp 6.0.4**: 3D model import/export
 - **llama.cpp**: Optional local LLM inference (enabled by default, disable with `-DENABLE_LOCAL_LLM=OFF`)
 - **Google Test**: Test framework (enabled with `-DBUILD_TESTS=ON`)
 - **ogre-procedural**: Bundled in `src/dependencies/ogre-procedural/` for procedural mesh generation


### PR DESCRIPTION
## Summary

- **Qt 6.9.1 → 6.9.3**: 250+ bug fixes and security updates (final 6.9 release)
- **Assimp 6.0.2 → 6.0.4**: FBX animation scaling fixes, glTF skinning export improvements, CVE security fixes
- **Ogre3D 14.4.1 → 14.5.2**: Linear workflow support, bone bounding radius fix, entity optimization for skeletal meshes

### Notable Ogre 14.5.x improvements relevant to QtMeshEditor

| Feature | Benefit |
|---------|---------|
| Bone bounding radius fix | Better skeleton handling for animation merging |
| Entity optimization (computeBoneBoundingRadius only when enabling) | Faster loading of animated meshes |
| Linear colour workflow | More accurate material rendering |
| CookTorrance shader fix | Correct PBR ambient color |
| WebP texture support | Additional texture format |

No breaking API changes — the codebase compiles and all tests pass without modification.

## Test plan

- [ ] CI builds on all 3 platforms (Windows, Linux, macOS)
- [ ] CI tests pass on Linux
- [ ] Verify mesh import/export still works (FBX, glTF, Collada, OBJ)
- [ ] Verify animation merging works
- [ ] Verify material editor works

🤖 Generated with [Claude Code](https://claude.com/claude-code)