### PR TITLE
Phase 3: Edit Mode — Vertex Editing (#258)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1784,8 +1784,8 @@ jobs:
 
       - name: Generate WinGet manifest
         run: |
-          # Install wingetcreate (Linux .NET tool)
-          dotnet tool install --global wingetcreate
+          # Install wingetcreate (.NET global tool — package name is Microsoft.WingetCreate)
+          dotnet tool install --global Microsoft.WingetCreate
           export PATH="$PATH:$HOME/.dotnet/tools"
 
           RAW_TAG="${{ github.event.release.tag_name }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,11 +28,40 @@ jobs:
 #             SLACK_MESSAGE: "Building QtMeshEditor in GitHub Actions - works! :D"
 
 ####################################################################
+# Asset Scan (runs first, before all builds)
+####################################################################
+
+ scan-assets-qtmesh:
+    # Validate repo assets using the published Docker image (latest).
+    # Runs on PRs, pushes to master, and releases.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Scan media/ via Docker (ghcr.io/fernandotonon/qtmesh:latest)
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            ghcr.io/fernandotonon/qtmesh:latest \
+            scan --config /workspace/qtmesh.yml --json || {
+            echo "::warning::Docker asset scan reported issues (using latest published image)"
+            true
+          }
+
+      - name: Scan media/ via GitHub Action (root action.yml)
+        uses: ./
+        with:
+          command: scan
+          input-file: .
+          options: --config /workspace/qtmesh.yml
+
+####################################################################
 # Windows Deploy
 ####################################################################
 
  build-n-cache-assimp-windows:
-   # scan-assets-qtmesh runs independently (no artifact dependency)
+   needs: scan-assets-qtmesh
    runs-on: windows-latest
    steps:
     - name: Cache Assimp
@@ -398,7 +427,7 @@ jobs:
 ####################################################################
 
  build-n-cache-assimp-linux:
-    # scan-assets-qtmesh runs independently (no artifact dependency)
+    needs: scan-assets-qtmesh
     runs-on: ubuntu-latest
     steps:
     - name: change folder permissions
@@ -1204,38 +1233,12 @@ jobs:
           true
         }
 
- scan-assets-qtmesh:
-    # Validate repo assets using the published Docker image (latest).
-    # Runs on PRs and pushes to demonstrate CI/Docker integration.
-    if: github.event_name != 'release'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Scan media/ via Docker (ghcr.io/fernandotonon/qtmesh:latest)
-        run: |
-          docker run --rm \
-            -v "${{ github.workspace }}:/workspace" \
-            -w /workspace \
-            ghcr.io/fernandotonon/qtmesh:latest \
-            scan --config /workspace/qtmesh.yml --json || {
-            echo "::warning::Docker asset scan reported issues (using latest published image)"
-            true
-          }
-
-      - name: Scan media/ via GitHub Action (root action.yml)
-        uses: ./
-        with:
-          command: scan
-          input-file: .
-          options: --config /workspace/qtmesh.yml
-
 ####################################################################
 # MacOS Deploy
 ####################################################################
 
  build-n-cache-assimp-macos:
-    # scan-assets-qtmesh runs independently (no artifact dependency)
+    needs: scan-assets-qtmesh
     runs-on: macos-latest
     steps:
     - name: change folder permissions

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -16,6 +16,53 @@ Rectangle {
             width: root.width
             spacing: 0
 
+            // ---- Edit Mode Indicator ----
+            Rectangle {
+                width: parent.width
+                height: 32
+                color: EditModeController.editModeActive
+                    ? "#3d6b3d" : PropertiesPanelController.headerColor
+                visible: true
+
+                RowLayout {
+                    anchors.fill: parent
+                    anchors.leftMargin: 8
+                    anchors.rightMargin: 8
+                    spacing: 8
+
+                    Text {
+                        text: EditModeController.modeLabel
+                        color: PropertiesPanelController.textColor
+                        font.bold: true
+                        font.pixelSize: 12
+                        Layout.fillWidth: true
+                    }
+
+                    Text {
+                        text: EditModeController.editModeActive
+                            ? "V:" + EditModeController.vertexCount +
+                              " T:" + EditModeController.triangleCount +
+                              " S:" + EditModeController.subMeshCount
+                            : ""
+                        color: PropertiesPanelController.textColor
+                        font.pixelSize: 10
+                        opacity: 0.7
+                        visible: EditModeController.editModeActive
+                    }
+
+                    Button {
+                        text: EditModeController.editModeActive ? "Exit" : "Edit"
+                        enabled: EditModeController.editModeActive || EditModeController.canEnterEditMode
+                        implicitWidth: 48
+                        implicitHeight: 24
+                        font.pixelSize: 10
+                        ToolTip.text: "Toggle Edit Mode (Tab)"
+                        ToolTip.visible: hovered
+                        onClicked: EditModeController.toggleEditMode()
+                    }
+                }
+            }
+
             // ---- Scene Outliner ----
             CollapsibleSection {
                 title: "Scene"

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -245,6 +245,7 @@ Rectangle {
             property int activeFalloff: EditModeController.softSelectionFalloff
             property int activeNormals: EditModeController.normalsMode
             property bool softSelOn: EditModeController.softSelectionEnabled
+            property bool wireframeOn: EditModeController.wireframeEnabled
 
             Connections {
                 target: EditModeController
@@ -252,6 +253,7 @@ Rectangle {
                 function onSoftSelectionFalloffChanged() { editToolsCol.activeFalloff = EditModeController.softSelectionFalloff }
                 function onNormalsModeChanged() { editToolsCol.activeNormals = EditModeController.normalsMode }
                 function onSoftSelectionEnabledChanged() { editToolsCol.softSelOn = EditModeController.softSelectionEnabled }
+                function onWireframeChanged() { editToolsCol.wireframeOn = EditModeController.wireframeEnabled }
             }
 
             // Selection mode buttons
@@ -379,6 +381,23 @@ Rectangle {
                         }
                     }
                 }
+            }
+
+            // Wireframe toggle (themed checkbox)
+            Row {
+                spacing: 6; width: parent.width - 16
+
+                Rectangle {
+                    width: 14; height: 14; anchors.verticalCenter: parent.verticalCenter
+                    border.color: PropertiesPanelController.borderColor; border.width: 1; radius: 2
+                    color: editToolsCol.wireframeOn ? PropertiesPanelController.highlightColor : "transparent"
+                    Behavior on color { ColorAnimation { duration: 50 } }
+                    Text { anchors.centerIn: parent; text: editToolsCol.wireframeOn ? "\u2713" : ""; color: "white"; font.pixelSize: 10 }
+                    MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor
+                        onClicked: { editToolsCol.wireframeOn = !editToolsCol.wireframeOn; EditModeController.wireframeEnabled = editToolsCol.wireframeOn }
+                    }
+                }
+                Text { text: "Wireframe"; font.pixelSize: 11; color: PropertiesPanelController.textColor; anchors.verticalCenter: parent.verticalCenter }
             }
 
             // Separator

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -63,6 +63,15 @@ Rectangle {
                 }
             }
 
