### PR TITLE
[codex] increase coverage for cli scan and import pipelines

### DIFF
--- a/src/Assimp/BoneProcessor_test.cpp
+++ b/src/Assimp/BoneProcessor_test.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <cmath>
 #include "BoneProcessor.h"
 
 class BoneProcessorTest : public ::testing::Test {
@@ -154,4 +155,91 @@ TEST_F(BoneProcessorTest, BoneTransformation) {
     EXPECT_EQ(testBone->getPosition(), expectedPosition);
     EXPECT_EQ(testBone->getOrientation(), expectedOrientation);
     EXPECT_EQ(testBone->getScale(), expectedScale);
+}
+
+TEST_F(BoneProcessorTest, BakeZupToYupRotatesOnlyRootBones)
+{
+    Ogre::SkeletonPtr skeleton = Ogre::SkeletonManager::getSingleton().create(
+        "BakeZupToYupSkeleton",
+        Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
+        true);
+    ASSERT_TRUE(skeleton);
+
+    Ogre::Bone* root = skeleton->createBone("Root");
+    Ogre::Bone* child = skeleton->createBone("Child");
+    root->addChild(child);
+
+    root->setPosition(Ogre::Vector3(0.0f, 0.0f, 2.0f));
+    root->setOrientation(Ogre::Quaternion::IDENTITY);
+    child->setPosition(Ogre::Vector3(1.0f, 2.0f, 3.0f));
+    child->setOrientation(Ogre::Quaternion::IDENTITY);
+
+    BoneProcessor::bakeZupToYup(skeleton);
+
+    const Ogre::Quaternion rx90(Ogre::Degree(90), Ogre::Vector3::UNIT_X);
+    const Ogre::Vector3 expectedRootPos = rx90 * Ogre::Vector3(0.0f, 0.0f, 2.0f);
+    EXPECT_NEAR(root->getPosition().x, expectedRootPos.x, 1e-5);
+    EXPECT_NEAR(root->getPosition().y, expectedRootPos.y, 1e-5);
+    EXPECT_NEAR(root->getPosition().z, expectedRootPos.z, 1e-5);
+    EXPECT_NEAR(std::abs(root->getOrientation().Dot(rx90)), 1.0f, 1e-5);
+
+    // Child local transforms are preserved.
+    EXPECT_EQ(child->getPosition(), Ogre::Vector3(1.0f, 2.0f, 3.0f));
+    EXPECT_EQ(child->getOrientation(), Ogre::Quaternion::IDENTITY);
+}
+
+TEST_F(BoneProcessorTest, AnimationOnlyHierarchyCreatesAnimatedBonesAndLeafChildren)
+{
+    mockScene.mNumMeshes = 0;
+    mockScene.mMeshes = nullptr;
+
+    aiNode* rootNode = new aiNode();
+    rootNode->mName = aiString("Root");
+    rootNode->mTransformation = aiMatrix4x4();
+
+    aiNode* armatureNode = new aiNode();
+    armatureNode->mName = aiString("Armature");
+    armatureNode->mTransformation = aiMatrix4x4();
+    armatureNode->mParent = rootNode;
+
+    aiNode* hipsNode = new aiNode();
+    hipsNode->mName = aiString("Hips");
+    hipsNode->mTransformation = aiMatrix4x4();
+    hipsNode->mParent = armatureNode;
+
+    aiNode* tipNode = new aiNode();
+    tipNode->mName = aiString("HandTip");
+    tipNode->mTransformation = aiMatrix4x4();
+    tipNode->mParent = hipsNode;
+
+    rootNode->mNumChildren = 1;
+    rootNode->mChildren = new aiNode*[1]{armatureNode};
+    armatureNode->mNumChildren = 1;
+    armatureNode->mChildren = new aiNode*[1]{hipsNode};
+    hipsNode->mNumChildren = 1;
+    hipsNode->mChildren = new aiNode*[1]{tipNode};
+    tipNode->mNumChildren = 0;
+    tipNode->mChildren = nullptr;
+
+    mockScene.mRootNode = rootNode;
+
+    aiAnimation* anim = new aiAnimation();
+    anim->mName = aiString("Take001");
+    anim->mNumChannels = 1;
+    anim->mChannels = new aiNodeAnim*[1];
+    anim->mChannels[0] = new aiNodeAnim();
+    anim->mChannels[0]->mNodeName = aiString("Hips");
+    anim->mChannels[0]->mNumPositionKeys = 0;
+    anim->mChannels[0]->mNumRotationKeys = 0;
+    anim->mChannels[0]->mNumScalingKeys = 0;
+
+    mockScene.mNumAnimations = 1;
+    mockScene.mAnimations = new aiAnimation*[1]{anim};
+
+    processor.processBones(mockSkeleton, &mockScene);
+
+    EXPECT_TRUE(mockSkeleton->hasBone("Hips"));
+    EXPECT_TRUE(mockSkeleton->hasBone("HandTip"));
+    EXPECT_FALSE(mockSkeleton->hasBone("Armature"));
+    EXPECT_EQ(mockSkeleton->getBone("HandTip")->getParent(), mockSkeleton->getBone("Hips"));
 }

--- a/src/Assimp/MaterialProcessor_test.cpp
+++ b/src/Assimp/MaterialProcessor_test.cpp
@@ -196,3 +196,58 @@ TEST(MaterialProcessorTest, ProcessMaterialReturnsExistingMaterialIfAlreadyCreat
 
     Ogre::MaterialManager::getSingleton().remove(name);
 }
+
+TEST(MaterialProcessorTest, ExistingMaterialWithoutNormalMapIsReturnedUnchanged) {
+    auto ogreRoot = std::make_unique<Ogre::Root>();
+    ensureMaterialManagerInitialised();
+
+    const std::string name = "MaterialProcessorExistingNoNormal";
+    Ogre::MaterialPtr existing = Ogre::MaterialManager::getSingleton().create(
+        name, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+    ASSERT_TRUE(existing);
+    ASSERT_NE(existing->getTechnique(0), nullptr);
+    ASSERT_NE(existing->getTechnique(0)->getPass(0), nullptr);
+    EXPECT_EQ(existing->getTechnique(0)->getPass(0)->getNumTextureUnitStates(), 0u);
+
+    MaterialProcessor processor;
+    aiScene scene{};
+    aiMaterial material;
+    aiString matName(name);
+    material.AddProperty(&matName, AI_MATKEY_NAME);
+
+    Ogre::MaterialPtr out = processor.processMaterial(&material, &scene);
+    ASSERT_TRUE(out);
+    EXPECT_EQ(out.get(), existing.get());
+    EXPECT_EQ(out->getTechnique(0)->getPass(0)->getNumTextureUnitStates(), 0u);
+
+    Ogre::MaterialManager::getSingleton().remove(name);
+}
+
+TEST(MaterialProcessorTest, LoadSceneUnnamedMaterialsGetSequentialImportedNames) {
+    auto ogreRoot = std::make_unique<Ogre::Root>();
+    ensureMaterialManagerInitialised();
+
+    // Ensure predictable names even if previous tests left materials around.
+    if (Ogre::MaterialManager::getSingleton().getByName("importedMaterial0"))
+        Ogre::MaterialManager::getSingleton().remove("importedMaterial0");
+    if (Ogre::MaterialManager::getSingleton().getByName("importedMaterial1"))
+        Ogre::MaterialManager::getSingleton().remove("importedMaterial1");
+
+    MaterialProcessor processor;
+    aiScene scene{};
+    scene.mNumMaterials = 2;
+    scene.mMaterials = new aiMaterial*[2];
+    scene.mMaterials[0] = new aiMaterial();
+    scene.mMaterials[1] = new aiMaterial();
+
+    processor.loadScene(&scene);
+
+    ASSERT_EQ(processor.size(), 2UL);
+    EXPECT_EQ(processor[0]->getName(), "importedMaterial0");
+    EXPECT_EQ(processor[1]->getName(), "importedMaterial1");
+
+    if (Ogre::MaterialManager::getSingleton().getByName("importedMaterial0"))
+        Ogre::MaterialManager::getSingleton().remove("importedMaterial0");
+    if (Ogre::MaterialManager::getSingleton().getByName("importedMaterial1"))
+        Ogre::MaterialManager::getSingleton().remove("importedMaterial1");
+}

--- a/src/CLIPipeline_test.cpp
+++ b/src/CLIPipeline_test.cpp
@@ -5,6 +5,7 @@
 #include <QJsonObject>
 #include <QJsonArray>
 #include <QSettings>
+#include <QTemporaryDir>
 #include <vector>
 #include <OgreMeshManager.h>
 #include <OgreHardwareBufferManager.h>
@@ -26,6 +27,23 @@ QString testDataDir()
     dir.cdUp(); // bin -> build_local
     dir.cdUp(); // build_local -> project root
     return dir.absoluteFilePath("media/models");
+}
+
+QString writeMinimalObj(const QString& dirPath, const QString& fileName)
+{
+    const QString path = QDir(dirPath).filePath(fileName);
+    QFile f(path);
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Text))
+        return QString();
+
+    f.write(
+        "o Tri\n"
+        "v 0 0 0\n"
+        "v 1 0 0\n"
+        "v 0 1 0\n"
+        "f 1 2 3\n");
+    f.close();
+    return path;
 }
 
 Ogre::MeshPtr createTwoSubmeshSharedMesh(const std::string& name)
