### PR TITLE
feat(cli): QtMesh Cloud nudge after info/scan + CI winget hardening

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1901,6 +1901,35 @@ jobs:
         env:
           WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
         run: |
+          $ErrorActionPreference = "Stop"
+
+          if (-not $env:WINGET_TOKEN) {
+            Write-Host "::error::WINGET_TOKEN secret is missing. Configure it in repo secrets with a classic PAT that has 'public_repo' scope."
+            exit 1
+          }
+
+          # Sanity-check the token before wingetcreate uses it. A revoked or
+          # scope-less PAT shows up here as a clear 401/403 instead of
+          # wingetcreate's generic "Failed to connect to GitHub".
+          Write-Host "Validating WINGET_TOKEN against GitHub API..."
+          $headers = @{
+            Authorization = "token $env:WINGET_TOKEN"
+            Accept        = "application/vnd.github+json"
+            "User-Agent"  = "QtMeshEditor-CI"
+          }
+          try {
+            $userResp = Invoke-WebRequest -Uri "https://api.github.com/user" -Headers $headers -UseBasicParsing
+            $scopes = $userResp.Headers['X-OAuth-Scopes']
+            $login  = ($userResp.Content | ConvertFrom-Json).login
+            Write-Host "Token OK for user '$login' with scopes: $scopes"
+            if ($scopes -and ($scopes -notmatch 'public_repo') -and ($scopes -notmatch '\brepo\b')) {
+              Write-Host "::warning::WINGET_TOKEN has scopes '$scopes'; wingetcreate --submit needs 'public_repo' or 'repo'."
+            }
+          } catch {
+            Write-Host "::error::Token validation failed: $($_.Exception.Message). Rotate WINGET_TOKEN (classic PAT with 'public_repo')."
+            exit 1
+          }
+
           # Download wingetcreate standalone exe from GitHub releases
           $wgcUrl = "https://github.com/microsoft/winget-create/releases/latest/download/wingetcreate.exe"
           Invoke-WebRequest -Uri $wgcUrl -OutFile wingetcreate.exe
@@ -1909,34 +1938,59 @@ jobs:
           $ver = $rawTag -replace '^v', ''
           $url = "https://github.com/fernandotonon/QtMeshEditor/releases/download/${rawTag}/QtMeshEditor-${rawTag}-bin-Windows.zip"
 
-          # Wait for the release asset to be downloadable (GitHub CDN propagation)
+          # Wait for the release asset to be downloadable (GitHub CDN propagation).
+          # Treat "still not available after all retries" as a hard error —
+          # wingetcreate would otherwise fail later with a confusing message.
           Write-Host "Waiting for release asset to be available..."
+          $assetReady = $false
           for ($attempt = 1; $attempt -le 10; $attempt++) {
             try {
               $resp = Invoke-WebRequest -Uri $url -Method Head -ErrorAction Stop
               Write-Host "Asset available (attempt $attempt)"
+              $assetReady = $true
               break
             } catch {
               Write-Host "Attempt ${attempt}: asset not yet available, waiting 30s..."
               Start-Sleep -Seconds 30
             }
           }
+          if (-not $assetReady) {
+            Write-Host "::error::Release asset $url never became available."
+            exit 1
+          }
 
