### PR TITLE
Increase MCPServer coverage

### DIFF
--- a/src/MCPServer_test.cpp
+++ b/src/MCPServer_test.cpp
@@ -12,6 +12,7 @@
 #include <memory>
 #include <QMainWindow>
 #include <unistd.h>
+#include <fcntl.h>
 
 #define private public
 #include "MCPServer.h"
@@ -45,6 +46,28 @@ static QByteArray readTransportMessage(int readFd)
     if (bytesRead > 0) {
         response.append(buffer, bytesRead);
     }
+    return response;
+}
+
+static QByteArray readTransportMessageNonBlocking(int readFd)
+{
+    const int flags = fcntl(readFd, F_GETFL, 0);
+    if (flags == -1) {
+        return {};
+    }
+
+    if (fcntl(readFd, F_SETFL, flags | O_NONBLOCK) == -1) {
+        return {};
+    }
+
+    QByteArray response;
+    char buffer[4096];
+    ssize_t bytesRead = read(readFd, buffer, sizeof(buffer));
+    if (bytesRead > 0) {
+        response.append(buffer, bytesRead);
+    }
+
+    fcntl(readFd, F_SETFL, flags);
     return response;
 }
 
@@ -2113,6 +2136,94 @@ TEST_F(MCPServerHttpTest, PostEmptyBody)
     EXPECT_EQ(getHttpStatus(response), 200);
 }
 
+TEST_F(MCPServerHttpTest, GetToolCallWithQueryStringStripsSuffix)
+{
+    server->setOgreInitFailed(true);
+
+    ASSERT_TRUE(server->startHttp(0));
+    int port = server->httpPort();
+
+    QByteArray request = "GET /api/tools/list_materials?format=json HTTP/1.1\r\n"
+                         "Host: 127.0.0.1\r\nConnection: close\r\n\r\n";
+
+    QByteArray response = sendHttpRequest(port, request);
+
+    ASSERT_FALSE(response.isEmpty());
+    EXPECT_EQ(getHttpStatus(response), 200);
+    EXPECT_TRUE(response.contains("application/json"));
+}
+
+TEST_F(MCPServerHttpTest, BusyToolRequestReturns503)
+{
+    server->setOgreInitFailed(true);
+
+    ASSERT_TRUE(server->startHttp(0));
+    server->m_httpBusy = true;
+    int port = server->httpPort();
+
+    QByteArray request = "GET /api/tools/list_materials HTTP/1.1\r\n"
+                         "Host: 127.0.0.1\r\nConnection: close\r\n\r\n";
+
+    QByteArray response = sendHttpRequest(port, request);
+
+    ASSERT_FALSE(response.isEmpty());
+    EXPECT_EQ(getHttpStatus(response), 503);
+    EXPECT_TRUE(response.contains("Server busy"));
+}
+
+TEST_F(MCPServerHttpTest, PartialPostBodyWaitsForCompletionBeforeResponding)
+{
+    server->setOgreInitFailed(true);
+
+    ASSERT_TRUE(server->startHttp(0));
+    int port = server->httpPort();
+
+    QTcpSocket socket;
+    socket.connectToHost("127.0.0.1", port);
+    ASSERT_TRUE(socket.waitForConnected(1000));
+
+    const QByteArray body = R"({"name":"PartialBodyMaterial"})";
+    const QByteArray partialBody = body.left(body.size() / 2);
+    QByteArray request = "POST /api/tools/create_material HTTP/1.1\r\n"
+                         "Host: 127.0.0.1\r\n"
+                         "Content-Type: application/json\r\n"
+                         "Content-Length: " + QByteArray::number(body.size()) + "\r\n"
+                         "Connection: close\r\n\r\n" + partialBody;
+
+    socket.write(request);
+    socket.flush();
+
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 50);
+    QThread::msleep(25);
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 50);
+    EXPECT_EQ(socket.bytesAvailable(), 0);
+
+    socket.write(body.mid(partialBody.size()));
+    socket.flush();
+
+    QByteArray response;
+    QElapsedTimer timer;
+    timer.start();
+    while (timer.elapsed() < 5000) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 50);
+        if (socket.bytesAvailable() > 0) {
+            response.append(socket.readAll());
+        }
+        if (socket.state() == QAbstractSocket::UnconnectedState && !response.isEmpty()) {
+            break;
+        }
+        QThread::msleep(10);
+    }
+
+    if (socket.bytesAvailable() > 0) {
+        response.append(socket.readAll());
+    }
+
+    ASSERT_FALSE(response.isEmpty());
+    EXPECT_EQ(getHttpStatus(response), 200);
+    EXPECT_TRUE(response.contains("application/json"));
+}
+
 // --- HTTP response contains CORS headers on all responses ---
 
 TEST_F(MCPServerHttpTest, CorsHeadersOnAllResponses)
