### PR TITLE
Enable CLI commands (qtmesh, qtmesheditor) from Homebrew install

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1758,10 +1758,10 @@ jobs:
 
         echo "Updating cask to version $VERSION with SHA256 $SHA256"
 
-        # Update version (Homebrew cask uses single quotes)
+        # Only update version and sha256 — the cask file contains CLI symlink
+        # stanzas (binary, postflight/uninstall_postflight for qtmesh) that
+        # must be preserved. sed only touches the matching lines.
         sed -i "s/version '.*'/version '$VERSION'/" "$CASK_FILE"
-
-        # Update sha256 (Homebrew cask uses single quotes)
         sed -i "s/sha256 '.*'/sha256 '$SHA256'/" "$CASK_FILE"
 
         echo "Updated cask file:"


### PR DESCRIPTION
## Summary
- Updated the Homebrew cask in `fernandotonon/homebrew-qtmesheditor` to create CLI symlinks on install
- `brew install --cask qtmesheditor` now provides both `qtmesheditor` (GUI) and `qtmesh` (CLI pipeline) commands
- Added a comment in CI workflow documenting that the sed-based cask update preserves the CLI stanzas

## Changes
- **homebrew-qtmesheditor repo** (already pushed): added `binary` stanza for `qtmesheditor`, `postflight`/`uninstall_postflight` for `qtmesh` symlink, updated caveats with CLI usage examples
- **This repo**: CI comment documenting the preservation of CLI stanzas during auto-update

## Test plan
- [x] `brew install --cask qtmesheditor` creates both symlinks
- [x] `qtmesheditor` launches the GUI
- [x] `qtmesh info model.fbx` works from terminal
- [ ] Next release auto-updates version/sha256 without breaking CLI stanzas

🤖 Generated with [Claude Code](https://claude.com/claude-code)