@@ -1748,4 +1766,180 @@ TEST_F(CLIPipelineCmdLodTest, CmdLod_InfoAndRemoveFromGeneratedMesh)
     QFile::remove(QDir::tempPath() + "/cli_lod_generated.material");
     QFile::remove(removedOut);
     QFile::remove(QDir::tempPath() + "/cli_lod_removed.material");
+}
+
+// -- cmdPose error paths (argument validation) --
+
+TEST(CLIPipelineCmdPoseError, NoFile)
+{
+    TestArgv args({"qtmesh", "pose"});
+    EXPECT_EQ(CLIPipeline::cmdPose(args.argc(), args.argv()), 2);
+}
+
+TEST(CLIPipelineCmdPoseError, MissingAnimation)
+{
+    TestArgv args({"qtmesh", "pose", "some_file.fbx", "--time", "0.0", "-o", "pose.obj"});
+    EXPECT_EQ(CLIPipeline::cmdPose(args.argc(), args.argv()), 2);
+}
+
+TEST(CLIPipelineCmdPoseError, MissingOutput)
+{
+    TestArgv args({"qtmesh", "pose", "some_file.fbx", "--animation", "Idle", "--time", "0.0"});
+    EXPECT_EQ(CLIPipeline::cmdPose(args.argc(), args.argv()), 2);
+}
+
+TEST(CLIPipelineCmdPoseError, MissingTimeAndCount)
+{
+    TestArgv args({"qtmesh", "pose", "some_file.fbx", "--animation", "Idle", "-o", "pose.obj"});
+    EXPECT_EQ(CLIPipeline::cmdPose(args.argc(), args.argv()), 2);
+}
+
+TEST(CLIPipelineCmdPoseError, NonexistentFile)
+{
+    TestArgv args({"qtmesh", "pose", "/tmp/qtmesh_pose_missing_12345.fbx", "--animation", "Idle", "--time", "0.0", "-o", "pose.obj"});
+    EXPECT_EQ(CLIPipeline::cmdPose(args.argc(), args.argv()), 1);
+}
+
+// -- cmdScan tests --
+
+TEST(CLIPipelineCmdScanError, InvalidFailOn)
+{
+    TestArgv args({"qtmesh", "scan", "--fail-on", "fatal"});
+    EXPECT_EQ(CLIPipeline::cmdScan(args.argc(), args.argv()), 2);
+}
+
+TEST(CLIPipelineCmdScanError, MissingConfigFile)
+{
+    TestArgv args({"qtmesh", "scan", "--config", "/tmp/qtmesh_scan_missing_config.yml"});
+    EXPECT_EQ(CLIPipeline::cmdScan(args.argc(), args.argv()), 2);
+}
+
+TEST(CLIPipelineCmdScanError, ScanRootMustBeDirectory)
+{
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+
+    const QString filePath = QDir(tmpDir.path()).filePath("not_a_dir.txt");
+    QFile file(filePath);
+    ASSERT_TRUE(file.open(QIODevice::WriteOnly | QIODevice::Text));
+    file.write("x");
+    file.close();
+
+    const QString configPath = QDir(tmpDir.path()).filePath("scan.yml");
+    QFile cfg(configPath);
+    ASSERT_TRUE(cfg.open(QIODevice::WriteOnly | QIODevice::Text));
+    cfg.write(
+        "scan:\n"
+        "  include:\n"
+        "    - \"**/*.obj\"\n");
+    cfg.close();
+
+    QByteArray filePathBa = filePath.toUtf8();
+    QByteArray configBa = configPath.toUtf8();
+    TestArgv args({"qtmesh", "scan", filePathBa.constData(), "--config", configBa.constData()});
+    EXPECT_EQ(CLIPipeline::cmdScan(args.argc(), args.argv()), 2);
+}
+
+TEST(CLIPipelineCmdScan, WritesJsonAndSarifReports)
+{
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+
+    const QString rootPath = QDir(tmpDir.path()).filePath("assets");
+    ASSERT_TRUE(QDir().mkpath(rootPath));
+    ASSERT_FALSE(writeMinimalObj(rootPath, "scan_mesh.obj").isEmpty());
+
+    const QString configPath = QDir(tmpDir.path()).filePath("scan.yml");
+    QFile cfg(configPath);
+    ASSERT_TRUE(cfg.open(QIODevice::WriteOnly | QIODevice::Text));
+    cfg.write(
+        "scan:\n"
+        "  include:\n"
+        "    - \"**/*.obj\"\n"
+        "rules:\n"
+        "  allow_missing_materials: true\n");
+    cfg.close();
+
+    const QString reportPath = QDir(tmpDir.path()).filePath("reports/out/scan.json");
+    const QString sarifPath = QDir(tmpDir.path()).filePath("reports/out/scan.sarif");
+    QFile::remove(reportPath);
+    QFile::remove(sarifPath);
+
+    QByteArray rootBa = rootPath.toUtf8();
+    QByteArray configBa = configPath.toUtf8();
+    QByteArray reportBa = reportPath.toUtf8();
+    QByteArray sarifBa = sarifPath.toUtf8();
+    TestArgv args({"qtmesh", "scan", rootBa.constData(), "--config", configBa.constData(),
+                   "--json", "--report", reportBa.constData(), "--sarif", sarifBa.constData(),
+                   "--fail-on", "never"});
+
+    EXPECT_EQ(CLIPipeline::cmdScan(args.argc(), args.argv()), 0);
+    ASSERT_TRUE(QFile::exists(reportPath));
+    ASSERT_TRUE(QFile::exists(sarifPath));
+
+    QFile reportFile(reportPath);
+    ASSERT_TRUE(reportFile.open(QIODevice::ReadOnly | QIODevice::Text));
+    const QString reportContent = QString::fromUtf8(reportFile.readAll());
+    EXPECT_TRUE(reportContent.contains("\"summary\""));
+    EXPECT_TRUE(reportContent.contains("\"assets\""));
+
+    QFile sarifFile(sarifPath);
+    ASSERT_TRUE(sarifFile.open(QIODevice::ReadOnly | QIODevice::Text));
+    const QString sarifContent = QString::fromUtf8(sarifFile.readAll());
+    EXPECT_TRUE(sarifContent.contains("\"runs\""));
+    EXPECT_TRUE(sarifContent.contains("qtmesh scan"));
+}
+
+TEST(CLIPipelineCmdScan, FailOnWarningReturnsFailure)
+{
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+
+    const QString rootPath = QDir(tmpDir.path()).filePath("assets");
+    ASSERT_TRUE(QDir().mkpath(rootPath));
+    ASSERT_FALSE(writeMinimalObj(rootPath, "PlayerModel.obj").isEmpty());
+
+    const QString configPath = QDir(tmpDir.path()).filePath("scan.yml");
+    QFile cfg(configPath);
+    ASSERT_TRUE(cfg.open(QIODevice::WriteOnly | QIODevice::Text));
+    cfg.write(
+        "scan:\n"
+        "  include:\n"
+        "    - \"**/*.obj\"\n"
+        "rules:\n"
+        "  file_name_case: snake_case\n");
+    cfg.close();
+
+    QByteArray rootBa = rootPath.toUtf8();
+    QByteArray configBa = configPath.toUtf8();
+    TestArgv args({"qtmesh", "scan", rootBa.constData(), "--config", configBa.constData(),
+                   "--fail-on", "warning"});
+    EXPECT_EQ(CLIPipeline::cmdScan(args.argc(), args.argv()), 1);
+}
+
+TEST(CLIPipelineCmdScan, FailOnNeverAllowsWarnings)
+{
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+
+    const QString rootPath = QDir(tmpDir.path()).filePath("assets");
+    ASSERT_TRUE(QDir().mkpath(rootPath));
+    ASSERT_FALSE(writeMinimalObj(rootPath, "PlayerModel.obj").isEmpty());
+
+    const QString configPath = QDir(tmpDir.path()).filePath("scan.yml");
+    QFile cfg(configPath);
+    ASSERT_TRUE(cfg.open(QIODevice::WriteOnly | QIODevice::Text));
+    cfg.write(
+        "scan:\n"
+        "  include:\n"
+        "    - \"**/*.obj\"\n"
+        "rules:\n"
+        "  file_name_case: snake_case\n");
+    cfg.close();
+
+    QByteArray rootBa = rootPath.toUtf8();
+    QByteArray configBa = configPath.toUtf8();
+    TestArgv args({"qtmesh", "scan", rootBa.constData(), "--config", configBa.constData(),
+                   "--fail-on", "never"});
+    EXPECT_EQ(CLIPipeline::cmdScan(args.argc(), args.argv()), 0);
 }

