### PR TITLE
Soft selection heat map and logarithmic radius slider

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 2.25.0 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 2.25.1 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -333,15 +333,41 @@ Rectangle {
                 spacing: 2
 
                 Text {
-                    text: "Radius: " + softRadiusSlider.value.toFixed(2)
+                    // Display the actual radius (log-mapped from slider)
+                    property real logRadius: {
+                        var minVal = 0.01; var maxVal = 20.0;
+                        return minVal * Math.pow(maxVal / minVal, softRadiusSlider.value);
+                    }
+                    text: "Radius: " + logRadius.toFixed(logRadius < 1 ? 3 : 2)
                     color: PropertiesPanelController.textColor; font.pixelSize: 10
                 }
                 Slider {
                     id: softRadiusSlider
                     width: parent.width
-                    from: 0.1; to: 20.0; stepSize: 0.1
-                    value: EditModeController.softSelectionRadius
-                    onValueChanged: EditModeController.softSelectionRadius = value
+                    from: 0.0; to: 1.0; stepSize: 0.005
+                    // Convert current radius to normalized log position
+                    property real minVal: 0.01
+                    property real maxVal: 20.0
+                    property bool updating: false
+                    Component.onCompleted: {
+                        updating = true;
+                        value = Math.log(EditModeController.softSelectionRadius / minVal) / Math.log(maxVal / minVal);
+                        updating = false;
+                    }
+                    onValueChanged: {
+                        if (!updating) {
+                            var radius = minVal * Math.pow(maxVal / minVal, value);
+                            EditModeController.softSelectionRadius = radius;
+                        }
+                    }
+                    Connections {
+                        target: EditModeController
+                        function onSoftSelectionRadiusChanged() {
+                            softRadiusSlider.updating = true;
+                            softRadiusSlider.value = Math.log(EditModeController.softSelectionRadius / softRadiusSlider.minVal) / Math.log(softRadiusSlider.maxVal / softRadiusSlider.minVal);
+                            softRadiusSlider.updating = false;
+                        }
+                    }
                 }
 
                 // Falloff mode

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -362,7 +362,7 @@ Rectangle {
                     }
                     Connections {
                         target: EditModeController
-                        function onSoftSelectionRadiusChanged() {
+                        function onSoftSelectionChanged() {
                             softRadiusSlider.updating = true;
                             softRadiusSlider.value = Math.log(EditModeController.softSelectionRadius / softRadiusSlider.minVal) / Math.log(softRadiusSlider.maxVal / softRadiusSlider.minVal);
                             softRadiusSlider.updating = false;

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -498,23 +498,27 @@ int EditModeController::localTriToGlobal(size_t subMeshIndex, size_t localTriInd
 
 Ogre::ColourValue EditModeController::weightToColor(float weight)
 {
-    // Heat map: red (1.0) → orange → yellow → green → cyan → blue (0.0)
-    if (weight > 0.8f) {
-        float t = (weight - 0.8f) / 0.2f;
-        return Ogre::ColourValue(1.0f, 0.4f * (1.0f - t), 0.0f, 1.0f);
-    } else if (weight > 0.6f) {
-        float t = (weight - 0.6f) / 0.2f;
-        return Ogre::ColourValue(1.0f, 0.6f + 0.4f * (1.0f - t), 0.0f, 1.0f);
-    } else if (weight > 0.4f) {
-        float t = (weight - 0.4f) / 0.2f;
-        return Ogre::ColourValue(1.0f - t, 1.0f, 0.0f, 1.0f);
-    } else if (weight > 0.2f) {
-        float t = (weight - 0.2f) / 0.2f;
-        return Ogre::ColourValue(0.0f, 1.0f, 1.0f - t, 1.0f);
-    } else {
+    weight = std::clamp(weight, 0.0f, 1.0f);
+
+    // Heat map: blue (0.0) → cyan → green → yellow → orange → red (1.0)
+    if (weight < 0.2f) {
         float t = weight / 0.2f;
-        return Ogre::ColourValue(0.0f, t, 1.0f, 1.0f);
+        return Ogre::ColourValue(0.0f, t, 1.0f, 1.0f);             // blue → cyan
     }
+    if (weight < 0.4f) {
+        float t = (weight - 0.2f) / 0.2f;
+        return Ogre::ColourValue(0.0f, 1.0f, 1.0f - t, 1.0f);      // cyan → green
+    }
+    if (weight < 0.6f) {
+        float t = (weight - 0.4f) / 0.2f;
+        return Ogre::ColourValue(t, 1.0f, 0.0f, 1.0f);             // green → yellow
+    }
+    if (weight < 0.8f) {
+        float t = (weight - 0.6f) / 0.2f;
+        return Ogre::ColourValue(1.0f, 1.0f - 0.6f * t, 0.0f, 1.0f); // yellow → orange
+    }
+    float t = (weight - 0.8f) / 0.2f;
+    return Ogre::ColourValue(1.0f, 0.4f * (1.0f - t), 0.0f, 1.0f); // orange → red
 }
 
 QPoint EditModeController::worldToScreen(const Ogre::Vector3& worldPos,

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -1332,17 +1332,31 @@ void EditModeController::updateSelectionOverlay()
     {
         m_overlayVertices->begin("EditMode/VertexSelection", Ogre::RenderOperation::OT_POINT_LIST);
 
-        // When soft selection is active, render all influenced vertices with heat map colors
-        auto weights = getSoftSelectionWeights();
-
-        for (const auto& [gi, weight] : weights) {
-            auto [subIdx, localIdx] = globalToLocal(gi);
-            if (subIdx < m_editableMesh->subMeshes().size() &&
-                localIdx < m_editableMesh->subMeshes()[subIdx].vertices.size())
-            {
-                const auto& pos = m_editableMesh->subMeshes()[subIdx].vertices[localIdx].position;
-                m_overlayVertices->position(pos);
-                m_overlayVertices->colour(weightToColor(weight));
+        if (m_softSelectionEnabled) {
+            // Heat map: render all influenced vertices with weight-based colors
+            auto weights = getSoftSelectionWeights();
+            for (const auto& [gi, weight] : weights) {
+                auto [subIdx, localIdx] = globalToLocal(gi);
+                if (subIdx < m_editableMesh->subMeshes().size() &&
+                    localIdx < m_editableMesh->subMeshes()[subIdx].vertices.size())
+                {
+                    const auto& pos = m_editableMesh->subMeshes()[subIdx].vertices[localIdx].position;
+                    m_overlayVertices->position(pos);
+                    m_overlayVertices->colour(weightToColor(weight));
+                }
+            }
+        } else {
+            // Fixed orange for selected vertices only
+            Ogre::ColourValue vertColor(1.0f, 0.6f, 0.0f, 1.0f);
+            for (int gi : m_selectedVertices) {
+                auto [subIdx, localIdx] = globalToLocal(gi);
+                if (subIdx < m_editableMesh->subMeshes().size() &&
+                    localIdx < m_editableMesh->subMeshes()[subIdx].vertices.size())
+                {
+                    const auto& pos = m_editableMesh->subMeshes()[subIdx].vertices[localIdx].position;
+                    m_overlayVertices->position(pos);
+                    m_overlayVertices->colour(vertColor);
+                }
             }
         }
 

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -496,6 +496,27 @@ int EditModeController::localTriToGlobal(size_t subMeshIndex, size_t localTriInd
 // Geometry helpers
 // ===========================================================================
 
+Ogre::ColourValue EditModeController::weightToColor(float weight)
+{
+    // Heat map: red (1.0) → orange → yellow → green → cyan → blue (0.0)
+    if (weight > 0.8f) {
+        float t = (weight - 0.8f) / 0.2f;
+        return Ogre::ColourValue(1.0f, 0.4f * (1.0f - t), 0.0f, 1.0f);
+    } else if (weight > 0.6f) {
+        float t = (weight - 0.6f) / 0.2f;
+        return Ogre::ColourValue(1.0f, 0.6f + 0.4f * (1.0f - t), 0.0f, 1.0f);
+    } else if (weight > 0.4f) {
+        float t = (weight - 0.4f) / 0.2f;
+        return Ogre::ColourValue(1.0f - t, 1.0f, 0.0f, 1.0f);
+    } else if (weight > 0.2f) {
+        float t = (weight - 0.2f) / 0.2f;
+        return Ogre::ColourValue(0.0f, 1.0f, 1.0f - t, 1.0f);
+    } else {
+        float t = weight / 0.2f;
+        return Ogre::ColourValue(0.0f, t, 1.0f, 1.0f);
+    }
+}
+
 QPoint EditModeController::worldToScreen(const Ogre::Vector3& worldPos,
                                           Ogre::Camera* camera,
                                           int viewportWidth, int viewportHeight)
@@ -1307,17 +1328,17 @@ void EditModeController::updateSelectionOverlay()
     {
         m_overlayVertices->begin("EditMode/VertexSelection", Ogre::RenderOperation::OT_POINT_LIST);
 
-        // Orange color for selected vertices
-        Ogre::ColourValue vertColor(1.0f, 0.6f, 0.0f, 1.0f);
+        // When soft selection is active, render all influenced vertices with heat map colors
+        auto weights = getSoftSelectionWeights();
 
-        for (int gi : m_selectedVertices) {
+        for (const auto& [gi, weight] : weights) {
             auto [subIdx, localIdx] = globalToLocal(gi);
             if (subIdx < m_editableMesh->subMeshes().size() &&
                 localIdx < m_editableMesh->subMeshes()[subIdx].vertices.size())
             {
                 const auto& pos = m_editableMesh->subMeshes()[subIdx].vertices[localIdx].position;
                 m_overlayVertices->position(pos);
-                m_overlayVertices->colour(vertColor);
+                m_overlayVertices->colour(weightToColor(weight));
             }
         }
 

--- a/src/EditModeController.h
+++ b/src/EditModeController.h
@@ -333,6 +333,10 @@ public:
                                       const Ogre::Vector3& v1,
                                       const Ogre::Vector3& v2);
 
+    /// Map a soft selection weight (0.0–1.0) to a heat map colour.
+    /// Red (1.0) → orange → yellow → green → cyan → blue (0.0).
+    static Ogre::ColourValue weightToColor(float weight);
+
     /// Convert a global vertex index to (subMeshIndex, localVertexIndex) pair.
     std::pair<size_t, size_t> globalToLocal(int globalIndex) const;
 

--- a/src/EditModeController_test.cpp
+++ b/src/EditModeController_test.cpp
@@ -123,6 +123,51 @@ TEST(EditModeControllerGeometry, RayTriangleIntersectOutsideTriangle) {
     EXPECT_LT(t, 0.0f);
 }
 
+// ===========================================================================
+// Weight-to-color heat map tests
+// ===========================================================================
+
+TEST(EditModeControllerGeometry, WeightToColorFullWeight) {
+    // weight 1.0 → red (R=1, G≈0, B=0)
+    auto c = EditModeController::weightToColor(1.0f);
+    EXPECT_FLOAT_EQ(c.r, 1.0f);
+    EXPECT_NEAR(c.g, 0.0f, 0.01f);
+    EXPECT_FLOAT_EQ(c.b, 0.0f);
+}
+
+TEST(EditModeControllerGeometry, WeightToColorZeroWeight) {
+    // weight 0.0 → blue (R=0, G=0, B=1)
+    auto c = EditModeController::weightToColor(0.0f);
+    EXPECT_FLOAT_EQ(c.r, 0.0f);
+    EXPECT_FLOAT_EQ(c.g, 0.0f);
+    EXPECT_FLOAT_EQ(c.b, 1.0f);
+}
+
+TEST(EditModeControllerGeometry, WeightToColorMidWeight) {
+    // weight 0.5 → green-ish (R≈0.5, G=1, B=0)
+    auto c = EditModeController::weightToColor(0.5f);
+    EXPECT_NEAR(c.r, 0.5f, 0.01f);
+    EXPECT_FLOAT_EQ(c.g, 1.0f);
+    EXPECT_FLOAT_EQ(c.b, 0.0f);
+}
+
+TEST(EditModeControllerGeometry, WeightToColorAlwaysOpaque) {
+    // All weights produce alpha = 1.0
+    for (float w : {0.0f, 0.1f, 0.25f, 0.5f, 0.75f, 0.9f, 1.0f}) {
+        auto c = EditModeController::weightToColor(w);
+        EXPECT_FLOAT_EQ(c.a, 1.0f);
+    }
+}
+
+TEST(EditModeControllerGeometry, WeightToColorGradientMonotonic) {
+    // Red channel should generally increase with weight
+    auto cLow = EditModeController::weightToColor(0.1f);
+    auto cMid = EditModeController::weightToColor(0.5f);
+    auto cHigh = EditModeController::weightToColor(0.9f);
+    EXPECT_LE(cLow.r, cMid.r);
+    EXPECT_LE(cMid.r, cHigh.r);
+}
+
 TEST(EditModeControllerGeometry, RayTriangleIntersectOriginOnTriangle) {
     // Ray origin is on the triangle, direction is perpendicular
     Ogre::Vector3 origin(0.1f, 0.0f, 0.1f);

--- a/src/EditModeController_test.cpp
+++ b/src/EditModeController_test.cpp
@@ -168,6 +168,18 @@ TEST(EditModeControllerGeometry, WeightToColorGradientMonotonic) {
     EXPECT_LE(cMid.r, cHigh.r);
 }
 
+TEST(EditModeControllerGeometry, WeightToColorBoundaryContinuity) {
+    // Check boundaries are continuous (no color jumps)
+    float boundaries[] = {0.2f, 0.4f, 0.6f, 0.8f};
+    for (float b : boundaries) {
+        auto cBelow = EditModeController::weightToColor(b - 0.001f);
+        auto cAbove = EditModeController::weightToColor(b + 0.001f);
+        EXPECT_NEAR(cBelow.r, cAbove.r, 0.05f) << "R discontinuity at " << b;
+        EXPECT_NEAR(cBelow.g, cAbove.g, 0.05f) << "G discontinuity at " << b;
+        EXPECT_NEAR(cBelow.b, cAbove.b, 0.05f) << "B discontinuity at " << b;
+    }
+}
+
 TEST(EditModeControllerGeometry, RayTriangleIntersectOriginOnTriangle) {
     // Ray origin is on the triangle, direction is perpendicular
     Ogre::Vector3 origin(0.1f, 0.0f, 0.1f);


### PR DESCRIPTION
## Summary
- Vertex overlay shows weight-based heat map colors (red→blue gradient) when soft selection is active
- Radius slider uses logarithmic mapping for fine precision at small values and coarser control at large values
- Extracted `weightToColor()` static helper with unit tests
- Version bump to 2.25.1

## Test plan
- [x] Unit tests for `weightToColor()` heat map (5 new tests, all pass)
- [ ] Manual: enter edit mode, enable soft selection, select vertex — verify heat map gradient on nearby vertices
- [ ] Manual: verify slider gives fine control near 0.01 and coarser control near 20.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Color gradient visualization for soft-selected vertices (blue→red) reflecting selection weight.
  * Soft selection radius slider now uses logarithmic scaling and stays synchronized with external changes for finer control.

* **Tests**
  * Added unit tests validating the weight-to-color mapping, endpoints, midpoints, continuity, and alpha behavior.

* **Version**
  * Project version updated to 2.25.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->