-          # Use wingetcreate's built-in --submit path. This goes through the
-          # GitHub Contents API (PUT /contents/:path), which works with a
-          # classic PAT that only has `public_repo` scope. The previous approach
-          # (manual `git clone` + `git push` to the fork) required the token's
-          # write-access scope to cover git-over-HTTPS for the fork, which is a
-          # different permission path and was 403-denied.
-          Write-Host "Submitting WinGet manifest for version $ver..."
-          .\wingetcreate.exe update FernandoTonon.QtMeshEditor `
-            --version $ver `
-            --urls $url `
-            --submit `
-            --token $env:WINGET_TOKEN
-          if ($LASTEXITCODE -ne 0) {
-            Write-Host "::error::wingetcreate submit failed with exit $LASTEXITCODE"
-            exit $LASTEXITCODE
+          # wingetcreate --submit goes through the GitHub Contents API (PUT
+          # /contents/:path), which works with a classic PAT that only has
+          # `public_repo` scope. The previous approach (manual `git clone` +
+          # `git push` to the fork) required write-access on the fork via
+          # git-over-HTTPS, a different permission path that was 403-denied.
+          #
+          # Retry up to three times on transient failures — wingetcreate's
+          # "Failed to connect to GitHub" sometimes hits during runner DNS
+          # flakes or microsoft/winget-pkgs being under load after a release.
+          $submitOk = $false
+          for ($attempt = 1; $attempt -le 3; $attempt++) {
+            Write-Host "Submitting WinGet manifest for version $ver (attempt $attempt)..."
+            .\wingetcreate.exe update FernandoTonon.QtMeshEditor `
+              --version $ver `
+              --urls $url `
+              --submit `
+              --token $env:WINGET_TOKEN
+            if ($LASTEXITCODE -eq 0) {
+              $submitOk = $true
+              break
+            }
+            Write-Host "::warning::wingetcreate exited $LASTEXITCODE on attempt $attempt."
+            if ($attempt -lt 3) {
+              Start-Sleep -Seconds 30
+            }
+          }
+          if (-not $submitOk) {
+            Write-Host "::error::wingetcreate submit failed after 3 attempts. Check:"
+            Write-Host "::error:: 1. WINGET_TOKEN is still valid and has 'public_repo' scope."
+            Write-Host "::error:: 2. The user's fork of microsoft/winget-pkgs hasn't diverged."
+            Write-Host "::error:: 3. https://www.githubstatus.com for GitHub API availability."
+            exit 1
           }
           Write-Host "WinGet PR submitted successfully."
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,9 @@ add_definitions( -DQTMESHEDITOR_VERSION=${QTMESHEDITOR_VERSION_STRING} )
 # Override with -DQTMESH_CLOUD_WEB_URL=https://... for self-hosted instances.
 set(QTMESH_CLOUD_WEB_URL "https://qtmesh.dev" CACHE STRING
     "QtMesh Cloud web UI base URL (no trailing slash)")
+# Normalize: strip a single trailing slash so callers can paste a copied URL
+# without breaking string concatenation downstream.
+string(REGEX REPLACE "/+$" "" QTMESH_CLOUD_WEB_URL "${QTMESH_CLOUD_WEB_URL}")
 add_definitions(-DQTMESH_CLOUD_WEB_URL="${QTMESH_CLOUD_WEB_URL}")
 
 set(CMAKE_CXX_STANDARD 17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,12 @@ endif()
 
 add_definitions( -DQTMESHEDITOR_VERSION=${QTMESHEDITOR_VERSION_STRING} )
 
+# Public QtMesh Cloud web URL (used by CLI promo + any future link-outs).
+# Override with -DQTMESH_CLOUD_WEB_URL=https://... for self-hosted instances.
+set(QTMESH_CLOUD_WEB_URL "https://qtmesh.dev" CACHE STRING
+    "QtMesh Cloud web UI base URL (no trailing slash)")
+add_definitions(-DQTMESH_CLOUD_WEB_URL="${QTMESH_CLOUD_WEB_URL}")
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -185,6 +185,23 @@ static QString resolveIngestToken(const QString& flagToken)
     return {};
 }
 
+#ifndef QTMESH_CLOUD_WEB_URL
+#define QTMESH_CLOUD_WEB_URL "https://qtmesh.dev"
+#endif
+
+/// One-line nudge pointing users at QtMesh Cloud so they can track
+/// historical scan results and mesh info. Skipped when a token is already
+/// configured (the user has signed up), or when the caller is emitting
+/// machine-readable JSON we mustn't pollute.
+static void maybePrintCloudPromo(bool jsonOutput)
+{
+    if (jsonOutput) return;
+    if (!resolveIngestToken({}).isEmpty()) return;
+    err() << "Tip: sign up at " << QTMESH_CLOUD_WEB_URL
+          << " to track your scans and view results in the dashboard."
+          << Qt::endl;
+}
+
 static bool s_verbose = false;
 static bool s_noTelemetry = false;
 
@@ -732,6 +749,7 @@ int CLIPipeline::cmdInfo(int argc, char* argv[])
             for (const auto& info : infos)
                 cliWrite(formatMeshInfoText(info));
         }
+        maybePrintCloudPromo(jsonOutput);
         return 0;
     }
 
@@ -763,6 +781,7 @@ int CLIPipeline::cmdInfo(int argc, char* argv[])
         }
     }
 
+    maybePrintCloudPromo(jsonOutput);
     return 0;
 }
 
@@ -2294,6 +2313,8 @@ int CLIPipeline::cmdScan(int argc, char* argv[])
             err() << Qt::endl;
         }
     }
+
+    maybePrintCloudPromo(jsonOutput);
 
     // Exit code from fail_on threshold (scan/lint outcome)
     int scanExit = 0;

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -191,12 +191,13 @@ static QString resolveIngestToken(const QString& flagToken)
 
 /// One-line nudge pointing users at QtMesh Cloud so they can track
 /// historical scan results and mesh info. Skipped when a token is already
-/// configured (the user has signed up), or when the caller is emitting
-/// machine-readable JSON we mustn't pollute.
-static void maybePrintCloudPromo(bool jsonOutput)
+/// configured (the user has signed up — passes flagToken so the per-command
+/// `--token` value short-circuits the same as env vars), or when the caller
+/// is emitting machine-readable JSON we mustn't pollute.
+static void maybePrintCloudPromo(bool jsonOutput, const QString& flagToken = {})
 {
     if (jsonOutput) return;
-    if (!resolveIngestToken({}).isEmpty()) return;
+    if (!resolveIngestToken(flagToken).isEmpty()) return;
     err() << "Tip: sign up at " << QTMESH_CLOUD_WEB_URL
           << " to track your scans and view results in the dashboard."
           << Qt::endl;
@@ -2314,7 +2315,7 @@ int CLIPipeline::cmdScan(int argc, char* argv[])
         }
     }
 
