### PR TITLE
fix(ci): add bundle-relative rpath to macOS QML plugins

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1595,6 +1595,29 @@ jobs:
                 exit 1
             fi
 
+            # Fix QML plugin rpaths so they resolve Qt frameworks inside the
+            # bundle. macdeployqt leaves the original Qt-SDK rpath
+            # (@loader_path/../../../lib) on the plugins, which at runtime
+            # points to Contents/PlugIns/qml/lib/ — a directory that doesn't
+            # exist in the bundle. Plugins fail to load with
+            #   "plugin qtquickcontrols2plugin not found"
+            # because their dependent frameworks (QtQuickControls2 etc.) can't
+            # be resolved. Adding @executable_path/../Frameworks — which always
+            # resolves to Contents/Frameworks for any dylib loaded by the
+            # main executable — makes Qt's frameworks visible to the plugins.
+            echo "Fixing QML plugin rpaths..."
+            APP_BUNDLE="${{github.workspace}}/bin/QtMeshEditor.app"
+            find "$APP_BUNDLE/Contents/PlugIns/qml" -name "*.dylib" -type f 2>/dev/null | while read -r plugin; do
+                sudo install_name_tool -add_rpath @executable_path/../Frameworks "$plugin" 2>/dev/null || true
+                sudo install_name_tool -add_rpath @loader_path/../../../../Frameworks "$plugin" 2>/dev/null || true
+            done
+            # Also fix regular Qt plugins (platforms, tls, etc.) and CA-root
+            # drivers for the same reason.
+            find "$APP_BUNDLE/Contents/PlugIns" -maxdepth 3 -name "*.dylib" -type f \
+                ! -path "*/qml/*" 2>/dev/null | while read -r plugin; do
+                sudo install_name_tool -add_rpath @executable_path/../Frameworks "$plugin" 2>/dev/null || true
+            done
+
     - name: Prepare for packing
       run: |
             sudo cp -R ${{github.workspace}}/bin/media ${{github.workspace}}/bin/QtMeshEditor.app/Contents/MacOS/media


### PR DESCRIPTION
## Summary
- The installed Homebrew bundle fails to load QtQuick.Controls QML with `plugin \"qtquickcontrols2plugin\" not found`.
- Root cause: QML plugin dylibs copied by macdeployqt keep their Qt-SDK rpath `@loader_path/../../../lib`, which inside the bundle resolves to `Contents/PlugIns/qml/lib` — a directory that doesn't exist. The plugin's framework dependencies (QtQuickControls2.framework etc.) can't be resolved, so Qt reports the plugin as missing.
- Fix: after `macdeployqt`, walk every `.dylib` under `Contents/PlugIns/qml` and add `@executable_path/../Frameworks` (the canonical bundle framework path). Also apply to non-QML plugins under `Contents/PlugIns/`.

## Verification
Patched the installed 2.27.0 bundle locally with the same `install_name_tool -add_rpath` call the CI will now run. The Controls plugin loads cleanly and AIChatPanel / PropertiesPanel / AssetBrowser no longer emit the import error.

## Test plan
- [ ] Next macOS CI run produces a bundle that loads all three QML panels without `plugin not found` errors.
- [ ] `otool -l Contents/PlugIns/qml/QtQuick/Controls/libqtquickcontrols2plugin.dylib | grep -A1 LC_RPATH` shows `@executable_path/../Frameworks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)