--- a/src/CLIPipeline_test.cpp
+++ b/src/CLIPipeline_test.cpp
@@ -1796,7 +1796,11 @@ TEST(CLIPipelineCmdPoseError, MissingTimeAndCount)
 
 TEST(CLIPipelineCmdPoseError, NonexistentFile)
 {
-    TestArgv args({"qtmesh", "pose", "/tmp/qtmesh_pose_missing_12345.fbx", "--animation", "Idle", "--time", "0.0", "-o", "pose.obj"});
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+    const QString missingFile = QDir(tmpDir.path()).filePath("qtmesh_pose_missing.fbx");
+    QByteArray missingFileBa = missingFile.toUtf8();
+    TestArgv args({"qtmesh", "pose", missingFileBa.constData(), "--animation", "Idle", "--time", "0.0", "-o", "pose.obj"});
     EXPECT_EQ(CLIPipeline::cmdPose(args.argc(), args.argv()), 1);
 }
 
@@ -1810,7 +1814,11 @@ TEST(CLIPipelineCmdScanError, InvalidFailOn)
 
 TEST(CLIPipelineCmdScanError, MissingConfigFile)
 {
-    TestArgv args({"qtmesh", "scan", "--config", "/tmp/qtmesh_scan_missing_config.yml"});
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+    const QString missingConfig = QDir(tmpDir.path()).filePath("qtmesh_scan_missing_config.yml");
+    QByteArray missingConfigBa = missingConfig.toUtf8();
+    TestArgv args({"qtmesh", "scan", "--config", missingConfigBa.constData()});
     EXPECT_EQ(CLIPipeline::cmdScan(args.argc(), args.argv()), 2);
 }
 

