### PR TITLE
fix(ci): run macdeployqt to bundle QML module plugins on macOS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1572,6 +1572,20 @@ jobs:
             # Copy Assimp libraries to MacOS directory
             sudo cp -R /usr/local/lib/libassimp* ${{github.workspace}}/bin/QtMeshEditor.app/Contents/MacOS/ || echo "Assimp libraries not found, continuing..."
 
+            # macdeployqt scans -qmldir for QML imports and bundles the module
+            # plugins (Controls, Layouts, Dialogs, ...) the manual copy misses —
+            # without it the inspector panel renders blank on installed bundles.
+            MACDEPLOYQT="/Users/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/$QT_ARCH_DIR/bin/macdeployqt"
+            if [ -x "$MACDEPLOYQT" ]; then
+                echo "Running macdeployqt against app bundle..."
+                sudo "$MACDEPLOYQT" "${{github.workspace}}/bin/QtMeshEditor.app" \
+                    -qmldir="${{github.workspace}}/qml" \
+                    -verbose=2 \
+                    -no-strip 2>&1 | tail -60 || echo "macdeployqt reported warnings, continuing..."
+            else
+                echo "WARNING: macdeployqt not found at $MACDEPLOYQT — QML modules may be incomplete"
+            fi
+
     - name: Prepare for packing
       run: |
             sudo cp -R ${{github.workspace}}/bin/media ${{github.workspace}}/bin/QtMeshEditor.app/Contents/MacOS/media

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1611,9 +1611,11 @@ jobs:
             sudo cp -R ${{github.workspace}}/resources/icon.icns ${{github.workspace}}/bin/QtMeshEditor.app/Contents/Resources
             sudo cp -R ${{github.workspace}}/bin/Info.plist ${{github.workspace}}/bin/QtMeshEditor.app/Contents/
             
-            # Fix library paths for proper app bundle structure
-            sudo install_name_tool -add_rpath @executable_path/../Frameworks ${{github.workspace}}/bin/QtMeshEditor.app/Contents/MacOS/QtMeshEditor
-            sudo install_name_tool -add_rpath @loader_path/ ${{github.workspace}}/bin/QtMeshEditor.app/Contents/MacOS/QtMeshEditor
+            # Fix library paths for proper app bundle structure.
+            # macdeployqt may have already added these rpaths, so ignore
+            # "would duplicate path" errors.
+            sudo install_name_tool -add_rpath @executable_path/../Frameworks ${{github.workspace}}/bin/QtMeshEditor.app/Contents/MacOS/QtMeshEditor 2>/dev/null || true
+            sudo install_name_tool -add_rpath @loader_path/ ${{github.workspace}}/bin/QtMeshEditor.app/Contents/MacOS/QtMeshEditor 2>/dev/null || true
 
             # Fix all dylibs in MacOS directory to use @rpath for their dependencies
             echo "Fixing dylib install names and rpaths..."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1578,12 +1578,21 @@ jobs:
             MACDEPLOYQT="/Users/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/$QT_ARCH_DIR/bin/macdeployqt"
             if [ -x "$MACDEPLOYQT" ]; then
                 echo "Running macdeployqt against app bundle..."
+                deploy_log=$(mktemp)
                 sudo "$MACDEPLOYQT" "${{github.workspace}}/bin/QtMeshEditor.app" \
                     -qmldir="${{github.workspace}}/qml" \
                     -verbose=2 \
-                    -no-strip 2>&1 | tail -60 || echo "macdeployqt reported warnings, continuing..."
+                    -no-strip > "$deploy_log" 2>&1
+                rc=$?
+                tail -60 "$deploy_log"
+                rm -f "$deploy_log"
+                if [ $rc -ne 0 ]; then
+                    echo "::error::macdeployqt exited with status $rc"
+                    exit $rc
+                fi
             else
-                echo "WARNING: macdeployqt not found at $MACDEPLOYQT — QML modules may be incomplete"
+                echo "::error::macdeployqt not found at $MACDEPLOYQT"
+                exit 1
             fi
 
     - name: Prepare for packing


### PR DESCRIPTION
## Summary
- Run `macdeployqt` on the macOS app bundle after the manual framework/QML module copy step so Qt can discover QML imports and bundle the missing module plugins (Controls, Layouts, Dialogs, Effects, Templates, NativeStyle, ...)
- Fixes: installed Homebrew bundles from 2.x releases had a blank Inspector panel and the Material editor list failed to open. Source builds were unaffected because the developer's Qt installation resolved the plugins directly.

## Root cause
Our manual `cp -R .../qml/QtQml .../PlugIns/qml/` only copies the top-level `QtQml` and `QtQuick` trees. QQuickWidget loads `QtQuick.Controls`, `QtQuick.Layouts`, `QtQuick.Dialogs`, `QtQuick.Effects`, `QtQuick.Templates`, `QtQuick.NativeStyle`, etc. at runtime — those module plugins and their backing `QtQuickControls2*.framework` dylibs were missing from installed bundles.

`macdeployqt -qmldir=<workspace>/qml` scans our QML source for imports and pulls in every missing module plugin plus its framework, and also fixes up rpaths/install_names.

## Test plan
- [x] Reproduced the missing-plugin state locally by running the manual CI copy commands against a clean `QtMeshEditor.app` — only `QtQml` and `QtQuick` appeared under `Contents/PlugIns/qml/`
- [x] Ran the new `macdeployqt` invocation against the same bundle — `Contents/PlugIns/qml/` now includes `QtQuick/{Controls,Dialogs,Effects,Layouts,Templates,NativeStyle,Window,Shapes,...}` and `Contents/Frameworks/` includes the matching `QtQuickControls2*.framework` dylibs
- [ ] Watch CI: macOS build job completes successfully
- [ ] Post-merge: cut a patch release and verify the Homebrew-installed bundle renders the Inspector panel and opens the Material editor list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced macOS application packaging in the build workflow to ensure all required QML modules are properly bundled with the application during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->