+            // ---- Edit Mode Tools ----
+            CollapsibleSection {
+                title: "Edit Mode Tools"
+                sectionVisible: EditModeController.editModeActive
+                expanded: true
+
+                Component.onCompleted: content = editModeToolsComponent
+            }
+
             // ---- Scene Outliner ----
             CollapsibleSection {
                 title: "Scene"
@@ -218,6 +227,230 @@ Rectangle {
                         ? outlinerColumn.treeModel.rowCount() : 0
                     Qt.callLater(function() { outlinerColumn.delegatesActive = true })
                 }
+            }
+        }
+    }
+
+    // ---- Edit Mode Tools Content ----
+    Component {
+        id: editModeToolsComponent
+
+        Column {
+            width: parent ? parent.width : 200
+            padding: 8
+            spacing: 6
+
+            // Selection mode buttons
+            Row {
+                spacing: 4
+                width: parent.width - 16
+
+                Text {
+                    text: "Select:"
+                    color: PropertiesPanelController.textColor
+                    font.pixelSize: 11
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+
+                Repeater {
+                    model: [
+                        { label: "Vertex", mode: 0 },
+                        { label: "Edge", mode: 1 },
+                        { label: "Face", mode: 2 }
+                    ]
+
+                    Rectangle {
+                        width: 52; height: 22; radius: 3
+                        color: EditModeController.selectionMode === modelData.mode
+                            ? PropertiesPanelController.highlightColor
+                            : PropertiesPanelController.buttonColor
+                        border.color: PropertiesPanelController.borderColor; border.width: 1
+
+                        Text {
+                            anchors.centerIn: parent
+                            text: modelData.label
+                            color: PropertiesPanelController.textColor
+                            font.pixelSize: 10
+                        }
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: EditModeController.selectionMode = modelData.mode
+                        }
+                    }
+                }
+            }
+
+            // Selected count display
+            Text {
+                text: "Selected: " + EditModeController.selectedVertexCount + " vertices, "
+                    + EditModeController.selectedEdgeCount + " edges, "
+                    + EditModeController.selectedFaceCount + " faces"
+                color: PropertiesPanelController.textColor
+                font.pixelSize: 10; opacity: 0.8
+                width: parent.width - 16
+                wrapMode: Text.Wrap
+            }
+
+            // Soft selection toggle
+            Row {
+                spacing: 6; width: parent.width - 16
+
+                CheckBox {
+                    id: softSelCheck
+                    text: "Soft Selection"
+                    checked: EditModeController.softSelectionEnabled
+                    onCheckedChanged: EditModeController.softSelectionEnabled = checked
+                    font.pixelSize: 10
+
+                    contentItem: Text {
+                        text: softSelCheck.text
+                        color: PropertiesPanelController.textColor
+                        font.pixelSize: 10
+                        leftPadding: softSelCheck.indicator.width + 4
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                }
+            }
+
+            // Soft selection radius slider
+            Column {
+                width: parent.width - 16
+                visible: EditModeController.softSelectionEnabled
+                spacing: 2
+
+                Text {
+                    text: "Radius: " + softRadiusSlider.value.toFixed(2)
+                    color: PropertiesPanelController.textColor; font.pixelSize: 10
+                }
+                Slider {
+                    id: softRadiusSlider
+                    width: parent.width
+                    from: 0.1; to: 20.0; stepSize: 0.1
+                    value: EditModeController.softSelectionRadius
+                    onValueChanged: EditModeController.softSelectionRadius = value
+                }
+
+                // Falloff mode
+                Row {
+                    spacing: 4
+
+                    Text {
+                        text: "Falloff:"
+                        color: PropertiesPanelController.textColor; font.pixelSize: 10
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+
+                    Repeater {
+                        model: [
+                            { label: "Linear", mode: 0 },
+                            { label: "Smooth", mode: 1 }
+                        ]
+
+                        Rectangle {
+                            width: 50; height: 20; radius: 3
+                            color: EditModeController.softSelectionFalloff === modelData.mode
+                                ? PropertiesPanelController.highlightColor
+                                : PropertiesPanelController.buttonColor
+                            border.color: PropertiesPanelController.borderColor; border.width: 1
+
+                            Text {
+                                anchors.centerIn: parent
+                                text: modelData.label
+                                color: PropertiesPanelController.textColor; font.pixelSize: 9
+                            }
+                            MouseArea {
+                                anchors.fill: parent
+                                onClicked: EditModeController.softSelectionFalloff = modelData.mode
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Separator
+            Rectangle { width: parent.width - 16; height: 1; color: PropertiesPanelController.borderColor }
+
+            // Normals recalculation
+            Row {
+                spacing: 4; width: parent.width - 16
+
+                Text {
+                    text: "Normals:"
+                    color: PropertiesPanelController.textColor; font.pixelSize: 11
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+
+                Repeater {
+                    model: [
+                        { label: "Smooth", mode: 0 },
+                        { label: "Flat", mode: 1 }
+                    ]
+
+                    Rectangle {
+                        width: 52; height: 22; radius: 3
+                        color: EditModeController.normalsMode === modelData.mode
+                            ? PropertiesPanelController.highlightColor
+                            : PropertiesPanelController.buttonColor
+                        border.color: PropertiesPanelController.borderColor; border.width: 1
+
+                        Text {
+                            anchors.centerIn: parent
+                            text: modelData.label
+                            color: PropertiesPanelController.textColor; font.pixelSize: 10
+                        }
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: EditModeController.normalsMode = modelData.mode
+                        }
+                    }
+                }
+            }
+
+            // Recalc Normals button
+            Rectangle {
+                width: parent.width - 16; height: 26; radius: 3
+                color: recalcMouse.pressed ? Qt.darker(PropertiesPanelController.highlightColor, 1.2)
+                     : recalcMouse.containsMouse ? Qt.lighter(PropertiesPanelController.highlightColor, 1.1)
+                     : PropertiesPanelController.highlightColor
+                Text { anchors.centerIn: parent; text: "Recalculate Normals"; color: "white"; font.pixelSize: 11 }
+                MouseArea {
+                    id: recalcMouse; anchors.fill: parent; hoverEnabled: true
+                    onClicked: EditModeController.recalculateNormals(EditModeController.normalsMode === 0)
+                }
+            }
+
+            // Separator
+            Rectangle { width: parent.width - 16; height: 1; color: PropertiesPanelController.borderColor }
+
+            // Mesh validation warnings
+            Text {
+                width: parent.width - 16
+                visible: EditModeController.hasValidationWarnings
+                text: "\u26A0 " + EditModeController.degenerateTriangleCount + " degenerate triangle(s)"
+                color: "#e0a030"; font.pixelSize: 11; font.bold: true
+                wrapMode: Text.Wrap
+            }
+
+            // Remove degenerates button
+            Rectangle {
+                width: parent.width - 16; height: 26; radius: 3
+                visible: EditModeController.hasValidationWarnings
+                color: removeDegMouse.pressed ? Qt.darker("#c04040", 1.2)
+                     : removeDegMouse.containsMouse ? Qt.lighter("#c04040", 1.2)
+                     : "#c04040"
+                Text { anchors.centerIn: parent; text: "Remove Degenerates"; color: "white"; font.pixelSize: 11 }
+                MouseArea {
+                    id: removeDegMouse; anchors.fill: parent; hoverEnabled: true
+                    onClicked: EditModeController.removeDegenerateTriangles()
+                }
+            }
+
+            // Validation OK
+            Text {
+                width: parent.width - 16
+                visible: EditModeController.editModeActive && !EditModeController.hasValidationWarnings
+                text: "\u2714 No degenerate triangles"
+                color: "#60c060"; font.pixelSize: 10
             }
         }
     }

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -236,9 +236,23 @@ Rectangle {
         id: editModeToolsComponent
 
         Column {
+            id: editToolsCol
             width: parent ? parent.width : 200
             padding: 8
             spacing: 6
+
+            property int activeSelMode: EditModeController.selectionMode
+            property int activeFalloff: EditModeController.softSelectionFalloff
+            property int activeNormals: EditModeController.normalsMode
+            property bool softSelOn: EditModeController.softSelectionEnabled
+
+            Connections {
+                target: EditModeController
+                function onSelectionModeChanged() { editToolsCol.activeSelMode = EditModeController.selectionMode }
+                function onSoftSelectionFalloffChanged() { editToolsCol.activeFalloff = EditModeController.softSelectionFalloff }
+                function onNormalsModeChanged() { editToolsCol.activeNormals = EditModeController.normalsMode }
+                function onSoftSelectionEnabledChanged() { editToolsCol.softSelOn = EditModeController.softSelectionEnabled }
+            }
 
             // Selection mode buttons
             Row {
@@ -261,10 +275,12 @@ Rectangle {
 
                     Rectangle {
                         width: 52; height: 22; radius: 3
-                        color: EditModeController.selectionMode === modelData.mode
+                        color: editToolsCol.activeSelMode === modelData.mode
                             ? PropertiesPanelController.highlightColor
-                            : PropertiesPanelController.buttonColor
+                            : selMa.containsMouse ? Qt.lighter(PropertiesPanelController.panelColor, 1.5)
+                            : PropertiesPanelController.headerColor
                         border.color: PropertiesPanelController.borderColor; border.width: 1
+                        Behavior on color { ColorAnimation { duration: 50 } }
 
                         Text {
                             anchors.centerIn: parent
@@ -273,8 +289,8 @@ Rectangle {
                             font.pixelSize: 10
                         }
                         MouseArea {
-                            anchors.fill: parent
-                            onClicked: EditModeController.selectionMode = modelData.mode
+                            id: selMa; anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor
+                            onClicked: { editToolsCol.activeSelMode = modelData.mode; EditModeController.selectionMode = modelData.mode }
                         }
                     }
                 }
@@ -291,25 +307,21 @@ Rectangle {
                 wrapMode: Text.Wrap
             }
 
-            // Soft selection toggle
+            // Soft selection toggle (themed checkbox)
             Row {
                 spacing: 6; width: parent.width - 16
 
-                CheckBox {
-                    id: softSelCheck
-                    text: "Soft Selection"
-                    checked: EditModeController.softSelectionEnabled
-                    onCheckedChanged: EditModeController.softSelectionEnabled = checked
-                    font.pixelSize: 10
-
-                    contentItem: Text {
-                        text: softSelCheck.text
-                        color: PropertiesPanelController.textColor
-                        font.pixelSize: 10
-                        leftPadding: softSelCheck.indicator.width + 4
-                        verticalAlignment: Text.AlignVCenter
+                Rectangle {
+                    width: 14; height: 14; anchors.verticalCenter: parent.verticalCenter
+                    border.color: PropertiesPanelController.borderColor; border.width: 1; radius: 2
+                    color: editToolsCol.softSelOn ? PropertiesPanelController.highlightColor : "transparent"
+                    Behavior on color { ColorAnimation { duration: 50 } }
+                    Text { anchors.centerIn: parent; text: editToolsCol.softSelOn ? "\u2713" : ""; color: "white"; font.pixelSize: 10 }
+                    MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor
+                        onClicked: { editToolsCol.softSelOn = !editToolsCol.softSelOn; EditModeController.softSelectionEnabled = editToolsCol.softSelOn }
                     }
                 }
+                Text { text: "Soft Selection"; font.pixelSize: 11; color: PropertiesPanelController.textColor; anchors.verticalCenter: parent.verticalCenter }
             }
 
             // Soft selection radius slider
@@ -348,10 +360,12 @@ Rectangle {
 
                         Rectangle {
                             width: 50; height: 20; radius: 3
-                            color: EditModeController.softSelectionFalloff === modelData.mode
+                            color: editToolsCol.activeFalloff === modelData.mode
                                 ? PropertiesPanelController.highlightColor
-                                : PropertiesPanelController.buttonColor
+                                : fallMa.containsMouse ? Qt.lighter(PropertiesPanelController.panelColor, 1.5)
+                                : PropertiesPanelController.headerColor
                             border.color: PropertiesPanelController.borderColor; border.width: 1
+                            Behavior on color { ColorAnimation { duration: 50 } }
 
                             Text {
                                 anchors.centerIn: parent
@@ -359,8 +373,8 @@ Rectangle {
                                 color: PropertiesPanelController.textColor; font.pixelSize: 9
                             }
                             MouseArea {
-                                anchors.fill: parent
-                                onClicked: EditModeController.softSelectionFalloff = modelData.mode
+                                id: fallMa; anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor
+                                onClicked: { editToolsCol.activeFalloff = modelData.mode; EditModeController.softSelectionFalloff = modelData.mode }
                             }
                         }
                     }
@@ -388,10 +402,12 @@ Rectangle {
 
                     Rectangle {
                         width: 52; height: 22; radius: 3
-                        color: EditModeController.normalsMode === modelData.mode
+                        color: editToolsCol.activeNormals === modelData.mode
                             ? PropertiesPanelController.highlightColor
-                            : PropertiesPanelController.buttonColor
+                            : normMa.containsMouse ? Qt.lighter(PropertiesPanelController.panelColor, 1.5)
+                            : PropertiesPanelController.headerColor
                         border.color: PropertiesPanelController.borderColor; border.width: 1
+                        Behavior on color { ColorAnimation { duration: 50 } }
 
                         Text {
                             anchors.centerIn: parent
@@ -399,8 +415,8 @@ Rectangle {
                             color: PropertiesPanelController.textColor; font.pixelSize: 10
                         }
                         MouseArea {
-                            anchors.fill: parent
-                            onClicked: EditModeController.normalsMode = modelData.mode
+                            id: normMa; anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor
+                            onClicked: { editToolsCol.activeNormals = modelData.mode; EditModeController.normalsMode = modelData.mode }
                         }
                     }
                 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,6 +66,8 @@ ScanConfig.cpp
 ScanEngine.cpp
 AssetBrowserController.cpp
 MaterialPreviewRenderer.cpp
+EditableMesh.cpp
+EditModeController.cpp
 )
 
 set(HEADER_FILES
@@ -135,6 +137,8 @@ ScanConfig.h
 ScanEngine.h
 AssetBrowserController.h
 MaterialPreviewRenderer.h
+EditableMesh.h
+EditModeController.h
 )
 
 set(TEST_SOURCES "")

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -30,7 +30,13 @@ THE SOFTWARE.
 #include "EditableMesh.h"
 #include "SelectionSet.h"
 #include "SentryReporter.h"
+#include "Manager.h"
+#include "OgreWidget.h"
+#include "SpaceCamera.h"
 #include <Ogre.h>
+#include <cmath>
+#include <algorithm>
+#include <limits>
 
 EditModeController* EditModeController::m_pSingleton = nullptr;
 
@@ -73,7 +79,15 @@ void EditModeController::kill()
 
 QString EditModeController::modeLabel() const
 {
-    return m_editModeActive ? QStringLiteral("Edit Mode") : QStringLiteral("Object Mode");
+    if (!m_editModeActive)
+        return QStringLiteral("Object Mode");
+
+    switch (m_selectionMode) {
+    case VertexMode: return QStringLiteral("Edit Mode (Vertex)");
+    case EdgeMode:   return QStringLiteral("Edit Mode (Edge)");
+    case FaceMode:   return QStringLiteral("Edit Mode (Face)");
+    }
+    return QStringLiteral("Edit Mode");
 }
 
 bool EditModeController::canEnterEditMode() const
@@ -135,6 +149,15 @@ bool EditModeController::enterEditMode()
 
     m_editModeActive = true;
 
+    // Reset selection state
+    m_selectionMode = VertexMode;
+    m_selectedVertices.clear();
+    m_selectedEdges.clear();
+    m_selectedFaces.clear();
+
+    // Create overlay materials and initial (empty) overlays
+    createOverlayMaterials();
+
     SentryReporter::addBreadcrumb("edit_mode",
         QString("Entered Edit Mode: %1 vertices, %2 triangles, %3 submeshes")
             .arg(m_editableMesh->totalVertexCount())
@@ -143,6 +166,8 @@ bool EditModeController::enterEditMode()
 
     emit editModeChanged();
     emit meshDataChanged();
+    emit selectionModeChanged();
+    emit editSelectionChanged();
 
     return true;
 }
@@ -159,12 +184,21 @@ void EditModeController::exitEditMode(bool commitChanges)
         SentryReporter::addBreadcrumb("edit_mode", "Exited Edit Mode: changes discarded");
     }
 
+    // Clean up selection overlays
+    destroySelectionOverlay();
+
+    // Clear selection state
+    m_selectedVertices.clear();
+    m_selectedEdges.clear();
+    m_selectedFaces.clear();
+
     m_editableMesh.reset();
     m_editEntity = nullptr;
     m_editModeActive = false;
 
     emit editModeChanged();
     emit meshDataChanged();
+    emit editSelectionChanged();
 }
 
 void EditModeController::onSelectionChanged()
@@ -181,4 +215,870 @@ void EditModeController::onSelectionChanged()
     }
 
     emit selectionStateChanged();
+}
+
+// ===========================================================================
+// Selection mode
+// ===========================================================================
+
+void EditModeController::setSelectionMode(int mode)
+{
+    if (mode < 0 || mode > 2)
+        return;
+
+    auto newMode = static_cast<SelectionMode>(mode);
+    if (m_selectionMode == newMode)
+        return;
+
+    m_selectionMode = newMode;
+
+    QString modeName;
+    switch (m_selectionMode) {
+    case VertexMode: modeName = "Vertex"; break;
+    case EdgeMode:   modeName = "Edge"; break;
+    case FaceMode:   modeName = "Face"; break;
+    }
+    SentryReporter::addBreadcrumb("edit_mode",
+        QString("Selection mode changed to %1").arg(modeName));
+
+    // Update overlay to show the correct selection type
+    updateSelectionOverlay();
+
+    emit selectionModeChanged();
+    emit editModeChanged(); // modeLabel changed
+}
+
+// ===========================================================================
+// Selection operations
+// ===========================================================================
+
+void EditModeController::selectAll()
+{
+    if (!m_editModeActive || !m_editableMesh)
+        return;
+
+    SentryReporter::addBreadcrumb("edit_mode", "Select All");
+
+    int totalVerts = static_cast<int>(m_editableMesh->totalVertexCount());
+    int totalTris = static_cast<int>(m_editableMesh->totalTriangleCount());
+
+    // Select all vertices
+    m_selectedVertices.clear();
+    for (int i = 0; i < totalVerts; ++i)
+        m_selectedVertices.insert(i);
+
+    // Select all edges (from all triangles)
+    m_selectedEdges.clear();
+    const auto& subMeshes = m_editableMesh->subMeshes();
+    int globalTriOffset = 0;
+    for (size_t si = 0; si < subMeshes.size(); ++si) {
+        int vertexOffset = localToGlobal(si, 0);
+        for (const auto& tri : subMeshes[si].triangles) {
+            int g0 = vertexOffset + static_cast<int>(tri.indices[0]);
+            int g1 = vertexOffset + static_cast<int>(tri.indices[1]);
+            int g2 = vertexOffset + static_cast<int>(tri.indices[2]);
+            m_selectedEdges.insert({std::min(g0, g1), std::max(g0, g1)});
+            m_selectedEdges.insert({std::min(g1, g2), std::max(g1, g2)});
+            m_selectedEdges.insert({std::min(g0, g2), std::max(g0, g2)});
+        }
+        globalTriOffset += static_cast<int>(subMeshes[si].triangles.size());
+    }
+
+    // Select all faces
+    m_selectedFaces.clear();
+    for (int i = 0; i < totalTris; ++i)
+        m_selectedFaces.insert(i);
+
+    updateSelectionOverlay();
+    emit editSelectionChanged();
+}
+
+void EditModeController::deselectAll()
+{
+    if (!m_editModeActive)
+        return;
+
+    SentryReporter::addBreadcrumb("edit_mode", "Deselect All");
+
+    m_selectedVertices.clear();
+    m_selectedEdges.clear();
+    m_selectedFaces.clear();
+
+    updateSelectionOverlay();
+    emit editSelectionChanged();
+}
+
+void EditModeController::selectVertex(int globalIndex, bool addToSelection)
+{
+    if (!m_editModeActive || !m_editableMesh)
+        return;
+    if (globalIndex < 0 || globalIndex >= static_cast<int>(m_editableMesh->totalVertexCount()))
+        return;
+
+    if (!addToSelection)
+        m_selectedVertices.clear();
+
+    m_selectedVertices.insert(globalIndex);
+    updateSelectionOverlay();
+    emit editSelectionChanged();
+}
+
+void EditModeController::deselectVertex(int globalIndex)
+{
+    if (m_selectedVertices.erase(globalIndex) > 0) {
+        updateSelectionOverlay();
+        emit editSelectionChanged();
+    }
+}
+
+void EditModeController::selectEdge(int v1, int v2, bool addToSelection)
+{
+    if (!m_editModeActive || !m_editableMesh)
+        return;
+
+    auto edge = std::make_pair(std::min(v1, v2), std::max(v1, v2));
+
+    if (!addToSelection) {
+        m_selectedEdges.clear();
+        m_selectedVertices.clear();
+    }
+
+    m_selectedEdges.insert(edge);
+    // Also select the endpoint vertices
+    m_selectedVertices.insert(edge.first);
+    m_selectedVertices.insert(edge.second);
+
+    updateSelectionOverlay();
+    emit editSelectionChanged();
+}
+
+void EditModeController::deselectEdge(int v1, int v2)
+{
+    auto edge = std::make_pair(std::min(v1, v2), std::max(v1, v2));
+    if (m_selectedEdges.erase(edge) > 0) {
+        // Note: we don't remove vertices here as they may be part of other selected edges
+        updateSelectionOverlay();
+        emit editSelectionChanged();
+    }
+}
+
+void EditModeController::selectFace(int triIndex, bool addToSelection)
+{
+    if (!m_editModeActive || !m_editableMesh)
+        return;
+    if (triIndex < 0 || triIndex >= static_cast<int>(m_editableMesh->totalTriangleCount()))
+        return;
+
+    if (!addToSelection) {
+        m_selectedFaces.clear();
+        m_selectedVertices.clear();
+        m_selectedEdges.clear();
+    }
+
+    m_selectedFaces.insert(triIndex);
+
+    // Also select the three vertices and three edges of the triangle
+    auto [subIdx, localTri] = globalTriToLocal(triIndex);
+    if (subIdx < m_editableMesh->subMeshes().size()) {
+        const auto& tri = m_editableMesh->subMeshes()[subIdx].triangles[localTri];
+        int vertOffset = localToGlobal(subIdx, 0);
+        int g0 = vertOffset + static_cast<int>(tri.indices[0]);
+        int g1 = vertOffset + static_cast<int>(tri.indices[1]);
+        int g2 = vertOffset + static_cast<int>(tri.indices[2]);
+
+        m_selectedVertices.insert(g0);
+        m_selectedVertices.insert(g1);
+        m_selectedVertices.insert(g2);
+
+        m_selectedEdges.insert({std::min(g0, g1), std::max(g0, g1)});
+        m_selectedEdges.insert({std::min(g1, g2), std::max(g1, g2)});
+        m_selectedEdges.insert({std::min(g0, g2), std::max(g0, g2)});
+    }
+
+    updateSelectionOverlay();
+    emit editSelectionChanged();
+}
+
+void EditModeController::deselectFace(int triIndex)
+{
+    if (m_selectedFaces.erase(triIndex) > 0) {
+        updateSelectionOverlay();
+        emit editSelectionChanged();
+    }
+}
+
+// ===========================================================================
+// Index conversion helpers
+// ===========================================================================
+
+std::pair<size_t, size_t> EditModeController::globalToLocal(int globalIndex) const
+{
+    if (!m_editableMesh)
+        return {0, 0};
+
+    int offset = 0;
+    for (size_t si = 0; si < m_editableMesh->subMeshes().size(); ++si) {
+        int subCount = static_cast<int>(m_editableMesh->subMeshes()[si].vertices.size());
+        if (globalIndex < offset + subCount)
+            return {si, static_cast<size_t>(globalIndex - offset)};
+        offset += subCount;
+    }
+    return {0, 0};
+}
+
+int EditModeController::localToGlobal(size_t subMeshIndex, size_t localVertexIndex) const
+{
+    if (!m_editableMesh)
+        return 0;
+
+    int offset = 0;
+    for (size_t si = 0; si < subMeshIndex && si < m_editableMesh->subMeshes().size(); ++si)
+        offset += static_cast<int>(m_editableMesh->subMeshes()[si].vertices.size());
+
+    return offset + static_cast<int>(localVertexIndex);
+}
+
+std::pair<size_t, size_t> EditModeController::globalTriToLocal(int globalTriIndex) const
+{
+    if (!m_editableMesh)
+        return {0, 0};
+
+    int offset = 0;
+    for (size_t si = 0; si < m_editableMesh->subMeshes().size(); ++si) {
+        int subCount = static_cast<int>(m_editableMesh->subMeshes()[si].triangles.size());
+        if (globalTriIndex < offset + subCount)
+            return {si, static_cast<size_t>(globalTriIndex - offset)};
+        offset += subCount;
+    }
+    return {0, 0};
+}
+
+int EditModeController::localTriToGlobal(size_t subMeshIndex, size_t localTriIndex) const
+{
+    if (!m_editableMesh)
+        return 0;
+
+    int offset = 0;
+    for (size_t si = 0; si < subMeshIndex && si < m_editableMesh->subMeshes().size(); ++si)
+        offset += static_cast<int>(m_editableMesh->subMeshes()[si].triangles.size());
+
+    return offset + static_cast<int>(localTriIndex);
+}
+
+// ===========================================================================
+// Geometry helpers
+// ===========================================================================
+
+QPoint EditModeController::worldToScreen(const Ogre::Vector3& worldPos,
+                                          Ogre::Camera* camera,
+                                          int viewportWidth, int viewportHeight)
+{
+    if (!camera)
+        return QPoint(-1, -1);
+
+    Ogre::Vector3 screenPos = camera->getProjectionMatrix() * camera->getViewMatrix() * worldPos;
+
+    // Convert from NDC (-1..1) to pixel coordinates
+    int x = static_cast<int>((screenPos.x * 0.5f + 0.5f) * viewportWidth);
+    int y = static_cast<int>((1.0f - (screenPos.y * 0.5f + 0.5f)) * viewportHeight);
+
+    return QPoint(x, y);
+}
+
+float EditModeController::pointToSegmentDistance(const QPoint& point,
+                                                  const QPoint& segA,
+                                                  const QPoint& segB)
+{
+    float px = static_cast<float>(point.x());
+    float py = static_cast<float>(point.y());
+    float ax = static_cast<float>(segA.x());
+    float ay = static_cast<float>(segA.y());
+    float bx = static_cast<float>(segB.x());
+    float by = static_cast<float>(segB.y());
+
+    float dx = bx - ax;
+    float dy = by - ay;
+    float lenSq = dx * dx + dy * dy;
+
+    if (lenSq < 1e-8f) {
+        // Degenerate segment (both endpoints are the same)
+        float ddx = px - ax;
+        float ddy = py - ay;
+        return std::sqrt(ddx * ddx + ddy * ddy);
+    }
+
+    // Parameter t of closest point on the line
+    float t = ((px - ax) * dx + (py - ay) * dy) / lenSq;
+    t = std::max(0.0f, std::min(1.0f, t));
+
+    float closestX = ax + t * dx;
+    float closestY = ay + t * dy;
+
+    float ddx = px - closestX;
+    float ddy = py - closestY;
+    return std::sqrt(ddx * ddx + ddy * ddy);
+}
+
+float EditModeController::rayTriangleIntersect(const Ogre::Vector3& rayOrigin,
+                                                const Ogre::Vector3& rayDir,
+                                                const Ogre::Vector3& v0,
+                                                const Ogre::Vector3& v1,
+                                                const Ogre::Vector3& v2)
+{
+    const float EPSILON = 1e-7f;
+
+    Ogre::Vector3 edge1 = v1 - v0;
+    Ogre::Vector3 edge2 = v2 - v0;
+    Ogre::Vector3 h = rayDir.crossProduct(edge2);
+    float a = edge1.dotProduct(h);
+
+    if (a > -EPSILON && a < EPSILON)
+        return -1.0f; // Ray is parallel to the triangle
+
+    float f = 1.0f / a;
+    Ogre::Vector3 s = rayOrigin - v0;
+    float u = f * s.dotProduct(h);
+
+    if (u < 0.0f || u > 1.0f)
+        return -1.0f;
+
+    Ogre::Vector3 q = s.crossProduct(edge1);
+    float v = f * rayDir.dotProduct(q);
+
+    if (v < 0.0f || u + v > 1.0f)
+        return -1.0f;
+
+    float t = f * edge2.dotProduct(q);
+
+    if (t > EPSILON)
+        return t;
+
+    return -1.0f;
+}
+
+// ===========================================================================
+// Hit testing
+// ===========================================================================
+
+int EditModeController::hitTestVertex(const QPoint& screenPos,
+                                       Ogre::Camera* camera,
+                                       int viewportWidth, int viewportHeight,
+                                       float pixelRadius) const
+{
+    if (!m_editableMesh || !m_editEntity || !camera)
+        return -1;
+
+    Ogre::SceneNode* node = m_editEntity->getParentSceneNode();
+    if (!node)
+        return -1;
+
+    float bestDistSq = pixelRadius * pixelRadius;
+    int bestIndex = -1;
+    int globalOffset = 0;
+
+    for (size_t si = 0; si < m_editableMesh->subMeshes().size(); ++si) {
+        const auto& sub = m_editableMesh->subMeshes()[si];
+        for (size_t vi = 0; vi < sub.vertices.size(); ++vi) {
+            int globalIdx = globalOffset + static_cast<int>(vi);
+
+            // Transform from local space to world space
+            Ogre::Vector3 worldPos = node->convertLocalToWorldPosition(sub.vertices[vi].position);
+
+            // Check if the vertex is behind the camera
+            Ogre::Vector3 camToVert = worldPos - camera->getDerivedPosition();
+            if (camToVert.dotProduct(camera->getDerivedDirection()) < 0)
+                continue;
+
+            QPoint sp = worldToScreen(worldPos, camera, viewportWidth, viewportHeight);
+            float dx = static_cast<float>(sp.x() - screenPos.x());
+            float dy = static_cast<float>(sp.y() - screenPos.y());
+            float distSq = dx * dx + dy * dy;
+
+            if (distSq < bestDistSq) {
+                bestDistSq = distSq;
+                bestIndex = globalIdx;
+            }
+        }
+        globalOffset += static_cast<int>(sub.vertices.size());
+    }
+
+    return bestIndex;
+}
+
+// LCOV_EXCL_START — requires active render window + camera for ray casting
+int EditModeController::hitTestFace(const QPoint& screenPos,
+                                     Ogre::Camera* camera,
+                                     int viewportWidth, int viewportHeight) const
+{
+    if (!m_editableMesh || !m_editEntity || !camera)
+        return -1;
+
+    Ogre::SceneNode* node = m_editEntity->getParentSceneNode();
+    if (!node)
+        return -1;
+
+    // Cast a ray from the camera through the click point
+    Ogre::Real nx = static_cast<Ogre::Real>(screenPos.x()) / static_cast<Ogre::Real>(viewportWidth);
+    Ogre::Real ny = static_cast<Ogre::Real>(screenPos.y()) / static_cast<Ogre::Real>(viewportHeight);
+    Ogre::Ray ray = camera->getCameraToViewportRay(nx, ny);
+
+    // Transform ray into entity's local space
+    Ogre::Affine3 worldToLocal = node->_getFullTransform().inverse();
+    Ogre::Vector3 localOrigin = worldToLocal * ray.getOrigin();
+    Ogre::Vector3 localDir = worldToLocal.linear() * ray.getDirection();
+    localDir.normalise();
+
+    float bestT = std::numeric_limits<float>::max();
+    int bestTriIndex = -1;
+    int globalTriOffset = 0;
+
+    for (size_t si = 0; si < m_editableMesh->subMeshes().size(); ++si) {
+        const auto& sub = m_editableMesh->subMeshes()[si];
+        for (size_t ti = 0; ti < sub.triangles.size(); ++ti) {
+            const auto& tri = sub.triangles[ti];
+
+            if (tri.indices[0] >= sub.vertices.size() ||
+                tri.indices[1] >= sub.vertices.size() ||
+                tri.indices[2] >= sub.vertices.size())
+            {
+                continue;
+            }
+
+            const Ogre::Vector3& v0 = sub.vertices[tri.indices[0]].position;
+            const Ogre::Vector3& v1 = sub.vertices[tri.indices[1]].position;
+            const Ogre::Vector3& v2 = sub.vertices[tri.indices[2]].position;
+
+            float t = rayTriangleIntersect(localOrigin, localDir, v0, v1, v2);
+            if (t >= 0.0f && t < bestT) {
+                bestT = t;
+                bestTriIndex = globalTriOffset + static_cast<int>(ti);
+            }
+        }
+        globalTriOffset += static_cast<int>(sub.triangles.size());
+    }
+
+    return bestTriIndex;
+}
+// LCOV_EXCL_STOP
+
+std::pair<int,int> EditModeController::hitTestEdge(const QPoint& screenPos,
+                                                    Ogre::Camera* camera,
+                                                    int viewportWidth, int viewportHeight,
+                                                    float pixelRadius) const
+{
+    if (!m_editableMesh || !m_editEntity || !camera)
+        return {-1, -1};
+
+    Ogre::SceneNode* node = m_editEntity->getParentSceneNode();
+    if (!node)
+        return {-1, -1};
+
+    float bestDist = pixelRadius;
+    std::pair<int,int> bestEdge = {-1, -1};
+
+    for (size_t si = 0; si < m_editableMesh->subMeshes().size(); ++si) {
+        const auto& sub = m_editableMesh->subMeshes()[si];
+        int vertOffset = localToGlobal(si, 0);
+
+        for (const auto& tri : sub.triangles) {
+            // Check each of the 3 edges in the triangle
+            int localIndices[3] = {
+                static_cast<int>(tri.indices[0]),
+                static_cast<int>(tri.indices[1]),
+                static_cast<int>(tri.indices[2])
+            };
+
+            for (int e = 0; e < 3; ++e) {
+                int li0 = localIndices[e];
+                int li1 = localIndices[(e + 1) % 3];
+
+                if (li0 >= static_cast<int>(sub.vertices.size()) ||
+                    li1 >= static_cast<int>(sub.vertices.size()))
+                    continue;
+
+                Ogre::Vector3 wp0 = node->convertLocalToWorldPosition(sub.vertices[li0].position);
+                Ogre::Vector3 wp1 = node->convertLocalToWorldPosition(sub.vertices[li1].position);
+
+                // Skip edges where both endpoints are behind the camera
+                Ogre::Vector3 camPos = camera->getDerivedPosition();
+                Ogre::Vector3 camDir = camera->getDerivedDirection();
+                bool behind0 = (wp0 - camPos).dotProduct(camDir) < 0;
+                bool behind1 = (wp1 - camPos).dotProduct(camDir) < 0;
+                if (behind0 && behind1)
+                    continue;
+
+                QPoint sp0 = worldToScreen(wp0, camera, viewportWidth, viewportHeight);
+                QPoint sp1 = worldToScreen(wp1, camera, viewportWidth, viewportHeight);
+
+                float dist = pointToSegmentDistance(screenPos, sp0, sp1);
+                if (dist < bestDist) {
+                    bestDist = dist;
+                    int g0 = vertOffset + li0;
+                    int g1 = vertOffset + li1;
+                    bestEdge = {std::min(g0, g1), std::max(g0, g1)};
+                }
+            }
+        }
+    }
+
+    return bestEdge;
+}
+
+void EditModeController::boxSelectVertices(const QRect& rect,
+                                            Ogre::Camera* camera,
+                                            int viewportWidth, int viewportHeight,
+                                            bool addToSelection)
+{
+    if (!m_editableMesh || !m_editEntity || !camera)
+        return;
+
+    Ogre::SceneNode* node = m_editEntity->getParentSceneNode();
+    if (!node)
+        return;
+
+    if (!addToSelection)
+        m_selectedVertices.clear();
+
+    int globalOffset = 0;
+    for (size_t si = 0; si < m_editableMesh->subMeshes().size(); ++si) {
+        const auto& sub = m_editableMesh->subMeshes()[si];
+        for (size_t vi = 0; vi < sub.vertices.size(); ++vi) {
+            Ogre::Vector3 worldPos = node->convertLocalToWorldPosition(sub.vertices[vi].position);
+
+            // Skip vertices behind camera
+            Ogre::Vector3 camToVert = worldPos - camera->getDerivedPosition();
+            if (camToVert.dotProduct(camera->getDerivedDirection()) < 0)
+                continue;
+
+            QPoint sp = worldToScreen(worldPos, camera, viewportWidth, viewportHeight);
+            if (rect.contains(sp))
+                m_selectedVertices.insert(globalOffset + static_cast<int>(vi));
+        }
+        globalOffset += static_cast<int>(sub.vertices.size());
+    }
+
+    updateSelectionOverlay();
+    emit editSelectionChanged();
+}
+
+// ===========================================================================
+// Mouse handling
+// ===========================================================================
+
+// LCOV_EXCL_START — mouse interaction requires active render window + camera
+void EditModeController::handleMouseClick(const QPoint& screenPos, OgreWidget* widget,
+                                           bool shiftHeld, bool ctrlHeld)
+{
+    if (!m_editModeActive || !widget)
+        return;
+
+    auto* cam = widget->getSpaceCamera();
+    if (!cam || !cam->getCamera())
+        return;
+
+    auto* camera = cam->getCamera();
+    auto* vp = camera->getViewport();
+    if (!vp)
+        return;
+
+#ifdef Q_OS_MACOS
+    int widthMod = 2;
+#else
+    int widthMod = 1;
+#endif
+    int vpWidth = vp->getActualWidth() / widthMod;
+    int vpHeight = vp->getActualHeight() / widthMod;
+
+    bool addToSelection = shiftHeld;
+    bool removeFromSelection = ctrlHeld;
+
+    switch (m_selectionMode) {
+    case VertexMode: {
+        int vi = hitTestVertex(screenPos, camera, vpWidth, vpHeight);
+        if (vi >= 0) {
+            if (removeFromSelection) {
+                deselectVertex(vi);
+            } else {
+                selectVertex(vi, addToSelection);
+            }
+        } else if (!addToSelection && !removeFromSelection) {
+            deselectAll();
+        }
+        break;
+    }
+    case EdgeMode: {
+        auto edge = hitTestEdge(screenPos, camera, vpWidth, vpHeight);
+        if (edge.first >= 0) {
+            if (removeFromSelection) {
+                deselectEdge(edge.first, edge.second);
+            } else {
+                selectEdge(edge.first, edge.second, addToSelection);
+            }
+        } else if (!addToSelection && !removeFromSelection) {
+            deselectAll();
+        }
+        break;
+    }
+    case FaceMode: {
+        int fi = hitTestFace(screenPos, camera, vpWidth, vpHeight);
+        if (fi >= 0) {
+            if (removeFromSelection) {
+                deselectFace(fi);
+            } else {
+                selectFace(fi, addToSelection);
+            }
+        } else if (!addToSelection && !removeFromSelection) {
+            deselectAll();
+        }
+        break;
+    }
+    }
+}
+
+void EditModeController::handleBoxSelect(const QPoint& startPos, const QPoint& endPos,
+                                           OgreWidget* widget, bool shiftHeld)
+{
+    if (!m_editModeActive || !widget)
+        return;
+
+    auto* cam = widget->getSpaceCamera();
+    if (!cam || !cam->getCamera())
+        return;
+
+    auto* camera = cam->getCamera();
+    auto* vp = camera->getViewport();
+    if (!vp)
+        return;
+
+#ifdef Q_OS_MACOS
+    int widthMod = 2;
+#else
+    int widthMod = 1;
+#endif
+    int vpWidth = vp->getActualWidth() / widthMod;
+    int vpHeight = vp->getActualHeight() / widthMod;
+
+    QRect rect(startPos, endPos);
+    rect = rect.normalized();
+
+    boxSelectVertices(rect, camera, vpWidth, vpHeight, shiftHeld);
+}
+// LCOV_EXCL_STOP
+
+// ===========================================================================
+// Selection overlay
+// ===========================================================================
+
+void EditModeController::createOverlayMaterials()
+{
+    auto& matMgr = Ogre::MaterialManager::getSingleton();
+
+    // Vertex selection material (orange points, no lighting, no depth test)
+    if (!matMgr.getByName("EditMode/VertexSelection"))
+    {
+        auto mat = matMgr.create("EditMode/VertexSelection",
+                                 Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME);
+        auto* pass = mat->getTechnique(0)->getPass(0);
+        pass->setLightingEnabled(false);
+        pass->setVertexColourTracking(Ogre::TVC_DIFFUSE);
+        pass->setDepthCheckEnabled(false);
+        pass->setDepthWriteEnabled(false);
+        pass->setPointSize(6.0f);
+        pass->setPointSpritesEnabled(false);
+    }
+
+    // Edge selection material (colored lines, no lighting, no depth test)
+    if (!matMgr.getByName("EditMode/EdgeSelection"))
+    {
+        auto mat = matMgr.create("EditMode/EdgeSelection",
+                                 Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME);
+        auto* pass = mat->getTechnique(0)->getPass(0);
+        pass->setLightingEnabled(false);
+        pass->setVertexColourTracking(Ogre::TVC_DIFFUSE);
+        pass->setDepthCheckEnabled(false);
+        pass->setDepthWriteEnabled(false);
+    }
+
+    // Face selection material (semi-transparent overlay, no lighting)
+    if (!matMgr.getByName("EditMode/FaceSelection"))
+    {
+        auto mat = matMgr.create("EditMode/FaceSelection",
+                                 Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME);
+        auto* pass = mat->getTechnique(0)->getPass(0);
+        pass->setLightingEnabled(false);
+        pass->setVertexColourTracking(Ogre::TVC_DIFFUSE);
+        pass->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
+        pass->setDepthCheckEnabled(true);
+        pass->setDepthWriteEnabled(false);
+        pass->setCullingMode(Ogre::CULL_NONE);
+    }
+}
+
+void EditModeController::updateSelectionOverlay()
+{
+    if (!m_editModeActive || !m_editableMesh || !m_editEntity)
+        return;
+
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    if (!sceneMgr)
+        return;
+
+    Ogre::SceneNode* parentNode = m_editEntity->getParentSceneNode();
+    if (!parentNode)
+        return;
+
+    // Create the overlay scene node if needed (child of entity's node)
+    if (!m_overlayNode)
+    {
+        m_overlayNode = parentNode->createChildSceneNode();
+    }
+
+    // -- Vertex overlay --
+    if (!m_overlayVertices)
+    {
+        m_overlayVertices = sceneMgr->createManualObject("EditMode_VertexOverlay");
+        m_overlayVertices->setDynamic(true);
+        m_overlayVertices->setRenderQueueGroup(Ogre::RENDER_QUEUE_OVERLAY);
+        m_overlayNode->attachObject(m_overlayVertices);
+    }
+
+    m_overlayVertices->clear();
+    if (!m_selectedVertices.empty())
+    {
+        m_overlayVertices->begin("EditMode/VertexSelection", Ogre::RenderOperation::OT_POINT_LIST);
+
+        // Orange color for selected vertices
+        Ogre::ColourValue vertColor(1.0f, 0.6f, 0.0f, 1.0f);
+
+        for (int gi : m_selectedVertices) {
+            auto [subIdx, localIdx] = globalToLocal(gi);
+            if (subIdx < m_editableMesh->subMeshes().size() &&
+                localIdx < m_editableMesh->subMeshes()[subIdx].vertices.size())
+            {
+                const auto& pos = m_editableMesh->subMeshes()[subIdx].vertices[localIdx].position;
+                m_overlayVertices->position(pos);
+                m_overlayVertices->colour(vertColor);
+            }
+        }
+
+        m_overlayVertices->end();
+    }
+
+    // -- Edge overlay --
+    if (!m_overlayEdges)
+    {
+        m_overlayEdges = sceneMgr->createManualObject("EditMode_EdgeOverlay");
+        m_overlayEdges->setDynamic(true);
+        m_overlayEdges->setRenderQueueGroup(Ogre::RENDER_QUEUE_OVERLAY);
+        m_overlayNode->attachObject(m_overlayEdges);
+    }
+
+    m_overlayEdges->clear();
+    if (!m_selectedEdges.empty())
+    {
+        m_overlayEdges->begin("EditMode/EdgeSelection", Ogre::RenderOperation::OT_LINE_LIST);
+
+        // Cyan color for selected edges
+        Ogre::ColourValue edgeColor(0.0f, 1.0f, 1.0f, 1.0f);
+
+        for (const auto& [g0, g1] : m_selectedEdges) {
+            auto [sub0, loc0] = globalToLocal(g0);
+            auto [sub1, loc1] = globalToLocal(g1);
+
+            if (sub0 < m_editableMesh->subMeshes().size() &&
+                loc0 < m_editableMesh->subMeshes()[sub0].vertices.size() &&
+                sub1 < m_editableMesh->subMeshes().size() &&
+                loc1 < m_editableMesh->subMeshes()[sub1].vertices.size())
+            {
+                const auto& p0 = m_editableMesh->subMeshes()[sub0].vertices[loc0].position;
+                const auto& p1 = m_editableMesh->subMeshes()[sub1].vertices[loc1].position;
+                m_overlayEdges->position(p0);
+                m_overlayEdges->colour(edgeColor);
+                m_overlayEdges->position(p1);
+                m_overlayEdges->colour(edgeColor);
+            }
+        }
+
+        m_overlayEdges->end();
+    }
+
+    // -- Face overlay --
+    if (!m_overlayFaces)
+    {
+        m_overlayFaces = sceneMgr->createManualObject("EditMode_FaceOverlay");
+        m_overlayFaces->setDynamic(true);
+        m_overlayFaces->setRenderQueueGroup(Ogre::RENDER_QUEUE_OVERLAY);
+        m_overlayNode->attachObject(m_overlayFaces);
+    }
+
+    m_overlayFaces->clear();
+    if (!m_selectedFaces.empty())
+    {
+        m_overlayFaces->begin("EditMode/FaceSelection", Ogre::RenderOperation::OT_TRIANGLE_LIST);
+
+        // Semi-transparent blue tint for selected faces
+        Ogre::ColourValue faceColor(0.2f, 0.4f, 1.0f, 0.35f);
+
+        for (int gi : m_selectedFaces) {
+            auto [subIdx, localTri] = globalTriToLocal(gi);
+            if (subIdx < m_editableMesh->subMeshes().size() &&
+                localTri < m_editableMesh->subMeshes()[subIdx].triangles.size())
+            {
+                const auto& tri = m_editableMesh->subMeshes()[subIdx].triangles[localTri];
+                const auto& verts = m_editableMesh->subMeshes()[subIdx].vertices;
+
+                if (tri.indices[0] < verts.size() &&
+                    tri.indices[1] < verts.size() &&
+                    tri.indices[2] < verts.size())
+                {
+                    // Offset slightly toward camera to avoid z-fighting
+                    Ogre::Vector3 faceNormal =
+                        (verts[tri.indices[1]].position - verts[tri.indices[0]].position)
+                            .crossProduct(verts[tri.indices[2]].position - verts[tri.indices[0]].position);
+                    faceNormal.normalise();
+                    Ogre::Vector3 offset = faceNormal * 0.001f;
+
+                    m_overlayFaces->position(verts[tri.indices[0]].position + offset);
+                    m_overlayFaces->colour(faceColor);
+                    m_overlayFaces->position(verts[tri.indices[1]].position + offset);
+                    m_overlayFaces->colour(faceColor);
+                    m_overlayFaces->position(verts[tri.indices[2]].position + offset);
+                    m_overlayFaces->colour(faceColor);
+                }
+            }
+        }
+
+        m_overlayFaces->end();
+    }
+}
+
+void EditModeController::destroySelectionOverlay()
+{
+    auto* mgr = Manager::getSingletonPtr();
+    if (!mgr)
+        return;
+    auto* sceneMgr = mgr->getSceneMgr();
+    if (!sceneMgr)
+        return;
+
+    if (m_overlayNode)
+    {
+        m_overlayNode->detachAllObjects();
+
+        if (m_overlayVertices) {
+            sceneMgr->destroyManualObject(m_overlayVertices);
+            m_overlayVertices = nullptr;
+        }
+        if (m_overlayEdges) {
+            sceneMgr->destroyManualObject(m_overlayEdges);
+            m_overlayEdges = nullptr;
+        }
+        if (m_overlayFaces) {
+            sceneMgr->destroyManualObject(m_overlayFaces);
+            m_overlayFaces = nullptr;
+        }
+
+        sceneMgr->destroySceneNode(m_overlayNode);
+        m_overlayNode = nullptr;
+    }
 }

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -31,6 +31,8 @@ THE SOFTWARE.
 #include "SelectionSet.h"
 #include "SentryReporter.h"
 #include "Manager.h"
+#include "NormalVisualizer.h"
+#include "mainwindow.h"
 #include "OgreWidget.h"
 #include "SpaceCamera.h"
 #include <Ogre.h>
@@ -180,6 +182,7 @@ void EditModeController::exitEditMode(bool commitChanges)
 
     if (commitChanges && m_editableMesh && m_editEntity) {
         m_editableMesh->commitToEntity(m_editEntity);
+    refreshNormalVisualizer();
         SentryReporter::addBreadcrumb("edit_mode", "Exited Edit Mode: changes committed");
     } else {
         SentryReporter::addBreadcrumb("edit_mode", "Exited Edit Mode: changes discarded");
@@ -992,6 +995,7 @@ void EditModeController::recalculateNormals(bool smooth)
 
     // Write normals back to the GPU buffers for immediate visual feedback
     m_editableMesh->commitToEntity(m_editEntity);
+    refreshNormalVisualizer();
 
     emit meshDataChanged();
 }
@@ -1027,6 +1031,7 @@ void EditModeController::removeDegenerateTriangles()
         // Recalculate normals and commit
         recalculateNormals(m_normalsMode == 0);
         m_editableMesh->commitToEntity(m_editEntity);
+    refreshNormalVisualizer();
         updateSelectionOverlay();
         emit meshDataChanged();
     }
@@ -1088,6 +1093,7 @@ void EditModeController::translateSelectedVertices(const Ogre::Vector3& delta)
         m_editableMesh->recalculateNormalsFlat();
 
     m_editableMesh->commitToEntity(m_editEntity);
+    refreshNormalVisualizer();
     updateSelectionOverlay();
     emit meshDataChanged();
 }
@@ -1120,6 +1126,7 @@ void EditModeController::rotateSelectedVertices(const Ogre::Quaternion& rotation
         m_editableMesh->recalculateNormalsFlat();
 
     m_editableMesh->commitToEntity(m_editEntity);
+    refreshNormalVisualizer();
     updateSelectionOverlay();
     emit meshDataChanged();
 }
@@ -1153,6 +1160,7 @@ void EditModeController::scaleSelectedVertices(const Ogre::Vector3& scaleFactor)
         m_editableMesh->recalculateNormalsFlat();
 
     m_editableMesh->commitToEntity(m_editEntity);
+    refreshNormalVisualizer();
     updateSelectionOverlay();
     emit meshDataChanged();
 }
@@ -1191,6 +1199,7 @@ void EditModeController::restoreVertexPositions(const std::map<int, Ogre::Vector
 
     if (m_editEntity) {
         m_editableMesh->commitToEntity(m_editEntity);
+    refreshNormalVisualizer();
         updateSelectionOverlay();
         emit meshDataChanged();
     }
@@ -1467,4 +1476,14 @@ void EditModeController::destroySelectionOverlay()
         sceneMgr->destroySceneNode(m_overlayNode);
         m_overlayNode = nullptr;
     }
+}
+
+
+void EditModeController::refreshNormalVisualizer()
+{
+    if (!m_editEntity) return;
+    auto* mainWin = Manager::getSingletonPtr() ? Manager::getSingleton()->getMainWindow() : nullptr;
+    if (!mainWin) return;
+    auto* nv = mainWin->findChild<NormalVisualizer*>();
+    if (nv) nv->refreshEntity(m_editEntity);
 }

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -1,0 +1,184 @@
+/*
+-----------------------------------------------------------------------------------
+A QtMeshEditor file
+
+Copyright (c) Fernando Tonon (https://github.com/fernandotonon)
+
+The MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-----------------------------------------------------------------------------------
+*/
+
+#include "EditModeController.h"
+#include "EditableMesh.h"
+#include "SelectionSet.h"
+#include "SentryReporter.h"
+#include <Ogre.h>
+
+EditModeController* EditModeController::m_pSingleton = nullptr;
+
+EditModeController::EditModeController()
+    : QObject(nullptr)
+{
+    // Track selection changes to update canEnterEditMode and auto-exit
+    connect(SelectionSet::getSingleton(), &SelectionSet::selectionChanged,
+            this, &EditModeController::onSelectionChanged);
+}
+
+EditModeController::~EditModeController()
+{
+    // Exit cleanly if still in edit mode
+    if (m_editModeActive)
+        exitEditMode(false);
+}
+
+EditModeController* EditModeController::instance()
+{
+    if (!m_pSingleton)
+        m_pSingleton = new EditModeController();
+    return m_pSingleton;
+}
+
+EditModeController* EditModeController::qmlInstance(QQmlEngine* engine, QJSEngine* scriptEngine)
+{
+    Q_UNUSED(engine);
+    Q_UNUSED(scriptEngine);
+    auto* inst = instance();
+    QQmlEngine::setObjectOwnership(inst, QQmlEngine::CppOwnership);
+    return inst;
+}
+
+void EditModeController::kill()
+{
+    delete m_pSingleton;
+    m_pSingleton = nullptr;
+}
+
+QString EditModeController::modeLabel() const
+{
+    return m_editModeActive ? QStringLiteral("Edit Mode") : QStringLiteral("Object Mode");
+}
+
+bool EditModeController::canEnterEditMode() const
+{
+    // Edit mode requires exactly one entity selected (either directly or via node)
+    auto* sel = SelectionSet::getSingleton();
+    QList<Ogre::Entity*> entities = sel->getResolvedEntities();
+    return entities.size() == 1;
+}
+
+int EditModeController::vertexCount() const
+{
+    if (!m_editableMesh) return 0;
+    return static_cast<int>(m_editableMesh->totalVertexCount());
+}
+
+int EditModeController::triangleCount() const
+{
+    if (!m_editableMesh) return 0;
+    return static_cast<int>(m_editableMesh->totalTriangleCount());
+}
+
+int EditModeController::subMeshCount() const
+{
+    if (!m_editableMesh) return 0;
+    return static_cast<int>(m_editableMesh->subMeshCount());
+}
+
+void EditModeController::toggleEditMode()
+{
+    if (m_editModeActive)
+        exitEditMode(true);
+    else
+        enterEditMode();
+}
+
+bool EditModeController::enterEditMode()
+{
+    if (m_editModeActive)
+        return true; // Already in edit mode
+
+    if (!canEnterEditMode()) {
+        SentryReporter::addBreadcrumb("edit_mode", "Cannot enter Edit Mode: no single entity selected");
+        return false;
+    }
+
+    auto* sel = SelectionSet::getSingleton();
+    QList<Ogre::Entity*> entities = sel->getResolvedEntities();
+    m_editEntity = entities.first();
+
+    // Decompose mesh into editable data
+    m_editableMesh = std::make_unique<EditableMesh>();
+    if (!m_editableMesh->loadFromEntity(m_editEntity)) {
+        SentryReporter::addBreadcrumb("edit_mode", "Failed to load mesh data for Edit Mode");
+        m_editableMesh.reset();
+        m_editEntity = nullptr;
+        return false;
+    }
+
+    m_editModeActive = true;
+
+    SentryReporter::addBreadcrumb("edit_mode",
+        QString("Entered Edit Mode: %1 vertices, %2 triangles, %3 submeshes")
+            .arg(m_editableMesh->totalVertexCount())
+            .arg(m_editableMesh->totalTriangleCount())
+            .arg(m_editableMesh->subMeshCount()));
+
+    emit editModeChanged();
+    emit meshDataChanged();
+
+    return true;
+}
+
+void EditModeController::exitEditMode(bool commitChanges)
+{
+    if (!m_editModeActive)
+        return;
+
+    if (commitChanges && m_editableMesh && m_editEntity) {
+        m_editableMesh->commitToEntity(m_editEntity);
+        SentryReporter::addBreadcrumb("edit_mode", "Exited Edit Mode: changes committed");
+    } else {
+        SentryReporter::addBreadcrumb("edit_mode", "Exited Edit Mode: changes discarded");
+    }
+
+    m_editableMesh.reset();
+    m_editEntity = nullptr;
+    m_editModeActive = false;
+
+    emit editModeChanged();
+    emit meshDataChanged();
+}
+
+void EditModeController::onSelectionChanged()
+{
+    // If selection changes while in edit mode and the edited entity is no
+    // longer selected, auto-exit edit mode (committing changes).
+    if (m_editModeActive && m_editEntity) {
+        auto* sel = SelectionSet::getSingleton();
+        QList<Ogre::Entity*> entities = sel->getResolvedEntities();
+        bool stillSelected = entities.contains(m_editEntity);
+        if (!stillSelected) {
+            exitEditMode(true);
+        }
+    }
+
+    emit selectionStateChanged();
+}

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -877,6 +877,7 @@ void EditModeController::setSoftSelectionEnabled(bool enabled)
         SentryReporter::addBreadcrumb("edit_mode",
             QString("Soft selection %1").arg(enabled ? "enabled" : "disabled"));
         emit softSelectionChanged();
+        updateSelectionOverlay();
     }
 }
 
@@ -885,6 +886,7 @@ void EditModeController::setSoftSelectionRadius(double radius)
     if (radius > 0.0 && m_softSelectionRadius != radius) {
         m_softSelectionRadius = radius;
         emit softSelectionChanged();
+        updateSelectionOverlay();
     }
 }
 
@@ -893,6 +895,7 @@ void EditModeController::setSoftSelectionFalloff(int falloff)
     if (falloff >= 0 && falloff <= 1 && m_softSelectionFalloff != falloff) {
         m_softSelectionFalloff = falloff;
         emit softSelectionChanged();
+        updateSelectionOverlay();
     }
 }
 

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -161,6 +161,10 @@ bool EditModeController::enterEditMode()
     // Create overlay materials and initial (empty) overlays
     createOverlayMaterials();
 
+    // Re-apply wireframe if it was enabled in a previous session
+    if (m_wireframeEnabled)
+        applyWireframeMaterials();
+
     SentryReporter::addBreadcrumb("edit_mode",
         QString("Entered Edit Mode: %1 vertices, %2 triangles, %3 submeshes")
             .arg(m_editableMesh->totalVertexCount())
@@ -193,21 +197,9 @@ void EditModeController::exitEditMode(bool commitChanges)
         SentryReporter::addBreadcrumb("edit_mode", "Exited Edit Mode: changes discarded");
     }
 
-    // Restore wireframe materials if enabled
-    if (m_wireframeEnabled) {
-        for (const auto& [idx, matName] : m_savedMaterials) {
-            if (m_editEntity && idx < m_editEntity->getNumSubEntities()) {
-                m_editEntity->getSubEntity(idx)->setMaterialName(matName);
-                Ogre::String wireName = matName + "_EditWireframe";
-                auto& matMgr = Ogre::MaterialManager::getSingleton();
-                if (matMgr.resourceExists(wireName))
-                    matMgr.remove(wireName);
-            }
-        }
-        m_savedMaterials.clear();
-        m_wireframeEnabled = false;
-        emit wireframeChanged();
-    }
+    // Restore original materials (keep m_wireframeEnabled so it persists)
+    if (!m_savedMaterials.empty())
+        removeWireframeMaterials();
 
     // Clean up selection overlays
     destroySelectionOverlay();
@@ -260,6 +252,11 @@ void EditModeController::setSelectionMode(int mode)
         return;
 
     m_selectionMode = newMode;
+
+    // Clear selection from previous mode
+    m_selectedVertices.clear();
+    m_selectedEdges.clear();
+    m_selectedFaces.clear();
 
     QString modeName;
     switch (m_selectionMode) {
@@ -1506,6 +1503,48 @@ void EditModeController::destroySelectionOverlay()
 // Wireframe toggle
 // ===========================================================================
 
+void EditModeController::applyWireframeMaterials()
+{
+    if (!m_editEntity)
+        return;
+
+    m_savedMaterials.clear();
+    for (unsigned int i = 0; i < m_editEntity->getNumSubEntities(); ++i) {
+        auto* subEnt = m_editEntity->getSubEntity(i);
+        m_savedMaterials[i] = subEnt->getMaterialName();
+
+        Ogre::String wireName = subEnt->getMaterialName() + "_EditWireframe";
+        auto& matMgr = Ogre::MaterialManager::getSingleton();
+        auto wireMat = matMgr.getByName(wireName);
+        if (!wireMat)
+            wireMat = subEnt->getMaterial()->clone(wireName);
+
+        for (unsigned short ti = 0; ti < wireMat->getNumTechniques(); ++ti) {
+            for (unsigned short pi = 0; pi < wireMat->getTechnique(ti)->getNumPasses(); ++pi) {
+                wireMat->getTechnique(ti)->getPass(pi)->setPolygonMode(Ogre::PM_WIREFRAME);
+            }
+        }
+        subEnt->setMaterialName(wireName);
+    }
+}
+
+void EditModeController::removeWireframeMaterials()
+{
+    if (!m_editEntity)
+        return;
+
+    for (const auto& [idx, matName] : m_savedMaterials) {
+        if (idx < m_editEntity->getNumSubEntities()) {
+            m_editEntity->getSubEntity(idx)->setMaterialName(matName);
+            Ogre::String wireName = matName + "_EditWireframe";
+            auto& matMgr = Ogre::MaterialManager::getSingleton();
+            if (matMgr.resourceExists(wireName))
+                matMgr.remove(wireName);
+        }
+    }
+    m_savedMaterials.clear();
+}
+
 void EditModeController::setWireframeEnabled(bool enabled)
 {
     if (m_wireframeEnabled == enabled)
@@ -1513,45 +1552,11 @@ void EditModeController::setWireframeEnabled(bool enabled)
 
     m_wireframeEnabled = enabled;
 
-    if (!m_editModeActive || !m_editEntity) {
-        emit wireframeChanged();
-        return;
-    }
-
-    if (enabled) {
-        // Save original materials and switch all sub-entities to wireframe
-        m_savedMaterials.clear();
-        for (unsigned int i = 0; i < m_editEntity->getNumSubEntities(); ++i) {
-            auto* subEnt = m_editEntity->getSubEntity(i);
-            m_savedMaterials[i] = subEnt->getMaterialName();
-
-            // Clone the material so we don't modify the original
-            Ogre::String wireName = subEnt->getMaterialName() + "_EditWireframe";
-            auto& matMgr = Ogre::MaterialManager::getSingleton();
-            auto wireMat = matMgr.getByName(wireName);
-            if (!wireMat) {
-                wireMat = subEnt->getMaterial()->clone(wireName);
-            }
-            for (unsigned short ti = 0; ti < wireMat->getNumTechniques(); ++ti) {
-                for (unsigned short pi = 0; pi < wireMat->getTechnique(ti)->getNumPasses(); ++pi) {
-                    wireMat->getTechnique(ti)->getPass(pi)->setPolygonMode(Ogre::PM_WIREFRAME);
-                }
-            }
-            subEnt->setMaterialName(wireName);
-        }
-    } else {
-        // Restore original materials
-        for (const auto& [idx, matName] : m_savedMaterials) {
-            if (idx < m_editEntity->getNumSubEntities()) {
-                m_editEntity->getSubEntity(idx)->setMaterialName(matName);
-                // Clean up the cloned wireframe material
-                Ogre::String wireName = matName + "_EditWireframe";
-                auto& matMgr = Ogre::MaterialManager::getSingleton();
-                if (matMgr.resourceExists(wireName))
-                    matMgr.remove(wireName);
-            }
-        }
-        m_savedMaterials.clear();
+    if (m_editModeActive && m_editEntity) {
+        if (enabled)
+            applyWireframeMaterials();
+        else
+            removeWireframeMaterials();
     }
 
     SentryReporter::addBreadcrumb("edit_mode",

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -866,6 +866,333 @@ void EditModeController::handleBoxSelect(const QPoint& startPos, const QPoint& e
 // LCOV_EXCL_STOP
 
 // ===========================================================================
+// Soft selection
+// ===========================================================================
+
+void EditModeController::setSoftSelectionEnabled(bool enabled)
+{
+    if (m_softSelectionEnabled != enabled) {
+        m_softSelectionEnabled = enabled;
+        SentryReporter::addBreadcrumb("edit_mode",
+            QString("Soft selection %1").arg(enabled ? "enabled" : "disabled"));
+        emit softSelectionChanged();
+    }
+}
+
+void EditModeController::setSoftSelectionRadius(double radius)
+{
+    if (radius > 0.0 && m_softSelectionRadius != radius) {
+        m_softSelectionRadius = radius;
+        emit softSelectionChanged();
+    }
+}
+
+void EditModeController::setSoftSelectionFalloff(int falloff)
+{
+    if (falloff >= 0 && falloff <= 1 && m_softSelectionFalloff != falloff) {
+        m_softSelectionFalloff = falloff;
+        emit softSelectionChanged();
+    }
+}
+
+std::map<int, float> EditModeController::getSoftSelectionWeights() const
+{
+    std::map<int, float> weights;
+    if (!m_editableMesh || m_selectedVertices.empty())
+        return weights;
+
+    // All selected vertices get weight 1.0
+    for (int gi : m_selectedVertices)
+        weights[gi] = 1.0f;
+
+    if (!m_softSelectionEnabled || m_softSelectionRadius <= 0.0)
+        return weights;
+
+    // Collect positions of selected vertices
+    std::vector<Ogre::Vector3> selectedPositions;
+    selectedPositions.reserve(m_selectedVertices.size());
+    for (int gi : m_selectedVertices) {
+        auto [subIdx, localIdx] = globalToLocal(gi);
+        if (subIdx < m_editableMesh->subMeshes().size() &&
+            localIdx < m_editableMesh->subMeshes()[subIdx].vertices.size())
+        {
+            selectedPositions.push_back(
+                m_editableMesh->subMeshes()[subIdx].vertices[localIdx].position);
+        }
+    }
+
+    float radius = static_cast<float>(m_softSelectionRadius);
+    int totalVerts = static_cast<int>(m_editableMesh->totalVertexCount());
+
+    for (int gi = 0; gi < totalVerts; ++gi) {
+        if (m_selectedVertices.count(gi))
+            continue; // Already weight 1.0
+
+        auto [subIdx, localIdx] = globalToLocal(gi);
+        if (subIdx >= m_editableMesh->subMeshes().size())
+            continue;
+        const auto& pos = m_editableMesh->subMeshes()[subIdx].vertices[localIdx].position;
+
+        // Find minimum distance to any selected vertex
+        float minDist = std::numeric_limits<float>::max();
+        for (const auto& selPos : selectedPositions) {
+            float dist = pos.distance(selPos);
+            if (dist < minDist)
+                minDist = dist;
+        }
+
+        if (minDist < radius) {
+            float t = minDist / radius; // 0 at selected vertex, 1 at radius boundary
+            float weight = 0.0f;
+            if (m_softSelectionFalloff == 0) {
+                // Linear falloff
+                weight = 1.0f - t;
+            } else {
+                // Smooth (cosine) falloff
+                weight = 0.5f * (1.0f + std::cos(t * static_cast<float>(M_PI)));
+            }
+            if (weight > 0.001f)
+                weights[gi] = weight;
+        }
+    }
+
+    return weights;
+}
+
+// ===========================================================================
+// Normals recalculation
+// ===========================================================================
+
+void EditModeController::setNormalsMode(int mode)
+{
+    if (mode >= 0 && mode <= 1 && m_normalsMode != mode) {
+        m_normalsMode = mode;
+        SentryReporter::addBreadcrumb("edit_mode",
+            QString("Normals mode changed to %1").arg(mode == 0 ? "smooth" : "flat"));
+        emit normalsModeChanged();
+    }
+}
+
+void EditModeController::recalculateNormals(bool smooth)
+{
+    if (!m_editModeActive || !m_editableMesh || !m_editEntity)
+        return;
+
+    SentryReporter::addBreadcrumb("edit_mode",
+        QString("Recalculate normals (%1)").arg(smooth ? "smooth" : "flat"));
+
+    if (smooth)
+        m_editableMesh->recalculateNormals();
+    else
+        m_editableMesh->recalculateNormalsFlat();
+
+    // Write normals back to the GPU buffers for immediate visual feedback
+    m_editableMesh->commitToEntity(m_editEntity);
+
+    emit meshDataChanged();
+}
+
+// ===========================================================================
+// Mesh validation after edits
+// ===========================================================================
+
+void EditModeController::validateMesh()
+{
+    if (!m_editableMesh) {
+        m_degenerateTriangleCount = 0;
+        emit validationChanged();
+        return;
+    }
+
+    int oldCount = m_degenerateTriangleCount;
+    m_degenerateTriangleCount = m_editableMesh->countDegenerateTriangles();
+    if (m_degenerateTriangleCount != oldCount)
+        emit validationChanged();
+}
+
+void EditModeController::removeDegenerateTriangles()
+{
+    if (!m_editModeActive || !m_editableMesh || !m_editEntity)
+        return;
+
+    SentryReporter::addBreadcrumb("edit_mode", "Remove degenerate triangles");
+
+    int removed = m_editableMesh->removeDegenerateTriangles();
+
+    if (removed > 0) {
+        // Recalculate normals and commit
+        recalculateNormals(m_normalsMode == 0);
+        m_editableMesh->commitToEntity(m_editEntity);
+        updateSelectionOverlay();
+        emit meshDataChanged();
+    }
+
+    // Re-validate
+    validateMesh();
+}
+
+// ===========================================================================
+// Vertex transform support
+// ===========================================================================
+
+Ogre::Vector3 EditModeController::getSelectedVerticesCentroid() const
+{
+    if (!m_editableMesh || m_selectedVertices.empty())
+        return Ogre::Vector3::ZERO;
+
+    Ogre::Vector3 centroid = Ogre::Vector3::ZERO;
+    int count = 0;
+
+    for (int gi : m_selectedVertices) {
+        auto [subIdx, localIdx] = globalToLocal(gi);
+        if (subIdx < m_editableMesh->subMeshes().size() &&
+            localIdx < m_editableMesh->subMeshes()[subIdx].vertices.size())
+        {
+            centroid += m_editableMesh->subMeshes()[subIdx].vertices[localIdx].position;
+            ++count;
+        }
+    }
+
+    if (count > 0)
+        centroid /= static_cast<Ogre::Real>(count);
+
+    return centroid;
+}
+
+void EditModeController::translateSelectedVertices(const Ogre::Vector3& delta)
+{
+    if (!m_editableMesh || m_selectedVertices.empty())
+        return;
+
+    auto weights = getSoftSelectionWeights();
+
+    for (const auto& [gi, weight] : weights) {
+        auto [subIdx, localIdx] = globalToLocal(gi);
+        if (subIdx < m_editableMesh->subMeshes().size() &&
+            localIdx < m_editableMesh->subMeshes()[subIdx].vertices.size())
+        {
+            Ogre::Vector3 pos = m_editableMesh->getVertexPosition(subIdx, localIdx);
+            pos += delta * weight;
+            m_editableMesh->setVertexPosition(subIdx, localIdx, pos);
+        }
+    }
+
+    // Recalculate normals and commit to GPU
+    if (m_normalsMode == 0)
+        m_editableMesh->recalculateNormals();
+    else
+        m_editableMesh->recalculateNormalsFlat();
+
+    m_editableMesh->commitToEntity(m_editEntity);
+    updateSelectionOverlay();
+    emit meshDataChanged();
+}
+
+void EditModeController::rotateSelectedVertices(const Ogre::Quaternion& rotation)
+{
+    if (!m_editableMesh || m_selectedVertices.empty())
+        return;
+
+    Ogre::Vector3 pivot = getSelectedVerticesCentroid();
+    auto weights = getSoftSelectionWeights();
+
+    for (const auto& [gi, weight] : weights) {
+        auto [subIdx, localIdx] = globalToLocal(gi);
+        if (subIdx < m_editableMesh->subMeshes().size() &&
+            localIdx < m_editableMesh->subMeshes()[subIdx].vertices.size())
+        {
+            Ogre::Vector3 pos = m_editableMesh->getVertexPosition(subIdx, localIdx);
+            Ogre::Vector3 offset = pos - pivot;
+            // Interpolate rotation by weight
+            Ogre::Quaternion weightedRot = Ogre::Quaternion::Slerp(weight, Ogre::Quaternion::IDENTITY, rotation);
+            Ogre::Vector3 rotatedOffset = weightedRot * offset;
+            m_editableMesh->setVertexPosition(subIdx, localIdx, pivot + rotatedOffset);
+        }
+    }
+
+    if (m_normalsMode == 0)
+        m_editableMesh->recalculateNormals();
+    else
+        m_editableMesh->recalculateNormalsFlat();
+
+    m_editableMesh->commitToEntity(m_editEntity);
+    updateSelectionOverlay();
+    emit meshDataChanged();
+}
+
+void EditModeController::scaleSelectedVertices(const Ogre::Vector3& scaleFactor)
+{
+    if (!m_editableMesh || m_selectedVertices.empty())
+        return;
+
+    Ogre::Vector3 pivot = getSelectedVerticesCentroid();
+    auto weights = getSoftSelectionWeights();
+
+    for (const auto& [gi, weight] : weights) {
+        auto [subIdx, localIdx] = globalToLocal(gi);
+        if (subIdx < m_editableMesh->subMeshes().size() &&
+            localIdx < m_editableMesh->subMeshes()[subIdx].vertices.size())
+        {
+            Ogre::Vector3 pos = m_editableMesh->getVertexPosition(subIdx, localIdx);
+            Ogre::Vector3 offset = pos - pivot;
+            // Interpolate scale by weight
+            Ogre::Vector3 weightedScale = Ogre::Vector3::UNIT_SCALE +
+                (scaleFactor - Ogre::Vector3::UNIT_SCALE) * weight;
+            Ogre::Vector3 scaledOffset = offset * weightedScale;
+            m_editableMesh->setVertexPosition(subIdx, localIdx, pivot + scaledOffset);
+        }
+    }
+
+    if (m_normalsMode == 0)
+        m_editableMesh->recalculateNormals();
+    else
+        m_editableMesh->recalculateNormalsFlat();
+
+    m_editableMesh->commitToEntity(m_editEntity);
+    updateSelectionOverlay();
+    emit meshDataChanged();
+}
+
+std::map<int, Ogre::Vector3> EditModeController::snapshotVertexPositions() const
+{
+    std::map<int, Ogre::Vector3> snapshot;
+    if (!m_editableMesh)
+        return snapshot;
+
+    auto weights = getSoftSelectionWeights();
+    for (const auto& [gi, weight] : weights) {
+        auto [subIdx, localIdx] = globalToLocal(gi);
+        if (subIdx < m_editableMesh->subMeshes().size() &&
+            localIdx < m_editableMesh->subMeshes()[subIdx].vertices.size())
+        {
+            snapshot[gi] = m_editableMesh->getVertexPosition(subIdx, localIdx);
+        }
+    }
+    return snapshot;
+}
+
+void EditModeController::restoreVertexPositions(const std::map<int, Ogre::Vector3>& snapshot)
+{
+    if (!m_editableMesh)
+        return;
+
+    for (const auto& [gi, pos] : snapshot) {
+        auto [subIdx, localIdx] = globalToLocal(gi);
+        if (subIdx < m_editableMesh->subMeshes().size() &&
+            localIdx < m_editableMesh->subMeshes()[subIdx].vertices.size())
+        {
+            m_editableMesh->setVertexPosition(subIdx, localIdx, pos);
+        }
+    }
+
+    if (m_editEntity) {
+        m_editableMesh->commitToEntity(m_editEntity);
+        updateSelectionOverlay();
+        emit meshDataChanged();
+    }
+}
+
+// ===========================================================================
 // Selection overlay
 // ===========================================================================
 

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -167,6 +167,9 @@ bool EditModeController::enterEditMode()
             .arg(m_editableMesh->totalTriangleCount())
             .arg(m_editableMesh->subMeshCount()));
 
+    // Run initial validation
+    validateMesh();
+
     emit editModeChanged();
     emit meshDataChanged();
     emit selectionModeChanged();
@@ -181,9 +184,11 @@ void EditModeController::exitEditMode(bool commitChanges)
         return;
 
     if (commitChanges && m_editableMesh && m_editEntity) {
-        m_editableMesh->commitToEntity(m_editEntity);
-    refreshNormalVisualizer();
-        SentryReporter::addBreadcrumb("edit_mode", "Exited Edit Mode: changes committed");
+        bool ok = m_editableMesh->commitToEntity(m_editEntity);
+        refreshNormalVisualizer();
+        SentryReporter::addBreadcrumb("edit_mode",
+            ok ? "Exited Edit Mode: changes committed"
+               : "Exited Edit Mode: commit failed");
     } else {
         SentryReporter::addBreadcrumb("edit_mode", "Exited Edit Mode: changes discarded");
     }
@@ -216,9 +221,13 @@ void EditModeController::exitEditMode(bool commitChanges)
     m_editEntity = nullptr;
     m_editModeActive = false;
 
+    // Reset validation state for next session
+    m_degenerateTriangleCount = 0;
+
     emit editModeChanged();
     emit meshDataChanged();
     emit editSelectionChanged();
+    emit validationChanged();
 }
 
 void EditModeController::onSelectionChanged()
@@ -1044,12 +1053,9 @@ void EditModeController::removeDegenerateTriangles()
     int removed = m_editableMesh->removeDegenerateTriangles();
 
     if (removed > 0) {
-        // Recalculate normals and commit
+        // recalculateNormals() already calls commitToEntity + refreshNormalVisualizer
         recalculateNormals(m_normalsMode == 0);
-        m_editableMesh->commitToEntity(m_editEntity);
-    refreshNormalVisualizer();
         updateSelectionOverlay();
-        emit meshDataChanged();
     }
 
     // Re-validate

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -188,6 +188,22 @@ void EditModeController::exitEditMode(bool commitChanges)
         SentryReporter::addBreadcrumb("edit_mode", "Exited Edit Mode: changes discarded");
     }
 
+    // Restore wireframe materials if enabled
+    if (m_wireframeEnabled) {
+        for (const auto& [idx, matName] : m_savedMaterials) {
+            if (m_editEntity && idx < m_editEntity->getNumSubEntities()) {
+                m_editEntity->getSubEntity(idx)->setMaterialName(matName);
+                Ogre::String wireName = matName + "_EditWireframe";
+                auto& matMgr = Ogre::MaterialManager::getSingleton();
+                if (matMgr.resourceExists(wireName))
+                    matMgr.remove(wireName);
+            }
+        }
+        m_savedMaterials.clear();
+        m_wireframeEnabled = false;
+        emit wireframeChanged();
+    }
+
     // Clean up selection overlays
     destroySelectionOverlay();
 
@@ -1478,6 +1494,63 @@ void EditModeController::destroySelectionOverlay()
     }
 }
 
+
+// ===========================================================================
+// Wireframe toggle
+// ===========================================================================
+
+void EditModeController::setWireframeEnabled(bool enabled)
+{
+    if (m_wireframeEnabled == enabled)
+        return;
+
+    m_wireframeEnabled = enabled;
+
+    if (!m_editModeActive || !m_editEntity) {
+        emit wireframeChanged();
+        return;
+    }
+
+    if (enabled) {
+        // Save original materials and switch all sub-entities to wireframe
+        m_savedMaterials.clear();
+        for (unsigned int i = 0; i < m_editEntity->getNumSubEntities(); ++i) {
+            auto* subEnt = m_editEntity->getSubEntity(i);
+            m_savedMaterials[i] = subEnt->getMaterialName();
+
+            // Clone the material so we don't modify the original
+            Ogre::String wireName = subEnt->getMaterialName() + "_EditWireframe";
+            auto& matMgr = Ogre::MaterialManager::getSingleton();
+            auto wireMat = matMgr.getByName(wireName);
+            if (!wireMat) {
+                wireMat = subEnt->getMaterial()->clone(wireName);
+            }
+            for (unsigned short ti = 0; ti < wireMat->getNumTechniques(); ++ti) {
+                for (unsigned short pi = 0; pi < wireMat->getTechnique(ti)->getNumPasses(); ++pi) {
+                    wireMat->getTechnique(ti)->getPass(pi)->setPolygonMode(Ogre::PM_WIREFRAME);
+                }
+            }
+            subEnt->setMaterialName(wireName);
+        }
+    } else {
+        // Restore original materials
+        for (const auto& [idx, matName] : m_savedMaterials) {
+            if (idx < m_editEntity->getNumSubEntities()) {
+                m_editEntity->getSubEntity(idx)->setMaterialName(matName);
+                // Clean up the cloned wireframe material
+                Ogre::String wireName = matName + "_EditWireframe";
+                auto& matMgr = Ogre::MaterialManager::getSingleton();
+                if (matMgr.resourceExists(wireName))
+                    matMgr.remove(wireName);
+            }
+        }
+        m_savedMaterials.clear();
+    }
+
+    SentryReporter::addBreadcrumb("edit_mode",
+        QString("Wireframe %1").arg(enabled ? "enabled" : "disabled"));
+    emit wireframeChanged();
+}
 
 void EditModeController::refreshNormalVisualizer()
 {

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -34,6 +34,7 @@ THE SOFTWARE.
 #include "OgreWidget.h"
 #include "SpaceCamera.h"
 #include <Ogre.h>
+#include <ProceduralSphereGenerator.h>
 #include <cmath>
 #include <algorithm>
 #include <limits>
@@ -1377,6 +1378,51 @@ void EditModeController::updateSelectionOverlay()
 
         m_overlayFaces->end();
     }
+
+    // -- Soft selection radius sphere --
+    if (m_softSelectionEnabled && !m_selectedVertices.empty()) {
+        Ogre::Vector3 centroid = getSelectedVerticesCentroid();
+
+        // Create sphere entity on first use
+        if (!m_softSelSphere) {
+            const std::string meshName = "__SoftSelSphere__";
+            if (!Ogre::MeshManager::getSingleton().resourceExists(meshName)) {
+                Procedural::SphereGenerator()
+                    .setRadius(1.0f)
+                    .setNumRings(16)
+                    .setNumSegments(16)
+                    .realizeMesh(meshName);
+            }
+
+            // Create a transparent glass-like material
+            const std::string matName = "EditMode/SoftSelRadius";
+            auto& matMgr = Ogre::MaterialManager::getSingleton();
+            if (!matMgr.resourceExists(matName)) {
+                auto mat = matMgr.create(matName, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+                auto* pass = mat->getTechnique(0)->getPass(0);
+                pass->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
+                pass->setDepthWriteEnabled(false);
+                pass->setDiffuse(Ogre::ColourValue(0.3f, 0.6f, 1.0f, 0.08f));
+                pass->setAmbient(Ogre::ColourValue(0.2f, 0.4f, 0.8f, 0.08f));
+                pass->setSpecular(Ogre::ColourValue(1.0f, 1.0f, 1.0f, 0.15f));
+                pass->setShininess(60.0f);
+                pass->setCullingMode(Ogre::CULL_NONE);
+            }
+
+            m_softSelSphereNode = m_overlayNode->createChildSceneNode();
+            m_softSelSphere = sceneMgr->createEntity("EditMode_SoftSelSphere", meshName);
+            m_softSelSphere->setMaterialName(matName);
+            m_softSelSphere->setRenderQueueGroup(Ogre::RENDER_QUEUE_OVERLAY - 1);
+            m_softSelSphereNode->attachObject(m_softSelSphere);
+        }
+
+        m_softSelSphereNode->setPosition(centroid);
+        float r = static_cast<float>(m_softSelectionRadius);
+        m_softSelSphereNode->setScale(r, r, r);
+        m_softSelSphereNode->setVisible(true);
+    } else if (m_softSelSphereNode) {
+        m_softSelSphereNode->setVisible(false);
+    }
 }
 
 void EditModeController::destroySelectionOverlay()
@@ -1403,6 +1449,16 @@ void EditModeController::destroySelectionOverlay()
         if (m_overlayFaces) {
             sceneMgr->destroyManualObject(m_overlayFaces);
             m_overlayFaces = nullptr;
+        }
+        if (m_softSelSphere) {
+            if (m_softSelSphereNode)
+                m_softSelSphereNode->detachAllObjects();
+            sceneMgr->destroyEntity(m_softSelSphere);
+            m_softSelSphere = nullptr;
+            if (m_softSelSphereNode) {
+                sceneMgr->destroySceneNode(m_softSelSphereNode);
+                m_softSelSphereNode = nullptr;
+            }
         }
 
         sceneMgr->destroySceneNode(m_overlayNode);

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -341,11 +341,12 @@ void EditModeController::selectVertex(int globalIndex, bool addToSelection)
 {
     if (!m_editModeActive || !m_editableMesh)
         return;
-    if (globalIndex < 0 || globalIndex >= static_cast<int>(m_editableMesh->totalVertexCount()))
-        return;
 
     if (!addToSelection)
         m_selectedVertices.clear();
+
+    if (globalIndex < 0 || globalIndex >= static_cast<int>(m_editableMesh->totalVertexCount()))
+        return;
 
     m_selectedVertices.insert(globalIndex);
     updateSelectionOverlay();

--- a/src/EditModeController.h
+++ b/src/EditModeController.h
@@ -35,8 +35,10 @@ THE SOFTWARE.
 #include <QRect>
 #include <memory>
 #include <set>
+#include <map>
 #include <utility>
 #include <OgreVector.h>
+#include <OgreQuaternion.h>
 
 class EditableMesh;
 class OgreWidget;
@@ -79,6 +81,18 @@ class EditModeController : public QObject
     Q_PROPERTY(int selectedVertexCount READ selectedVertexCount NOTIFY editSelectionChanged)
     Q_PROPERTY(int selectedEdgeCount READ selectedEdgeCount NOTIFY editSelectionChanged)
     Q_PROPERTY(int selectedFaceCount READ selectedFaceCount NOTIFY editSelectionChanged)
+
+    // Soft selection (proportional editing)
+    Q_PROPERTY(bool softSelectionEnabled READ softSelectionEnabled WRITE setSoftSelectionEnabled NOTIFY softSelectionChanged)
+    Q_PROPERTY(double softSelectionRadius READ softSelectionRadius WRITE setSoftSelectionRadius NOTIFY softSelectionChanged)
+    Q_PROPERTY(int softSelectionFalloff READ softSelectionFalloff WRITE setSoftSelectionFalloff NOTIFY softSelectionChanged)
+
+    // Normals recalculation
+    Q_PROPERTY(int normalsMode READ normalsMode WRITE setNormalsMode NOTIFY normalsModeChanged)
+
+    // Mesh validation after edits
+    Q_PROPERTY(int degenerateTriangleCount READ degenerateTriangleCount NOTIFY validationChanged)
+    Q_PROPERTY(bool hasValidationWarnings READ hasValidationWarnings NOTIFY validationChanged)
 
 public:
     /// Selection component mode for edit mode.
@@ -125,6 +139,58 @@ public:
     const std::set<int>& selectedVertices() const { return m_selectedVertices; }
     const std::set<std::pair<int,int>>& selectedEdges() const { return m_selectedEdges; }
     const std::set<int>& selectedFaces() const { return m_selectedFaces; }
+    /// @}
+
+    /// @name Soft selection (proportional editing)
+    /// @{
+    bool softSelectionEnabled() const { return m_softSelectionEnabled; }
+    void setSoftSelectionEnabled(bool enabled);
+    double softSelectionRadius() const { return m_softSelectionRadius; }
+    void setSoftSelectionRadius(double radius);
+    int softSelectionFalloff() const { return m_softSelectionFalloff; }
+    void setSoftSelectionFalloff(int falloff);
+
+    /// Compute soft selection weights for all vertices.
+    /// Returns a map of global vertex index -> weight (0.0 to 1.0).
+    /// Selected vertices get weight 1.0; nearby vertices get falloff weight.
+    std::map<int, float> getSoftSelectionWeights() const;
+    /// @}
+
+    /// @name Normals recalculation
+    /// @{
+    int normalsMode() const { return m_normalsMode; }
+    void setNormalsMode(int mode);
+    Q_INVOKABLE void recalculateNormals(bool smooth = true);
+    /// @}
+
+    /// @name Mesh validation after edits
+    /// @{
+    int degenerateTriangleCount() const { return m_degenerateTriangleCount; }
+    bool hasValidationWarnings() const { return m_degenerateTriangleCount > 0; }
+    Q_INVOKABLE void validateMesh();
+    Q_INVOKABLE void removeDegenerateTriangles();
+    /// @}
+
+    /// @name Vertex transform support
+    /// @{
+    /// Get the centroid of selected vertices in local mesh space.
+    Ogre::Vector3 getSelectedVerticesCentroid() const;
+
+    /// Apply a translation delta to selected vertices (with optional soft selection).
+    void translateSelectedVertices(const Ogre::Vector3& delta);
+
+    /// Apply a rotation to selected vertices around the centroid (with optional soft selection).
+    void rotateSelectedVertices(const Ogre::Quaternion& rotation);
+
+    /// Apply a scale to selected vertices around the centroid (with optional soft selection).
+    void scaleSelectedVertices(const Ogre::Vector3& scaleFactor);
+
+    /// Snapshot current positions of all affected vertices (selected + soft selection).
+    /// Call before starting a transform drag.
+    std::map<int, Ogre::Vector3> snapshotVertexPositions() const;
+
+    /// Restore vertex positions from a snapshot.
+    void restoreVertexPositions(const std::map<int, Ogre::Vector3>& snapshot);
     /// @}
 
     /// @name Selection operations
@@ -286,6 +352,12 @@ signals:
     void selectionModeChanged();
     /// Emitted when the edit-mode selection (vertices/edges/faces) changes.
     void editSelectionChanged();
+    /// Emitted when soft selection settings change.
+    void softSelectionChanged();
+    /// Emitted when normals mode changes.
+    void normalsModeChanged();
+    /// Emitted when mesh validation results change.
+    void validationChanged();
 
 private slots:
     void onSelectionChanged();
@@ -318,6 +390,17 @@ private:
     Ogre::ManualObject* m_overlayEdges = nullptr;
     Ogre::ManualObject* m_overlayFaces = nullptr;
     Ogre::SceneNode* m_overlayNode = nullptr;
+
+    // Soft selection (proportional editing)
+    bool m_softSelectionEnabled = false;
+    double m_softSelectionRadius = 2.0;
+    int m_softSelectionFalloff = 0; ///< 0=linear, 1=smooth (cosine)
+
+    // Normals mode: 0=smooth (default), 1=flat
+    int m_normalsMode = 0;
+
+    // Mesh validation
+    int m_degenerateTriangleCount = 0;
 };
 
 #endif // EDITMODECONTROLLER_H

--- a/src/EditModeController.h
+++ b/src/EditModeController.h
@@ -111,6 +111,11 @@ public:
     /// Returns true if the current selection allows entering edit mode
     /// (exactly one mesh entity selected).
     bool canEnterEditMode() const;
+
+    /// Wireframe overlay toggle for edit mode
+    Q_PROPERTY(bool wireframeEnabled READ wireframeEnabled WRITE setWireframeEnabled NOTIFY wireframeChanged)
+    bool wireframeEnabled() const { return m_wireframeEnabled; }
+    void setWireframeEnabled(bool enabled);
     /// @}
 
     /// @name Mesh info (only valid when in edit mode)
@@ -350,6 +355,8 @@ signals:
     void selectionStateChanged();
     /// Emitted when the component selection mode changes (Vertex/Edge/Face).
     void selectionModeChanged();
+    /// Emitted when wireframe mode is toggled.
+    void wireframeChanged();
     /// Emitted when the edit-mode selection (vertices/edges/faces) changes.
     void editSelectionChanged();
     /// Emitted when soft selection settings change.
@@ -399,6 +406,10 @@ private:
     int m_softSelectionFalloff = 0; ///< 0=linear, 1=smooth (cosine)
     Ogre::Entity* m_softSelSphere = nullptr;
     Ogre::SceneNode* m_softSelSphereNode = nullptr;
+
+    // Wireframe mode
+    bool m_wireframeEnabled = false;
+    std::map<unsigned int, Ogre::String> m_savedMaterials; ///< SubEntity index → original material name
 
     // Normals mode: 0=smooth (default), 1=flat
     int m_normalsMode = 0;

--- a/src/EditModeController.h
+++ b/src/EditModeController.h
@@ -407,6 +407,10 @@ private:
     Ogre::Entity* m_softSelSphere = nullptr;
     Ogre::SceneNode* m_softSelSphereNode = nullptr;
 
+    // Wireframe helpers
+    void applyWireframeMaterials();
+    void removeWireframeMaterials();
+
     // Wireframe mode
     bool m_wireframeEnabled = false;
     std::map<unsigned int, Ogre::String> m_savedMaterials; ///< SubEntity index → original material name

--- a/src/EditModeController.h
+++ b/src/EditModeController.h
@@ -395,6 +395,8 @@ private:
     bool m_softSelectionEnabled = false;
     double m_softSelectionRadius = 2.0;
     int m_softSelectionFalloff = 0; ///< 0=linear, 1=smooth (cosine)
+    Ogre::Entity* m_softSelSphere = nullptr;
+    Ogre::SceneNode* m_softSelSphereNode = nullptr;
 
     // Normals mode: 0=smooth (default), 1=flat
     int m_normalsMode = 0;

--- a/src/EditModeController.h
+++ b/src/EditModeController.h
@@ -1,0 +1,123 @@
+/*
+-----------------------------------------------------------------------------------
+A QtMeshEditor file
+
+Copyright (c) Fernando Tonon (https://github.com/fernandotonon)
+
+The MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-----------------------------------------------------------------------------------
+*/
+
+#ifndef EDITMODECONTROLLER_H
+#define EDITMODECONTROLLER_H
+
+#include <QObject>
+#include <QQmlEngine>
+#include <memory>
+
+class EditableMesh;
+
+namespace Ogre { class Entity; }
+
+/**
+ * @brief QML_SINGLETON that manages Object Mode / Edit Mode state.
+ *
+ * In Object Mode, the user manipulates entire scene nodes (translate,
+ * rotate, scale). In Edit Mode, the user can manipulate individual
+ * vertices, edges, and faces of a single mesh entity.
+ *
+ * Entering Edit Mode decomposes the selected entity's mesh into an
+ * editable representation (EditableMesh). Exiting Edit Mode commits
+ * the changes back to the Ogre buffers and recalculates normals/bounds.
+ *
+ * The Tab key toggles between modes.
+ */
+class EditModeController : public QObject
+{
+    Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
+
+    Q_PROPERTY(bool editModeActive READ isEditModeActive NOTIFY editModeChanged)
+    Q_PROPERTY(QString modeLabel READ modeLabel NOTIFY editModeChanged)
+    Q_PROPERTY(bool canEnterEditMode READ canEnterEditMode NOTIFY selectionStateChanged)
+    Q_PROPERTY(int vertexCount READ vertexCount NOTIFY meshDataChanged)
+    Q_PROPERTY(int triangleCount READ triangleCount NOTIFY meshDataChanged)
+    Q_PROPERTY(int subMeshCount READ subMeshCount NOTIFY meshDataChanged)
+
+public:
+    static EditModeController* instance();
+    static EditModeController* qmlInstance(QQmlEngine* engine, QJSEngine* scriptEngine);
+    static void kill();
+
+    /// @name Mode state
+    /// @{
+    bool isEditModeActive() const { return m_editModeActive; }
+    QString modeLabel() const;
+
+    /// Returns true if the current selection allows entering edit mode
+    /// (exactly one mesh entity selected).
+    bool canEnterEditMode() const;
+    /// @}
+
+    /// @name Mesh info (only valid when in edit mode)
+    /// @{
+    int vertexCount() const;
+    int triangleCount() const;
+    int subMeshCount() const;
+    /// @}
+
+    /// @name Mode transitions
+    /// @{
+    Q_INVOKABLE void toggleEditMode();
+    Q_INVOKABLE bool enterEditMode();
+    Q_INVOKABLE void exitEditMode(bool commitChanges = true);
+    /// @}
+
+    /// Access the current editable mesh (nullptr if not in edit mode).
+    EditableMesh* currentMesh() const { return m_editableMesh.get(); }
+
+    /// Returns the entity being edited (nullptr if not in edit mode).
+    Ogre::Entity* editEntity() const { return m_editEntity; }
+
+signals:
+    /// Emitted when entering or exiting edit mode.
+    void editModeChanged();
+    /// Emitted when the mesh data is modified during edit mode.
+    void meshDataChanged();
+    /// Emitted when the selection changes (to update canEnterEditMode).
+    void selectionStateChanged();
+
+private slots:
+    void onSelectionChanged();
+
+private:
+    EditModeController();
+    ~EditModeController() override;
+
+    static EditModeController* m_pSingleton;
+
+    bool m_editModeActive = false;
+    std::unique_ptr<EditableMesh> m_editableMesh;
+    Ogre::Entity* m_editEntity = nullptr;
+};
+
+#endif // EDITMODECONTROLLER_H

--- a/src/EditModeController.h
+++ b/src/EditModeController.h
@@ -31,11 +31,23 @@ THE SOFTWARE.
 
 #include <QObject>
 #include <QQmlEngine>
+#include <QPoint>
+#include <QRect>
 #include <memory>
+#include <set>
+#include <utility>
+#include <OgreVector.h>
 
 class EditableMesh;
+class OgreWidget;
 
-namespace Ogre { class Entity; }
+namespace Ogre {
+    class Entity;
+    class Camera;
+    class SceneManager;
+    class SceneNode;
+    class ManualObject;
+}
 
 /**
  * @brief QML_SINGLETON that manages Object Mode / Edit Mode state.
@@ -48,7 +60,8 @@ namespace Ogre { class Entity; }
  * editable representation (EditableMesh). Exiting Edit Mode commits
  * the changes back to the Ogre buffers and recalculates normals/bounds.
  *
- * The Tab key toggles between modes.
+ * The Tab key toggles between modes. In edit mode, 1/2/3 keys switch
+ * between Vertex/Edge/Face selection modes.
  */
 class EditModeController : public QObject
 {
@@ -62,8 +75,16 @@ class EditModeController : public QObject
     Q_PROPERTY(int vertexCount READ vertexCount NOTIFY meshDataChanged)
     Q_PROPERTY(int triangleCount READ triangleCount NOTIFY meshDataChanged)
     Q_PROPERTY(int subMeshCount READ subMeshCount NOTIFY meshDataChanged)
+    Q_PROPERTY(int selectionMode READ selectionMode WRITE setSelectionMode NOTIFY selectionModeChanged)
+    Q_PROPERTY(int selectedVertexCount READ selectedVertexCount NOTIFY editSelectionChanged)
+    Q_PROPERTY(int selectedEdgeCount READ selectedEdgeCount NOTIFY editSelectionChanged)
+    Q_PROPERTY(int selectedFaceCount READ selectedFaceCount NOTIFY editSelectionChanged)
 
 public:
+    /// Selection component mode for edit mode.
+    enum SelectionMode { VertexMode = 0, EdgeMode = 1, FaceMode = 2 };
+    Q_ENUM(SelectionMode)
+
     static EditModeController* instance();
     static EditModeController* qmlInstance(QQmlEngine* engine, QJSEngine* scriptEngine);
     static void kill();
@@ -92,11 +113,167 @@ public:
     Q_INVOKABLE void exitEditMode(bool commitChanges = true);
     /// @}
 
+    /// @name Component selection mode (Vertex/Edge/Face)
+    /// @{
+    int selectionMode() const { return static_cast<int>(m_selectionMode); }
+    void setSelectionMode(int mode);
+
+    int selectedVertexCount() const { return static_cast<int>(m_selectedVertices.size()); }
+    int selectedEdgeCount() const { return static_cast<int>(m_selectedEdges.size()); }
+    int selectedFaceCount() const { return static_cast<int>(m_selectedFaces.size()); }
+
+    const std::set<int>& selectedVertices() const { return m_selectedVertices; }
+    const std::set<std::pair<int,int>>& selectedEdges() const { return m_selectedEdges; }
+    const std::set<int>& selectedFaces() const { return m_selectedFaces; }
+    /// @}
+
+    /// @name Selection operations
+    /// @{
+    Q_INVOKABLE void selectAll();
+    Q_INVOKABLE void deselectAll();
+
+    /// Select a vertex by global index. If addToSelection is false, clears
+    /// prior selection first.
+    void selectVertex(int globalIndex, bool addToSelection = false);
+
+    /// Deselect a vertex by global index.
+    void deselectVertex(int globalIndex);
+
+    /// Select an edge (pair of global vertex indices, stored min-first).
+    void selectEdge(int v1, int v2, bool addToSelection = false);
+
+    /// Deselect an edge by vertex pair.
+    void deselectEdge(int v1, int v2);
+
+    /// Select a face (triangle) by global triangle index.
+    void selectFace(int triIndex, bool addToSelection = false);
+
+    /// Deselect a face by global triangle index.
+    void deselectFace(int triIndex);
+    /// @}
+
+    /// @name Hit testing
+    /// @{
+    /**
+     * @brief Find the closest vertex to a screen-space point.
+     *
+     * Projects each vertex from local to world to screen space and returns
+     * the global vertex index of the nearest within a pixel radius, or -1.
+     *
+     * @param screenPos Click position in widget coordinates.
+     * @param camera The Ogre camera used for projection.
+     * @param viewportWidth Width of the viewport in pixels.
+     * @param viewportHeight Height of the viewport in pixels.
+     * @param pixelRadius Maximum screen-space distance in pixels (default 10).
+     * @return Global vertex index or -1 if none within radius.
+     */
+    int hitTestVertex(const QPoint& screenPos, Ogre::Camera* camera,
+                      int viewportWidth, int viewportHeight,
+                      float pixelRadius = 10.0f) const;
+
+    /**
+     * @brief Find the closest face (triangle) to a screen-space point via ray intersection.
+     *
+     * Casts a ray from the camera through the click point and tests against
+     * each triangle in the EditableMesh (in local space, transformed by entity node).
+     *
+     * @return Global triangle index or -1 if no hit.
+     */
+    int hitTestFace(const QPoint& screenPos, Ogre::Camera* camera,
+                    int viewportWidth, int viewportHeight) const;
+
+    /**
+     * @brief Find the closest edge to a screen-space point.
+     *
+     * Projects edge endpoints to screen space and returns the edge with
+     * minimum screen-space distance below threshold. The edge is returned
+     * as a pair (min vertex index, max vertex index).
+     *
+     * @return Vertex pair or (-1, -1) if no edge within threshold.
+     */
+    std::pair<int,int> hitTestEdge(const QPoint& screenPos, Ogre::Camera* camera,
+                                   int viewportWidth, int viewportHeight,
+                                   float pixelRadius = 10.0f) const;
+
+    /**
+     * @brief Select vertices within a screen-space rectangle (box select).
+     *
+     * @param rect Screen-space rectangle.
+     * @param camera The Ogre camera used for projection.
+     * @param viewportWidth Width of the viewport in pixels.
+     * @param viewportHeight Height of the viewport in pixels.
+     * @param addToSelection If true, adds to existing selection.
+     */
+    void boxSelectVertices(const QRect& rect, Ogre::Camera* camera,
+                           int viewportWidth, int viewportHeight,
+                           bool addToSelection = false);
+    /// @}
+
+    /// @name Mouse handling (called from TransformOperator when in edit mode)
+    /// @{
+    /**
+     * @brief Handle a mouse click in edit mode.
+     *
+     * Performs hit testing based on current selection mode and updates
+     * the selection accordingly.
+     *
+     * @param screenPos Click position in widget coordinates.
+     * @param widget The active OgreWidget.
+     * @param shiftHeld True if Shift modifier is held (add to selection).
+     * @param ctrlHeld True if Ctrl modifier is held (remove from selection).
+     */
+    void handleMouseClick(const QPoint& screenPos, OgreWidget* widget,
+                          bool shiftHeld, bool ctrlHeld);
+
+    /**
+     * @brief Handle box selection completion in edit mode.
+     *
+     * @param startPos Starting corner of the selection box.
+     * @param endPos Ending corner of the selection box.
+     * @param widget The active OgreWidget.
+     * @param shiftHeld True if Shift modifier is held.
+     */
+    void handleBoxSelect(const QPoint& startPos, const QPoint& endPos,
+                         OgreWidget* widget, bool shiftHeld);
+    /// @}
+
     /// Access the current editable mesh (nullptr if not in edit mode).
     EditableMesh* currentMesh() const { return m_editableMesh.get(); }
 
     /// Returns the entity being edited (nullptr if not in edit mode).
     Ogre::Entity* editEntity() const { return m_editEntity; }
+
+    /// @name Geometry helpers (public for testing)
+    /// @{
+
+    /// Convert a local-space vertex position to screen-space using entity transform and camera.
+    static QPoint worldToScreen(const Ogre::Vector3& worldPos, Ogre::Camera* camera,
+                                int viewportWidth, int viewportHeight);
+
+    /// Compute the distance from a point to a line segment in 2D.
+    static float pointToSegmentDistance(const QPoint& point,
+                                        const QPoint& segA, const QPoint& segB);
+
+    /// Ray-triangle intersection (Moller-Trumbore algorithm).
+    /// Returns the distance t along the ray, or -1 if no intersection.
+    static float rayTriangleIntersect(const Ogre::Vector3& rayOrigin,
+                                      const Ogre::Vector3& rayDir,
+                                      const Ogre::Vector3& v0,
+                                      const Ogre::Vector3& v1,
+                                      const Ogre::Vector3& v2);
+
+    /// Convert a global vertex index to (subMeshIndex, localVertexIndex) pair.
+    std::pair<size_t, size_t> globalToLocal(int globalIndex) const;
+
+    /// Convert (subMeshIndex, localVertexIndex) to a global vertex index.
+    int localToGlobal(size_t subMeshIndex, size_t localVertexIndex) const;
+
+    /// Convert a global triangle index to (subMeshIndex, localTriangleIndex) pair.
+    std::pair<size_t, size_t> globalTriToLocal(int globalTriIndex) const;
+
+    /// Convert (subMeshIndex, localTriangleIndex) to a global triangle index.
+    int localTriToGlobal(size_t subMeshIndex, size_t localTriIndex) const;
+    /// @}
 
 signals:
     /// Emitted when entering or exiting edit mode.
@@ -105,6 +282,10 @@ signals:
     void meshDataChanged();
     /// Emitted when the selection changes (to update canEnterEditMode).
     void selectionStateChanged();
+    /// Emitted when the component selection mode changes (Vertex/Edge/Face).
+    void selectionModeChanged();
+    /// Emitted when the edit-mode selection (vertices/edges/faces) changes.
+    void editSelectionChanged();
 
 private slots:
     void onSelectionChanged();
@@ -113,11 +294,30 @@ private:
     EditModeController();
     ~EditModeController() override;
 
+    /// Build or rebuild the selection overlay ManualObject.
+    void updateSelectionOverlay();
+    /// Destroy the selection overlay ManualObject and scene node.
+    void destroySelectionOverlay();
+    /// Create the materials used for selection overlays.
+    void createOverlayMaterials();
+
     static EditModeController* m_pSingleton;
 
     bool m_editModeActive = false;
     std::unique_ptr<EditableMesh> m_editableMesh;
     Ogre::Entity* m_editEntity = nullptr;
+
+    // Component selection state
+    SelectionMode m_selectionMode = VertexMode;
+    std::set<int> m_selectedVertices;              ///< Global vertex indices
+    std::set<std::pair<int,int>> m_selectedEdges;  ///< Edges as (min, max) vertex pairs
+    std::set<int> m_selectedFaces;                 ///< Global triangle indices
+
+    // Selection overlay
+    Ogre::ManualObject* m_overlayVertices = nullptr;
+    Ogre::ManualObject* m_overlayEdges = nullptr;
+    Ogre::ManualObject* m_overlayFaces = nullptr;
+    Ogre::SceneNode* m_overlayNode = nullptr;
 };
 
 #endif // EDITMODECONTROLLER_H

--- a/src/EditModeController.h
+++ b/src/EditModeController.h
@@ -379,6 +379,8 @@ private:
     std::unique_ptr<EditableMesh> m_editableMesh;
     Ogre::Entity* m_editEntity = nullptr;
 
+    void refreshNormalVisualizer();
+
     // Component selection state
     SelectionMode m_selectionMode = VertexMode;
     std::set<int> m_selectedVertices;              ///< Global vertex indices

--- a/src/EditModeController_test.cpp
+++ b/src/EditModeController_test.cpp
@@ -211,10 +211,8 @@ TEST_F(EditModeControllerSelectionTest, SetSelectionModeInvalid) {
 
 TEST_F(EditModeControllerSelectionTest, ModeLabelShowsSelectionMode) {
     auto meshPtr = createInMemoryTriangleMesh("EditCtrl_modelabel");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_modelabel_node");
-    auto* entity = sceneMgr->createEntity("EditCtrl_modelabel_ent", meshPtr);
-    node->attachObject(entity);
+    Manager::getSingleton()->createEntity(node, meshPtr);
 
     SelectionSet::getSingleton()->clear();
     SelectionSet::getSingleton()->selectOne(node);
@@ -238,10 +236,8 @@ TEST_F(EditModeControllerSelectionTest, ModeLabelShowsSelectionMode) {
 
 TEST_F(EditModeControllerSelectionTest, VertexSelection) {
     auto meshPtr = createInMemoryTriangleMesh("EditCtrl_vertsel");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_vertsel_node");
-    auto* entity = sceneMgr->createEntity("EditCtrl_vertsel_ent", meshPtr);
-    node->attachObject(entity);
+    Manager::getSingleton()->createEntity(node, meshPtr);
 
     SelectionSet::getSingleton()->clear();
     SelectionSet::getSingleton()->selectOne(node);
@@ -282,10 +278,8 @@ TEST_F(EditModeControllerSelectionTest, VertexSelection) {
 
 TEST_F(EditModeControllerSelectionTest, EdgeSelection) {
     auto meshPtr = createInMemoryTriangleMesh("EditCtrl_edgesel");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_edgesel_node");
-    auto* entity = sceneMgr->createEntity("EditCtrl_edgesel_ent", meshPtr);
-    node->attachObject(entity);
+    Manager::getSingleton()->createEntity(node, meshPtr);
 
     SelectionSet::getSingleton()->clear();
     SelectionSet::getSingleton()->selectOne(node);
@@ -319,10 +313,8 @@ TEST_F(EditModeControllerSelectionTest, EdgeSelection) {
 
 TEST_F(EditModeControllerSelectionTest, FaceSelection) {
     auto meshPtr = createInMemoryTriangleMesh("EditCtrl_facesel");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_facesel_node");
-    auto* entity = sceneMgr->createEntity("EditCtrl_facesel_ent", meshPtr);
-    node->attachObject(entity);
+    Manager::getSingleton()->createEntity(node, meshPtr);
 
     SelectionSet::getSingleton()->clear();
     SelectionSet::getSingleton()->selectOne(node);
@@ -351,10 +343,8 @@ TEST_F(EditModeControllerSelectionTest, FaceSelection) {
 
 TEST_F(EditModeControllerSelectionTest, SelectAllDeselectAll) {
     auto meshPtr = createInMemoryTriangleMesh("EditCtrl_selectall");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_selectall_node");
-    auto* entity = sceneMgr->createEntity("EditCtrl_selectall_ent", meshPtr);
-    node->attachObject(entity);
+    Manager::getSingleton()->createEntity(node, meshPtr);
 
     SelectionSet::getSingleton()->clear();
     SelectionSet::getSingleton()->selectOne(node);
@@ -380,10 +370,8 @@ TEST_F(EditModeControllerSelectionTest, SelectAllDeselectAll) {
 
 TEST_F(EditModeControllerSelectionTest, ExitEditModeClearsSelection) {
     auto meshPtr = createInMemoryTriangleMesh("EditCtrl_exitclears");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_exitclears_node");
-    auto* entity = sceneMgr->createEntity("EditCtrl_exitclears_ent", meshPtr);
-    node->attachObject(entity);
+    Manager::getSingleton()->createEntity(node, meshPtr);
 
     SelectionSet::getSingleton()->clear();
     SelectionSet::getSingleton()->selectOne(node);
@@ -408,10 +396,8 @@ TEST_F(EditModeControllerSelectionTest, ExitEditModeClearsSelection) {
 
 TEST_F(EditModeControllerSelectionTest, GlobalToLocalConversion) {
     auto meshPtr = createInMemoryTriangleMesh("EditCtrl_g2l");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_g2l_node");
-    auto* entity = sceneMgr->createEntity("EditCtrl_g2l_ent", meshPtr);
-    node->attachObject(entity);
+    Manager::getSingleton()->createEntity(node, meshPtr);
 
     SelectionSet::getSingleton()->clear();
     SelectionSet::getSingleton()->selectOne(node);
@@ -443,10 +429,8 @@ TEST_F(EditModeControllerSelectionTest, GlobalToLocalConversion) {
 
 TEST_F(EditModeControllerSelectionTest, GlobalTriToLocalConversion) {
     auto meshPtr = createInMemoryTriangleMesh("EditCtrl_gt2l");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_gt2l_node");
-    auto* entity = sceneMgr->createEntity("EditCtrl_gt2l_ent", meshPtr);
-    node->attachObject(entity);
+    Manager::getSingleton()->createEntity(node, meshPtr);
 
     SelectionSet::getSingleton()->clear();
     SelectionSet::getSingleton()->selectOne(node);
@@ -470,10 +454,8 @@ TEST_F(EditModeControllerSelectionTest, GlobalTriToLocalConversion) {
 
 TEST_F(EditModeControllerSelectionTest, HitTestVertexNullCamera) {
     auto meshPtr = createInMemoryTriangleMesh("EditCtrl_hitvert_null");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_hitvert_null_node");
-    auto* entity = sceneMgr->createEntity("EditCtrl_hitvert_null_ent", meshPtr);
-    node->attachObject(entity);
+    Manager::getSingleton()->createEntity(node, meshPtr);
 
     SelectionSet::getSingleton()->clear();
     SelectionSet::getSingleton()->selectOne(node);
@@ -491,10 +473,8 @@ TEST_F(EditModeControllerSelectionTest, HitTestVertexNullCamera) {
 
 TEST_F(EditModeControllerSelectionTest, HitTestFaceNullCamera) {
     auto meshPtr = createInMemoryTriangleMesh("EditCtrl_hitface_null");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_hitface_null_node");
-    auto* entity = sceneMgr->createEntity("EditCtrl_hitface_null_ent", meshPtr);
-    node->attachObject(entity);
+    Manager::getSingleton()->createEntity(node, meshPtr);
 
     SelectionSet::getSingleton()->clear();
     SelectionSet::getSingleton()->selectOne(node);
@@ -511,10 +491,8 @@ TEST_F(EditModeControllerSelectionTest, HitTestFaceNullCamera) {
 
 TEST_F(EditModeControllerSelectionTest, HitTestEdgeNullCamera) {
     auto meshPtr = createInMemoryTriangleMesh("EditCtrl_hitedge_null");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_hitedge_null_node");
-    auto* entity = sceneMgr->createEntity("EditCtrl_hitedge_null_ent", meshPtr);
-    node->attachObject(entity);
+    Manager::getSingleton()->createEntity(node, meshPtr);
 
     SelectionSet::getSingleton()->clear();
     SelectionSet::getSingleton()->selectOne(node);
@@ -571,10 +549,8 @@ TEST_F(EditModeControllerSelectionTest, WireframeToggleNotInEditMode) {
 
 TEST_F(EditModeControllerSelectionTest, WireframeToggleInEditMode) {
     auto meshPtr = createInMemoryTriangleMesh("EditCtrl_wireframe");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_wireframe_node");
-    auto* entity = sceneMgr->createEntity("EditCtrl_wireframe_ent", meshPtr);
-    node->attachObject(entity);
+    auto* entity = Manager::getSingleton()->createEntity(node, meshPtr);
 
     SelectionSet::getSingleton()->clear();
     SelectionSet::getSingleton()->selectOne(node);
@@ -604,10 +580,8 @@ TEST_F(EditModeControllerSelectionTest, WireframeToggleInEditMode) {
 
 TEST_F(EditModeControllerSelectionTest, WireframeRestoredOnExitEditMode) {
     auto meshPtr = createInMemoryTriangleMesh("EditCtrl_wire_exit");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_wire_exit_node");
-    auto* entity = sceneMgr->createEntity("EditCtrl_wire_exit_ent", meshPtr);
-    node->attachObject(entity);
+    auto* entity = Manager::getSingleton()->createEntity(node, meshPtr);
 
     SelectionSet::getSingleton()->clear();
     SelectionSet::getSingleton()->selectOne(node);
@@ -632,10 +606,8 @@ TEST_F(EditModeControllerSelectionTest, WireframeRestoredOnExitEditMode) {
 
 TEST_F(EditModeControllerSelectionTest, WireframeSignalEmission) {
     auto meshPtr = createInMemoryTriangleMesh("EditCtrl_wire_signal");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_wire_signal_node");
-    auto* entity = sceneMgr->createEntity("EditCtrl_wire_signal_ent", meshPtr);
-    node->attachObject(entity);
+    auto* entity = Manager::getSingleton()->createEntity(node, meshPtr);
 
     SelectionSet::getSingleton()->clear();
     SelectionSet::getSingleton()->selectOne(node);
@@ -669,10 +641,8 @@ TEST_F(EditModeControllerSelectionTest, WireframeSignalEmission) {
 
 TEST_F(EditModeControllerSelectionTest, SignalEmission) {
     auto meshPtr = createInMemoryTriangleMesh("EditCtrl_signals");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_signals_node");
-    auto* entity = sceneMgr->createEntity("EditCtrl_signals_ent", meshPtr);
-    node->attachObject(entity);
+    Manager::getSingleton()->createEntity(node, meshPtr);
 
     SelectionSet::getSingleton()->clear();
     SelectionSet::getSingleton()->selectOne(node);

--- a/src/EditModeController_test.cpp
+++ b/src/EditModeController_test.cpp
@@ -648,7 +648,9 @@ TEST_F(EditModeControllerSelectionTest, SignalEmission) {
     SelectionSet::getSingleton()->selectOne(node);
 
     auto* ctrl = EditModeController::instance();
+    ASSERT_TRUE(ctrl->enterEditMode());
 
+    // Connect signals after enterEditMode to only count user-initiated changes
     int selModeChanges = 0;
     int editSelChanges = 0;
     auto conn1 = QObject::connect(ctrl, &EditModeController::selectionModeChanged,
@@ -656,16 +658,14 @@ TEST_F(EditModeControllerSelectionTest, SignalEmission) {
     auto conn2 = QObject::connect(ctrl, &EditModeController::editSelectionChanged,
                                    [&]() { ++editSelChanges; });
 
-    ASSERT_TRUE(ctrl->enterEditMode());
-
     ctrl->setSelectionMode(EditModeController::EdgeMode);
     EXPECT_EQ(selModeChanges, 1);
 
     ctrl->selectVertex(0);
-    EXPECT_EQ(editSelChanges, 2); // 1 from enterEditMode + 1 from selectVertex
+    EXPECT_EQ(editSelChanges, 1);
 
     ctrl->deselectAll();
-    EXPECT_EQ(editSelChanges, 3);
+    EXPECT_EQ(editSelChanges, 2);
 
     QObject::disconnect(conn1);
     QObject::disconnect(conn2);

--- a/src/EditModeController_test.cpp
+++ b/src/EditModeController_test.cpp
@@ -1,0 +1,569 @@
+/*
+-----------------------------------------------------------------------------------
+A QtMeshEditor file
+
+Copyright (c) Fernando Tonon (https://github.com/fernandotonon)
+
+The MIT License
+-----------------------------------------------------------------------------------
+*/
+
+#include <gtest/gtest.h>
+#include "EditModeController.h"
+#include "EditableMesh.h"
+#include "TestHelpers.h"
+#include "Manager.h"
+#include "SelectionSet.h"
+#include <Ogre.h>
+#include <set>
+#include <utility>
+#include <cmath>
+
+// ===========================================================================
+// Pure geometry tests (no Ogre needed)
+// ===========================================================================
+
+TEST(EditModeControllerGeometry, WorldToScreenBasicCenter) {
+    // worldToScreen with a null camera returns (-1,-1)
+    auto pt = EditModeController::worldToScreen(Ogre::Vector3::ZERO, nullptr, 800, 600);
+    EXPECT_EQ(pt.x(), -1);
+    EXPECT_EQ(pt.y(), -1);
+}
+
+TEST(EditModeControllerGeometry, PointToSegmentDistanceDegenerate) {
+    // Degenerate segment (both endpoints the same)
+    QPoint p(5, 5);
+    QPoint a(0, 0);
+    float dist = EditModeController::pointToSegmentDistance(p, a, a);
+    EXPECT_NEAR(dist, std::sqrt(50.0f), 0.01f);
+}
+
+TEST(EditModeControllerGeometry, PointToSegmentDistanceOnSegment) {
+    // Point is on the segment
+    QPoint p(5, 0);
+    QPoint a(0, 0);
+    QPoint b(10, 0);
+    float dist = EditModeController::pointToSegmentDistance(p, a, b);
+    EXPECT_NEAR(dist, 0.0f, 0.01f);
+}
+
+TEST(EditModeControllerGeometry, PointToSegmentDistancePerpendicular) {
+    // Point directly above mid-segment
+    QPoint p(5, 3);
+    QPoint a(0, 0);
+    QPoint b(10, 0);
+    float dist = EditModeController::pointToSegmentDistance(p, a, b);
+    EXPECT_NEAR(dist, 3.0f, 0.01f);
+}
+
+TEST(EditModeControllerGeometry, PointToSegmentDistanceBeyondEndpoint) {
+    // Point is beyond endpoint b
+    QPoint p(15, 0);
+    QPoint a(0, 0);
+    QPoint b(10, 0);
+    float dist = EditModeController::pointToSegmentDistance(p, a, b);
+    EXPECT_NEAR(dist, 5.0f, 0.01f);
+}
+
+TEST(EditModeControllerGeometry, PointToSegmentDistanceBeforeStart) {
+    // Point is before start a
+    QPoint p(-5, 0);
+    QPoint a(0, 0);
+    QPoint b(10, 0);
+    float dist = EditModeController::pointToSegmentDistance(p, a, b);
+    EXPECT_NEAR(dist, 5.0f, 0.01f);
+}
+
+TEST(EditModeControllerGeometry, RayTriangleIntersectHit) {
+    // Ray going straight down into a triangle lying on XZ plane
+    Ogre::Vector3 origin(0.25f, 1.0f, 0.25f);
+    Ogre::Vector3 dir(0.0f, -1.0f, 0.0f);
+    Ogre::Vector3 v0(0, 0, 0);
+    Ogre::Vector3 v1(1, 0, 0);
+    Ogre::Vector3 v2(0, 0, 1);
+
+    float t = EditModeController::rayTriangleIntersect(origin, dir, v0, v1, v2);
+    EXPECT_GT(t, 0.0f);
+    EXPECT_NEAR(t, 1.0f, 0.01f);
+}
+
+TEST(EditModeControllerGeometry, RayTriangleIntersectMiss) {
+    // Ray going away from the triangle
+    Ogre::Vector3 origin(0.25f, 1.0f, 0.25f);
+    Ogre::Vector3 dir(0.0f, 1.0f, 0.0f); // going up, away from XZ triangle
+    Ogre::Vector3 v0(0, 0, 0);
+    Ogre::Vector3 v1(1, 0, 0);
+    Ogre::Vector3 v2(0, 0, 1);
+
+    float t = EditModeController::rayTriangleIntersect(origin, dir, v0, v1, v2);
+    EXPECT_LT(t, 0.0f);
+}
+
+TEST(EditModeControllerGeometry, RayTriangleIntersectParallel) {
+    // Ray parallel to the triangle
+    Ogre::Vector3 origin(0, 1, 0);
+    Ogre::Vector3 dir(1, 0, 0); // parallel to XZ plane
+    Ogre::Vector3 v0(0, 0, 0);
+    Ogre::Vector3 v1(1, 0, 0);
+    Ogre::Vector3 v2(0, 0, 1);
+
+    float t = EditModeController::rayTriangleIntersect(origin, dir, v0, v1, v2);
+    EXPECT_LT(t, 0.0f);
+}
+
+TEST(EditModeControllerGeometry, RayTriangleIntersectOutsideTriangle) {
+    // Ray hits the plane but outside the triangle
+    Ogre::Vector3 origin(2.0f, 1.0f, 2.0f);
+    Ogre::Vector3 dir(0, -1, 0);
+    Ogre::Vector3 v0(0, 0, 0);
+    Ogre::Vector3 v1(1, 0, 0);
+    Ogre::Vector3 v2(0, 0, 1);
+
+    float t = EditModeController::rayTriangleIntersect(origin, dir, v0, v1, v2);
+    EXPECT_LT(t, 0.0f);
+}
+
+TEST(EditModeControllerGeometry, RayTriangleIntersectOriginOnTriangle) {
+    // Ray origin is on the triangle, direction is perpendicular
+    Ogre::Vector3 origin(0.1f, 0.0f, 0.1f);
+    Ogre::Vector3 dir(0, -1, 0);
+    Ogre::Vector3 v0(0, 0, 0);
+    Ogre::Vector3 v1(1, 0, 0);
+    Ogre::Vector3 v2(0, 0, 1);
+
+    // t should be negative or zero (origin is on the plane)
+    float t = EditModeController::rayTriangleIntersect(origin, dir, v0, v1, v2);
+    EXPECT_LT(t, 0.01f);
+}
+
+// ===========================================================================
+// Selection state tests (require Ogre for EditableMesh)
+// ===========================================================================
+
+class EditModeControllerSelectionTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        if (!tryInitOgre()) {
+            GTEST_SKIP() << "Ogre not available";
+            return;
+        }
+        if (!canLoadMeshFiles()) {
+            GTEST_SKIP() << "Cannot create hardware buffers";
+            return;
+        }
+        createStandardOgreMaterials();
+    }
+};
+
+TEST_F(EditModeControllerSelectionTest, InitialSelectionState) {
+    auto* ctrl = EditModeController::instance();
+    EXPECT_EQ(ctrl->selectionMode(), EditModeController::VertexMode);
+    EXPECT_EQ(ctrl->selectedVertexCount(), 0);
+    EXPECT_EQ(ctrl->selectedEdgeCount(), 0);
+    EXPECT_EQ(ctrl->selectedFaceCount(), 0);
+}
+
+TEST_F(EditModeControllerSelectionTest, SetSelectionMode) {
+    auto* ctrl = EditModeController::instance();
+
+    ctrl->setSelectionMode(EditModeController::EdgeMode);
+    EXPECT_EQ(ctrl->selectionMode(), EditModeController::EdgeMode);
+
+    ctrl->setSelectionMode(EditModeController::FaceMode);
+    EXPECT_EQ(ctrl->selectionMode(), EditModeController::FaceMode);
+
+    ctrl->setSelectionMode(EditModeController::VertexMode);
+    EXPECT_EQ(ctrl->selectionMode(), EditModeController::VertexMode);
+}
+
+TEST_F(EditModeControllerSelectionTest, SetSelectionModeInvalid) {
+    auto* ctrl = EditModeController::instance();
+    ctrl->setSelectionMode(EditModeController::VertexMode);
+
+    // Invalid mode values should be ignored
+    ctrl->setSelectionMode(-1);
+    EXPECT_EQ(ctrl->selectionMode(), EditModeController::VertexMode);
+
+    ctrl->setSelectionMode(99);
+    EXPECT_EQ(ctrl->selectionMode(), EditModeController::VertexMode);
+}
+
+TEST_F(EditModeControllerSelectionTest, ModeLabelShowsSelectionMode) {
+    auto meshPtr = createInMemoryTriangleMesh("EditCtrl_modelabel");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_modelabel_node");
+    auto* entity = sceneMgr->createEntity("EditCtrl_modelabel_ent", meshPtr);
+    node->attachObject(entity);
+
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->selectOne(node);
+
+    auto* ctrl = EditModeController::instance();
+    ASSERT_TRUE(ctrl->enterEditMode());
+
+    EXPECT_EQ(ctrl->modeLabel(), "Edit Mode (Vertex)");
+
+    ctrl->setSelectionMode(EditModeController::EdgeMode);
+    EXPECT_EQ(ctrl->modeLabel(), "Edit Mode (Edge)");
+
+    ctrl->setSelectionMode(EditModeController::FaceMode);
+    EXPECT_EQ(ctrl->modeLabel(), "Edit Mode (Face)");
+
+    ctrl->exitEditMode(false);
+    EXPECT_EQ(ctrl->modeLabel(), "Object Mode");
+
+    Manager::getSingleton()->destroySceneNode("EditCtrl_modelabel_node");
+}
+
+TEST_F(EditModeControllerSelectionTest, VertexSelection) {
+    auto meshPtr = createInMemoryTriangleMesh("EditCtrl_vertsel");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_vertsel_node");
+    auto* entity = sceneMgr->createEntity("EditCtrl_vertsel_ent", meshPtr);
+    node->attachObject(entity);
+
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->selectOne(node);
+
+    auto* ctrl = EditModeController::instance();
+    ASSERT_TRUE(ctrl->enterEditMode());
+    ASSERT_EQ(ctrl->vertexCount(), 3);
+
+    // Select vertex 0
+    ctrl->selectVertex(0);
+    EXPECT_EQ(ctrl->selectedVertexCount(), 1);
+    EXPECT_TRUE(ctrl->selectedVertices().count(0) > 0);
+
+    // Select vertex 1 (replaces selection)
+    ctrl->selectVertex(1, false);
+    EXPECT_EQ(ctrl->selectedVertexCount(), 1);
+    EXPECT_TRUE(ctrl->selectedVertices().count(1) > 0);
+    EXPECT_TRUE(ctrl->selectedVertices().count(0) == 0);
+
+    // Add vertex 2 to selection
+    ctrl->selectVertex(2, true);
+    EXPECT_EQ(ctrl->selectedVertexCount(), 2);
+    EXPECT_TRUE(ctrl->selectedVertices().count(1) > 0);
+    EXPECT_TRUE(ctrl->selectedVertices().count(2) > 0);
+
+    // Deselect vertex 1
+    ctrl->deselectVertex(1);
+    EXPECT_EQ(ctrl->selectedVertexCount(), 1);
+    EXPECT_TRUE(ctrl->selectedVertices().count(2) > 0);
+
+    // Out-of-range vertex is ignored
+    ctrl->selectVertex(999);
+    EXPECT_EQ(ctrl->selectedVertexCount(), 0); // replaces selection with invalid
+
+    ctrl->exitEditMode(false);
+    Manager::getSingleton()->destroySceneNode("EditCtrl_vertsel_node");
+}
+
+TEST_F(EditModeControllerSelectionTest, EdgeSelection) {
+    auto meshPtr = createInMemoryTriangleMesh("EditCtrl_edgesel");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_edgesel_node");
+    auto* entity = sceneMgr->createEntity("EditCtrl_edgesel_ent", meshPtr);
+    node->attachObject(entity);
+
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->selectOne(node);
+
+    auto* ctrl = EditModeController::instance();
+    ASSERT_TRUE(ctrl->enterEditMode());
+
+    // Select edge (0, 1)
+    ctrl->selectEdge(0, 1);
+    EXPECT_EQ(ctrl->selectedEdgeCount(), 1);
+    EXPECT_EQ(ctrl->selectedVertexCount(), 2); // both endpoints selected
+    EXPECT_TRUE(ctrl->selectedEdges().count({0, 1}) > 0);
+
+    // Select edge (1, 2) — should replace
+    ctrl->selectEdge(2, 1, false); // order-independent: stored as (1, 2)
+    EXPECT_EQ(ctrl->selectedEdgeCount(), 1);
+    EXPECT_TRUE(ctrl->selectedEdges().count({1, 2}) > 0);
+
+    // Add edge (0, 2)
+    ctrl->selectEdge(0, 2, true);
+    EXPECT_EQ(ctrl->selectedEdgeCount(), 2);
+
+    // Deselect
+    ctrl->deselectEdge(1, 2);
+    EXPECT_EQ(ctrl->selectedEdgeCount(), 1);
+    EXPECT_TRUE(ctrl->selectedEdges().count({0, 2}) > 0);
+
+    ctrl->exitEditMode(false);
+    Manager::getSingleton()->destroySceneNode("EditCtrl_edgesel_node");
+}
+
+TEST_F(EditModeControllerSelectionTest, FaceSelection) {
+    auto meshPtr = createInMemoryTriangleMesh("EditCtrl_facesel");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_facesel_node");
+    auto* entity = sceneMgr->createEntity("EditCtrl_facesel_ent", meshPtr);
+    node->attachObject(entity);
+
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->selectOne(node);
+
+    auto* ctrl = EditModeController::instance();
+    ASSERT_TRUE(ctrl->enterEditMode());
+    ASSERT_EQ(ctrl->triangleCount(), 1);
+
+    // Select face 0
+    ctrl->selectFace(0);
+    EXPECT_EQ(ctrl->selectedFaceCount(), 1);
+    EXPECT_EQ(ctrl->selectedVertexCount(), 3); // all 3 vertices selected
+    EXPECT_EQ(ctrl->selectedEdgeCount(), 3);   // all 3 edges selected
+
+    // Deselect face
+    ctrl->deselectFace(0);
+    EXPECT_EQ(ctrl->selectedFaceCount(), 0);
+
+    // Out-of-range face is ignored
+    ctrl->selectFace(999);
+    EXPECT_EQ(ctrl->selectedFaceCount(), 0);
+
+    ctrl->exitEditMode(false);
+    Manager::getSingleton()->destroySceneNode("EditCtrl_facesel_node");
+}
+
+TEST_F(EditModeControllerSelectionTest, SelectAllDeselectAll) {
+    auto meshPtr = createInMemoryTriangleMesh("EditCtrl_selectall");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_selectall_node");
+    auto* entity = sceneMgr->createEntity("EditCtrl_selectall_ent", meshPtr);
+    node->attachObject(entity);
+
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->selectOne(node);
+
+    auto* ctrl = EditModeController::instance();
+    ASSERT_TRUE(ctrl->enterEditMode());
+
+    // Select all
+    ctrl->selectAll();
+    EXPECT_EQ(ctrl->selectedVertexCount(), 3);
+    EXPECT_EQ(ctrl->selectedFaceCount(), 1);
+    EXPECT_GT(ctrl->selectedEdgeCount(), 0);
+
+    // Deselect all
+    ctrl->deselectAll();
+    EXPECT_EQ(ctrl->selectedVertexCount(), 0);
+    EXPECT_EQ(ctrl->selectedFaceCount(), 0);
+    EXPECT_EQ(ctrl->selectedEdgeCount(), 0);
+
+    ctrl->exitEditMode(false);
+    Manager::getSingleton()->destroySceneNode("EditCtrl_selectall_node");
+}
+
+TEST_F(EditModeControllerSelectionTest, ExitEditModeClearsSelection) {
+    auto meshPtr = createInMemoryTriangleMesh("EditCtrl_exitclears");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_exitclears_node");
+    auto* entity = sceneMgr->createEntity("EditCtrl_exitclears_ent", meshPtr);
+    node->attachObject(entity);
+
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->selectOne(node);
+
+    auto* ctrl = EditModeController::instance();
+    ASSERT_TRUE(ctrl->enterEditMode());
+
+    ctrl->selectAll();
+    EXPECT_GT(ctrl->selectedVertexCount(), 0);
+
+    ctrl->exitEditMode(false);
+    EXPECT_EQ(ctrl->selectedVertexCount(), 0);
+    EXPECT_EQ(ctrl->selectedEdgeCount(), 0);
+    EXPECT_EQ(ctrl->selectedFaceCount(), 0);
+
+    Manager::getSingleton()->destroySceneNode("EditCtrl_exitclears_node");
+}
+
+// ===========================================================================
+// Index conversion tests
+// ===========================================================================
+
+TEST_F(EditModeControllerSelectionTest, GlobalToLocalConversion) {
+    auto meshPtr = createInMemoryTriangleMesh("EditCtrl_g2l");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_g2l_node");
+    auto* entity = sceneMgr->createEntity("EditCtrl_g2l_ent", meshPtr);
+    node->attachObject(entity);
+
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->selectOne(node);
+
+    auto* ctrl = EditModeController::instance();
+    ASSERT_TRUE(ctrl->enterEditMode());
+
+    // Single submesh with 3 vertices
+    auto [sub0, loc0] = ctrl->globalToLocal(0);
+    EXPECT_EQ(sub0, 0u);
+    EXPECT_EQ(loc0, 0u);
+
+    auto [sub1, loc1] = ctrl->globalToLocal(1);
+    EXPECT_EQ(sub1, 0u);
+    EXPECT_EQ(loc1, 1u);
+
+    auto [sub2, loc2] = ctrl->globalToLocal(2);
+    EXPECT_EQ(sub2, 0u);
+    EXPECT_EQ(loc2, 2u);
+
+    // Round-trip
+    EXPECT_EQ(ctrl->localToGlobal(0, 0), 0);
+    EXPECT_EQ(ctrl->localToGlobal(0, 1), 1);
+    EXPECT_EQ(ctrl->localToGlobal(0, 2), 2);
+
+    ctrl->exitEditMode(false);
+    Manager::getSingleton()->destroySceneNode("EditCtrl_g2l_node");
+}
+
+TEST_F(EditModeControllerSelectionTest, GlobalTriToLocalConversion) {
+    auto meshPtr = createInMemoryTriangleMesh("EditCtrl_gt2l");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_gt2l_node");
+    auto* entity = sceneMgr->createEntity("EditCtrl_gt2l_ent", meshPtr);
+    node->attachObject(entity);
+
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->selectOne(node);
+
+    auto* ctrl = EditModeController::instance();
+    ASSERT_TRUE(ctrl->enterEditMode());
+
+    auto [sub, local] = ctrl->globalTriToLocal(0);
+    EXPECT_EQ(sub, 0u);
+    EXPECT_EQ(local, 0u);
+
+    EXPECT_EQ(ctrl->localTriToGlobal(0, 0), 0);
+
+    ctrl->exitEditMode(false);
+    Manager::getSingleton()->destroySceneNode("EditCtrl_gt2l_node");
+}
+
+// ===========================================================================
+// Hit testing (vertex) with Ogre camera - requires render window
+// ===========================================================================
+
+TEST_F(EditModeControllerSelectionTest, HitTestVertexNullCamera) {
+    auto meshPtr = createInMemoryTriangleMesh("EditCtrl_hitvert_null");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_hitvert_null_node");
+    auto* entity = sceneMgr->createEntity("EditCtrl_hitvert_null_ent", meshPtr);
+    node->attachObject(entity);
+
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->selectOne(node);
+
+    auto* ctrl = EditModeController::instance();
+    ASSERT_TRUE(ctrl->enterEditMode());
+
+    // Null camera should return -1
+    int result = ctrl->hitTestVertex(QPoint(100, 100), nullptr, 800, 600);
+    EXPECT_EQ(result, -1);
+
+    ctrl->exitEditMode(false);
+    Manager::getSingleton()->destroySceneNode("EditCtrl_hitvert_null_node");
+}
+
+TEST_F(EditModeControllerSelectionTest, HitTestFaceNullCamera) {
+    auto meshPtr = createInMemoryTriangleMesh("EditCtrl_hitface_null");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_hitface_null_node");
+    auto* entity = sceneMgr->createEntity("EditCtrl_hitface_null_ent", meshPtr);
+    node->attachObject(entity);
+
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->selectOne(node);
+
+    auto* ctrl = EditModeController::instance();
+    ASSERT_TRUE(ctrl->enterEditMode());
+
+    int result = ctrl->hitTestFace(QPoint(100, 100), nullptr, 800, 600);
+    EXPECT_EQ(result, -1);
+
+    ctrl->exitEditMode(false);
+    Manager::getSingleton()->destroySceneNode("EditCtrl_hitface_null_node");
+}
+
+TEST_F(EditModeControllerSelectionTest, HitTestEdgeNullCamera) {
+    auto meshPtr = createInMemoryTriangleMesh("EditCtrl_hitedge_null");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_hitedge_null_node");
+    auto* entity = sceneMgr->createEntity("EditCtrl_hitedge_null_ent", meshPtr);
+    node->attachObject(entity);
+
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->selectOne(node);
+
+    auto* ctrl = EditModeController::instance();
+    ASSERT_TRUE(ctrl->enterEditMode());
+
+    auto [e1, e2] = ctrl->hitTestEdge(QPoint(100, 100), nullptr, 800, 600);
+    EXPECT_EQ(e1, -1);
+    EXPECT_EQ(e2, -1);
+
+    ctrl->exitEditMode(false);
+    Manager::getSingleton()->destroySceneNode("EditCtrl_hitedge_null_node");
+}
+
+TEST_F(EditModeControllerSelectionTest, SelectOperationsNotInEditMode) {
+    // All selection operations should be no-ops when not in edit mode
+    auto* ctrl = EditModeController::instance();
+    EXPECT_FALSE(ctrl->isEditModeActive());
+
+    ctrl->selectVertex(0);
+    EXPECT_EQ(ctrl->selectedVertexCount(), 0);
+
+    ctrl->selectEdge(0, 1);
+    EXPECT_EQ(ctrl->selectedEdgeCount(), 0);
+
+    ctrl->selectFace(0);
+    EXPECT_EQ(ctrl->selectedFaceCount(), 0);
+
+    ctrl->selectAll();
+    EXPECT_EQ(ctrl->selectedVertexCount(), 0);
+}
+
+// ===========================================================================
+// Signal emission tests
+// ===========================================================================
+
+TEST_F(EditModeControllerSelectionTest, SignalEmission) {
+    auto meshPtr = createInMemoryTriangleMesh("EditCtrl_signals");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_signals_node");
+    auto* entity = sceneMgr->createEntity("EditCtrl_signals_ent", meshPtr);
+    node->attachObject(entity);
+
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->selectOne(node);
+
+    auto* ctrl = EditModeController::instance();
+
+    int selModeChanges = 0;
+    int editSelChanges = 0;
+    auto conn1 = QObject::connect(ctrl, &EditModeController::selectionModeChanged,
+                                   [&]() { ++selModeChanges; });
+    auto conn2 = QObject::connect(ctrl, &EditModeController::editSelectionChanged,
+                                   [&]() { ++editSelChanges; });
+
+    ASSERT_TRUE(ctrl->enterEditMode());
+
+    ctrl->setSelectionMode(EditModeController::EdgeMode);
+    EXPECT_EQ(selModeChanges, 1);
+
+    ctrl->selectVertex(0);
+    EXPECT_EQ(editSelChanges, 2); // 1 from enterEditMode + 1 from selectVertex
+
+    ctrl->deselectAll();
+    EXPECT_EQ(editSelChanges, 3);
+
+    QObject::disconnect(conn1);
+    QObject::disconnect(conn2);
+
+    ctrl->exitEditMode(false);
+    Manager::getSingleton()->destroySceneNode("EditCtrl_signals_node");
+}

--- a/src/EditModeController_test.cpp
+++ b/src/EditModeController_test.cpp
@@ -549,6 +549,121 @@ TEST_F(EditModeControllerSelectionTest, SelectOperationsNotInEditMode) {
 }
 
 // ===========================================================================
+// Wireframe toggle tests
+// ===========================================================================
+
+TEST_F(EditModeControllerSelectionTest, WireframeDefaultOff) {
+    auto* ctrl = EditModeController::instance();
+    EXPECT_FALSE(ctrl->wireframeEnabled());
+}
+
+TEST_F(EditModeControllerSelectionTest, WireframeToggleNotInEditMode) {
+    auto* ctrl = EditModeController::instance();
+    EXPECT_FALSE(ctrl->isEditModeActive());
+
+    // Toggling wireframe outside edit mode should still update the property
+    ctrl->setWireframeEnabled(true);
+    EXPECT_TRUE(ctrl->wireframeEnabled());
+
+    ctrl->setWireframeEnabled(false);
+    EXPECT_FALSE(ctrl->wireframeEnabled());
+}
+
+TEST_F(EditModeControllerSelectionTest, WireframeToggleInEditMode) {
+    auto meshPtr = createInMemoryTriangleMesh("EditCtrl_wireframe");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_wireframe_node");
+    auto* entity = sceneMgr->createEntity("EditCtrl_wireframe_ent", meshPtr);
+    node->attachObject(entity);
+
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->selectOne(node);
+
+    auto* ctrl = EditModeController::instance();
+    ASSERT_TRUE(ctrl->enterEditMode());
+
+    // Save original material name
+    Ogre::String origMat = entity->getSubEntity(0)->getMaterialName();
+
+    // Enable wireframe
+    ctrl->setWireframeEnabled(true);
+    EXPECT_TRUE(ctrl->wireframeEnabled());
+    // Material should have changed to a wireframe clone
+    Ogre::String wireMat = entity->getSubEntity(0)->getMaterialName();
+    EXPECT_NE(wireMat, origMat);
+    EXPECT_TRUE(wireMat.find("_EditWireframe") != Ogre::String::npos);
+
+    // Disable wireframe — should restore original material
+    ctrl->setWireframeEnabled(false);
+    EXPECT_FALSE(ctrl->wireframeEnabled());
+    EXPECT_EQ(entity->getSubEntity(0)->getMaterialName(), origMat);
+
+    ctrl->exitEditMode(false);
+    Manager::getSingleton()->destroySceneNode("EditCtrl_wireframe_node");
+}
+
+TEST_F(EditModeControllerSelectionTest, WireframeRestoredOnExitEditMode) {
+    auto meshPtr = createInMemoryTriangleMesh("EditCtrl_wire_exit");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_wire_exit_node");
+    auto* entity = sceneMgr->createEntity("EditCtrl_wire_exit_ent", meshPtr);
+    node->attachObject(entity);
+
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->selectOne(node);
+
+    auto* ctrl = EditModeController::instance();
+    ASSERT_TRUE(ctrl->enterEditMode());
+
+    Ogre::String origMat = entity->getSubEntity(0)->getMaterialName();
+
+    // Enable wireframe then exit edit mode without disabling it
+    ctrl->setWireframeEnabled(true);
+    EXPECT_TRUE(ctrl->wireframeEnabled());
+
+    ctrl->exitEditMode(false);
+
+    // Material should be restored and wireframe should be off
+    EXPECT_FALSE(ctrl->wireframeEnabled());
+    EXPECT_EQ(entity->getSubEntity(0)->getMaterialName(), origMat);
+
+    Manager::getSingleton()->destroySceneNode("EditCtrl_wire_exit_node");
+}
+
+TEST_F(EditModeControllerSelectionTest, WireframeSignalEmission) {
+    auto meshPtr = createInMemoryTriangleMesh("EditCtrl_wire_signal");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_wire_signal_node");
+    auto* entity = sceneMgr->createEntity("EditCtrl_wire_signal_ent", meshPtr);
+    node->attachObject(entity);
+
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->selectOne(node);
+
+    auto* ctrl = EditModeController::instance();
+    ASSERT_TRUE(ctrl->enterEditMode());
+
+    int wireframeChanges = 0;
+    auto conn = QObject::connect(ctrl, &EditModeController::wireframeChanged,
+                                  [&]() { ++wireframeChanges; });
+
+    ctrl->setWireframeEnabled(true);
+    EXPECT_EQ(wireframeChanges, 1);
+
+    // Setting same value should not emit
+    ctrl->setWireframeEnabled(true);
+    EXPECT_EQ(wireframeChanges, 1);
+
+    ctrl->setWireframeEnabled(false);
+    EXPECT_EQ(wireframeChanges, 2);
+
+    QObject::disconnect(conn);
+
+    ctrl->exitEditMode(false);
+    Manager::getSingleton()->destroySceneNode("EditCtrl_wire_signal_node");
+}
+
+// ===========================================================================
 // Signal emission tests
 // ===========================================================================
 

--- a/src/EditModeController_test.cpp
+++ b/src/EditModeController_test.cpp
@@ -142,6 +142,9 @@ TEST(EditModeControllerGeometry, RayTriangleIntersectOriginOnTriangle) {
 
 class EditModeControllerSelectionTest : public ::testing::Test {
 protected:
+    Ogre::SceneNode* m_node = nullptr;
+    static int s_counter;
+
     void SetUp() override {
         if (!tryInitOgre()) {
             GTEST_SKIP() << "Ogre not available";
@@ -152,8 +155,26 @@ protected:
             return;
         }
         createStandardOgreMaterials();
+
+        // Create a triangle mesh entity and select it (required for enterEditMode)
+        std::string meshName = "EditSelTestMesh_" + std::to_string(++s_counter);
+        auto mesh = createInMemoryTriangleMesh(meshName);
+        m_node = Manager::getSingleton()->addSceneNode("EditSelTestNode");
+        Manager::getSingleton()->createEntity(m_node, mesh);
+        SelectionSet::getSingleton()->selectOne(m_node);
+    }
+
+    void TearDown() override {
+        auto* ctrl = EditModeController::instance();
+        if (ctrl->isEditModeActive())
+            ctrl->exitEditMode(false);
+        if (m_node) {
+            Manager::getSingleton()->destroySceneNode(m_node);
+            m_node = nullptr;
+        }
     }
 };
+int EditModeControllerSelectionTest::s_counter = 0;
 
 TEST_F(EditModeControllerSelectionTest, InitialSelectionState) {
     auto* ctrl = EditModeController::instance();

--- a/src/EditModeController_test.cpp
+++ b/src/EditModeController_test.cpp
@@ -597,9 +597,12 @@ TEST_F(EditModeControllerSelectionTest, WireframeRestoredOnExitEditMode) {
 
     ctrl->exitEditMode(false);
 
-    // Material should be restored and wireframe should be off
-    EXPECT_FALSE(ctrl->wireframeEnabled());
+    // Material should be restored, but wireframe state persists
+    EXPECT_TRUE(ctrl->wireframeEnabled());
     EXPECT_EQ(entity->getSubEntity(0)->getMaterialName(), origMat);
+
+    // Reset for other tests
+    ctrl->setWireframeEnabled(false);
 
     Manager::getSingleton()->destroySceneNode("EditCtrl_wire_exit_node");
 }
@@ -633,6 +636,80 @@ TEST_F(EditModeControllerSelectionTest, WireframeSignalEmission) {
 
     ctrl->exitEditMode(false);
     Manager::getSingleton()->destroySceneNode("EditCtrl_wire_signal_node");
+}
+
+// ===========================================================================
+// Selection mode change clears selection
+// ===========================================================================
+
+TEST_F(EditModeControllerSelectionTest, SelectionModeSwitchClearsSelection) {
+    auto meshPtr = createInMemoryTriangleMesh("EditCtrl_modeswitch");
+    auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_modeswitch_node");
+    Manager::getSingleton()->createEntity(node, meshPtr);
+
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->selectOne(node);
+
+    auto* ctrl = EditModeController::instance();
+    ASSERT_TRUE(ctrl->enterEditMode());
+
+    // Select a vertex in vertex mode
+    ctrl->selectVertex(0);
+    EXPECT_EQ(ctrl->selectedVertexCount(), 1);
+
+    // Switch to edge mode — selection should be cleared
+    ctrl->setSelectionMode(EditModeController::EdgeMode);
+    EXPECT_EQ(ctrl->selectedVertexCount(), 0);
+    EXPECT_EQ(ctrl->selectedEdgeCount(), 0);
+    EXPECT_EQ(ctrl->selectedFaceCount(), 0);
+
+    // Select an edge, then switch to face mode
+    ctrl->selectEdge(0, 1);
+    EXPECT_EQ(ctrl->selectedEdgeCount(), 1);
+
+    ctrl->setSelectionMode(EditModeController::FaceMode);
+    EXPECT_EQ(ctrl->selectedVertexCount(), 0);
+    EXPECT_EQ(ctrl->selectedEdgeCount(), 0);
+    EXPECT_EQ(ctrl->selectedFaceCount(), 0);
+
+    ctrl->exitEditMode(false);
+    Manager::getSingleton()->destroySceneNode("EditCtrl_modeswitch_node");
+}
+
+// ===========================================================================
+// Wireframe persists across edit mode sessions
+// ===========================================================================
+
+TEST_F(EditModeControllerSelectionTest, WireframePersistsAcrossSessions) {
+    auto meshPtr = createInMemoryTriangleMesh("EditCtrl_wire_persist");
+    auto* node = Manager::getSingleton()->addSceneNode("EditCtrl_wire_persist_node");
+    auto* entity = Manager::getSingleton()->createEntity(node, meshPtr);
+
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->selectOne(node);
+
+    auto* ctrl = EditModeController::instance();
+
+    // First session: enable wireframe
+    ASSERT_TRUE(ctrl->enterEditMode());
+    ctrl->setWireframeEnabled(true);
+    EXPECT_TRUE(ctrl->wireframeEnabled());
+    Ogre::String origMat = ctrl->editEntity()->getSubEntity(0)->getMaterialName();
+    EXPECT_TRUE(origMat.find("_EditWireframe") != Ogre::String::npos);
+    ctrl->exitEditMode(false);
+
+    // Wireframe state persists after exit
+    EXPECT_TRUE(ctrl->wireframeEnabled());
+
+    // Second session: wireframe should be re-applied automatically
+    ASSERT_TRUE(ctrl->enterEditMode());
+    EXPECT_TRUE(ctrl->wireframeEnabled());
+    Ogre::String matAfterReenter = ctrl->editEntity()->getSubEntity(0)->getMaterialName();
+    EXPECT_TRUE(matAfterReenter.find("_EditWireframe") != Ogre::String::npos);
+
+    ctrl->exitEditMode(false);
+    ctrl->setWireframeEnabled(false);
+    Manager::getSingleton()->destroySceneNode("EditCtrl_wire_persist_node");
 }
 
 // ===========================================================================

--- a/src/EditableMesh.cpp
+++ b/src/EditableMesh.cpp
@@ -232,6 +232,91 @@ void EditableMesh::recalculateNormals()
     }
 }
 
+void EditableMesh::recalculateNormalsFlat()
+{
+    for (auto& sub : m_subMeshes) {
+        // Zero out all normals
+        for (auto& v : sub.vertices) {
+            v.normal = Ogre::Vector3::ZERO;
+            v.hasNormal = true;
+        }
+
+        // Assign face normal to each vertex of each triangle
+        for (const auto& tri : sub.triangles) {
+            if (tri.indices[0] >= sub.vertices.size() ||
+                tri.indices[1] >= sub.vertices.size() ||
+                tri.indices[2] >= sub.vertices.size())
+                continue;
+
+            const Ogre::Vector3& v0 = sub.vertices[tri.indices[0]].position;
+            const Ogre::Vector3& v1 = sub.vertices[tri.indices[1]].position;
+            const Ogre::Vector3& v2 = sub.vertices[tri.indices[2]].position;
+
+            Ogre::Vector3 faceNormal = (v1 - v0).crossProduct(v2 - v0);
+            Ogre::Real len = faceNormal.length();
+            if (len > 1e-8f)
+                faceNormal /= len;
+
+            // Flat shading: each vertex gets the face normal directly
+            sub.vertices[tri.indices[0]].normal = faceNormal;
+            sub.vertices[tri.indices[1]].normal = faceNormal;
+            sub.vertices[tri.indices[2]].normal = faceNormal;
+        }
+    }
+}
+
+int EditableMesh::countDegenerateTriangles(float epsilon) const
+{
+    int count = 0;
+    for (const auto& sub : m_subMeshes) {
+        for (const auto& tri : sub.triangles) {
+            if (tri.indices[0] >= sub.vertices.size() ||
+                tri.indices[1] >= sub.vertices.size() ||
+                tri.indices[2] >= sub.vertices.size())
+                continue;
+
+            const Ogre::Vector3& v0 = sub.vertices[tri.indices[0]].position;
+            const Ogre::Vector3& v1 = sub.vertices[tri.indices[1]].position;
+            const Ogre::Vector3& v2 = sub.vertices[tri.indices[2]].position;
+
+            float area = (v1 - v0).crossProduct(v2 - v0).length();
+            if (area < epsilon)
+                ++count;
+        }
+    }
+    return count;
+}
+
+int EditableMesh::removeDegenerateTriangles(float epsilon)
+{
+    int totalRemoved = 0;
+    for (auto& sub : m_subMeshes) {
+        std::vector<EditableTriangle> kept;
+        kept.reserve(sub.triangles.size());
+        for (const auto& tri : sub.triangles) {
+            if (tri.indices[0] >= sub.vertices.size() ||
+                tri.indices[1] >= sub.vertices.size() ||
+                tri.indices[2] >= sub.vertices.size()) {
+                ++totalRemoved;
+                continue;
+            }
+
+            const Ogre::Vector3& v0 = sub.vertices[tri.indices[0]].position;
+            const Ogre::Vector3& v1 = sub.vertices[tri.indices[1]].position;
+            const Ogre::Vector3& v2 = sub.vertices[tri.indices[2]].position;
+
+            float area = (v1 - v0).crossProduct(v2 - v0).length();
+            if (area < epsilon) {
+                ++totalRemoved;
+            } else {
+                kept.push_back(tri);
+            }
+        }
+        sub.triangles = std::move(kept);
+    }
+    return totalRemoved;
+}
+
 Ogre::AxisAlignedBox EditableMesh::calculateBounds() const
 {
     Ogre::Vector3 minimum(std::numeric_limits<Ogre::Real>::max());

--- a/src/EditableMesh.cpp
+++ b/src/EditableMesh.cpp
@@ -107,8 +107,11 @@ bool EditableMesh::commitToEntity(Ogre::Entity* entity)
     if (m_subMeshes.size() != static_cast<size_t>(mesh->getNumSubMeshes()))
         return false;
 
-    // Recalculate normals before writing back
-    recalculateNormals();
+    // Recalculate normals before writing back (respects current mode)
+    if (m_flatNormals)
+        recalculateNormalsFlat();
+    else
+        recalculateNormals();
 
     // For submeshes that use shared vertices, write the first such submesh's
     // data back to the shared buffer (all such submeshes share the same vertex data).

--- a/src/EditableMesh.cpp
+++ b/src/EditableMesh.cpp
@@ -1,0 +1,484 @@
+/*
+-----------------------------------------------------------------------------------
+A QtMeshEditor file
+
+Copyright (c) Fernando Tonon (https://github.com/fernandotonon)
+
+The MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-----------------------------------------------------------------------------------
+*/
+
+#include "EditableMesh.h"
+#include "SubMeshTransform.h"
+#include <limits>
+#include <cmath>
+
+bool EditableMesh::loadFromEntity(Ogre::Entity* entity)
+{
+    if (!entity)
+        return false;
+
+    Ogre::MeshPtr meshPtr = entity->getMesh();
+    if (!meshPtr)
+        return false;
+
+    m_sourceEntity = entity;
+    m_subMeshes.clear();
+
+    Ogre::Mesh* mesh = meshPtr.get();
+
+    // Read shared vertex data once if any submesh uses it
+    std::vector<EditableVertex> sharedVertices;
+    bool hasSharedVertexData = (mesh->sharedVertexData != nullptr);
+    if (hasSharedVertexData) {
+        readVertexData(mesh->sharedVertexData, sharedVertices);
+    }
+
+    for (unsigned short i = 0; i < mesh->getNumSubMeshes(); ++i) {
+        Ogre::SubMesh* subMesh = mesh->getSubMesh(i);
+        EditableSubMesh editSub;
+
+        editSub.usesSharedVertices = subMesh->useSharedVertices;
+        editSub.materialName = subMesh->getMaterialName();
+
+        // Read vertices
+        if (subMesh->useSharedVertices) {
+            editSub.vertices = sharedVertices;
+        } else {
+            readVertexData(subMesh->vertexData, editSub.vertices);
+        }
+
+        // Read bone assignments for this submesh
+        if (mesh->hasSkeleton()) {
+            const Ogre::SubMesh::VertexBoneAssignmentList& boneAssignments =
+                subMesh->useSharedVertices ? mesh->getBoneAssignments() : subMesh->getBoneAssignments();
+
+            for (auto it = boneAssignments.begin(); it != boneAssignments.end(); ++it) {
+                const Ogre::VertexBoneAssignment& vba = it->second;
+                if (vba.vertexIndex < editSub.vertices.size()) {
+                    EditableBoneAssignment eba;
+                    eba.boneIndex = vba.boneIndex;
+                    eba.weight = vba.weight;
+                    editSub.vertices[vba.vertexIndex].boneAssignments.push_back(eba);
+                }
+            }
+        }
+
+        // Read triangles
+        if (subMesh->indexData) {
+            readIndexData(subMesh->indexData, editSub.triangles);
+        }
+
+        m_subMeshes.push_back(std::move(editSub));
+    }
+
+    return true;
+}
+
+bool EditableMesh::commitToEntity(Ogre::Entity* entity)
+{
+    if (!entity)
+        return false;
+
+    Ogre::MeshPtr meshPtr = entity->getMesh();
+    if (!meshPtr)
+        return false;
+
+    Ogre::Mesh* mesh = meshPtr.get();
+
+    if (m_subMeshes.size() != static_cast<size_t>(mesh->getNumSubMeshes()))
+        return false;
+
+    // Recalculate normals before writing back
+    recalculateNormals();
+
+    // For submeshes that use shared vertices, write the first such submesh's
+    // data back to the shared buffer (all such submeshes share the same vertex data).
+    bool wroteShared = false;
+
+    for (unsigned short i = 0; i < mesh->getNumSubMeshes(); ++i) {
+        Ogre::SubMesh* subMesh = mesh->getSubMesh(i);
+        const EditableSubMesh& editSub = m_subMeshes[i];
+
+        if (subMesh->useSharedVertices) {
+            if (!wroteShared && mesh->sharedVertexData) {
+                writeVertexData(mesh->sharedVertexData, editSub.vertices);
+                wroteShared = true;
+            }
+        } else {
+            if (subMesh->vertexData) {
+                writeVertexData(subMesh->vertexData, editSub.vertices);
+            }
+        }
+    }
+
+    // Recalculate mesh bounds
+    SubMeshTransform::recalculateMeshBounds(mesh);
+
+    return true;
+}
+
+size_t EditableMesh::totalVertexCount() const
+{
+    size_t total = 0;
+    for (const auto& sub : m_subMeshes)
+        total += sub.vertices.size();
+    return total;
+}
+
+size_t EditableMesh::totalTriangleCount() const
+{
+    size_t total = 0;
+    for (const auto& sub : m_subMeshes)
+        total += sub.triangles.size();
+    return total;
+}
+
+void EditableMesh::setVertexPosition(size_t subMeshIndex, size_t vertexIndex, const Ogre::Vector3& pos)
+{
+    if (subMeshIndex < m_subMeshes.size() && vertexIndex < m_subMeshes[subMeshIndex].vertices.size())
+        m_subMeshes[subMeshIndex].vertices[vertexIndex].position = pos;
+}
+
+Ogre::Vector3 EditableMesh::getVertexPosition(size_t subMeshIndex, size_t vertexIndex) const
+{
+    if (subMeshIndex < m_subMeshes.size() && vertexIndex < m_subMeshes[subMeshIndex].vertices.size())
+        return m_subMeshes[subMeshIndex].vertices[vertexIndex].position;
+    return Ogre::Vector3::ZERO;
+}
+
+void EditableMesh::setVertexNormal(size_t subMeshIndex, size_t vertexIndex, const Ogre::Vector3& normal)
+{
+    if (subMeshIndex < m_subMeshes.size() && vertexIndex < m_subMeshes[subMeshIndex].vertices.size()) {
+        m_subMeshes[subMeshIndex].vertices[vertexIndex].normal = normal;
+        m_subMeshes[subMeshIndex].vertices[vertexIndex].hasNormal = true;
+    }
+}
+
+Ogre::Vector3 EditableMesh::getVertexNormal(size_t subMeshIndex, size_t vertexIndex) const
+{
+    if (subMeshIndex < m_subMeshes.size() && vertexIndex < m_subMeshes[subMeshIndex].vertices.size())
+        return m_subMeshes[subMeshIndex].vertices[vertexIndex].normal;
+    return Ogre::Vector3::ZERO;
+}
+
+void EditableMesh::setVertexUV(size_t subMeshIndex, size_t vertexIndex, const Ogre::Vector2& uv)
+{
+    if (subMeshIndex < m_subMeshes.size() && vertexIndex < m_subMeshes[subMeshIndex].vertices.size()) {
+        m_subMeshes[subMeshIndex].vertices[vertexIndex].uv = uv;
+        m_subMeshes[subMeshIndex].vertices[vertexIndex].hasUV = true;
+    }
+}
+
+Ogre::Vector2 EditableMesh::getVertexUV(size_t subMeshIndex, size_t vertexIndex) const
+{
+    if (subMeshIndex < m_subMeshes.size() && vertexIndex < m_subMeshes[subMeshIndex].vertices.size())
+        return m_subMeshes[subMeshIndex].vertices[vertexIndex].uv;
+    return Ogre::Vector2::ZERO;
+}
+
+void EditableMesh::recalculateNormals()
+{
+    for (auto& sub : m_subMeshes) {
+        // Zero out all normals
+        for (auto& v : sub.vertices) {
+            v.normal = Ogre::Vector3::ZERO;
+            v.hasNormal = true;
+        }
+
+        // Accumulate face normals (area-weighted)
+        for (const auto& tri : sub.triangles) {
+            if (tri.indices[0] >= sub.vertices.size() ||
+                tri.indices[1] >= sub.vertices.size() ||
+                tri.indices[2] >= sub.vertices.size())
+                continue;
+
+            const Ogre::Vector3& v0 = sub.vertices[tri.indices[0]].position;
+            const Ogre::Vector3& v1 = sub.vertices[tri.indices[1]].position;
+            const Ogre::Vector3& v2 = sub.vertices[tri.indices[2]].position;
+
+            // Cross product gives area-weighted face normal
+            Ogre::Vector3 faceNormal = (v1 - v0).crossProduct(v2 - v0);
+
+            sub.vertices[tri.indices[0]].normal += faceNormal;
+            sub.vertices[tri.indices[1]].normal += faceNormal;
+            sub.vertices[tri.indices[2]].normal += faceNormal;
+        }
+
+        // Normalize
+        for (auto& v : sub.vertices) {
+            Ogre::Real len = v.normal.length();
+            if (len > 1e-8f)
+                v.normal /= len;
+        }
+    }
+}
+
+Ogre::AxisAlignedBox EditableMesh::calculateBounds() const
+{
+    Ogre::Vector3 minimum(std::numeric_limits<Ogre::Real>::max());
+    Ogre::Vector3 maximum(std::numeric_limits<Ogre::Real>::lowest());
+
+    bool hasVertex = false;
+    for (const auto& sub : m_subMeshes) {
+        for (const auto& v : sub.vertices) {
+            minimum.makeFloor(v.position);
+            maximum.makeCeil(v.position);
+            hasVertex = true;
+        }
+    }
+
+    if (!hasVertex)
+        return Ogre::AxisAlignedBox();
+
+    return Ogre::AxisAlignedBox(minimum, maximum);
+}
+
+bool EditableMesh::readVertexData(Ogre::VertexData* vertexData, std::vector<EditableVertex>& vertices)
+{
+    if (!vertexData || vertexData->vertexCount == 0)
+        return false;
+
+    vertices.resize(vertexData->vertexCount);
+
+    auto* decl = vertexData->vertexDeclaration;
+    auto* binding = vertexData->vertexBufferBinding;
+
+    // Read positions
+    const auto* posElem = decl->findElementBySemantic(Ogre::VES_POSITION);
+    if (posElem) {
+        auto vbuf = binding->getBuffer(posElem->getSource());
+        auto* base = static_cast<unsigned char*>(vbuf->lock(Ogre::HardwareBuffer::HBL_READ_ONLY));
+        for (size_t j = 0; j < vertexData->vertexCount; ++j) {
+            Ogre::Real* pReal;
+            posElem->baseVertexPointerToElement(base + j * vbuf->getVertexSize(), &pReal);
+            vertices[j].position = Ogre::Vector3(pReal[0], pReal[1], pReal[2]);
+        }
+        vbuf->unlock();
+    }
+
+    // Read normals
+    const auto* normElem = decl->findElementBySemantic(Ogre::VES_NORMAL);
+    if (normElem) {
+        auto vbuf = binding->getBuffer(normElem->getSource());
+        auto* base = static_cast<unsigned char*>(vbuf->lock(Ogre::HardwareBuffer::HBL_READ_ONLY));
+        for (size_t j = 0; j < vertexData->vertexCount; ++j) {
+            Ogre::Real* pReal;
+            normElem->baseVertexPointerToElement(base + j * vbuf->getVertexSize(), &pReal);
+            vertices[j].normal = Ogre::Vector3(pReal[0], pReal[1], pReal[2]);
+            vertices[j].hasNormal = true;
+        }
+        vbuf->unlock();
+    }
+
+    // Read UVs
+    const auto* uvElem = decl->findElementBySemantic(Ogre::VES_TEXTURE_COORDINATES);
+    if (uvElem) {
+        auto vbuf = binding->getBuffer(uvElem->getSource());
+        auto* base = static_cast<unsigned char*>(vbuf->lock(Ogre::HardwareBuffer::HBL_READ_ONLY));
+        for (size_t j = 0; j < vertexData->vertexCount; ++j) {
+            Ogre::Real* pReal;
+            uvElem->baseVertexPointerToElement(base + j * vbuf->getVertexSize(), &pReal);
+            vertices[j].uv = Ogre::Vector2(pReal[0], pReal[1]);
+            vertices[j].hasUV = true;
+        }
+        vbuf->unlock();
+    }
+
+    // Read vertex colors
+    const auto* colElem = decl->findElementBySemantic(Ogre::VES_DIFFUSE);
+    if (colElem) {
+        auto vbuf = binding->getBuffer(colElem->getSource());
+        auto* base = static_cast<unsigned char*>(vbuf->lock(Ogre::HardwareBuffer::HBL_READ_ONLY));
+        for (size_t j = 0; j < vertexData->vertexCount; ++j) {
+            Ogre::RGBA* pRGBA;
+            colElem->baseVertexPointerToElement(base + j * vbuf->getVertexSize(), &pRGBA);
+            Ogre::ColourValue cv;
+            cv.setAsRGBA(*pRGBA);
+            vertices[j].color = cv;
+            vertices[j].hasColor = true;
+        }
+        vbuf->unlock();
+    }
+
+    return true;
+}
+
+bool EditableMesh::readIndexData(Ogre::IndexData* indexData, std::vector<EditableTriangle>& triangles)
+{
+    if (!indexData || indexData->indexCount == 0)
+        return false;
+
+    // Only support triangle lists (3 indices per triangle)
+    if (indexData->indexCount % 3 != 0)
+        return false;
+
+    size_t triCount = indexData->indexCount / 3;
+    triangles.resize(triCount);
+
+    auto ibuf = indexData->indexBuffer;
+    bool use32bit = (ibuf->getType() == Ogre::HardwareIndexBuffer::IT_32BIT);
+
+    auto* data = static_cast<unsigned char*>(ibuf->lock(Ogre::HardwareBuffer::HBL_READ_ONLY));
+
+    for (size_t t = 0; t < triCount; ++t) {
+        if (use32bit) {
+            auto* idx = reinterpret_cast<uint32_t*>(data) + t * 3;
+            triangles[t].indices[0] = idx[0];
+            triangles[t].indices[1] = idx[1];
+            triangles[t].indices[2] = idx[2];
+        } else {
+            auto* idx = reinterpret_cast<uint16_t*>(data) + t * 3;
+            triangles[t].indices[0] = idx[0];
+            triangles[t].indices[1] = idx[1];
+            triangles[t].indices[2] = idx[2];
+        }
+    }
+
+    ibuf->unlock();
+    return true;
+}
+
+bool EditableMesh::writeVertexData(Ogre::VertexData* vertexData, const std::vector<EditableVertex>& vertices)
+{
+    if (!vertexData || vertices.empty())
+        return false;
+
+    auto* decl = vertexData->vertexDeclaration;
+    auto* binding = vertexData->vertexBufferBinding;
+
+    // Write positions
+    const auto* posElem = decl->findElementBySemantic(Ogre::VES_POSITION);
+    if (posElem) {
+        unsigned short source = posElem->getSource();
+        auto vbuf = binding->getBuffer(source);
+        size_t bufSize = vbuf->getSizeInBytes();
+        size_t vertexSize = vbuf->getVertexSize();
+
+        // Upgrade static buffers to dynamic for immediate GPU visibility
+        // (same pattern as SubMeshTransform::writePositions)
+        if (vbuf->getUsage() & Ogre::HardwareBuffer::HBU_STATIC) {
+            std::vector<unsigned char> oldData(bufSize);
+            vbuf->readData(0, bufSize, oldData.data());
+
+            auto newBuf = Ogre::HardwareBufferManager::getSingleton().createVertexBuffer(
+                vertexSize, vertexData->vertexCount,
+                Ogre::HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY, true);
+            newBuf->writeData(0, bufSize, oldData.data(), true);
+            binding->setBinding(source, newBuf);
+            vbuf = newBuf;
+        }
+
+        // Read full buffer, modify positions, write back with DISCARD
+        std::vector<unsigned char> bufCopy(bufSize);
+        vbuf->readData(0, bufSize, bufCopy.data());
+
+        size_t count = std::min(vertices.size(), static_cast<size_t>(vertexData->vertexCount));
+        for (size_t j = 0; j < count; ++j) {
+            Ogre::Real* pReal;
+            posElem->baseVertexPointerToElement(bufCopy.data() + j * vertexSize, &pReal);
+            pReal[0] = vertices[j].position.x;
+            pReal[1] = vertices[j].position.y;
+            pReal[2] = vertices[j].position.z;
+        }
+
+        auto* dest = static_cast<unsigned char*>(vbuf->lock(Ogre::HardwareBuffer::HBL_DISCARD));
+        memcpy(dest, bufCopy.data(), bufSize);
+        vbuf->unlock();
+    }
+
+    // Write normals
+    const auto* normElem = decl->findElementBySemantic(Ogre::VES_NORMAL);
+    if (normElem) {
+        unsigned short source = normElem->getSource();
+        auto vbuf = binding->getBuffer(source);
+        size_t bufSize = vbuf->getSizeInBytes();
+        size_t vertexSize = vbuf->getVertexSize();
+
+        if (vbuf->getUsage() & Ogre::HardwareBuffer::HBU_STATIC) {
+            std::vector<unsigned char> oldData(bufSize);
+            vbuf->readData(0, bufSize, oldData.data());
+
+            auto newBuf = Ogre::HardwareBufferManager::getSingleton().createVertexBuffer(
+                vertexSize, vertexData->vertexCount,
+                Ogre::HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY, true);
+            newBuf->writeData(0, bufSize, oldData.data(), true);
+            binding->setBinding(source, newBuf);
+            vbuf = newBuf;
+        }
+
+        std::vector<unsigned char> bufCopy(bufSize);
+        vbuf->readData(0, bufSize, bufCopy.data());
+
+        size_t count = std::min(vertices.size(), static_cast<size_t>(vertexData->vertexCount));
+        for (size_t j = 0; j < count; ++j) {
+            if (!vertices[j].hasNormal) continue;
+            Ogre::Real* pReal;
+            normElem->baseVertexPointerToElement(bufCopy.data() + j * vertexSize, &pReal);
+            pReal[0] = vertices[j].normal.x;
+            pReal[1] = vertices[j].normal.y;
+            pReal[2] = vertices[j].normal.z;
+        }
+
+        auto* dest = static_cast<unsigned char*>(vbuf->lock(Ogre::HardwareBuffer::HBL_DISCARD));
+        memcpy(dest, bufCopy.data(), bufSize);
+        vbuf->unlock();
+    }
+
+    // Write UVs
+    const auto* uvElem = decl->findElementBySemantic(Ogre::VES_TEXTURE_COORDINATES);
+    if (uvElem) {
+        unsigned short source = uvElem->getSource();
+        auto vbuf = binding->getBuffer(source);
+        size_t bufSize = vbuf->getSizeInBytes();
+        size_t vertexSize = vbuf->getVertexSize();
+
+        if (vbuf->getUsage() & Ogre::HardwareBuffer::HBU_STATIC) {
+            std::vector<unsigned char> oldData(bufSize);
+            vbuf->readData(0, bufSize, oldData.data());
+
+            auto newBuf = Ogre::HardwareBufferManager::getSingleton().createVertexBuffer(
+                vertexSize, vertexData->vertexCount,
+                Ogre::HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY, true);
+            newBuf->writeData(0, bufSize, oldData.data(), true);
+            binding->setBinding(source, newBuf);
+            vbuf = newBuf;
+        }
+
+        std::vector<unsigned char> bufCopy(bufSize);
+        vbuf->readData(0, bufSize, bufCopy.data());
+
+        size_t count = std::min(vertices.size(), static_cast<size_t>(vertexData->vertexCount));
+        for (size_t j = 0; j < count; ++j) {
+            if (!vertices[j].hasUV) continue;
+            Ogre::Real* pReal;
+            uvElem->baseVertexPointerToElement(bufCopy.data() + j * vertexSize, &pReal);
+            pReal[0] = vertices[j].uv.x;
+            pReal[1] = vertices[j].uv.y;
+        }
+
+        auto* dest = static_cast<unsigned char*>(vbuf->lock(Ogre::HardwareBuffer::HBL_DISCARD));
+        memcpy(dest, bufCopy.data(), bufSize);
+        vbuf->unlock();
+    }
+
+    return true;
+}

--- a/src/EditableMesh.cpp
+++ b/src/EditableMesh.cpp
@@ -28,8 +28,10 @@ THE SOFTWARE.
 
 #include "EditableMesh.h"
 #include "SubMeshTransform.h"
+#include <OgreSubEntity.h>
 #include <limits>
 #include <cmath>
+#include <cstring>
 
 bool EditableMesh::loadFromEntity(Ogre::Entity* entity)
 {
@@ -135,6 +137,43 @@ bool EditableMesh::commitToEntity(Ogre::Entity* entity)
 
     // Recalculate mesh bounds
     SubMeshTransform::recalculateMeshBounds(mesh);
+
+    // For skeletal entities, also update the SubEntity animation blend buffers
+    // (Ogre renders from these, not the mesh VBO). Same pattern as SubMeshTransform.
+    if (entity->hasSkeleton()) {
+        for (unsigned short i = 0; i < entity->getNumSubEntities(); ++i) {
+            Ogre::SubEntity* sub = entity->getSubEntity(i);
+            Ogre::VertexData* animData = sub->_getSkelAnimVertexData();
+            if (!animData || animData->vertexCount == 0) continue;
+
+            const auto* posElem = animData->vertexDeclaration
+                ->findElementBySemantic(Ogre::VES_POSITION);
+            if (!posElem) continue;
+
+            unsigned short source = posElem->getSource();
+            auto animBuf = animData->vertexBufferBinding->getBuffer(source);
+            size_t animBufSize = animBuf->getSizeInBytes();
+            size_t animVertSize = animBuf->getVertexSize();
+
+            std::vector<unsigned char> animCopy(animBufSize);
+            animBuf->readData(0, animBufSize, animCopy.data());
+
+            const auto& verts = m_subMeshes[i].vertices;
+            size_t count = std::min(verts.size(), static_cast<size_t>(animData->vertexCount));
+            for (size_t j = 0; j < count; ++j) {
+                Ogre::Real* pReal;
+                posElem->baseVertexPointerToElement(animCopy.data() + j * animVertSize, &pReal);
+                pReal[0] = verts[j].position.x;
+                pReal[1] = verts[j].position.y;
+                pReal[2] = verts[j].position.z;
+            }
+
+            auto* dest = static_cast<unsigned char*>(
+                animBuf->lock(Ogre::HardwareBuffer::HBL_DISCARD));
+            memcpy(dest, animCopy.data(), animBufSize);
+            animBuf->unlock();
+        }
+    }
 
     return true;
 }

--- a/src/EditableMesh.h
+++ b/src/EditableMesh.h
@@ -1,0 +1,196 @@
+/*
+-----------------------------------------------------------------------------------
+A QtMeshEditor file
+
+Copyright (c) Fernando Tonon (https://github.com/fernandotonon)
+
+The MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-----------------------------------------------------------------------------------
+*/
+
+#ifndef EDITABLEMESH_H
+#define EDITABLEMESH_H
+
+#include <Ogre.h>
+#include <vector>
+#include <string>
+
+/**
+ * @brief Vertex bone assignment data for skeletal meshes.
+ */
+struct EditableBoneAssignment {
+    unsigned short boneIndex = 0;
+    float weight = 0.0f;
+};
+
+/**
+ * @brief A single editable vertex with all supported attributes.
+ *
+ * Stores the vertex data copied from Ogre's hardware buffers so it can be
+ * freely manipulated without GPU buffer locks.
+ */
+struct EditableVertex {
+    Ogre::Vector3 position = Ogre::Vector3::ZERO;
+    Ogre::Vector3 normal = Ogre::Vector3::ZERO;
+    Ogre::Vector2 uv = Ogre::Vector2::ZERO;
+    Ogre::ColourValue color = Ogre::ColourValue::White;
+    std::vector<EditableBoneAssignment> boneAssignments;
+
+    bool hasNormal = false;
+    bool hasUV = false;
+    bool hasColor = false;
+};
+
+/**
+ * @brief A single triangle referencing three vertices by index.
+ */
+struct EditableTriangle {
+    unsigned int indices[3] = {0, 0, 0};
+};
+
+/**
+ * @brief An editable copy of a single Ogre SubMesh.
+ *
+ * Contains all vertices, triangles, and the material name. Tracks whether
+ * the original SubMesh used shared vertex data.
+ */
+struct EditableSubMesh {
+    std::vector<EditableVertex> vertices;
+    std::vector<EditableTriangle> triangles;
+    std::string materialName;
+    bool usesSharedVertices = false;
+};
+
+/**
+ * @brief Indexed mesh representation for topology queries and editing.
+ *
+ * On Edit Mode enter, converts Ogre::Entity's SubMesh vertex/index buffers
+ * into an internal editable format. On Edit Mode exit, writes changes back
+ * to the Ogre buffers, recalculates normals and bounds.
+ *
+ * Supports: vertex positions, normals, UVs, vertex colors, bone weights.
+ * Handles multi-submesh entities and shared vertex data.
+ */
+class EditableMesh
+{
+public:
+    EditableMesh() = default;
+    ~EditableMesh() = default;
+
+    // Non-copyable, movable
+    EditableMesh(const EditableMesh&) = delete;
+    EditableMesh& operator=(const EditableMesh&) = delete;
+    EditableMesh(EditableMesh&&) = default;
+    EditableMesh& operator=(EditableMesh&&) = default;
+
+    /**
+     * @brief Load mesh data from an Ogre::Entity into the editable representation.
+     *
+     * Reads vertex buffers (positions, normals, UVs, colors) and index buffers
+     * from each SubMesh. For submeshes using shared vertex data, duplicates the
+     * shared vertices into each submesh's own vertex list, remapping indices.
+     *
+     * @param entity The source entity. Must not be null.
+     * @return true on success, false if the entity has no mesh data.
+     */
+    bool loadFromEntity(Ogre::Entity* entity);
+
+    /**
+     * @brief Write edited mesh data back to the Ogre::Entity's buffers.
+     *
+     * Recalculates normals and mesh bounds, then writes vertex positions,
+     * normals, and UVs back to the hardware buffers. Handles the static-to-dynamic
+     * buffer upgrade for immediate GPU visibility.
+     *
+     * @param entity The target entity (should be the same entity used in loadFromEntity).
+     * @return true on success, false on failure.
+     */
+    bool commitToEntity(Ogre::Entity* entity);
+
+    /// @name Accessors
+    /// @{
+    const std::vector<EditableSubMesh>& subMeshes() const { return m_subMeshes; }
+    std::vector<EditableSubMesh>& subMeshes() { return m_subMeshes; }
+    size_t subMeshCount() const { return m_subMeshes.size(); }
+    size_t totalVertexCount() const;
+    size_t totalTriangleCount() const;
+    /// @}
+
+    /// @name Vertex manipulation
+    /// @{
+    void setVertexPosition(size_t subMeshIndex, size_t vertexIndex, const Ogre::Vector3& pos);
+    Ogre::Vector3 getVertexPosition(size_t subMeshIndex, size_t vertexIndex) const;
+
+    void setVertexNormal(size_t subMeshIndex, size_t vertexIndex, const Ogre::Vector3& normal);
+    Ogre::Vector3 getVertexNormal(size_t subMeshIndex, size_t vertexIndex) const;
+
+    void setVertexUV(size_t subMeshIndex, size_t vertexIndex, const Ogre::Vector2& uv);
+    Ogre::Vector2 getVertexUV(size_t subMeshIndex, size_t vertexIndex) const;
+    /// @}
+
+    /**
+     * @brief Recalculate all vertex normals from triangle geometry.
+     *
+     * Computes face normals for each triangle and averages them at each vertex
+     * (area-weighted smooth normals).
+     */
+    void recalculateNormals();
+
+    /**
+     * @brief Calculate the axis-aligned bounding box of the entire mesh.
+     */
+    Ogre::AxisAlignedBox calculateBounds() const;
+
+private:
+    /**
+     * @brief Read vertex attributes from an Ogre::VertexData into EditableVertex array.
+     *
+     * @param vertexData The Ogre vertex data to read from.
+     * @param[out] vertices Output vector of editable vertices.
+     * @return true on success.
+     */
+    bool readVertexData(Ogre::VertexData* vertexData, std::vector<EditableVertex>& vertices);
+
+    /**
+     * @brief Read index data from an Ogre::IndexData into EditableTriangle array.
+     *
+     * @param indexData The Ogre index data to read from.
+     * @param[out] triangles Output vector of triangles.
+     * @return true on success.
+     */
+    bool readIndexData(Ogre::IndexData* indexData, std::vector<EditableTriangle>& triangles);
+
+    /**
+     * @brief Write vertex data back to Ogre vertex buffers.
+     *
+     * Handles static-to-dynamic buffer upgrade for immediate GPU visibility.
+     *
+     * @param vertexData The Ogre vertex data to write to.
+     * @param vertices The source editable vertices.
+     * @return true on success.
+     */
+    bool writeVertexData(Ogre::VertexData* vertexData, const std::vector<EditableVertex>& vertices);
+
+    std::vector<EditableSubMesh> m_subMeshes;
+    Ogre::Entity* m_sourceEntity = nullptr;
+};
+
+#endif // EDITABLEMESH_H

--- a/src/EditableMesh.h
+++ b/src/EditableMesh.h
@@ -155,6 +155,25 @@ public:
     void recalculateNormals();
 
     /**
+     * @brief Recalculate all vertex normals using flat shading.
+     *
+     * Each vertex gets the face normal of its triangle (no averaging).
+     * Note: this means shared vertices get the normal of the last triangle processed.
+     */
+    void recalculateNormalsFlat();
+
+    /**
+     * @brief Count the number of degenerate triangles (area below epsilon).
+     */
+    int countDegenerateTriangles(float epsilon = 1e-6f) const;
+
+    /**
+     * @brief Remove degenerate triangles (area below epsilon).
+     * @return Number of triangles removed.
+     */
+    int removeDegenerateTriangles(float epsilon = 1e-6f);
+
+    /**
      * @brief Calculate the axis-aligned bounding box of the entire mesh.
      */
     Ogre::AxisAlignedBox calculateBounds() const;

--- a/src/EditableMesh.h
+++ b/src/EditableMesh.h
@@ -162,6 +162,10 @@ public:
      */
     void recalculateNormalsFlat();
 
+    /// Set the normals mode (true=flat, false=smooth). Used by commitToEntity().
+    void setFlatNormals(bool flat) { m_flatNormals = flat; }
+    bool isFlatNormals() const { return m_flatNormals; }
+
     /**
      * @brief Count the number of degenerate triangles (area below epsilon).
      */
@@ -210,6 +214,7 @@ private:
 
     std::vector<EditableSubMesh> m_subMeshes;
     Ogre::Entity* m_sourceEntity = nullptr;
+    bool m_flatNormals = false; // true = flat normals, false = smooth
 };
 
 #endif // EDITABLEMESH_H

--- a/src/EditableMesh_test.cpp
+++ b/src/EditableMesh_test.cpp
@@ -125,9 +125,8 @@ TEST_F(EditableMeshTest, LoadFromEntityTriangleMesh) {
     EXPECT_FLOAT_EQ(uv1.x, 1.0f);
     EXPECT_FLOAT_EQ(uv1.y, 0.0f);
 
-    // Check material name (default for shared vertices)
-    EXPECT_FALSE(editMesh.subMeshes()[0].materialName.empty() &&
-                 editMesh.subMeshes()[0].usesSharedVertices);
+    // The in-memory triangle mesh uses shared vertices
+    EXPECT_TRUE(editMesh.subMeshes()[0].usesSharedVertices);
 
     // Cleanup
     Manager::getSingleton()->destroySceneNode("EditableMesh_triangle_node");

--- a/src/EditableMesh_test.cpp
+++ b/src/EditableMesh_test.cpp
@@ -340,7 +340,7 @@ TEST_F(EditModeControllerTest, EnterAndExitEditMode) {
     // Enter edit mode
     EXPECT_TRUE(ctrl->enterEditMode());
     EXPECT_TRUE(ctrl->isEditModeActive());
-    EXPECT_EQ(ctrl->modeLabel(), "Edit Mode");
+    EXPECT_EQ(ctrl->modeLabel(), "Edit Mode (Vertex)");
     EXPECT_NE(ctrl->currentMesh(), nullptr);
     EXPECT_EQ(ctrl->editEntity(), entity);
     EXPECT_EQ(ctrl->vertexCount(), 3);

--- a/src/EditableMesh_test.cpp
+++ b/src/EditableMesh_test.cpp
@@ -424,3 +424,340 @@ TEST_F(EditModeControllerTest, AutoExitOnSelectionChange) {
     Manager::getSingleton()->destroySceneNode("EditMode_auto_exit1_node");
     Manager::getSingleton()->destroySceneNode("EditMode_auto_exit2_node");
 }
+
+// ===========================================================================
+// Phase 3 Items 6-8: Vertex Transform, Normals, Validation
+// ===========================================================================
+
+// ---- Item 7: Flat normals recalculation ----
+TEST(EditableMeshStandalone, RecalculateNormalsFlatEmpty) {
+    EditableMesh mesh;
+    // Should not crash on empty mesh
+    mesh.recalculateNormalsFlat();
+    EXPECT_EQ(mesh.totalVertexCount(), 0u);
+}
+
+TEST_F(EditableMeshTest, RecalculateNormalsFlat) {
+    auto meshPtr = createInMemoryTriangleMesh("EditableMesh_flat_normals");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditableMesh_flat_normals_node");
+    auto* entity = sceneMgr->createEntity("EditableMesh_flat_normals_ent", meshPtr);
+    node->attachObject(entity);
+
+    EditableMesh editMesh;
+    ASSERT_TRUE(editMesh.loadFromEntity(entity));
+
+    // Zero out normals
+    editMesh.setVertexNormal(0, 0, Ogre::Vector3::ZERO);
+    editMesh.setVertexNormal(0, 1, Ogre::Vector3::ZERO);
+    editMesh.setVertexNormal(0, 2, Ogre::Vector3::ZERO);
+
+    // Recalculate flat normals
+    editMesh.recalculateNormalsFlat();
+
+    // All vertices in a single flat triangle should have the same face normal
+    auto norm0 = editMesh.getVertexNormal(0, 0);
+    auto norm1 = editMesh.getVertexNormal(0, 1);
+    auto norm2 = editMesh.getVertexNormal(0, 2);
+
+    // Should point in Z direction for XY-plane triangle
+    EXPECT_NEAR(std::abs(norm0.z), 1.0f, 0.01f);
+    EXPECT_NEAR(std::abs(norm1.z), 1.0f, 0.01f);
+    EXPECT_NEAR(std::abs(norm2.z), 1.0f, 0.01f);
+
+    // All normals should be identical
+    EXPECT_FLOAT_EQ(norm0.x, norm1.x);
+    EXPECT_FLOAT_EQ(norm0.y, norm1.y);
+    EXPECT_FLOAT_EQ(norm0.z, norm1.z);
+
+    Manager::getSingleton()->destroySceneNode("EditableMesh_flat_normals_node");
+}
+
+// ---- Item 8: Degenerate triangle detection ----
+TEST(EditableMeshStandalone, CountDegenerateTrianglesEmpty) {
+    EditableMesh mesh;
+    EXPECT_EQ(mesh.countDegenerateTriangles(), 0);
+}
+
+TEST(EditableMeshStandalone, CountDegenerateTrianglesManual) {
+    EditableMesh mesh;
+    EditableSubMesh sub;
+
+    // Add 3 vertices forming a valid triangle
+    EditableVertex v0, v1, v2;
+    v0.position = Ogre::Vector3(0, 0, 0);
+    v1.position = Ogre::Vector3(1, 0, 0);
+    v2.position = Ogre::Vector3(0, 1, 0);
+    sub.vertices.push_back(v0);
+    sub.vertices.push_back(v1);
+    sub.vertices.push_back(v2);
+
+    // Add a valid triangle
+    EditableTriangle tri;
+    tri.indices[0] = 0;
+    tri.indices[1] = 1;
+    tri.indices[2] = 2;
+    sub.triangles.push_back(tri);
+
+    // Add a degenerate triangle (all same vertex)
+    EditableTriangle degTri;
+    degTri.indices[0] = 0;
+    degTri.indices[1] = 0;
+    degTri.indices[2] = 0;
+    sub.triangles.push_back(degTri);
+
+    mesh.subMeshes().push_back(std::move(sub));
+
+    EXPECT_EQ(mesh.countDegenerateTriangles(), 1);
+}
+
+TEST(EditableMeshStandalone, RemoveDegenerateTriangles) {
+    EditableMesh mesh;
+    EditableSubMesh sub;
+
+    EditableVertex v0, v1, v2;
+    v0.position = Ogre::Vector3(0, 0, 0);
+    v1.position = Ogre::Vector3(1, 0, 0);
+    v2.position = Ogre::Vector3(0, 1, 0);
+    sub.vertices.push_back(v0);
+    sub.vertices.push_back(v1);
+    sub.vertices.push_back(v2);
+
+    // Valid triangle
+    EditableTriangle tri1;
+    tri1.indices[0] = 0;
+    tri1.indices[1] = 1;
+    tri1.indices[2] = 2;
+    sub.triangles.push_back(tri1);
+
+    // Degenerate triangle
+    EditableTriangle tri2;
+    tri2.indices[0] = 0;
+    tri2.indices[1] = 0;
+    tri2.indices[2] = 0;
+    sub.triangles.push_back(tri2);
+
+    mesh.subMeshes().push_back(std::move(sub));
+
+    EXPECT_EQ(mesh.totalTriangleCount(), 2u);
+    int removed = mesh.removeDegenerateTriangles();
+    EXPECT_EQ(removed, 1);
+    EXPECT_EQ(mesh.totalTriangleCount(), 1u);
+    EXPECT_EQ(mesh.countDegenerateTriangles(), 0);
+}
+
+// ---- Item 6: Soft selection ----
+TEST_F(EditModeControllerTest, SoftSelectionDefaults) {
+    auto* ctrl = EditModeController::instance();
+    EXPECT_FALSE(ctrl->softSelectionEnabled());
+    EXPECT_DOUBLE_EQ(ctrl->softSelectionRadius(), 2.0);
+    EXPECT_EQ(ctrl->softSelectionFalloff(), 0);
+}
+
+TEST_F(EditModeControllerTest, SoftSelectionSetters) {
+    auto* ctrl = EditModeController::instance();
+
+    ctrl->setSoftSelectionEnabled(true);
+    EXPECT_TRUE(ctrl->softSelectionEnabled());
+
+    ctrl->setSoftSelectionRadius(5.0);
+    EXPECT_DOUBLE_EQ(ctrl->softSelectionRadius(), 5.0);
+
+    ctrl->setSoftSelectionFalloff(1);
+    EXPECT_EQ(ctrl->softSelectionFalloff(), 1);
+
+    // Reset
+    ctrl->setSoftSelectionEnabled(false);
+    ctrl->setSoftSelectionRadius(2.0);
+    ctrl->setSoftSelectionFalloff(0);
+}
+
+TEST_F(EditModeControllerTest, SoftSelectionWeightsWithoutSelection) {
+    auto* ctrl = EditModeController::instance();
+    // No edit mode, so weights should be empty
+    auto weights = ctrl->getSoftSelectionWeights();
+    EXPECT_TRUE(weights.empty());
+}
+
+TEST_F(EditModeControllerTest, VertexCentroid) {
+    auto meshPtr = createInMemoryTriangleMesh("EditMode_centroid");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditMode_centroid_node");
+    auto* entity = sceneMgr->createEntity("EditMode_centroid_ent", meshPtr);
+    node->attachObject(entity);
+
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->selectOne(node);
+
+    auto* ctrl = EditModeController::instance();
+    ASSERT_TRUE(ctrl->enterEditMode());
+
+    // Select first two vertices: (0,0,0) and (1,0,0)
+    ctrl->selectVertex(0, false);
+    ctrl->selectVertex(1, true);
+
+    auto centroid = ctrl->getSelectedVerticesCentroid();
+    EXPECT_NEAR(centroid.x, 0.5f, 0.01f);
+    EXPECT_NEAR(centroid.y, 0.0f, 0.01f);
+    EXPECT_NEAR(centroid.z, 0.0f, 0.01f);
+
+    ctrl->exitEditMode(false);
+    Manager::getSingleton()->destroySceneNode("EditMode_centroid_node");
+}
+
+TEST_F(EditModeControllerTest, TranslateSelectedVertices) {
+    auto meshPtr = createInMemoryTriangleMesh("EditMode_translate_vert");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditMode_translate_vert_node");
+    auto* entity = sceneMgr->createEntity("EditMode_translate_vert_ent", meshPtr);
+    node->attachObject(entity);
+
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->selectOne(node);
+
+    auto* ctrl = EditModeController::instance();
+    ASSERT_TRUE(ctrl->enterEditMode());
+
+    // Select vertex 0 at (0,0,0)
+    ctrl->selectVertex(0, false);
+
+    // Translate by (1,2,3)
+    ctrl->translateSelectedVertices(Ogre::Vector3(1.0f, 2.0f, 3.0f));
+
+    // Check the vertex moved
+    auto pos = ctrl->currentMesh()->getVertexPosition(0, 0);
+    EXPECT_NEAR(pos.x, 1.0f, 0.01f);
+    EXPECT_NEAR(pos.y, 2.0f, 0.01f);
+    EXPECT_NEAR(pos.z, 3.0f, 0.01f);
+
+    // Other vertices should not have moved
+    auto pos1 = ctrl->currentMesh()->getVertexPosition(0, 1);
+    EXPECT_NEAR(pos1.x, 1.0f, 0.01f);
+    EXPECT_NEAR(pos1.y, 0.0f, 0.01f);
+
+    ctrl->exitEditMode(false);
+    Manager::getSingleton()->destroySceneNode("EditMode_translate_vert_node");
+}
+
+TEST_F(EditModeControllerTest, SnapshotAndRestore) {
+    auto meshPtr = createInMemoryTriangleMesh("EditMode_snapshot");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditMode_snapshot_node");
+    auto* entity = sceneMgr->createEntity("EditMode_snapshot_ent", meshPtr);
+    node->attachObject(entity);
+
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->selectOne(node);
+
+    auto* ctrl = EditModeController::instance();
+    ASSERT_TRUE(ctrl->enterEditMode());
+
+    ctrl->selectVertex(0, false);
+
+    // Snapshot original positions
+    auto snapshot = ctrl->snapshotVertexPositions();
+    EXPECT_FALSE(snapshot.empty());
+
+    // Modify vertex
+    ctrl->translateSelectedVertices(Ogre::Vector3(5.0f, 5.0f, 5.0f));
+
+    // Restore
+    ctrl->restoreVertexPositions(snapshot);
+
+    auto pos = ctrl->currentMesh()->getVertexPosition(0, 0);
+    EXPECT_NEAR(pos.x, 0.0f, 0.01f);
+    EXPECT_NEAR(pos.y, 0.0f, 0.01f);
+    EXPECT_NEAR(pos.z, 0.0f, 0.01f);
+
+    ctrl->exitEditMode(false);
+    Manager::getSingleton()->destroySceneNode("EditMode_snapshot_node");
+}
+
+// ---- Item 7: Normals mode ----
+TEST_F(EditModeControllerTest, NormalsMode) {
+    auto* ctrl = EditModeController::instance();
+    EXPECT_EQ(ctrl->normalsMode(), 0); // default smooth
+
+    ctrl->setNormalsMode(1); // flat
+    EXPECT_EQ(ctrl->normalsMode(), 1);
+
+    ctrl->setNormalsMode(0); // reset
+    EXPECT_EQ(ctrl->normalsMode(), 0);
+
+    // Invalid mode should be rejected
+    ctrl->setNormalsMode(5);
+    EXPECT_EQ(ctrl->normalsMode(), 0);
+}
+
+// ---- Item 8: Mesh validation ----
+TEST_F(EditModeControllerTest, ValidateMesh) {
+    auto meshPtr = createInMemoryTriangleMesh("EditMode_validate");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditMode_validate_node");
+    auto* entity = sceneMgr->createEntity("EditMode_validate_ent", meshPtr);
+    node->attachObject(entity);
+
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->selectOne(node);
+
+    auto* ctrl = EditModeController::instance();
+    ASSERT_TRUE(ctrl->enterEditMode());
+
+    // Initially the triangle should be valid
+    ctrl->validateMesh();
+    EXPECT_EQ(ctrl->degenerateTriangleCount(), 0);
+    EXPECT_FALSE(ctrl->hasValidationWarnings());
+
+    // Move a vertex to create a degenerate triangle
+    // Set vertex 1 to same position as vertex 0
+    ctrl->currentMesh()->setVertexPosition(0, 1, Ogre::Vector3(0.0f, 0.0f, 0.0f));
+    ctrl->validateMesh();
+    EXPECT_GT(ctrl->degenerateTriangleCount(), 0);
+    EXPECT_TRUE(ctrl->hasValidationWarnings());
+
+    ctrl->exitEditMode(false);
+    Manager::getSingleton()->destroySceneNode("EditMode_validate_node");
+}
+
+TEST_F(EditModeControllerTest, SoftSelectionWeightsInEditMode) {
+    auto meshPtr = createInMemoryTriangleMesh("EditMode_soft_weights");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditMode_soft_weights_node");
+    auto* entity = sceneMgr->createEntity("EditMode_soft_weights_ent", meshPtr);
+    node->attachObject(entity);
+
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->selectOne(node);
+
+    auto* ctrl = EditModeController::instance();
+    ASSERT_TRUE(ctrl->enterEditMode());
+
+    // Select vertex 0
+    ctrl->selectVertex(0, false);
+
+    // Without soft selection, only selected vertex gets weight
+    auto weights = ctrl->getSoftSelectionWeights();
+    EXPECT_EQ(weights.size(), 1u);
+    EXPECT_FLOAT_EQ(weights[0], 1.0f);
+
+    // Enable soft selection with large radius to include all vertices
+    ctrl->setSoftSelectionEnabled(true);
+    ctrl->setSoftSelectionRadius(10.0);
+    weights = ctrl->getSoftSelectionWeights();
+    // Should include at least the selected vertex and nearby vertices
+    EXPECT_GE(weights.size(), 1u);
+    EXPECT_FLOAT_EQ(weights[0], 1.0f);
+
+    // Check that nearby vertices have weight < 1.0 but > 0
+    for (const auto& [gi, w] : weights) {
+        if (gi != 0) {
+            EXPECT_GT(w, 0.0f);
+            EXPECT_LE(w, 1.0f);
+        }
+    }
+
+    // Reset
+    ctrl->setSoftSelectionEnabled(false);
+    ctrl->exitEditMode(false);
+    Manager::getSingleton()->destroySceneNode("EditMode_soft_weights_node");
+}

--- a/src/EditableMesh_test.cpp
+++ b/src/EditableMesh_test.cpp
@@ -1,0 +1,426 @@
+/*
+-----------------------------------------------------------------------------------
+A QtMeshEditor file
+
+Copyright (c) Fernando Tonon (https://github.com/fernandotonon)
+
+The MIT License
+-----------------------------------------------------------------------------------
+*/
+
+#include <gtest/gtest.h>
+#include "EditableMesh.h"
+#include "EditModeController.h"
+#include "TestHelpers.h"
+#include "Manager.h"
+#include "SelectionSet.h"
+
+// ===========================================================================
+// EditableMesh unit tests
+// ===========================================================================
+
+class EditableMeshTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        if (!tryInitOgre()) {
+            GTEST_SKIP() << "Ogre not available";
+            return;
+        }
+        if (!canLoadMeshFiles()) {
+            GTEST_SKIP() << "Cannot create hardware buffers";
+            return;
+        }
+        createStandardOgreMaterials();
+    }
+};
+
+// These tests don't need Ogre, so use standalone TEST instead of TEST_F
+TEST(EditableMeshStandalone, LoadFromEntityNullReturnsFailure) {
+    EditableMesh mesh;
+    EXPECT_FALSE(mesh.loadFromEntity(nullptr));
+}
+
+TEST(EditableMeshStandalone, CommitToEntityNullReturnsFailure) {
+    EditableMesh mesh;
+    EXPECT_FALSE(mesh.commitToEntity(nullptr));
+}
+
+TEST(EditableMeshStandalone, CalculateBoundsEmpty) {
+    EditableMesh editMesh;
+    auto bounds = editMesh.calculateBounds();
+    EXPECT_TRUE(bounds.isNull());
+}
+
+TEST(EditableMeshStandalone, InitialState) {
+    EditableMesh mesh;
+    EXPECT_EQ(mesh.subMeshCount(), 0u);
+    EXPECT_EQ(mesh.totalVertexCount(), 0u);
+    EXPECT_EQ(mesh.totalTriangleCount(), 0u);
+    EXPECT_TRUE(mesh.subMeshes().empty());
+}
+
+TEST(EditableMeshStandalone, RecalculateNormalsNoSubmeshes) {
+    EditableMesh mesh;
+    // Should not crash on empty mesh
+    mesh.recalculateNormals();
+    EXPECT_EQ(mesh.totalVertexCount(), 0u);
+}
+
+TEST(EditableMeshStandalone, OutOfBoundsAccessReturnsZero) {
+    EditableMesh mesh;
+    auto pos = mesh.getVertexPosition(0, 0);
+    EXPECT_FLOAT_EQ(pos.x, 0.0f);
+    EXPECT_FLOAT_EQ(pos.y, 0.0f);
+    EXPECT_FLOAT_EQ(pos.z, 0.0f);
+
+    auto norm = mesh.getVertexNormal(99, 0);
+    EXPECT_FLOAT_EQ(norm.x, 0.0f);
+
+    auto uv = mesh.getVertexUV(0, 999);
+    EXPECT_FLOAT_EQ(uv.x, 0.0f);
+}
+
+TEST_F(EditableMeshTest, LoadFromEntityTriangleMesh) {
+    auto meshPtr = createInMemoryTriangleMesh("EditableMesh_triangle");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditableMesh_triangle_node");
+    auto* entity = sceneMgr->createEntity("EditableMesh_triangle_ent", meshPtr);
+    node->attachObject(entity);
+
+    EditableMesh editMesh;
+    ASSERT_TRUE(editMesh.loadFromEntity(entity));
+
+    // The triangle mesh has 1 submesh with 3 vertices and 1 triangle
+    EXPECT_EQ(editMesh.subMeshCount(), 1u);
+    EXPECT_EQ(editMesh.totalVertexCount(), 3u);
+    EXPECT_EQ(editMesh.totalTriangleCount(), 1u);
+
+    // Check vertex positions match what we put in createInMemoryTriangleMesh
+    auto pos0 = editMesh.getVertexPosition(0, 0);
+    auto pos1 = editMesh.getVertexPosition(0, 1);
+    auto pos2 = editMesh.getVertexPosition(0, 2);
+
+    EXPECT_FLOAT_EQ(pos0.x, 0.0f);
+    EXPECT_FLOAT_EQ(pos0.y, 0.0f);
+    EXPECT_FLOAT_EQ(pos0.z, 0.0f);
+
+    EXPECT_FLOAT_EQ(pos1.x, 1.0f);
+    EXPECT_FLOAT_EQ(pos1.y, 0.0f);
+    EXPECT_FLOAT_EQ(pos1.z, 0.0f);
+
+    EXPECT_FLOAT_EQ(pos2.x, 0.0f);
+    EXPECT_FLOAT_EQ(pos2.y, 1.0f);
+    EXPECT_FLOAT_EQ(pos2.z, 0.0f);
+
+    // Check normals were read
+    auto norm0 = editMesh.getVertexNormal(0, 0);
+    EXPECT_FLOAT_EQ(norm0.x, 0.0f);
+    EXPECT_FLOAT_EQ(norm0.y, 0.0f);
+    EXPECT_FLOAT_EQ(norm0.z, 1.0f);
+
+    // Check UVs
+    auto uv0 = editMesh.getVertexUV(0, 0);
+    EXPECT_FLOAT_EQ(uv0.x, 0.0f);
+    EXPECT_FLOAT_EQ(uv0.y, 0.0f);
+
+    auto uv1 = editMesh.getVertexUV(0, 1);
+    EXPECT_FLOAT_EQ(uv1.x, 1.0f);
+    EXPECT_FLOAT_EQ(uv1.y, 0.0f);
+
+    // Check material name (default for shared vertices)
+    EXPECT_FALSE(editMesh.subMeshes()[0].materialName.empty() &&
+                 editMesh.subMeshes()[0].usesSharedVertices);
+
+    // Cleanup
+    Manager::getSingleton()->destroySceneNode("EditableMesh_triangle_node");
+}
+
+TEST_F(EditableMeshTest, VertexManipulation) {
+    auto meshPtr = createInMemoryTriangleMesh("EditableMesh_manip");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditableMesh_manip_node");
+    auto* entity = sceneMgr->createEntity("EditableMesh_manip_ent", meshPtr);
+    node->attachObject(entity);
+
+    EditableMesh editMesh;
+    ASSERT_TRUE(editMesh.loadFromEntity(entity));
+
+    // Move vertex 0
+    Ogre::Vector3 newPos(5.0f, 5.0f, 5.0f);
+    editMesh.setVertexPosition(0, 0, newPos);
+    auto readBack = editMesh.getVertexPosition(0, 0);
+    EXPECT_FLOAT_EQ(readBack.x, 5.0f);
+    EXPECT_FLOAT_EQ(readBack.y, 5.0f);
+    EXPECT_FLOAT_EQ(readBack.z, 5.0f);
+
+    // Out-of-bounds access should not crash and return zero
+    auto oob = editMesh.getVertexPosition(99, 0);
+    EXPECT_FLOAT_EQ(oob.x, 0.0f);
+
+    auto oob2 = editMesh.getVertexPosition(0, 999);
+    EXPECT_FLOAT_EQ(oob2.x, 0.0f);
+
+    Manager::getSingleton()->destroySceneNode("EditableMesh_manip_node");
+}
+
+TEST_F(EditableMeshTest, RecalculateNormals) {
+    auto meshPtr = createInMemoryTriangleMesh("EditableMesh_normals");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditableMesh_normals_node");
+    auto* entity = sceneMgr->createEntity("EditableMesh_normals_ent", meshPtr);
+    node->attachObject(entity);
+
+    EditableMesh editMesh;
+    ASSERT_TRUE(editMesh.loadFromEntity(entity));
+
+    // Zero out normals first
+    editMesh.setVertexNormal(0, 0, Ogre::Vector3::ZERO);
+    editMesh.setVertexNormal(0, 1, Ogre::Vector3::ZERO);
+    editMesh.setVertexNormal(0, 2, Ogre::Vector3::ZERO);
+
+    // Recalculate — the triangle lies in the XY plane, so normals should point in Z
+    editMesh.recalculateNormals();
+
+    auto norm0 = editMesh.getVertexNormal(0, 0);
+    auto norm1 = editMesh.getVertexNormal(0, 1);
+    auto norm2 = editMesh.getVertexNormal(0, 2);
+
+    // All three vertices should have the same normal (flat shading of single triangle)
+    EXPECT_NEAR(norm0.x, 0.0f, 0.01f);
+    EXPECT_NEAR(norm0.y, 0.0f, 0.01f);
+    EXPECT_NEAR(std::abs(norm0.z), 1.0f, 0.01f);
+
+    EXPECT_NEAR(norm1.x, 0.0f, 0.01f);
+    EXPECT_NEAR(norm1.y, 0.0f, 0.01f);
+    EXPECT_NEAR(std::abs(norm1.z), 1.0f, 0.01f);
+
+    EXPECT_NEAR(norm2.x, 0.0f, 0.01f);
+    EXPECT_NEAR(norm2.y, 0.0f, 0.01f);
+    EXPECT_NEAR(std::abs(norm2.z), 1.0f, 0.01f);
+
+    Manager::getSingleton()->destroySceneNode("EditableMesh_normals_node");
+}
+
+TEST_F(EditableMeshTest, CalculateBoundsTriangle) {
+    auto meshPtr = createInMemoryTriangleMesh("EditableMesh_bounds");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditableMesh_bounds_node");
+    auto* entity = sceneMgr->createEntity("EditableMesh_bounds_ent", meshPtr);
+    node->attachObject(entity);
+
+    EditableMesh editMesh;
+    ASSERT_TRUE(editMesh.loadFromEntity(entity));
+
+    auto bounds = editMesh.calculateBounds();
+    EXPECT_FALSE(bounds.isNull());
+
+    // Triangle has vertices at (0,0,0), (1,0,0), (0,1,0)
+    auto minPt = bounds.getMinimum();
+    auto maxPt = bounds.getMaximum();
+    EXPECT_FLOAT_EQ(minPt.x, 0.0f);
+    EXPECT_FLOAT_EQ(minPt.y, 0.0f);
+    EXPECT_FLOAT_EQ(minPt.z, 0.0f);
+    EXPECT_FLOAT_EQ(maxPt.x, 1.0f);
+    EXPECT_FLOAT_EQ(maxPt.y, 1.0f);
+    EXPECT_FLOAT_EQ(maxPt.z, 0.0f);
+
+    Manager::getSingleton()->destroySceneNode("EditableMesh_bounds_node");
+}
+
+TEST_F(EditableMeshTest, CommitToEntity) {
+    auto meshPtr = createInMemoryTriangleMesh("EditableMesh_commit");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditableMesh_commit_node");
+    auto* entity = sceneMgr->createEntity("EditableMesh_commit_ent", meshPtr);
+    node->attachObject(entity);
+
+    EditableMesh editMesh;
+    ASSERT_TRUE(editMesh.loadFromEntity(entity));
+
+    // Move vertex 0 to a new position
+    editMesh.setVertexPosition(0, 0, Ogre::Vector3(10.0f, 20.0f, 30.0f));
+
+    // Commit changes
+    ASSERT_TRUE(editMesh.commitToEntity(entity));
+
+    // Re-read from the entity to verify the GPU buffers were updated
+    EditableMesh verifyMesh;
+    ASSERT_TRUE(verifyMesh.loadFromEntity(entity));
+
+    auto pos0 = verifyMesh.getVertexPosition(0, 0);
+    EXPECT_FLOAT_EQ(pos0.x, 10.0f);
+    EXPECT_FLOAT_EQ(pos0.y, 20.0f);
+    EXPECT_FLOAT_EQ(pos0.z, 30.0f);
+
+    Manager::getSingleton()->destroySceneNode("EditableMesh_commit_node");
+}
+
+TEST_F(EditableMeshTest, LoadSkeletonMeshWithBoneAssignments) {
+    auto meshPtr = createInMemorySkeletonMesh("EditableMesh_skel");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditableMesh_skel_node");
+    auto* entity = sceneMgr->createEntity("EditableMesh_skel_ent", meshPtr);
+    node->attachObject(entity);
+
+    EditableMesh editMesh;
+    ASSERT_TRUE(editMesh.loadFromEntity(entity));
+
+    EXPECT_EQ(editMesh.subMeshCount(), 1u);
+    EXPECT_EQ(editMesh.totalVertexCount(), 3u);
+
+    // Check bone assignments were loaded
+    const auto& vertices = editMesh.subMeshes()[0].vertices;
+    for (const auto& v : vertices) {
+        EXPECT_FALSE(v.boneAssignments.empty());
+        // Each vertex should be assigned to bone 1 with weight 1.0
+        EXPECT_EQ(v.boneAssignments[0].boneIndex, 1);
+        EXPECT_FLOAT_EQ(v.boneAssignments[0].weight, 1.0f);
+    }
+
+    Manager::getSingleton()->destroySceneNode("EditableMesh_skel_node");
+}
+
+TEST_F(EditableMeshTest, UVManipulation) {
+    auto meshPtr = createInMemoryTriangleMesh("EditableMesh_uv");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditableMesh_uv_node");
+    auto* entity = sceneMgr->createEntity("EditableMesh_uv_ent", meshPtr);
+    node->attachObject(entity);
+
+    EditableMesh editMesh;
+    ASSERT_TRUE(editMesh.loadFromEntity(entity));
+
+    // Modify UV
+    editMesh.setVertexUV(0, 0, Ogre::Vector2(0.5f, 0.75f));
+    auto uv = editMesh.getVertexUV(0, 0);
+    EXPECT_FLOAT_EQ(uv.x, 0.5f);
+    EXPECT_FLOAT_EQ(uv.y, 0.75f);
+
+    Manager::getSingleton()->destroySceneNode("EditableMesh_uv_node");
+}
+
+// ===========================================================================
+// EditModeController unit tests
+// ===========================================================================
+
+class EditModeControllerTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        if (!tryInitOgre()) {
+            GTEST_SKIP() << "Ogre not available";
+            return;
+        }
+        if (!canLoadMeshFiles()) {
+            GTEST_SKIP() << "Cannot create hardware buffers";
+            return;
+        }
+        createStandardOgreMaterials();
+    }
+};
+
+TEST_F(EditModeControllerTest, InitialState) {
+    // Ensure edit mode is not active on startup
+    auto* ctrl = EditModeController::instance();
+    EXPECT_FALSE(ctrl->isEditModeActive());
+    EXPECT_EQ(ctrl->modeLabel(), "Object Mode");
+    EXPECT_EQ(ctrl->vertexCount(), 0);
+    EXPECT_EQ(ctrl->triangleCount(), 0);
+    EXPECT_EQ(ctrl->subMeshCount(), 0);
+    EXPECT_EQ(ctrl->currentMesh(), nullptr);
+    EXPECT_EQ(ctrl->editEntity(), nullptr);
+}
+
+TEST_F(EditModeControllerTest, CannotEnterWithoutSelection) {
+    auto* ctrl = EditModeController::instance();
+    SelectionSet::getSingleton()->clear();
+
+    EXPECT_FALSE(ctrl->canEnterEditMode());
+    EXPECT_FALSE(ctrl->enterEditMode());
+    EXPECT_FALSE(ctrl->isEditModeActive());
+}
+
+TEST_F(EditModeControllerTest, EnterAndExitEditMode) {
+    auto meshPtr = createInMemoryTriangleMesh("EditMode_enter_exit");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditMode_enter_exit_node");
+    auto* entity = sceneMgr->createEntity("EditMode_enter_exit_ent", meshPtr);
+    node->attachObject(entity);
+
+    // Select the node
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->selectOne(node);
+
+    auto* ctrl = EditModeController::instance();
+    EXPECT_TRUE(ctrl->canEnterEditMode());
+
+    // Enter edit mode
+    EXPECT_TRUE(ctrl->enterEditMode());
+    EXPECT_TRUE(ctrl->isEditModeActive());
+    EXPECT_EQ(ctrl->modeLabel(), "Edit Mode");
+    EXPECT_NE(ctrl->currentMesh(), nullptr);
+    EXPECT_EQ(ctrl->editEntity(), entity);
+    EXPECT_EQ(ctrl->vertexCount(), 3);
+    EXPECT_EQ(ctrl->triangleCount(), 1);
+    EXPECT_EQ(ctrl->subMeshCount(), 1);
+
+    // Exit edit mode
+    ctrl->exitEditMode(true);
+    EXPECT_FALSE(ctrl->isEditModeActive());
+    EXPECT_EQ(ctrl->modeLabel(), "Object Mode");
+    EXPECT_EQ(ctrl->currentMesh(), nullptr);
+    EXPECT_EQ(ctrl->editEntity(), nullptr);
+    EXPECT_EQ(ctrl->vertexCount(), 0);
+
+    Manager::getSingleton()->destroySceneNode("EditMode_enter_exit_node");
+}
+
+TEST_F(EditModeControllerTest, ToggleEditMode) {
+    auto meshPtr = createInMemoryTriangleMesh("EditMode_toggle");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("EditMode_toggle_node");
+    auto* entity = sceneMgr->createEntity("EditMode_toggle_ent", meshPtr);
+    node->attachObject(entity);
+
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->selectOne(node);
+
+    auto* ctrl = EditModeController::instance();
+
+    // Toggle on
+    ctrl->toggleEditMode();
+    EXPECT_TRUE(ctrl->isEditModeActive());
+
+    // Toggle off
+    ctrl->toggleEditMode();
+    EXPECT_FALSE(ctrl->isEditModeActive());
+
+    Manager::getSingleton()->destroySceneNode("EditMode_toggle_node");
+}
+
+TEST_F(EditModeControllerTest, AutoExitOnSelectionChange) {
+    auto meshPtr1 = createInMemoryTriangleMesh("EditMode_auto_exit1");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node1 = Manager::getSingleton()->addSceneNode("EditMode_auto_exit1_node");
+    auto* entity1 = sceneMgr->createEntity("EditMode_auto_exit1_ent", meshPtr1);
+    node1->attachObject(entity1);
+
+    auto meshPtr2 = createInMemoryTriangleMesh("EditMode_auto_exit2");
+    auto* node2 = Manager::getSingleton()->addSceneNode("EditMode_auto_exit2_node");
+    auto* entity2 = sceneMgr->createEntity("EditMode_auto_exit2_ent", meshPtr2);
+    node2->attachObject(entity2);
+
+    // Select first node and enter edit mode
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->selectOne(node1);
+
+    auto* ctrl = EditModeController::instance();
+    ASSERT_TRUE(ctrl->enterEditMode());
+    EXPECT_TRUE(ctrl->isEditModeActive());
+
+    // Change selection to second node — should auto-exit edit mode
+    SelectionSet::getSingleton()->selectOne(node2);
+    EXPECT_FALSE(ctrl->isEditModeActive());
+
+    Manager::getSingleton()->destroySceneNode("EditMode_auto_exit1_node");
+    Manager::getSingleton()->destroySceneNode("EditMode_auto_exit2_node");
+}

--- a/src/EditableMesh_test.cpp
+++ b/src/EditableMesh_test.cpp
@@ -82,10 +82,8 @@ TEST(EditableMeshStandalone, OutOfBoundsAccessReturnsZero) {
 
 TEST_F(EditableMeshTest, LoadFromEntityTriangleMesh) {
     auto meshPtr = createInMemoryTriangleMesh("EditableMesh_triangle");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditableMesh_triangle_node");
-    auto* entity = sceneMgr->createEntity("EditableMesh_triangle_ent", meshPtr);
-    node->attachObject(entity);
+    auto* entity = Manager::getSingleton()->createEntity(node, meshPtr);
 
     EditableMesh editMesh;
     ASSERT_TRUE(editMesh.loadFromEntity(entity));
@@ -137,10 +135,8 @@ TEST_F(EditableMeshTest, LoadFromEntityTriangleMesh) {
 
 TEST_F(EditableMeshTest, VertexManipulation) {
     auto meshPtr = createInMemoryTriangleMesh("EditableMesh_manip");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditableMesh_manip_node");
-    auto* entity = sceneMgr->createEntity("EditableMesh_manip_ent", meshPtr);
-    node->attachObject(entity);
+    auto* entity = Manager::getSingleton()->createEntity(node, meshPtr);
 
     EditableMesh editMesh;
     ASSERT_TRUE(editMesh.loadFromEntity(entity));
@@ -165,10 +161,8 @@ TEST_F(EditableMeshTest, VertexManipulation) {
 
 TEST_F(EditableMeshTest, RecalculateNormals) {
     auto meshPtr = createInMemoryTriangleMesh("EditableMesh_normals");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditableMesh_normals_node");
-    auto* entity = sceneMgr->createEntity("EditableMesh_normals_ent", meshPtr);
-    node->attachObject(entity);
+    auto* entity = Manager::getSingleton()->createEntity(node, meshPtr);
 
     EditableMesh editMesh;
     ASSERT_TRUE(editMesh.loadFromEntity(entity));
@@ -203,10 +197,8 @@ TEST_F(EditableMeshTest, RecalculateNormals) {
 
 TEST_F(EditableMeshTest, CalculateBoundsTriangle) {
     auto meshPtr = createInMemoryTriangleMesh("EditableMesh_bounds");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditableMesh_bounds_node");
-    auto* entity = sceneMgr->createEntity("EditableMesh_bounds_ent", meshPtr);
-    node->attachObject(entity);
+    auto* entity = Manager::getSingleton()->createEntity(node, meshPtr);
 
     EditableMesh editMesh;
     ASSERT_TRUE(editMesh.loadFromEntity(entity));
@@ -229,10 +221,8 @@ TEST_F(EditableMeshTest, CalculateBoundsTriangle) {
 
 TEST_F(EditableMeshTest, CommitToEntity) {
     auto meshPtr = createInMemoryTriangleMesh("EditableMesh_commit");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditableMesh_commit_node");
-    auto* entity = sceneMgr->createEntity("EditableMesh_commit_ent", meshPtr);
-    node->attachObject(entity);
+    auto* entity = Manager::getSingleton()->createEntity(node, meshPtr);
 
     EditableMesh editMesh;
     ASSERT_TRUE(editMesh.loadFromEntity(entity));
@@ -257,10 +247,8 @@ TEST_F(EditableMeshTest, CommitToEntity) {
 
 TEST_F(EditableMeshTest, LoadSkeletonMeshWithBoneAssignments) {
     auto meshPtr = createInMemorySkeletonMesh("EditableMesh_skel");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditableMesh_skel_node");
-    auto* entity = sceneMgr->createEntity("EditableMesh_skel_ent", meshPtr);
-    node->attachObject(entity);
+    auto* entity = Manager::getSingleton()->createEntity(node, meshPtr);
 
     EditableMesh editMesh;
     ASSERT_TRUE(editMesh.loadFromEntity(entity));
@@ -282,10 +270,8 @@ TEST_F(EditableMeshTest, LoadSkeletonMeshWithBoneAssignments) {
 
 TEST_F(EditableMeshTest, UVManipulation) {
     auto meshPtr = createInMemoryTriangleMesh("EditableMesh_uv");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditableMesh_uv_node");
-    auto* entity = sceneMgr->createEntity("EditableMesh_uv_ent", meshPtr);
-    node->attachObject(entity);
+    auto* entity = Manager::getSingleton()->createEntity(node, meshPtr);
 
     EditableMesh editMesh;
     ASSERT_TRUE(editMesh.loadFromEntity(entity));
@@ -341,10 +327,8 @@ TEST_F(EditModeControllerTest, CannotEnterWithoutSelection) {
 
 TEST_F(EditModeControllerTest, EnterAndExitEditMode) {
     auto meshPtr = createInMemoryTriangleMesh("EditMode_enter_exit");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditMode_enter_exit_node");
-    auto* entity = sceneMgr->createEntity("EditMode_enter_exit_ent", meshPtr);
-    node->attachObject(entity);
+    auto* entity = Manager::getSingleton()->createEntity(node, meshPtr);
 
     // Select the node
     SelectionSet::getSingleton()->clear();
@@ -376,10 +360,8 @@ TEST_F(EditModeControllerTest, EnterAndExitEditMode) {
 
 TEST_F(EditModeControllerTest, ToggleEditMode) {
     auto meshPtr = createInMemoryTriangleMesh("EditMode_toggle");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditMode_toggle_node");
-    auto* entity = sceneMgr->createEntity("EditMode_toggle_ent", meshPtr);
-    node->attachObject(entity);
+    auto* entity = Manager::getSingleton()->createEntity(node, meshPtr);
 
     SelectionSet::getSingleton()->clear();
     SelectionSet::getSingleton()->selectOne(node);
@@ -399,15 +381,12 @@ TEST_F(EditModeControllerTest, ToggleEditMode) {
 
 TEST_F(EditModeControllerTest, AutoExitOnSelectionChange) {
     auto meshPtr1 = createInMemoryTriangleMesh("EditMode_auto_exit1");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node1 = Manager::getSingleton()->addSceneNode("EditMode_auto_exit1_node");
-    auto* entity1 = sceneMgr->createEntity("EditMode_auto_exit1_ent", meshPtr1);
-    node1->attachObject(entity1);
+    auto* entity1 = Manager::getSingleton()->createEntity(node1, meshPtr1);
 
     auto meshPtr2 = createInMemoryTriangleMesh("EditMode_auto_exit2");
     auto* node2 = Manager::getSingleton()->addSceneNode("EditMode_auto_exit2_node");
-    auto* entity2 = sceneMgr->createEntity("EditMode_auto_exit2_ent", meshPtr2);
-    node2->attachObject(entity2);
+    Manager::getSingleton()->createEntity(node2, meshPtr2);
 
     // Select first node and enter edit mode
     SelectionSet::getSingleton()->clear();
@@ -439,10 +418,8 @@ TEST(EditableMeshStandalone, RecalculateNormalsFlatEmpty) {
 
 TEST_F(EditableMeshTest, RecalculateNormalsFlat) {
     auto meshPtr = createInMemoryTriangleMesh("EditableMesh_flat_normals");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditableMesh_flat_normals_node");
-    auto* entity = sceneMgr->createEntity("EditableMesh_flat_normals_ent", meshPtr);
-    node->attachObject(entity);
+    auto* entity = Manager::getSingleton()->createEntity(node, meshPtr);
 
     EditableMesh editMesh;
     ASSERT_TRUE(editMesh.loadFromEntity(entity));
@@ -581,10 +558,8 @@ TEST_F(EditModeControllerTest, SoftSelectionWeightsWithoutSelection) {
 
 TEST_F(EditModeControllerTest, VertexCentroid) {
     auto meshPtr = createInMemoryTriangleMesh("EditMode_centroid");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditMode_centroid_node");
-    auto* entity = sceneMgr->createEntity("EditMode_centroid_ent", meshPtr);
-    node->attachObject(entity);
+    auto* entity = Manager::getSingleton()->createEntity(node, meshPtr);
 
     SelectionSet::getSingleton()->clear();
     SelectionSet::getSingleton()->selectOne(node);
@@ -607,10 +582,8 @@ TEST_F(EditModeControllerTest, VertexCentroid) {
 
 TEST_F(EditModeControllerTest, TranslateSelectedVertices) {
     auto meshPtr = createInMemoryTriangleMesh("EditMode_translate_vert");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditMode_translate_vert_node");
-    auto* entity = sceneMgr->createEntity("EditMode_translate_vert_ent", meshPtr);
-    node->attachObject(entity);
+    auto* entity = Manager::getSingleton()->createEntity(node, meshPtr);
 
     SelectionSet::getSingleton()->clear();
     SelectionSet::getSingleton()->selectOne(node);
@@ -641,10 +614,8 @@ TEST_F(EditModeControllerTest, TranslateSelectedVertices) {
 
 TEST_F(EditModeControllerTest, SnapshotAndRestore) {
     auto meshPtr = createInMemoryTriangleMesh("EditMode_snapshot");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditMode_snapshot_node");
-    auto* entity = sceneMgr->createEntity("EditMode_snapshot_ent", meshPtr);
-    node->attachObject(entity);
+    auto* entity = Manager::getSingleton()->createEntity(node, meshPtr);
 
     SelectionSet::getSingleton()->clear();
     SelectionSet::getSingleton()->selectOne(node);
@@ -692,10 +663,8 @@ TEST_F(EditModeControllerTest, NormalsMode) {
 // ---- Item 8: Mesh validation ----
 TEST_F(EditModeControllerTest, ValidateMesh) {
     auto meshPtr = createInMemoryTriangleMesh("EditMode_validate");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditMode_validate_node");
-    auto* entity = sceneMgr->createEntity("EditMode_validate_ent", meshPtr);
-    node->attachObject(entity);
+    auto* entity = Manager::getSingleton()->createEntity(node, meshPtr);
 
     SelectionSet::getSingleton()->clear();
     SelectionSet::getSingleton()->selectOne(node);
@@ -721,10 +690,8 @@ TEST_F(EditModeControllerTest, ValidateMesh) {
 
 TEST_F(EditModeControllerTest, SoftSelectionWeightsInEditMode) {
     auto meshPtr = createInMemoryTriangleMesh("EditMode_soft_weights");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
     auto* node = Manager::getSingleton()->addSceneNode("EditMode_soft_weights_node");
-    auto* entity = sceneMgr->createEntity("EditMode_soft_weights_ent", meshPtr);
-    node->attachObject(entity);
+    auto* entity = Manager::getSingleton()->createEntity(node, meshPtr);
 
     SelectionSet::getSingleton()->clear();
     SelectionSet::getSingleton()->selectOne(node);

--- a/src/NormalVisualizer.cpp
+++ b/src/NormalVisualizer.cpp
@@ -74,6 +74,13 @@ void NormalVisualizer::setVisible(bool visible)
     }
 }
 
+void NormalVisualizer::refreshEntity(Ogre::Entity* entity)
+{
+    if (!mVisible || !entity) return;
+    destroyOverlayForEntity(entity);
+    buildOverlayForEntity(entity);
+}
+
 void NormalVisualizer::onEntityCreated(Ogre::Entity* const& entity)
 {
     if (mVisible)

--- a/src/NormalVisualizer.h
+++ b/src/NormalVisualizer.h
@@ -17,6 +17,9 @@ public:
 
     bool isVisible() const { return mVisible; }
 
+    /// Rebuild the normal overlay for a specific entity (e.g. after vertex editing)
+    void refreshEntity(Ogre::Entity* entity);
+
 public slots:
     void setVisible(bool visible);
 

--- a/src/TransformOperator.cpp
+++ b/src/TransformOperator.cpp
@@ -85,6 +85,12 @@ TransformOperator::TransformOperator() : QObject(nullptr)
 
     connect(SelectionSet::getSingleton(),SIGNAL(selectionChanged()),this,SLOT(onSelectionChanged()));
 
+    // Update gizmo when edit mode selection changes (vertices selected/deselected)
+    connect(EditModeController::instance(), &EditModeController::editSelectionChanged,
+            this, &TransformOperator::onSelectionChanged);
+    connect(EditModeController::instance(), &EditModeController::editModeChanged,
+            this, &TransformOperator::onSelectionChanged);
+
     QtInputManager::getInstance().AddMouseListener(this);
 
     // Load snap settings from QSettings
@@ -512,7 +518,11 @@ void TransformOperator::removeSelected()
 void TransformOperator::updateGizmo()
 {
     updateGizmoPosition();
-    if(SelectionSet::getSingleton()->hasNodes()||SelectionSet::getSingleton()->hasEntities()||SelectionSet::getSingleton()->hasSubEntities())
+    bool editModeHasSelection = EditModeController::instance()->isEditModeActive()
+        && !EditModeController::instance()->selectedVertices().empty();
+
+    if(SelectionSet::getSingleton()->hasNodes()||SelectionSet::getSingleton()->hasEntities()
+       ||SelectionSet::getSingleton()->hasSubEntities()||editModeHasSelection)
     {
         // Determine gizmo orientation based on transform space
         Ogre::Quaternion gizmoOrientation;
@@ -627,6 +637,22 @@ void TransformOperator::updateGizmoPosition()
             // Sub-entity pointers may be stale — skip gizmo positioning
         }
     }
+
+    // In edit mode, position gizmo at the centroid of selected vertices
+    if (EditModeController::instance()->isEditModeActive()
+        && !EditModeController::instance()->selectedVertices().empty()
+        && EditModeController::instance()->editEntity())
+    {
+        auto* editCtrl = EditModeController::instance();
+        Ogre::Vector3 localCentroid = editCtrl->getSelectedVerticesCentroid();
+        Ogre::SceneNode* entityNode = editCtrl->editEntity()->getParentSceneNode();
+        if (entityNode) {
+            Ogre::Vector3 worldCentroid = entityNode->convertLocalToWorldPosition(localCentroid);
+            m_pTransformNode->setPosition(worldCentroid);
+            currentPosition = worldCentroid;
+        }
+    }
+
     emit selectedPositionChanged(currentPosition);
     emit selectedOrientationChanged(currentOrientation);
     emit selectedScaleChanged(currentScale);
@@ -830,6 +856,41 @@ void TransformOperator::mousePressEvent(QMouseEvent *e)
             return;
         }
 
+        // In edit mode with a transform tool and selected vertices: start vertex transform
+        if (EditModeController::instance()->isEditModeActive()
+            && mTransformState != TS_SELECT && mTransformState != TS_NONE
+            && !EditModeController::instance()->selectedVertices().empty())
+        {
+            auto* editCtrl = EditModeController::instance();
+
+            if (mTransformState == TS_TRANSLATE)
+                SentryReporter::addBreadcrumb("ui.transform", "Edit mode: translate vertices");
+            else if (mTransformState == TS_ROTATE)
+                SentryReporter::addBreadcrumb("ui.transform", "Edit mode: rotate vertices");
+            else if (mTransformState == TS_SCALE)
+                SentryReporter::addBreadcrumb("ui.transform", "Edit mode: scale vertices");
+
+            // Snapshot vertex positions for undo
+            mEditModeStartPositions = editCtrl->snapshotVertexPositions();
+            mEditModeTransformActive = true;
+
+            // Reset snap accumulators
+            mSnapTranslationAccum = Ogre::Vector3::ZERO;
+            mSnapRotationAccum = Ogre::Vector3::ZERO;
+            mSnapScaleAccum = Ogre::Vector3::ZERO;
+            mSnapScaleCumulative = Ogre::Vector3::UNIT_SCALE;
+
+            Ogre::Ray mouseRay = rayFromScreenPoint(e->pos());
+            std::pair<bool, Ogre::Real> result = mouseRay.intersects(
+                Ogre::Plane(mouseRay.getDirection(), m_pTransformNode->getPosition()));
+            if (result.first) {
+                mStartPoint = mouseRay.getPoint(result.second);
+                if (mTransformState == TS_SCALE)
+                    mScaleStartDistance = (mStartPoint - m_pTransformNode->getPosition()).length();
+            }
+            return;
+        }
+
         if(mTransformState == TS_SELECT)
         {
             mScreenStart = e->pos();
@@ -906,6 +967,114 @@ void TransformOperator::mousePressEvent(QMouseEvent *e)
 
 void TransformOperator::mouseMoveEvent(QMouseEvent *e)
 {
+    // Edit mode vertex transform: intercept drag and route to EditModeController
+    if (mEditModeTransformActive && EditModeController::instance()->isEditModeActive()
+        && !mStartPoint.isZeroLength())
+    {
+        auto* editCtrl = EditModeController::instance();
+        Ogre::Ray mouseRay = rayFromScreenPoint(e->pos());
+        std::pair<bool, Ogre::Real> result = mouseRay.intersects(
+            Ogre::Plane(mouseRay.getDirection(), m_pTransformNode->getPosition()));
+
+        if (result.first)
+        {
+            Ogre::Vector3 point = mouseRay.getPoint(result.second);
+
+            if (mTransformState == TS_TRANSLATE)
+            {
+                Ogre::Vector3 worldDelta = point - mStartPoint;
+                Ogre::Vector3 translation;
+
+                if (mTransformSpace == SPACE_LOCAL && !mTransformVector.isZeroLength()) {
+                    Ogre::Quaternion gizmoOrientation = m_pTransformNode->getOrientation();
+                    Ogre::Vector3 localDelta = gizmoOrientation.Inverse() * worldDelta;
+                    localDelta *= mTransformVector;
+                    translation = gizmoOrientation * localDelta;
+                } else {
+                    translation = worldDelta * mTransformVector;
+                }
+
+                // Convert world-space translation to local mesh space
+                Ogre::SceneNode* entityNode = editCtrl->editEntity()->getParentSceneNode();
+                if (entityNode) {
+                    Ogre::Quaternion worldOrient = entityNode->_getDerivedOrientation();
+                    Ogre::Vector3 worldScale = entityNode->_getDerivedScale();
+                    Ogre::Vector3 localTranslation = worldOrient.Inverse() * translation;
+                    localTranslation /= worldScale;
+
+                    // Restore to start positions then apply new delta
+                    editCtrl->restoreVertexPositions(mEditModeStartPositions);
+                    editCtrl->translateSelectedVertices(localTranslation);
+                }
+
+                mStartPoint = point;
+                // Re-snapshot so incremental deltas accumulate correctly
+                mEditModeStartPositions = editCtrl->snapshotVertexPositions();
+                updateGizmoPosition();
+            }
+            else if (mTransformState == TS_ROTATE)
+            {
+                Ogre::Vector3 vectorStart = mStartPoint - m_pTransformNode->getPosition();
+                Ogre::Vector3 vectorEnd = point - m_pTransformNode->getPosition();
+
+                Ogre::Quaternion rotation;
+                if (mTransformSpace == SPACE_LOCAL && !mTransformVector.isZeroLength()) {
+                    Ogre::Quaternion gizmoOri = m_pTransformNode->getOrientation();
+                    Ogre::Vector3 localStart = gizmoOri.Inverse() * vectorStart;
+                    Ogre::Vector3 localEnd = gizmoOri.Inverse() * vectorEnd;
+                    Ogre::Quaternion localRot = localStart.getRotationTo(localEnd);
+                    localRot.x *= mTransformVector.x;
+                    localRot.y *= mTransformVector.y;
+                    localRot.z *= mTransformVector.z;
+                    localRot.normalise();
+                    rotation = gizmoOri * localRot * gizmoOri.Inverse();
+                } else {
+                    rotation = vectorStart.getRotationTo(vectorEnd);
+                    rotation.x *= mTransformVector.x;
+                    rotation.y *= mTransformVector.y;
+                    rotation.z *= mTransformVector.z;
+                    rotation.normalise();
+                }
+
+                // Convert world rotation to local mesh space
+                Ogre::SceneNode* entityNode = editCtrl->editEntity()->getParentSceneNode();
+                if (entityNode) {
+                    Ogre::Quaternion worldOrient = entityNode->_getDerivedOrientation();
+                    Ogre::Quaternion localRotation = worldOrient.Inverse() * rotation * worldOrient;
+
+                    editCtrl->restoreVertexPositions(mEditModeStartPositions);
+                    editCtrl->rotateSelectedVertices(localRotation);
+                }
+
+                mStartPoint = point;
+                mEditModeStartPositions = editCtrl->snapshotVertexPositions();
+                updateGizmoPosition();
+            }
+            else if (mTransformState == TS_SCALE)
+            {
+                Ogre::Real currentDistance = (point - m_pTransformNode->getPosition()).length();
+                if (mScaleStartDistance > 0.001f)
+                {
+                    Ogre::Real ratio = currentDistance / mScaleStartDistance;
+                    Ogre::Vector3 scaleFactor = Ogre::Vector3::UNIT_SCALE;
+
+                    if (mTransformVector == Ogre::Vector3::ZERO)
+                        scaleFactor = Ogre::Vector3(ratio, ratio, ratio);
+                    else
+                        scaleFactor = Ogre::Vector3::UNIT_SCALE + (mTransformVector * (ratio - 1.0f));
+
+                    editCtrl->restoreVertexPositions(mEditModeStartPositions);
+                    editCtrl->scaleSelectedVertices(scaleFactor);
+
+                    mScaleStartDistance = currentDistance;
+                    mEditModeStartPositions = editCtrl->snapshotVertexPositions();
+                    updateGizmoPosition();
+                }
+            }
+        }
+        return;
+    }
+
     if(mTransformState == TS_SELECT)
     {
         if(m_pSelectionBox->isVisible() && m_pActiveWidget)
@@ -1171,6 +1340,53 @@ void TransformOperator::mouseMoveEvent(QMouseEvent *e)
 
 void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
 {
+    // Push undo command for edit mode vertex transforms
+    if (mEditModeTransformActive && (e->button() == Qt::LeftButton))
+    {
+        auto* editCtrl = EditModeController::instance();
+        if (editCtrl->isEditModeActive() && !mEditModeStartPositions.empty())
+        {
+            // Snapshot current (post-transform) positions
+            auto newPositions = editCtrl->snapshotVertexPositions();
+
+            // Check if anything actually changed
+            bool changed = false;
+            for (const auto& [gi, pos] : mEditModeStartPositions) {
+                auto it = newPositions.find(gi);
+                if (it != newPositions.end() && it->second != pos) {
+                    changed = true;
+                    break;
+                }
+            }
+
+            if (changed) {
+                QString desc;
+                if (mTransformState == TS_TRANSLATE) desc = "Edit Vertex Translate";
+                else if (mTransformState == TS_ROTATE) desc = "Edit Vertex Rotate";
+                else if (mTransformState == TS_SCALE) desc = "Edit Vertex Scale";
+                else desc = "Edit Vertex Transform";
+
+                UndoManager::getSingleton()->push(
+                    new EditVertexTransformCommand(mEditModeStartPositions, newPositions, desc));
+
+                // Validate mesh after edit
+                editCtrl->validateMesh();
+            }
+        }
+
+        mEditModeTransformActive = false;
+        mEditModeStartPositions.clear();
+        mStartPoint = Ogre::Vector3::ZERO;
+        mScaleStartDistance = 0.0f;
+
+        // Don't fall through to object-mode handlers
+        if (m_pSelectionBox->isVisible()) {
+            m_pSelectionBox->clear();
+            m_pSelectionBox->setVisible(false);
+        }
+        return;
+    }
+
     // Push undo commands for sub-entity vertex transforms
     if (SelectionSet::getSingleton()->hasSubEntities() && !mUndoSubEntities.isEmpty()
         && (e->button() == Qt::LeftButton))

--- a/src/TransformOperator.cpp
+++ b/src/TransformOperator.cpp
@@ -22,6 +22,7 @@
 #include "ViewportGrid.h"
 #include "UndoManager.h"
 #include "commands/TransformCommands.h"
+#include "EditModeController.h"
 #include <Ogre.h>
 
 // TODO  create a virtual class GizmoObject & add Rotation & Translation Gizmo to have only one interface
@@ -820,6 +821,14 @@ void TransformOperator::mousePressEvent(QMouseEvent *e)
 {
     if (e->button()==Qt::LeftButton)
     {
+        // In edit mode, delegate selection to EditModeController
+        if (EditModeController::instance()->isEditModeActive() && mTransformState == TS_SELECT)
+        {
+            mScreenStart = e->pos();
+            m_pSelectionBox->clear();
+            m_pSelectionBox->setVisible(true);
+            return;
+        }
 
         if(mTransformState == TS_SELECT)
         {
@@ -1274,6 +1283,32 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
 
     if(m_pSelectionBox->isVisible())
     {
+        // In edit mode, delegate to EditModeController for component selection
+        if (EditModeController::instance()->isEditModeActive())
+        {
+            bool shiftHeld = e->modifiers().testFlag(Qt::ShiftModifier);
+            bool ctrlHeld = e->modifiers().testFlag(Qt::ControlModifier);
+
+            // If the rectangle is very small, treat as a click
+            QRect rect(mScreenStart, e->pos());
+            rect = rect.normalized();
+
+            if (rect.width() < 5 && rect.height() < 5) {
+                // Point select
+                EditModeController::instance()->handleMouseClick(
+                    mScreenStart, m_pActiveWidget, shiftHeld, ctrlHeld);
+            } else {
+                // Box select
+                EditModeController::instance()->handleBoxSelect(
+                    mScreenStart, e->pos(), m_pActiveWidget, shiftHeld);
+            }
+
+            mScreenStart = QPoint(invalidPosition);
+            m_pSelectionBox->clear();
+            m_pSelectionBox->setVisible(false);
+            return;
+        }
+
         // Perform a box selection
         SelectionMode   selectionMode = NEW_SELECT;
         if(e->modifiers().testFlag(Qt::ControlModifier))

--- a/src/TransformOperator.cpp
+++ b/src/TransformOperator.cpp
@@ -586,7 +586,17 @@ void TransformOperator::updateGizmoPosition()
     Ogre::Vector3 currentOrientation = Ogre::Vector3::ZERO;
     Ogre::Vector3 currentScale = Ogre::Vector3::UNIT_SCALE;
 
-    if(SelectionSet::getSingleton()->hasNodes())
+    // Edit mode: position gizmo at selected vertices centroid (world space)
+    auto* editCtrl = EditModeController::instance();
+    if (editCtrl->isEditModeActive() && !editCtrl->selectedVertices().empty()
+        && editCtrl->editEntity() && editCtrl->editEntity()->getParentSceneNode())
+    {
+        Ogre::Vector3 localCentroid = editCtrl->getSelectedVerticesCentroid();
+        Ogre::SceneNode* node = editCtrl->editEntity()->getParentSceneNode();
+        Ogre::Vector3 worldCentroid = node->convertLocalToWorldPosition(localCentroid);
+        m_pTransformNode->setPosition(worldCentroid);
+    }
+    else if(SelectionSet::getSingleton()->hasNodes())
     {
         currentOrientation  = SelectionSet::getSingleton()->getSelectionOrientation();
         currentScale        = SelectionSet::getSingleton()->getSelectionScale();
@@ -872,6 +882,7 @@ void TransformOperator::mousePressEvent(QMouseEvent *e)
 
             // Snapshot vertex positions for undo
             mEditModeStartPositions = editCtrl->snapshotVertexPositions();
+            mEditModeUndoSnapshot = mEditModeStartPositions; // immutable copy for undo
             mEditModeTransformActive = true;
 
             // Reset snap accumulators
@@ -1349,9 +1360,9 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
             // Snapshot current (post-transform) positions
             auto newPositions = editCtrl->snapshotVertexPositions();
 
-            // Check if anything actually changed
+            // Check if anything actually changed (compare against immutable undo snapshot)
             bool changed = false;
-            for (const auto& [gi, pos] : mEditModeStartPositions) {
+            for (const auto& [gi, pos] : mEditModeUndoSnapshot) {
                 auto it = newPositions.find(gi);
                 if (it != newPositions.end() && it->second != pos) {
                     changed = true;
@@ -1367,7 +1378,7 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
                 else desc = "Edit Vertex Transform";
 
                 UndoManager::getSingleton()->push(
-                    new EditVertexTransformCommand(mEditModeStartPositions, newPositions, desc));
+                    new EditVertexTransformCommand(mEditModeUndoSnapshot, newPositions, desc));
 
                 // Validate mesh after edit
                 editCtrl->validateMesh();
@@ -1376,6 +1387,7 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
 
         mEditModeTransformActive = false;
         mEditModeStartPositions.clear();
+        mEditModeUndoSnapshot.clear();
         mStartPoint = Ogre::Vector3::ZERO;
         mScaleStartDistance = 0.0f;
 

--- a/src/TransformOperator.h
+++ b/src/TransformOperator.h
@@ -188,7 +188,8 @@ private:
     QList<std::vector<Ogre::Vector3>>       mUndoSubMeshPositions;
 
     // Edit mode undo state: vertex positions captured at drag start
-    std::map<int, Ogre::Vector3>            mEditModeStartPositions;
+    std::map<int, Ogre::Vector3>            mEditModeStartPositions;   ///< Rolling snapshot (updated each frame)
+    std::map<int, Ogre::Vector3>            mEditModeUndoSnapshot;     ///< Immutable snapshot from press (for undo)
     bool                                    mEditModeTransformActive = false;
 #ifdef Q_OS_MACOS
     int mWindowSizeModifier = 2;

--- a/src/TransformOperator.h
+++ b/src/TransformOperator.h
@@ -5,6 +5,7 @@
 #include <QPoint>
 #include <QList>
 #include <vector>
+#include <map>
 #include <OgreRay.h>
 #include <OgreVector.h>
 #include "QtInputManager.h"
@@ -185,6 +186,10 @@ private:
     // Sub-entity undo state: vertex positions captured at drag start
     QList<Ogre::SubEntity*>                 mUndoSubEntities;
     QList<std::vector<Ogre::Vector3>>       mUndoSubMeshPositions;
+
+    // Edit mode undo state: vertex positions captured at drag start
+    std::map<int, Ogre::Vector3>            mEditModeStartPositions;
+    bool                                    mEditModeTransformActive = false;
 #ifdef Q_OS_MACOS
     int mWindowSizeModifier = 2;
 #else

--- a/src/commands/TransformCommands.cpp
+++ b/src/commands/TransformCommands.cpp
@@ -2,6 +2,8 @@
 #include "../Manager.h"
 #include "../SelectionSet.h"
 #include "../SubMeshTransform.h"
+#include "../EditModeController.h"
+#include "../EditableMesh.h"
 #include <Ogre.h>
 
 // Check if a scene node pointer is still valid (not destroyed)
@@ -530,4 +532,45 @@ void SubMeshTransformCommand::redo()
     {
         SubMeshTransform::writePositions(mEntity, mSubMeshIndex, mNewPositions);
     }
+}
+
+// ---- EditVertexTransformCommand ----
+
+EditVertexTransformCommand::EditVertexTransformCommand(
+    const std::map<int, Ogre::Vector3>& oldPositions,
+    const std::map<int, Ogre::Vector3>& newPositions,
+    const QString& description,
+    QUndoCommand* parent)
+    : QUndoCommand(description, parent)
+    , mOldPositions(oldPositions)
+    , mNewPositions(newPositions)
+    , mFirstRedo(true)
+{
+}
+
+void EditVertexTransformCommand::undo()
+{
+    auto* ctrl = EditModeController::instance();
+    if (!ctrl->isEditModeActive() || !ctrl->currentMesh())
+        return;
+
+    ctrl->restoreVertexPositions(mOldPositions);
+    ctrl->recalculateNormals(ctrl->normalsMode() == 0);
+    ctrl->validateMesh();
+}
+
+void EditVertexTransformCommand::redo()
+{
+    if (mFirstRedo) {
+        mFirstRedo = false;
+        return;
+    }
+
+    auto* ctrl = EditModeController::instance();
+    if (!ctrl->isEditModeActive() || !ctrl->currentMesh())
+        return;
+
+    ctrl->restoreVertexPositions(mNewPositions);
+    ctrl->recalculateNormals(ctrl->normalsMode() == 0);
+    ctrl->validateMesh();
 }

--- a/src/commands/TransformCommands.h
+++ b/src/commands/TransformCommands.h
@@ -4,6 +4,7 @@
 #include <QUndoCommand>
 #include <QList>
 #include <vector>
+#include <map>
 #include <OgreVector.h>
 #include <OgreQuaternion.h>
 
@@ -206,6 +207,24 @@ private:
     unsigned int mSubMeshIndex;
     std::vector<Ogre::Vector3> mOriginalPositions;
     std::vector<Ogre::Vector3> mNewPositions;
+    bool mFirstRedo = true;
+};
+
+// Edit-mode vertex transform: stores full vertex position snapshot for undo/redo
+class EditVertexTransformCommand : public QUndoCommand
+{
+public:
+    EditVertexTransformCommand(const std::map<int, Ogre::Vector3>& oldPositions,
+                               const std::map<int, Ogre::Vector3>& newPositions,
+                               const QString& description = "Edit Vertex Transform",
+                               QUndoCommand* parent = nullptr);
+
+    void undo() override;
+    void redo() override;
+
+private:
+    std::map<int, Ogre::Vector3> mOldPositions; ///< global index -> old position
+    std::map<int, Ogre::Vector3> mNewPositions; ///< global index -> new position
     bool mFirstRedo = true;
 };
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -284,7 +284,10 @@ void MainWindow::initToolBar()
     connect(ui->actionTranslate_Object, &QAction::triggered, this, [this]{setTransformState(TransformOperator::TS_TRANSLATE);});
     connect(ui->actionRotate_Object, &QAction::triggered, this, [this]{setTransformState(TransformOperator::TS_ROTATE);});
     connect(ui->actionScale_Object, &QAction::triggered, this, [this]{setTransformState(TransformOperator::TS_SCALE);});
-    connect(ui->actionRemove_Object, SIGNAL(triggered()), TransformOperator::getSingleton(), SLOT(removeSelected()));
+    connect(ui->actionRemove_Object, &QAction::triggered, this, []{
+        if (!EditModeController::instance()->isEditModeActive())
+            TransformOperator::getSingleton()->removeSelected();
+    });
     connect(ui->actionToggle_Transform_Space, &QAction::toggled, this, [this](bool checked){
         TransformOperator::getSingleton()->setTransformSpace(
             checked ? TransformOperator::SPACE_LOCAL : TransformOperator::SPACE_WORLD);
@@ -993,8 +996,10 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
         TransformOperator::getSingleton()->cyclePivotMode();
        break;
     case Qt::Key_Delete:
-        SentryReporter::addBreadcrumb("ui.shortcut", "Delete — Remove selected");
-        TransformOperator::getSingleton()->removeSelected();
+        if (!EditModeController::instance()->isEditModeActive()) {
+            SentryReporter::addBreadcrumb("ui.shortcut", "Delete — Remove selected");
+            TransformOperator::getSingleton()->removeSelected();
+        }
        break;
     case Qt::Key_Tab:
         SentryReporter::addBreadcrumb("ui.shortcut", "Tab — Toggle Edit Mode");

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -914,6 +914,43 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
 {
     QtInputManager::getInstance().keyPressEvent(event);
 
+    // Edit mode shortcuts take priority when edit mode is active
+    auto* editCtrl = EditModeController::instance();
+    if (editCtrl->isEditModeActive()) {
+        switch (event->key()) {
+        case Qt::Key_1:
+            SentryReporter::addBreadcrumb("ui.shortcut", "1 — Vertex selection mode");
+            editCtrl->setSelectionMode(EditModeController::VertexMode);
+            event->accept();
+            return;
+        case Qt::Key_2:
+            SentryReporter::addBreadcrumb("ui.shortcut", "2 — Edge selection mode");
+            editCtrl->setSelectionMode(EditModeController::EdgeMode);
+            event->accept();
+            return;
+        case Qt::Key_3:
+            SentryReporter::addBreadcrumb("ui.shortcut", "3 — Face selection mode");
+            editCtrl->setSelectionMode(EditModeController::FaceMode);
+            event->accept();
+            return;
+        case Qt::Key_A:
+            if (event->modifiers() & Qt::ControlModifier) {
+                SentryReporter::addBreadcrumb("ui.shortcut", "Ctrl+A — Select All (edit mode)");
+                editCtrl->selectAll();
+                event->accept();
+                return;
+            } else if (event->modifiers() & Qt::AltModifier) {
+                SentryReporter::addBreadcrumb("ui.shortcut", "Alt+A — Deselect All (edit mode)");
+                editCtrl->deselectAll();
+                event->accept();
+                return;
+            }
+            break;
+        default:
+            break;
+        }
+    }
+
     switch(event->key()){
     case Qt::Key_Q:
         SentryReporter::addBreadcrumb("ui.shortcut", "Q — Select mode");

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -61,6 +61,7 @@
 #include "AIChatManager.h"
 #include "WelcomeScreenController.h"
 #include "AssetBrowserController.h"
+#include "EditModeController.h"
 #include <QDockWidget>
 #include <QQuickWidget>
 #include <QQmlContext>
@@ -153,6 +154,14 @@ MainWindow::MainWindow(QWidget *parent) :
     });
     m_pTimer->start(0);
 
+    // Edit Mode indicator in status bar
+    m_editModeLabel = new QLabel("Object Mode", this);
+    m_editModeLabel->setStyleSheet("QLabel { font-weight: bold; padding: 2px 8px; }");
+    statusBar()->addPermanentWidget(m_editModeLabel);
+    connect(EditModeController::instance(), &EditModeController::editModeChanged,
+            this, &MainWindow::updateEditModeIndicator);
+    updateEditModeIndicator();
+
     // Auto-start MCP HTTP server if enabled in settings
     QSettings mcpSettings;
     bool mcpEnabled = mcpSettings.value("MCP/enabled", false).toBool();
@@ -234,6 +243,7 @@ MainWindow::~MainWindow()
     // Only destroy Manager if it still exists and belongs to this MainWindow
     // (In tests, Manager may be destroyed separately in TearDown)
     // These singletons are safe to destroy unconditionally.
+    EditModeController::kill();
     SubEntityHighlight::kill();
     AnimationControlController::kill();
     MeshLodController::kill();
@@ -371,6 +381,10 @@ void MainWindow::initToolBar()
         qmlRegisterSingletonType<AssetBrowserController>("AssetBrowser", 1, 0, "AssetBrowserController",
             [](QQmlEngine* engine, QJSEngine*) -> QObject* {
                 return AssetBrowserController::qmlInstance(engine, nullptr);
+            });
+        qmlRegisterSingletonType<EditModeController>("PropertiesPanel", 1, 0, "EditModeController",
+            [](QQmlEngine* engine, QJSEngine*) -> QObject* {
+                return EditModeController::qmlInstance(engine, nullptr);
             });
 
         m_propertiesPanel->setSource(QUrl("qrc:/PropertiesPanel/PropertiesPanel.qml"));
@@ -945,6 +959,11 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
         SentryReporter::addBreadcrumb("ui.shortcut", "Delete — Remove selected");
         TransformOperator::getSingleton()->removeSelected();
        break;
+    case Qt::Key_Tab:
+        SentryReporter::addBreadcrumb("ui.shortcut", "Tab — Toggle Edit Mode");
+        EditModeController::instance()->toggleEditMode();
+        event->accept();
+       break;
     default:
        break;
     }
@@ -1417,6 +1436,22 @@ void MainWindow::setTransformState(TransformOperator::TransformState newState)
     ui->actionScale_Object->setChecked(newState == TransformOperator::TS_SCALE);
 
     TransformOperator::getSingleton()->onTransformStateChange(newState);
+}
+
+void MainWindow::updateEditModeIndicator()
+{
+    if (!m_editModeLabel) return;
+    auto* ctrl = EditModeController::instance();
+    if (ctrl->isEditModeActive()) {
+        m_editModeLabel->setText("Edit Mode");
+        m_editModeLabel->setStyleSheet(
+            "QLabel { font-weight: bold; padding: 2px 8px; "
+            "background-color: #3d6b3d; color: white; border-radius: 3px; }");
+    } else {
+        m_editModeLabel->setText("Object Mode");
+        m_editModeLabel->setStyleSheet(
+            "QLabel { font-weight: bold; padding: 2px 8px; }");
+    }
 }
 
 // LCOV_EXCL_START — creates OgreWidget, requires display

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -17,9 +17,11 @@ class NormalVisualizer;
 class MeshInfoOverlay;
 class ViewCubeController;
 class PropertiesPanelController;
+class EditModeController;
 class WelcomeScreenController;
 class AssetBrowserController;
 class QQuickWidget;
+class QLabel;
 
 namespace Ui {
 class MainWindow;
@@ -153,6 +155,9 @@ private:
     void showWelcomeScreen();
     void hideWelcomeScreen();
     void repositionWelcomeScreen();
+
+    QLabel* m_editModeLabel = nullptr;
+    void updateEditModeIndicator();
 };
 
 #endif // MAINWINDOW_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -77,6 +77,8 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/ScanEngine.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AssetBrowserController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MaterialPreviewRenderer.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/EditableMesh.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/EditModeController.cpp
     )
 
     set(TEST_HEADER_FILES
@@ -146,6 +148,8 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/ScanEngine.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AssetBrowserController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MaterialPreviewRenderer.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/EditableMesh.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/EditModeController.h
     )
 
     # Add Ogre-Procedural sources (matching src/CMakeLists.txt)


### PR DESCRIPTION
## Summary
Full Edit Mode implementation for direct mesh geometry editing (#258). All 8 items complete.

### Item 1-2: Mode Toggle + Mesh Data Structure
- Tab key toggles Object/Edit Mode
- EditableMesh: indexed mesh with vertices (pos/normal/UV/color/bones), triangles
- Load from Ogre entity, commit back with buffer upgrade

### Item 3-5: Vertex/Edge/Face Selection
- 1/2/3 keys switch selection mode
- Click select (screen-space projection), box select, Shift/Ctrl modifiers
- ManualObject overlays: orange points, cyan lines, blue faces
- Moller-Trumbore ray-triangle intersection for face picking

### Item 6: Vertex Transform
- Gizmo translate/rotate/scale on selected vertices
- Soft selection with linear/smooth falloff and radius slider
- EditVertexTransformCommand for undo/redo

### Item 7: Normals Recalculation
- Smooth (area-weighted) and flat normals modes
- Auto-recalculate after edits, manual trigger button

### Item 8: Mesh Validation
- Degenerate triangle detection and removal
- Warning display + auto-fix button

### Stats
- 62 new tests (EditableMesh: 35, EditModeController: 27)
- 4620 lines added across 15 files

## Test plan
- [ ] Tab enters/exits edit mode on selected entity
- [ ] 1/2/3 switch vertex/edge/face selection
- [ ] Click selects vertices/edges/faces with overlays
- [ ] Gizmo translates selected vertices in edit mode
- [ ] Soft selection affects nearby vertices
- [ ] Normals recalculate after edits
- [ ] Degenerate warning shows after bad edits
- [ ] Undo/redo works for vertex transforms
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent Edit Mode header and “Edit Mode Tools” panel with Edit/Exit toggle, mode label and live vertex/triangle/submesh counts
  * Vertex/edge/face selection modes, selection-box and visual overlays, selection count readouts
  * Soft selection (enable, radius, falloff), normals mode (smooth/flat) and one-click Recalculate Normals
  * Mesh validation warnings and Remove Degenerates action
  * Vertex transform tools (translate/rotate/scale) with undo/redo, gizmo integration and keyboard shortcuts (Tab to toggle, 1/2/3 for modes, Ctrl+A/Alt+A for select/deselect)

* **Tests**
  * Comprehensive unit and integration tests covering geometry helpers, editable-mesh operations, edit-mode lifecycle, selection, hit-testing and undo/redo
<!-- end of auto-generated comment: release notes by coderabbit.ai -->