--- a/src/MeshImporterExporter_test.cpp
+++ b/src/MeshImporterExporter_test.cpp
@@ -1281,3 +1281,15 @@ TEST(MeshImporterExporterStandaloneTest, FormatFileURI_GlbFormat_CorrectExtensio
     QString result = MeshImporterExporter::formatFileURI("/tmp/model", "glTF 2.0 Binary (*.glb)");
     EXPECT_EQ(result, "/tmp/model.glb");
 }
+
+TEST(MeshImporterExporterStandaloneTest, FormatFileURI_HumanReadableUnknownFormatDoesNotAppend)
+{
+    QString result = MeshImporterExporter::formatFileURI("/tmp/model", "Custom Export Format");
+    EXPECT_EQ(result, "/tmp/model");
+}
+
+TEST(MeshImporterExporterStandaloneTest, FormatFileURI_ShortAliasUppercaseIsAppendedAsGiven)
+{
+    QString result = MeshImporterExporter::formatFileURI("/tmp/model", "FBX");
+    EXPECT_EQ(result, "/tmp/model.FBX");
+}

--- a/src/ScanEngine_test.cpp
+++ b/src/ScanEngine_test.cpp
@@ -250,7 +250,7 @@ TEST(ScanEngineTest, ConvertNameToCase_KebabCase)
 TEST(ScanEngineTest, ConvertNameToCase_LowercaseAndUnknown)
 {
     EXPECT_EQ(ScanEngine::convertNameToCase("PlayerModel.FBX", "lowercase"), "playermodel.FBX");
-    EXPECT_EQ(ScanEngine::convertNameToCase("PlayerModel.fbx", "camelCase"), "PlayerModel.fbx");
+    EXPECT_EQ(ScanEngine::convertNameToCase("PlayerModel.fbx", "unknown_case"), "PlayerModel.fbx");
 }
 
 // ---------------------------------------------------------------------------
@@ -303,11 +303,17 @@ TEST(ScanEngineTest, EnumerateFiles_ExcludePattern)
 
 TEST(ScanEngineTest, EnumerateFiles_NonexistentRootReturnsEmpty)
 {
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+
     ScanConfig config;
     config.includePatterns = {"**/*.fbx"};
     config.excludePatterns = {};
 
-    const QStringList files = ScanEngine::enumerateFiles(config, "/tmp/definitely_missing_qtmesh_scan_root");
+    const QString missingRoot = QDir(tmpDir.path()).filePath("definitely_missing_qtmesh_scan_root");
+    ASSERT_FALSE(QDir(missingRoot).exists());
+
+    const QStringList files = ScanEngine::enumerateFiles(config, missingRoot);
     EXPECT_TRUE(files.isEmpty());
 }
 

--- a/src/ScanEngine_test.cpp
+++ b/src/ScanEngine_test.cpp
@@ -2,9 +2,39 @@
 #include "ScanConfig.h"
 #include "ScanEngine.h"
 
+#include <QCoreApplication>
 #include <QDir>
 #include <QFile>
 #include <QTemporaryDir>
+
+namespace {
+QString writeMinimalObj(const QString& dirPath, const QString& fileName)
+{
+    const QString path = QDir(dirPath).filePath(fileName);
+    QFile f(path);
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Text))
+        return QString();
+
+    const QByteArray obj =
+        "o Tri\n"
+        "v 0 0 0\n"
+        "v 1 0 0\n"
+        "v 0 1 0\n"
+        "f 1 2 3\n";
+    f.write(obj);
+    f.close();
+    return path;
+}
+
+QString testDataDir()
+{
+    QString binDir = QCoreApplication::applicationDirPath();
+    QDir dir(binDir);
+    dir.cdUp(); // debug -> build_*
+    dir.cdUp(); // build_* -> project root
+    return dir.absoluteFilePath("media/models");
+}
+} // namespace
 
 // ---------------------------------------------------------------------------
 // YAML parser tests
@@ -194,6 +224,11 @@ TEST(ScanEngineTest, CheckNameCase_Lowercase)
     EXPECT_FALSE(ScanEngine::checkNameCase("PlayerModel.fbx", "lowercase"));
 }
 
+TEST(ScanEngineTest, CheckNameCase_UnknownConventionPasses)
+{
+    EXPECT_TRUE(ScanEngine::checkNameCase("AnyName.fbx", "unknown_case"));
+}
+
 // ---------------------------------------------------------------------------
 // Name conversion tests
 // ---------------------------------------------------------------------------
@@ -210,6 +245,12 @@ TEST(ScanEngineTest, ConvertNameToCase_KebabCase)
     EXPECT_EQ(ScanEngine::convertNameToCase("PlayerModel.fbx", "kebab-case"), "player-model.fbx");
     // Underscores are replaced with hyphens in kebab conversion
     EXPECT_EQ(ScanEngine::convertNameToCase("player_model.fbx", "kebab-case"), "player-model.fbx");
+}
+
+TEST(ScanEngineTest, ConvertNameToCase_LowercaseAndUnknown)
+{
+    EXPECT_EQ(ScanEngine::convertNameToCase("PlayerModel.FBX", "lowercase"), "playermodel.FBX");
+    EXPECT_EQ(ScanEngine::convertNameToCase("PlayerModel.fbx", "camelCase"), "PlayerModel.fbx");
 }
 
 // ---------------------------------------------------------------------------
@@ -258,6 +299,16 @@ TEST(ScanEngineTest, EnumerateFiles_ExcludePattern)
     QStringList files = ScanEngine::enumerateFiles(config, tmpDir.path());
     EXPECT_EQ(files.size(), 1);
     EXPECT_TRUE(files[0].endsWith("model.fbx"));
