### PR TITLE
Fix CI release build failures in Sentry debug symbol steps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -240,14 +240,12 @@ jobs:
         SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
         SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
       run: |
-        Copy-Item "${{github.workspace}}/bin/QtMeshEditor.exe" "${{github.workspace}}/bin/QtMeshEditor.debug.exe"
-        & "D:/a/QtMeshEditor/Qt/Tools/mingw1310_64/bin/strip.exe" --strip-debug "${{github.workspace}}/bin/QtMeshEditor.exe"
-        # Install sentry-cli via PowerShell (npm may not be in PATH)
-        Invoke-WebRequest -Uri "https://release-registry.services.sentry.io/apps/sentry-cli/latest?response=download&arch=x86_64&platform=Windows&package=sentry-cli" -OutFile "${{github.workspace}}/sentry-cli.exe"
-        & "${{github.workspace}}/sentry-cli.exe" debug-files upload --include-sources "${{github.workspace}}/bin/QtMeshEditor.debug.exe"
-        Remove-Item "${{github.workspace}}/bin/QtMeshEditor.debug.exe"
-        Remove-Item "${{github.workspace}}/sentry-cli.exe" -ErrorAction SilentlyContinue
-      shell: powershell
+        cp "${{github.workspace}}/bin/QtMeshEditor.exe" "${{github.workspace}}/bin/QtMeshEditor.debug.exe"
+        "D:/a/QtMeshEditor/Qt/Tools/mingw1310_64/bin/strip.exe" --strip-debug "${{github.workspace}}/bin/QtMeshEditor.exe"
+        curl -sL https://sentry.io/get-cli/ | bash
+        sentry-cli debug-files upload --include-sources "${{github.workspace}}/bin/QtMeshEditor.debug.exe"
+        rm -f "${{github.workspace}}/bin/QtMeshEditor.debug.exe"
+      shell: bash
 
     - name: Copy assimp dll to the binary folder
       run: |


### PR DESCRIPTION
## Summary
- **Linux**: Add `sudo` to `objcopy`/`strip` commands (binary is owned by root from `sudo make install`)
- **macOS**: Add `sudo` to `dsymutil`/`strip` commands (same root ownership issue)
- **Windows**: Download `sentry-cli` binary directly instead of `npm install -g @sentry/cli` (the PATH override excluded Node.js, causing `npm: not recognized` error)

These failures only occur on `release` events (tag creation) since the Sentry debug symbol upload steps are gated by `if: github.event_name == 'release'`.

## Test plan
- [ ] Merge and create a new release tag to verify all 3 platforms build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined deployment pipeline for Windows, Linux, and macOS.
  * More reliable debug-symbol extraction and upload flow.
  * Switched to a simpler, more robust CLI installation and invocation during deploy.
  * Ensured symbol handling runs with appropriate elevated permissions for consistent results across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->