### PR TITLE
[codex] increase test coverage for MaterialHighlighter execution paths

### DIFF
--- a/src/MaterialHighlighter_test.cpp
+++ b/src/MaterialHighlighter_test.cpp
@@ -345,15 +345,18 @@ TEST(MaterialHighlighterTest, RealHighlighterFormatsSingleLineCommentAsItalic) {
     QTextDocument doc;
     RealMaterialHighlighter highlighter(&doc);
 
-    doc.setPlainText("material Test // this is a comment");
+    const QString testText = "material Test // this is a comment";
+    doc.setPlainText(testText);
     highlighter.rehighlight();
 
     const QTextBlock block = doc.firstBlock();
     const QList<QTextLayout::FormatRange> formats = block.layout()->formats();
+    const int commentStartPos = testText.indexOf("//");
+    ASSERT_GE(commentStartPos, 0);
 
     bool foundItalicComment = false;
     for (const auto& range : formats) {
-        if (range.start >= 14 && range.format.fontItalic()) {
+        if (range.start >= commentStartPos && range.format.fontItalic()) {
             foundItalicComment = true;
             break;
         }


### PR DESCRIPTION
## Summary
- add 3 execution-based tests in `MaterialHighlighter_test.cpp`
- verify real syntax formatting is applied for keywords
- verify single-line comments are rendered italic in formatted ranges
- verify multiline comment block-state transitions across QTextDocument blocks

## Why
`MaterialHighlighter.cpp` had uncovered paths in runtime formatting and multiline comment state handling. Existing tests were mostly regex-only and did not exercise full highlighter execution on document blocks.

## Impact
- improves regression protection for syntax highlighting behavior
- increases line/branch execution in `MaterialHighlighter.cpp`

## Root Cause
Coverage gaps existed because tests validated regex patterns directly but did not run the full highlighter pipeline on text blocks and block states.

## Validation
- `QT_QPA_PLATFORM=offscreen ./build_cov_local/debug/UnitTests --gtest_filter='MaterialHighlighterTest.*'`
- result: all tests in `MaterialHighlighterTest` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration tests verifying keyword highlighting produces bold styling.
  * Added tests confirming single-line comments are rendered italic from the comment start.
  * Added tests ensuring multi-line comment state correctly propagates across blocks and resets after the closing token.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->