+}
+
+TEST(ScanEngineTest, EnumerateFiles_NonexistentRootReturnsEmpty)
+{
+    ScanConfig config;
+    config.includePatterns = {"**/*.fbx"};
+    config.excludePatterns = {};
+
+    const QStringList files = ScanEngine::enumerateFiles(config, "/tmp/definitely_missing_qtmesh_scan_root");
+    EXPECT_TRUE(files.isEmpty());
 }
 
 // ---------------------------------------------------------------------------
@@ -309,6 +360,19 @@ TEST(ScanEngineTest, EvaluateRules_AllowedFormats)
     auto findings = ScanEngine::evaluateRules(asset, config);
     EXPECT_GE(findings.size(), 1);
     EXPECT_EQ(findings[0].rule, "allowed_formats");
+}
+
+TEST(ScanEngineTest, EvaluateRules_AllowedFormatsCaseInsensitivePasses)
+{
+    AssetInfo asset;
+    asset.relativePath = "model.FBX";
+    asset.format = "FBX";
+
+    ScanConfig config = ScanConfig::defaults();
+    config.allowedFormats = {"fbx", "glb"};
+
+    const auto findings = ScanEngine::evaluateRules(asset, config);
+    EXPECT_TRUE(findings.isEmpty());
 }
 
 TEST(ScanEngineTest, EvaluateRules_MaxFileSize)
@@ -400,6 +464,86 @@ TEST(ScanEngineTest, EvaluateRules_MissingMaterials)
     EXPECT_TRUE(found);
 }
 
+TEST(ScanEngineTest, EvaluateRules_LoadErrorShortCircuitsOtherRules)
+{
+    AssetInfo asset;
+    asset.relativePath = "broken.fbx";
+    asset.format = "fbx";
+    asset.loadError = true;
+    asset.errorMessage = "mock parse failure";
+
+    ScanConfig config = ScanConfig::defaults();
+    config.maxVertexCount = 1;
+
+    const auto findings = ScanEngine::evaluateRules(asset, config);
+    ASSERT_EQ(findings.size(), 1);
+    EXPECT_EQ(findings[0].rule, "load_error");
+    EXPECT_EQ(findings[0].severity, Severity::Error);
+    EXPECT_TRUE(findings[0].message.contains("mock parse failure"));
+}
+
+TEST(ScanEngineTest, EvaluateRules_MinThresholdsAndRequirements)
+{
+    AssetInfo asset;
+    asset.filePath = "/tmp/asset/model.fbx";
+    asset.relativePath = "model.fbx";
+    asset.format = "fbx";
+    asset.fileSize = 8; // bytes
+    asset.meshCount = 0;
+    asset.materialCount = 0;
+    asset.vertexCount = 0;
+    asset.animationCount = 0;
+    asset.hasEmbeddedTextures = true;
+
+    ScanConfig config = ScanConfig::defaults();
+    config.minFileSizeMb = 0.1;
+    config.minMeshCount = 1;
+    config.minMaterialCount = 1;
+    config.minVertexCount = 1;
+    config.requireAnimations = true;
+    config.allowEmbeddedTextures = false;
+
+    const auto findings = ScanEngine::evaluateRules(asset, config);
+    QStringList rules;
+    for (const auto& f : findings)
+        rules.append(f.rule);
+
+    EXPECT_TRUE(rules.contains("min_file_size_mb"));
+    EXPECT_TRUE(rules.contains("min_mesh_count"));
+    EXPECT_TRUE(rules.contains("min_material_count"));
+    EXPECT_TRUE(rules.contains("min_vertex_count"));
+    EXPECT_TRUE(rules.contains("require_animations"));
+    EXPECT_TRUE(rules.contains("allow_embedded_textures"));
+}
+
+TEST(ScanEngineTest, EvaluateRules_RequireTexturesExistWarnsForMissingOnly)
+{
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+
+    const QString assetPath = writeMinimalObj(tmpDir.path(), "mesh.obj");
+    ASSERT_FALSE(assetPath.isEmpty());
+    ASSERT_TRUE(QFile(assetPath).exists());
+
+    QFile existing(QDir(tmpDir.path()).filePath("existing.png"));
+    ASSERT_TRUE(existing.open(QIODevice::WriteOnly));
+    existing.close();
+
+    AssetInfo asset;
+    asset.filePath = assetPath;
+    asset.relativePath = "mesh.obj";
+    asset.format = "obj";
+    asset.texturePaths = {"existing.png", "missing.png"};
+
+    ScanConfig config = ScanConfig::defaults();
+    config.requireTexturesExist = true;
+
+    const auto findings = ScanEngine::evaluateRules(asset, config);
+    ASSERT_EQ(findings.size(), 1);
+    EXPECT_EQ(findings[0].rule, "require_textures_exist");
+    EXPECT_TRUE(findings[0].message.contains("missing.png"));
+}
+
 // ---------------------------------------------------------------------------
 // Formatter tests
 // ---------------------------------------------------------------------------
@@ -436,6 +580,39 @@ TEST(ScanEngineTest, FormatJson_Structure)
     EXPECT_TRUE(json.contains("bad.fbx"));
 }
 
+TEST(ScanEngineTest, FormatJson_IncludesAnimationsBonesAndLoadError)
+{
+    ScanResult result;
+
+    AssetInfo asset;
+    asset.relativePath = "anim.fbx";
+    asset.format = "fbx";
+    asset.animationNames = {"Walk"};
+    asset.animationDurations = {1.25};
+    asset.animationKeyframeCounts = {42};
+    asset.boneNames = {"Hips", "Spine"};
+    asset.loadError = true;
+    asset.errorMessage = "mock error";
+    result.assets.append(asset);
+
+    Finding finding;
+    finding.file = "anim.fbx";
+    finding.rule = "file_name_case";
+    finding.severity = Severity::Warning;
+    finding.message = "warn";
+    finding.fixable = true;
+    finding.fixed = true;
+    result.findings.append(finding);
+
+    const QString json = ScanEngine::formatJson(result);
+    EXPECT_TRUE(json.contains("\"animations\""));
+    EXPECT_TRUE(json.contains("\"bones\""));
+    EXPECT_TRUE(json.contains("\"loadError\": true"));
+    EXPECT_TRUE(json.contains("\"errorMessage\": \"mock error\""));
+    EXPECT_TRUE(json.contains("\"fixable\": true"));
+    EXPECT_TRUE(json.contains("\"fixed\": true"));
+}
+
 TEST(ScanEngineTest, FormatText_ContainsSummary)
 {
     ScanResult result;
@@ -454,6 +631,38 @@ TEST(ScanEngineTest, FormatText_ContainsSummary)
     EXPECT_TRUE(text.contains("Passed:"));
 }
 
