### PR TITLE
Expand MainWindow and TransformOperator coverage

### DIFF
--- a/src/TransformOperator_test.cpp
+++ b/src/TransformOperator_test.cpp
@@ -285,6 +285,8 @@ TEST_F(TransformOperatorTests, UpdateGizmoUsesRootOrientationForMultipleLocalNod
     ASSERT_NE(nodeA, nullptr);
     ASSERT_NE(nodeB, nullptr);
 
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->append(nodeA);
     SelectionSet::getSingleton()->append(nodeB);
     nodeA->setOrientation(Ogre::Quaternion(Ogre::Degree(15), Ogre::Vector3::UNIT_X));
     nodeB->setOrientation(Ogre::Quaternion(Ogre::Degree(25), Ogre::Vector3::UNIT_Z));
@@ -344,6 +346,8 @@ TEST_F(TransformOperatorTests, SetSelectedScaleForNodeUsesSelectionAverage)
     ASSERT_NE(nodeA, nullptr);
     ASSERT_NE(nodeB, nullptr);
 
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->append(nodeA);
     SelectionSet::getSingleton()->append(nodeB);
     nodeA->setScale(Ogre::Vector3(1.0f, 1.0f, 1.0f));
     nodeB->setScale(Ogre::Vector3(3.0f, 3.0f, 3.0f));

--- a/src/mainwindow_test.cpp
+++ b/src/mainwindow_test.cpp
@@ -222,7 +222,7 @@ TEST_F(MainWindowTest, DropEventKeepsOnlySupportedFiles) {
     mimeData->setUrls({
         QUrl::fromLocalFile("/tmp/first.mesh"),
         QUrl::fromLocalFile("/tmp/second.obj"),
-        QUrl::fromLocalFile("/tmp/ignore.txt")
+        QUrl::fromLocalFile("/tmp/ignore.unsupported")
     });
     QDropEvent event(QPointF(0, 0), Qt::CopyAction, mimeData, Qt::LeftButton, Qt::NoModifier);
 
@@ -231,7 +231,7 @@ TEST_F(MainWindowTest, DropEventKeepsOnlySupportedFiles) {
     EXPECT_EQ(window->mUriList.size(), 2);
     EXPECT_TRUE(window->mUriList.contains("/tmp/first.mesh"));
     EXPECT_TRUE(window->mUriList.contains("/tmp/second.obj"));
-    EXPECT_FALSE(window->mUriList.contains("/tmp/ignore.txt"));
+    EXPECT_FALSE(window->mUriList.contains("/tmp/ignore.unsupported"));
     delete mimeData;
 }
 


### PR DESCRIPTION
## Summary
- add broader MainWindow coverage for drag/drop, recent files, MCP server state, and merge-animation enablement
- add broader TransformOperator coverage for gizmo visibility, local/world orientation, selection averages, and tracked entity transforms
- target larger uncovered logic blocks to move overall coverage more than the prior small increments

## Testing
- local configure in this worktree is still blocked on long external dependency bootstrap
- GitHub Actions will be the authoritative validation for this batch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / UI Behavior**
  * Drag-and-drop now accepts copy actions and ignores unsupported file types.
  * Recent-files menu entries show basenames, full-path tooltips, and safely handle empty-invocation cases.
  * Merge-animations control enables/disables appropriately based on selection content.
  * Gizmo visibility and tracking now update correctly for translate/rotate/scale/select states and multi-selection scenarios.

* **Tests**
  * Expanded automated tests covering gizmo visibility/positioning, selection scaling/rotation/orientation propagation, entity scale/orientation tracking, drag-and-drop behavior, recent-files handling, and server lifecycle edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->