### PR TITLE
fix(ci): replace git-database API with wingetcreate --submit for WinGet publish

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1684,22 +1684,27 @@ jobs:
         run: |
           Invoke-WebRequest -Uri https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
 
-      - name: Generate WinGet manifests
+      - name: Submit to WinGet
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
         run: |
           $rawTag = "${{ github.event.release.tag_name }}"
           $ver = $rawTag.TrimStart("v")
           $url = "https://github.com/fernandotonon/QtMeshEditor/releases/download/${rawTag}/QtMeshEditor-${rawTag}-bin-Windows.zip"
 
-          # wingetcreate downloads the installer to compute its hash, so the release asset
-          # must be propagated before this runs. Retry up to 5 times.
-          Write-Host "Generating manifests for version $ver..."
+          # wingetcreate --submit uses the Contents API (PUT /repos/.../contents/...)
+          # which works with public_repo scope — unlike the git database API (blobs/trees)
+          # which requires repo scope.
+          # Retry up to 5 times to allow the release asset to propagate.
+          Write-Host "Submitting WinGet manifest for version $ver..."
           $success = $false
           for ($attempt = 1; $attempt -le 5; $attempt++) {
             Write-Host "Attempt $attempt ..."
             .\wingetcreate.exe update FernandoTonon.QtMeshEditor `
               --version $ver `
               --urls $url `
-              --out winget-manifests 2>&1 | Tee-Object -Variable output
+              --token $env:WINGET_TOKEN `
+              --submit 2>&1 | Tee-Object -Variable output
             Write-Host $output
             if ($LASTEXITCODE -eq 0) { $success = $true; break }
             if ($attempt -lt 5) {
@@ -1709,102 +1714,10 @@ jobs:
             }
           }
           if (-not $success) {
-            Write-Host "::error::wingetcreate manifest generation failed after 5 attempts"
+            Write-Host "::error::WinGet submission failed after 5 attempts"
             exit 1
           }
