### PR TITLE
Optimize QtMeshEditor landing page for clarity and conversion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,7 +264,7 @@ Manual alternative: `./scripts/update-winget.sh <version>` generates the manifes
 The `qtmesh` CLI is published as a GitHub Action on the [GitHub Actions Marketplace](https://github.com/marketplace/actions/qtmesheditor). The `action.yml` lives at the repo root.
 
 ```yaml
-- uses: fernandotonon/QtMeshEditor@2.28.0
+- uses: fernandotonon/QtMeshEditor@v1
   with:
     command: scan
     input-file: ./assets

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,7 +264,7 @@ Manual alternative: `./scripts/update-winget.sh <version>` generates the manifes
 The `qtmesh` CLI is published as a GitHub Action on the [GitHub Actions Marketplace](https://github.com/marketplace/actions/qtmesheditor). The `action.yml` lives at the repo root.
 
 ```yaml
-- uses: fernandotonon/QtMeshEditor@v1
+- uses: fernandotonon/QtMeshEditor@2.28.0
   with:
     command: scan
     input-file: ./assets

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run QtMesh scan
-        uses: fernandotonon/QtMeshEditor@v1
+        uses: fernandotonon/QtMeshEditor@2.28.0
         with:
           command: scan
         env:
@@ -57,27 +57,27 @@ jobs:
 
 To fail CI when upload fails, add `qtmesh-strict-upload: true` (or pass `--strict-upload` in `options`).
 
-If you want an exact release tag (instead of `@v1`) with the latest version prefilled, copy the snippet from QtMesh Cloud onboarding step 3.
+Use the latest action release tag (currently `@2.28.0`) from QtMesh Cloud onboarding step 3 when updating this workflow.
 
 <details>
 <summary>More CI examples</summary>
 
 ```yaml
 # Validate a specific mesh
-- uses: fernandotonon/QtMeshEditor@v1
+- uses: fernandotonon/QtMeshEditor@2.28.0
   with:
     command: validate
     input-file: ./models/character.fbx
 
 # Convert FBX → glTF
-- uses: fernandotonon/QtMeshEditor@v1
+- uses: fernandotonon/QtMeshEditor@2.28.0
   with:
     command: convert
     input-file: ./models/character.fbx
     output-file: ./output/character.gltf2
 
 # Resample Mixamo animations (200+ keyframes → 30)
-- uses: fernandotonon/QtMeshEditor@v1
+- uses: fernandotonon/QtMeshEditor@2.28.0
   with:
     command: anim
     input-file: ./animations/dance.fbx
@@ -85,7 +85,7 @@ If you want an exact release tag (instead of `@v1`) with the latest version pref
     options: --resample 30
 
 # Get mesh info as JSON
-- uses: fernandotonon/QtMeshEditor@v1
+- uses: fernandotonon/QtMeshEditor@2.28.0
   id: info
   with:
     command: info
@@ -167,7 +167,7 @@ jobs:
 
       - name: Run scan + generate badge JSON files
         id: scan
-        uses: fernandotonon/QtMeshEditor@v1
+        uses: fernandotonon/QtMeshEditor@2.28.0
         with:
           command: scan
           input-file: .

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ jobs:
 
 To fail CI when upload fails, add `qtmesh-strict-upload: true` (or pass `--strict-upload` in `options`).
 
-Use the latest action release tag (currently `@2.28.0`) from QtMesh Cloud onboarding step 3 when updating this workflow.
+Use the latest action release tag from the [releases page](https://github.com/fernandotonon/QtMeshEditor/releases/latest) (also shown in QtMesh Cloud onboarding step 3) when updating this workflow.
 
 <details>
 <summary>More CI examples</summary>

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -6,6 +6,8 @@ import CodePanel from './components/CodePanel';
 import FeatureCard from './components/FeatureCard';
 import Section from './components/Section';
 import {
+  audienceCards,
+  beforeAfter,
   cloudBadgeMarkdown,
   cloudBadgeSteps,
   cloudBadgeUploadExample,
@@ -20,19 +22,18 @@ import {
   pipelineFlow,
   proofPoints,
   trustItems,
-  useCases
 } from './data/content';
 
 const PLATFORM_BY_OS = {
   windows: 'Windows',
   macos: 'macOS',
-  linux: 'Linux'
+  linux: 'Linux',
 };
 
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
 const QTMESH_RELEASES_LATEST_API = 'https://api.github.com/repos/fernandotonon/QtMeshEditor/releases/latest';
-const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@v1';
+const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@2.28.0';
 
 function actionRefFromTag(tagName) {
   const tag = String(tagName || '').trim();
@@ -105,6 +106,7 @@ function App() {
   const [isInstallPortalOpen, setIsInstallPortalOpen] = useState(false);
   const [copyState, setCopyState] = useState('idle');
   const [qtmeshActionRef, setQtmeshActionRef] = useState(QTMESH_ACTION_REF_FALLBACK);
+  const [activeCliTab, setActiveCliTab] = useState('scan');
   const portalDialogRef = useRef(null);
   const portalTriggerRef = useRef(null);
   const detectedOs = useMemo(detectVisitorOs, []);
@@ -114,10 +116,48 @@ function App() {
     [detectedPlatform]
   );
   const recommendedStore = recommendedInstall ? getStoreLabel(recommendedInstall.method) : null;
-  const primaryCtaLabel = recommendedStore ? `Install via ${recommendedStore}` : 'Open Install Portal';
   const githubActionExample = useMemo(
     () => pipelineExamples.githubAction.replace('__QTMESH_ACTION_REF__', qtmeshActionRef),
     [qtmeshActionRef]
+  );
+
+  const cliTabs = useMemo(
+    () => [
+      { id: 'scan', label: 'Scan', title: 'Scan repo assets', code: pipelineExamples.scan, language: 'scan' },
+      { id: 'fix', label: 'Fix', title: 'Fix and optimize', code: pipelineExamples.fix, language: 'fix' },
+      { id: 'convert', label: 'Convert', title: 'Convert formats', code: pipelineExamples.convert, language: 'convert' },
+      { id: 'merge', label: 'Merge', title: 'Merge animation clips', code: pipelineExamples.merge, language: 'anim' },
+      { id: 'docker', label: 'Docker', title: 'Docker workflow', code: pipelineExamples.docker, language: 'docker' },
+      { id: 'gha', label: 'GitHub Actions', title: 'GitHub Actions workflow', code: githubActionExample, language: 'yaml' },
+    ],
+    [githubActionExample]
+  );
+  const activeCliExample = cliTabs.find((tab) => tab.id === activeCliTab) || cliTabs[0];
+
+  const cloudBadgePreview = useMemo(
+    () => [
+      {
+        key: 'status',
+        alt: 'QtMesh status badge',
+        src: `${links.qtmeshCloudApi}/v1/u/u-28680b9c/p/qtmesheditor/badges/qtmesh-status.svg`,
+      },
+      {
+        key: 'score',
+        alt: 'QtMesh score badge',
+        src: `${links.qtmeshCloudApi}/v1/u/u-28680b9c/p/qtmesheditor/badges/qtmesh-score.svg`,
+      },
+      {
+        key: 'errors',
+        alt: 'QtMesh errors badge',
+        src: `${links.qtmeshCloudApi}/v1/u/u-28680b9c/p/qtmesheditor/badges/qtmesh-errors.svg`,
+      },
+      {
+        key: 'warnings',
+        alt: 'QtMesh warnings badge',
+        src: `${links.qtmeshCloudApi}/v1/u/u-28680b9c/p/qtmesheditor/badges/qtmesh-warnings.svg`,
+      },
+    ],
+    []
   );
 
   useEffect(() => {
@@ -255,24 +295,24 @@ function App() {
         <main className={styles.main}>
           <header className={`${styles.hero} reveal`}>
             <div className={styles.heroCopy}>
-              <p className={styles.kicker}>QtMeshEditor</p>
+              <p className={styles.kicker}>QtMeshEditor | CI/CD for 3D Assets</p>
               <h1 className={styles.heroTitle}>{hero.title}</h1>
               <p className={styles.heroSubtitle}>{hero.subtitle}</p>
 
-              <div className={styles.ctaRow}>
-                <button
-                  type="button"
-                  className={`${styles.ctaButton} ${styles.ctaButtonPrimary}`}
-                  onClick={handleOpenInstallPortal}
-                >
-                  {primaryCtaLabel}
-                </button>
-                <ButtonLink href={links.github} variant="secondary">
-                  {hero.ctaSecondary}
-                </ButtonLink>
-                <ButtonLink href={links.docs} variant="secondary">
-                  {hero.ctaDocs}
-                </ButtonLink>
+              <div className={styles.heroCtaPanel}>
+                <div className={styles.ctaRow}>
+                  <button
+                    type="button"
+                    className={`${styles.ctaButton} ${styles.ctaButtonPrimary}`}
+                    onClick={handleOpenInstallPortal}
+                  >
+                    {hero.ctaPrimary}
+                  </button>
+                  <ButtonLink href={links.github} variant="secondary">
+                    {hero.ctaSecondary}
+                  </ButtonLink>
+                </div>
+                <p className={styles.ctaHint}>Install from winget, Homebrew, snap, Docker, or release binaries.</p>
               </div>
 
               <ul className={styles.proofRow} aria-label="Product proof points">
@@ -285,136 +325,150 @@ function App() {
             </div>
 
             <figure className={styles.heroMediaCard}>
-              <img className={styles.heroImage} src={media.skeletonPreview.src} alt={media.skeletonPreview.alt} />
-              <figcaption className={styles.mediaCaption}>Pipeline validation and inspection workflow</figcaption>
+              <img className={styles.heroImage} src={media.pipelineCiCd.src} alt={media.pipelineCiCd.alt} />
+              <figcaption className={styles.mediaCaption}>Scan → Validate → Upload → Badges</figcaption>
+              <div className={styles.heroWorkflowBar} aria-label="Pipeline workflow overview">
+                <span>Scan</span>
+                <span>Validate</span>
+                <span>Upload</span>
+                <span>Badges</span>
+              </div>
+              <div className={styles.heroBadgeStrip}>
+                {cloudBadgePreview.slice(0, 3).map((badge) => (
+                  <img key={badge.key} src={badge.src} alt={badge.alt} loading="lazy" />
+                ))}
+              </div>
             </figure>
           </header>
 
           <Section
-            id="qtmesh-cloud-badges"
-            eyebrow="Main Topic"
-            title="QtMesh Cloud badges and scan history"
-            subtitle="Register your repository in QtMesh Cloud and publish real CI scan results as live SVG badges for status, errors, and warnings."
+            id="quick-workflow"
+            eyebrow="Quick Workflow"
+            title="Understand the pipeline in one glance"
+            subtitle="One strong flow: catch issues early, keep imports predictable, and publish visible quality signals."
           >
-            <div className={styles.pipelineFlow}>
-              {cloudBadgeSteps.map((item, index) => (
-                <article key={item.title} className={styles.pipelineNode}>
-                  <span className={styles.pipelineNodeIndex}>{index + 1}</span>
-                  <h3 className={styles.pipelineNodeTitle}>{item.title}</h3>
-                  <p className={styles.pipelineNodeBody}>{item.body}</p>
-                </article>
-              ))}
-            </div>
-
-            <div className={styles.codeGrid}>
-              <CodePanel title="GitHub Actions: upload scan report" code={cloudBadgeUploadExample} label="yaml" />
-              <CodePanel title="README badge snippet" code={cloudBadgeMarkdown} label="md" />
-            </div>
-
-            <div className={styles.cliLinks}>
-              <a href={links.qtmeshCloud} target="_blank" rel="noreferrer">
-                Register on QtMesh Cloud
-              </a>
-              <a href={`${links.qtmeshCloudApi}/v1/u/u-28680b9c/p/qtmesheditor/badges/qtmesh-status.svg`} target="_blank" rel="noreferrer">
-                View live badge example
-              </a>
-              <a href={links.docs} target="_blank" rel="noreferrer">
-                Read integration docs
-              </a>
-            </div>
-          </Section>
-
-          <Section
-            id="pipeline"
-            eyebrow="Pipeline Overview"
-            title="CI/CD for 3D assets"
-            subtitle="One toolchain for scan, validate, fix, convert, and publish across local scripts and automation workflows. Scan and validation are being expanded as first-class pipeline checks."
-          >
-            <div className={styles.pipelineFlow}>
-              {pipelineFlow.map((item, index) => (
-                <article key={item.title} className={styles.pipelineNode}>
-                  <span className={styles.pipelineNodeIndex}>{index + 1}</span>
-                  <h3 className={styles.pipelineNodeTitle}>{item.title}</h3>
-                  <p className={styles.pipelineNodeBody}>{item.body}</p>
-                </article>
-              ))}
-            </div>
-
-            <div className={styles.demoLayout}>
+            <div className={styles.quickWorkflowLayout}>
               <figure className={`${styles.demoMain} reveal`}>
-                <img
-                  className={styles.demoImage}
-                  src={media.pipelineCiCd.src}
-                  alt={media.pipelineCiCd.alt}
-                  loading="lazy"
-                />
+                <img className={styles.demoImage} src={media.skeletonPreview.src} alt={media.skeletonPreview.alt} loading="lazy" />
               </figure>
 
-              <article className={styles.pipelinePanel}>
-                <h3>Pipeline run in three commands</h3>
-                <p>
-                  Use the same command sequence in local checks and CI jobs to keep asset handling deterministic.
-                </p>
-                <pre className={styles.pipelineSnippet}>
-                  <code>{pipelineExamples.scanFixConvert}</code>
-                </pre>
+              <article className={styles.quickWorkflowPanel}>
+                <h3>Commit-to-report workflow</h3>
+                <ul className={styles.workflowList}>
+                  {pipelineFlow.map((item) => (
+                    <li key={item.title} className={styles.workflowListItem}>
+                      <strong>{item.title}</strong>
+                      <p>{item.body}</p>
+                    </li>
+                  ))}
+                </ul>
               </article>
             </div>
           </Section>
 
           <Section
-            id="use-cases"
-            eyebrow="Core Use Cases"
-            title="Built for real asset production tasks"
-            subtitle="Pipeline-focused workflows for technical artists, indie teams, and studios shipping content continuously."
+            id="qtmesh-cloud-badges"
+            eyebrow="QtMesh Cloud"
+            title="Track 3D asset quality in CI"
+            subtitle="Get visibility, quality gates, and historical tracking for your 3D asset pipeline."
           >
-            <div className={styles.useCaseGrid}>
-              {useCases.map((item) => (
-                <FeatureCard key={item.title} title={item.title} body={item.body} tag="Pipeline" />
+            <p className={styles.sectionLeadCompact}>
+              QtMesh Cloud turns each scan into a shareable quality signal for developers, technical artists, and production leads.
+            </p>
+
+            <div className={styles.badgeShowcase}>
+              {cloudBadgePreview.map((badge) => (
+                <article key={badge.key} className={styles.badgeShowcaseCard}>
+                  <img src={badge.src} alt={badge.alt} loading="lazy" />
+                </article>
               ))}
+            </div>
+
+            <div className={styles.cloudStepGrid}>
+              {cloudBadgeSteps.map((item, index) => (
+                <article key={item.title} className={styles.cloudStepCard}>
+                  <span className={styles.cloudStepIndex}>{index + 1}</span>
+                  <h3>{item.title}</h3>
+                  <p>{item.body}</p>
+                </article>
+              ))}
+            </div>
+
+            <details className={styles.expandable}>
+              <summary>Show full GitHub upload example</summary>
+              <div className={styles.expandableBody}>
+                <CodePanel title="GitHub Actions: upload scan report" code={cloudBadgeUploadExample} label="yaml" />
+              </div>
+            </details>
+
+            <details className={styles.expandable}>
+              <summary>Show README badge snippet</summary>
+              <pre className={styles.inlineCodeBlock}>
+                <code>{cloudBadgeMarkdown}</code>
+              </pre>
+            </details>
+
+            <div className={styles.cliLinks}>
+              <a href={links.qtmeshCloud} target="_blank" rel="noreferrer">
+                Open QtMesh Cloud
+              </a>
+              <a href={`${links.qtmeshCloudApi}/v1/u/u-28680b9c/p/qtmesheditor/badges/qtmesh-status.svg`} target="_blank" rel="noreferrer">
+                View live badge example
+              </a>
             </div>
           </Section>
 
           <Section
-            id="cli"
-            eyebrow="CLI + CI"
-            title="Script your 3D asset pipeline"
-            subtitle="Run the same `qtmesh` operations locally, in Docker, and inside GitHub Actions."
+            id="before-after"
+            eyebrow="Before vs After"
+            title="From asset pipeline surprises to predictable delivery"
+            subtitle="A small change in process creates a big difference in production reliability."
           >
-            <div className={styles.cliIntro}>
-              <p>
-                Repo-wide scan and validation commands are expanding. The examples below show the intended pipeline
-                shape while keeping fix, convert, merge, and automation fully scriptable today.
-              </p>
-            </div>
+            <div className={styles.beforeAfterGrid}>
+              <article className={`${styles.outcomeCard} ${styles.outcomeBefore}`}>
+                <h3>Before</h3>
+                <ul>
+                  {beforeAfter.before.map((item) => (
+                    <li key={item}>
+                      <span aria-hidden="true">✕</span>
+                      <p>{item}</p>
+                    </li>
+                  ))}
+                </ul>
+              </article>
 
-            <div className={styles.codeGrid}>
-              <CodePanel title="Scan repo assets" code={pipelineExamples.scan} label="scan" />
-              <CodePanel title="Fix and optimize" code={pipelineExamples.fix} label="fix" />
-              <CodePanel title="Convert formats" code={pipelineExamples.convert} label="convert" />
-              <CodePanel title="Merge animations" code={pipelineExamples.merge} label="anim" />
-              <CodePanel title="Docker" code={pipelineExamples.docker} label="docker" />
-              <CodePanel title="GitHub Actions" code={githubActionExample} label="ci" />
+              <article className={`${styles.outcomeCard} ${styles.outcomeAfter}`}>
+                <h3>After</h3>
+                <ul>
+                  {beforeAfter.after.map((item) => (
+                    <li key={item}>
+                      <span aria-hidden="true">✓</span>
+                      <p>{item}</p>
+                    </li>
+                  ))}
+                </ul>
+              </article>
             </div>
+          </Section>
 
-            <div className={styles.cliLinks}>
-              <a href={links.actions} target="_blank" rel="noreferrer">
-                GitHub Action
-              </a>
-              <a href={links.docs} target="_blank" rel="noreferrer">
-                CLI Documentation
-              </a>
-              <a href={links.releases} target="_blank" rel="noreferrer">
-                Latest release binaries
-              </a>
+          <Section
+            id="who-for"
+            eyebrow="Who It's For"
+            title="Built for teams shipping 3D content continuously"
+            subtitle="Focused workflows for game developers, technical artists, and studio CI/CD teams."
+          >
+            <div className={styles.audienceGrid}>
+              {audienceCards.map((item) => (
+                <FeatureCard key={item.title} title={item.title} body={item.body} tag={item.tag} />
+              ))}
             </div>
           </Section>
 
           <Section
             id="mixamo"
             eyebrow="Animation Merge Workflow"
-            title="Fast Mixamo and Unreal animation merging"
-            subtitle="Use QtMeshEditor as a practical entry-point workflow, then plug output directly into the broader pipeline."
+            title="Merge animation clips into one predictable output"
+            subtitle="Combine Mixamo, Unreal, and DCC clips, then export a clean asset ready for engine import and CI."
           >
             <div className={styles.demoLayout}>
               <figure className={`${styles.demoMain} reveal`}>
@@ -433,13 +487,82 @@ function App() {
                 ))}
               </ol>
             </div>
+
+            <div className={styles.mixamoActions}>
+              <ButtonLink href={`${links.docs}#cmd-anim`} variant="secondary">
+                See animation workflow
+              </ButtonLink>
+            </div>
+          </Section>
+
+          <Section
+            id="pipeline"
+            eyebrow="Pipeline Overview"
+            title="CI/CD pipeline flow for 3D assets"
+            subtitle="Use one deterministic flow for local checks and CI runs."
+          >
+            <div className={styles.pipelineFlow}>
+              {pipelineFlow.map((item, index) => (
+                <article key={item.title} className={styles.pipelineNode}>
+                  <span className={styles.pipelineNodeIndex}>{index + 1}</span>
+                  <h3 className={styles.pipelineNodeTitle}>{item.title}</h3>
+                  <p className={styles.pipelineNodeBody}>{item.body}</p>
+                </article>
+              ))}
+            </div>
+
+            <article className={styles.pipelinePanel}>
+              <h3>Pipeline run in three commands</h3>
+              <p>Keep asset handling deterministic from workstation to CI.</p>
+              <pre className={styles.pipelineSnippet}>
+                <code>{pipelineExamples.scanFixConvert}</code>
+              </pre>
+            </article>
+          </Section>
+
+          <Section
+            id="cli"
+            eyebrow="CLI + CI"
+            title="Use real commands, not toy snippets"
+            subtitle="Switch between scan, fix, convert, merge, Docker, and GitHub Actions examples."
+          >
+            <div className={styles.cliTabs} role="tablist" aria-label="CLI and CI examples">
+              {cliTabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  type="button"
+                  role="tab"
+                  aria-selected={activeCliExample.id === tab.id}
+                  className={`${styles.cliTabButton} ${activeCliExample.id === tab.id ? styles.cliTabButtonActive : ''}`}
+                  onClick={() => setActiveCliTab(tab.id)}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+
+            <div className={styles.cliTabPanel} role="tabpanel">
+              <CodePanel title={activeCliExample.title} code={activeCliExample.code} label={activeCliExample.language} />
+            </div>
+
+            <div className={styles.cliLinks}>
+              <a href={links.actions} target="_blank" rel="noreferrer">
+                GitHub Action
+              </a>
+              <a href={links.docs} target="_blank" rel="noreferrer">
+                CLI Documentation
+              </a>
+              <a href={links.releases} target="_blank" rel="noreferrer">
+                Latest release binaries
+              </a>
+            </div>
           </Section>
 
           <Section
             id="features"
             eyebrow="Advanced Features"
-            title="Extended capabilities for specialized workflows"
-            subtitle="Advanced tools stay available without overshadowing the core pipeline flow."
+            title="Deeper capabilities for specialized workflows"
+            subtitle="Keep advanced tooling available without hiding the core CI/CD path."
           >
             <div className={styles.highlightGrid}>
               {highlightFeatures.map((feature) => (
@@ -459,7 +582,7 @@ function App() {
               </figure>
               <figure className={styles.previewCard}>
                 <img src={media.mcpPreview.src} alt={media.mcpPreview.alt} loading="lazy" />
-                <figcaption>MCP integration for advanced agent-driven automation.</figcaption>
+                <figcaption>MCP integration for agent-driven pipeline automation.</figcaption>
               </figure>
             </div>
           </Section>
@@ -467,44 +590,68 @@ function App() {
           <Section
             id="install"
             eyebrow="Install"
-            title="Install QtMeshEditor your way"
-            subtitle="Store-first installs with winget, Homebrew, and snap, plus Docker and release binaries."
+            title="Install QtMeshEditor and start scanning"
+            subtitle="Choose your platform path: winget, Homebrew, snap, Docker, or release binaries."
           >
-            <div className={styles.installPortalEntry}>
-              <p>
-                Store options include <code>winget</code>, <code>Homebrew</code>, and <code>snap</code>. You can also
-                use Docker or download binaries from the latest release.
-              </p>
-              <div className={styles.installPortalEntryActions}>
-                <button
-                  type="button"
-                  className={`${styles.ctaButton} ${styles.ctaButtonPrimary}`}
-                  onClick={handleOpenInstallPortal}
-                >
-                  Open Install Portal
-                </button>
-                <a href={links.releases} target="_blank" rel="noreferrer">
-                  Download from latest release
-                </a>
-              </div>
+            <div className={styles.installPortalEntryActions}>
+              <button
+                type="button"
+                className={`${styles.ctaButton} ${styles.ctaButtonPrimary}`}
+                onClick={handleOpenInstallPortal}
+              >
+                {hero.ctaPrimary}
+              </button>
+              <a href={links.releases} target="_blank" rel="noreferrer">
+                Download latest release binaries
+              </a>
+            </div>
+
+            <div className={styles.installGrid}>
+              {installOptions.map((option) => (
+                <article key={option.platform} className={styles.installMethodCard}>
+                  <div className={styles.installMethodHeader}>
+                    <h3>{option.platform}</h3>
+                    <span>{option.method}</span>
+                  </div>
+                  <pre>
+                    <code>{option.command}</code>
+                  </pre>
+                </article>
+              ))}
             </div>
           </Section>
 
           <Section
             id="trust"
             eyebrow="Open Source Trust"
-            title="Built in public for long-term production use"
-            subtitle="Open source, multi-platform, and focused on practical pipeline outcomes for small teams and studios."
+            title="Credible, technical, and built in public"
+            subtitle="Community-driven since 2012 with practical tooling for production asset pipelines."
           >
-            <div className={styles.trustLead}>
+            <div className={styles.trustMetrics}>
               <a href="https://github.com/fernandotonon/QtMeshEditor/stargazers" target="_blank" rel="noreferrer">
                 <img
-                  className={styles.starBadge}
-                  src="https://img.shields.io/github/stars/fernandotonon/QtMeshEditor.svg?style=social&label=Star"
-                  alt="GitHub stars for QtMeshEditor"
+                  src="https://img.shields.io/github/stars/fernandotonon/QtMeshEditor?style=for-the-badge&label=GitHub%20stars"
+                  alt="QtMeshEditor GitHub stars"
                   loading="lazy"
                 />
               </a>
+              <a href={links.releases} target="_blank" rel="noreferrer">
+                <img
+                  src="https://img.shields.io/github/v/release/fernandotonon/QtMeshEditor?style=for-the-badge&label=Latest%20release"
+                  alt="QtMeshEditor latest release"
+                  loading="lazy"
+                />
+              </a>
+              <a href={links.license} target="_blank" rel="noreferrer">
+                <img
+                  src="https://img.shields.io/github/license/fernandotonon/QtMeshEditor?style=for-the-badge&label=License"
+                  alt="QtMeshEditor license badge"
+                  loading="lazy"
+                />
+              </a>
+            </div>
+
+            <div className={styles.trustLead}>
               <p className={styles.trustCopy}>Active development since 2012 • MIT license • Community-driven roadmap</p>
             </div>
 

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -660,14 +660,6 @@ function App() {
                 <FeatureCard key={item.title} title={item.title} body={item.body} />
               ))}
             </div>
-
-            <nav className={styles.communityLinks} aria-label="Community links">
-              {footerLinks.map((item) => (
-                <a key={item.label} href={item.href} target="_blank" rel="noreferrer">
-                  {item.label}
-                </a>
-              ))}
-            </nav>
           </Section>
         </main>
 

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -5,6 +5,7 @@ import ButtonLink from './components/ButtonLink';
 import CodePanel from './components/CodePanel';
 import FeatureCard from './components/FeatureCard';
 import Section from './components/Section';
+import useQtmeshActionRef from './hooks/useQtmeshActionRef';
 import {
   audienceCards,
   beforeAfter,
@@ -32,14 +33,6 @@ const PLATFORM_BY_OS = {
 
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
-const QTMESH_RELEASES_LATEST_API = 'https://api.github.com/repos/fernandotonon/QtMeshEditor/releases/latest';
-const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@2.28.0';
-
-function actionRefFromTag(tagName) {
-  const tag = String(tagName || '').trim();
-  if (!tag || !/^v?\d/.test(tag)) return QTMESH_ACTION_REF_FALLBACK;
-  return `fernandotonon/QtMeshEditor@${tag}`;
-}
 
 function detectVisitorOs() {
   if (typeof navigator === 'undefined') {
@@ -105,10 +98,11 @@ async function copyText(text) {
 function App() {
   const [isInstallPortalOpen, setIsInstallPortalOpen] = useState(false);
   const [copyState, setCopyState] = useState('idle');
-  const [qtmeshActionRef, setQtmeshActionRef] = useState(QTMESH_ACTION_REF_FALLBACK);
+  const qtmeshActionRef = useQtmeshActionRef();
   const [activeCliTab, setActiveCliTab] = useState('scan');
   const portalDialogRef = useRef(null);
   const portalTriggerRef = useRef(null);
+  const cliTabButtonRefs = useRef([]);
   const detectedOs = useMemo(detectVisitorOs, []);
   const detectedPlatform = PLATFORM_BY_OS[detectedOs];
   const recommendedInstall = useMemo(
@@ -133,6 +127,7 @@ function App() {
     [githubActionExample]
   );
   const activeCliExample = cliTabs.find((tab) => tab.id === activeCliTab) || cliTabs[0];
+  const cliTabPanelId = 'cli-tab-panel';
 
   const cloudBadgePreview = useMemo(
     () => [
@@ -159,27 +154,6 @@ function App() {
     ],
     []
   );
-
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const res = await fetch(QTMESH_RELEASES_LATEST_API, {
-          headers: { Accept: 'application/vnd.github+json' },
-        });
-        if (!res.ok) return;
-        const data = await res.json();
-        if (cancelled) return;
-        setQtmeshActionRef(actionRefFromTag(data?.tag_name));
-      } catch (_e) {
-        // Keep fallback ref when GitHub API is unavailable.
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   useEffect(() => {
     if (!isInstallPortalOpen || typeof document === 'undefined') {
@@ -285,6 +259,30 @@ function App() {
   function handleOpenInstallPortal(event) {
     portalTriggerRef.current = event.currentTarget;
     setIsInstallPortalOpen(true);
+  }
+
+  function handleCliTabKeyDown(event, index) {
+    if (!['ArrowRight', 'ArrowLeft', 'Home', 'End'].includes(event.key)) {
+      return;
+    }
+
+    event.preventDefault();
+    const lastIndex = cliTabs.length - 1;
+    let nextIndex = index;
+
+    if (event.key === 'ArrowRight') {
+      nextIndex = index === lastIndex ? 0 : index + 1;
+    } else if (event.key === 'ArrowLeft') {
+      nextIndex = index === 0 ? lastIndex : index - 1;
+    } else if (event.key === 'Home') {
+      nextIndex = 0;
+    } else if (event.key === 'End') {
+      nextIndex = lastIndex;
+    }
+
+    setActiveCliTab(cliTabs[nextIndex].id);
+    const nextTab = cliTabButtonRefs.current[nextIndex];
+    if (nextTab) nextTab.focus();
   }
 
   return (
@@ -527,26 +525,42 @@ function App() {
             subtitle="Switch between scan, fix, convert, merge, Docker, and GitHub Actions examples."
           >
             <div className={styles.cliTabs} role="tablist" aria-label="CLI and CI examples">
-              {cliTabs.map((tab) => (
-                <button
-                  key={tab.id}
-                  type="button"
-                  role="tab"
-                  aria-selected={activeCliExample.id === tab.id}
-                  className={`${styles.cliTabButton} ${activeCliExample.id === tab.id ? styles.cliTabButtonActive : ''}`}
-                  onClick={() => setActiveCliTab(tab.id)}
-                >
-                  {tab.label}
-                </button>
-              ))}
+              {cliTabs.map((tab, index) => {
+                const isActive = activeCliExample.id === tab.id;
+                const tabId = `cli-tab-${tab.id}`;
+                return (
+                  <button
+                    key={tab.id}
+                    id={tabId}
+                    type="button"
+                    role="tab"
+                    aria-selected={isActive}
+                    aria-controls={cliTabPanelId}
+                    tabIndex={isActive ? 0 : -1}
+                    className={`${styles.cliTabButton} ${isActive ? styles.cliTabButtonActive : ''}`}
+                    onClick={() => setActiveCliTab(tab.id)}
+                    onKeyDown={(event) => handleCliTabKeyDown(event, index)}
+                    ref={(node) => {
+                      cliTabButtonRefs.current[index] = node;
+                    }}
+                  >
+                    {tab.label}
+                  </button>
+                );
+              })}
             </div>
 
-            <div className={styles.cliTabPanel} role="tabpanel">
+            <div
+              className={styles.cliTabPanel}
+              id={cliTabPanelId}
+              role="tabpanel"
+              aria-labelledby={`cli-tab-${activeCliExample.id}`}
+            >
               <CodePanel title={activeCliExample.title} code={activeCliExample.code} label={activeCliExample.language} />
             </div>
 
             <div className={styles.cliLinks}>
-              <a href={links.actions} target="_blank" rel="noreferrer">
+              <a href={links.marketplace} target="_blank" rel="noreferrer">
                 GitHub Action
               </a>
               <a href={links.docs} target="_blank" rel="noreferrer">

--- a/website/src/App.module.css
+++ b/website/src/App.module.css
@@ -729,15 +729,7 @@
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
-.communityLinks {
-  margin-top: 1rem;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-}
-
 .cliLinks a,
-.communityLinks a,
 .footerLinks a {
   color: var(--accent-1);
   text-decoration: none;
@@ -745,7 +737,6 @@
 }
 
 .cliLinks a:hover,
-.communityLinks a:hover,
 .footerLinks a:hover {
   color: #9cdfff;
 }

--- a/website/src/App.module.css
+++ b/website/src/App.module.css
@@ -19,16 +19,16 @@
 .main {
   position: relative;
   z-index: 1;
-  padding-bottom: 3.5rem;
+  padding-bottom: 4rem;
 }
 
 .hero {
   width: min(1120px, 92vw);
   margin: 0 auto;
-  padding: 4.7rem 0 0;
+  padding: 4.6rem 0 0;
   display: grid;
-  grid-template-columns: 1.05fr 0.95fr;
-  gap: 2rem;
+  grid-template-columns: 1.04fr 0.96fr;
+  gap: 1.65rem;
   align-items: center;
 }
 
@@ -39,7 +39,7 @@
 .kicker {
   margin: 0;
   color: var(--accent-1);
-  font-size: 0.84rem;
+  font-size: 0.82rem;
   font-weight: 700;
   letter-spacing: 0.09em;
   text-transform: uppercase;
@@ -47,32 +47,40 @@
 
 .heroTitle {
   margin: 0.7rem 0 0;
-  font-size: clamp(2.1rem, 5vw, 4rem);
-  line-height: 1.02;
+  font-size: clamp(2.2rem, 5vw, 4.05rem);
+  line-height: 1.01;
   text-wrap: balance;
 }
 
 .heroSubtitle {
-  margin: 1rem 0 0;
+  margin: 0.95rem 0 0;
   color: var(--text-1);
   max-width: 58ch;
-  font-size: clamp(1rem, 1.9vw, 1.16rem);
+  font-size: clamp(1rem, 1.8vw, 1.15rem);
+}
+
+.heroCtaPanel {
+  margin-top: 1.25rem;
+  border: 1px solid var(--stroke-strong);
+  border-radius: 0.95rem;
+  padding: 0.85rem;
+  background: linear-gradient(180deg, rgba(18, 30, 50, 0.88), rgba(10, 17, 29, 0.92));
+  box-shadow: 0 10px 35px rgba(0, 0, 0, 0.28);
 }
 
 .ctaRow {
-  margin-top: 1.4rem;
   display: flex;
   flex-wrap: wrap;
-  gap: 0.7rem;
+  gap: 0.72rem;
 }
 
 .ctaButton {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 0.75rem;
+  border-radius: 0.78rem;
   border: 1px solid transparent;
-  padding: 0.75rem 1.2rem;
+  padding: 0.78rem 1.28rem;
   font-weight: 700;
   letter-spacing: 0.01em;
   transition: transform 140ms ease, box-shadow 140ms ease, background-color 140ms ease;
@@ -90,30 +98,542 @@
 .ctaButtonPrimary {
   background: linear-gradient(135deg, var(--accent-1), var(--accent-2));
   color: var(--surface-0);
-  box-shadow: 0 10px 30px rgba(46, 188, 255, 0.25);
+  box-shadow: 0 12px 34px rgba(46, 188, 255, 0.33);
 }
 
 .ctaButtonPrimary:hover {
-  box-shadow: 0 16px 34px rgba(46, 188, 255, 0.35);
+  box-shadow: 0 18px 42px rgba(46, 188, 255, 0.42);
 }
 
-.installPortalEntry {
-  border: 1px solid var(--stroke);
-  border-radius: 0.95rem;
-  background: linear-gradient(180deg, rgba(15, 24, 40, 0.95), rgba(9, 16, 27, 0.95));
-  padding: 0.9rem;
+.ctaHint {
+  margin: 0.58rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.84rem;
 }
 
-.installPortalEntry p {
-  margin: 0;
+.proofRow {
+  list-style: none;
+  margin: 1rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.proofPill {
+  border-radius: 999px;
+  border: 1px solid var(--stroke-strong);
+  background: var(--surface-2);
+  padding: 0.34rem 0.74rem;
+  font-size: 0.82rem;
   color: var(--text-1);
 }
 
-.installPortalEntryActions {
+.heroMediaCard {
+  margin: 0;
+  border-radius: 1.05rem;
+  border: 1px solid var(--stroke);
+  background: linear-gradient(180deg, rgba(13, 23, 39, 0.98), rgba(8, 13, 22, 0.98));
+  box-shadow: 0 22px 55px rgba(0, 0, 0, 0.42);
+  overflow: hidden;
+}
+
+.heroImage {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+}
+
+.mediaCaption {
+  margin: 0;
+  padding: 0.68rem 0.9rem 0;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+}
+
+.heroWorkflowBar {
+  margin: 0.62rem 0.9rem 0;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.45rem;
+}
+
+.heroWorkflowBar span {
+  text-align: center;
+  border: 1px solid rgba(103, 211, 255, 0.35);
+  background: rgba(103, 211, 255, 0.1);
+  color: #bfefff;
+  border-radius: 999px;
+  font-size: 0.76rem;
+  font-weight: 700;
+  padding: 0.2rem 0.45rem;
+  letter-spacing: 0.03em;
+}
+
+.heroBadgeStrip {
+  margin: 0.65rem 0.9rem 0.88rem;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.42rem;
+}
+
+.heroBadgeStrip img {
+  width: 100%;
+  display: block;
+}
+
+.quickWorkflowLayout {
+  display: grid;
+  grid-template-columns: 1.12fr 0.88fr;
+  gap: 1rem;
+  align-items: start;
+}
+
+.demoMain {
+  margin: 0;
+  border: 1px solid var(--stroke);
+  border-radius: 1rem;
+  overflow: hidden;
+  background: var(--surface-1);
+}
+
+.demoImage {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+}
+
+.quickWorkflowPanel {
+  border: 1px solid var(--stroke);
+  border-radius: 0.95rem;
+  padding: 0.9rem;
+  background: linear-gradient(180deg, rgba(13, 21, 35, 0.98), rgba(10, 15, 26, 0.98));
+}
+
+.quickWorkflowPanel h3 {
+  margin: 0;
+  font-size: 1.02rem;
+}
+
+.workflowList {
+  margin: 0.72rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.62rem;
+}
+
+.workflowListItem {
+  border: 1px solid var(--stroke);
+  border-radius: 0.78rem;
+  padding: 0.62rem 0.72rem;
+  background: rgba(15, 25, 42, 0.72);
+}
+
+.workflowListItem strong {
+  font-size: 0.9rem;
+  color: #ddf6ff;
+}
+
+.workflowListItem p {
+  margin: 0.26rem 0 0;
+  color: var(--text-1);
+  font-size: 0.86rem;
+  line-height: 1.44;
+}
+
+.sectionLeadCompact {
+  margin: 0;
+  color: var(--text-1);
+  max-width: 74ch;
+}
+
+.badgeShowcase {
+  margin-top: 1rem;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.62rem;
+}
+
+.badgeShowcaseCard {
+  border: 1px solid var(--stroke);
+  background: var(--surface-1);
+  border-radius: 0.82rem;
+  padding: 0.62rem;
+}
+
+.badgeShowcaseCard img {
+  display: block;
+  width: 100%;
+}
+
+.cloudStepGrid {
+  margin-top: 0.82rem;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.72rem;
+}
+
+.cloudStepCard {
+  border: 1px solid var(--stroke);
+  border-radius: 0.92rem;
+  background: linear-gradient(180deg, rgba(16, 24, 40, 0.95), rgba(11, 17, 30, 0.96));
+  padding: 0.86rem;
+  min-height: 146px;
+}
+
+.cloudStepIndex {
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 999px;
+  border: 1px solid rgba(46, 188, 255, 0.4);
+  background: rgba(46, 188, 255, 0.16);
+  color: var(--accent-1);
+  font-size: 0.82rem;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cloudStepCard h3 {
+  margin: 0.54rem 0 0;
+  font-size: 1rem;
+}
+
+.cloudStepCard p {
+  margin: 0.4rem 0 0;
+  color: var(--text-1);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.expandable {
   margin-top: 0.75rem;
+  border: 1px solid var(--stroke);
+  border-radius: 0.88rem;
+  background: rgba(11, 18, 30, 0.9);
+  overflow: hidden;
+}
+
+.expandable summary {
+  cursor: pointer;
+  list-style: none;
+  padding: 0.68rem 0.82rem;
+  font-weight: 700;
+  color: #cff3ff;
+  background: rgba(14, 23, 39, 0.95);
+  border-bottom: 1px solid transparent;
+}
+
+.expandable[open] summary {
+  border-bottom-color: var(--stroke);
+}
+
+.expandableBody {
+  padding: 0.75rem;
+}
+
+.inlineCodeBlock {
+  margin: 0;
+  padding: 0.72rem 0.8rem;
+  overflow: auto;
+  background: rgba(8, 13, 23, 0.92);
+  color: #dce8ff;
+  font-size: 0.84rem;
+  line-height: 1.48;
+}
+
+.cliLinks {
+  margin-top: 0.86rem;
   display: flex;
   flex-wrap: wrap;
+  gap: 0.9rem;
+}
+
+.beforeAfterGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.84rem;
+}
+
+.outcomeCard {
+  border: 1px solid var(--stroke);
+  border-radius: 1rem;
+  padding: 0.95rem;
+}
+
+.outcomeCard h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.outcomeCard ul {
+  list-style: none;
+  margin: 0.72rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.outcomeCard li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.58rem;
+  align-items: start;
+}
+
+.outcomeCard li span {
+  width: 1.28rem;
+  height: 1.28rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.outcomeCard li p {
+  margin: 0;
+  color: var(--text-1);
+  line-height: 1.45;
+}
+
+.outcomeBefore {
+  background: linear-gradient(180deg, rgba(37, 16, 24, 0.84), rgba(23, 10, 16, 0.84));
+}
+
+.outcomeBefore li span {
+  border: 1px solid rgba(255, 112, 131, 0.45);
+  color: #ff9db0;
+  background: rgba(255, 112, 131, 0.14);
+}
+
+.outcomeAfter {
+  background: linear-gradient(180deg, rgba(13, 31, 30, 0.84), rgba(8, 20, 20, 0.84));
+}
+
+.outcomeAfter li span {
+  border: 1px solid rgba(85, 227, 183, 0.45);
+  color: #9ff2d6;
+  background: rgba(85, 227, 183, 0.15);
+}
+
+.audienceGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.82rem;
+}
+
+.demoLayout {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 1rem;
+  align-items: start;
+}
+
+.steps {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.stepItem {
+  border: 1px solid var(--stroke);
+  border-radius: 0.9rem;
+  background: linear-gradient(180deg, rgba(16, 24, 40, 0.96), rgba(12, 18, 30, 0.96));
+  padding: 0.85rem;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: start;
+}
+
+.stepIndex {
+  width: 1.65rem;
+  height: 1.65rem;
+  border-radius: 999px;
+  background: rgba(46, 188, 255, 0.18);
+  border: 1px solid rgba(46, 188, 255, 0.35);
+  color: var(--accent-1);
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.86rem;
+}
+
+.stepTitle {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.stepBody {
+  margin: 0.35rem 0 0;
+  color: var(--text-1);
+  font-size: 0.92rem;
+}
+
+.mixamoActions {
+  margin-top: 0.82rem;
+}
+
+.pipelineFlow {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 0.8rem;
+  margin-bottom: 0.85rem;
+}
+
+.pipelineNode {
+  border: 1px solid var(--stroke);
+  border-radius: 0.95rem;
+  background: linear-gradient(180deg, rgba(16, 24, 40, 0.95), rgba(11, 17, 30, 0.96));
+  padding: 0.9rem;
+  min-height: 150px;
+}
+
+.pipelineNodeIndex {
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 999px;
+  border: 1px solid rgba(46, 188, 255, 0.4);
+  background: rgba(46, 188, 255, 0.16);
+  color: var(--accent-1);
+  font-size: 0.82rem;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.pipelineNodeTitle {
+  margin: 0.5rem 0 0;
+  font-size: 1rem;
+}
+
+.pipelineNodeBody {
+  margin: 0.4rem 0 0;
+  color: var(--text-1);
+  font-size: 0.9rem;
+  line-height: 1.48;
+}
+
+.pipelinePanel {
+  border: 1px solid var(--stroke);
+  border-radius: 0.95rem;
+  padding: 0.9rem;
+  background: linear-gradient(180deg, rgba(13, 21, 35, 0.98), rgba(10, 15, 26, 0.98));
+}
+
+.pipelinePanel h3 {
+  margin: 0;
+  font-size: 1.03rem;
+}
+
+.pipelinePanel p {
+  margin: 0.5rem 0 0;
+  color: var(--text-1);
+  font-size: 0.91rem;
+}
+
+.pipelineSnippet {
+  margin: 0.75rem 0 0;
+  border: 1px solid var(--stroke-strong);
+  border-radius: 0.75rem;
+  padding: 0.7rem 0.8rem;
+  overflow-x: auto;
+  background: rgba(7, 12, 20, 0.9);
+}
+
+.pipelineSnippet code {
+  color: #baf6ff;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  white-space: pre;
+}
+
+.cliTabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.cliTabButton {
+  border: 1px solid var(--stroke-strong);
+  border-radius: 999px;
+  background: var(--surface-2);
+  color: var(--text-1);
+  padding: 0.35rem 0.78rem;
+  font-weight: 700;
+  font-size: 0.83rem;
+  cursor: pointer;
+}
+
+.cliTabButton:hover {
+  background: var(--surface-3);
+  color: var(--text-0);
+}
+
+.cliTabButtonActive {
+  border-color: rgba(103, 211, 255, 0.56);
+  background: rgba(103, 211, 255, 0.16);
+  color: #d8f6ff;
+}
+
+.cliTabPanel {
+  margin-top: 0.78rem;
+}
+
+.highlightGrid,
+.installGrid,
+.trustGrid {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.highlightGrid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.previewStrip {
+  margin-top: 1rem;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.8rem;
+}
+
+.previewCard {
+  margin: 0;
+  border: 1px solid var(--stroke);
+  border-radius: 0.9rem;
+  overflow: hidden;
+  background: var(--surface-1);
+}
+
+.previewCard img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+}
+
+.previewCard figcaption {
+  margin: 0;
+  padding: 0.62rem 0.72rem;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.installPortalEntryActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.82rem;
   align-items: center;
 }
 
@@ -125,6 +645,138 @@
 
 .installPortalEntryActions a:hover {
   color: #9cdfff;
+}
+
+.installGrid {
+  margin-top: 0.88rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.installMethodCard {
+  border: 1px solid var(--stroke);
+  border-radius: 0.95rem;
+  background: linear-gradient(180deg, rgba(16, 24, 40, 0.95), rgba(11, 17, 30, 0.96));
+  padding: 0.82rem;
+}
+
+.installMethodHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.72rem;
+}
+
+.installMethodHeader h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.installMethodHeader span {
+  color: var(--accent-1);
+  border: 1px solid rgba(46, 188, 255, 0.35);
+  border-radius: 999px;
+  padding: 0.14rem 0.52rem;
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
+.installMethodCard pre {
+  margin: 0.62rem 0 0;
+  border: 1px solid var(--stroke-strong);
+  border-radius: 0.72rem;
+  padding: 0.66rem 0.74rem;
+  overflow-x: auto;
+  background: rgba(8, 13, 22, 0.92);
+}
+
+.installMethodCard code {
+  color: #baf6ff;
+  font-size: 0.82rem;
+  line-height: 1.48;
+  white-space: pre-wrap;
+}
+
+.trustMetrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.66rem;
+  align-items: center;
+}
+
+.trustMetrics img {
+  display: block;
+}
+
+.trustLead {
+  margin-top: 0.86rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.8rem;
+  padding: 0.9rem;
+  border-radius: 1rem;
+  border: 1px solid var(--stroke);
+  background: linear-gradient(180deg, rgba(18, 27, 45, 0.96), rgba(12, 17, 29, 0.96));
+}
+
+.trustCopy {
+  margin: 0;
+  color: var(--text-1);
+}
+
+.trustGrid {
+  margin-top: 0.9rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.communityLinks {
+  margin-top: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.cliLinks a,
+.communityLinks a,
+.footerLinks a {
+  color: var(--accent-1);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.cliLinks a:hover,
+.communityLinks a:hover,
+.footerLinks a:hover {
+  color: #9cdfff;
+}
+
+.footer {
+  position: relative;
+  z-index: 1;
+  border-top: 1px solid var(--stroke);
+  background: rgba(3, 7, 14, 0.85);
+}
+
+.footerInner {
+  width: min(1120px, 92vw);
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+  padding: 1rem 0 1.15rem;
+}
+
+.footerInner p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.footerLinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
 }
 
 .installPortalBackdrop {
@@ -284,361 +936,18 @@
   color: var(--text-1);
 }
 
-.proofRow {
-  list-style: none;
-  margin: 1.2rem 0 0;
-  padding: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.55rem;
-}
-
-.proofPill {
-  border-radius: 999px;
-  border: 1px solid var(--stroke-strong);
-  background: var(--surface-2);
-  padding: 0.33rem 0.72rem;
-  font-size: 0.82rem;
-  color: var(--text-1);
-}
-
-.heroMediaCard {
-  margin: 0;
-  border-radius: 1.05rem;
-  border: 1px solid var(--stroke);
-  background: linear-gradient(180deg, rgba(13, 23, 39, 0.98), rgba(8, 13, 22, 0.98));
-  box-shadow: 0 20px 52px rgba(0, 0, 0, 0.4);
-  overflow: hidden;
-}
-
-.heroImage {
-  display: block;
-  width: 100%;
-  aspect-ratio: 16 / 10;
-  object-fit: cover;
-}
-
-.mediaCaption {
-  margin: 0;
-  padding: 0.7rem 0.9rem 0.8rem;
-  color: var(--text-muted);
-  font-size: 0.83rem;
-}
-
-.pipelineFlow {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 0.8rem;
-  margin-bottom: 1rem;
-}
-
-.pipelineNode {
-  border: 1px solid var(--stroke);
-  border-radius: 0.95rem;
-  background: linear-gradient(180deg, rgba(16, 24, 40, 0.95), rgba(11, 17, 30, 0.96));
-  padding: 0.9rem;
-  min-height: 154px;
-}
-
-.pipelineNodeIndex {
-  width: 1.6rem;
-  height: 1.6rem;
-  border-radius: 999px;
-  border: 1px solid rgba(46, 188, 255, 0.4);
-  background: rgba(46, 188, 255, 0.16);
-  color: var(--accent-1);
-  font-size: 0.82rem;
-  font-weight: 700;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.pipelineNodeTitle {
-  margin: 0.5rem 0 0;
-  font-size: 1rem;
-}
-
-.pipelineNodeBody {
-  margin: 0.4rem 0 0;
-  color: var(--text-1);
-  font-size: 0.9rem;
-  line-height: 1.48;
-}
-
-.demoLayout {
-  display: grid;
-  grid-template-columns: 1.2fr 0.8fr;
-  gap: 1rem;
-  align-items: start;
-}
-
-.pipelinePanel {
-  border: 1px solid var(--stroke);
-  border-radius: 0.95rem;
-  padding: 0.9rem;
-  background: linear-gradient(180deg, rgba(13, 21, 35, 0.98), rgba(10, 15, 26, 0.98));
-}
-
-.pipelinePanel h3 {
-  margin: 0;
-  font-size: 1.03rem;
-}
-
-.pipelinePanel p {
-  margin: 0.5rem 0 0;
-  color: var(--text-1);
-  font-size: 0.91rem;
-}
-
-.pipelineSnippet {
-  margin: 0.75rem 0 0;
-  border: 1px solid var(--stroke-strong);
-  border-radius: 0.75rem;
-  padding: 0.7rem 0.8rem;
-  overflow-x: auto;
-  background: rgba(7, 12, 20, 0.9);
-}
-
-.pipelineSnippet code {
-  color: #baf6ff;
-  font-size: 0.82rem;
-  line-height: 1.5;
-  white-space: pre;
-}
-
-.demoMain {
-  margin: 0;
-  border: 1px solid var(--stroke);
-  border-radius: 1rem;
-  overflow: hidden;
-  background: var(--surface-1);
-}
-
-.demoImage {
-  display: block;
-  width: 100%;
-  aspect-ratio: 16 / 10;
-  object-fit: cover;
-}
-
-.steps {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: 0.75rem;
-}
-
-.stepItem {
-  border: 1px solid var(--stroke);
-  border-radius: 0.9rem;
-  background: linear-gradient(180deg, rgba(16, 24, 40, 0.96), rgba(12, 18, 30, 0.96));
-  padding: 0.85rem;
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 0.75rem;
-  align-items: start;
-}
-
-.stepIndex {
-  width: 1.65rem;
-  height: 1.65rem;
-  border-radius: 999px;
-  background: rgba(46, 188, 255, 0.18);
-  border: 1px solid rgba(46, 188, 255, 0.35);
-  color: var(--accent-1);
-  font-weight: 700;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 0.86rem;
-}
-
-.stepTitle {
-  margin: 0;
-  font-size: 1rem;
-}
-
-.stepBody {
-  margin: 0.35rem 0 0;
-  color: var(--text-1);
-  font-size: 0.92rem;
-}
-
-.previewStrip {
-  margin-top: 1rem;
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.8rem;
-}
-
-.previewCard {
-  margin: 0;
-  border: 1px solid var(--stroke);
-  border-radius: 0.9rem;
-  overflow: hidden;
-  background: var(--surface-1);
-}
-
-.previewCard img {
-  display: block;
-  width: 100%;
-  aspect-ratio: 16 / 10;
-  object-fit: cover;
-}
-
-.previewCard figcaption {
-  margin: 0;
-  padding: 0.62rem 0.72rem;
-  color: var(--text-muted);
-  font-size: 0.8rem;
-}
-
-.useCaseGrid,
-.highlightGrid,
-.installGrid,
-.trustGrid {
-  display: grid;
-  gap: 0.8rem;
-}
-
-.useCaseGrid {
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-}
-
-.cliIntro {
-  display: grid;
-  gap: 0.75rem;
-}
-
-.cliIntro p {
-  margin: 0;
-  color: var(--text-1);
-  max-width: 80ch;
-}
-
-.codeGrid {
-  margin-top: 1rem;
-  display: grid;
-  gap: 0.8rem;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.codeGrid > :nth-child(6) {
-  grid-column: span 2;
-}
-
-.cliLinks {
-  margin-top: 0.85rem;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-}
-
-.cliLinks a,
-.communityLinks a,
-.footerLinks a {
-  color: var(--accent-1);
-  text-decoration: none;
-  font-weight: 600;
-}
-
-.cliLinks a:hover,
-.communityLinks a:hover,
-.footerLinks a:hover {
-  color: #9cdfff;
-}
-
-.comparisonGrid {
-  display: grid;
-  gap: 0.8rem;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.highlightGrid {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.installGrid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.trustLead {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.8rem;
-  padding: 0.9rem;
-  border-radius: 1rem;
-  border: 1px solid var(--stroke);
-  background: linear-gradient(180deg, rgba(18, 27, 45, 0.96), rgba(12, 17, 29, 0.96));
-}
-
-.starBadge {
-  display: block;
-}
-
-.trustCopy {
-  margin: 0;
-  color: var(--text-1);
-}
-
-.trustGrid {
-  margin-top: 0.9rem;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.communityLinks {
-  margin-top: 1rem;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-}
-
-.footer {
-  position: relative;
-  z-index: 1;
-  border-top: 1px solid var(--stroke);
-  background: rgba(3, 7, 14, 0.85);
-}
-
-.footerInner {
-  width: min(1120px, 92vw);
-  margin: 0 auto;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 0.8rem;
-  flex-wrap: wrap;
-  padding: 1rem 0 1.15rem;
-}
-
-.footerInner p {
-  margin: 0;
-  color: var(--text-muted);
-}
-
-.footerLinks {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.85rem;
-}
-
-@media (max-width: 1020px) {
+@media (max-width: 1080px) {
   .hero,
+  .quickWorkflowLayout,
   .demoLayout {
     grid-template-columns: 1fr;
   }
 
   .pipelineFlow,
-  .useCaseGrid,
-  .comparisonGrid,
+  .cloudStepGrid,
+  .audienceGrid,
+  .highlightGrid,
   .trustGrid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .highlightGrid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
@@ -660,19 +969,18 @@
     align-self: start;
   }
 
-  .previewStrip,
+  .heroWorkflowBar,
+  .heroBadgeStrip,
+  .badgeShowcase,
+  .cloudStepGrid,
+  .beforeAfterGrid,
+  .audienceGrid,
   .pipelineFlow,
-  .useCaseGrid,
-  .codeGrid,
-  .comparisonGrid,
   .highlightGrid,
+  .previewStrip,
   .installGrid,
   .trustGrid {
     grid-template-columns: 1fr;
-  }
-
-  .codeGrid > :nth-child(6) {
-    grid-column: auto;
   }
 
   .proofPill {

--- a/website/src/DocsApp.jsx
+++ b/website/src/DocsApp.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import s from './DocsApp.module.css';
+import useQtmeshActionRef from './hooks/useQtmeshActionRef';
 
 const NAV = [
   { section: 'Getting Started', items: [
@@ -31,15 +32,6 @@ const NAV = [
     { id: 'ci-cd', label: 'CI/CD Patterns' },
   ]},
 ];
-
-const QTMESH_RELEASES_LATEST_API = 'https://api.github.com/repos/fernandotonon/QtMeshEditor/releases/latest';
-const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@2.28.0';
-
-function actionRefFromTag(tagName) {
-  const tag = String(tagName || '').trim();
-  if (!tag || !/^v?\d/.test(tag)) return QTMESH_ACTION_REF_FALLBACK;
-  return `fernandotonon/QtMeshEditor@${tag}`;
-}
 
 function Code({ children }) {
   return <code className={s.code}>{children}</code>;
@@ -104,7 +96,7 @@ function CmdSection({ id, name, synopsis, description, examples, options, childr
 export default function DocsApp() {
   const [active, setActive] = useState('installation');
   const [menuOpen, setMenuOpen] = useState(false);
-  const [qtmeshActionRef, setQtmeshActionRef] = useState(QTMESH_ACTION_REF_FALLBACK);
+  const qtmeshActionRef = useQtmeshActionRef();
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -117,26 +109,6 @@ export default function DocsApp() {
     );
     document.querySelectorAll('section[id]').forEach(el => observer.observe(el));
     return () => observer.disconnect();
-  }, []);
-
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const res = await fetch(QTMESH_RELEASES_LATEST_API, {
-          headers: { Accept: 'application/vnd.github+json' },
-        });
-        if (!res.ok) return;
-        const data = await res.json();
-        if (cancelled) return;
-        setQtmeshActionRef(actionRefFromTag(data?.tag_name));
-      } catch (_e) {
-        // Keep fallback ref when GitHub API is unavailable.
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
   }, []);
 
   return (

--- a/website/src/DocsApp.jsx
+++ b/website/src/DocsApp.jsx
@@ -33,7 +33,7 @@ const NAV = [
 ];
 
 const QTMESH_RELEASES_LATEST_API = 'https://api.github.com/repos/fernandotonon/QtMeshEditor/releases/latest';
-const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@v1';
+const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@2.28.0';
 
 function actionRefFromTag(tagName) {
   const tag = String(tagName || '').trim();

--- a/website/src/data/content.js
+++ b/website/src/data/content.js
@@ -8,7 +8,6 @@ export const links = {
   issues: 'https://github.com/fernandotonon/QtMeshEditor/issues',
   forum: 'https://forums.ogre3d.org/viewtopic.php?t=76016',
   license: 'https://opensource.org/license/mit',
-  actions: 'https://github.com/marketplace/actions/qtmesheditor',
   marketplace: 'https://github.com/marketplace/actions/qtmesheditor'
 };
 

--- a/website/src/data/content.js
+++ b/website/src/data/content.js
@@ -8,7 +8,7 @@ export const links = {
   issues: 'https://github.com/fernandotonon/QtMeshEditor/issues',
   forum: 'https://forums.ogre3d.org/viewtopic.php?t=76016',
   license: 'https://opensource.org/license/mit',
-  actions: 'https://github.com/fernandotonon/qtmesh',
+  actions: 'https://github.com/marketplace/actions/qtmesheditor',
   marketplace: 'https://github.com/marketplace/actions/qtmesheditor'
 };
 
@@ -36,55 +36,70 @@ export const media = {
 };
 
 export const hero = {
-  title: 'Automate your 3D asset pipeline.',
+  title: 'Catch 3D asset issues before they break your game.',
   subtitle:
-    'QtMeshEditor gives indie teams and studios one technical workflow to fix, convert, merge, and automate 3D assets with GUI + CLI + CI/CD support, with repo-wide scanning and validation evolving quickly.',
-  ctaPrimary: 'Download Latest',
+    'QtMeshEditor helps developers and technical artists lint, validate, fix, and track 3D asset pipelines across GUI, CLI, Docker, GitHub Actions, and QtMesh Cloud reporting.',
+  ctaPrimary: 'Download QtMeshEditor',
   ctaSecondary: 'View on GitHub',
   ctaDocs: 'Documentation'
 };
 
-export const proofPoints = ['Free & open source', 'Windows / macOS / Linux', 'GUI + CLI', 'Docker + GitHub Actions'];
+export const proofPoints = [
+  'CI/CD for 3D assets',
+  'GUI + CLI + Docker',
+  'GitHub Actions + QtMesh Cloud',
+  'Open source (MIT)'
+];
 
 export const pipelineFlow = [
   {
     title: 'Scan',
-    body: 'Pipeline scanning is in active development, focused on repo-wide checks for broken files and policy issues.'
+    body: 'Scan repository assets for format, naming, and structural issues before integration.'
   },
   {
     title: 'Validate',
-    body: 'Evolving validation workflows enforce consistency for geometry, naming, and structure before integration.'
+    body: 'Apply quality rules consistently so imports and runtime behavior stay predictable.'
   },
   {
     title: 'Fix & Optimize',
-    body: 'Apply deterministic cleanup and optimization steps so assets remain stable across machines and CI jobs.'
+    body: 'Run deterministic cleanup and optimization to reduce pipeline drift across environments.'
   },
   {
     title: 'Convert & Ship',
-    body: 'Export to engine-ready formats and publish artifacts from local scripts, Docker, or GitHub Actions.'
+    body: 'Convert and publish engine-ready artifacts through local scripts, Docker, and CI.'
   }
 ];
 
-export const useCases = [
+export const beforeAfter = {
+  before: [
+    'Broken animations discovered late',
+    'Missing materials after import',
+    'Inconsistent naming across teams',
+    'Pipeline surprises near release'
+  ],
+  after: [
+    'Validated assets at every push',
+    'Predictable imports and outputs',
+    'CI visibility for asset quality',
+    'Shareable quality badges for stakeholders'
+  ]
+};
+
+export const audienceCards = [
   {
-    title: 'Scan assets in repositories (in progress)',
-    body: 'Add repo-wide checks that surface pipeline issues early and support stricter CI gates over time.'
+    title: 'Indie game developers',
+    body: 'Catch asset regressions early and keep production moving without building custom tooling from scratch.',
+    tag: 'Indie'
   },
   {
-    title: 'Fix and optimize meshes',
-    body: 'Repair and optimize imported assets to keep runtime and tooling behavior predictable.'
+    title: 'Technical artists / pipeline owners',
+    body: 'Standardize checks, automate fixes, and keep DCC-to-engine handoffs consistent across contributors.',
+    tag: 'Technical Art'
   },
   {
-    title: 'Convert across formats',
-    body: 'Move assets between DCC tools and engines with import/export support for 40+ formats.'
-  },
-  {
-    title: 'Merge animation clips',
-    body: 'Combine Mixamo, Unreal exports, and DCC clips into clean output files for engine ingestion.'
-  },
-  {
-    title: 'GitHub Actions (Marketplace)',
-    body: 'Use the onboarding-style workflow template and keep the action ref current from the latest release.'
+    title: 'Studios with CI/CD workflows',
+    body: 'Add quality gates for 3D assets like code, with historical tracking and visible health signals in CI.',
+    tag: 'Studio CI/CD'
   }
 ];
 
@@ -100,20 +115,16 @@ export const pipelineExamples = {
 
 export const cloudBadgeSteps = [
   {
-    title: 'Create your QtMesh Cloud project',
-    body: 'Sign in at qtmesh.dev, then create a project and choose a stable slug for badge URLs.'
+    title: 'Connect a project',
+    body: 'Create a QtMesh Cloud project and store a project token in CI secrets.'
   },
   {
-    title: 'Store your token in CI secrets',
-    body: 'Generate a project token and save it as QTMESH_CLOUD_TOKEN in your GitHub repository secrets.'
+    title: 'Upload scan results on every run',
+    body: 'Send scan JSON to /v1/ingest/scan to keep branch and commit quality history.'
   },
   {
-    title: 'Upload each scan report from CI',
-    body: 'POST the JSON report to /v1/ingest/scan so QtMesh Cloud tracks history and refreshes badge values.'
-  },
-  {
-    title: 'Embed live SVG badges',
-    body: 'Use owner slug + project slug in badge URLs to show real status, errors, and warnings in your README or website.'
+    title: 'Publish live badges',
+    body: 'Expose status, score, errors, and warnings with badge URLs tied to your project.'
   }
 ];
 
@@ -149,26 +160,26 @@ export const cloudBadgeUploadExample = `- name: Scan assets
 export const mixamoSteps = [
   {
     title: 'Import base + clips',
-    body: 'Load a base character and animation clips from Mixamo, Unreal export, or DCC tools.'
+    body: 'Bring in Mixamo, Unreal, and DCC clips around a shared rig base.'
   },
   {
     title: 'Merge into one asset',
-    body: 'Compose multiple actions into one predictable output file for gameplay integration.'
+    body: 'Merge clips into one predictable output for gameplay and content review.'
   },
   {
     title: 'Export to your runtime format',
-    body: 'Export to glTF, FBX-compatible workflows, Collada, OBJ, or Ogre Mesh and continue the pipeline.'
+    body: 'Export to glTF/FBX/Collada/Ogre Mesh and feed directly into CI and engine import.'
   }
 ];
 
 export const highlightFeatures = [
   {
     title: 'Scene save/load',
-    body: 'Store full scenes with meshes, transforms, materials, skeletons, and animations for repeatable edits.'
+    body: 'Store full scenes with meshes, transforms, materials, skeletons, and animations.'
   },
   {
     title: 'Material tools',
-    body: 'Adjust materials visually with realtime feedback during look-dev and technical review.'
+    body: 'Adjust materials visually with realtime feedback for look-dev and QA.'
   },
   {
     title: 'REST API',
@@ -176,7 +187,7 @@ export const highlightFeatures = [
   },
   {
     title: 'MCP / AI agent integration',
-    body: 'Expose pipeline tools through MCP for advanced scripted and agent-driven workflows.'
+    body: 'Expose pipeline tools through MCP for scripted and agent-driven workflows.'
   }
 ];
 
@@ -210,11 +221,11 @@ export const trustItems = [
   },
   {
     title: 'Active since 2012',
-    body: 'Long-running project with continuous evolution across GUI, CLI, and pipeline tooling.'
+    body: 'Long-running project with steady evolution across editor, CLI, and CI workflows.'
   },
   {
     title: 'Pipeline-first by design',
-    body: 'Built around practical asset flow outcomes: validate, fix, convert, merge, and automate.'
+    body: 'Built around real asset outcomes: validate, fix, convert, merge, and automate.'
   }
 ];
 

--- a/website/src/hooks/useQtmeshActionRef.js
+++ b/website/src/hooks/useQtmeshActionRef.js
@@ -1,0 +1,109 @@
+import { useEffect, useState } from 'react';
+
+const QTMESH_RELEASES_LATEST_API = 'https://api.github.com/repos/fernandotonon/QtMeshEditor/releases/latest';
+const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@2.28.0';
+const CACHE_KEY = 'qtmesh.actionRef.cache.v1';
+const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+
+let inFlightRequest = null;
+let memoryCache = null;
+
+function actionRefFromTag(tagName) {
+  const tag = String(tagName || '').trim();
+  if (!tag || !/^v?\d/.test(tag)) return QTMESH_ACTION_REF_FALLBACK;
+  return `fernandotonon/QtMeshEditor@${tag}`;
+}
+
+function isValidCache(payload, now) {
+  if (!payload || typeof payload !== 'object') return false;
+  if (typeof payload.ref !== 'string' || !payload.ref.startsWith('fernandotonon/QtMeshEditor@')) return false;
+  if (typeof payload.fetchedAt !== 'number') return false;
+  if (now - payload.fetchedAt > CACHE_TTL_MS) return false;
+  return true;
+}
+
+function readCache() {
+  const now = Date.now();
+  if (memoryCache && isValidCache(memoryCache, now)) {
+    return memoryCache;
+  }
+
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    const stored = window.localStorage.getItem(CACHE_KEY);
+    if (!stored) return null;
+    const parsed = JSON.parse(stored);
+    if (!isValidCache(parsed, now)) return null;
+    memoryCache = parsed;
+    return parsed;
+  } catch (_error) {
+    return null;
+  }
+}
+
+function writeCache(ref) {
+  const payload = { ref, fetchedAt: Date.now() };
+  memoryCache = payload;
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(CACHE_KEY, JSON.stringify(payload));
+  } catch (_error) {
+    // Ignore storage failures (private mode, quota, etc).
+  }
+}
+
+async function fetchLatestActionRef() {
+  if (inFlightRequest) {
+    return inFlightRequest;
+  }
+
+  inFlightRequest = (async () => {
+    const response = await fetch(QTMESH_RELEASES_LATEST_API, {
+      headers: { Accept: 'application/vnd.github+json' },
+    });
+    if (!response.ok) {
+      throw new Error(`GitHub API request failed with status ${response.status}`);
+    }
+    const payload = await response.json();
+    const resolvedRef = actionRefFromTag(payload?.tag_name);
+    writeCache(resolvedRef);
+    return resolvedRef;
+  })();
+
+  try {
+    return await inFlightRequest;
+  } finally {
+    inFlightRequest = null;
+  }
+}
+
+export default function useQtmeshActionRef() {
+  const cached = readCache();
+  const [qtmeshActionRef, setQtmeshActionRef] = useState(cached?.ref || QTMESH_ACTION_REF_FALLBACK);
+
+  useEffect(() => {
+    const freshCache = readCache();
+    if (freshCache?.ref) {
+      setQtmeshActionRef(freshCache.ref);
+      return undefined;
+    }
+
+    let cancelled = false;
+    fetchLatestActionRef()
+      .then((resolvedRef) => {
+        if (!cancelled) setQtmeshActionRef(resolvedRef);
+      })
+      .catch(() => {
+        // Keep fallback ref when GitHub API is unavailable.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return qtmeshActionRef;
+}


### PR DESCRIPTION
## Summary
- redesign the homepage structure for clearer positioning as "CI/CD for 3D Assets"
- strengthen the hero with a pain-focused value proposition, stronger CTA treatment, and a single primary/secondary CTA set
- add a larger above-the-fold workflow visual and move high-value differentiation earlier (QtMesh Cloud, animation workflow)
- reduce text density with cards, compact sections, details toggles, and tabbed CLI/CI examples
- add new skimmable sections: Before vs After and Who it’s for
- improve install/trust sections and preserve dark technical visual language across responsive breakpoints
- align docs/readme action examples away from stale `@v1` references and use current `@2.28.0` baseline

## Validation
- `npm run build` (in `website/`)

## Notes
- homepage action snippet now resolves the latest release ref from GitHub API at runtime with `@2.28.0` fallback


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Interactive tabbed CLI examples for scan, fix, convert, merge, docker, and GitHub Actions workflows
  * "Before vs After" feature comparison section
  * "Who It's For" audience cards showcasing use cases
  * New quick workflow section with visual CI/CD pipeline overview
  * Badge showcase for QtMesh Cloud integration status

* **Updates**
  * Pinned GitHub Action reference to stable version 2.28.0 for improved reliability
  * Redesigned hero section with updated messaging and visual layout
  * Reorganized landing page sections with streamlined content
  * Updated install options interface and trust metrics display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->