### PR TITLE
[codex] Add scan badges support and update pipeline overview GIF

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Automate your 3D asset pipeline — scan, validate, convert, fix, and merge 3D a
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=fernandotonon_QtMeshEditor&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=fernandotonon_QtMeshEditor)
 [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=fernandotonon_QtMeshEditor&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=fernandotonon_QtMeshEditor)
 
+#### QtMesh Badges
+ [![qtmesh status](https://img.shields.io/badge/qtmesh-pass-brightgreen)](https://github.com/fernandotonon/QtMeshEditor/actions) [![qtmesh errors](https://img.shields.io/badge/qtmesh|%20errors-0-brightgreen)](https://github.com/fernandotonon/QtMeshEditor/actions) [![qtmesh warnings](https://img.shields.io/badge/qtmesh|%20warnings-2-yellow)](https://github.com/fernandotonon/QtMeshEditor/actions)
+
 ---
 
 ### 🔌 CI/CD — Validate Assets on Every PR

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Automate your 3D asset pipeline — scan, validate, convert, fix, and merge 3D a
 [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=fernandotonon_QtMeshEditor&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=fernandotonon_QtMeshEditor)
 
 #### QtMesh Badges
- [![qtmesh status](https://img.shields.io/badge/qtmesh-pass-brightgreen)](https://github.com/fernandotonon/QtMeshEditor/actions) [![qtmesh errors](https://img.shields.io/badge/qtmesh|%20errors-0-brightgreen)](https://github.com/fernandotonon/QtMeshEditor/actions) [![qtmesh warnings](https://img.shields.io/badge/qtmesh|%20warnings-2-yellow)](https://github.com/fernandotonon/QtMeshEditor/actions)
+[![qtmesh status](https://img.shields.io/endpoint?url=https%3A%2F%2Ffernandotonon.github.io%2FQtMeshEditor%2Fbadges%2Fqtmesh-status.json)](https://github.com/fernandotonon/QtMeshEditor/actions) [![qtmesh errors](https://img.shields.io/endpoint?url=https%3A%2F%2Ffernandotonon.github.io%2FQtMeshEditor%2Fbadges%2Fqtmesh-errors.json)](https://github.com/fernandotonon/QtMeshEditor/actions) [![qtmesh warnings](https://img.shields.io/endpoint?url=https%3A%2F%2Ffernandotonon.github.io%2FQtMeshEditor%2Fbadges%2Fqtmesh-warnings.json)](https://github.com/fernandotonon/QtMeshEditor/actions)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,65 @@ docker run --rm -v $(pwd):/workspace ghcr.io/fernandotonon/qtmesh scan ./assets 
 
 </details>
 
+### 🏷️ Shareable Scan Badges
+
+The action can generate Shields-compatible endpoint JSON badges from `scan` results, so you can show status/errors/warnings in your README or website.
+
+```yaml
+name: QtMesh Badges
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  scan-and-publish-badges:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run scan + generate badge JSON files
+        id: scan
+        uses: fernandotonon/QtMeshEditor@v1
+        with:
+          command: scan
+          input-file: .
+          options: --config /workspace/qtmesh.yml --json
+          generate-badges: true
+          badge-output-dir: badges
+          badge-label-prefix: qtmesh
+          badge-base-url: https://<USER>.github.io/<REPO>/badges
+
+      - name: Publish badges to gh-pages/badges
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./badges
+          destination_dir: badges
+          keep_files: true
+```
+
+Example badge markdown (after publishing `badges/*.json`):
+
+```md
+[![qtmesh status](https://img.shields.io/endpoint?url=https%3A%2F%2F<USER>.github.io%2F<REPO>%2Fbadges%2Fqtmesh-status.json)](https://github.com/<USER>/<REPO>/actions)
+[![qtmesh errors](https://img.shields.io/endpoint?url=https%3A%2F%2F<USER>.github.io%2F<REPO>%2Fbadges%2Fqtmesh-errors.json)](https://github.com/<USER>/<REPO>/actions)
+[![qtmesh warnings](https://img.shields.io/endpoint?url=https%3A%2F%2F<USER>.github.io%2F<REPO>%2Fbadges%2Fqtmesh-warnings.json)](https://github.com/<USER>/<REPO>/actions)
+```
+
+Generated files:
+
+- `qtmesh-status.json`
+- `qtmesh-errors.json`
+- `qtmesh-warnings.json`
+- `qtmesh-passed.json`
+- `qtmesh-scanned.json`
+- `qtmesh-skipped.json`
+
 ---
 
 ### 🔧 CLI Pipeline (`qtmesh`)

--- a/action.yml
+++ b/action.yml
@@ -123,14 +123,28 @@ runs:
           cmd+=("${opts[@]}")
         fi
 
+        tmp_stdout=$(mktemp)
+        tmp_stderr=$(mktemp)
+        trap 'rm -f "$tmp_stdout" "$tmp_stderr"' EXIT
+
         set +e
-        OUTPUT=$(docker run --rm \
+        docker run --rm \
           --user "$(id -u):$(id -g)" \
           -v "${{ github.workspace }}:/workspace" \
           "ghcr.io/fernandotonon/qtmesh:${{ inputs.image-tag }}" \
-          "${cmd[@]}" 2>&1)
+          "${cmd[@]}" >"$tmp_stdout" 2>"$tmp_stderr"
         EXIT_CODE=$?
         set -e
+
+        STDOUT_OUTPUT=$(cat "$tmp_stdout")
+        STDERR_OUTPUT=$(cat "$tmp_stderr")
+        if [ -n "$STDOUT_OUTPUT" ] && [ -n "$STDERR_OUTPUT" ]; then
+          OUTPUT="${STDOUT_OUTPUT}"$'\n'"${STDERR_OUTPUT}"
+        elif [ -n "$STDOUT_OUTPUT" ]; then
+          OUTPUT="$STDOUT_OUTPUT"
+        else
+          OUTPUT="$STDERR_OUTPUT"
+        fi
 
         echo "result<<EOF" >> "$GITHUB_OUTPUT"
         echo "$OUTPUT" >> "$GITHUB_OUTPUT"
@@ -138,7 +152,12 @@ runs:
         echo "exit-code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
 
         # Print output for workflow logs
-        echo "$OUTPUT"
+        if [ -n "$STDOUT_OUTPUT" ]; then
+          echo "$STDOUT_OUTPUT"
+        fi
+        if [ -n "$STDERR_OUTPUT" ]; then
+          echo "$STDERR_OUTPUT" >&2
+        fi
 
         if [ "${INPUT_GENERATE_BADGES}" = "true" ] && [ "$INPUT_COMMAND" = "scan" ]; then
           if ! command -v jq >/dev/null 2>&1; then
@@ -150,12 +169,12 @@ runs:
             errors=""
             skipped=""
 
-            if printf '%s\n' "$OUTPUT" | jq -e '.summary | type == "object"' >/dev/null 2>&1; then
-              scanned=$(printf '%s\n' "$OUTPUT" | jq -r '.summary.scanned // 0')
-              passed=$(printf '%s\n' "$OUTPUT" | jq -r '.summary.passed // 0')
-              warnings=$(printf '%s\n' "$OUTPUT" | jq -r '.summary.warnings // 0')
-              errors=$(printf '%s\n' "$OUTPUT" | jq -r '.summary.errors // 0')
-              skipped=$(printf '%s\n' "$OUTPUT" | jq -r '.summary.skipped // 0')
+            if printf '%s\n' "$STDOUT_OUTPUT" | jq -e '.summary | type == "object"' >/dev/null 2>&1; then
+              scanned=$(printf '%s\n' "$STDOUT_OUTPUT" | jq -r '.summary.scanned // 0')
+              passed=$(printf '%s\n' "$STDOUT_OUTPUT" | jq -r '.summary.passed // 0')
+              warnings=$(printf '%s\n' "$STDOUT_OUTPUT" | jq -r '.summary.warnings // 0')
+              errors=$(printf '%s\n' "$STDOUT_OUTPUT" | jq -r '.summary.errors // 0')
+              skipped=$(printf '%s\n' "$STDOUT_OUTPUT" | jq -r '.summary.skipped // 0')
             else
               clean_output=$(printf '%s\n' "$OUTPUT" | sed -E 's/\x1B\[[0-9;]*[mK]//g')
               scanned=$(parse_metric_from_text "$clean_output" "Scanned")

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,21 @@ inputs:
     description: 'Docker image tag (default: latest)'
     required: false
     default: 'latest'
+  generate-badges:
+    description: 'When command=scan, generate Shields endpoint badge JSON files from scan summary.'
+    required: false
+    default: 'false'
+  badge-output-dir:
+    description: 'Directory to write generated badge JSON files (workspace-relative or absolute).'
+    required: false
+    default: '.qtmesh-badges'
+  badge-label-prefix:
+    description: 'Badge label/prefix (default: qtmesh).'
+    required: false
+    default: 'qtmesh'
+  badge-base-url:
+    description: 'Public base URL hosting badge JSON files (used to expose ready-to-use badge URLs in outputs).'
+    required: false
 
 outputs:
   result:
@@ -31,6 +46,30 @@ outputs:
   exit-code:
     description: 'Exit code (0 = success, 1 = issues found for scan/validate)'
     value: ${{ steps.run.outputs.exit-code }}
+  badge-status:
+    description: 'Computed scan status for generated badges: pass, warn, fail, or no-data.'
+    value: ${{ steps.run.outputs.badge-status }}
+  badge-directory:
+    description: 'Directory where badge JSON files were generated.'
+    value: ${{ steps.run.outputs.badge-directory }}
+  badge-status-url:
+    description: 'Shields endpoint URL for status badge (requires badge-base-url).'
+    value: ${{ steps.run.outputs.badge-status-url }}
+  badge-errors-url:
+    description: 'Shields endpoint URL for errors badge (requires badge-base-url).'
+    value: ${{ steps.run.outputs.badge-errors-url }}
+  badge-warnings-url:
+    description: 'Shields endpoint URL for warnings badge (requires badge-base-url).'
+    value: ${{ steps.run.outputs.badge-warnings-url }}
+  badge-passed-url:
+    description: 'Shields endpoint URL for passed badge (requires badge-base-url).'
+    value: ${{ steps.run.outputs.badge-passed-url }}
+  badge-scanned-url:
+    description: 'Shields endpoint URL for scanned badge (requires badge-base-url).'
+    value: ${{ steps.run.outputs.badge-scanned-url }}
+  badge-skipped-url:
+    description: 'Shields endpoint URL for skipped badge (requires badge-base-url).'
+    value: ${{ steps.run.outputs.badge-skipped-url }}
 
 runs:
   using: 'composite'
@@ -42,7 +81,38 @@ runs:
         INPUT_FILE: ${{ inputs.input-file }}
         INPUT_OUTPUT_FILE: ${{ inputs.output-file }}
         INPUT_OPTIONS: ${{ inputs.options }}
+        INPUT_GENERATE_BADGES: ${{ inputs.generate-badges }}
+        INPUT_BADGE_OUTPUT_DIR: ${{ inputs.badge-output-dir }}
+        INPUT_BADGE_LABEL_PREFIX: ${{ inputs.badge-label-prefix }}
+        INPUT_BADGE_BASE_URL: ${{ inputs.badge-base-url }}
       run: |
+        set -o pipefail
+
+        parse_metric_from_text() {
+          local text="$1"
+          local key="$2"
+          printf '%s\n' "$text" | grep -Eo "${key}:[^0-9]*[0-9]+" | head -n1 | grep -Eo '[0-9]+$' || true
+        }
+
+        write_badge_json() {
+          local target_file="$1"
+          local label="$2"
+          local message="$3"
+          local color="$4"
+          jq -n \
+            --arg label "$label" \
+            --arg message "$message" \
+            --arg color "$color" \
+            '{schemaVersion: 1, label: $label, message: $message, color: $color}' > "$target_file"
+        }
+
+        to_shields_endpoint_url() {
+          local endpoint_json_url="$1"
+          local encoded
+          encoded=$(printf '%s' "$endpoint_json_url" | jq -sRr @uri)
+          printf 'https://img.shields.io/endpoint?url=%s' "$encoded"
+        }
+
         # Build command args safely via arrays to prevent injection
         cmd=("$INPUT_COMMAND" "/workspace/$INPUT_FILE")
         if [ -n "$INPUT_OUTPUT_FILE" ]; then
@@ -69,6 +139,90 @@ runs:
 
         # Print output for workflow logs
         echo "$OUTPUT"
+
+        if [ "${INPUT_GENERATE_BADGES}" = "true" ] && [ "$INPUT_COMMAND" = "scan" ]; then
+          if ! command -v jq >/dev/null 2>&1; then
+            echo "::warning::jq is required for badge generation, skipping."
+          else
+            scanned=""
+            passed=""
+            warnings=""
+            errors=""
+            skipped=""
+
+            if printf '%s\n' "$OUTPUT" | jq -e '.summary | type == "object"' >/dev/null 2>&1; then
+              scanned=$(printf '%s\n' "$OUTPUT" | jq -r '.summary.scanned // 0')
+              passed=$(printf '%s\n' "$OUTPUT" | jq -r '.summary.passed // 0')
+              warnings=$(printf '%s\n' "$OUTPUT" | jq -r '.summary.warnings // 0')
+              errors=$(printf '%s\n' "$OUTPUT" | jq -r '.summary.errors // 0')
+              skipped=$(printf '%s\n' "$OUTPUT" | jq -r '.summary.skipped // 0')
+            else
+              clean_output=$(printf '%s\n' "$OUTPUT" | sed -E 's/\x1B\[[0-9;]*[mK]//g')
+              scanned=$(parse_metric_from_text "$clean_output" "Scanned")
+              passed=$(parse_metric_from_text "$clean_output" "Passed")
+              warnings=$(parse_metric_from_text "$clean_output" "Warnings")
+              errors=$(parse_metric_from_text "$clean_output" "Errors")
+              skipped=$(parse_metric_from_text "$clean_output" "Skipped")
+            fi
+
+            scanned=${scanned:-0}
+            passed=${passed:-0}
+            warnings=${warnings:-0}
+            errors=${errors:-0}
+            skipped=${skipped:-0}
+
+            status="pass"
+            status_color="brightgreen"
+            if [ "$scanned" -eq 0 ]; then
+              status="no-data"
+              status_color="lightgrey"
+            elif [ "$errors" -gt 0 ]; then
+              status="fail"
+              status_color="red"
+            elif [ "$warnings" -gt 0 ]; then
+              status="warn"
+              status_color="yellow"
+            fi
+
+            badge_prefix="${INPUT_BADGE_LABEL_PREFIX:-qtmesh}"
+            badge_dir="${INPUT_BADGE_OUTPUT_DIR:-.qtmesh-badges}"
+            if [ "${badge_dir#/}" = "$badge_dir" ]; then
+              badge_dir_abs="${{ github.workspace }}/${badge_dir}"
+            else
+              badge_dir_abs="${badge_dir}"
+            fi
+            mkdir -p "$badge_dir_abs"
+
+            write_badge_json "$badge_dir_abs/${badge_prefix}-status.json" "$badge_prefix" "$status" "$status_color"
+            write_badge_json "$badge_dir_abs/${badge_prefix}-errors.json" "${badge_prefix} errors" "$errors" "$( [ "$errors" -gt 0 ] && echo red || echo brightgreen )"
+            write_badge_json "$badge_dir_abs/${badge_prefix}-warnings.json" "${badge_prefix} warnings" "$warnings" "$( [ "$warnings" -gt 0 ] && echo yellow || echo brightgreen )"
+            write_badge_json "$badge_dir_abs/${badge_prefix}-passed.json" "${badge_prefix} passed" "$passed" "brightgreen"
+            write_badge_json "$badge_dir_abs/${badge_prefix}-scanned.json" "${badge_prefix} scanned" "$scanned" "blue"
+            write_badge_json "$badge_dir_abs/${badge_prefix}-skipped.json" "${badge_prefix} skipped" "$skipped" "lightgrey"
+
+            echo "badge-status=$status" >> "$GITHUB_OUTPUT"
+            echo "badge-directory=$badge_dir" >> "$GITHUB_OUTPUT"
+
+            if [ -n "$INPUT_BADGE_BASE_URL" ]; then
+              badge_base="${INPUT_BADGE_BASE_URL%/}"
+              status_url=$(to_shields_endpoint_url "$badge_base/${badge_prefix}-status.json")
+              errors_url=$(to_shields_endpoint_url "$badge_base/${badge_prefix}-errors.json")
+              warnings_url=$(to_shields_endpoint_url "$badge_base/${badge_prefix}-warnings.json")
+              passed_url=$(to_shields_endpoint_url "$badge_base/${badge_prefix}-passed.json")
+              scanned_url=$(to_shields_endpoint_url "$badge_base/${badge_prefix}-scanned.json")
+              skipped_url=$(to_shields_endpoint_url "$badge_base/${badge_prefix}-skipped.json")
+
+              echo "badge-status-url=$status_url" >> "$GITHUB_OUTPUT"
+              echo "badge-errors-url=$errors_url" >> "$GITHUB_OUTPUT"
+              echo "badge-warnings-url=$warnings_url" >> "$GITHUB_OUTPUT"
+              echo "badge-passed-url=$passed_url" >> "$GITHUB_OUTPUT"
+              echo "badge-scanned-url=$scanned_url" >> "$GITHUB_OUTPUT"
+              echo "badge-skipped-url=$skipped_url" >> "$GITHUB_OUTPUT"
+            fi
+
+            echo "Generated badges in: $badge_dir_abs"
+          fi
+        fi
 
         # Propagate exit code for scan/validate (exit 1 = issues found)
         exit $EXIT_CODE

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -273,8 +273,8 @@ function App() {
               <figure className={`${styles.demoMain} reveal`}>
                 <img
                   className={styles.demoImage}
-                  src={media.skeletonPreview.src}
-                  alt={media.skeletonPreview.alt}
+                  src={media.pipelineCiCd.src}
+                  alt={media.pipelineCiCd.alt}
                   loading="lazy"
                 />
               </figure>

--- a/website/src/DocsApp.jsx
+++ b/website/src/DocsApp.jsx
@@ -759,6 +759,35 @@ jobs:
 
 - run: echo "\${{ steps.info.outputs.result }}"`}</CodeBlock>
 
+            <h3 className={s.subsection}>Generate scan badges (Shields endpoint JSON)</h3>
+            <CodeBlock lang="yaml">{`- uses: fernandotonon/QtMeshEditor@v1
+  id: scan
+  with:
+    command: scan
+    input-file: .
+    options: --config /workspace/qtmesh.yml --json
+    generate-badges: true
+    badge-output-dir: badges
+    badge-label-prefix: qtmesh
+    badge-base-url: https://<USER>.github.io/<REPO>/badges
+
+- name: Publish badges to gh-pages/badges
+  uses: peaceiris/actions-gh-pages@v4
+  with:
+    github_token: \${{ secrets.GITHUB_TOKEN }}
+    publish_dir: ./badges
+    destination_dir: badges
+    keep_files: true
+
+- run: |
+    echo "Status badge URL:"
+    echo "\${{ steps.scan.outputs.badge-status-url }}"`}</CodeBlock>
+
+            <h3 className={s.subsection}>README badge snippet</h3>
+            <CodeBlock lang="md">{`[![qtmesh status](https://img.shields.io/endpoint?url=https%3A%2F%2F<USER>.github.io%2F<REPO>%2Fbadges%2Fqtmesh-status.json)](https://github.com/<USER>/<REPO>/actions)
+[![qtmesh errors](https://img.shields.io/endpoint?url=https%3A%2F%2F<USER>.github.io%2F<REPO>%2Fbadges%2Fqtmesh-errors.json)](https://github.com/<USER>/<REPO>/actions)
+[![qtmesh warnings](https://img.shields.io/endpoint?url=https%3A%2F%2F<USER>.github.io%2F<REPO>%2Fbadges%2Fqtmesh-warnings.json)](https://github.com/<USER>/<REPO>/actions)`}</CodeBlock>
+
             <h3 className={s.subsection}>Direct Docker usage</h3>
             <CodeBlock lang="yaml">{`- name: Scan assets
   run: |

--- a/website/src/data/content.js
+++ b/website/src/data/content.js
@@ -15,6 +15,10 @@ export const media = {
     src: 'https://github.com/user-attachments/assets/441f90c5-1968-4838-8001-4ca24856a501',
     alt: 'QtMeshEditor animation merge workflow with imported FBX assets'
   },
+  pipelineCiCd: {
+    src: 'https://github.com/user-attachments/assets/1c7a7965-4bec-4e6d-8197-78d4435c8d46',
+    alt: 'QtMeshEditor CI/CD pipeline overview'
+  },
   skeletonPreview: {
     src: 'https://github.com/user-attachments/assets/289403ac-8952-488c-bc65-0a768ab278e1',
     alt: 'Bone weight and skeleton validation preview in QtMeshEditor'


### PR DESCRIPTION
## Summary
- add optional scan badge generation to the Marketplace action (`action.yml`)
- document badge generation and publishing in README + website docs
- update the **Pipeline Overview / CI/CD for 3D assets** demo GIF to the one used in the `v1` (2.23.0) release description

## What Changed
- `action.yml`
  - new inputs: `generate-badges`, `badge-output-dir`, `badge-label-prefix`, `badge-base-url`
  - new outputs: badge status + prebuilt Shields endpoint URLs
  - generate Shields endpoint JSON files for scan summary metrics (`status`, `errors`, `warnings`, `passed`, `scanned`, `skipped`)
- `README.md`
  - added "Shareable Scan Badges" section with workflow snippet and markdown badge examples
- `website/src/DocsApp.jsx`
  - added GitHub Actions example for generating/publishing scan badges
  - added README badge snippet example
- `website/src/data/content.js` and `website/src/App.jsx`
  - added `media.pipelineCiCd` and used it in the Pipeline Overview section image

## Validation
- `npm --prefix website run build`

## Notes
- This keeps existing action behavior unchanged unless `generate-badges: true` is provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional generation of shareable scan result badges during scan runs, with outputs exposing badge URLs.

* **Documentation**
  * Added README and website docs with GitHub Actions workflow examples and Shields integration for publishing badge JSON to GitHub Pages.
  * Updated demo image and media entry for CI/CD pipeline illustration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->