-          # Show what was generated
-          Get-ChildItem -Recurse winget-manifests | Select-Object FullName
-
-      - name: Submit PR to WinGet via gh
-        env:
-          GH_TOKEN: ${{ secrets.WINGET_TOKEN }}
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $rawTag = "${{ github.event.release.tag_name }}"
-          $ver = $rawTag.TrimStart("v")
-          $fork = "fernandotonon/winget-pkgs"
-          $branch = "submit-FernandoTonon.QtMeshEditor-$ver"
-
-          # Sync fork with upstream
-          Write-Host "Syncing fork with upstream..."
-          gh repo sync $fork --source microsoft/winget-pkgs --branch master
-
-          # Get base commit SHA from fork master, then resolve to its tree SHA.
-          # GitHub's git/trees API requires a tree SHA for base_tree, not a commit SHA.
-          $baseSha = gh api "repos/$fork/git/ref/heads/master" --jq '.object.sha'
-          Write-Host "Base commit SHA: $baseSha"
-          $baseTreeSha = gh api "repos/$fork/git/commits/$baseSha" --jq '.tree.sha'
-          Write-Host "Base tree SHA: $baseTreeSha"
-
-          # Upload each manifest file as a blob and build the tree array
-          $manifestRelPath = "manifests/f/FernandoTonon/QtMeshEditor/$ver"
-          $localDir = "winget-manifests\$manifestRelPath"
-          $tree = @()
-          foreach ($file in Get-ChildItem $localDir) {
-            Write-Host "Uploading blob: $($file.Name)"
-            $bytes = [System.IO.File]::ReadAllBytes($file.FullName)
-            $b64   = [Convert]::ToBase64String($bytes)
-            $blobSha = gh api "repos/$fork/git/blobs" -X POST `
-              -f "encoding=base64" -f "content=$b64" --jq '.sha'
-            if (-not $blobSha) { throw "Failed to upload blob for $($file.Name)" }
-            $tree += [PSCustomObject]@{
-              path = "$manifestRelPath/$($file.Name)"
-              mode = "100644"
-              type = "blob"
-              sha  = $blobSha
-            }
-          }
-
-          # Create tree on fork (base_tree must be a tree SHA, not a commit SHA)
-          $treeJson = [PSCustomObject]@{ base_tree = $baseTreeSha; tree = $tree } |
-            ConvertTo-Json -Depth 10 -Compress
-          $tmpTree = [System.IO.Path]::GetTempFileName()
-          try {
-            [System.IO.File]::WriteAllText($tmpTree, $treeJson)
-            $treeSha = gh api "repos/$fork/git/trees" -X POST --input $tmpTree --jq '.sha'
-          } finally { Remove-Item $tmpTree -ErrorAction SilentlyContinue }
-          if (-not $treeSha) { throw "Failed to create git tree" }
-          Write-Host "Tree SHA: $treeSha"
-
-          # Create commit on fork
-          $commitJson = [PSCustomObject]@{
-            message = "Add FernandoTonon.QtMeshEditor $ver"
-            tree    = $treeSha
-            parents = @($baseSha)
-          } | ConvertTo-Json -Compress
-          $tmpCommit = [System.IO.Path]::GetTempFileName()
-          try {
-            [System.IO.File]::WriteAllText($tmpCommit, $commitJson)
-            $commitSha = gh api "repos/$fork/git/commits" -X POST --input $tmpCommit --jq '.sha'
-          } finally { Remove-Item $tmpCommit -ErrorAction SilentlyContinue }
-          if (-not $commitSha) { throw "Failed to create git commit" }
-          Write-Host "Commit SHA: $commitSha"
-
-          # Push new branch to fork (idempotent: update ref if branch already exists)
-          $refExists = gh api "repos/$fork/git/ref/heads/$branch" --jq '.ref' 2>$null
-          if ($refExists) {
-            Write-Host "Branch already exists — updating ref..."
-            gh api "repos/$fork/git/refs/heads/$branch" -X PATCH -f "sha=$commitSha" -f "force=true"
-          } else {
-            gh api "repos/$fork/git/refs" -X POST `
-              -f "ref=refs/heads/$branch" -f "sha=$commitSha"
-          }
-          Write-Host "Branch ready: $branch"
-
-          # Open PR against microsoft/winget-pkgs (skip if one already exists for this branch)
-          $existingPr = gh pr list --repo microsoft/winget-pkgs `
-            --head "fernandotonon:$branch" --base master --state open --json url --jq '.[0].url' 2>$null
-          if ($existingPr) {
-            Write-Host "PR already exists: $existingPr — skipping creation."
-          } else {
-            gh pr create `
-              --repo microsoft/winget-pkgs `
-              --title "Add FernandoTonon.QtMeshEditor $ver" `
-              --body "Submitting FernandoTonon.QtMeshEditor version $ver.`n`nAuto-generated by QtMeshEditor CI." `
-              --head "fernandotonon:$branch" `
-              --base master
-            Write-Host "WinGet PR submitted successfully."
-          }
+          Write-Host "WinGet PR submitted successfully."
 
 ####################################################################
 # Snap Store Publish (after Linux .deb is built)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,7 +237,7 @@ QtMeshEditor is available via WinGet: `winget install FernandoTonon.QtMeshEditor
 - `.github/workflows/deploy.yml` — `winget-publish` job auto-submits to microsoft/winget-pkgs on release
 
 **Updating for new release:**
-The `winget-publish` CI job uses `wingetcreate` to automatically submit a PR to microsoft/winget-pkgs when a GitHub Release is published. Requires a `WINGET_TOKEN` secret (GitHub PAT with `public_repo` scope for the winget-pkgs fork).
+The `winget-publish` CI job uses `wingetcreate --submit` to automatically submit a PR to microsoft/winget-pkgs when a GitHub Release is published. Requires a `WINGET_TOKEN` secret (GitHub PAT with `public_repo` scope). **Do not use the git database API** (blobs/trees/commits endpoints) — that requires `repo` scope. `wingetcreate --submit` uses the Contents API which works with `public_repo`.
 
 Manual alternative: `./scripts/update-winget.sh <version>` generates the manifest locally.
 


### PR DESCRIPTION
## Problem

The `winget-publish` job was failing with HTTP 403 on every release because the manual git database API (blobs/trees/commits) requires **`repo` scope**, but `WINGET_TOKEN` only has **`public_repo` scope**.

Additional bugs in the old script:
- `-f "force=true"` should be `-F "force=true"` (string vs boolean in `gh api` PATCH refs)
- `$ErrorActionPreference = 'Stop'` doesn't terminate on native executable failures — errors cascaded silently, passing JSON error strings as commit SHAs

## Fix

Replace the two-step "generate manifests → manual gh api" flow with a single `wingetcreate --submit --token` call.

`wingetcreate --submit` uses GitHub's **Contents API** (`PUT /repos/.../contents/...`) which works with `public_repo` scope. The 5-attempt retry loop is preserved for release asset propagation delay.

## Test plan

- [ ] CI `winget-publish` job passes on next release
- [ ] `wingetcreate --submit` creates a PR in microsoft/winget-pkgs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Windows WinGet publishing workflow for faster, more direct package submissions.

* **Documentation**
  * Updated WinGet release automation guidance documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->