### PR TITLE
Exclude GCC implicit exception branches from coverage report

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -876,6 +876,8 @@ jobs:
               --exclude '.*/ui_files/' \
               --exclude '.*/moc_' \
               --exclude '.*qrc_.*\.cpp' \
+              --exclude-throw-branches \
+              --exclude-unreachable-branches \
               --sonarqube=coverage.xml \
               --gcov-executable gcov \
               build \


### PR DESCRIPTION
## Summary

- Add `--exclude-throw-branches` and `--exclude-unreachable-branches` flags to the gcovr command in CI
- GCC's `--coverage` generates 2 branches for every function call (normal return vs exception thrown), causing SonarCloud to report "1 of 2 conditions" on simple calls like `writeObjects()` that have no actual branching logic
- These gcovr flags filter out compiler-generated exception/unreachable branches, so condition coverage reflects real logic branches only

## Test plan

- [ ] CI builds and runs tests successfully
- [ ] SonarCloud condition coverage no longer shows partial coverage on plain function calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configuration to refine code coverage reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->