### PR TITLE
Add Snap Store packaging and CI publish

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1567,15 +1567,13 @@ jobs:
         name: linux-binaries
         path: .
 
-    - name: Prepare snap build
-      run: |
-        # Place the .deb where snapcraft.yaml expects it
-        cp qtmesheditor_amd64.deb snap/../qtmesheditor_amd64.deb
+    - name: Verify snap input artifact
+      run: test -f ./qtmesheditor_amd64.deb
 
-    - uses: snapcore/action-build@v1
+    - uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1
       id: build
 
-    - uses: snapcore/action-publish@v1
+    - uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_TOKEN }}
       with:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: qtmesheditor
-version: '2.14.1'
+adopt-info: qtmesheditor
 summary: Free 3D asset tool for indie game developers
 description: |
   Merge Mixamo animations, convert between 40+ 3D formats, edit materials
@@ -62,6 +62,14 @@ parts:
         curl -L -o /tmp/qtmesheditor.deb "$DEB_URL"
         dpkg-deb -x /tmp/qtmesheditor.deb "$CRAFT_PART_INSTALL"
       fi
+
+      # Extract version from the .deb control metadata
+      DEB_PATH="$CRAFT_PART_SRC/qtmesheditor_amd64.deb"
+      if [ ! -f "$DEB_PATH" ]; then
+        DEB_PATH="/tmp/qtmesheditor.deb"
+      fi
+      VERSION=$(dpkg-deb -f "$DEB_PATH" Version)
+      craftctl set version="$VERSION"
 
       # Fix plugins.cfg to use snap-relative path
       if [ -f "$CRAFT_PART_INSTALL/usr/share/qtmesheditor/cfg/plugins.cfg" ]; then


### PR DESCRIPTION
## Summary
- Add `snap/snapcraft.yaml` for Snap Store distribution
- Add `snap-publish` CI job to `deploy.yml` that builds and publishes the snap on release

## Details

The snap reuses the existing `.deb` artifact from the Linux build (no duplicate compilation). It exposes two apps:
- **`qtmesheditor`** — GUI with gnome extension, opengl/x11/wayland/desktop plugs
- **`qtmesh`** — CLI with offscreen rendering for headless batch processing

The CI job runs after `build-linux` on release events, downloads the `.deb` artifact, builds the snap via `snapcore/action-build`, and publishes to the Snap Store via `snapcore/action-publish` using the `SNAP_STORE_TOKEN` secret.

After merge and next release, users can install with:
```
sudo snap install qtmesheditor
```

## Test plan
- [ ] Verify CI passes (no snap build on PRs, only on release)
- [ ] On next release, verify snap-publish job runs and publishes successfully
- [ ] Test `sudo snap install qtmesheditor` from the Snap Store

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Snap package for both the GUI application and its CLI, bringing native Snap installation and required runtime libraries.
* **Chores**
  * Enabled automated publishing to the Snap Store.
  * Expanded Docker image publishing to Docker Hub and GitHub Container Registry with versioned and latest tags and post-publish verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->