+TEST(ScanEngineTest, FormatText_IncludesFixedAndSkippedWhenPresent)
+{
+    ScanResult result;
+    result.fixed = 2;
+    result.skipped = 1;
+    result.elapsedMs = 250.0;
+
+    ScanConfig config;
+    const QString text = ScanEngine::formatText(result, config);
+    EXPECT_TRUE(text.contains("Fixed:"));
+    EXPECT_TRUE(text.contains("Skipped:"));
+}
+
+TEST(ScanEngineTest, FormatText_ShowsInfoFindingLabel)
+{
+    ScanResult result;
+    AssetInfo asset;
+    asset.relativePath = "asset.fbx";
+    result.assets.append(asset);
+
+    Finding infoFinding;
+    infoFinding.file = "asset.fbx";
+    infoFinding.rule = "advice";
+    infoFinding.severity = Severity::Info;
+    infoFinding.message = "informational";
+    result.findings.append(infoFinding);
+
+    ScanConfig config;
+    const QString text = ScanEngine::formatText(result, config);
+    EXPECT_TRUE(text.contains("[info] advice: informational"));
+}
+
 TEST(ScanEngineTest, FormatSarif_ValidStructure)
 {
     ScanResult result;
@@ -468,6 +677,37 @@ TEST(ScanEngineTest, FormatSarif_ValidStructure)
     EXPECT_TRUE(sarif.contains("\"version\": \"2.1.0\""));
     EXPECT_TRUE(sarif.contains("qtmesh scan"));
     EXPECT_TRUE(sarif.contains("max_vertex_count"));
+}
+
+TEST(ScanEngineTest, FormatSarif_FixableProperties)
+{
+    ScanResult result;
+    Finding f;
+    f.file = "model.fbx";
+    f.rule = "file_name_case";
+    f.severity = Severity::Warning;
+    f.message = "Expected snake_case";
+    f.fixable = true;
+    f.fixed = true;
+    result.findings.append(f);
+
+    const QString sarif = ScanEngine::formatSarif(result);
+    EXPECT_TRUE(sarif.contains("\"fixable\": true"));
+    EXPECT_TRUE(sarif.contains("\"fixed\": true"));
+}
+
+TEST(ScanEngineTest, FormatSarif_InfoSeverityUsesNoteLevel)
+{
+    ScanResult result;
+    Finding f;
+    f.file = "model.fbx";
+    f.rule = "note_rule";
+    f.severity = Severity::Info;
+    f.message = "info message";
+    result.findings.append(f);
+
+    const QString sarif = ScanEngine::formatSarif(result);
+    EXPECT_TRUE(sarif.contains("\"level\": \"note\""));
 }
 
 // ---------------------------------------------------------------------------
@@ -494,6 +734,12 @@ TEST(ScanEngineTest, MatchesWildcard_CaseInsensitive)
 {
     EXPECT_TRUE(ScanEngine::matchesWildcard("walk", "Walk"));
     EXPECT_TRUE(ScanEngine::matchesWildcard("ATTACK1", "attack*"));
+}
+
+TEST(ScanEngineTest, MatchesGlob_QuestionMark)
+{
+    EXPECT_TRUE(ScanEngine::matchesGlob("ab.fbx", "a?.fbx"));
+    EXPECT_FALSE(ScanEngine::matchesGlob("abc.fbx", "a?.fbx"));
 }
 
 // ---------------------------------------------------------------------------
@@ -811,4 +1057,255 @@ TEST(ScanEngineTest, ScopedRules_OverlappingLastWins)
     // Only first scope matches
     ScanConfig effective2 = config.withScopeOverrides("characters/hero.fbx");
     EXPECT_EQ(effective2.maxVertexCount, 50000);
