### PR TITLE
[codex] Reposition website as a 3D asset pipeline tool

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -3,18 +3,18 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>QtMeshEditor | Merge Mixamo Animations & Automate 3D Asset Pipelines</title>
+    <title>QtMeshEditor | CI/CD for 3D Assets</title>
     <meta
       name="description"
-      content="QtMeshEditor helps indie game developers merge Mixamo animations in seconds, convert 40+ 3D formats, inspect skeletons, and automate asset workflows with the qtmesh CLI."
+      content="QtMeshEditor is a 3D asset pipeline tool for scan and validation workflows, mesh fixes, format conversion, animation merge, and CI/CD automation with CLI, Docker, and GitHub Actions."
     />
     <link rel="canonical" href="https://fernandotonon.github.io/QtMeshEditor/" />
 
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="QtMeshEditor | Merge Mixamo Animations & Automate 3D Asset Pipelines" />
+    <meta property="og:title" content="QtMeshEditor | CI/CD for 3D Assets" />
     <meta
       property="og:description"
-      content="Merge animations, convert and inspect 3D assets, and automate your pipeline with GUI + CLI tooling."
+      content="Automate your 3D asset pipeline: scan, validate, fix, convert, and merge assets using GUI + CLI + GitHub Actions."
     />
     <meta property="og:url" content="https://fernandotonon.github.io/QtMeshEditor/" />
     <meta
@@ -23,10 +23,10 @@
     />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="QtMeshEditor | Merge Mixamo Animations & Automate 3D Asset Pipelines" />
+    <meta name="twitter:title" content="QtMeshEditor | CI/CD for 3D Assets" />
     <meta
       name="twitter:description"
-      content="A focused 3D asset tool for indie devs: Mixamo merge workflows, 40+ format conversion, and qtmesh CLI automation."
+      content="A practical 3D asset pipeline tool for indie teams and studios: scan, fix, convert, merge, and automate with qtmesh."
     />
     <meta
       name="twitter:image"
@@ -53,7 +53,7 @@
         "license": "https://opensource.org/license/mit",
         "url": "https://github.com/fernandotonon/QtMeshEditor",
         "downloadUrl": "https://github.com/fernandotonon/QtMeshEditor/releases/latest",
-        "description": "Open-source 3D asset tool for indie game developers. Merge Mixamo animations, convert 40+ formats, inspect skeletons, and automate pipelines with qtmesh CLI."
+        "description": "Open-source 3D asset pipeline tool for indie teams and studios. Scan and validate assets, fix and optimize meshes, convert formats, merge animations, and automate CI/CD with qtmesh CLI."
       }
     </script>
   </head>

--- a/website/index.html
+++ b/website/index.html
@@ -6,7 +6,7 @@
     <title>QtMeshEditor | CI/CD for 3D Assets</title>
     <meta
       name="description"
-      content="QtMeshEditor is a 3D asset pipeline tool for scan and validation workflows, mesh fixes, format conversion, animation merge, and CI/CD automation with CLI, Docker, and GitHub Actions."
+      content="QtMeshEditor is a 3D asset pipeline tool with scan and validation preview workflows, mesh fixes, format conversion, animation merge, and CI/CD automation with CLI, Docker, and GitHub Actions."
     />
     <link rel="canonical" href="https://fernandotonon.github.io/QtMeshEditor/" />
 
@@ -14,7 +14,7 @@
     <meta property="og:title" content="QtMeshEditor | CI/CD for 3D Assets" />
     <meta
       property="og:description"
-      content="Automate your 3D asset pipeline: scan, validate, fix, convert, and merge assets using GUI + CLI + GitHub Actions."
+      content="Automate your 3D asset pipeline with preview scan/validation plus fix, convert, and merge workflows using GUI + CLI + GitHub Actions."
     />
     <meta property="og:url" content="https://fernandotonon.github.io/QtMeshEditor/" />
     <meta
@@ -26,7 +26,7 @@
     <meta name="twitter:title" content="QtMeshEditor | CI/CD for 3D Assets" />
     <meta
       name="twitter:description"
-      content="A practical 3D asset pipeline tool for indie teams and studios: scan, fix, convert, merge, and automate with qtmesh."
+      content="A practical 3D asset pipeline tool for indie teams and studios: preview scan/validation, fix, convert, merge, and automate with qtmesh."
     />
     <meta
       name="twitter:image"