-    maybePrintCloudPromo(jsonOutput);
+    maybePrintCloudPromo(jsonOutput, tokenArg);
 
     // Exit code from fail_on threshold (scan/lint outcome)
     int scanExit = 0;

--- a/winget/manifests/f/FernandoTonon/QtMeshEditor/2.28.0/FernandoTonon.QtMeshEditor.installer.yaml
+++ b/winget/manifests/f/FernandoTonon/QtMeshEditor/2.28.0/FernandoTonon.QtMeshEditor.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: FernandoTonon.QtMeshEditor
+PackageVersion: 2.28.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: bin\QtMeshEditor.exe
+    PortableCommandAlias: qtmesheditor
+  - RelativeFilePath: bin\qtmesh.exe
+    PortableCommandAlias: qtmesh
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/fernandotonon/QtMeshEditor/releases/download/2.28.0/QtMeshEditor-2.28.0-bin-Windows.zip
+    InstallerSha256: 050BEC5A8FFFC418C61000D679D680A62E290CB66D56FD8F7A5C7B2DA48A6754
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/winget/manifests/f/FernandoTonon/QtMeshEditor/2.28.0/FernandoTonon.QtMeshEditor.locale.en-US.yaml
+++ b/winget/manifests/f/FernandoTonon/QtMeshEditor/2.28.0/FernandoTonon.QtMeshEditor.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: FernandoTonon.QtMeshEditor
+PackageVersion: 2.28.0
+PackageLocale: en-US
+Publisher: Fernando Tonon
+PublisherUrl: https://github.com/fernandotonon
+PublisherSupportUrl: https://github.com/fernandotonon/QtMeshEditor/issues
+PackageName: QtMeshEditor
+PackageUrl: https://github.com/fernandotonon/QtMeshEditor
+License: MIT
+LicenseUrl: https://github.com/fernandotonon/QtMeshEditor/blob/master/License
+ShortDescription: Free 3D asset tool for indie game developers
+Description: |-
+  QtMeshEditor is a free 3D asset tool for indie game developers.
+  Merge animations from multiple files, convert between 40+ formats,
+  edit materials with AI, and inspect skeletons and bone weights.
+  Supports GUI, CLI (qtmesh), and REST API via MCP server.
+Tags:
+  - 3d
+  - mesh-editor
+  - animation
+  - fbx
+  - gltf
+  - ogre3d
+  - game-development
+  - material-editor
+Moniker: qtmesheditor
+ReleaseNotesUrl: https://github.com/fernandotonon/QtMeshEditor/releases/tag/2.28.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/winget/manifests/f/FernandoTonon/QtMeshEditor/2.28.0/FernandoTonon.QtMeshEditor.yaml
+++ b/winget/manifests/f/FernandoTonon/QtMeshEditor/2.28.0/FernandoTonon.QtMeshEditor.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: FernandoTonon.QtMeshEditor
+PackageVersion: 2.28.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
## Summary

- Adds a one-line CLI nudge after \`qtmesh info\` and \`qtmesh scan\` pointing users at https://qtmesh.dev so they can sign up to track scan history. Suppressed when a token is configured (\`--token\`, \`QTMESH_TOKEN\`, \`QTMESH_CLOUD_TOKEN\`) or when output is JSON.
- Wires \`QTMESH_CLOUD_WEB_URL\` (default \`https://qtmesh.dev\`) as a cached CMake variable + preprocessor define so a self-hosted instance can override.
- Hardens the WinGet publish CI step:
  - Validates \`WINGET_TOKEN\` against \`/user\` upfront so a revoked / under-scoped PAT surfaces a clear 401/403.
  - Treats "asset never available" as a hard failure rather than letting \`wingetcreate\` fail with a confusing message.
  - Retries \`wingetcreate update --submit\` up to 3× on transient errors and prints a concrete remediation checklist on final failure.
- Bundles the generated 2.28.0 manifest under \`winget/manifests/\` next to prior releases.

## Why winget-publish keeps failing

The \`wingetcreate --submit\` job has been failing for the last two releases with a generic \"Failed to connect to GitHub\" — no diagnostic context. The asset HEAD-check loop succeeded in the latest run (the zip was downloaded and a SHA was generated), so the failure happens inside wingetcreate itself when it tries to fork/PR. The new validation + retry + actionable error messages should let us pinpoint the root cause on the next run.

## Manual fallback already in flight

Submitted 2.28.0 to microsoft/winget-pkgs manually: https://github.com/microsoft/winget-pkgs/pull/362955.

## Test plan

- [x] \`qtmesh info <file>\` prints the tip when no token is set.
- [x] \`qtmesh info <file>\` is silent when \`QTMESH_TOKEN\` is set.
- [x] \`qtmesh info <file> --json\` is silent (no JSON pollution).
- [x] \`qtmesh scan <dir>\` prints the tip when no token.
- [x] All 101 \`CLIPipeline*\` unit tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * QtMeshEditor is now available via Windows Package Manager (WinGet) for easier installation
  * Added promotional messaging in CLI commands directing users to cloud services

* **Chores**
  * Enhanced deployment automation with improved validation, error handling, and retry logic
  * Updated build configuration for cloud service URL management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->