+}
+
+// ---------------------------------------------------------------------------
+// applyFixes / run integration tests
+// ---------------------------------------------------------------------------
+
+TEST(ScanEngineTest, ApplyFixes_DisabledDoesNotChangeFindingsOrPath)
+{
+    AssetInfo asset;
+    asset.filePath = "/tmp/PlayerModel.fbx";
+    asset.relativePath = "PlayerModel.fbx";
+
+    Finding finding;
+    finding.file = asset.relativePath;
+    finding.rule = "file_name_case";
+    finding.severity = Severity::Warning;
+    finding.message = "Expected snake_case";
+    finding.fixable = true;
+    QList<Finding> findings{finding};
+
+    ScanConfig config = ScanConfig::defaults();
+    config.fixEnabled = false;
+    config.fileNameCase = "snake_case";
+
+    ScanEngine::applyFixes(config, asset, findings);
+    EXPECT_EQ(asset.filePath, "/tmp/PlayerModel.fbx");
+    EXPECT_FALSE(findings[0].fixed);
+    EXPECT_FALSE(findings[0].message.contains("dry-run"));
+}
+
+TEST(ScanEngineTest, ApplyFixes_DryRunDoesNotRename)
+{
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+
+    const QString oldPath = writeMinimalObj(tmpDir.path(), "PlayerModel.obj");
+    ASSERT_FALSE(oldPath.isEmpty());
+
+    AssetInfo asset;
+    asset.filePath = oldPath;
+    asset.relativePath = "PlayerModel.obj";
+
+    Finding finding;
+    finding.file = asset.relativePath;
+    finding.rule = "file_name_case";
+    finding.severity = Severity::Warning;
+    finding.message = "Expected snake_case";
+    finding.fixable = true;
+    QList<Finding> findings{finding};
+
+    ScanConfig config = ScanConfig::defaults();
+    config.fixEnabled = true;
+    config.dryRun = true;
+    config.fileNameCase = "snake_case";
+
+    ScanEngine::applyFixes(config, asset, findings);
+
+    const QString newPath = QDir(tmpDir.path()).filePath("player_model.obj");
+    EXPECT_TRUE(QFile::exists(oldPath));
+    EXPECT_FALSE(QFile::exists(newPath));
+    EXPECT_FALSE(findings[0].fixed);
+    EXPECT_TRUE(findings[0].message.contains("dry-run"));
+}
+
+TEST(ScanEngineTest, ApplyFixes_RenameSuccessUpdatesAssetPaths)
+{
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+
+    QDir(tmpDir.path()).mkpath("nested");
+    const QString oldPath = writeMinimalObj(QDir(tmpDir.path()).filePath("nested"), "PlayerModel.obj");
+    ASSERT_FALSE(oldPath.isEmpty());
+
+    AssetInfo asset;
+    asset.filePath = oldPath;
+    asset.relativePath = "nested/PlayerModel.obj";
+
+    Finding finding;
+    finding.file = asset.relativePath;
+    finding.rule = "file_name_case";
+    finding.severity = Severity::Warning;
+    finding.message = "Expected snake_case";
+    finding.fixable = true;
+    QList<Finding> findings{finding};
+
+    ScanConfig config = ScanConfig::defaults();
+    config.fixEnabled = true;
+    config.fileNameCase = "snake_case";
+
+    ScanEngine::applyFixes(config, asset, findings);
+
+    const QString newPath = QDir(tmpDir.path()).filePath("nested/player_model.obj");
+    EXPECT_FALSE(QFile::exists(oldPath));
+    EXPECT_TRUE(QFile::exists(newPath));
+    EXPECT_TRUE(findings[0].fixed);
+    EXPECT_TRUE(findings[0].message.contains("renamed"));
+    EXPECT_EQ(asset.filePath, newPath);
+    EXPECT_EQ(asset.relativePath, "nested/player_model.obj");
+}
+
+TEST(ScanEngineTest, ApplyFixes_RenameFailureAddsFailureMessage)
+{
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+
+    const QString oldPath = writeMinimalObj(tmpDir.path(), "PlayerModel.obj");
+    const QString newPath = writeMinimalObj(tmpDir.path(), "player_model.obj");
+    ASSERT_FALSE(oldPath.isEmpty());
+    ASSERT_FALSE(newPath.isEmpty());
+
+    AssetInfo asset;
+    asset.filePath = oldPath;
+    asset.relativePath = "PlayerModel.obj";
+
+    Finding finding;
+    finding.file = asset.relativePath;
+    finding.rule = "file_name_case";
+    finding.severity = Severity::Warning;
+    finding.message = "Expected snake_case";
+    finding.fixable = true;
+    QList<Finding> findings{finding};
+
+    ScanConfig config = ScanConfig::defaults();
+    config.fixEnabled = true;
+    config.fileNameCase = "snake_case";
+
+    ScanEngine::applyFixes(config, asset, findings);
+
+    EXPECT_TRUE(QFile::exists(oldPath));
+    EXPECT_TRUE(QFile::exists(newPath));
+    EXPECT_FALSE(findings[0].fixed);
+    EXPECT_TRUE(findings[0].message.contains("fix failed"));
+}
+
+TEST(ScanEngineTest, Run_AggregatesPassedAndSkippedCounts)
+{
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+
+    const QString validObj = writeMinimalObj(tmpDir.path(), "good.obj");
+    ASSERT_FALSE(validObj.isEmpty());
+
+    QFile invalidFbx(QDir(tmpDir.path()).filePath("broken.fbx"));
+    ASSERT_TRUE(invalidFbx.open(QIODevice::WriteOnly | QIODevice::Text));
+    invalidFbx.write("not an fbx");
+    invalidFbx.close();
+
+    ScanConfig config = ScanConfig::defaults();
+    config.includePatterns = {"**/*.obj", "**/*.fbx"};
+    config.excludePatterns = {};
+    config.failOn = "never";
+
+    const ScanResult result = ScanEngine::run(config, tmpDir.path());
+    EXPECT_EQ(result.scanned, 2);
+    EXPECT_EQ(result.passed, 1);
+    EXPECT_EQ(result.skipped, 1);
+    EXPECT_GE(result.errors, 1);
+    EXPECT_EQ(result.assets.size(), 2);
+}
+
+TEST(ScanEngineTest, Run_UsesConfiguredRootsWhenNoOverrideProvided)
+{
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+
+    const QString rootA = QDir(tmpDir.path()).filePath("a");
+    const QString rootB = QDir(tmpDir.path()).filePath("b");
+    ASSERT_TRUE(QDir().mkpath(rootA));
+    ASSERT_TRUE(QDir().mkpath(rootB));
+    ASSERT_FALSE(writeMinimalObj(rootA, "a.obj").isEmpty());
+    ASSERT_FALSE(writeMinimalObj(rootB, "b.obj").isEmpty());
+
+    ScanConfig config = ScanConfig::defaults();
+    config.roots = {rootA, rootB};
+    config.includePatterns = {"**/*.obj"};
+    config.excludePatterns = {};
+
+    const ScanResult result = ScanEngine::run(config);
+    EXPECT_EQ(result.scanned, 2);
+    EXPECT_EQ(result.passed, 2);
+    EXPECT_EQ(result.errors, 0);
+}
+
+TEST(ScanEngineTest, InspectAsset_InvalidFileSetsLoadError)
+{
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+
+    const QString path = QDir(tmpDir.path()).filePath("broken.fbx");
+    QFile f(path);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly | QIODevice::Text));
+    f.write("not an fbx file");
+    f.close();
+
+    const AssetInfo info = ScanEngine::inspectAsset(path, tmpDir.path());
+    EXPECT_TRUE(info.loadError);
+    EXPECT_FALSE(info.errorMessage.isEmpty());
+}
+
+TEST(ScanEngineTest, InspectAsset_ObjParsesGeometryAndTextureReferences)
+{
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+
+    QFile mtl(QDir(tmpDir.path()).filePath("mesh.mtl"));
+    ASSERT_TRUE(mtl.open(QIODevice::WriteOnly | QIODevice::Text));
+    mtl.write(
+        "newmtl testmat\n"
+        "Kd 1.0 1.0 1.0\n"
+        "map_Kd texture.png\n");
+    mtl.close();
+
+    QFile obj(QDir(tmpDir.path()).filePath("mesh.obj"));
+    ASSERT_TRUE(obj.open(QIODevice::WriteOnly | QIODevice::Text));
+    obj.write(
+        "mtllib mesh.mtl\n"
+        "usemtl testmat\n"
+        "v 0 0 0\n"
+        "v 1 0 0\n"
+        "v 0 1 0\n"
+        "vt 0 0\n"
+        "vt 1 0\n"
+        "vt 0 1\n"
+        "f 1/1 2/2 3/3\n");
+    obj.close();
+
+    const AssetInfo info = ScanEngine::inspectAsset(obj.fileName(), tmpDir.path());
+    ASSERT_FALSE(info.loadError);
+    EXPECT_EQ(info.relativePath, "mesh.obj");
+    EXPECT_EQ(info.meshCount, 1u);
+    EXPECT_EQ(info.vertexCount, 3u);
+    EXPECT_EQ(info.faceCount, 1u);
+    EXPECT_GE(info.materialCount, 1u);
+    EXPECT_GE(info.textureRefCount, 1u);
+    EXPECT_TRUE(info.texturePaths.contains("texture.png"));
+    EXPECT_FALSE(info.hasEmbeddedTextures);
+}
+
+TEST(ScanEngineTest, InspectAsset_AnimatedFixtureCollectsAnimationMetadata)
+{
+    const QString filePath = testDataDir() + "/Twist Dance.fbx";
+    ASSERT_TRUE(QFile::exists(filePath)) << "Animated fixture missing: " << filePath.toStdString();
+
+    const AssetInfo info = ScanEngine::inspectAsset(filePath, QFileInfo(filePath).absolutePath());
+    ASSERT_FALSE(info.loadError);
+    EXPECT_GT(info.meshCount, 0u);
+    EXPECT_GT(info.animationCount, 0u);
+    EXPECT_FALSE(info.animationNames.isEmpty());
+    EXPECT_FALSE(info.animationDurations.isEmpty());
+    EXPECT_FALSE(info.animationKeyframeCounts.isEmpty());
+    EXPECT_EQ(info.animationNames.size(), info.animationDurations.size());
 }