@@ -53,7 +53,7 @@
         "license": "https://opensource.org/license/mit",
         "url": "https://github.com/fernandotonon/QtMeshEditor",
         "downloadUrl": "https://github.com/fernandotonon/QtMeshEditor/releases/latest",
-        "description": "Open-source 3D asset pipeline tool for indie teams and studios. Scan and validate assets, fix and optimize meshes, convert formats, merge animations, and automate CI/CD with qtmesh CLI."
+        "description": "Open-source 3D asset pipeline tool for indie teams and studios. Includes preview scan and validation workflows plus mesh fixing, optimization, format conversion, animation merging, and CI/CD automation with qtmesh CLI."
       }
     </script>
   </head>

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -102,7 +102,7 @@ function App() {
     [detectedPlatform]
   );
   const recommendedStore = recommendedInstall ? getStoreLabel(recommendedInstall.method) : null;
-  const primaryCtaLabel = recommendedStore ? `Install via ${recommendedStore}` : hero.ctaPrimary;
+  const primaryCtaLabel = recommendedStore ? `Install via ${recommendedStore}` : 'Open Install Portal';
 
   useEffect(() => {
     if (!isInstallPortalOpen || typeof document === 'undefined') {
@@ -322,6 +322,7 @@ function App() {
               <CodePanel title="Fix and optimize" code={pipelineExamples.fix} label="fix" />
               <CodePanel title="Convert formats" code={pipelineExamples.convert} label="convert" />
               <CodePanel title="Merge animations" code={pipelineExamples.merge} label="anim" />
+              <CodePanel title="Docker" code={pipelineExamples.docker} label="docker" />
               <CodePanel title="GitHub Actions" code={pipelineExamples.githubAction} label="ci" />
             </div>
 

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -6,15 +6,15 @@ import CodePanel from './components/CodePanel';
 import FeatureCard from './components/FeatureCard';
 import Section from './components/Section';
 import {
-  comparisonItems,
   footerLinks,
   hero,
   highlightFeatures,
   installOptions,
   links,
   media,
-  mergeSteps,
+  mixamoSteps,
   pipelineExamples,
+  pipelineFlow,
   proofPoints,
   trustItems,
   useCases
@@ -102,7 +102,7 @@ function App() {
     [detectedPlatform]
   );
   const recommendedStore = recommendedInstall ? getStoreLabel(recommendedInstall.method) : null;
-  const primaryCtaLabel = recommendedStore ? `Install via ${recommendedStore}` : 'Open Install Portal';
+  const primaryCtaLabel = recommendedStore ? `Install via ${recommendedStore}` : hero.ctaPrimary;
 
   useEffect(() => {
     if (!isInstallPortalOpen || typeof document === 'undefined') {
@@ -230,11 +230,11 @@ function App() {
                 >
                   {primaryCtaLabel}
                 </button>
-                <ButtonLink href={links.docs} variant="secondary">
-                  {hero.ctaDocs}
-                </ButtonLink>
                 <ButtonLink href={links.github} variant="secondary">
                   {hero.ctaSecondary}
+                </ButtonLink>
+                <ButtonLink href={links.docs} variant="secondary">
+                  {hero.ctaDocs}
                 </ButtonLink>
               </div>
 
@@ -248,142 +248,160 @@ function App() {
             </div>
 
             <figure className={styles.heroMediaCard}>
-              <img className={styles.heroImage} src={media.mergeDemo.src} alt={media.mergeDemo.alt} />
-              <figcaption className={styles.mediaCaption}>Merge workflow in action</figcaption>
+              <img className={styles.heroImage} src={media.skeletonPreview.src} alt={media.skeletonPreview.alt} />
+              <figcaption className={styles.mediaCaption}>Pipeline validation and inspection workflow</figcaption>
             </figure>
           </header>
 
-        <Section
-          id="demo"
-          eyebrow="Visual Proof"
-          title="Merge animation clips without pipeline friction"
-          subtitle="The main workflow stays focused: load assets, merge clips, export to the format your engine needs."
-        >
-          <div className={styles.demoLayout}>
-            <figure className={`${styles.demoMain} reveal`}>
-              <img className={styles.demoImage} src={media.mergeDemo.src} alt={media.mergeDemo.alt} loading="lazy" />
-            </figure>
-
-            <ol className={styles.steps}>
-              {mergeSteps.map((step, index) => (
-                <li key={step.title} className={styles.stepItem}>
-                  <span className={styles.stepIndex}>{index + 1}</span>
-                  <div>
-                    <h3 className={styles.stepTitle}>{step.title}</h3>
-                    <p className={styles.stepBody}>{step.body}</p>
-                  </div>
-                </li>
+          <Section
+            id="pipeline"
+            eyebrow="Pipeline Overview"
+            title="CI/CD for 3D assets"
+            subtitle="One toolchain for scan, validate, fix, convert, and publish across local scripts and automation workflows. Scan and validation are being expanded as first-class pipeline checks."
+          >
+            <div className={styles.pipelineFlow}>
+              {pipelineFlow.map((item, index) => (
+                <article key={item.title} className={styles.pipelineNode}>
+                  <span className={styles.pipelineNodeIndex}>{index + 1}</span>
+                  <h3 className={styles.pipelineNodeTitle}>{item.title}</h3>
+                  <p className={styles.pipelineNodeBody}>{item.body}</p>
+                </article>
               ))}
-            </ol>
-          </div>
+            </div>
 
-          <div className={styles.previewStrip}>
-            <figure className={styles.previewCard}>
-              <img src={media.skeletonPreview.src} alt={media.skeletonPreview.alt} loading="lazy" />
-              <figcaption>Skeleton and weight inspection</figcaption>
-            </figure>
-            <figure className={styles.previewCard}>
-              <img src={media.aiMaterials.src} alt={media.aiMaterials.alt} loading="lazy" />
-              <figcaption>AI-assisted materials</figcaption>
-            </figure>
-            <figure className={styles.previewCard}>
-              <img src={media.mcpPreview.src} alt={media.mcpPreview.alt} loading="lazy" />
-              <figcaption>MCP tool integration</figcaption>
-            </figure>
-          </div>
-        </Section>
+            <div className={styles.demoLayout}>
+              <figure className={`${styles.demoMain} reveal`}>
+                <img
+                  className={styles.demoImage}
+                  src={media.skeletonPreview.src}
+                  alt={media.skeletonPreview.alt}
+                  loading="lazy"
+                />
+              </figure>
 
-        <Section
-          id="use-cases"
-          eyebrow="Core Workflows"
-          title="Built for daily gamedev asset tasks"
-          subtitle="QtMeshEditor prioritizes real production tasks over generic feature sprawl."
-        >
-          <div className={styles.useCaseGrid}>
-            {useCases.map((item) => (
-              <FeatureCard key={item.title} title={item.title} body={item.body} tag="Core" />
-            ))}
-          </div>
-        </Section>
+              <article className={styles.pipelinePanel}>
+                <h3>Pipeline run in three commands</h3>
+                <p>
+                  Use the same command sequence in local checks and CI jobs to keep asset handling deterministic.
+                </p>
+                <pre className={styles.pipelineSnippet}>
+                  <code>{pipelineExamples.scanFixConvert}</code>
+                </pre>
+              </article>
+            </div>
+          </Section>
 
-        <Section
-          id="cli"
-          eyebrow="Scriptable Pipeline"
-          title="Use qtmesh in local scripts, Docker, and CI"
-          subtitle="Run the same commands locally and in build pipelines to keep asset processing repeatable and team-friendly."
-        >
-          <div className={styles.cliIntro}>
-            <p>
-              The <code>qtmesh</code> CLI ships with QtMeshEditor and is designed for production automation.
-              Use it for format conversion, asset inspection, and animation merge tasks without opening the GUI.
-            </p>
-            <p>
-              Docker image and GitHub Action support are available for containerized workflows and CI/CD pipelines.
-            </p>
-          </div>
+          <Section
+            id="use-cases"
+            eyebrow="Core Use Cases"
+            title="Built for real asset production tasks"
+            subtitle="Pipeline-focused workflows for technical artists, indie teams, and studios shipping content continuously."
+          >
+            <div className={styles.useCaseGrid}>
+              {useCases.map((item) => (
+                <FeatureCard key={item.title} title={item.title} body={item.body} tag="Pipeline" />
+              ))}
+            </div>
+          </Section>
 
-          <div className={styles.codeGrid}>
-            <CodePanel title="Inspect meshes" code={pipelineExamples.inspect} />
-            <CodePanel title="Convert formats" code={pipelineExamples.convert} />
-            <CodePanel title="Merge animations" code={pipelineExamples.merge} />
-            <CodePanel title="Docker CLI" code={pipelineExamples.docker} label="docker" />
-            <CodePanel title="GitHub Actions" code={pipelineExamples.githubAction} label="ci" />
-          </div>
+          <Section
+            id="cli"
+            eyebrow="CLI + CI"
+            title="Script your 3D asset pipeline"
+            subtitle="Run the same `qtmesh` operations locally, in Docker, and inside GitHub Actions."
+          >
+            <div className={styles.cliIntro}>
+              <p>
+                Repo-wide scan and validation commands are expanding. The examples below show the intended pipeline
+                shape while keeping fix, convert, merge, and automation fully scriptable today.
+              </p>
+            </div>
 
-          <div className={styles.cliLinks}>
-            <a href={links.actions} target="_blank" rel="noreferrer">
-              GitHub Action
-            </a>
-            <a href={links.releases} target="_blank" rel="noreferrer">
-              Latest release binaries
-            </a>
-            <a href={links.docs} target="_blank" rel="noreferrer">
-              Full documentation
-            </a>
-          </div>
-        </Section>
+            <div className={styles.codeGrid}>
+              <CodePanel title="Scan repo assets" code={pipelineExamples.scan} label="scan" />
+              <CodePanel title="Fix and optimize" code={pipelineExamples.fix} label="fix" />
+              <CodePanel title="Convert formats" code={pipelineExamples.convert} label="convert" />
+              <CodePanel title="Merge animations" code={pipelineExamples.merge} label="anim" />
+              <CodePanel title="GitHub Actions" code={pipelineExamples.githubAction} label="ci" />
+            </div>
 
-        <Section
-          id="comparison"
-          eyebrow="Why It Works"
-          title="Pick the right mode for each step"
-          subtitle="Manual edits, scripted tasks, and CI pipelines can all use the same toolchain."
-        >
-          <div className={styles.comparisonGrid}>
-            {comparisonItems.map((item) => (
-              <FeatureCard key={item.title} title={item.title} body={item.body} />
-            ))}
-          </div>
-        </Section>
+            <div className={styles.cliLinks}>
+              <a href={links.actions} target="_blank" rel="noreferrer">
+                GitHub Action
+              </a>
+              <a href={links.docs} target="_blank" rel="noreferrer">
+                CLI Documentation
+              </a>
+              <a href={links.releases} target="_blank" rel="noreferrer">
+                Latest release binaries
+              </a>
+            </div>
+          </Section>
 
-        <Section
-          id="features"
-          eyebrow="Extended Features"
-          title="Advanced capabilities when you need them"
-          subtitle="AI and integration features are available without obscuring the core asset workflow."
-        >
-          <div className={styles.highlightGrid}>
-            {highlightFeatures.map((feature) => (
-              <FeatureCard
-                key={feature.title}
-                title={feature.title}
-                body={feature.body}
-                tag={feature.title.includes('AI') || feature.title.includes('MCP') ? 'Advanced' : 'Feature'}
-              />
-            ))}
-          </div>
-        </Section>
+          <Section
+            id="mixamo"
+            eyebrow="Animation Merge Workflow"
+            title="Fast Mixamo and Unreal animation merging"
+            subtitle="Use QtMeshEditor as a practical entry-point workflow, then plug output directly into the broader pipeline."
+          >
+            <div className={styles.demoLayout}>
+              <figure className={`${styles.demoMain} reveal`}>
+                <img className={styles.demoImage} src={media.mergeDemo.src} alt={media.mergeDemo.alt} loading="lazy" />
+              </figure>
+
+              <ol className={styles.steps}>
+                {mixamoSteps.map((step, index) => (
+                  <li key={step.title} className={styles.stepItem}>
+                    <span className={styles.stepIndex}>{index + 1}</span>
+                    <div>
+                      <h3 className={styles.stepTitle}>{step.title}</h3>
+                      <p className={styles.stepBody}>{step.body}</p>
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            </div>
+          </Section>
+
+          <Section
+            id="features"
+            eyebrow="Advanced Features"
+            title="Extended capabilities for specialized workflows"
+            subtitle="Advanced tools stay available without overshadowing the core pipeline flow."
+          >
+            <div className={styles.highlightGrid}>
+              {highlightFeatures.map((feature) => (
+                <FeatureCard
+                  key={feature.title}
+                  title={feature.title}
+                  body={feature.body}
+                  tag={feature.title.includes('AI') || feature.title.includes('MCP') ? 'Advanced' : 'Feature'}
+                />
+              ))}
+            </div>
+
+            <div className={styles.previewStrip}>
+              <figure className={styles.previewCard}>
+                <img src={media.aiMaterials.src} alt={media.aiMaterials.alt} loading="lazy" />
+                <figcaption>Material editing workflows for look-dev and technical review.</figcaption>
+              </figure>
+              <figure className={styles.previewCard}>
+                <img src={media.mcpPreview.src} alt={media.mcpPreview.alt} loading="lazy" />
+                <figcaption>MCP integration for advanced agent-driven automation.</figcaption>
+              </figure>
+            </div>
+          </Section>
 
           <Section
             id="install"
             eyebrow="Install"
             title="Install QtMeshEditor your way"
-            subtitle="Open the install portal to get store-first commands for your platform."
+            subtitle="Store-first installs with winget, Homebrew, and snap, plus Docker and release binaries."
           >
             <div className={styles.installPortalEntry}>
               <p>
                 Store options include <code>winget</code>, <code>Homebrew</code>, and <code>snap</code>. You can also
-                download binaries directly from the latest release.
+                use Docker or download binaries from the latest release.
               </p>
               <div className={styles.installPortalEntryActions}>
                 <button
@@ -404,7 +422,7 @@ function App() {
             id="trust"
             eyebrow="Open Source Trust"
             title="Built in public for long-term production use"
-            subtitle="Used by developers around the world for practical 3D asset preparation and pipeline automation."
+            subtitle="Open source, multi-platform, and focused on practical pipeline outcomes for small teams and studios."
           >
             <div className={styles.trustLead}>
               <a href="https://github.com/fernandotonon/QtMeshEditor/stargazers" target="_blank" rel="noreferrer">
@@ -486,9 +504,7 @@ function App() {
 
               <div className={styles.installPortalGrid}>
                 {recommendedInstall ? (
-                  <article
-                    className={`${styles.installPortalCard} ${styles.installPortalCardRecommended}`}
-                  >
+                  <article className={`${styles.installPortalCard} ${styles.installPortalCardRecommended}`}>
                     <div className={styles.installPortalCardTop}>
                       <h3>{recommendedInstall.platform}</h3>
                       <div className={styles.installPortalCardActions}>

--- a/website/src/App.module.css
+++ b/website/src/App.module.css
@@ -525,7 +525,7 @@
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.codeGrid > :nth-child(5) {
+.codeGrid > :nth-child(6) {
   grid-column: span 2;
 }
 
@@ -671,7 +671,7 @@
     grid-template-columns: 1fr;
   }
 
-  .codeGrid > :nth-child(5) {
+  .codeGrid > :nth-child(6) {
     grid-column: auto;
   }
 

--- a/website/src/App.module.css
+++ b/website/src/App.module.css
@@ -325,11 +325,86 @@
   font-size: 0.83rem;
 }
 
+.pipelineFlow {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.8rem;
+  margin-bottom: 1rem;
+}
+
+.pipelineNode {
+  border: 1px solid var(--stroke);
+  border-radius: 0.95rem;
+  background: linear-gradient(180deg, rgba(16, 24, 40, 0.95), rgba(11, 17, 30, 0.96));
+  padding: 0.9rem;
+  min-height: 154px;
+}
+
+.pipelineNodeIndex {
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 999px;
+  border: 1px solid rgba(46, 188, 255, 0.4);
+  background: rgba(46, 188, 255, 0.16);
+  color: var(--accent-1);
+  font-size: 0.82rem;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.pipelineNodeTitle {
+  margin: 0.5rem 0 0;
+  font-size: 1rem;
+}
+
+.pipelineNodeBody {
+  margin: 0.4rem 0 0;
+  color: var(--text-1);
+  font-size: 0.9rem;
+  line-height: 1.48;
+}
+
 .demoLayout {
   display: grid;
   grid-template-columns: 1.2fr 0.8fr;
   gap: 1rem;
   align-items: start;
+}
+
+.pipelinePanel {
+  border: 1px solid var(--stroke);
+  border-radius: 0.95rem;
+  padding: 0.9rem;
+  background: linear-gradient(180deg, rgba(13, 21, 35, 0.98), rgba(10, 15, 26, 0.98));
+}
+
+.pipelinePanel h3 {
+  margin: 0;
+  font-size: 1.03rem;
+}
+
+.pipelinePanel p {
+  margin: 0.5rem 0 0;
+  color: var(--text-1);
+  font-size: 0.91rem;
+}
+
+.pipelineSnippet {
+  margin: 0.75rem 0 0;
+  border: 1px solid var(--stroke-strong);
+  border-radius: 0.75rem;
+  padding: 0.7rem 0.8rem;
+  overflow-x: auto;
+  background: rgba(7, 12, 20, 0.9);
+}
+
+.pipelineSnippet code {
+  color: #baf6ff;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  white-space: pre;
 }
 
 .demoMain {
@@ -394,7 +469,7 @@
 .previewStrip {
   margin-top: 1rem;
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.8rem;
 }
 
@@ -556,6 +631,7 @@
     grid-template-columns: 1fr;
   }
 
+  .pipelineFlow,
   .useCaseGrid,
   .comparisonGrid,
   .trustGrid {
@@ -585,6 +661,7 @@
   }
 
   .previewStrip,
+  .pipelineFlow,
   .useCaseGrid,
   .codeGrid,
   .comparisonGrid,

--- a/website/src/data/content.js
+++ b/website/src/data/content.js
@@ -82,12 +82,12 @@ export const useCases = [
 ];
 
 export const pipelineExamples = {
-  scan: `# Preview workflow (actively evolving)\nqtmesh scan ./assets --fail-on error\nqtmesh scan ./assets --format sarif -o reports/qtmesh.sarif`,
+  scan: `# Preview workflow (actively evolving)\nqtmesh scan ./assets --fail-on error\nqtmesh scan ./assets --sarif reports/qtmesh.sarif --report reports/qtmesh.json`,
   fix: `qtmesh fix model.fbx -o fixed.fbx\nqtmesh fix model.fbx --all -o fixed.fbx`,
   convert: `qtmesh convert model.fbx -o model.glb2\nqtmesh convert model.dae -o model.mesh`,
   merge: `qtmesh anim base.fbx \\\n  --merge walk.fbx run.fbx jump.fbx idle.fbx \\\n  -o merged.fbx`,
   docker: `docker run --rm --user "$(id -u):$(id -g)" -v $(pwd):/workspace \\\n  ghcr.io/fernandotonon/qtmesh scan ./assets --fail-on error`,
-  githubAction: `- uses: fernandotonon/QtMeshEditor/.github/actions/qtmesh@master\n  with:\n    command: scan\n    input-file: assets\n    options: --fail-on error`,
+  githubAction: `- uses: fernandotonon/QtMeshEditor/.github/actions/qtmesh@c56db1ce3f2b29960cc1c9f82f5be98a51594138\n  with:\n    command: scan\n    input-file: assets\n    options: --fail-on error`,
   scanFixConvert: `qtmesh scan ./assets --fail-on error\nqtmesh fix character.fbx --all -o character_fixed.fbx\nqtmesh convert character_fixed.fbx -o character.glb2`
 };
 

--- a/website/src/data/content.js
+++ b/website/src/data/content.js
@@ -16,7 +16,7 @@ export const media = {
   },
   skeletonPreview: {
     src: 'https://github.com/user-attachments/assets/289403ac-8952-488c-bc65-0a768ab278e1',
-    alt: 'Bone weight visualization inside QtMeshEditor'
+    alt: 'Bone weight and skeleton validation preview in QtMeshEditor'
   },
   mcpPreview: {
     src: 'https://github.com/user-attachments/assets/ed3b7e9d-22ba-4e6e-a06c-868570db7a07',
@@ -29,106 +29,99 @@ export const media = {
 };
 
 export const hero = {
-  title: 'Merge Mixamo animations and ship 3D assets faster.',
+  title: 'Automate your 3D asset pipeline.',
   subtitle:
-    'QtMeshEditor is a focused GUI + CLI toolkit for indie teams: merge animation clips, convert 40+ formats, inspect skeletons, and automate repeatable asset tasks.',
+    'QtMeshEditor gives indie teams and studios one technical workflow to fix, convert, merge, and automate 3D assets with GUI + CLI + CI/CD support, with repo-wide scanning and validation evolving quickly.',
   ctaPrimary: 'Download Latest',
   ctaSecondary: 'View on GitHub',
   ctaDocs: 'Documentation'
 };
 
-export const proofPoints = ['Free & open source', 'Windows / macOS / Linux', 'GUI + CLI', '40+ formats'];
+export const proofPoints = ['Free & open source', 'Windows / macOS / Linux', 'GUI + CLI', 'Docker + GitHub Actions'];
 
-export const mergeSteps = [
+export const pipelineFlow = [
   {
-    title: 'Load files',
-    body: 'Import your base character and animation clips from Mixamo, Unreal export, or DCC tools.'
+    title: 'Scan',
+    body: 'Pipeline scanning is in active development, focused on repo-wide checks for broken files and policy issues.'
   },
   {
-    title: 'Merge animations',
-    body: 'Select clips and merge them into one clean character file in seconds.'
+    title: 'Validate',
+    body: 'Evolving validation workflows enforce consistency for geometry, naming, and structure before integration.'
   },
   {
-    title: 'Export to your engine',
-    body: 'Export to glTF, FBX-compatible workflows, Collada, OBJ, or Ogre Mesh and keep moving.'
+    title: 'Fix & Optimize',
+    body: 'Apply deterministic cleanup and optimization steps so assets remain stable across machines and CI jobs.'
+  },
+  {
+    title: 'Convert & Ship',
+    body: 'Export to engine-ready formats and publish artifacts from local scripts, Docker, or GitHub Actions.'
   }
 ];
 
 export const useCases = [
   {
-    title: 'Merge animations',
-    body: 'Combine separate animation clips into one asset to simplify import and iteration.'
+    title: 'Scan assets in repositories (in progress)',
+    body: 'Add repo-wide checks that surface pipeline issues early and support stricter CI gates over time.'
   },
   {
-    title: 'Convert formats',
-    body: 'Move assets across DCC tools and engines with import/export support for 40+ formats.'
+    title: 'Fix and optimize meshes',
+    body: 'Repair and optimize imported assets to keep runtime and tooling behavior predictable.'
   },
   {
-    title: 'Inspect skeletons and weights',
-    body: 'Audit bone hierarchies, inspect skinning, and catch rig problems before runtime.'
+    title: 'Convert across formats',
+    body: 'Move assets between DCC tools and engines with import/export support for 40+ formats.'
   },
   {
-    title: 'Automate with qtmesh CLI',
-    body: 'Run conversions, merges, and checks from scripts, CI jobs, and build pipelines.'
+    title: 'Merge animation clips',
+    body: 'Combine Mixamo, Unreal exports, and DCC clips into clean output files for engine ingestion.'
+  },
+  {
+    title: 'Run in CI/CD',
+    body: 'Use the same commands in local scripts, Docker containers, and GitHub Actions workflows.'
   }
 ];
 
 export const pipelineExamples = {
-  inspect: `qtmesh info model.fbx
-qtmesh info model.fbx --json`,
-  convert: `qtmesh convert model.fbx -o model.gltf2
-qtmesh convert model.dae -o model.mesh`,
-  merge: `qtmesh anim base.fbx \\
-  --merge walk.fbx run.fbx jump.fbx idle.fbx \\
-  -o merged.fbx`,
-  docker: `docker run --rm --user "$(id -u):$(id -g)" -v $(pwd):/workspace \\
-  ghcr.io/fernandotonon/qtmesh convert model.fbx -o model.gltf2`,
-  githubAction: `- uses: fernandotonon/QtMeshEditor/.github/actions/qtmesh@master
-  with:
-    command: anim
-    input-file: assets/base.fbx
-    options: --merge assets/walk.fbx assets/run.fbx -o assets/merged.fbx`
+  scan: `# Preview workflow (actively evolving)\nqtmesh scan ./assets --fail-on error\nqtmesh scan ./assets --format sarif -o reports/qtmesh.sarif`,
+  fix: `qtmesh fix model.fbx -o fixed.fbx\nqtmesh fix model.fbx --all -o fixed.fbx`,
+  convert: `qtmesh convert model.fbx -o model.glb2\nqtmesh convert model.dae -o model.mesh`,
+  merge: `qtmesh anim base.fbx \\\n  --merge walk.fbx run.fbx jump.fbx idle.fbx \\\n  -o merged.fbx`,
+  docker: `docker run --rm --user "$(id -u):$(id -g)" -v $(pwd):/workspace \\\n  ghcr.io/fernandotonon/qtmesh scan ./assets --fail-on error`,
+  githubAction: `- uses: fernandotonon/QtMeshEditor/.github/actions/qtmesh@master\n  with:\n    command: scan\n    input-file: assets\n    options: --fail-on error`,
+  scanFixConvert: `qtmesh scan ./assets --fail-on error\nqtmesh fix character.fbx --all -o character_fixed.fbx\nqtmesh convert character_fixed.fbx -o character.glb2`
 };
 
-export const comparisonItems = [
+export const mixamoSteps = [
   {
-    title: 'GUI for manual work',
-    body: 'Visual editing for skeleton fixes, material tweaks, and export validation.'
+    title: 'Import base + clips',
+    body: 'Load a base character and animation clips from Mixamo, Unreal export, or DCC tools.'
   },
   {
-    title: 'CLI for automation',
-    body: 'Scriptable commands for repeatable conversion and merge jobs.'
+    title: 'Merge into one asset',
+    body: 'Compose multiple actions into one predictable output file for gameplay integration.'
   },
   {
-    title: 'Docker + Actions for pipelines',
-    body: 'Containerize qtmesh and run asset steps inside GitHub Actions CI/CD.'
+    title: 'Export to your runtime format',
+    body: 'Export to glTF, FBX-compatible workflows, Collada, OBJ, or Ogre Mesh and continue the pipeline.'
   }
 ];
 
 export const highlightFeatures = [
   {
     title: 'Scene save/load',
-    body: 'Store complete scenes with meshes, transforms, materials, skeletons, and animations.'
+    body: 'Store full scenes with meshes, transforms, materials, skeletons, and animations for repeatable edits.'
   },
   {
-    title: 'Material editor',
-    body: 'Adjust material values with realtime visual feedback during look-dev.'
-  },
-  {
-    title: 'AI-assisted materials',
-    body: 'Generate or refine material setups quickly when exploration speed matters.'
-  },
-  {
-    title: 'MCP / AI agent integration',
-    body: 'Expose editor tools through MCP for advanced scripted agent workflows.'
+    title: 'Material tools',
+    body: 'Adjust materials visually with realtime feedback during look-dev and technical review.'
   },
   {
     title: 'REST API',
     body: 'Drive mesh and scene operations from external tools and automation scripts.'
   },
   {
-    title: 'Multi-platform distribution',
-    body: 'Available via winget, Homebrew, snap, .deb packages, Docker, and release binaries.'
+    title: 'MCP / AI agent integration',
+    body: 'Expose pipeline tools through MCP for advanced scripted and agent-driven workflows.'
   }
 ];
 
@@ -162,11 +155,11 @@ export const trustItems = [
   },
   {
     title: 'Active since 2012',
-    body: 'Long-running project with continuous evolution across GUI, CLI, and formats.'
+    body: 'Long-running project with continuous evolution across GUI, CLI, and pipeline tooling.'
   },
   {
-    title: 'Indie-friendly',
-    body: 'Built for practical day-to-day asset work in small teams and solo projects.'
+    title: 'Pipeline-first by design',
+    body: 'Built around practical asset flow outcomes: validate, fix, convert, merge, and automate.'
   }
 ];
 


### PR DESCRIPTION
## Summary
- reposition the homepage around a pipeline-first message: **CI/CD for 3D assets**
- restructure the landing flow to emphasize scan/validate/fix/convert/merge and automation before advanced features
- keep Mixamo merge visible as a strong workflow while no longer making it the primary identity

## What Changed
- rewrote homepage content and section order for conversion and visual hierarchy
- added a new pipeline overview block (`scan -> validate -> fix/optimize -> convert/ship`)
- refreshed CLI/CI examples and copy for pipeline use cases
- moved advanced features (materials, REST API, MCP/AI) lower on the page
- updated install/trust framing and CTA placement
- updated SEO metadata (title/description/OG/Twitter/JSON-LD) to pipeline positioning

## Notes on Scan Messaging
- scan/validation are described honestly as evolving/in-progress pipeline capabilities
- existing stable capabilities (fix, convert, merge, CLI automation, Docker, GitHub Action) remain fully highlighted

## Validation
- `npm run build` (website) passes successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New visual "Pipeline" flow showing Scan → Validate → Fix & Optimize → Convert & Ship stages.
  * Added CI/CD examples (Docker + GitHub Actions) and combined scan/fix/convert example.
  * New Mixamo-guided step section and updated pipeline media/captions.

* **Updates**
  * Site messaging refocused to CI/CD-centered 3D asset pipelines.
  * Revised hero, features, use-cases, preview strip, and install/trust copy.
  * Reorganized sections and improved responsive layout for pipeline and preview displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->