### PR TITLE
Fix winget-publish: switch to wingetcreate update

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1665,111 +1665,37 @@ jobs:
         run: |
           Invoke-WebRequest -Uri https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
 
-      - name: Generate manifests and submit to WinGet
+      - name: Submit to WinGet
         run: |
           $rawTag = "${{ github.event.release.tag_name }}"
-          # Strip leading "v" so manifest PackageVersion and directory are always bare numbers.
-          # GitHub download URLs and ReleaseNotesUrl still use the raw tag.
           $ver = $rawTag.TrimStart("v")
           $url = "https://github.com/fernandotonon/QtMeshEditor/releases/download/${rawTag}/QtMeshEditor-${rawTag}-bin-Windows.zip"
 
-          # Download ZIP and compute SHA256 without interactive inspection.
-          # Using wingetcreate submit (not update) so it never needs to inspect
-          # the ZIP interactively, which fails in CI (Sharprompt requires a terminal).
-          # Retry up to 5 times with backoff — the asset may not yet be propagated
-          # when this job starts (mirrors the DMG retry logic in the homebrew job).
-          Write-Host "Downloading $url ..."
+          # wingetcreate update finds the latest published manifest, bumps version/URL/hash,
+          # and opens a PR — no manual manifest assembly required.
+          # Retry up to 5 times: the release asset may not be propagated yet when this job starts.
+          Write-Host "Submitting version $ver to WinGet via wingetcreate update..."
+          $success = $false
           for ($attempt = 1; $attempt -le 5; $attempt++) {
-            try {
-              Invoke-WebRequest -Uri $url -OutFile installer.zip
-              break
-            } catch {
-              Remove-Item installer.zip -ErrorAction SilentlyContinue
-              if ($attempt -eq 5) { throw }
-              $delay = $attempt * 15
-              Write-Host "Download attempt $attempt failed. Retrying in $delay seconds..."
+            Write-Host "Attempt $attempt ..."
+            .\wingetcreate.exe update FernandoTonon.QtMeshEditor `
+              --version $ver `
+              --urls $url `
+              --submit `
+              --token ${{ secrets.WINGET_TOKEN }} 2>&1 | Tee-Object -Variable output
+            Write-Host $output
+            if ($LASTEXITCODE -eq 0) { $success = $true; break }
+            if ($attempt -lt 5) {
+              $delay = $attempt * 30
+              Write-Host "wingetcreate exited $LASTEXITCODE — retrying in $delay s..."
               Start-Sleep -Seconds $delay
             }
           }
-          $sha256 = (Get-FileHash -Algorithm SHA256 installer.zip).Hash.ToUpper()
-          Write-Host "SHA256: $sha256"
-
-          # Build manifest directory structure
-          $manifestDir = "manifests\f\FernandoTonon\QtMeshEditor\$ver"
-          New-Item -ItemType Directory -Force -Path $manifestDir | Out-Null
-
-          # Write installer.yaml using array-join to avoid here-string YAML ambiguity.
-          # NestedInstallerFiles are specified explicitly — this is the whole point:
-          # wingetcreate submit validates without re-inspecting the ZIP.
-          @(
-            "# yaml-language-server: `$schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json",
-            "PackageIdentifier: FernandoTonon.QtMeshEditor",
-            "PackageVersion: $ver",
-            "InstallerType: zip",
-            "NestedInstallerType: portable",
-            "NestedInstallerFiles:",
-            "  - RelativeFilePath: bin\QtMeshEditor.exe",
-            "    PortableCommandAlias: qtmesheditor",
-            "  - RelativeFilePath: bin\qtmesh.exe",
-            "    PortableCommandAlias: qtmesh",
-            "Installers:",
-            "  - Architecture: x64",
-            "    InstallerUrl: $url",
-            "    InstallerSha256: $sha256",
-            "ManifestType: installer",
-            "ManifestVersion: 1.12.0"
-          ) -join "`n" | Set-Content "$manifestDir\FernandoTonon.QtMeshEditor.installer.yaml" -Encoding UTF8
-
-          # Write locale.en-US.yaml
-          @(
-            "# yaml-language-server: `$schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json",
-            "PackageIdentifier: FernandoTonon.QtMeshEditor",
-            "PackageVersion: $ver",
-            "PackageLocale: en-US",
-            "Publisher: Fernando Tonon",
-            "PublisherUrl: https://github.com/fernandotonon",
-            "PublisherSupportUrl: https://github.com/fernandotonon/QtMeshEditor/issues",
-            "PackageName: QtMeshEditor",
-            "PackageUrl: https://github.com/fernandotonon/QtMeshEditor",
-            "License: MIT",
-            "LicenseUrl: https://github.com/fernandotonon/QtMeshEditor/blob/master/License",
-            "ShortDescription: Free 3D asset tool for indie game developers",
-            "Description: |-",
-            "  QtMeshEditor is a free 3D asset tool for indie game developers.",
-            "  Merge animations from multiple files, convert between 40+ formats,",
-            "  edit materials with AI, and inspect skeletons and bone weights.",
-            "  Supports GUI, CLI (qtmesh), and REST API via MCP server.",
-            "Tags:",
-            "  - 3d",
-            "  - mesh-editor",
-            "  - animation",
-            "  - fbx",
-            "  - gltf",
-            "  - ogre3d",
-            "  - game-development",
-            "  - material-editor",
-            "Moniker: qtmesheditor",
-            "ReleaseNotesUrl: https://github.com/fernandotonon/QtMeshEditor/releases/tag/$rawTag",
-            "ManifestType: defaultLocale",
-            "ManifestVersion: 1.12.0"
-          ) -join "`n" | Set-Content "$manifestDir\FernandoTonon.QtMeshEditor.locale.en-US.yaml" -Encoding UTF8
-
-          # Write version.yaml
-          @(
-            "# yaml-language-server: `$schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json",
-            "PackageIdentifier: FernandoTonon.QtMeshEditor",
-            "PackageVersion: $ver",
-            "DefaultLocale: en-US",
-            "ManifestType: version",
-            "ManifestVersion: 1.12.0"
-          ) -join "`n" | Set-Content "$manifestDir\FernandoTonon.QtMeshEditor.yaml" -Encoding UTF8
-
-          Write-Host "Submitting manifests from $manifestDir ..."
-          .\wingetcreate.exe submit $manifestDir --token ${{ secrets.WINGET_TOKEN }}
-          if ($LASTEXITCODE -ne 0) {
-            Write-Host "::error::wingetcreate submit failed with exit code $LASTEXITCODE"
-            exit $LASTEXITCODE
+          if (-not $success) {
+            Write-Host "::error::wingetcreate update failed after 5 attempts (last exit code $LASTEXITCODE)"
+            exit 1
           }
+          Write-Host "WinGet submission succeeded."
 
 ####################################################################
 # Snap Store Publish (after Linux .deb is built)

--- a/winget/manifests/f/FernandoTonon/QtMeshEditor/2.20.0/FernandoTonon.QtMeshEditor.installer.yaml
+++ b/winget/manifests/f/FernandoTonon/QtMeshEditor/2.20.0/FernandoTonon.QtMeshEditor.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: FernandoTonon.QtMeshEditor
+PackageVersion: 2.20.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: bin\QtMeshEditor.exe
+    PortableCommandAlias: qtmesheditor
+  - RelativeFilePath: bin\qtmesh.exe
+    PortableCommandAlias: qtmesh
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/fernandotonon/QtMeshEditor/releases/download/2.20.0/QtMeshEditor-2.20.0-bin-Windows.zip
+    InstallerSha256: C551020163802E9E725A585F9F4A72068CCB3830C2B4A394E3BD4A3FE3EFE7A2
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/winget/manifests/f/FernandoTonon/QtMeshEditor/2.20.0/FernandoTonon.QtMeshEditor.locale.en-US.yaml
+++ b/winget/manifests/f/FernandoTonon/QtMeshEditor/2.20.0/FernandoTonon.QtMeshEditor.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: FernandoTonon.QtMeshEditor
+PackageVersion: 2.20.0
+PackageLocale: en-US
+Publisher: Fernando Tonon
+PublisherUrl: https://github.com/fernandotonon
+PublisherSupportUrl: https://github.com/fernandotonon/QtMeshEditor/issues
+PackageName: QtMeshEditor
+PackageUrl: https://github.com/fernandotonon/QtMeshEditor
+License: MIT
+LicenseUrl: https://github.com/fernandotonon/QtMeshEditor/blob/master/License
+ShortDescription: Free 3D asset tool for indie game developers
+Description: |-
+  QtMeshEditor is a free 3D asset tool for indie game developers.
+  Merge animations from multiple files, convert between 40+ formats,
+  edit materials with AI, and inspect skeletons and bone weights.
+  Supports GUI, CLI (qtmesh), and REST API via MCP server.
+Tags:
+  - 3d
+  - mesh-editor
+  - animation
+  - fbx
+  - gltf
+  - ogre3d
+  - game-development
+  - material-editor
+Moniker: qtmesheditor
+ReleaseNotesUrl: https://github.com/fernandotonon/QtMeshEditor/releases/tag/2.20.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/winget/manifests/f/FernandoTonon/QtMeshEditor/2.20.0/FernandoTonon.QtMeshEditor.yaml
+++ b/winget/manifests/f/FernandoTonon/QtMeshEditor/2.20.0/FernandoTonon.QtMeshEditor.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: FernandoTonon.QtMeshEditor
+PackageVersion: 2.20.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Problem

The `winget-publish` CI job was failing silently — `wingetcreate submit <dir>` exited with code 1 but produced no visible error output, making it impossible to diagnose.

## Fix

Replace the fragile manual-manifest-assembly + `submit` approach with `wingetcreate update`, which:

- Takes `--version`, `--urls`, and `--submit` as explicit arguments — no YAML hand-crafting required
- Pipes stdout+stderr via `Tee-Object` so any error from wingetcreate is visible in the CI log
- Retries up to 5 times (30 s × attempt) to handle release-asset propagation delays
- Inherits `NestedInstallerFiles` / `PortableCommandAlias` settings from the already-published manifest in `microsoft/winget-pkgs`

## Also included

- `winget/manifests/f/FernandoTonon/QtMeshEditor/2.20.0/` — manifests generated by `scripts/update-winget.sh 2.20.0` for the 2.20.0 release (SHA256: `C551020163802E9E725A585F9F4A72068CCB3830C2B4A394E3BD4A3FE3EFE7A2`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows Package Manager support for QtMeshEditor 2.20.0, enabling users to install via `winget install` command.
  * Improved deployment automation for package publishing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->