### PR TITLE
Fix sentry-cli path on Windows Git Bash

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -243,7 +243,7 @@ jobs:
         cp "${{github.workspace}}/bin/QtMeshEditor.exe" "${{github.workspace}}/bin/QtMeshEditor.debug.exe"
         "D:/a/QtMeshEditor/Qt/Tools/mingw1310_64/bin/strip.exe" --strip-debug "${{github.workspace}}/bin/QtMeshEditor.exe"
         curl -sL https://sentry.io/get-cli/ | bash
-        sentry-cli debug-files upload --include-sources "${{github.workspace}}/bin/QtMeshEditor.debug.exe"
+        /usr/local/bin/sentry-cli debug-files upload --include-sources "${{github.workspace}}/bin/QtMeshEditor.debug.exe"
         rm -f "${{github.workspace}}/bin/QtMeshEditor.debug.exe"
       shell: bash
 


### PR DESCRIPTION
## Summary
- The `curl` sentry-cli installer places the binary at `/usr/local/bin/sentry-cli`, which is not in Git Bash's PATH on Windows runners
- Use the full path `/usr/local/bin/sentry-cli` instead of just `sentry-cli`

## Test plan
- [ ] Merge and verify Windows release build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configuration for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->