### PR TITLE
Fix Docker publish ordering: run after build-linux

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1528,3 +1528,89 @@ jobs:
         git add Casks/qtmesheditor.rb
         git commit -m "Update QtMeshEditor to ${{ github.ref_name }}" || echo "No changes to commit"
         git push
+
+####################################################################
+# Docker Image Publish (after Linux .deb is built)
+####################################################################
+
+ docker-publish:
+    needs: build-linux
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY_GHCR: ghcr.io
+      DOCKER_IMAGE_NAME: fernandotonon/qtmesheditor
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download .deb artifact from build-linux
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-binaries
+          path: .
+
+      - name: Prepare .deb for Docker build
+        run: |
+          shopt -s nullglob
+          debs=(./*.deb)
+          if [ "${#debs[@]}" -ne 1 ]; then
+            echo "Expected exactly one .deb, found ${#debs[@]}" >&2
+            ls -la ./*.deb 2>/dev/null || true
+            exit 1
+          fi
+          mv "${debs[0]}" ./qtmesheditor.deb
+          ls -la ./qtmesheditor.deb
+
+      - name: Extract version from downloaded package
+        id: version
+        run: |
+          VERSION=$(dpkg-deb -f ./qtmesheditor.deb Version | sed 's/-.*//')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Extracted version: $VERSION"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY_GHCR }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Compute Docker tags
+        id: tags
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAGS="${{ env.REGISTRY_GHCR }}/${{ env.DOCKER_IMAGE_NAME }}:${VERSION}"
+          TAGS="${TAGS},${{ env.REGISTRY_GHCR }}/${{ env.DOCKER_IMAGE_NAME }}:latest"
+          TAGS="${TAGS},${{ env.DOCKER_IMAGE_NAME }}:${VERSION}"
+          TAGS="${TAGS},${{ env.DOCKER_IMAGE_NAME }}:latest"
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+          tags: ${{ steps.tags.outputs.tags }}
+          labels: |
+            org.opencontainers.image.title=qtmesh
+            org.opencontainers.image.description=qtmesh CLI - 3D mesh conversion, optimization, and animation tools
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+            org.opencontainers.image.source=https://github.com/fernandotonon/QtMeshEditor
+
+      - name: Verify image
+        run: |
+          docker run --rm "${{ env.REGISTRY_GHCR }}/${{ env.DOCKER_IMAGE_NAME }}:${{ steps.version.outputs.version }}" --help

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,12 +1,10 @@
-name: Docker Publish
+name: Docker Publish (Manual)
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release tag to build from (e.g. v2.11.0). Leave empty for latest.'
+        description: 'Release tag to build from (e.g. 2.11.1). Leave empty for latest.'
         required: false
         default: ''
 
@@ -27,9 +25,7 @@ jobs:
       - name: Determine release tag
         id: tag
         run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            TAG="${{ github.event.release.tag_name }}"
-          elif [ -n "${{ github.event.inputs.version }}" ]; then
+          if [ -n "${{ github.event.inputs.version }}" ]; then
             TAG="${{ github.event.inputs.version }}"
           else
             TAG="latest"
@@ -76,7 +72,6 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
-        if: github.event_name == 'release'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -85,15 +80,14 @@ jobs:
         id: tags
         run: |
           VERSION="${{ steps.version.outputs.version }}"
+          TAG="${{ steps.tag.outputs.tag }}"
           TAGS="${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME }}:${VERSION}"
-          # Only tag :latest for release events or unversioned dispatch
-          if [ "${{ github.event_name }}" = "release" ] || [ "${{ steps.tag.outputs.tag }}" = "latest" ]; then
+          # Only tag :latest for unversioned dispatch (avoids overwriting latest with old version)
+          if [ "$TAG" = "latest" ]; then
             TAGS="${TAGS},${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME }}:latest"
-          fi
-          if [ "${{ github.event_name }}" = "release" ]; then
-            TAGS="${TAGS},${{ env.IMAGE_NAME }}:${VERSION}"
             TAGS="${TAGS},${{ env.IMAGE_NAME }}:latest"
           fi
+          TAGS="${TAGS},${{ env.IMAGE_NAME }}:${VERSION}"
           echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
 
       - name: Build and push Docker image


### PR DESCRIPTION
## Summary
- Moves the Docker publish job into `deploy.yml` with `needs: build-linux` so it runs after the `.deb` is built
- The job downloads the `linux-binaries` artifact directly instead of trying to fetch from the release (which wasn't uploaded yet)
- Converts `docker-publish.yml` to `workflow_dispatch` only, for manual rebuilds from existing releases

## Why
The separate `docker-publish.yml` triggered on `release: published` but ran concurrently with the build jobs, so the `.deb` didn't exist yet — causing the download to fail.

## Test plan
- [ ] Create a release and verify `docker-publish` job runs after `build-linux` completes
- [ ] Verify the Docker image is pushed to ghcr.io
- [ ] Test manual dispatch of `Docker Publish (Manual)` workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added automated Docker image publishing to Docker Hub and GHCR following release events.
  * Updated release workflow to support manual image build triggering with version specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->