### PR TITLE
feat(cli): scan token-first rules, default path and include globs

### DIFF
--- a/.github/actions/qtmesh/action.yml
+++ b/.github/actions/qtmesh/action.yml
@@ -6,8 +6,9 @@ inputs:
     description: 'Subcommand: info, fix, convert, anim, validate, lod, pose, scan'
     required: true
   input-file:
-    description: 'Input file or directory path (relative to workspace)'
-    required: true
+    description: 'Directory or file to scan (relative to workspace). Defaults to .'
+    required: false
+    default: '.'
   output-file:
     description: 'Output file path (for convert/fix/anim rename/merge)'
     required: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 2.27.0 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 2.27.1 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 2.26.0 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 2.27.0 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 2.27.1 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 2.26.1 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ docker run --rm -v $(pwd):/workspace ghcr.io/fernandotonon/qtmesh scan ./assets 
 
 ### ☁️ QtMesh Cloud Badges (Recommended)
 
-Register your repository in [QtMesh Cloud](https://qtmesh.ftonon.uk) to publish real scan badges from CI.
+Register your repository in [QtMesh Cloud](https://qtmesh.dev) to publish real scan badges from CI.
 
-1. Sign in at [qtmesh.ftonon.uk](https://qtmesh.ftonon.uk) and create a project (choose a slug like `my-game-assets`).
+1. Sign in at [qtmesh.dev](https://qtmesh.dev) and create a project (choose a slug like `my-game-assets`).
 2. Create a project token in QtMesh Cloud.
 3. Add the token as a GitHub secret named `QTMESH_CLOUD_TOKEN`.
-4. Upload each `scan` JSON report from CI to `https://api.qtmesh.ftonon.uk/v1/ingest/scan`.
+4. Upload each `scan` JSON report from CI to `https://api.qtmesh.dev/v1/ingest/scan`.
 
 Example upload step:
 
@@ -99,7 +99,7 @@ Example upload step:
 - name: Upload scan to QtMesh Cloud
   env:
     QTMESH_CLOUD_TOKEN: ${{ secrets.QTMESH_CLOUD_TOKEN }}
-    QTMESH_CLOUD_API_URL: https://api.qtmesh.ftonon.uk
+    QTMESH_CLOUD_API_URL: https://api.qtmesh.dev
   run: |
     jq --arg branch "${GITHUB_REF_NAME}" \
        --arg sha "${GITHUB_SHA}" \
@@ -117,9 +117,9 @@ Example upload step:
 Badge markdown (replace `<project-slug>`):
 
 ```md
-[![qtmesh status](https://api.qtmesh.ftonon.uk/v1/projects/<project-slug>/badges/qtmesh-status.svg)](https://qtmesh.ftonon.uk)
-[![qtmesh errors](https://api.qtmesh.ftonon.uk/v1/projects/<project-slug>/badges/qtmesh-errors.svg)](https://qtmesh.ftonon.uk)
-[![qtmesh warnings](https://api.qtmesh.ftonon.uk/v1/projects/<project-slug>/badges/qtmesh-warnings.svg)](https://qtmesh.ftonon.uk)
+[![qtmesh status](https://api.qtmesh.dev/v1/projects/<project-slug>/badges/qtmesh-status.svg)](https://qtmesh.dev)
+[![qtmesh errors](https://api.qtmesh.dev/v1/projects/<project-slug>/badges/qtmesh-errors.svg)](https://qtmesh.dev)
+[![qtmesh warnings](https://api.qtmesh.dev/v1/projects/<project-slug>/badges/qtmesh-warnings.svg)](https://qtmesh.dev)
 ```
 
 ### 🏷️ Self-Hosted Scan Badges (Legacy)

--- a/action.yml
+++ b/action.yml
@@ -133,6 +133,17 @@ runs:
         }
 
         # Build command args safely via arrays to prevent injection
+        if [ "$INPUT_COMMAND" = "scan" ]; then
+          if [ -z "${INPUT_FILE:-}" ]; then
+            INPUT_FILE="."
+          fi
+        else
+          if [ -z "${INPUT_FILE:-}" ] || [ "${INPUT_FILE}" = "." ]; then
+            echo "Error: input-file is required for command '$INPUT_COMMAND' (only scan defaults to '.')"
+            exit 2
+          fi
+        fi
+
         cmd=("$INPUT_COMMAND" "/workspace/$INPUT_FILE")
         if [ -n "$INPUT_OUTPUT_FILE" ]; then
           cmd+=("-o" "/workspace/$INPUT_OUTPUT_FILE")

--- a/action.yml
+++ b/action.yml
@@ -11,8 +11,9 @@ inputs:
     description: 'Subcommand: scan, info, validate, convert, fix, anim, lod, pose'
     required: true
   input-file:
-    description: 'Input file or directory path (relative to workspace)'
-    required: true
+    description: 'Directory or file to scan (relative to workspace). Defaults to . (workspace root).'
+    required: false
+    default: '.'
   output-file:
     description: 'Output file path (for convert/fix/anim/pose)'
     required: false

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -243,7 +243,7 @@ void CLIPipeline::printUsage()
         "                                    Export a single posed frame as static mesh\n"
         "  pose <file> --animation <name> --count N -o <pattern>\n"
         "                                    Export N evenly spaced frames (use %02d in pattern)\n"
-        "  scan [path] [options]             Scan directory for 3D asset issues (CI linting)\n"
+        "  scan [path] [options]           Scan directory for 3D asset issues (default path: .)\n"
         "\n"
         "Scan options:\n"
         "  --config <file>           Config file (default: qtmesh.yml, qtmesh.json)\n"
@@ -286,10 +286,11 @@ void CLIPipeline::printUsage()
         "  --no-upload               Skip POSTing scan JSON to QtMesh Cloud when a token is set\n"
         "  --strict-upload           Exit 1 if cloud upload fails (default: warn only)\n"
         "\n"
-        "  Cloud rules: if no --config and no local qtmesh.yml|yaml|json, QTMESH_TOKEN loads\n"
-        "  remote rules from the API; otherwise built-in defaults apply if the API is unreachable.\n"
-        "  --config or a local file skips fetching remote rules; scan JSON still uploads when a\n"
-        "  token is set (unless --no-upload). Override API base with QTMESH_API_BASE.\n"
+        "  Cloud rules: if no --config and QTMESH_TOKEN or --token is set, remote rules are\n"
+        "  fetched first (local qtmesh.yml is ignored). If the API fails, built-in defaults apply.\n"
+        "  Without a token, qtmesh.yml|yaml|json in the cwd is used if present.\n"
+        "  --config always wins. Scan JSON uploads when a token is set (unless --no-upload).\n"
+        "  Override API base with QTMESH_API_BASE.\n"
         "\n"
         "Fix flags:\n"
         "  --remove-degenerates  Remove degenerate triangles\n"
@@ -2024,8 +2025,8 @@ int CLIPipeline::cmdScan(int argc, char* argv[])
 
     // Load config (precedence):
     // 1) --config path (never fetch remote rules)
-    // 2) Else local qtmesh.yml | yaml | json in cwd (never fetch remote rules)
-    // 3) Else if ingest token set → GET /v1/ingest/rules, or defaults if API fails
+    // 2) Else if ingest token set → GET /v1/ingest/rules (skips local qtmesh.yml|yaml|json)
+    // 3) Else local qtmesh.yml | yaml | json in cwd
     // 4) Else built-in defaults
     ScanConfig config;
     if (!configPath.isEmpty()) {
@@ -2040,37 +2041,36 @@ int CLIPipeline::cmdScan(int argc, char* argv[])
                  << Qt::endl;
         }
     } else {
-        QString localAutoPath;
-        if (QFileInfo::exists(QStringLiteral("qtmesh.yml")))
-            localAutoPath = QStringLiteral("qtmesh.yml");
-        else if (QFileInfo::exists(QStringLiteral("qtmesh.yaml")))
-            localAutoPath = QStringLiteral("qtmesh.yaml");
-        else if (QFileInfo::exists(QStringLiteral("qtmesh.json")))
-            localAutoPath = QStringLiteral("qtmesh.json");
-
-        if (!localAutoPath.isEmpty()) {
-            config = ScanConfig::loadFromFile(localAutoPath);
-            err() << "Note: Using local " << localAutoPath
-                 << " — QtMesh Cloud remote rules are not used for validation." << Qt::endl;
-        } else {
-            const QString ingestForRules = resolveIngestToken(tokenArg);
-            if (!ingestForRules.isEmpty()) {
+        const QString ingestForRules = resolveIngestToken(tokenArg);
+        if (!ingestForRules.isEmpty()) {
+            SentryReporter::addBreadcrumb(QStringLiteral("cli.scan"),
+                QStringLiteral("QtMesh Cloud fetchRules: requested"));
+            const auto rules = QtMeshCloudClient::fetchRules(ingestForRules);
+            if (rules.ok) {
+                config = ScanConfig::fromJson(rules.config);
+                err() << "Note: Using QtMesh Cloud rules (source: " << rules.source << ")." << Qt::endl;
                 SentryReporter::addBreadcrumb(QStringLiteral("cli.scan"),
-                    QStringLiteral("QtMesh Cloud fetchRules: requested"));
-                const auto rules = QtMeshCloudClient::fetchRules(ingestForRules);
-                if (rules.ok) {
-                    config = ScanConfig::fromJson(rules.config);
-                    err() << "Note: Using QtMesh Cloud rules (source: " << rules.source << ")." << Qt::endl;
-                    SentryReporter::addBreadcrumb(QStringLiteral("cli.scan"),
-                        QStringLiteral("QtMesh Cloud fetchRules: ok source=%1").arg(rules.source));
-                } else {
-                    err() << "Warning: Could not load QtMesh Cloud rules (" << rules.errorString
-                         << "). Using built-in defaults." << Qt::endl;
-                    config = ScanConfig::defaults();
-                    SentryReporter::addBreadcrumb(QStringLiteral("cli.scan"),
-                        QStringLiteral("QtMesh Cloud fetchRules: failed %1").arg(rules.errorString),
-                        QStringLiteral("warning"));
-                }
+                    QStringLiteral("QtMesh Cloud fetchRules: ok source=%1").arg(rules.source));
+            } else {
+                err() << "Warning: Could not load QtMesh Cloud rules (" << rules.errorString
+                     << "). Using built-in defaults." << Qt::endl;
+                config = ScanConfig::defaults();
+                SentryReporter::addBreadcrumb(QStringLiteral("cli.scan"),
+                    QStringLiteral("QtMesh Cloud fetchRules: failed %1").arg(rules.errorString),
+                    QStringLiteral("warning"));
+            }
+        } else {
+            QString localAutoPath;
+            if (QFileInfo::exists(QStringLiteral("qtmesh.yml")))
+                localAutoPath = QStringLiteral("qtmesh.yml");
+            else if (QFileInfo::exists(QStringLiteral("qtmesh.yaml")))
+                localAutoPath = QStringLiteral("qtmesh.yaml");
+            else if (QFileInfo::exists(QStringLiteral("qtmesh.json")))
+                localAutoPath = QStringLiteral("qtmesh.json");
+
+            if (!localAutoPath.isEmpty()) {
+                config = ScanConfig::loadFromFile(localAutoPath);
+                err() << "Note: Using local " << localAutoPath << "." << Qt::endl;
             } else {
                 config = ScanConfig::defaults();
             }

--- a/src/CLIPipeline_test.cpp
+++ b/src/CLIPipeline_test.cpp
@@ -2337,7 +2337,36 @@ TEST(CLIPipelineCmdScanCloud, UploadFailureDoesNotChangeExitCodeWithoutStrict)
     EXPECT_EQ(CLIPipeline::cmdScan(args.argc(), args.argv()), 0);
 }
 
-TEST(CLIPipelineCmdScanCloud, LocalYmlOverridesRemoteTokenForRules)
+TEST(CLIPipelineCmdScanCloud, LocalQtmeshYmlAppliesWhenNoToken)
+{
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+    const QString rootPath = QDir(tmpDir.path()).filePath("assets");
+    ASSERT_TRUE(QDir().mkpath(rootPath));
+    ASSERT_FALSE(writeMinimalObj(rootPath, "scan_mesh.obj").isEmpty());
+
+    const QString ymlPath = QDir(tmpDir.path()).filePath("qtmesh.yml");
+    QFile yml(ymlPath);
+    ASSERT_TRUE(yml.open(QIODevice::WriteOnly | QIODevice::Text));
+    yml.write(
+        "scan:\n"
+        "  include:\n"
+        "    - \"**/*.obj\"\n"
+        "rules:\n"
+        "  max_vertex_count: 2\n");
+    yml.close();
+
+    ScopedCurrentDir scoped(tmpDir.path());
+    ScopedEnvVar clearTok("QTMESH_TOKEN", "");
+    ScopedEnvVar clearCloud("QTMESH_CLOUD_TOKEN", "");
+    ScopedEnvVar api("QTMESH_API_BASE", "http://127.0.0.1:1");
+
+    QByteArray rootBa = rootPath.toUtf8();
+    TestArgv args({"qtmesh", "scan", rootBa.constData()});
+    EXPECT_EQ(CLIPipeline::cmdScan(args.argc(), args.argv()), 1);
+}
+
+TEST(CLIPipelineCmdScanCloud, TokenSkipsLocalQtmeshYmlUsesDefaultsWhenApiFails)
 {
     QTemporaryDir tmpDir;
     ASSERT_TRUE(tmpDir.isValid());
@@ -2362,5 +2391,6 @@ TEST(CLIPipelineCmdScanCloud, LocalYmlOverridesRemoteTokenForRules)
 
     QByteArray rootBa = rootPath.toUtf8();
     TestArgv args({"qtmesh", "scan", rootBa.constData()});
-    EXPECT_EQ(CLIPipeline::cmdScan(args.argc(), args.argv()), 1);
+    // Cloud fetch fails → defaults (no max_vertex_count) → scan passes.
+    EXPECT_EQ(CLIPipeline::cmdScan(args.argc(), args.argv()), 0);
 }

--- a/src/ScanConfig.cpp
+++ b/src/ScanConfig.cpp
@@ -1,11 +1,14 @@
 #include "ScanConfig.h"
 #include "ScanEngine.h"
 
+#include <assimp/Importer.hpp>
+
 #include <QFile>
 #include <QFileInfo>
-#include <QJsonDocument>
 #include <QJsonArray>
+#include <QJsonDocument>
 #include <QRegularExpression>
+#include <QSet>
 #include <QTextStream>
 
 // ---------------------------------------------------------------------------
@@ -280,6 +283,44 @@ ScanConfig ScanConfig::withScopeOverrides(const QString& relativePath) const
 // ScanConfig loading
 // ---------------------------------------------------------------------------
 
+ScanConfig::ScanConfig()
+    : includePatterns(ScanConfig::defaultIncludePatternsForAssimpImports())
+{
+}
+
+QStringList ScanConfig::defaultIncludePatternsForAssimpImports()
+{
+    QSet<QString> extSet;
+    Assimp::Importer importer;
+    for (unsigned i = 0; i < importer.GetImporterCount(); ++i) {
+        const aiImporterDesc* desc = importer.GetImporterInfo(i);
+        if (!desc || !desc->mFileExtensions)
+            continue;
+        const QString extList = QString::fromLatin1(desc->mFileExtensions);
+        static const QRegularExpression sep(QStringLiteral("[;\\s,]+"));
+        const QStringList parts = extList.split(sep, Qt::SkipEmptyParts);
+        for (const QString& raw : parts) {
+            QString ext = raw.trimmed().toLower();
+            if (ext.startsWith(QLatin1Char('.')))
+                ext.remove(0, 1);
+            if (ext.isEmpty())
+                continue;
+            extSet.insert(ext);
+        }
+    }
+    // Ogre mesh formats used by the editor (may or may not appear as separate Assimp importers)
+    extSet.insert(QStringLiteral("mesh"));
+    extSet.insert(QStringLiteral("mesh.xml"));
+
+    QStringList globs;
+    globs.reserve(extSet.size());
+    for (const QString& ext : extSet) {
+        globs.append(QStringLiteral("**/*.") + ext);
+    }
+    globs.sort(Qt::CaseInsensitive);
+    return globs;
+}
+
 ScanConfig ScanConfig::defaults()
 {
     return ScanConfig();
@@ -319,11 +360,16 @@ ScanConfig ScanConfig::fromVariantMap(const QVariantMap& root)
     if (!scan.isEmpty()) {
         if (scan.contains("roots"))
             config.roots = scan.value("roots").toStringList();
-        if (scan.contains("include"))
+        if (scan.contains("include")) {
             config.includePatterns = scan.value("include").toStringList();
+            if (config.includePatterns.isEmpty())
+                config.includePatterns = ScanConfig::defaultIncludePatternsForAssimpImports();
+        }
         if (scan.contains("exclude"))
             config.excludePatterns = scan.value("exclude").toStringList();
     }
+    if (config.includePatterns.isEmpty())
+        config.includePatterns = ScanConfig::defaultIncludePatternsForAssimpImports();
 
     // rules section
     QVariantMap rules = root.value("rules").toMap();

--- a/src/ScanConfig.cpp
+++ b/src/ScanConfig.cpp
@@ -2,6 +2,7 @@
 #include "ScanEngine.h"
 
 #include <assimp/Importer.hpp>
+#include <assimp/importerdesc.h>
 
 #include <QFile>
 #include <QFileInfo>
@@ -290,35 +291,38 @@ ScanConfig::ScanConfig()
 
 QStringList ScanConfig::defaultIncludePatternsForAssimpImports()
 {
-    QSet<QString> extSet;
-    Assimp::Importer importer;
-    for (unsigned i = 0; i < importer.GetImporterCount(); ++i) {
-        const aiImporterDesc* desc = importer.GetImporterInfo(i);
-        if (!desc || !desc->mFileExtensions)
-            continue;
-        const QString extList = QString::fromLatin1(desc->mFileExtensions);
-        static const QRegularExpression sep(QStringLiteral("[;\\s,]+"));
-        const QStringList parts = extList.split(sep, Qt::SkipEmptyParts);
-        for (const QString& raw : parts) {
-            QString ext = raw.trimmed().toLower();
-            if (ext.startsWith(QLatin1Char('.')))
-                ext.remove(0, 1);
-            if (ext.isEmpty())
+    static const QStringList cached = []() {
+        QSet<QString> extSet;
+        Assimp::Importer importer;
+        for (unsigned i = 0; i < importer.GetImporterCount(); ++i) {
+            const aiImporterDesc* desc = importer.GetImporterInfo(i);
+            if (!desc || !desc->mFileExtensions)
                 continue;
-            extSet.insert(ext);
+            const QString extList = QString::fromLatin1(desc->mFileExtensions);
+            static const QRegularExpression sep(QStringLiteral("[;\\s,]+"));
+            const QStringList parts = extList.split(sep, Qt::SkipEmptyParts);
+            for (const QString& raw : parts) {
+                QString ext = raw.trimmed().toLower();
+                if (ext.startsWith(QLatin1Char('.')))
+                    ext.remove(0, 1);
+                if (ext.isEmpty())
+                    continue;
+                extSet.insert(ext);
+            }
         }
-    }
-    // Ogre mesh formats used by the editor (may or may not appear as separate Assimp importers)
-    extSet.insert(QStringLiteral("mesh"));
-    extSet.insert(QStringLiteral("mesh.xml"));
+        // Ogre mesh formats used by the editor (may or may not appear as separate Assimp importers)
+        extSet.insert(QStringLiteral("mesh"));
+        extSet.insert(QStringLiteral("mesh.xml"));
 
-    QStringList globs;
-    globs.reserve(extSet.size());
-    for (const QString& ext : extSet) {
-        globs.append(QStringLiteral("**/*.") + ext);
-    }
-    globs.sort(Qt::CaseInsensitive);
-    return globs;
+        QStringList globs;
+        globs.reserve(extSet.size());
+        for (const QString& ext : extSet) {
+            globs.append(QStringLiteral("**/*.") + ext);
+        }
+        globs.sort(Qt::CaseInsensitive);
+        return globs;
+    }();
+    return cached;
 }
 
 ScanConfig ScanConfig::defaults()
@@ -362,14 +366,10 @@ ScanConfig ScanConfig::fromVariantMap(const QVariantMap& root)
             config.roots = scan.value("roots").toStringList();
         if (scan.contains("include")) {
             config.includePatterns = scan.value("include").toStringList();
-            if (config.includePatterns.isEmpty())
-                config.includePatterns = ScanConfig::defaultIncludePatternsForAssimpImports();
         }
         if (scan.contains("exclude"))
             config.excludePatterns = scan.value("exclude").toStringList();
     }
-    if (config.includePatterns.isEmpty())
-        config.includePatterns = ScanConfig::defaultIncludePatternsForAssimpImports();
 
     // rules section
     QVariantMap rules = root.value("rules").toMap();

--- a/src/ScanConfig.h
+++ b/src/ScanConfig.h
@@ -18,10 +18,8 @@ struct ScanConfig {
 
     // scan section
     QStringList roots;
-    QStringList includePatterns = {
-        "**/*.fbx", "**/*.glb", "**/*.glb2", "**/*.gltf", "**/*.gltf2",
-        "**/*.obj", "**/*.dae", "**/*.stl", "**/*.ply", "**/*.3ds", "**/*.mesh"
-    };
+    /// Glob patterns; default ctor fills with all Assimp import extensions (plus Ogre .mesh / .mesh.xml).
+    QStringList includePatterns;
     QStringList excludePatterns = {
         "**/node_modules/**", "**/.git/**", "**/build/**", "**/Build/**"
     };
@@ -68,6 +66,11 @@ struct ScanConfig {
     QString reportOutput;
     QString sarifOutput;
     QString failOn = "error";         // info, warning, error, never
+
+    ScanConfig();
+
+    /// `**/*.<ext>` for every file extension registered by Assimp importers, plus `mesh` / `mesh.xml`.
+    static QStringList defaultIncludePatternsForAssimpImports();
 
     static ScanConfig defaults();
     static ScanConfig loadFromFile(const QString& path);

--- a/src/ScanEngine_test.cpp
+++ b/src/ScanEngine_test.cpp
@@ -164,6 +164,23 @@ TEST(ScanConfigTest, LoadFromVariantMap)
     EXPECT_EQ(config.failOn, "warning");
 }
 
+TEST(ScanConfigTest, DefaultConstructorIncludesAssimpGlobPatterns)
+{
+    const ScanConfig c;
+    EXPECT_GT(c.includePatterns.size(), 8);
+    bool hasMeshGlob = false;
+    bool hasFbxGlob = false;
+    for (const QString& p : c.includePatterns) {
+        if (p.endsWith(QStringLiteral("/mesh"), Qt::CaseInsensitive)
+            || p.endsWith(QStringLiteral(".mesh"), Qt::CaseInsensitive))
+            hasMeshGlob = true;
+        if (p.contains(QStringLiteral("fbx"), Qt::CaseInsensitive))
+            hasFbxGlob = true;
+    }
+    EXPECT_TRUE(hasFbxGlob);
+    EXPECT_TRUE(hasMeshGlob);
+}
+
 // ---------------------------------------------------------------------------
 // Glob matching tests
 // ---------------------------------------------------------------------------

--- a/website/src/DocsApp.jsx
+++ b/website/src/DocsApp.jsx
@@ -693,13 +693,13 @@ scopes:
           <section className={s.section} id="qtmesh-cloud">
             <h2 className={s.sectionTitle}>QtMesh Cloud Badges</h2>
             <p className={s.para}>
-              Use <a href="https://qtmesh.ftonon.uk" target="_blank" rel="noopener" style={{color: 'var(--accent-1)'}}>QtMesh Cloud</a> to
+              Use <a href="https://qtmesh.dev" target="_blank" rel="noopener" style={{color: 'var(--accent-1)'}}>QtMesh Cloud</a> to
               store scan history and serve live SVG badges from real CI results.
             </p>
 
             <h3 className={s.subsection}>1. Register project and token</h3>
             <ol className={s.para} style={{ marginTop: '0.6rem', paddingLeft: '1.25rem' }}>
-              <li>Sign in at <Code>https://qtmesh.ftonon.uk</Code> and create your project.</li>
+              <li>Sign in at <Code>https://qtmesh.dev</Code> and create your project.</li>
               <li>Choose a project slug (for example <Code>my-game-assets</Code>).</li>
               <li>Create a project token and save it in GitHub Secrets as <Code>QTMESH_CLOUD_TOKEN</Code>.</li>
             </ol>
@@ -716,7 +716,7 @@ scopes:
 - name: Upload scan to QtMesh Cloud
   env:
     QTMESH_CLOUD_TOKEN: \${{ secrets.QTMESH_CLOUD_TOKEN }}
-    QTMESH_CLOUD_API_URL: https://api.qtmesh.ftonon.uk
+    QTMESH_CLOUD_API_URL: https://api.qtmesh.dev
   run: |
     jq --arg branch "\${GITHUB_REF_NAME}" \\
        --arg sha "\${GITHUB_SHA}" \\
@@ -731,9 +731,9 @@ scopes:
       --data-binary @qtmesh-scan-upload.json`}</CodeBlock>
 
             <h3 className={s.subsection}>3. Use live badge URLs</h3>
-            <CodeBlock lang="md">{`[![qtmesh status](https://api.qtmesh.ftonon.uk/v1/projects/<project-slug>/badges/qtmesh-status.svg)](https://qtmesh.ftonon.uk)
-[![qtmesh errors](https://api.qtmesh.ftonon.uk/v1/projects/<project-slug>/badges/qtmesh-errors.svg)](https://qtmesh.ftonon.uk)
-[![qtmesh warnings](https://api.qtmesh.ftonon.uk/v1/projects/<project-slug>/badges/qtmesh-warnings.svg)](https://qtmesh.ftonon.uk)`}</CodeBlock>
+            <CodeBlock lang="md">{`[![qtmesh status](https://api.qtmesh.dev/v1/projects/<project-slug>/badges/qtmesh-status.svg)](https://qtmesh.dev)
+[![qtmesh errors](https://api.qtmesh.dev/v1/projects/<project-slug>/badges/qtmesh-errors.svg)](https://qtmesh.dev)
+[![qtmesh warnings](https://api.qtmesh.dev/v1/projects/<project-slug>/badges/qtmesh-warnings.svg)](https://qtmesh.dev)`}</CodeBlock>
 
             <p className={s.para}>
               Badge values update after each successful upload to <Code>/v1/ingest/scan</Code>.

--- a/website/src/data/content.js
+++ b/website/src/data/content.js
@@ -1,8 +1,8 @@
 export const links = {
   github: 'https://github.com/fernandotonon/QtMeshEditor',
   docs: './docs.html',
-  qtmeshCloud: 'https://qtmesh.ftonon.uk',
-  qtmeshCloudApi: 'https://api.qtmesh.ftonon.uk',
+  qtmeshCloud: 'https://qtmesh.dev',
+  qtmeshCloudApi: 'https://api.qtmesh.dev',
   releases: 'https://github.com/fernandotonon/QtMeshEditor/releases/latest',
   allReleases: 'https://github.com/fernandotonon/QtMeshEditor/releases',
   issues: 'https://github.com/fernandotonon/QtMeshEditor/issues',
@@ -101,7 +101,7 @@ export const pipelineExamples = {
 export const cloudBadgeSteps = [
   {
     title: 'Create your QtMesh Cloud project',
-    body: 'Sign in at qtmesh.ftonon.uk, then create a project and choose a stable slug for badge URLs.'
+    body: 'Sign in at qtmesh.dev, then create a project and choose a stable slug for badge URLs.'
   },
   {
     title: 'Store your token in CI secrets',
@@ -117,9 +117,9 @@ export const cloudBadgeSteps = [
   }
 ];
 
-export const cloudBadgeMarkdown = `[![qtmesh status](https://api.qtmesh.ftonon.uk/v1/projects/<project-slug>/badges/qtmesh-status.svg)](https://qtmesh.ftonon.uk)
-[![qtmesh errors](https://api.qtmesh.ftonon.uk/v1/projects/<project-slug>/badges/qtmesh-errors.svg)](https://qtmesh.ftonon.uk)
-[![qtmesh warnings](https://api.qtmesh.ftonon.uk/v1/projects/<project-slug>/badges/qtmesh-warnings.svg)](https://qtmesh.ftonon.uk)`;
+export const cloudBadgeMarkdown = `[![qtmesh status](https://api.qtmesh.dev/v1/projects/<project-slug>/badges/qtmesh-status.svg)](https://qtmesh.dev)
+[![qtmesh errors](https://api.qtmesh.dev/v1/projects/<project-slug>/badges/qtmesh-errors.svg)](https://qtmesh.dev)
+[![qtmesh warnings](https://api.qtmesh.dev/v1/projects/<project-slug>/badges/qtmesh-warnings.svg)](https://qtmesh.dev)`;
 
 export const cloudBadgeUploadExample = `- name: Scan assets
   run: |
@@ -132,7 +132,7 @@ export const cloudBadgeUploadExample = `- name: Scan assets
 - name: Upload scan to QtMesh Cloud
   env:
     QTMESH_CLOUD_TOKEN: \${{ secrets.QTMESH_CLOUD_TOKEN }}
-    QTMESH_CLOUD_API_URL: https://api.qtmesh.ftonon.uk
+    QTMESH_CLOUD_API_URL: https://api.qtmesh.dev
   run: |
     jq --arg branch "\${GITHUB_REF_NAME}" \\
        --arg sha "\${GITHUB_SHA}" \\


### PR DESCRIPTION
## Summary
- **`qtmesh scan`** with no path scans the **current directory** (same as ScanEngine when no override and no `scan.roots` in config).
- **Config precedence** when `--config` is **not** passed: **ingest token** → fetch rules from **QtMesh Cloud** → on failure use built-in defaults; **without** a token, auto-load `qtmesh.yml` / `qtmesh.yaml` / `qtmesh.json` if present, else defaults.
- **Default `scan.include`**: all file extensions registered by **Assimp** importers, plus **`.mesh`** and **`.mesh.xml`** for Ogre; overridden only when set in YAML/JSON/API config.
- **GitHub Action**: `input-file` is **optional**, default `.`.

## Testing
- Added unit tests for default include globs and for local `qtmesh.yml` applying when **no** token (env cleared in test).
- CI should run `UnitTests` on Linux.

## API / token note
A manual `GET https://api.qtmesh.dev/v1/ingest/rules` with a test token returned **401 Unauthorized** — that indicates an **invalid, expired, or wrong-format** ingest token on the **qtmesh.dev** side, not a client regression. Please confirm the **ingest** token from the dashboard matches what the CLI expects (e.g. `Authorization: Bearer …`). **Do not commit tokens to the repo.**

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-detect supported file formats for scanning, including Assimp-compatible formats and Ogre mesh files.

* **Bug Fixes**
  * Cloud rules now take precedence over local configuration when an authentication token is present; fall back to defaults if cloud fetch fails.

* **Chores**
  * Project version bumped to 2.27.0.
  * File/directory input parameter made optional; defaults to the workspace root when unspecified.

* **Tests**
  * Added and adjusted tests to verify cloud-vs-local rule precedence and default include patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->