@@ -3691,6 +3802,46 @@ TEST_F(MCPServerProtocolTest, ProcessMessageUnknownMethodReturnsMethodNotFound)
     EXPECT_TRUE(response["error"].toObject()["message"].toString().contains("Method not found"));
 }
 
+TEST_F(MCPServerProtocolTest, ProcessMessagePingReturnsEmptyResult)
+{
+    const QJsonObject request{
+        {"jsonrpc", "2.0"},
+        {"id", 11},
+        {"method", "ping"},
+        {"params", QJsonObject{}}
+    };
+
+    const QJsonObject response = processAndRead(QJsonDocument(request).toJson(QJsonDocument::Compact));
+    ASSERT_TRUE(response.contains("result"));
+    EXPECT_EQ(response["id"].toInt(), 11);
+    EXPECT_TRUE(response["result"].toObject().isEmpty());
+}
+
+TEST_F(MCPServerProtocolTest, ProcessMessageInitializedNotificationDoesNotRespond)
+{
+    const QJsonObject request{
+        {"jsonrpc", "2.0"},
+        {"method", "notifications/initialized"},
+        {"params", QJsonObject{}}
+    };
+
+    server->processMessage(QJsonDocument(request).toJson(QJsonDocument::Compact));
+    EXPECT_TRUE(readTransportMessageNonBlocking(outputPipe[0]).isEmpty());
+    EXPECT_FALSE(server->m_initialized);
+}
+
+TEST_F(MCPServerProtocolTest, ProcessMessageCancelledNotificationDoesNotRespond)
+{
+    const QJsonObject request{
+        {"jsonrpc", "2.0"},
+        {"method", "notifications/cancelled"},
+        {"params", QJsonObject{{"requestId", 5}}}
+    };
+
+    server->processMessage(QJsonDocument(request).toJson(QJsonDocument::Compact));
+    EXPECT_TRUE(readTransportMessageNonBlocking(outputPipe[0]).isEmpty());
+}
+
 TEST_F(MCPServerProtocolTest, HandleResourcesListReturnsExpectedUris)
 {
     const QJsonObject result = server->handleResourcesList();
@@ -3719,6 +3870,12 @@ TEST_F(MCPServerProtocolTest, HandleResourcesReadSceneInfoReturnsSerializedText)
     ASSERT_EQ(contents.size(), 1);
     EXPECT_EQ(contents[0].toObject()["mimeType"].toString(), "application/json");
     EXPECT_TRUE(contents[0].toObject()["text"].toString().contains("Scene Information"));
+}
+
+TEST_F(MCPServerProtocolTest, HandleResourcesReadUnknownUriReturnsEmptyContents)
+{
+    const QJsonObject result = server->handleResourcesRead(QJsonObject{{"uri", "qtmesheditor://unknown"}});
+    EXPECT_TRUE(result["contents"].toArray().isEmpty());
 }
 
 TEST_F(MCPServerProtocolTest, BuildToolsListContainsCoreToolDefinitions)
