### PR TITLE
fix(ci): WinGet publish job — manifest paths

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1893,14 +1893,14 @@ jobs:
           BRANCH="qtmesheditor-${VER}"
           DEST_DIR="manifests/f/FernandoTonon/QtMeshEditor/${VER}"
 
-          # wingetcreate --out manifests writes to manifests/manifests/f/<Publisher>/...
-          # (older layouts may use manifests/f/... only)
-          if [ -d "../manifests/manifests/f/FernandoTonon/QtMeshEditor/${VER}" ]; then
+          # Probe from repo root (cwd is $GITHUB_WORKSPACE). After cd winget-pkgs, sources live under ../manifests/...
+          # wingetcreate --out manifests writes to manifests/manifests/f/<Publisher>/... (or manifests/f/... on older layouts)
+          if [ -d "manifests/manifests/f/FernandoTonon/QtMeshEditor/${VER}" ]; then
             MANIFEST_SRC="../manifests/manifests/f/FernandoTonon/QtMeshEditor/${VER}"
-          elif [ -d "../manifests/f/FernandoTonon/QtMeshEditor/${VER}" ]; then
+          elif [ -d "manifests/f/FernandoTonon/QtMeshEditor/${VER}" ]; then
             MANIFEST_SRC="../manifests/f/FernandoTonon/QtMeshEditor/${VER}"
           else
-            echo "::error::Could not find generated WinGet manifests for ${VER} under ../manifests"
+            echo "::error::Could not find generated WinGet manifests for ${VER} under manifests/"
             exit 1
           fi
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1867,13 +1867,14 @@ jobs:
           }
 
           Write-Host "Generating WinGet manifest for version $ver..."
