### PR TITLE
fix(ci): use wingetcreate --submit for WinGet publish

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1873,8 +1873,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Generate WinGet manifest
+      - name: Submit WinGet manifest
         shell: pwsh
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
         run: |
           # Download wingetcreate standalone exe from GitHub releases
           $wgcUrl = "https://github.com/microsoft/winget-create/releases/latest/download/wingetcreate.exe"
@@ -1897,93 +1899,23 @@ jobs:
             }
           }
 
-          Write-Host "Generating WinGet manifest for version $ver..."
-          # --out manifests nests under manifests/ (output path includes manifests\f\...)
+          # Use wingetcreate's built-in --submit path. This goes through the
+          # GitHub Contents API (PUT /contents/:path), which works with a
+          # classic PAT that only has `public_repo` scope. The previous approach
+          # (manual `git clone` + `git push` to the fork) required the token's
+          # write-access scope to cover git-over-HTTPS for the fork, which is a
+          # different permission path and was 403-denied.
+          Write-Host "Submitting WinGet manifest for version $ver..."
           .\wingetcreate.exe update FernandoTonon.QtMeshEditor `
             --version $ver `
             --urls $url `
-            --out manifests
-
-          Write-Host "Manifest generated:"
-          Get-ChildItem -Recurse -File manifests | Get-Content
-
-      - name: Submit PR to winget-pkgs
-        continue-on-error: true   # don't fail the release if submission fails
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.WINGET_TOKEN }}
-        run: |
-          set -e
-          RAW_TAG="${{ github.event.release.tag_name }}"
-          VER="${RAW_TAG#v}"
-          BRANCH="qtmesheditor-${VER}"
-          DEST_DIR="manifests/f/FernandoTonon/QtMeshEditor/${VER}"
-
-          # Probe from repo root (cwd is $GITHUB_WORKSPACE). After cd winget-pkgs, sources live under ../manifests/...
-          # wingetcreate --out manifests writes to manifests/manifests/f/<Publisher>/... (or manifests/f/... on older layouts)
-          if [ -d "manifests/manifests/f/FernandoTonon/QtMeshEditor/${VER}" ]; then
-            MANIFEST_SRC="../manifests/manifests/f/FernandoTonon/QtMeshEditor/${VER}"
-          elif [ -d "manifests/f/FernandoTonon/QtMeshEditor/${VER}" ]; then
-            MANIFEST_SRC="../manifests/f/FernandoTonon/QtMeshEditor/${VER}"
-          else
-            echo "::error::Could not find generated WinGet manifests for ${VER} under manifests/"
-            exit 1
-          fi
-
-          # Derive fork owner from the authenticated token (may differ from repo owner)
-          FORK_OWNER="$(gh api user --jq .login)"
-          echo "Authenticated as: $FORK_OWNER"
-
-          # Ensure we have a fork of winget-pkgs
-          gh repo fork microsoft/winget-pkgs --clone=false 2>/dev/null || true
-
-          # Clone the fork (shallow) using a token-embedded URL so git push works
-          # without relying on a credential helper (previous git push attempts
-          # returned 403 because gh auth setup-git was not providing creds).
-          git clone --depth 1 \
-            "https://x-access-token:${GH_TOKEN}@github.com/${FORK_OWNER}/winget-pkgs.git" \
-            winget-pkgs
-          cd winget-pkgs
-
-          # Handle reruns: if branch already exists, check it out; otherwise create it
-          if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
-            echo "Branch $BRANCH already exists, updating..."
-            git fetch origin "$BRANCH"
-            git checkout "$BRANCH"
-          else
-            git checkout -b "$BRANCH"
-          fi
-
-          # Copy manifests
-          mkdir -p "${DEST_DIR}"
-          cp -r "${MANIFEST_SRC}/." "${DEST_DIR}/"
-
-          # Commit and push
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
-            exit 0
-          fi
-          git commit -m "Update FernandoTonon.QtMeshEditor to ${VER}"
-          git push -u origin "$BRANCH"
-
-          # Open PR (or skip if one already exists for this branch)
-          EXISTING_PR="$(gh pr list --repo microsoft/winget-pkgs --head "${FORK_OWNER}:${BRANCH}" --json number --jq '.[0].number' 2>/dev/null || true)"
-          if [ -n "$EXISTING_PR" ] && [ "$EXISTING_PR" != "null" ]; then
-            echo "PR #${EXISTING_PR} already exists for this version, skipping creation."
-          else
-            gh pr create \
-              --repo microsoft/winget-pkgs \
-              --head "${FORK_OWNER}:${BRANCH}" \
-              --title "Update FernandoTonon.QtMeshEditor to ${VER}" \
-              --body "## Automated update
-          Version: ${VER}
-          Release: https://github.com/fernandotonon/QtMeshEditor/releases/tag/${RAW_TAG}"
-          fi
-
-          echo "WinGet PR submitted successfully."
+            --submit `
+            --token $env:WINGET_TOKEN
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::error::wingetcreate submit failed with exit $LASTEXITCODE"
+            exit $LASTEXITCODE
+          }
+          Write-Host "WinGet PR submitted successfully."
 
 ####################################################################
 # Snap Store Publish (after Linux .deb is built)


### PR DESCRIPTION
## Problem

The `winget-publish` job has been silently failing since release 2.21. The step reported green because `continue-on-error: true` was set, but the actual logs show:

```
remote: Permission to fernandotonon/winget-pkgs.git denied to fernandotonon.
fatal: unable to access 'https://github.com/fernandotonon/winget-pkgs.git/': The requested URL returned error: 403
```

## Root cause

The workflow was doing manual `git clone` + `git push` to the `fernandotonon/winget-pkgs` fork. That requires the `WINGET_TOKEN` to have **git-over-HTTPS write scope** on the fork.

`WINGET_TOKEN` is a classic PAT with only `public_repo` scope. `public_repo` grants access via the GitHub **Contents REST API** (`PUT /repos/:owner/:repo/contents/:path`), but NOT git-push access to forks — those are two different permission paths on GitHub's side.

Things that worked with the current token (confirming the diagnosis):
- `gh api user` (reads auth user)
- `gh repo fork microsoft/winget-pkgs` (API call)
- `git clone` (public read, no auth needed)

Things that didn't:
- `git push -u origin <branch>` → 403

## Fix

Switch to `wingetcreate update ... --submit --token $WINGET_TOKEN`, which:
- Uses the Contents API (works with `public_repo` scope, as documented in CLAUDE.md)
- Handles fork creation, manifest upload, and PR submission in a single command
- Is the upstream-supported path from microsoft/winget-create

This was the original approach before 34fe349, which replaced it to work around a "Failed to connect to GitHub" error in an older wingetcreate release. That error no longer occurs in current versions.

Also drop `continue-on-error: true` so a real submission failure fails the job and is visible instead of being hidden.

## Test plan

- [ ] Merge and cut a test release (or `workflow_dispatch` on `deploy.yml` from the release event... though release event requires an actual release). Will validate on the next tag.
- [x] YAML parses (`python3 -c 'import yaml; yaml.safe_load(open(...))'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the WinGet publishing workflow to improve deployment efficiency and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->