@@ -3770,4 +3927,91 @@ TEST_F(MCPServerProtocolTest, OnReadyReadRecoversAfterInvalidHeaderAndParsesMess
     server->m_stdinNotifier = nullptr;
     close(inputPipe[0]);
     close(inputPipe[1]);
+}
+
+TEST_F(MCPServerProtocolTest, OnReadyReadWaitsForCompleteTransportBody)
+{
+    int inputPipe[2] = {-1, -1};
+    ASSERT_EQ(pipe(inputPipe), 0);
+
+    server->m_stdinFd = inputPipe[0];
+    server->m_stdinNotifier = new QSocketNotifier(server->m_stdinFd, QSocketNotifier::Read, server.get());
+
+    const QJsonObject request{
+        {"jsonrpc", "2.0"},
+        {"id", 9},
+        {"method", "ping"},
+        {"params", QJsonObject{}}
+    };
+    const QByteArray payload = QJsonDocument(request).toJson(QJsonDocument::Compact);
+    const QByteArray header = QByteArray("Content-Length: ") + QByteArray::number(payload.size()) + "\r\n\r\n";
+
+    ASSERT_GT(write(inputPipe[1], header.constData(), header.size()), 0);
+    server->onReadyRead();
+    EXPECT_TRUE(readTransportMessageNonBlocking(outputPipe[0]).isEmpty());
+    EXPECT_EQ(server->m_buffer, header);
+
+    ASSERT_GT(write(inputPipe[1], payload.constData(), payload.size()), 0);
+    server->onReadyRead();
+
+    const QJsonObject response = extractJsonBody(readTransportMessage(outputPipe[0]));
+    EXPECT_EQ(response["id"].toInt(), 9);
+    EXPECT_TRUE(response["result"].toObject().isEmpty());
+    EXPECT_TRUE(server->m_buffer.isEmpty());
+
+    delete server->m_stdinNotifier;
+    server->m_stdinNotifier = nullptr;
+    close(inputPipe[0]);
+    close(inputPipe[1]);
+}
+
+TEST_F(MCPServerProtocolTest, OnReadyReadSkipsInvalidContentLengthAndProcessesNextMessage)
+{
+    int inputPipe[2] = {-1, -1};
+    ASSERT_EQ(pipe(inputPipe), 0);
+
+    server->m_stdinFd = inputPipe[0];
+    server->m_stdinNotifier = new QSocketNotifier(server->m_stdinFd, QSocketNotifier::Read, server.get());
+
+    const QJsonObject request{
+        {"jsonrpc", "2.0"},
+        {"id", 12},
+        {"method", "ping"},
+        {"params", QJsonObject{}}
+    };
+    const QByteArray payload = QByteArray("Content-Length: 0\r\n\r\n") + makeTransport(QJsonDocument(request).toJson(QJsonDocument::Compact));
+    ASSERT_GT(write(inputPipe[1], payload.constData(), payload.size()), 0);
+
+    server->onReadyRead();
+
+    const QJsonObject response = extractJsonBody(readTransportMessage(outputPipe[0]));
+    EXPECT_EQ(response["id"].toInt(), 12);
+    EXPECT_TRUE(response["result"].toObject().isEmpty());
+
+    delete server->m_stdinNotifier;
+    server->m_stdinNotifier = nullptr;
+    close(inputPipe[0]);
+    close(inputPipe[1]);
+}
+
+TEST_F(MCPServerProtocolTest, SendNotificationSerializesMethodAndParams)
+{
+    server->sendNotification("notifications/test", QJsonObject{{"value", 42}});
+
+    const QJsonObject response = extractJsonBody(readTransportMessage(outputPipe[0]));
+    EXPECT_EQ(response["jsonrpc"].toString(), "2.0");
+    EXPECT_EQ(response["method"].toString(), "notifications/test");
+    EXPECT_EQ(response["params"].toObject()["value"].toInt(), 42);
+    EXPECT_FALSE(response.contains("id"));
+}
+
+TEST_F(MCPServerProtocolTest, SendErrorSerializesJsonRpcError)
+{
+    server->sendError(QJsonValue("req-1"), -32001, "custom failure");
+
+    const QJsonObject response = extractJsonBody(readTransportMessage(outputPipe[0]));
+    EXPECT_EQ(response["jsonrpc"].toString(), "2.0");
+    EXPECT_EQ(response["id"].toString(), "req-1");
+    EXPECT_EQ(response["error"].toObject()["code"].toInt(), -32001);
+    EXPECT_EQ(response["error"].toObject()["message"].toString(), "custom failure");
 }


### PR DESCRIPTION
## Summary
- expand MCPServer protocol coverage for ping, notifications, resource edge cases, and transport parsing
- add HTTP coverage for query-string tool routes, busy-server handling, and partial request bodies
- harden no-response assertions with non-blocking pipe reads to avoid test hangs

## Testing
- local configure currently blocked by external dependency/bootstrap time in this worktree
- focused MCPServer validation still needs a full UnitTests build in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for HTTP endpoint behavior including query string handling, busy server responses, and partial body streaming.
  * Enhanced MCP protocol testing for ping/notification handling, resource reading, and message buffering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->