### PR TITLE
[codex] Align QtMesh Cloud metadata upload and onboarding docs

### DIFF
--- a/.github/actions/qtmesh/action.yml
+++ b/.github/actions/qtmesh/action.yml
@@ -82,6 +82,11 @@ runs:
         if [ -n "${INPUT_QTMESH_API_BASE:-}" ]; then
           docker_env+=(--env "QTMESH_API_BASE=${INPUT_QTMESH_API_BASE}")
         fi
+        for ga_name in GITHUB_REPOSITORY GITHUB_REF_NAME GITHUB_HEAD_REF GITHUB_BASE_REF GITHUB_SHA GITHUB_RUN_ID GITHUB_RUN_NUMBER GITHUB_WORKFLOW GITHUB_JOB GITHUB_ACTOR; do
+          if [ -n "${!ga_name:-}" ]; then
+            docker_env+=(--env "${ga_name}=${!ga_name}")
+          fi
+        done
 
         OUTPUT=$(docker run --rm \
           --user "$(id -u):$(id -g)" \

--- a/README.md
+++ b/README.md
@@ -24,29 +24,40 @@ Automate your 3D asset pipeline — scan, validate, convert, fix, and merge 3D a
 
 ---
 
-### 🔌 CI/CD — Validate Assets on Every PR
+### 🔌 CI/CD — GitHub Actions (Onboarding Step 3)
 
-Available on the [GitHub Actions Marketplace](https://github.com/marketplace/actions/qtmesheditor). Scan, validate, convert, and optimize 3D assets in any workflow:
+Available on the [GitHub Actions Marketplace](https://github.com/marketplace/actions/qtmesheditor).
 
-```yaml
-# Scan all assets for issues (fails on warnings)
-- uses: fernandotonon/QtMeshEditor@v1
-  with:
-    command: scan
-    input-file: ./assets
-    options: --fail-on warning
-```
+[![Latest action release](https://img.shields.io/github/v/release/fernandotonon/QtMeshEditor?label=latest%20action)](https://github.com/fernandotonon/QtMeshEditor/releases/latest)
 
-To **POST scan results to QtMesh Cloud**, pass the ingest token into the action (recommended):
+Use this workflow template (same shape as QtMesh Cloud onboarding step 3):
 
 ```yaml
-- uses: fernandotonon/QtMeshEditor@v1
-  with:
-    command: scan
-    qtmesh-token: ${{ secrets.QTMESH_CLOUD_TOKEN }}
+name: QtMesh Scan
+
+on:
+  push:
+    branches: [ "master" ]
+
+jobs:
+  scan-assets-qtmesh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run QtMesh scan
+        uses: fernandotonon/QtMeshEditor@v1
+        with:
+          command: scan
+        env:
+          QTMESH_CLOUD_TOKEN: ${{ secrets.QTMESH_CLOUD_TOKEN }}
 ```
 
-Alternatively set `QTMESH_CLOUD_TOKEN` on the step; current action versions forward it into the Docker container so the CLI can upload (same as `qtmesh-token` → `QTMESH_TOKEN`).
+`QTMESH_CLOUD_TOKEN` is forwarded into the container and used by `scan` upload. GitHub Actions metadata (`GITHUB_*`) is also forwarded so uploads include `meta` fields (branch/commit/run and context used by QtMesh Cloud).
+
+To fail CI when upload fails, add `qtmesh-strict-upload: true` (or pass `--strict-upload` in `options`).
+
+If you want an exact release tag (instead of `@v1`) with the latest version prefilled, copy the snippet from QtMesh Cloud onboarding step 3.
 
 <details>
 <summary>More CI examples</summary>
@@ -112,7 +123,7 @@ Example upload step:
     QTMESH_CLOUD_TOKEN: ${{ secrets.QTMESH_CLOUD_TOKEN }}
     QTMESH_CLOUD_API_URL: https://api.qtmesh.dev
   run: |
-    jq --arg branch "${GITHUB_REF_NAME}" \
+    jq --arg branch "${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}" \
        --arg sha "${GITHUB_SHA}" \
        --arg runId "${GITHUB_RUN_ID}" \
        '. + {meta: {branch: $branch, commitSha: $sha, runId: $runId}}' \
@@ -125,12 +136,12 @@ Example upload step:
       --data-binary @qtmesh-scan-upload.json
 ```
 
-Badge markdown (replace `<project-slug>`):
+Badge markdown (replace `<owner-slug>` and `<project-slug>`):
 
 ```md
-[![qtmesh status](https://api.qtmesh.dev/v1/projects/<project-slug>/badges/qtmesh-status.svg)](https://qtmesh.dev)
-[![qtmesh errors](https://api.qtmesh.dev/v1/projects/<project-slug>/badges/qtmesh-errors.svg)](https://qtmesh.dev)
-[![qtmesh warnings](https://api.qtmesh.dev/v1/projects/<project-slug>/badges/qtmesh-warnings.svg)](https://qtmesh.dev)
+[![qtmesh status](https://api.qtmesh.dev/v1/u/<owner-slug>/p/<project-slug>/badges/qtmesh-status.svg)](https://qtmesh.dev)
+[![qtmesh errors](https://api.qtmesh.dev/v1/u/<owner-slug>/p/<project-slug>/badges/qtmesh-errors.svg)](https://qtmesh.dev)
+[![qtmesh warnings](https://api.qtmesh.dev/v1/u/<owner-slug>/p/<project-slug>/badges/qtmesh-warnings.svg)](https://qtmesh.dev)
 ```
 
 ### 🏷️ Self-Hosted Scan Badges (Legacy)

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     description: 'Additional CLI flags (e.g. --json, --fail-on warning, --resample 30)'
     required: false
   image-tag:
-    description: 'Docker image tag (default: latest)'
+    description: 'ghcr.io/fernandotonon/qtmesh image tag. Pin to the same release as uses: ...@x.y.z so CLI matches the action (latest may lag or differ).'
     required: false
     default: 'latest'
   generate-badges:
@@ -177,6 +177,13 @@ runs:
         if [ -n "${INPUT_QTMESH_API_BASE:-}" ]; then
           docker_env+=(--env "QTMESH_API_BASE=${INPUT_QTMESH_API_BASE}")
         fi
+        # GitHub Actions sets these on the runner; forward into the container so uploads include
+        # meta (repo, branch, sha, run id) for QtMesh Cloud dashboard / project linkage.
+        for ga_name in GITHUB_REPOSITORY GITHUB_REF_NAME GITHUB_HEAD_REF GITHUB_BASE_REF GITHUB_SHA GITHUB_RUN_ID GITHUB_RUN_NUMBER GITHUB_WORKFLOW GITHUB_JOB GITHUB_ACTOR; do
+          if [ -n "${!ga_name:-}" ]; then
+            docker_env+=(--env "${ga_name}=${!ga_name}")
+          fi
+        done
 
         set +e
         docker run --rm \

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -2274,7 +2274,8 @@ int CLIPipeline::cmdScan(int argc, char* argv[])
     if (!ingestToken.isEmpty() && !noUpload) {
         SentryReporter::addBreadcrumb(QStringLiteral("cli.scan"),
             QStringLiteral("QtMesh Cloud uploadScan: posting"));
-        const auto up = QtMeshCloudClient::uploadScanReport(ingestToken, reportJson);
+        const QJsonObject reportForUpload = ScanEngine::mergeGithubActionsMetaIntoReport(reportJson);
+        const auto up = QtMeshCloudClient::uploadScanReport(ingestToken, reportForUpload);
         uploadOk = up.ok;
         if (up.ok) {
             SentryReporter::addBreadcrumb(QStringLiteral("cli.scan"),

--- a/src/ScanEngine.cpp
+++ b/src/ScanEngine.cpp
@@ -765,6 +765,44 @@ QJsonObject ScanEngine::scanReportToJsonObject(const ScanResult& result)
     return root;
 }
 
+QJsonObject ScanEngine::mergeGithubActionsMetaIntoReport(const QJsonObject& report)
+{
+    // PR workflows set GITHUB_HEAD_REF (source branch). Push workflows only set GITHUB_REF_NAME.
+    const QByteArray branch = [&]() -> QByteArray {
+        const QByteArray headRef = qgetenv("GITHUB_HEAD_REF");
+        if (!headRef.isEmpty())
+            return headRef;
+        return qgetenv("GITHUB_REF_NAME");
+    }();
+
+    static const struct {
+        const char* envVar;
+        const char* jsonKey;
+    } kMappings[] = {
+        {"GITHUB_REPOSITORY", "repository"},
+        {"GITHUB_BASE_REF", "baseBranch"},
+        {"GITHUB_SHA", "commitSha"},
+        {"GITHUB_RUN_ID", "runId"},
+        {"GITHUB_RUN_NUMBER", "runNumber"},
+        {"GITHUB_WORKFLOW", "workflow"},
+        {"GITHUB_JOB", "job"},
+        {"GITHUB_ACTOR", "actor"},
+    };
+
+    QJsonObject out = report;
+    QJsonObject meta = out.value(QStringLiteral("meta")).toObject();
+    if (!branch.isEmpty())
+        meta[QStringLiteral("branch")] = QString::fromUtf8(branch);
+    for (const auto& m : kMappings) {
+        const QByteArray v = qgetenv(m.envVar);
+        if (!v.isEmpty())
+            meta[QString::fromLatin1(m.jsonKey)] = QString::fromUtf8(v);
+    }
+    if (!meta.isEmpty())
+        out.insert(QStringLiteral("meta"), meta);
+    return out;
+}
+
 QString ScanEngine::formatJson(const ScanResult& result)
 {
     return QString::fromUtf8(QJsonDocument(scanReportToJsonObject(result)).toJson(QJsonDocument::Indented));

--- a/src/ScanEngine.h
+++ b/src/ScanEngine.h
@@ -97,6 +97,9 @@ public:
     /// Canonical JSON object for `--json`, report files, and QtMesh Cloud upload (identical schema).
     static QJsonObject scanReportToJsonObject(const ScanResult& result);
 
+    /// Merge `GITHUB_*` environment (when set, e.g. in GitHub Actions) into `meta` for `/v1/ingest/scan` (prefers GITHUB_HEAD_REF over GITHUB_REF_NAME for branch).
+    static QJsonObject mergeGithubActionsMetaIntoReport(const QJsonObject& report);
+
     /// UTC ISO-8601 timestamps for reports (`scanStartedUtc` / `scanCompletedUtc`); missing values use `scanCompletedUtc` or current UTC.
     static void scanReportUtcTimes(const ScanResult& result, QString* scanStartedUtc, QString* scanCompletedUtc);
     static QString formatJson(const ScanResult& result);

--- a/src/ScanEngine_test.cpp
+++ b/src/ScanEngine_test.cpp
@@ -1440,3 +1440,80 @@ TEST(ScanEngineTest, InspectAsset_AnimatedFixtureCollectsAnimationMetadata)
     EXPECT_FALSE(info.animationKeyframeCounts.isEmpty());
     EXPECT_EQ(info.animationNames.size(), info.animationDurations.size());
 }
+
+namespace {
+
+class TestEnvVar {
+public:
+    TestEnvVar(const char* name, const QByteArray& value)
+        : m_name(name)
+        , m_had(qEnvironmentVariableIsSet(name))
+        , m_old(qgetenv(name))
+    {
+        qputenv(name, value);
+    }
+
+    ~TestEnvVar()
+    {
+        if (m_had)
+            qputenv(m_name, m_old);
+        else
+            qunsetenv(m_name);
+    }
+
+private:
+    const char* m_name = nullptr;
+    bool m_had = false;
+    QByteArray m_old;
+};
+
+} // namespace
+
+TEST(ScanEngineTest, MergeGithubActionsMetaIntoReport_FillsMetaFromEnv)
+{
+    QJsonObject base;
+    base.insert(QStringLiteral("version"), QJsonValue(QStringLiteral("1.0")));
+
+    TestEnvVar repo("GITHUB_REPOSITORY", "acme/game");
+    TestEnvVar headRef("GITHUB_HEAD_REF", "");
+    TestEnvVar refName("GITHUB_REF_NAME", "main");
+    TestEnvVar sha("GITHUB_SHA", "deadbeef");
+    TestEnvVar runId("GITHUB_RUN_ID", "42");
+
+    const QJsonObject merged = ScanEngine::mergeGithubActionsMetaIntoReport(base);
+    const QJsonObject meta = merged.value(QStringLiteral("meta")).toObject();
+    EXPECT_EQ(meta.value(QStringLiteral("repository")).toString(), QStringLiteral("acme/game"));
+    EXPECT_EQ(meta.value(QStringLiteral("branch")).toString(), QStringLiteral("main"));
+    EXPECT_EQ(meta.value(QStringLiteral("commitSha")).toString(), QStringLiteral("deadbeef"));
+    EXPECT_EQ(meta.value(QStringLiteral("runId")).toString(), QStringLiteral("42"));
+}
+
+TEST(ScanEngineTest, MergeGithubActionsMetaIntoReport_PrefersHeadRefAndIncludesBaseRef)
+{
+    QJsonObject base;
+    base.insert(QStringLiteral("version"), QJsonValue(QStringLiteral("1.0")));
+
+    TestEnvVar headRef("GITHUB_HEAD_REF", "feature/upload-meta");
+    TestEnvVar refName("GITHUB_REF_NAME", "123/merge");
+    TestEnvVar baseRef("GITHUB_BASE_REF", "main");
+
+    const QJsonObject merged = ScanEngine::mergeGithubActionsMetaIntoReport(base);
+    const QJsonObject meta = merged.value(QStringLiteral("meta")).toObject();
+    EXPECT_EQ(meta.value(QStringLiteral("branch")).toString(), QStringLiteral("feature/upload-meta"));
+    EXPECT_EQ(meta.value(QStringLiteral("baseBranch")).toString(), QStringLiteral("main"));
+}
+
+TEST(ScanEngineTest, MergeGithubActionsMetaIntoReport_PreservesExistingMeta)
+{
+    QJsonObject metaIn;
+    metaIn.insert(QStringLiteral("custom"), 1);
+    QJsonObject base;
+    base.insert(QStringLiteral("meta"), metaIn);
+
+    TestEnvVar repo("GITHUB_REPOSITORY", "acme/game");
+
+    const QJsonObject merged = ScanEngine::mergeGithubActionsMetaIntoReport(base);
+    const QJsonObject meta = merged.value(QStringLiteral("meta")).toObject();
+    EXPECT_EQ(meta.value(QStringLiteral("custom")).toInt(), 1);
+    EXPECT_EQ(meta.value(QStringLiteral("repository")).toString(), QStringLiteral("acme/game"));
+}

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -31,6 +31,14 @@ const PLATFORM_BY_OS = {
 
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+const QTMESH_RELEASES_LATEST_API = 'https://api.github.com/repos/fernandotonon/QtMeshEditor/releases/latest';
+const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@v1';
+
+function actionRefFromTag(tagName) {
+  const tag = String(tagName || '').trim();
+  if (!tag || !/^v?\d/.test(tag)) return QTMESH_ACTION_REF_FALLBACK;
+  return `fernandotonon/QtMeshEditor@${tag}`;
+}
 
 function detectVisitorOs() {
   if (typeof navigator === 'undefined') {
@@ -96,6 +104,7 @@ async function copyText(text) {
 function App() {
   const [isInstallPortalOpen, setIsInstallPortalOpen] = useState(false);
   const [copyState, setCopyState] = useState('idle');
+  const [qtmeshActionRef, setQtmeshActionRef] = useState(QTMESH_ACTION_REF_FALLBACK);
   const portalDialogRef = useRef(null);
   const portalTriggerRef = useRef(null);
   const detectedOs = useMemo(detectVisitorOs, []);
@@ -106,6 +115,31 @@ function App() {
   );
   const recommendedStore = recommendedInstall ? getStoreLabel(recommendedInstall.method) : null;
   const primaryCtaLabel = recommendedStore ? `Install via ${recommendedStore}` : 'Open Install Portal';
+  const githubActionExample = useMemo(
+    () => pipelineExamples.githubAction.replace('__QTMESH_ACTION_REF__', qtmeshActionRef),
+    [qtmeshActionRef]
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(QTMESH_RELEASES_LATEST_API, {
+          headers: { Accept: 'application/vnd.github+json' },
+        });
+        if (!res.ok) return;
+        const data = await res.json();
+        if (cancelled) return;
+        setQtmeshActionRef(actionRefFromTag(data?.tag_name));
+      } catch (_e) {
+        // Keep fallback ref when GitHub API is unavailable.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     if (!isInstallPortalOpen || typeof document === 'undefined') {
@@ -281,7 +315,7 @@ function App() {
               <a href={links.qtmeshCloud} target="_blank" rel="noreferrer">
                 Register on QtMesh Cloud
               </a>
-              <a href={`${links.qtmeshCloudApi}/v1/projects/qtmesheditor/badges/qtmesh-status.svg`} target="_blank" rel="noreferrer">
+              <a href={`${links.qtmeshCloudApi}/v1/u/u-28680b9c/p/qtmesheditor/badges/qtmesh-status.svg`} target="_blank" rel="noreferrer">
                 View live badge example
               </a>
               <a href={links.docs} target="_blank" rel="noreferrer">
@@ -360,7 +394,7 @@ function App() {
               <CodePanel title="Convert formats" code={pipelineExamples.convert} label="convert" />
               <CodePanel title="Merge animations" code={pipelineExamples.merge} label="anim" />
               <CodePanel title="Docker" code={pipelineExamples.docker} label="docker" />
-              <CodePanel title="GitHub Actions" code={pipelineExamples.githubAction} label="ci" />
+              <CodePanel title="GitHub Actions" code={githubActionExample} label="ci" />
             </div>
 
             <div className={styles.cliLinks}>

--- a/website/src/DocsApp.jsx
+++ b/website/src/DocsApp.jsx
@@ -32,6 +32,15 @@ const NAV = [
   ]},
 ];
 
+const QTMESH_RELEASES_LATEST_API = 'https://api.github.com/repos/fernandotonon/QtMeshEditor/releases/latest';
+const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@v1';
+
+function actionRefFromTag(tagName) {
+  const tag = String(tagName || '').trim();
+  if (!tag || !/^v?\d/.test(tag)) return QTMESH_ACTION_REF_FALLBACK;
+  return `fernandotonon/QtMeshEditor@${tag}`;
+}
+
 function Code({ children }) {
   return <code className={s.code}>{children}</code>;
 }
@@ -95,6 +104,7 @@ function CmdSection({ id, name, synopsis, description, examples, options, childr
 export default function DocsApp() {
   const [active, setActive] = useState('installation');
   const [menuOpen, setMenuOpen] = useState(false);
+  const [qtmeshActionRef, setQtmeshActionRef] = useState(QTMESH_ACTION_REF_FALLBACK);
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -107,6 +117,26 @@ export default function DocsApp() {
     );
     document.querySelectorAll('section[id]').forEach(el => observer.observe(el));
     return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(QTMESH_RELEASES_LATEST_API, {
+          headers: { Accept: 'application/vnd.github+json' },
+        });
+        if (!res.ok) return;
+        const data = await res.json();
+        if (cancelled) return;
+        setQtmeshActionRef(actionRefFromTag(data?.tag_name));
+      } catch (_e) {
+        // Keep fallback ref when GitHub API is unavailable.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   return (
@@ -358,7 +388,7 @@ qtmesh pose <file> --animation <name> --count N -o <pattern>`}
             ]}
           />
 
-          <CmdSection id="cmd-scan" name="scan" description={<>Recursively scan a directory for 3D asset issues. Think of it as <strong>ESLint for 3D assets</strong>. Checks format restrictions, complexity limits, naming conventions, skeleton/animation content, and more. Supports YAML configuration, scoped rules per folder, JSON output, and auto-fix. Also available as a <a href="https://github.com/marketplace/actions/qtmesheditor" className={s.link}>GitHub Action</a>: <Code>fernandotonon/QtMeshEditor@v1</Code>.</>}
+          <CmdSection id="cmd-scan" name="scan" description={<>Recursively scan a directory for 3D asset issues. Think of it as <strong>ESLint for 3D assets</strong>. Checks format restrictions, complexity limits, naming conventions, skeleton/animation content, and more. Supports YAML configuration, scoped rules per folder, JSON output, and auto-fix. Also available as a <a href="https://github.com/marketplace/actions/qtmesheditor" className={s.link}>GitHub Action</a>: <Code>{qtmeshActionRef}</Code>.</>}
             synopsis={`qtmesh scan [path] [options]`}
             options={[
               ['--config <file>', 'Config file path (default: qtmesh.yml, qtmesh.yaml, qtmesh.json)'],
@@ -718,7 +748,7 @@ scopes:
     QTMESH_CLOUD_TOKEN: \${{ secrets.QTMESH_CLOUD_TOKEN }}
     QTMESH_CLOUD_API_URL: https://api.qtmesh.dev
   run: |
-    jq --arg branch "\${GITHUB_REF_NAME}" \\
+    jq --arg branch "\${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}" \\
        --arg sha "\${GITHUB_SHA}" \\
        --arg runId "\${GITHUB_RUN_ID}" \\
        '. + {meta: {branch: $branch, commitSha: $sha, runId: $runId}}' \\
@@ -731,9 +761,9 @@ scopes:
       --data-binary @qtmesh-scan-upload.json`}</CodeBlock>
 
             <h3 className={s.subsection}>3. Use live badge URLs</h3>
-            <CodeBlock lang="md">{`[![qtmesh status](https://api.qtmesh.dev/v1/projects/<project-slug>/badges/qtmesh-status.svg)](https://qtmesh.dev)
-[![qtmesh errors](https://api.qtmesh.dev/v1/projects/<project-slug>/badges/qtmesh-errors.svg)](https://qtmesh.dev)
-[![qtmesh warnings](https://api.qtmesh.dev/v1/projects/<project-slug>/badges/qtmesh-warnings.svg)](https://qtmesh.dev)`}</CodeBlock>
+            <CodeBlock lang="md">{`[![qtmesh status](https://api.qtmesh.dev/v1/u/<owner-slug>/p/<project-slug>/badges/qtmesh-status.svg)](https://qtmesh.dev)
+[![qtmesh errors](https://api.qtmesh.dev/v1/u/<owner-slug>/p/<project-slug>/badges/qtmesh-errors.svg)](https://qtmesh.dev)
+[![qtmesh warnings](https://api.qtmesh.dev/v1/u/<owner-slug>/p/<project-slug>/badges/qtmesh-warnings.svg)](https://qtmesh.dev)`}</CodeBlock>
 
             <p className={s.para}>
               Badge values update after each successful upload to <Code>/v1/ingest/scan</Code>.
@@ -763,37 +793,46 @@ docker run --rm -v $(pwd):/workspace ghcr.io/fernandotonon/qtmesh \\
           <section className={s.section} id="github-actions">
             <h2 className={s.sectionTitle}>GitHub Actions</h2>
             <p className={s.para}>
-              The <Code>qtmesh</Code> action is available on the <a href="https://github.com/marketplace/actions/qtmesheditor" className={s.link}>GitHub Actions Marketplace</a>. Add it to any workflow with one line.
+              The <Code>qtmesh</Code> action is available on the <a href="https://github.com/marketplace/actions/qtmesheditor" className={s.link}>GitHub Actions Marketplace</a>. This page resolves the latest release ref automatically: <Code>{qtmeshActionRef}</Code>.
             </p>
 
-            <h3 className={s.subsection}>Scan assets on every PR</h3>
-            <CodeBlock lang="yaml">{`name: Validate 3D Assets
-on: [pull_request]
+            <h3 className={s.subsection}>Onboarding Step 3 template</h3>
+            <CodeBlock lang="yaml">{`name: QtMesh Scan
+
+on:
+  push:
+    branches: [ "master" ]
 
 jobs:
-  scan:
+  scan-assets-qtmesh:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: fernandotonon/QtMeshEditor@v1
+
+      - name: Run QtMesh scan
+        uses: ${qtmeshActionRef}
         with:
           command: scan
-          input-file: ./assets
-          options: --fail-on warning`}</CodeBlock>
+        env:
+          QTMESH_CLOUD_TOKEN: \${{ secrets.QTMESH_CLOUD_TOKEN }}`}</CodeBlock>
+            <p className={s.para}>
+              Set <Code>QTMESH_CLOUD_TOKEN</Code> in repository secrets to upload scan results to QtMesh Cloud.
+              Add <Code>qtmesh-strict-upload: true</Code> if upload failures should fail the job.
+            </p>
 
             <h3 className={s.subsection}>Convert and validate</h3>
-            <CodeBlock lang="yaml">{`- uses: fernandotonon/QtMeshEditor@v1
+            <CodeBlock lang="yaml">{`- uses: ${qtmeshActionRef}
   with:
     command: validate
     input-file: ./models/character.fbx
 
-- uses: fernandotonon/QtMeshEditor@v1
+- uses: ${qtmeshActionRef}
   with:
     command: convert
     input-file: ./models/character.fbx
     output-file: ./output/character.glb2
 
-- uses: fernandotonon/QtMeshEditor@v1
+- uses: ${qtmeshActionRef}
   with:
     command: anim
     input-file: ./animations/dance.fbx
@@ -801,7 +840,7 @@ jobs:
     options: --resample 30`}</CodeBlock>
 
             <h3 className={s.subsection}>Get mesh info as JSON</h3>
-            <CodeBlock lang="yaml">{`- uses: fernandotonon/QtMeshEditor@v1
+            <CodeBlock lang="yaml">{`- uses: ${qtmeshActionRef}
   id: info
   with:
     command: info
@@ -811,7 +850,7 @@ jobs:
 - run: echo "\${{ steps.info.outputs.result }}"`}</CodeBlock>
 
             <h3 className={s.subsection}>Self-hosted scan badges (legacy Shields endpoint JSON)</h3>
-            <CodeBlock lang="yaml">{`- uses: fernandotonon/QtMeshEditor@v1
+            <CodeBlock lang="yaml">{`- uses: ${qtmeshActionRef}
   id: scan
   with:
     command: scan

--- a/website/src/data/content.js
+++ b/website/src/data/content.js
@@ -84,7 +84,7 @@ export const useCases = [
   },
   {
     title: 'GitHub Actions (Marketplace)',
-    body: 'Add `fernandotonon/QtMeshEditor@v1` to any workflow. Scan assets on every PR, convert formats, validate meshes — one line in your YAML.'
+    body: 'Use the onboarding-style workflow template and keep the action ref current from the latest release.'
   }
 ];
 
@@ -94,7 +94,7 @@ export const pipelineExamples = {
   convert: `qtmesh convert model.fbx -o model.glb2\nqtmesh convert model.dae -o model.mesh`,
   merge: `qtmesh anim base.fbx \\\n  --merge walk.fbx run.fbx jump.fbx idle.fbx \\\n  -o merged.fbx`,
   docker: `docker run --rm --user "$(id -u):$(id -g)" -v $(pwd):/workspace \\\n  ghcr.io/fernandotonon/qtmesh scan ./assets --fail-on error`,
-  githubAction: `# GitHub Actions Marketplace: fernandotonon/qtmesh\n- uses: fernandotonon/QtMeshEditor@v1\n  with:\n    command: scan\n    input-file: ./assets\n    options: --fail-on warning`,
+  githubAction: `name: QtMesh Scan\n\non:\n  push:\n    branches: [ "master" ]\n\njobs:\n  scan-assets-qtmesh:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n\n      - name: Run QtMesh scan\n        uses: __QTMESH_ACTION_REF__\n        with:\n          command: scan\n        env:\n          QTMESH_CLOUD_TOKEN: \${{ secrets.QTMESH_CLOUD_TOKEN }}`,
   scanFixConvert: `qtmesh scan ./assets --fail-on error\nqtmesh fix character.fbx --all -o character_fixed.fbx\nqtmesh convert character_fixed.fbx -o character.glb2`
 };
 
@@ -113,13 +113,13 @@ export const cloudBadgeSteps = [
   },
   {
     title: 'Embed live SVG badges',
-    body: 'Use the project slug in badge URLs to show real status, errors, and warnings in your README or website.'
+    body: 'Use owner slug + project slug in badge URLs to show real status, errors, and warnings in your README or website.'
   }
 ];
 
-export const cloudBadgeMarkdown = `[![qtmesh status](https://api.qtmesh.dev/v1/projects/<project-slug>/badges/qtmesh-status.svg)](https://qtmesh.dev)
-[![qtmesh errors](https://api.qtmesh.dev/v1/projects/<project-slug>/badges/qtmesh-errors.svg)](https://qtmesh.dev)
-[![qtmesh warnings](https://api.qtmesh.dev/v1/projects/<project-slug>/badges/qtmesh-warnings.svg)](https://qtmesh.dev)`;
+export const cloudBadgeMarkdown = `[![qtmesh status](https://api.qtmesh.dev/v1/u/<owner-slug>/p/<project-slug>/badges/qtmesh-status.svg)](https://qtmesh.dev)
+[![qtmesh errors](https://api.qtmesh.dev/v1/u/<owner-slug>/p/<project-slug>/badges/qtmesh-errors.svg)](https://qtmesh.dev)
+[![qtmesh warnings](https://api.qtmesh.dev/v1/u/<owner-slug>/p/<project-slug>/badges/qtmesh-warnings.svg)](https://qtmesh.dev)`;
 
 export const cloudBadgeUploadExample = `- name: Scan assets
   run: |
@@ -134,7 +134,7 @@ export const cloudBadgeUploadExample = `- name: Scan assets
     QTMESH_CLOUD_TOKEN: \${{ secrets.QTMESH_CLOUD_TOKEN }}
     QTMESH_CLOUD_API_URL: https://api.qtmesh.dev
   run: |
-    jq --arg branch "\${GITHUB_REF_NAME}" \\
+    jq --arg branch "\${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}" \\
        --arg sha "\${GITHUB_SHA}" \\
        --arg runId "\${GITHUB_RUN_ID}" \\
        '. + {meta: {branch: $branch, commitSha: $sha, runId: $runId}}' \\


### PR DESCRIPTION
## Summary
- forward additional GitHub Actions context into the action container (`GITHUB_HEAD_REF`, `GITHUB_BASE_REF`, etc.)
- enrich scan upload metadata with PR-safe branch resolution (`GITHUB_HEAD_REF` preferred over `GITHUB_REF_NAME`)
- add tests for metadata merge behavior (fills env metadata, preserves existing metadata, head/base branch behavior)
- align README and website GitHub Actions examples with QtMesh Cloud onboarding step 3
- update badge URL documentation to current QtMesh Cloud route shape (`/v1/u/<owner>/p/<project>/badges/...`)
- make website action snippets resolve and display the latest release ref dynamically from GitHub Releases API

## Why
QtMesh Cloud ingest currently relies on CI metadata (`branch`, `commitSha`, `runId`) for scan history context. Existing docs/snippets had drift from onboarding and included stale/hardcoded examples. PR workflows also need branch handling that prefers `GITHUB_HEAD_REF`.

## Root Cause
- branch metadata from GitHub Actions used only `GITHUB_REF_NAME`, which can be merge refs in PR events
- docs had stale examples and old badge URL shape
- website snippets were static and could become outdated between releases

## Impact
- better metadata quality for cloud uploads (especially PR branch identity)
- onboarding-consistent GitHub Actions setup in README and website docs
- fewer stale-action-version docs issues via runtime latest-tag resolution on website
- corrected badge URL docs for current QtMesh Cloud API routes

## Validation
- `npm run build` in `website/` ✅
- attempted targeted C++ tests: `ctest --test-dir build -R ScanEngineTest --output-on-failure` (no tests discovered in this local build directory)