--- a/src/TransformOperator_test.cpp
+++ b/src/TransformOperator_test.cpp
@@ -177,6 +177,54 @@ TEST_F(TransformOperatorTests, SelectionBoxColourRoundTrips)
     EXPECT_FLOAT_EQ(current.a, colour.a);
 }
 
+TEST_F(TransformOperatorTests, PivotModeCycleWrapsAndEmitsSignal)
+{
+    op->setPivotMode(TransformOperator::PIVOT_CENTER);
+
+    QSignalSpy spy(op, &TransformOperator::pivotModeChanged);
+    ASSERT_TRUE(spy.isValid());
+    spy.clear();
+
+    op->cyclePivotMode();
+    EXPECT_EQ(op->pivotMode(), TransformOperator::PIVOT_BOTTOM);
+    op->cyclePivotMode();
+    EXPECT_EQ(op->pivotMode(), TransformOperator::PIVOT_ORIGIN);
+    op->cyclePivotMode();
+    EXPECT_EQ(op->pivotMode(), TransformOperator::PIVOT_CENTER);
+
+    EXPECT_EQ(spy.count(), 3);
+}
+
+TEST_F(TransformOperatorTests, PivotPointWithEmptySelectionIsZero)
+{
+    SelectionSet::getSingleton()->clear();
+    EXPECT_EQ(op->getPivotPoint(), Ogre::Vector3::ZERO);
+}
+
+TEST_F(TransformOperatorTests, PivotPointForNodeSelectionSupportsCenterBottomAndOrigin)
+{
+    Ogre::SceneNode* nodeA = createSelectedNode("PivotNodeA");
+    Ogre::SceneNode* nodeB = Manager::getSingleton()->addSceneNode("PivotNodeB");
+    ASSERT_NE(nodeA, nullptr);
+    ASSERT_NE(nodeB, nullptr);
+
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->append(nodeA);
+    SelectionSet::getSingleton()->append(nodeB);
+
+    nodeA->setPosition(Ogre::Vector3(0.0f, 4.0f, 10.0f));
+    nodeB->setPosition(Ogre::Vector3(6.0f, 2.0f, 2.0f));
+
+    op->setPivotMode(TransformOperator::PIVOT_CENTER);
+    expectVectorNear(op->getPivotPoint(), Ogre::Vector3(3.0f, 3.0f, 6.0f));
+
+    op->setPivotMode(TransformOperator::PIVOT_BOTTOM);
+    expectVectorNear(op->getPivotPoint(), Ogre::Vector3(3.0f, 2.0f, 6.0f));
+
+    op->setPivotMode(TransformOperator::PIVOT_ORIGIN);
+    expectVectorNear(op->getPivotPoint(), Ogre::Vector3(3.0f, 3.0f, 6.0f));
+}
+
 TEST_F(TransformOperatorTests, UpdateGizmoWithoutSelectionHidesEveryGizmo)
 {
     op->m_pRotationGizmo->setVisible(true);


### PR DESCRIPTION
## Summary
Increase test coverage for CLI scan/import flows, scan-engine rule handling, and Assimp/transform edge cases.

## Technical Details
- Added targeted tests in:
  - `src/Assimp/BoneProcessor_test.cpp`
  - `src/Assimp/MaterialProcessor_test.cpp`
  - `src/CLIPipeline_test.cpp`
  - `src/MeshImporterExporter_test.cpp`
  - `src/ScanEngine_test.cpp`
  - `src/TransformOperator_test.cpp`
- Added cross-platform missing-path construction in CLI tests (no hardcoded `/tmp`).
- Made nonexistent scan-root coverage test platform-portable.
- Kept animated fixture coverage strict (assert present) to avoid skipped-test CI policy violations.

### :sparkles: Features
- Expanded branch coverage for CLI `pose` and `scan` command validation/report paths.
- Expanded scan-engine formatter/rule/fix/integration coverage.

### :bug: Bugfixes
- Fixed test portability issues across Linux/macOS/Windows by replacing hardcoded POSIX-only paths.
- Clarified unknown conversion-case expectation in `ScanEngine` tests.

## Validation
- `cmake --build build_cov_local -j$(nproc) --target UnitTests`
- `QT_QPA_PLATFORM=offscreen ./build_cov_local/debug/UnitTests --gtest_filter='BoneProcessorTest.*:MaterialProcessorTest.*:CLIPipelineCmdPoseError.*:CLIPipelineCmdScan*.*:ScanEngineTest.*:ScanConfigTest.*:TransformOperatorTests.Pivot*:MeshImporterExporterStandaloneTest.FormatFileURI_HumanReadableUnknownFormatDoesNotAppend:MeshImporterExporterStandaloneTest.FormatFileURI_ShortAliasUppercaseIsAppendedAsGiven'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Comprehensive test expansion across multiple components: bone processing, material handling, CLI pipeline operations, mesh import/export functionality, scan engine workflows, and transform operations.
  * Added test coverage for error conditions, file operations, format conversions, naming conventions, case-sensitivity matching, and pivot-mode cycling.
  * Introduced utility helpers for test file generation and data directory resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->