### PR TITLE
Suppress Docker warnings, bump to 2.11.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 2.11.1 LANGUAGES CXX)
+project(QtMeshEditor VERSION 2.11.2 LANGUAGES CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,11 @@ LABEL org.opencontainers.image.source="https://github.com/fernandotonon/QtMeshEd
 LABEL org.opencontainers.image.description="qtmesh CLI - 3D mesh conversion, optimization, and animation tools"
 LABEL org.opencontainers.image.version="${VERSION}"
 
+# Suppress Qt locale warning and Mesa EGL/DRI3 warnings
+ENV LANG=C.UTF-8
+ENV LIBGL_ALWAYS_SOFTWARE=1
+ENV MESA_LOG_LEVEL=0
+
 WORKDIR /workspace
 USER qtmesh
 ENTRYPOINT ["docker-entrypoint.sh"]


### PR DESCRIPTION
## Summary
- Suppress Qt locale and Mesa EGL/DRI3 warnings in Docker container via environment variables
- Bump version to 2.11.2

## Test plan
- [ ] CI builds pass
- [ ] Docker image produces clean output (no warnings on stderr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version incremented to 2.11.2
  * Docker environment configuration enhanced with software rendering enforcement and warning suppression for improved stability in containerized deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->