### PR TITLE
Fix winget-publish: generate manifests directly to avoid Sharprompt CI failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1652,8 +1652,21 @@ jobs:
           # Download ZIP and compute SHA256 without interactive inspection.
           # Using wingetcreate submit (not update) so it never needs to inspect
           # the ZIP interactively, which fails in CI (Sharprompt requires a terminal).
+          # Retry up to 5 times with backoff — the asset may not yet be propagated
+          # when this job starts (mirrors the DMG retry logic in the homebrew job).
           Write-Host "Downloading $url ..."
-          Invoke-WebRequest -Uri $url -OutFile installer.zip
+          for ($attempt = 1; $attempt -le 5; $attempt++) {
+            try {
+              Invoke-WebRequest -Uri $url -OutFile installer.zip
+              break
+            } catch {
+              Remove-Item installer.zip -ErrorAction SilentlyContinue
+              if ($attempt -eq 5) { throw }
+              $delay = $attempt * 15
+              Write-Host "Download attempt $attempt failed. Retrying in $delay seconds..."
+              Start-Sleep -Seconds $delay
+            }
+          }
           $sha256 = (Get-FileHash -Algorithm SHA256 installer.zip).Hash.ToUpper()
           Write-Host "SHA256: $sha256"
 


### PR DESCRIPTION
## Summary
- `wingetcreate update` inspects the ZIP interactively via Sharprompt when there are multiple `NestedInstallerFiles`, causing CI to throw `Sharprompt requires an interactive environment` and silently fail behind `continue-on-error: true`
- Replace with: download ZIP → compute SHA256 → write all three YAML manifests directly → `wingetcreate submit <dir>`
- This bypasses the interactive inspection entirely since `NestedInstallerFiles` are specified explicitly in the generated installer YAML

## Test plan
- [ ] Trigger a release to verify the `winget-publish` job completes without error
- [ ] Confirm a PR is submitted to `microsoft/winget-pkgs` with the correct manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Windows package publishing now generates and submits local installer manifests from the release workflow, with cleaner release version handling.
  * Deployment pipeline error handling tightened: failed submissions now surface as explicit failures, improving reliability and clarity of Windows package updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->