### PR TITLE
feat(bevel): carve concave/convex profile into adjacent faces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 2.28.1 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 2.28.2 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/src/HalfEdgeMesh.cpp
+++ b/src/HalfEdgeMesh.cpp
@@ -2243,15 +2243,27 @@ std::vector<int> HalfEdgeMesh::bevelEdges(const std::vector<int>& edgeIndices, /
                                const std::vector<RingStep>& ring,
                                bool isV1, bool fWalksAB) {
             if (ring.empty()) {
-                // No ring (boundary or non-manifold): 2-face cap via original v.
-                // Skip for shaped profiles so the cap doesn't mask the
-                // concave arc carved into the neighbor faces.
+                // No ring (boundary or non-manifold): no neighbor-face
+                // retriangulation ran, so chain edges aren't already
+                // shared with an adjacent face. Cap the open chamfer end
+                // ourselves. For shaped profiles we fan v across the full
+                // chain polyline (one tri per chain edge); for flat, one
+                // triangle (v, innerA, innerB) suffices.
                 const bool shaped = isV1 ? v1Shaped : v2Shaped;
-                if (shaped) return;
-                int vf1 = innerA, vf2 = innerB;
                 auto tri = [&](int x, int y, int z) {
                     appendTriangle(x, y, z, info.subMeshIndex);
                 };
+                if (shaped) {
+                    const auto& chain = isV1 ? v1Chain : v2Chain;
+                    const bool flip = isV1 ? !fWalksAB : fWalksAB;
+                    for (size_t i = 0; i + 1 < chain.size(); ++i) {
+                        int a = chain[i], b = chain[i + 1];
+                        if (flip) std::swap(a, b);
+                        tri(v, a, b);
+                    }
+                    return;
+                }
+                int vf1 = innerA, vf2 = innerB;
                 if (isV1) {
                     if (fWalksAB) tri(v, vf2, vf1);
                     else          tri(v, vf1, vf2);
@@ -2364,19 +2376,38 @@ std::vector<int> HalfEdgeMesh::bevelEdges(const std::vector<int>& edgeIndices, /
             if (polygon.size() == 2) {
                 if (hasEmittedEdge(polygon[0], polygon[1])) return;
 
-                // For shaped (non-flat) profiles, the chamfer's v-end is
-                // already closed by the front/back neighbor-face splice
-                // (which consumes the chain edges) plus the strip. No cap
-                // is needed — emitting the 3-vertex cap (v, innerA, innerB)
-                // would place a flat triangle covering the concave arc.
-                // The original vertex v ends up unreferenced, which is
-                // harmless (unused vertices are pruned on conversion).
-                const bool shaped = isV1 ? v1Shaped : v2Shaped;
-                if (shaped) return;
-
                 auto tri = [&](int x, int y, int z) {
                     appendTriangle(x, y, z, info.subMeshIndex);
                 };
+
+                // For shaped profiles the single-edge cap (v, innerA,
+                // innerB) would stretch across the concave arc and hide
+                // the intermediate vertices beneath a flat triangle.
+                // Check whether the chain's interior edges are already
+                // covered by the neighbor-face splice — if so, the
+                // chamfer's v-end is already closed and no cap is needed.
+                // If not (e.g. a smooth/no-crease mesh where
+                // processRingNeighbors never fires for this endpoint), we
+                // still need a cap: fan v across the chain polyline so
+                // the cap follows the arc instead of crossing it.
+                const bool shaped = isV1 ? v1Shaped : v2Shaped;
+                if (shaped) {
+                    const auto& chain = isV1 ? v1Chain : v2Chain;
+                    bool chainClosed = true;
+                    for (size_t i = 0; i + 1 < chain.size(); ++i) {
+                        if (!hasEmittedEdge(chain[i], chain[i + 1])) {
+                            chainClosed = false; break;
+                        }
+                    }
+                    if (chainClosed) return;
+                    const bool flip = isV1 ? !fWalksAB : fWalksAB;
+                    for (size_t i = 0; i + 1 < chain.size(); ++i) {
+                        int a = chain[i], b = chain[i + 1];
+                        if (flip) std::swap(a, b);
+                        tri(v, a, b);
+                    }
+                    return;
+                }
                 // Winding: innerA is on the f1 side, innerB on f2 side.
                 // For v1 (the first endpoint) with fWalksAB, the beveled
                 // edge goes v1→v2 inside f1 — so the cap's outward normal

--- a/src/HalfEdgeMesh.cpp
+++ b/src/HalfEdgeMesh.cpp
@@ -31,6 +31,7 @@ THE SOFTWARE.
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <functional>
 #include <set>
 #include <unordered_set>
 
@@ -1182,6 +1183,108 @@ std::vector<int> HalfEdgeMesh::bevelEdges(const std::vector<int>& edgeIndices, /
     // these or to newVertices is a bevel-introduced gap).
     std::unordered_set<int> bevelTouchedVerts;
 
+    // Ear-clip a simple (possibly concave) polygon lying roughly in the
+    // plane of `refNormal`. `poly` is a list of HE vertex indices in
+    // boundary order matching the source face (CCW from outside). Emits
+    // each triangle via `emit` using the refNormal's orientation for
+    // winding. Handles concave polygons produced by splicing chain
+    // intermediates into neighbor-face polygons — a plain fan from poly[0]
+    // would create an artificial diagonal across the concave arc.
+    auto triangulatePolygon = [&](const std::vector<int>& poly,
+                                  const Ogre::Vector3& refNormal,
+                                  const std::function<void(int,int,int)>& emit) {
+        if (poly.size() < 3) return;
+        if (poly.size() == 3) { emit(poly[0], poly[1], poly[2]); return; }
+        Ogre::Vector3 nrm = refNormal;
+        if (nrm.length() < 1e-8f) nrm = Ogre::Vector3::UNIT_Y;
+        else nrm.normalise();
+        Ogre::Vector3 u = std::abs(nrm.x) < 0.9f
+            ? Ogre::Vector3::UNIT_X.crossProduct(nrm)
+            : Ogre::Vector3::UNIT_Y.crossProduct(nrm);
+        u.normalise();
+        Ogre::Vector3 v2 = nrm.crossProduct(u);
+        auto project = [&](const Ogre::Vector3& p) {
+            return Ogre::Vector2(p.dotProduct(u), p.dotProduct(v2));
+        };
+        std::vector<Ogre::Vector2> pts2D;
+        pts2D.reserve(poly.size());
+        for (int idx : poly) pts2D.push_back(project(m_vertices[idx].position));
+        float signedArea = 0.0f;
+        for (size_t i = 0; i < pts2D.size(); ++i) {
+            const auto& a = pts2D[i];
+            const auto& b = pts2D[(i + 1) % pts2D.size()];
+            signedArea += a.x * b.y - b.x * a.y;
+        }
+        std::vector<int> p = poly;
+        std::vector<Ogre::Vector2> pxy = pts2D;
+        bool reversed = false;
+        if (signedArea < 0.0f) {
+            std::reverse(p.begin(), p.end());
+            std::reverse(pxy.begin(), pxy.end());
+            reversed = true;
+        }
+        auto cross2 = [](const Ogre::Vector2& a,
+                         const Ogre::Vector2& b,
+                         const Ogre::Vector2& c) {
+            return (b.x - a.x) * (c.y - a.y)
+                 - (b.y - a.y) * (c.x - a.x);
+        };
+        auto pointInTri = [&](const Ogre::Vector2& q,
+                              const Ogre::Vector2& a,
+                              const Ogre::Vector2& b,
+                              const Ogre::Vector2& c) {
+            float d1 = cross2(q, a, b);
+            float d2 = cross2(q, b, c);
+            float d3 = cross2(q, c, a);
+            bool hasNeg = (d1 < 0) || (d2 < 0) || (d3 < 0);
+            bool hasPos = (d1 > 0) || (d2 > 0) || (d3 > 0);
+            return !(hasNeg && hasPos);
+        };
+        std::vector<bool> removed(p.size(), false);
+        size_t remaining = p.size();
+        size_t cur = 0;
+        int guard = 0;
+        const int guardLimit = static_cast<int>(p.size() * p.size() + 10);
+        // When the 2D orientation was flipped to CCW, emit back in the
+        // caller's original orientation by swapping the last two indices.
+        auto emitKeep = [&](int a, int b, int c) {
+            if (reversed) emit(a, c, b);
+            else          emit(a, b, c);
+        };
+        while (remaining > 3 && guard++ < guardLimit) {
+            while (removed[cur]) cur = (cur + 1) % p.size();
+            size_t prev = (cur + p.size() - 1) % p.size();
+            while (removed[prev]) prev = (prev + p.size() - 1) % p.size();
+            size_t next = (cur + 1) % p.size();
+            while (removed[next]) next = (next + 1) % p.size();
+            const auto& A = pxy[prev];
+            const auto& B = pxy[cur];
+            const auto& C = pxy[next];
+            float conv = cross2(A, B, C);
+            if (conv > 0.0f) {
+                bool isEar = true;
+                for (size_t i = 0; i < p.size(); ++i) {
+                    if (removed[i] || i == prev || i == cur || i == next) continue;
+                    if (pointInTri(pxy[i], A, B, C)) { isEar = false; break; }
+                }
+                if (isEar) {
+                    emitKeep(p[prev], p[cur], p[next]);
+                    removed[cur] = true;
+                    --remaining;
+                    cur = prev;
+                    continue;
+                }
+            }
+            cur = next;
+        }
+        if (remaining == 3) {
+            size_t idx[3]; size_t ii = 0;
+            for (size_t i = 0; i < p.size(); ++i)
+                if (!removed[i]) idx[ii++] = i;
+            if (ii == 3) emitKeep(p[idx[0]], p[idx[1]], p[idx[2]]);
+        }
+    };
+
     for (const auto& info : clean) {
         float w = effectiveWidth(info);
         if (w < 1e-5f) continue;
@@ -1684,6 +1787,81 @@ std::vector<int> HalfEdgeMesh::bevelEdges(const std::vector<int>& edgeIndices, /
                                  fullRingV1, fullRingV2);
 
         // =====================================================================
+        // Build chamfer-chain intermediates here (before Phase 5) so the
+        // neighbor-face retriangulation below can splice them into the cut
+        // polyline when the profile is concave/convex. Phase 6 reuses the
+        // same chains to emit the chamfer-strip tris.
+        //
+        // vChain = [innerA, interm_1, ..., interm_{N-1}, innerB]
+        //        = [f1-side, ..., f2-side] at endpoint v.
+        // Each intermediate offset: (profilePoints[i-1] - 0.5) * w along
+        // `outward` (chord-midpoint toward v). Linear, no sin attenuation.
+        // =====================================================================
+        auto computeOutward = [&](const Ogre::Vector3& pA,
+                                  const Ogre::Vector3& pB,
+                                  const Ogre::Vector3& pV) {
+            const auto chord = pB - pA;
+            auto outward = pV - (pA + pB) * 0.5f;
+            if (const float chordLen2 = chord.squaredLength(); chordLen2 > 1e-12f)
+                outward -= chord * (outward.dotProduct(chord) / chordLen2);
+            if (outward.length() > 1e-6f) outward.normalise();
+            else                          outward = Ogre::Vector3::ZERO;
+            return outward;
+        };
+        auto appendChamferVertex = [&](int v, const Ogre::Vector3& pos) {
+            HEVertex nv = m_vertices[v];
+            nv.position = pos;
+            nv.halfEdge = -1;
+            const auto idx = static_cast<int>(m_vertices.size());
+            m_vertices.push_back(nv);
+            newVertices.push_back(idx);
+            return idx;
+        };
+        auto buildSegmentVerts = [&](int v, int innerA, int innerB) {
+            std::vector<int> chain;
+            chain.reserve(segments + 1);
+            chain.push_back(innerA);
+            if (segments > 1) {
+                const auto pA = m_vertices[innerA].position;
+                const auto pB = m_vertices[innerB].position;
+                const auto chord = pB - pA;
+                const auto outward = computeOutward(pA, pB, m_vertices[v].position);
+                for (int i = 1; i < segments; ++i) {
+                    const float t = static_cast<float>(i)
+                                  / static_cast<float>(segments);
+                    const float pt = profilePoints[i - 1];
+                    const auto pos = pA + chord * t + outward * ((pt - 0.5f) * w);
+                    chain.push_back(appendChamferVertex(v, pos));
+                }
+            }
+            chain.push_back(innerB);
+            return chain;
+        };
+        const std::vector<int> v1Chain = buildSegmentVerts(info.v1, v1a, v1b);
+        const std::vector<int> v2Chain = buildSegmentVerts(info.v2, v2a, v2b);
+
+        // A chain is "shaped" when any interior vertex is non-collinear
+        // with its endpoints. For flat chamfers the chain is collinear and
+        // we keep the plain fan (manifold guarantees hold automatically).
+        auto chainIsShaped = [&](const std::vector<int>& chain) {
+            if (chain.size() <= 2) return false;
+            const auto& pA = m_vertices[chain.front()].position;
+            const auto& pB = m_vertices[chain.back()].position;
+            const auto ab = pB - pA;
+            const float abLen2 = ab.squaredLength();
+            if (abLen2 < 1e-12f) return false;
+            for (size_t i = 1; i + 1 < chain.size(); ++i) {
+                const auto& p = m_vertices[chain[i]].position;
+                const auto d = p - pA;
+                const auto proj = ab * (d.dotProduct(ab) / abLen2);
+                if ((d - proj).squaredLength() > 1e-8f) return true;
+            }
+            return false;
+        };
+        const bool v1Shaped = chainIsShaped(v1Chain);
+        const bool v2Shaped = chainIsShaped(v2Chain);
+
+        // =====================================================================
         // Phase 5: rewire pure-neighbor faces (faces in the ring that aren't
         // f1 or f2). Each neighbor face has 0, 1, or 2 of its v-incident edges
         // as bevel-boundary. Retriangulate accordingly.
@@ -1802,9 +1980,44 @@ std::vector<int> HalfEdgeMesh::bevelEdges(const std::vector<int>& edgeIndices, /
             // v's on-edge offsets on the same edge — those are collinear and
             // produce zero-area tris.
             if (uOut >= 0 && uIn >= 0) {
-                // v cut off; polygon = (uOut, outX, inX, uIn). Fan from uOut.
-                tri(uOut, outX, inX);
-                tri(uOut, inX, uIn);
+                // Base polygon walks v's corner: uOut → outX → inX → uIn,
+                // closing back to uOut. For shaped profiles, insert chain
+                // intermediates between uIn and the close-back-to-uOut so
+                // the cut polyline follows the chamfer curve. The direction
+                // of intermediate insertion is chosen so each chain edge
+                // is emitted in the OPPOSITE direction from the strip's
+                // same-edge emission — yielding a manifold join.
+                std::vector<int> polygon = {uOut, outX, inX, uIn};
+                const bool shaped = (v == info.v1) ? v1Shaped : v2Shaped;
+                if (shaped) {
+                    const auto& chain = (v == info.v1) ? v1Chain : v2Chain;
+                    const int cFront = chain.front();
+                    const int cBack  = chain.back();
+                    if (cFront == uIn && cBack == uOut) {
+                        // Chain runs uIn → ... → uOut. To close the polygon
+                        // uIn → chain[1] → chain[2] → ... → uOut, push
+                        // chain's interior in FORWARD order.
+                        for (size_t i = 1; i + 1 < chain.size(); ++i)
+                            polygon.push_back(chain[i]);
+                    } else if (cFront == uOut && cBack == uIn) {
+                        // Chain runs uOut → ... → uIn. To close uIn → ...
+                        // → uOut, push chain's interior in REVERSE order.
+                        for (size_t i = chain.size() - 2; i >= 1; --i)
+                            polygon.push_back(chain[i]);
+                    }
+                }
+                Ogre::Vector3 refNrm = Ogre::Vector3::ZERO;
+                {
+                    const auto fv = faceVertices(fIdx);
+                    if (fv.size() == 3) {
+                        const auto& p0 = m_vertices[fv[0]].position;
+                        const auto& p1 = m_vertices[fv[1]].position;
+                        const auto& p2 = m_vertices[fv[2]].position;
+                        refNrm = (p1 - p0).crossProduct(p2 - p0);
+                    }
+                }
+                triangulatePolygon(polygon, refNrm,
+                                   [&](int a, int b, int c) { tri(a, b, c); });
             } else if (uOut >= 0) {
                 // Only outX edge is split. Polygon at v's corner = (v, uOut),
                 // then main body (uOut, outX, inX). Tri 1: (v, uOut, inX) =
@@ -1917,6 +2130,24 @@ std::vector<int> HalfEdgeMesh::bevelEdges(const std::vector<int>& edgeIndices, /
                     }
                     polygon.push_back(uRight);
 
+                    // Splice chain intermediates between uRight and the
+                    // implicit close-back-to-uLeft so the neighbor face's
+                    // cut polyline follows the chamfer's concave/convex
+                    // curve instead of a straight diagonal.
+                    const bool shaped = (v == info.v1) ? v1Shaped : v2Shaped;
+                    if (shaped) {
+                        const auto& chain = (v == info.v1) ? v1Chain : v2Chain;
+                        const int cFront = chain.front();
+                        const int cBack  = chain.back();
+                        if (cFront == uLeft && cBack == uRight) {
+                            for (size_t i = chain.size() - 2; i >= 1; --i)
+                                polygon.push_back(chain[i]);
+                        } else if (cFront == uRight && cBack == uLeft) {
+                            for (size_t i = 1; i + 1 < chain.size(); ++i)
+                                polygon.push_back(chain[i]);
+                        }
+                    }
+
                     // Dedupe consecutive duplicates and positional matches.
                     std::vector<int> dedup;
                     dedup.reserve(polygon.size());
@@ -1937,15 +2168,27 @@ std::vector<int> HalfEdgeMesh::bevelEdges(const std::vector<int>& edgeIndices, /
                         continue;
                     }
 
-                    // Emit fan from dedup[0]. Winding: original faces were
-                    // CCW (v, outX, inX) — the polygon as built above walks
-                    // in the same rotational direction around v, so fan from
-                    // dedup[0] preserves CCW.
+                    // Triangulate via ear-clipping. Shaped profiles make
+                    // the polygon concave (intermediates bulge inward), and
+                    // a plain fan from dedup[0] would emit a tri spanning
+                    // the straight diagonal dedup[0]↔dedup[last], hiding
+                    // the concave arc. Ear-clipping handles concave simple
+                    // polygons correctly.
                     int subIdx = m_faces[ring[group[0]].face].subMeshIndex;
-                    for (size_t i = 1; i + 1 < dedup.size(); ++i) {
-                        appendTriangle(dedup[0], dedup[i], dedup[i + 1], subIdx);
-                        recordTriEdges(dedup[0], dedup[i], dedup[i + 1]);
+                    Ogre::Vector3 refNrm = Ogre::Vector3::ZERO;
+                    {
+                        const auto fv = faceVertices(ring[group[0]].face);
+                        if (fv.size() == 3) {
+                            const auto& p0 = m_vertices[fv[0]].position;
+                            const auto& p1 = m_vertices[fv[1]].position;
+                            const auto& p2 = m_vertices[fv[2]].position;
+                            refNrm = (p1 - p0).crossProduct(p2 - p0);
+                        }
                     }
+                    triangulatePolygon(dedup, refNrm, [&](int a, int b, int c) {
+                        appendTriangle(a, b, c, subIdx);
+                        recordTriEdges(a, b, c);
+                    });
                     for (int gi : group) {
                         facesToRemove.push_back(ring[gi].face);
                     }
@@ -1963,87 +2206,8 @@ std::vector<int> HalfEdgeMesh::bevelEdges(const std::vector<int>& edgeIndices, /
 
         // =====================================================================
         // Phase 6: chamfer strip between f1's and f2's inner offsets.
-        //
-        // For segments=1 (default), this is the original two-triangle quad
-        // bridging (v1a, v2a) on f1's side to (v1b, v2b) on f2's side.
-        //
-        // For segments>1, we subdivide the strip into `segments` quads along
-        // a profile curve. At each endpoint v ∈ {v1, v2} we compute N-1
-        // intermediate offset vertices between vA = inner_on_f1 and
-        // vB = inner_on_f2, parametrized t = i / segments for i in [1..N-1].
-        // Position is lerp(vA.pos, vB.pos, t) plus a per-point bulge along
-        // the chamfer-plane normal: offset = (profilePoints[i-1] - 0.5) * w.
-        // - p = 0.5 → flat (no bulge), reproduces the original geometry.
-        // - p > 0.5 → convex (rounded outward, fillet-like).
-        // - p < 0.5 → concave (cut inward, groove-like).
-        //
-        // The scalar-profile entry point (scalar overload) pre-fills the
-        // vector with the old sin-envelope so the single-number UX keeps
-        // working; callers with explicit per-segment values get a linear
-        // interpretation matching what the user draws in the graph.
-        //
-        // The bulge direction "outward" is away from v (the original corner
-        // we cut off), so positive bulge pushes the strip toward where the
-        // original sharp edge USED to be.
-        //
-        // We do NOT record these edges in emittedEdges because the cap check
-        // in buildCorner is "does a NON-CHAMFER tri cover the chamfer-end
-        // edge?". The chamfer itself always has that edge.
+        // Chain intermediates were built before Phase 5 (see above).
         // =====================================================================
-        // Outward bulge direction: from the chord midpoint toward the
-        // original corner v. Convex profile bulges in this direction
-        // (rounded fillet), concave bulges opposite (digs into the solid).
-        auto computeOutward = [&](const Ogre::Vector3& pA,
-                                  const Ogre::Vector3& pB,
-                                  const Ogre::Vector3& pV) {
-            const auto chord = pB - pA;
-            auto outward = pV - (pA + pB) * 0.5f;
-            if (const float chordLen2 = chord.squaredLength(); chordLen2 > 1e-12f)
-                outward -= chord * (outward.dotProduct(chord) / chordLen2);
-            if (outward.length() > 1e-6f) outward.normalise();
-            else                          outward = Ogre::Vector3::ZERO;
-            return outward;
-        };
-
-        // Append one new vertex cloned from `v` and positioned at `pos`.
-        // Returns the new vertex index and records it in newVertices.
-        auto appendChamferVertex = [&](int v, const Ogre::Vector3& pos) {
-            HEVertex nv = m_vertices[v];
-            nv.position = pos;
-            nv.halfEdge = -1;
-            const auto idx = static_cast<int>(m_vertices.size());
-            m_vertices.push_back(nv);
-            newVertices.push_back(idx);
-            return idx;
-        };
-
-        // Build one endpoint's chain: innerA → N-1 intermediates → innerB.
-        // Each intermediate is offset along `outward` by
-        //   (profilePoints[i-1] - 0.5) * w
-        // linearly. The user's drawn curve translates directly into the
-        // resulting bulge.
-        auto buildSegmentVerts = [&](int v, int innerA, int innerB) {
-            std::vector<int> chain;
-            chain.reserve(segments + 1);
-            chain.push_back(innerA);
-            if (segments > 1) {
-                const auto pA = m_vertices[innerA].position;
-                const auto pB = m_vertices[innerB].position;
-                const auto chord = pB - pA;
-                const auto outward = computeOutward(pA, pB, m_vertices[v].position);
-                for (int i = 1; i < segments; ++i) {
-                    const float t = static_cast<float>(i)
-                                  / static_cast<float>(segments);
-                    const float pt = profilePoints[i - 1];
-                    const auto pos = pA + chord * t + outward * ((pt - 0.5f) * w);
-                    chain.push_back(appendChamferVertex(v, pos));
-                }
-            }
-            chain.push_back(innerB);
-            return chain;
-        };
-        const std::vector<int> v1Chain = buildSegmentVerts(info.v1, v1a, v1b);
-        const std::vector<int> v2Chain = buildSegmentVerts(info.v2, v2a, v2b);
         // Emit two triangles per strip i: bridges chain[i]->chain[i+1] on each
         // endpoint. Original (segments=1) winding is preserved when N=1.
         for (int i = 0; i < segments; ++i) {
@@ -2080,8 +2244,10 @@ std::vector<int> HalfEdgeMesh::bevelEdges(const std::vector<int>& edgeIndices, /
                                bool isV1, bool fWalksAB) {
             if (ring.empty()) {
                 // No ring (boundary or non-manifold): 2-face cap via original v.
-                // Use the same winding as the full-ring cap below — the cap
-                // geometry is identical in both cases.
+                // Skip for shaped profiles so the cap doesn't mask the
+                // concave arc carved into the neighbor faces.
+                const bool shaped = isV1 ? v1Shaped : v2Shaped;
+                if (shaped) return;
                 int vf1 = innerA, vf2 = innerB;
                 auto tri = [&](int x, int y, int z) {
                     appendTriangle(x, y, z, info.subMeshIndex);
@@ -2197,6 +2363,17 @@ std::vector<int> HalfEdgeMesh::bevelEdges(const std::vector<int>& edgeIndices, /
             }
             if (polygon.size() == 2) {
                 if (hasEmittedEdge(polygon[0], polygon[1])) return;
+
+                // For shaped (non-flat) profiles, the chamfer's v-end is
+                // already closed by the front/back neighbor-face splice
+                // (which consumes the chain edges) plus the strip. No cap
+                // is needed — emitting the 3-vertex cap (v, innerA, innerB)
+                // would place a flat triangle covering the concave arc.
+                // The original vertex v ends up unreferenced, which is
+                // harmless (unused vertices are pruned on conversion).
+                const bool shaped = isV1 ? v1Shaped : v2Shaped;
+                if (shaped) return;
+
                 auto tri = [&](int x, int y, int z) {
                     appendTriangle(x, y, z, info.subMeshIndex);
                 };

--- a/src/HalfEdgeMesh_test.cpp
+++ b/src/HalfEdgeMesh_test.cpp
@@ -2681,12 +2681,37 @@ namespace {
     }
 }
 
+// A v5-side intermediate must lie OFF both bevel-boundary cube edges
+// (v5↔v4 along -X and v5↔v7 along -Y). v1a lies on v5→v4, v1b on
+// v5→v7 — those are end-offsets, not shaped chain interior. A true
+// interior vertex is offset along the XY diagonal away from v5.
+namespace {
+    bool isStrictInteriorAtV5(const Ogre::Vector3& p) {
+        // Edge v5→v4 has y=1, z=1; edge v5→v7 has x=1, z=1.
+        const bool onV5V4 = std::abs(p.y - 1.0f) < 1e-4f
+                         && std::abs(p.z - 1.0f) < 1e-4f;
+        const bool onV5V7 = std::abs(p.x - 1.0f) < 1e-4f
+                         && std::abs(p.z - 1.0f) < 1e-4f;
+        return !onV5V4 && !onV5V7;
+    }
+    bool isStrictInteriorAtV3(const Ogre::Vector3& p) {
+        // Edge v3→v2 (x=-1 at... actually v2=(-1,1,-1), so v3→v2 has y=1,z=-1);
+        // edge v3→v1 has (v1=(1,-1,-1)) so x=1,z=-1.
+        const bool onV3V2 = std::abs(p.y - 1.0f) < 1e-4f
+                         && std::abs(p.z + 1.0f) < 1e-4f;
+        const bool onV3V1 = std::abs(p.x - 1.0f) < 1e-4f
+                         && std::abs(p.z + 1.0f) < 1e-4f;
+        return !onV3V2 && !onV3V1;
+    }
+}
+
 TEST(HalfEdgeMeshStandalone, BevelConcaveCarvesAdjacentFaces) {
     // Beveling the top-right cube edge (v5-v3 along Z) with a concave
     // profile should leave the +Z and -Z faces with triangulations that
-    // reference the chain intermediates. Without the splice those faces
-    // would be fanned straight across the cut corner and never touch any
-    // intermediate vertex.
+    // reference the STRICT chain interior — not the inner offsets
+    // v1a/v1b/v2a/v2b which a straight-cut triangulation would already
+    // include. Without the splice the adjacent faces are fanned across
+    // the cut corner and never touch an interior vertex.
     auto em = makeCubeMesh();
     HalfEdgeMesh he;
     ASSERT_TRUE(he.buildFromEditableMesh(em));
@@ -2698,18 +2723,19 @@ TEST(HalfEdgeMeshStandalone, BevelConcaveCarvesAdjacentFaces) {
     ASSERT_TRUE(he.toEditableMesh(back));
     EXPECT_TRUE(isManifold(back));
 
-    // Collect chain intermediate positions at each endpoint (they're the
-    // new verts with Z matching each cube face).
+    // Strict interiors only: new verts on each plane that aren't on
+    // either bevel-boundary cube edge at that endpoint.
     std::vector<Ogre::Vector3> interZpos, interZneg;
     for (int v : newVerts) {
         const auto& p = he.vertex(v).position;
-        if (std::abs(p.z - 1.0f) < 1e-4f) interZpos.push_back(p);
-        else if (std::abs(p.z + 1.0f) < 1e-4f) interZneg.push_back(p);
+        if (std::abs(p.z - 1.0f) < 1e-4f && isStrictInteriorAtV5(p))
+            interZpos.push_back(p);
+        else if (std::abs(p.z + 1.0f) < 1e-4f && isStrictInteriorAtV3(p))
+            interZneg.push_back(p);
     }
-    // With segments=4 we have N-1=3 intermediates per endpoint plus the
-    // inner offsets v1a/v1b (also at z=±1). Expect at least 3 per side.
-    ASSERT_GE(interZpos.size(), 3u);
-    ASSERT_GE(interZneg.size(), 3u);
+    // segments=4 → exactly 3 strict interior intermediates per endpoint.
+    ASSERT_EQ(interZpos.size(), 3u);
+    ASSERT_EQ(interZneg.size(), 3u);
 
     const Ogre::Vector3 v5(1, 1, 1);
     const Ogre::Vector3 v3(1, 1, -1);
@@ -2717,11 +2743,11 @@ TEST(HalfEdgeMeshStandalone, BevelConcaveCarvesAdjacentFaces) {
     auto probeBack  = probeFaceAtPlane(back, -1.0f, v3, interZneg);
 
     EXPECT_TRUE(probeFront.refsIntermediate)
-        << "front face (+Z) triangulation must reference at least one "
-           "chain intermediate when the profile is concave";
+        << "front face (+Z) triangulation must reference a strict chain "
+           "interior vertex when the profile is concave";
     EXPECT_TRUE(probeBack.refsIntermediate)
-        << "back face (-Z) triangulation must reference at least one "
-           "chain intermediate when the profile is concave";
+        << "back face (-Z) triangulation must reference a strict chain "
+           "interior vertex when the profile is concave";
 }
 
 TEST(HalfEdgeMeshStandalone, BevelConcaveRemovesOriginalCornerFromCap) {
@@ -2778,14 +2804,16 @@ TEST(HalfEdgeMeshStandalone, BevelFlatStillManifold) {
 }
 
 TEST(HalfEdgeMeshStandalone, BevelConvexCarvesAdjacentFaces) {
-    // Convex profile variant: intermediates bulge outward, but they still
-    // must end up on the adjacent faces' triangulation.
+    // Convex profile (moderate 0.75). Max convex (1.0) pushes some
+    // intermediates past the face plane's own edges, which is a visual
+    // edge case — use a moderate value so the interior stays within the
+    // face and we can probe that the adjacent face references it.
     auto em = makeCubeMesh();
     HalfEdgeMesh he;
     ASSERT_TRUE(he.buildFromEditableMesh(em));
     int edgeIdx = findEdge(he, 5, 3);
     ASSERT_GE(edgeIdx, 0);
-    auto newVerts = he.bevelEdges({edgeIdx}, 0.1f, 4, 1.0f);
+    auto newVerts = he.bevelEdges({edgeIdx}, 0.1f, 4, 0.75f);
     ASSERT_FALSE(newVerts.empty());
     EditableMesh back;
     ASSERT_TRUE(he.toEditableMesh(back));
@@ -2794,9 +2822,13 @@ TEST(HalfEdgeMeshStandalone, BevelConvexCarvesAdjacentFaces) {
     std::vector<Ogre::Vector3> interZpos, interZneg;
     for (int v : newVerts) {
         const auto& p = he.vertex(v).position;
-        if (std::abs(p.z - 1.0f) < 1e-4f) interZpos.push_back(p);
-        else if (std::abs(p.z + 1.0f) < 1e-4f) interZneg.push_back(p);
+        if (std::abs(p.z - 1.0f) < 1e-4f && isStrictInteriorAtV5(p))
+            interZpos.push_back(p);
+        else if (std::abs(p.z + 1.0f) < 1e-4f && isStrictInteriorAtV3(p))
+            interZneg.push_back(p);
     }
+    ASSERT_GE(interZpos.size(), 1u);
+    ASSERT_GE(interZneg.size(), 1u);
     const Ogre::Vector3 v5(1, 1, 1);
     const Ogre::Vector3 v3(1, 1, -1);
     auto probeFront = probeFaceAtPlane(back,  1.0f, v5, interZpos);

--- a/src/HalfEdgeMesh_test.cpp
+++ b/src/HalfEdgeMesh_test.cpp
@@ -2625,3 +2625,182 @@ TEST(HalfEdgeMeshStandalone, BevelVectorOverloadAllConvexMovesPointsToward) {
     ASSERT_FALSE(std::isnan(dConvex));
     EXPECT_LT(dConvex, dFlat) << "all-convex points should pull the strip toward v5";
 }
+
+// ===========================================================================
+// Tests: shaped profile carves into adjacent (non-beveled) faces
+// ===========================================================================
+//
+// When the chamfer profile is concave or convex, the chain intermediates must
+// become part of the adjacent faces' triangulation — not just the chamfer
+// strip. Without this the adjacent faces keep a straight cut and hide the
+// profile. These tests verify the triangulation on the +Z and -Z cube faces
+// (the faces perpendicular to the beveled edge v5-v3) actually references
+// the intermediate vertices, and that no flat cap triangle is emitted at
+// the bevel endpoints.
+
+namespace {
+    struct AdjFaceProbe {
+        size_t triCountOnPlane = 0;   // tris whose verts all lie on the plane
+        bool refsIntermediate = false; // any tri uses a chain intermediate?
+        bool hasOriginalCorner = false; // any tri uses the original v5 / v3?
+    };
+
+    // Probe triangles lying on `z = planeZ` (within tolerance). `corner` is
+    // the cube corner vertex (v5 or v3) at that plane. `intermediates`
+    // are positions the chain produced (same Z). Returns counts/flags.
+    AdjFaceProbe probeFaceAtPlane(const EditableMesh& em,
+                                  float planeZ,
+                                  const Ogre::Vector3& corner,
+                                  const std::vector<Ogre::Vector3>& intermediates)
+    {
+        AdjFaceProbe p;
+        const auto& sub = em.subMeshes()[0];
+        auto isOnPlane = [&](unsigned idx) {
+            return std::abs(sub.vertices[idx].position.z - planeZ) < 1e-4f;
+        };
+        auto isCorner = [&](unsigned idx) {
+            return sub.vertices[idx].position.squaredDistance(corner) < 1e-6f;
+        };
+        auto isIntermediate = [&](unsigned idx) {
+            const auto& pos = sub.vertices[idx].position;
+            for (const auto& ip : intermediates)
+                if (pos.squaredDistance(ip) < 1e-5f) return true;
+            return false;
+        };
+        for (const auto& tri : sub.triangles) {
+            if (!isOnPlane(tri.indices[0])) continue;
+            if (!isOnPlane(tri.indices[1])) continue;
+            if (!isOnPlane(tri.indices[2])) continue;
+            ++p.triCountOnPlane;
+            for (int k = 0; k < 3; ++k) {
+                if (isIntermediate(tri.indices[k])) p.refsIntermediate = true;
+                if (isCorner(tri.indices[k])) p.hasOriginalCorner = true;
+            }
+        }
+        return p;
+    }
+}
+
+TEST(HalfEdgeMeshStandalone, BevelConcaveCarvesAdjacentFaces) {
+    // Beveling the top-right cube edge (v5-v3 along Z) with a concave
+    // profile should leave the +Z and -Z faces with triangulations that
+    // reference the chain intermediates. Without the splice those faces
+    // would be fanned straight across the cut corner and never touch any
+    // intermediate vertex.
+    auto em = makeCubeMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    int edgeIdx = findEdge(he, 5, 3);
+    ASSERT_GE(edgeIdx, 0);
+    auto newVerts = he.bevelEdges({edgeIdx}, 0.1f, 4, 0.0f);
+    ASSERT_FALSE(newVerts.empty());
+    EditableMesh back;
+    ASSERT_TRUE(he.toEditableMesh(back));
+    EXPECT_TRUE(isManifold(back));
+
+    // Collect chain intermediate positions at each endpoint (they're the
+    // new verts with Z matching each cube face).
+    std::vector<Ogre::Vector3> interZpos, interZneg;
+    for (int v : newVerts) {
+        const auto& p = he.vertex(v).position;
+        if (std::abs(p.z - 1.0f) < 1e-4f) interZpos.push_back(p);
+        else if (std::abs(p.z + 1.0f) < 1e-4f) interZneg.push_back(p);
+    }
+    // With segments=4 we have N-1=3 intermediates per endpoint plus the
+    // inner offsets v1a/v1b (also at z=±1). Expect at least 3 per side.
+    ASSERT_GE(interZpos.size(), 3u);
+    ASSERT_GE(interZneg.size(), 3u);
+
+    const Ogre::Vector3 v5(1, 1, 1);
+    const Ogre::Vector3 v3(1, 1, -1);
+    auto probeFront = probeFaceAtPlane(back,  1.0f, v5, interZpos);
+    auto probeBack  = probeFaceAtPlane(back, -1.0f, v3, interZneg);
+
+    EXPECT_TRUE(probeFront.refsIntermediate)
+        << "front face (+Z) triangulation must reference at least one "
+           "chain intermediate when the profile is concave";
+    EXPECT_TRUE(probeBack.refsIntermediate)
+        << "back face (-Z) triangulation must reference at least one "
+           "chain intermediate when the profile is concave";
+}
+
+TEST(HalfEdgeMeshStandalone, BevelConcaveRemovesOriginalCornerFromCap) {
+    // When the profile is shaped, the endpoint corner cap would mask the
+    // concave arc on the adjacent faces with a flat triangle. The bevel
+    // skips the cap for shaped profiles — so after the operation the
+    // original corner vertex (v5 / v3) should not be referenced by any
+    // triangle.
+    auto em = makeCubeMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    int edgeIdx = findEdge(he, 5, 3);
+    ASSERT_GE(edgeIdx, 0);
+    auto newVerts = he.bevelEdges({edgeIdx}, 0.1f, 4, 0.0f);
+    ASSERT_FALSE(newVerts.empty());
+    EditableMesh back;
+    ASSERT_TRUE(he.toEditableMesh(back));
+
+    const auto& sub = back.subMeshes()[0];
+    const Ogre::Vector3 v5(1, 1, 1);
+    const Ogre::Vector3 v3(1, 1, -1);
+    auto usesCorner = [&](const Ogre::Vector3& corner) {
+        for (const auto& tri : sub.triangles) {
+            for (int k = 0; k < 3; ++k) {
+                if (sub.vertices[tri.indices[k]].position
+                        .squaredDistance(corner) < 1e-6f) return true;
+            }
+        }
+        return false;
+    };
+    EXPECT_FALSE(usesCorner(v5))
+        << "v5 should be unreferenced (cap skipped) for shaped profile";
+    EXPECT_FALSE(usesCorner(v3))
+        << "v3 should be unreferenced (cap skipped) for shaped profile";
+}
+
+TEST(HalfEdgeMeshStandalone, BevelFlatStillManifold) {
+    // Sanity guard for the cap-skip change: a plain flat chamfer must
+    // remain closed (manifold) across both bevel endpoints. Neither cap
+    // nor splice should be needed when the chamfer strip's v-end edge is
+    // already a single straight edge shared with the neighbor face group.
+    auto em = makeCubeMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    int edgeIdx = findEdge(he, 5, 3);
+    ASSERT_GE(edgeIdx, 0);
+    auto newVerts = he.bevelEdges({edgeIdx}, 0.1f);
+    ASSERT_FALSE(newVerts.empty());
+    EditableMesh back;
+    ASSERT_TRUE(he.toEditableMesh(back));
+    EXPECT_TRUE(isManifold(back));
+    const auto stats = statsOf(back);
+    EXPECT_EQ(stats.boundaryEdges, 0u);
+}
+
+TEST(HalfEdgeMeshStandalone, BevelConvexCarvesAdjacentFaces) {
+    // Convex profile variant: intermediates bulge outward, but they still
+    // must end up on the adjacent faces' triangulation.
+    auto em = makeCubeMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    int edgeIdx = findEdge(he, 5, 3);
+    ASSERT_GE(edgeIdx, 0);
+    auto newVerts = he.bevelEdges({edgeIdx}, 0.1f, 4, 1.0f);
+    ASSERT_FALSE(newVerts.empty());
+    EditableMesh back;
+    ASSERT_TRUE(he.toEditableMesh(back));
+    EXPECT_TRUE(isManifold(back));
+
+    std::vector<Ogre::Vector3> interZpos, interZneg;
+    for (int v : newVerts) {
+        const auto& p = he.vertex(v).position;
+        if (std::abs(p.z - 1.0f) < 1e-4f) interZpos.push_back(p);
+        else if (std::abs(p.z + 1.0f) < 1e-4f) interZneg.push_back(p);
+    }
+    const Ogre::Vector3 v5(1, 1, 1);
+    const Ogre::Vector3 v3(1, 1, -1);
+    auto probeFront = probeFaceAtPlane(back,  1.0f, v5, interZpos);
+    auto probeBack  = probeFaceAtPlane(back, -1.0f, v3, interZneg);
+    EXPECT_TRUE(probeFront.refsIntermediate);
+    EXPECT_TRUE(probeBack.refsIntermediate);
+}


### PR DESCRIPTION
## Summary
- The profile graph now visibly carves into the faces adjacent to the beveled edge — not just the chamfer strip — so concave/convex profiles look right from any angle.
- Flat chamfer behavior is unchanged; all existing bevel tests still pass.

## Details
Previously the chamfer strip showed the profile curve correctly, but the two faces perpendicular to the beveled edge kept a straight diagonal cut. That's because Phase 5 neighbor retriangulation ran before the chain intermediates were built, and its fan-from-vertex triangulation covered the cut region with a straight spoke that hid the arc.

This PR:
- Moves chain construction ahead of Phase 5 so both retriangulation paths can see the intermediates.
- Splices intermediates into the neighbor-face polygon in both code paths (group-merge + single-face).
- Adds a generic ear-clipping helper (`triangulatePolygon`) so the resulting concave polygons triangulate without artificial diagonals.
- Matches insertion direction on each side so chain edges pair up opposite to the strip's emissions (manifold).
- Skips the endpoint corner cap (`buildCorner`) when the profile is shaped, since the flat cap would otherwise mask the arc.

## Tests
4 new unit tests verify:
- Adjacent faces reference chain intermediates for concave profiles.
- Same for convex profiles.
- Original corner vertex is unreferenced when shaped.
- Flat chamfer remains manifold (regression guard).

## Test plan
- [x] `UnitTests --gtest_filter="*Bevel*"` — 39 bevel tests pass.
- [x] Interactive verification: bevel a cube's corner edge, raise segments, drag profile concave → concave arcs visible on both front and back faces.
- [ ] CI: Linux / macOS / Windows builds, unit-tests-linux, SonarCloud, CodeRabbit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump to 2.28.2

* **Bug Fixes**
  * Improved triangulation robustness for chamfered concave polygons
  * Fixed chamfer cap behavior for shaped profiles to prevent overlap artifacts

* **Tests**
  * Added regression tests for shaped profile bevel operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->