+          # --out manifests nests under manifests/ (output path includes manifests\f\...)
           .\wingetcreate.exe update FernandoTonon.QtMeshEditor `
             --version $ver `
             --urls $url `
             --out manifests
 
           Write-Host "Manifest generated:"
-          Get-ChildItem -Recurse manifests | Get-Content
+          Get-ChildItem -Recurse -File manifests | Get-Content
 
       - name: Submit PR to winget-pkgs
         continue-on-error: true   # don't fail the release if submission fails
@@ -1884,7 +1885,18 @@ jobs:
           RAW_TAG="${{ github.event.release.tag_name }}"
           VER="${RAW_TAG#v}"
           BRANCH="qtmesheditor-${VER}"
-          MANIFEST_DIR="manifests/f/FernandoTonon/QtMeshEditor/${VER}"
+          DEST_DIR="manifests/f/FernandoTonon/QtMeshEditor/${VER}"
+
+          # wingetcreate --out manifests writes to manifests/manifests/f/<Publisher>/...
+          # (older layouts may use manifests/f/... only)
+          if [ -d "../manifests/manifests/f/FernandoTonon/QtMeshEditor/${VER}" ]; then
+            MANIFEST_SRC="../manifests/manifests/f/FernandoTonon/QtMeshEditor/${VER}"
+          elif [ -d "../manifests/f/FernandoTonon/QtMeshEditor/${VER}" ]; then
+            MANIFEST_SRC="../manifests/f/FernandoTonon/QtMeshEditor/${VER}"
+          else
+            echo "::error::Could not find generated WinGet manifests for ${VER} under ../manifests"
+            exit 1
+          fi
 
           # Derive fork owner from the authenticated token (may differ from repo owner)
           FORK_OWNER="$(gh api user --jq .login)"
@@ -1910,8 +1922,8 @@ jobs:
           fi
 
           # Copy manifests
-          mkdir -p "manifests/f/FernandoTonon/QtMeshEditor/${VER}"
-          cp -r "../${MANIFEST_DIR}/." "manifests/f/FernandoTonon/QtMeshEditor/${VER}/"
+          mkdir -p "${DEST_DIR}"
+          cp -r "${MANIFEST_SRC}/." "${DEST_DIR}/"
 
           # Commit and push
           git config user.name "github-actions[bot]"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -746,6 +746,9 @@ jobs:
             rm -f ./pack-deb/usr/share/qtmesheditor/media/models/"Rumba Dancing.fbx"
             rm -f ./pack-deb/usr/share/qtmesheditor/media/models/"Hip Hop Dancing.fbx"
             cp -R ./bin/platforms/ ./pack-deb/usr/share/qtmesheditor/
+            if [ -d ./bin/tls ]; then
+              cp -R ./bin/tls/ ./pack-deb/usr/share/qtmesheditor/tls/
+            fi
 
             # Copy bundled libraries to private lib directory
             cp -R ./bin/*.so* ./pack-deb/usr/lib/qtmesheditor/
@@ -1557,6 +1560,9 @@ jobs:
             
             # Copy plugins to proper PlugIns directory
             sudo cp -R /Users/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/$QT_ARCH_DIR/plugins/platforms/* ${{github.workspace}}/bin/QtMeshEditor.app/Contents/PlugIns/platforms/
+            # Qt 6: HTTPS / QNetworkAccessManager needs TLS plugins (qsecuretransportbackend, etc.)
+            sudo mkdir -p ${{github.workspace}}/bin/QtMeshEditor.app/Contents/PlugIns/tls
+            sudo cp -R /Users/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/$QT_ARCH_DIR/plugins/tls/* ${{github.workspace}}/bin/QtMeshEditor.app/Contents/PlugIns/tls/
 
             # Copy QML plugins for QtQuick components
             sudo mkdir -p ${{github.workspace}}/bin/QtMeshEditor.app/Contents/PlugIns/qml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,6 +349,10 @@ IF(WIN32)
                 MESSAGE(STATUS "Installing platform plugin ${platform}.dll")
                 INSTALL(FILES ${QT_DIR}/../../../plugins/platforms/${platform}.dll DESTINATION ${CMAKE_INSTALL_PREFIX}/platforms/)
         ENDFOREACH(platform)
+        # Qt 6: HTTPS requires TLS backend plugins (otherwise QNetworkAccessManager: "TLS initialization failed")
+        if(IS_DIRECTORY "${QT_DIR}/../../../plugins/tls")
+                install(DIRECTORY "${QT_DIR}/../../../plugins/tls/" DESTINATION "${CMAKE_INSTALL_PREFIX}/tls")
+        endif()
 
 ELSEIF(APPLE)
 #        FOREACH(qtlib ${QTLIBLIST})
@@ -379,6 +383,10 @@ ELSEIF(UNIX)
         FOREACH(platform ${QTPLATFORMSLIST})
                 INSTALL(FILES ${QT_DIR}/../../../plugins/platforms/lib${platform}.so DESTINATION ${CMAKE_INSTALL_PREFIX}/platforms/)
         ENDFOREACH(platform)
+        # Qt 6: HTTPS requires TLS backend plugins (otherwise QNetworkAccessManager: "TLS initialization failed")
+        if(IS_DIRECTORY "${QT_DIR}/../../../plugins/tls")
+                install(DIRECTORY "${QT_DIR}/../../../plugins/tls/" DESTINATION "${CMAKE_INSTALL_PREFIX}/tls")
+        endif()
 
         # Install Qt QML modules required for Material Editor
         # When Qt libraries are bundled, Qt can't find system QML modules automatically

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ARG VERSION=latest
 
 # Runtime system deps only (X11, Mesa GL, virtual framebuffer)
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
     xvfb x11-utils libxcb-cursor0 libxcb-xinerama0 libx11-6 libxrandr2 \
     libgl1-mesa-dri libegl-mesa0 libgbm1 libglx-mesa0 \
     libglut3.12 libcurl4t64 libopengl0 libgomp1 \


### PR DESCRIPTION
## Problem
The `winget-publish` job failed on Generate WinGet manifest:
- `Get-ChildItem` returned directories (e.g. `manifests\manifests`), so `Get-Content` errored.

After that, copies to winget-pkgs would use the wrong path: `wingetcreate --out manifests` nests manifests under an extra `manifests/` segment.

## Changes
- **PowerShell**: `Get-ChildItem -Recurse -File manifests` so only files go to `Get-Content`.
- **Submit PR**: Resolve source as `../manifests/manifests/f/...` with fallback to `../manifests/f/...`; fail clearly if neither exists.

## Testing
Manual review of workflow; next release or workflow_dispatch will exercise the job.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TLS backend plugins are now packaged with installers/bundles when present (Debian and macOS), ensuring TLS plugins are available at runtime.
* **Chores**
  * Improved Windows Package Manager manifest generation and copy steps to handle multiple manifest directory layouts more reliably.
* **Chores**
  * Docker runtime image now includes ca-certificates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->