### PR TITLE
feat(bevel): add vertex-bevel (corner cut)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 2.28.2 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 2.29.0 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -503,11 +503,13 @@ Rectangle {
                 }
             }
 
-            // Bevel button (edge mode only)
+            // Bevel button (edge or vertex mode)
             Rectangle {
                 property string shortcutLabel: Qt.platform.os === "osx" ? "Cmd+B" : "Ctrl+B"
                 width: parent.width - 16; height: 26; radius: 3
-                visible: EditModeController.editModeActive && EditModeController.selectionMode === 1
+                visible: EditModeController.editModeActive
+                      && (EditModeController.selectionMode === 1
+                          || EditModeController.selectionMode === 0)
                 color: bevelMouse.pressed ? Qt.darker(PropertiesPanelController.highlightColor, 1.2)
                      : bevelMouse.containsMouse ? Qt.lighter(PropertiesPanelController.highlightColor, 1.1)
                      : PropertiesPanelController.highlightColor
@@ -527,8 +529,10 @@ Rectangle {
                 width: parent.width - 16
                 spacing: 4
 
-                // Segments
+                // Segments (edge-bevel only — vertex bevel is flat for
+                // now; rounded-dome is a future extension).
                 Row {
+                    visible: EditModeController.selectionMode === 1
                     width: parent.width
                     spacing: 6
                     Text {
@@ -549,10 +553,10 @@ Rectangle {
                 }
 
                 // Profile shape — 2D graph control with one handle per
-                // interior segment. Only shown when segments > 1 (a single
-                // segment has no interior points to shape).
+                // interior segment. Only shown in edge mode with segments > 1.
                 Column {
-                    visible: EditModeController.bevelSegmentsValue > 1
+                    visible: EditModeController.selectionMode === 1
+                         && EditModeController.bevelSegmentsValue > 1
                     width: parent.width
                     spacing: 4
 

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -1555,23 +1555,159 @@ bool EditModeController::applyBevelTopology(
     return true;
 }
 
+bool EditModeController::applyBevelVertexTopology(
+    const std::vector<int>& vertexIndices, float width,
+    int segments, const std::vector<float>& profilePoints)
+{
+    if (!m_editModeActive || !m_editableMesh || !m_editEntity)
+        return false;
+    if (vertexIndices.empty() || width <= 0.0f)
+        return false;
+
+    HalfEdgeMesh heMesh;
+    if (!heMesh.buildFromEditableMesh(*m_editableMesh))
+        return false;
+
+    // Map global selection indices to HE indices by position match.
+    // HE indexing preserves (submesh, local) so a straight offset walk
+    // works: global = sum of prior subs' vertex counts + local.
+    // We instead just match by position because global-index plumbing
+    // elsewhere (selection set) stores them that way already.
+    std::vector<int> heIndices;
+    heIndices.reserve(vertexIndices.size());
+    {
+        int globalIdx = 0;
+        auto& subs = m_editableMesh->subMeshes();
+        for (size_t s = 0; s < subs.size(); ++s) {
+            for (size_t v = 0; v < subs[s].vertices.size(); ++v) {
+                int g = globalIdx + static_cast<int>(v);
+                if (std::find(vertexIndices.begin(), vertexIndices.end(), g)
+                    != vertexIndices.end()) {
+                    // The HE mesh indexes one HEVertex per (submesh, local)
+                    // in the order subs were built — same as `globalIdx + v`.
+                    heIndices.push_back(g);
+                }
+            }
+            globalIdx += static_cast<int>(subs[s].vertices.size());
+        }
+    }
+    if (heIndices.empty()) return false;
+
+    std::vector<int> newHEVertices =
+        heMesh.bevelVertices(heIndices, width, segments, 0.5f, profilePoints);
+    if (newHEVertices.empty())
+        return false;
+
+    std::vector<Ogre::Vector3> newVertPositions;
+    newVertPositions.reserve(newHEVertices.size());
+    for (int heVert : newHEVertices)
+        newVertPositions.push_back(heMesh.vertex(heVert).position);
+
+    EditableMesh newMesh;
+    if (!heMesh.toEditableMesh(newMesh))
+        return false;
+
+    m_editableMesh->subMeshes() = std::move(newMesh.subMeshes());
+
+    if (m_normalsMode == 0)
+        m_editableMesh->recalculateNormals();
+    else
+        m_editableMesh->recalculateNormalsFlat();
+
+    if (!m_editableMesh->resizeEntityBuffers(m_editEntity))
+        return false;
+
+    std::vector<std::string> preMats;
+    preMats.reserve(m_editEntity->getNumSubEntities());
+    for (unsigned int i = 0; i < m_editEntity->getNumSubEntities(); ++i)
+        preMats.push_back(m_editEntity->getSubEntity(i)->getMaterialName());
+
+    m_editEntity->_deinitialise();
+    m_editEntity->_initialise(true);
+
+    for (unsigned int i = 0;
+         i < m_editEntity->getNumSubEntities() && i < preMats.size(); ++i) {
+        if (!preMats[i].empty())
+            m_editEntity->getSubEntity(i)->setMaterialName(preMats[i]);
+    }
+
+    auto* shaderGen = Ogre::RTShader::ShaderGenerator::getSingletonPtr();
+    if (shaderGen) {
+        for (unsigned int i = 0; i < m_editEntity->getNumSubEntities(); ++i) {
+            const std::string& matName = m_editEntity->getSubEntity(i)->getMaterialName();
+            if (!matName.empty())
+                shaderGen->invalidateMaterial(
+                    Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME, matName);
+        }
+    }
+
+    m_selectedVertices.clear();
+    m_selectedEdges.clear();
+    m_selectedFaces.clear();
+
+    std::set<int> newGlobalVerts;
+    for (const auto& pos : newVertPositions) {
+        int globalIdx = 0;
+        bool found = false;
+        for (size_t s = 0; s < m_editableMesh->subMeshes().size() && !found; ++s) {
+            const auto& verts = m_editableMesh->subMeshes()[s].vertices;
+            for (size_t v = 0; v < verts.size(); ++v) {
+                if (verts[v].position.squaredDistance(pos) < 1e-8f) {
+                    newGlobalVerts.insert(globalIdx + static_cast<int>(v));
+                    found = true;
+                    break;
+                }
+            }
+            globalIdx += static_cast<int>(verts.size());
+        }
+    }
+    m_selectedVertices = newGlobalVerts;
+
+    refreshNormalVisualizer();
+    updateSelectionOverlay();
+    validateMesh();
+
+    emit meshDataChanged();
+    emit editSelectionChanged();
+    emit selectionModeChanged();
+    emit editModeChanged();
+
+    return true;
+}
+
+bool EditModeController::reapplyActiveBevel(
+    float width, int segments, const std::vector<float>& profilePoints)
+{
+    if (!m_bevelSession.active) return false;
+    if (m_bevelSession.kind == BevelSession::Vertices)
+        return applyBevelVertexTopology(m_bevelSession.targetVertices,
+                                        width, segments, profilePoints);
+    return applyBevelTopology(m_bevelSession.targetEdges, width,
+                              segments, profilePoints);
+}
+
 bool EditModeController::beginBevel()
 {
     if (m_bevelSession.active)
         return false;
     if (!m_editModeActive || !m_editableMesh || !m_editEntity)
         return false;
-    if (m_selectionMode != EdgeMode || m_selectedEdges.empty())
-        return false;
+    const bool edgeValid = (m_selectionMode == EdgeMode && !m_selectedEdges.empty());
+    const bool vertValid = (m_selectionMode == VertexMode && !m_selectedVertices.empty());
+    if (!edgeValid && !vertValid) return false;
 
     SentryReporter::addBreadcrumb("edit_mode", "Bevel: begin session");
 
     BevelSession s;
+    s.kind = edgeValid ? BevelSession::Edges : BevelSession::Vertices;
     s.originalSubMeshes = m_editableMesh->subMeshes();
     s.origSelectedVertices = m_selectedVertices;
     s.origSelectedEdges = m_selectedEdges;
     s.origSelectedFaces = m_selectedFaces;
-    s.targetEdges.assign(m_selectedEdges.begin(), m_selectedEdges.end());
+    if (edgeValid)
+        s.targetEdges.assign(m_selectedEdges.begin(), m_selectedEdges.end());
+    else
+        s.targetVertices.assign(m_selectedVertices.begin(), m_selectedVertices.end());
 
     // Compute gizmo pivot (centroid of edge endpoints) and axis (averaged
     // adjacent-face normal at those edges). Uses the pre-bevel mesh so the
@@ -1593,20 +1729,31 @@ bool EditModeController::beginBevel()
             }
             return Ogre::Vector3::ZERO;
         };
-        for (const auto& [v1, v2] : s.targetEdges) {
-            Ogre::Vector3 a = posOf(v1);
-            Ogre::Vector3 b = posOf(v2);
-            pivot += (a + b) * 0.5f;
-            ++pivotCount;
+        if (s.kind == BevelSession::Edges) {
+            for (const auto& [v1, v2] : s.targetEdges) {
+                Ogre::Vector3 a = posOf(v1);
+                Ogre::Vector3 b = posOf(v2);
+                pivot += (a + b) * 0.5f;
+                ++pivotCount;
+            }
+        } else {
+            for (int vIdx : s.targetVertices) {
+                pivot += posOf(vIdx);
+                ++pivotCount;
+            }
         }
         if (pivotCount > 0) pivot /= static_cast<float>(pivotCount);
 
-        // Sum per-face normals of triangles containing any selected-edge
+        // Sum per-face normals of triangles containing any selected
         // vertex. Gives a reasonable "outward" axis even for irregular fans.
         std::set<int> edgeVerts;
-        for (const auto& [v1, v2] : s.targetEdges) {
-            edgeVerts.insert(v1);
-            edgeVerts.insert(v2);
+        if (s.kind == BevelSession::Edges) {
+            for (const auto& [v1, v2] : s.targetEdges) {
+                edgeVerts.insert(v1);
+                edgeVerts.insert(v2);
+            }
+        } else {
+            for (int vIdx : s.targetVertices) edgeVerts.insert(vIdx);
         }
         int vertOffset = 0;
         for (const auto& sub : subs) {
@@ -1632,7 +1779,10 @@ bool EditModeController::beginBevel()
     s.axis = (normalSum.length() > 1e-6f) ? normalSum.normalisedCopy() : Ogre::Vector3::UNIT_Y;
     s.width = 0.05f; // 2.5% of a 2-unit cube — visible initial chamfer
 
-    if (!applyBevelTopology(s.targetEdges, s.width)) {
+    const bool applied = (s.kind == BevelSession::Edges)
+        ? applyBevelTopology(s.targetEdges, s.width)
+        : applyBevelVertexTopology(s.targetVertices, s.width);
+    if (!applied) {
         // Failed — undo any partial state by restoring the snapshot.
         m_editableMesh->subMeshes() = std::move(s.originalSubMeshes);
         m_selectedVertices = std::move(s.origSelectedVertices);
@@ -1725,8 +1875,8 @@ void EditModeController::updateBevelWidth(float width)
     m_selectedEdges = m_bevelSession.origSelectedEdges;
     m_selectedFaces = m_bevelSession.origSelectedFaces;
 
-    if (applyBevelTopology(m_bevelSession.targetEdges, width,
-                           m_bevelSession.segments, m_bevelSession.profilePoints))
+    if (reapplyActiveBevel(width, m_bevelSession.segments,
+                           m_bevelSession.profilePoints))
         m_bevelSession.width = width;
 }
 
@@ -1773,8 +1923,7 @@ void EditModeController::updateBevelSegments(int segments)
     m_selectedEdges = m_bevelSession.origSelectedEdges;
     m_selectedFaces = m_bevelSession.origSelectedFaces;
 
-    if (applyBevelTopology(m_bevelSession.targetEdges, m_bevelSession.width,
-                           segments, newPoints)) {
+    if (reapplyActiveBevel(m_bevelSession.width, segments, newPoints)) {
         m_bevelSession.segments = segments;
         m_bevelSession.profilePoints = std::move(newPoints);
         emit bevelProfilePointsChanged();
@@ -1799,7 +1948,7 @@ void EditModeController::updateBevelProfilePoint(int index, float value)
     m_selectedEdges = m_bevelSession.origSelectedEdges;
     m_selectedFaces = m_bevelSession.origSelectedFaces;
 
-    if (applyBevelTopology(m_bevelSession.targetEdges, m_bevelSession.width,
+    if (reapplyActiveBevel(m_bevelSession.width,
                            m_bevelSession.segments, newPoints)) {
         m_bevelSession.profilePoints = std::move(newPoints);
         emit bevelProfilePointsChanged();
@@ -1819,7 +1968,7 @@ void EditModeController::resetBevelProfile()
     m_selectedEdges = m_bevelSession.origSelectedEdges;
     m_selectedFaces = m_bevelSession.origSelectedFaces;
 
-    if (applyBevelTopology(m_bevelSession.targetEdges, m_bevelSession.width,
+    if (reapplyActiveBevel(m_bevelSession.width,
                            m_bevelSession.segments, newPoints)) {
         m_bevelSession.profilePoints = std::move(newPoints);
         emit bevelProfilePointsChanged();

--- a/src/EditModeController.h
+++ b/src/EditModeController.h
@@ -530,6 +530,10 @@ private:
     // Bevel session state — populated on beginBevel, consumed on commit/cancel.
     struct BevelSession {
         bool active = false;
+        // What kind of bevel this session is operating on. Decides which
+        // HalfEdgeMesh API applyBevelTopology calls.
+        enum Kind { Edges, Vertices };
+        Kind kind = Edges;
         // Snapshot of submeshes before any bevel was applied. Used to restart
         // the bevel at a new width and to restore on cancel or undo.
         std::vector<EditableSubMesh> originalSubMeshes;
@@ -537,9 +541,10 @@ private:
         std::set<int> origSelectedVertices;
         std::set<std::pair<int,int>> origSelectedEdges;
         std::set<int> origSelectedFaces;
-        // The edges targeted by the bevel, captured so updateBevelWidth can
-        // re-run against the same topology on each drag tick.
+        // Kind == Edges: the edges targeted by the bevel.
         std::vector<std::pair<int,int>> targetEdges;
+        // Kind == Vertices: the vertex indices targeted by the bevel.
+        std::vector<int> targetVertices;
         Ogre::Vector3 pivot = Ogre::Vector3::ZERO; ///< Gizmo pivot (chamfer region center).
         Ogre::Vector3 axis = Ogre::Vector3::UNIT_Y; ///< Gizmo axis (averaged surface normal).
         float width = 0.0f;                         ///< Currently-applied width.
@@ -558,6 +563,20 @@ private:
                             float width,
                             int segments = 1,
                             const std::vector<float>& profilePoints = {});
+
+    /// Vertex-bevel variant: applies bevelVertices on the given vertex
+    /// indices and propagates the result through the same mesh-rebuild
+    /// pipeline as applyBevelTopology.
+    bool applyBevelVertexTopology(const std::vector<int>& vertexIndices,
+                                  float width,
+                                  int segments = 1,
+                                  const std::vector<float>& profilePoints = {});
+
+    /// Dispatcher used by updateBevelWidth/Segments/Profile. Reads
+    /// m_bevelSession.kind and calls the right applyBevel*Topology.
+    bool reapplyActiveBevel(float width,
+                            int segments,
+                            const std::vector<float>& profilePoints);
 
     /// World-space pivot (entity transform applied to session.pivot).
     Ogre::Vector3 bevelGizmoWorldOrigin() const;

--- a/src/EditModeController_test.cpp
+++ b/src/EditModeController_test.cpp
@@ -1164,3 +1164,33 @@ TEST_F(EditModeControllerBevelE2ETest, SessionEndClearsProfilePoints) {
     EXPECT_EQ(ctrl->bevelProfilePoints().size(), 0);
 }
 
+TEST_F(EditModeControllerBevelE2ETest, BevelCubeCornerVertexProducesClosedManifold) {
+    auto* ctrl = EditModeController::instance();
+    ctrl->enterEditMode();
+    ctrl->setSelectionMode(EditModeController::VertexMode);
+
+    // Select the top-right-front corner v5 (index 5 in makeCubeMesh).
+    ctrl->selectVertex(5, false);
+    ASSERT_EQ(ctrl->selectedVertexCount(), 1);
+
+    ASSERT_TRUE(ctrl->bevelSelection()) << "vertex bevel should succeed";
+    EXPECT_TRUE(ctrl->bevelSessionActive());
+
+    // Verify manifold: every edge should have exactly 2 directed uses,
+    // giving 0 boundary edges.
+    std::vector<Ogre::Vector3> positions;
+    std::vector<std::array<unsigned, 3>> tris;
+    extractEntityBuffers(m_entity, positions, tris);
+    std::map<std::pair<unsigned, unsigned>, int> edgeUse;
+    for (const auto& t : tris) {
+        for (int k = 0; k < 3; ++k) {
+            unsigned u = t[k], v = t[(k + 1) % 3];
+            auto key = std::make_pair(std::min(u, v), std::max(u, v));
+            ++edgeUse[key];
+        }
+    }
+    size_t boundaryEdges = 0;
+    for (auto& [_, c] : edgeUse) if (c == 1) ++boundaryEdges;
+    EXPECT_EQ(boundaryEdges, 0u) << "vertex bevel leaves " << boundaryEdges << " boundary edges";
+}
+

--- a/src/HalfEdgeMesh.cpp
+++ b/src/HalfEdgeMesh.cpp
@@ -2834,6 +2834,467 @@ std::vector<int> HalfEdgeMesh::bevelEdges(const std::vector<int>& edgeIndices, /
     return newVertices;
 }
 
+// ===========================================================================
+// bevelVertices — corner cut at each selected vertex.
+// ===========================================================================
+//
+// For each vertex v of valence N >= 3:
+//   1. Walk v's face ring, collecting the ring-ordered sequence of incident
+//      faces and their half-edges. Skip boundary verts for the MVP.
+//   2. For each outgoing edge v->x_i (i = 0..N-1), create a new vertex o_i
+//      at v + (x_i - v) * offset / |x_i - v|. offset is clamped per-vertex
+//      to half the shortest incident edge so neighboring vertex bevels
+//      don't overlap.
+//   3. For each face f that contained v: replace v with the two edge
+//      offsets on that face's two v-edges. The old triangle (v, a, b)
+//      becomes a quad (o_a, a, b, o_b), triangulated as two tris.
+//   4. Emit a new "cap" face using all o_i in ring order. Valence 3 gives
+//      a single triangle, higher valence an N-gon fanned from o_0.
+//
+// This MVP emits a flat cap (segments=1). Shaped profiles and segments>1
+// are TODO (rounded dome). Unused params are accepted for forward
+// compatibility with the edge-bevel API.
+std::vector<int> HalfEdgeMesh::bevelVertices(
+    const std::vector<int>& vertexIndices,
+    float width,
+    int segments,
+    float profile,
+    const std::vector<float>& profilePointsIn)
+{
+    (void)segments; (void)profile; (void)profilePointsIn; // reserved for dome
+
+    std::vector<int> newVertices;
+    if (vertexIndices.empty() || width <= 0.0f) return newVertices;
+
+    // Multi-vertex support: when multiple vertices are passed, we bevel
+    // them sequentially — one per internal iteration. Each iteration
+    // rebuilds the half-edge adjacency before the next vertex is
+    // processed, so the next bevel sees the updated topology from the
+    // previous one. This sidesteps the shared-edge-gap problem that
+    // arises when two adjacent vertices are processed in the same pass.
+    //
+    // When two selected vertices share an edge, each side should claim
+    // HALF of that edge. Without an up-front budget, the first vertex
+    // to run clamps to edge_length/2 and the second clamps against the
+    // now-shortened edge, producing asymmetric offsets that "push" each
+    // other. Precompute a per-vertex width from the PRISTINE mesh so
+    // both sides converge to the midpoint when they meet.
+    if (vertexIndices.size() > 1) {
+        std::unordered_set<int> selected(vertexIndices.begin(), vertexIndices.end());
+        std::vector<float> perVertexWidth(vertexIndices.size(), width);
+        for (size_t i = 0; i < vertexIndices.size(); ++i) {
+            int v = vertexIndices[i];
+            if (v < 0 || v >= static_cast<int>(m_vertices.size())) continue;
+            int startHE = m_vertices[v].halfEdge;
+            if (startHE < 0) continue;
+            int he = startHE;
+            float minBudget = std::numeric_limits<float>::max();
+            for (int guard = 0; guard < 1024; ++guard) {
+                if (he < 0) break;
+                int n = m_halfEdges[he].vertex;
+                const float edgeLen =
+                    m_vertices[v].position.distance(m_vertices[n].position);
+                // If the far endpoint is also selected, each end owns
+                // half the edge; otherwise the whole shortest-edge-
+                // halves rule (match single-vertex clamp behaviour).
+                float share = selected.count(n) ? 0.5f : 1.0f;
+                float budget = edgeLen * 0.49f * share;
+                if (budget < minBudget) minBudget = budget;
+                int prev = m_halfEdges[he].prev;
+                int twin = m_halfEdges[prev].twin;
+                if (twin < 0) break;
+                he = twin;
+                if (he == startHE) break;
+            }
+            if (minBudget < width) perVertexWidth[i] = minBudget;
+        }
+        for (size_t i = 0; i < vertexIndices.size(); ++i) {
+            auto added = bevelVertices({vertexIndices[i]}, perVertexWidth[i]);
+            newVertices.insert(newVertices.end(), added.begin(), added.end());
+        }
+        return newVertices;
+    }
+
+    // Walk v's outgoing half-edges in ring order. Returns one step per
+    // incident face. For our mesh representation an interior "diagonal"
+    // edge inside a logical polygon (two coplanar tris sharing it) still
+    // shows up as a ring step — the MVP accepts that and just cuts each
+    // tri corner. A future improvement could merge coplanar siblings so
+    // a cube-corner bevel always produces N = topological valence.
+    struct RingStep {
+        int face;
+        int outHE;       // outgoing half-edge from v in this face
+        int neighbor;    // far endpoint of this outgoing edge (a v-neighbor)
+        int vEdgeNext;   // the face's third corner from v's perspective
+                         // (target of m_halfEdges[outHE].next)
+    };
+    auto buildRing = [&](int v) -> std::vector<RingStep> {
+        std::vector<RingStep> ring;
+        if (v < 0 || v >= static_cast<int>(m_vertices.size())) return ring;
+        int startHE = m_vertices[v].halfEdge;
+        if (startHE < 0) return ring;
+        int he = startHE;
+        for (int guard = 0; guard < 1024; ++guard) {
+            if (he < 0) return {};
+            int face = m_halfEdges[he].face;
+            if (face < 0) return {}; // boundary — bail
+            RingStep step;
+            step.face = face;
+            step.outHE = he;
+            step.neighbor = m_halfEdges[he].vertex;
+            step.vEdgeNext = m_halfEdges[m_halfEdges[he].next].vertex;
+            ring.push_back(step);
+            int prev = m_halfEdges[he].prev;
+            int twin = m_halfEdges[prev].twin;
+            if (twin < 0) return {}; // boundary
+            he = twin;
+            if (he == startHE) return ring;
+        }
+        return {}; // guard tripped
+    };
+
+    // True if the edge between two ring-adjacent faces is a geometric
+    // crease (non-coplanar). A "diagonal" inside a planar polygon
+    // (two coplanar tris sharing a diagonal) is NOT a crease.
+    auto facesFormCrease = [&](int fA, int fB) {
+        auto faceNormal = [&](int f) {
+            Ogre::Vector3 n = Ogre::Vector3::ZERO;
+            auto fv = faceVertices(f);
+            if (fv.size() != 3) return n;
+            const auto& p0 = m_vertices[fv[0]].position;
+            const auto& p1 = m_vertices[fv[1]].position;
+            const auto& p2 = m_vertices[fv[2]].position;
+            n = (p1 - p0).crossProduct(p2 - p0);
+            if (n.length() > 1e-8f) n.normalise();
+            return n;
+        };
+        auto nA = faceNormal(fA), nB = faceNormal(fB);
+        if (nA.length() < 0.5f || nB.length() < 0.5f) return true;
+        return nA.dotProduct(nB) < 0.999f;
+    };
+
+    // Pre-compute each vertex's ring + clamped offset + new edge-offset
+    // vertex indices. We defer face removal / re-emission to a second
+    // pass so ring-walking isn't disturbed mid-loop.
+    struct VertBevelPlan {
+        int v;
+        std::vector<RingStep> ring;
+        std::vector<int> edgeOffsets;    // one new vertex per CREASE
+                                         // (topological edge at v)
+        std::vector<int> stepToCrease;   // interleaved creaseL/creaseR
+        std::vector<int> creaseTargets;  // ring-ordered crease neighbors
+        std::vector<char> isCrease;      // per ring step
+        int subMeshIndex;                // for the new cap face
+    };
+    std::vector<VertBevelPlan> plans;
+    plans.reserve(vertexIndices.size());
+    std::unordered_set<int> beveledVerts(vertexIndices.begin(), vertexIndices.end());
+    std::unordered_set<int> facesToRemove;
+
+    for (int v : vertexIndices) {
+        if (v < 0 || v >= static_cast<int>(m_vertices.size())) continue;
+        auto ring = buildRing(v);
+        if (ring.empty()) continue;
+        const int N = static_cast<int>(ring.size());
+
+        // Identify creases: ring step i's outgoing edge (v→neighbor_i)
+        // is a crease iff the edge's two faces (prev step's face and
+        // step i's face) are non-coplanar. isCreaseAtStep[i] marks this.
+        std::vector<bool> isCreaseAtStep(N, false);
+        for (int i = 0; i < N; ++i) {
+            int prev = (i - 1 + N) % N;
+            isCreaseAtStep[i] = facesFormCrease(ring[prev].face, ring[i].face);
+        }
+        // Topological valence = number of creases.
+        int topoValence = 0;
+        for (bool b : isCreaseAtStep) if (b) ++topoValence;
+        if (topoValence < 3) continue;
+
+        // For each ring step i, stepToCrease[i] = crease index (in
+        // creaseOrder) of the crease at step i's OUTGOING edge if it's
+        // a crease, else the crease to the RIGHT (the next crease when
+        // walking forward — equivalently the crease at the start of the
+        // coplanar run this step belongs to).
+        //
+        // We actually want two mappings per step:
+        //   creaseL[i] = crease at the outgoing edge (v→neighbor_i)
+        //                or, if not a crease, the crease at the run's
+        //                starting edge.
+        //   creaseR[i] = crease at the next-step's outgoing edge
+        //                (v→ring[(i+1)%N].neighbor) or, if not a crease,
+        //                the crease at the end of the run.
+        // Within a coplanar run, creaseL == creaseR — all interior tris
+        // of the run share the same two offsets at v's corner.
+        std::vector<int> creaseOrder;      // ordered list of crease step indices
+        std::vector<int> creaseL(N, -1);
+        std::vector<int> creaseR(N, -1);
+        for (int i = 0; i < N; ++i) {
+            if (isCreaseAtStep[i]) creaseOrder.push_back(i);
+        }
+        // creaseL[i] = index in creaseOrder of the most-recent crease
+        // at-or-before step i (walking backward). This is the crease on
+        // step i's outgoing edge (v→neighbor_i) when step i IS a crease,
+        // or the crease at the start of its coplanar run otherwise.
+        //
+        // creaseR[i] = index in creaseOrder of the NEXT crease strictly
+        // AFTER step i (walking forward, wrapping around). This is the
+        // crease on step (i+1)'s outgoing edge if that's a crease, or
+        // the next crease further along.
+        {
+            int startStep = creaseOrder[0];
+            int curCreaseIdx = -1;
+            for (int k = 0; k < N; ++k) {
+                int i = (startStep + k) % N;
+                if (isCreaseAtStep[i]) {
+                    curCreaseIdx = static_cast<int>(
+                        std::find(creaseOrder.begin(), creaseOrder.end(), i)
+                        - creaseOrder.begin());
+                }
+                creaseL[i] = curCreaseIdx;
+            }
+            // creaseR: walk forward looking for strict-next crease.
+            for (int i = 0; i < N; ++i) {
+                int cur = -1;
+                for (int k = 1; k <= N; ++k) {
+                    int j = (i + k) % N;
+                    if (isCreaseAtStep[j]) {
+                        cur = static_cast<int>(
+                            std::find(creaseOrder.begin(), creaseOrder.end(), j)
+                            - creaseOrder.begin());
+                        break;
+                    }
+                }
+                creaseR[i] = cur;
+            }
+        }
+
+        // The target vertex of crease c is ring[creaseOrder[c]].neighbor
+        // (the far endpoint of the v→neighbor edge that crease sits on).
+        std::vector<int> creaseTargets(creaseOrder.size());
+        for (size_t c = 0; c < creaseOrder.size(); ++c) {
+            creaseTargets[c] = ring[creaseOrder[c]].neighbor;
+        }
+
+        // Shortest crease edge from v.
+        float minEdgeLen = std::numeric_limits<float>::max();
+        for (int tgt : creaseTargets) {
+            float d = m_vertices[v].position.distance(m_vertices[tgt].position);
+            if (d < minEdgeLen) minEdgeLen = d;
+        }
+        const float offset = std::min(width, 0.49f * minEdgeLen);
+        if (offset <= 1e-6f) continue;
+
+        VertBevelPlan plan;
+        plan.v = v;
+        plan.ring = ring;
+        plan.subMeshIndex = m_faces[ring[0].face].subMeshIndex;
+        plan.edgeOffsets.resize(creaseTargets.size());
+        plan.creaseTargets = creaseTargets;
+        // Pack creaseL and creaseR into a single vector: even indices
+        // are creaseL, odd are creaseR.
+        plan.stepToCrease.resize(N * 2);
+        for (int i = 0; i < N; ++i) {
+            plan.stepToCrease[2 * i + 0] = creaseL[i];
+            plan.stepToCrease[2 * i + 1] = creaseR[i];
+        }
+        plan.isCrease.assign(isCreaseAtStep.begin(), isCreaseAtStep.end());
+
+        // Snapshot pV by value — m_vertices grows inside the loop so a
+        // reference would dangle after the first push_back reallocation.
+        const Ogre::Vector3 pV = m_vertices[v].position;
+        HEVertex vProto = m_vertices[v];
+        vProto.halfEdge = -1;
+        for (size_t c = 0; c < creaseTargets.size(); ++c) {
+            const Ogre::Vector3 pN = m_vertices[creaseTargets[c]].position;
+            Ogre::Vector3 dir = pN - pV;
+            const float len = dir.length();
+            if (len < 1e-8f) { plan.edgeOffsets[c] = -1; continue; }
+            dir /= len;
+            HEVertex nv = vProto;
+            nv.position = pV + dir * offset;
+            int idx = static_cast<int>(m_vertices.size());
+            m_vertices.push_back(nv);
+            newVertices.push_back(idx);
+            plan.edgeOffsets[c] = idx;
+        }
+
+        plans.push_back(std::move(plan));
+    }
+
+    if (plans.empty()) return newVertices;
+
+    // Build a per-edge "offset-at-v-toward-t" map. For each plan, plan's
+    // vertex v has offsets[c] along the edge v→creaseTargets[c]. If the
+    // neighbor t is ALSO beveled, t's own plan has an offset along t→v
+    // that we want to substitute for t in this plan's face retri.
+    //
+    // Key: (vertex, targetVertex). Value: offset HE index.
+    std::unordered_map<long long, int> offsetAtVTowardT;
+    auto edgeKey = [](int a, int b) {
+        return static_cast<long long>(a) * 1000000LL + b;
+    };
+    for (const auto& p : plans) {
+        for (size_t c = 0; c < p.creaseTargets.size(); ++c) {
+            if (p.edgeOffsets[c] < 0) continue;
+            offsetAtVTowardT[edgeKey(p.v, p.creaseTargets[c])] = p.edgeOffsets[c];
+        }
+    }
+    // Helper: substitute neighbor by the neighbor's own offset-toward-v
+    // if the neighbor is also beveled.
+    auto substituteIfBeveled = [&](int planV, int neighbor) {
+        auto it = offsetAtVTowardT.find(edgeKey(neighbor, planV));
+        return (it != offsetAtVTowardT.end()) ? it->second : neighbor;
+    };
+
+    // Pass 2: for each planned vertex, retriangulate each face to
+    // replace v with the two crease offsets bracketing its run; emit
+    // the cap N-gon (one tri per crease fanned from crease 0).
+    for (const auto& plan : plans) {
+        (void)beveledVerts;
+
+        // Retriangulate coplanar runs. A run is a maximal contiguous
+        // block of ring steps whose outgoing edges (except the first)
+        // are all non-creases — i.e., the same logical polygon
+        // triangulated along its diagonals.
+        //
+        // Each run's polygon is:
+        //   [o_L, n_0', vEdgeNext_0', vEdgeNext_1', ..., vEdgeNext_last', o_R]
+        // where primes mean "substitute a beveled neighbor by its own
+        // offset toward this plan's v". Fan from o_L.
+        //
+        // Ownership rule for multi-vertex bevels: a run might include
+        // vertices that are themselves beveled. To avoid another plan
+        // also retriangulating the same tri, we only retriangulate
+        // faces whose lowest-index corner in {v, any other beveled
+        // vertex in the tri} equals this plan's v. I.e., the
+        // lowest-index plan among those touching the tri owns it.
+        // A run is "owned" by this plan when plan.v is the lowest-index
+        // beveled vertex among all vertices appearing in the run's
+        // faces. Ensures each logical face is retriangulated exactly
+        // once regardless of how many of its corners are beveled.
+        auto runOwnedByThisPlan = [&](const std::vector<int>& runSteps) {
+            int lowestBeveled = plan.v;
+            for (int s : runSteps) {
+                auto fv = faceVertices(plan.ring[s].face);
+                for (int fvIdx : fv) {
+                    if (beveledVerts.count(fvIdx) && fvIdx < lowestBeveled)
+                        lowestBeveled = fvIdx;
+                }
+            }
+            return lowestBeveled == plan.v;
+        };
+
+        auto isCrease = [&](int i) -> bool { return plan.isCrease[i] != 0; };
+        const int N = static_cast<int>(plan.ring.size());
+        int runStart = -1;
+        for (int i = 0; i < N; ++i) {
+            if (isCrease(i)) { runStart = i; break; }
+        }
+        if (runStart < 0) continue;
+
+        int cursor = runStart;
+        for (int visited = 0; visited < N; ) {
+            std::vector<int> runSteps;
+            runSteps.push_back(cursor);
+            ++visited;
+            int nextStep = (cursor + 1) % N;
+            while (visited < N && !isCrease(nextStep)) {
+                runSteps.push_back(nextStep);
+                ++visited;
+                nextStep = (nextStep + 1) % N;
+            }
+
+            // Ownership check: only the lowest-index beveled vertex
+            // that appears in ANY face of the run retriangulates it.
+            // Other beveled verts in the run just leave the tri alone
+            // here — the owner's polygon (with substitutions for those
+            // other beveled corners) covers it.
+            if (!runOwnedByThisPlan(runSteps)) {
+                // Even when not owning, we still need to mark the
+                // member faces for removal — they'll be re-added by
+                // the owner's polygon emission below.
+                cursor = nextStep;
+                continue;
+            }
+
+            const int cL = plan.stepToCrease[2 * runSteps.front() + 0];
+            const int cR = plan.stepToCrease[2 * runSteps.back() + 1];
+            if (cL < 0 || cR < 0) { cursor = nextStep; continue; }
+            const int o_L = plan.edgeOffsets[cL];
+            const int o_R = plan.edgeOffsets[cR];
+
+            std::vector<int> polygon;
+            polygon.push_back(o_L);
+            polygon.push_back(substituteIfBeveled(
+                plan.v, plan.ring[runSteps.front()].neighbor));
+            for (int s : runSteps) {
+                polygon.push_back(substituteIfBeveled(
+                    plan.v, plan.ring[s].vEdgeNext));
+            }
+            polygon.push_back(o_R);
+
+            // Dedupe consecutive duplicates and positional matches.
+            std::vector<int> dedup;
+            for (int idx : polygon) {
+                if (!dedup.empty() && dedup.back() == idx) continue;
+                if (!dedup.empty() &&
+                    m_vertices[dedup.back()].position.squaredDistance(
+                        m_vertices[idx].position) < 1e-10f) continue;
+                dedup.push_back(idx);
+            }
+            if (dedup.size() >= 2 && dedup.front() == dedup.back())
+                dedup.pop_back();
+            if (dedup.size() < 3) { cursor = nextStep; continue; }
+
+            const int sub = m_faces[plan.ring[runSteps[0]].face].subMeshIndex;
+            for (size_t i = 1; i + 1 < dedup.size(); ++i) {
+                appendTriangle(dedup[0], dedup[i], dedup[i + 1], sub);
+            }
+            for (int s : runSteps) {
+                facesToRemove.insert(plan.ring[s].face);
+            }
+
+            cursor = nextStep;
+        }
+
+        // Cap N-gon: fan from creaseTarget[0]'s offset across the
+        // remaining offsets in ring order. creaseOrder walks CCW around
+        // v from outside the solid, so this CCW-from-outside winding
+        // from inside-v's-old-position fans correctly as a face
+        // replacing v.
+        const int M = static_cast<int>(plan.edgeOffsets.size());
+        for (int i = 1; i + 1 < M; ++i) {
+            appendTriangle(plan.edgeOffsets[0],
+                           plan.edgeOffsets[i],
+                           plan.edgeOffsets[i + 1],
+                           plan.subMeshIndex);
+        }
+    }
+
+    // Remove the old faces.
+    for (int f : facesToRemove) {
+        int startHE = m_faces[f].halfEdge;
+        if (startHE < 0) continue;
+        int he = startHE;
+        do {
+            int next = m_halfEdges[he].next;
+            m_halfEdges[he].face = -1;
+            m_halfEdges[he].twin = -1;
+            m_halfEdges[he].next = -1;
+            m_halfEdges[he].prev = -1;
+            he = next;
+        } while (he != startHE && he >= 0);
+        m_faces[f].halfEdge = -1;
+    }
+
+    rebuildEdgesAndTwins();
+    compactBoundaryHalfEdges();
+    buildBoundaryHalfEdges();
+    fixVertexHalfEdges();
+
+    return newVertices;
+}
+
 bool HalfEdgeMesh::validate() const
 {
     // Check 1: Twin symmetry

--- a/src/HalfEdgeMesh.h
+++ b/src/HalfEdgeMesh.h
@@ -326,6 +326,47 @@ public:
                                 float profile = 0.5f,
                                 const std::vector<float>& profilePoints = {});
 
+    /**
+     * @brief Bevel selected vertices (corner cut).
+     *
+     * For each selected vertex v of valence N >= 3, replaces v with an
+     * N-gon face. Each edge incident to v is split at distance `width`
+     * from v (clamped to half the shortest incident edge), giving N new
+     * vertices. Each face originally at v is retriangulated to exchange
+     * v's corner for the two edge offsets on its two v-edges. Then the
+     * N offsets are triangulated into a "cap" face sitting where v used
+     * to be.
+     *
+     * Limitations (MVP):
+     * - Valence < 3 vertices are skipped (nothing sensible to bevel).
+     * - Boundary vertices are skipped.
+     * - `segments` and `profilePoints` are reserved for a future
+     *   rounded-dome implementation; this MVP always emits a flat cap.
+     *
+     * Multi-vertex selections are processed sequentially (one vertex at
+     * a time, rebuilding the half-edge structure between iterations).
+     * This keeps shared-edge pairs manifold at the cost of slight O(N²)
+     * growth with selection size, which is fine for interactive use.
+     *
+     * @param vertexIndices The vertex indices to bevel.
+     * @param width The offset distance along each incident edge. Clamped
+     *              per-vertex to min(shortest_edge) / 2 to avoid self-
+     *              intersection with the neighbor's own bevel.
+     * @param segments Radial subdivisions of the cap (1 = flat N-gon,
+     *                 2+ = rounded dome). Clamped to [1, 16].
+     * @param profile Profile-curve shape in [0, 1]. Same semantics as
+     *                edge bevel.
+     * @param profilePoints Optional per-ring profile values (size = segments - 1).
+     *                When empty, `profile` drives the sin envelope.
+     * @return Indices of the newly created vertices. Empty if the
+     *         operation was skipped or failed.
+     */
+    std::vector<int> bevelVertices(const std::vector<int>& vertexIndices,
+                                   float width,
+                                   int segments = 1,
+                                   float profile = 0.5f,
+                                   const std::vector<float>& profilePoints = {});
+
     /// @}
 
     /// @name Validation

--- a/src/HalfEdgeMesh_test.cpp
+++ b/src/HalfEdgeMesh_test.cpp
@@ -2836,3 +2836,163 @@ TEST(HalfEdgeMeshStandalone, BevelConvexCarvesAdjacentFaces) {
     EXPECT_TRUE(probeFront.refsIntermediate);
     EXPECT_TRUE(probeBack.refsIntermediate);
 }
+
+// ===========================================================================
+// Tests: bevelVertices (corner cut)
+// ===========================================================================
+
+TEST(HalfEdgeMeshStandalone, BevelVertexCubeCornerProducesTriangleCap) {
+    // Beveling a cube corner (valence 3) should produce a triangular
+    // cap face at the corner. All three original quads sharing that
+    // corner become pentagons — i.e. the old 2 tris per side become 3
+    // tris per side (one quad = two tris turns into one pentagon = three
+    // tris when fanned). The total tri count increases by 1 per face
+    // touched + 1 for the new cap.
+    auto em = makeCubeMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    const int v5 = 5; // (1, 1, 1) — corner where top, right, front meet
+    auto newVerts = he.bevelVertices({v5}, 0.1f);
+    ASSERT_EQ(newVerts.size(), 3u)
+        << "valence-3 corner should produce 3 edge offsets";
+
+    EXPECT_TRUE(he.validate());
+
+    EditableMesh back;
+    ASSERT_TRUE(he.toEditableMesh(back));
+    EXPECT_TRUE(isManifold(back));
+    const auto stats = statsOf(back);
+    EXPECT_EQ(stats.boundaryEdges, 0u);
+}
+
+TEST(HalfEdgeMeshStandalone, BevelVertexLowValenceIsSkipped) {
+    // Valence < 3 has nothing sensible to bevel — should be a no-op.
+    // Build a tiny 2-tri strip and try to bevel an interior vertex
+    // whose valence is 2 in our mini mesh.
+    EditableMesh em;
+    EditableSubMesh sub;
+    sub.materialName = "M";
+    auto mkV = [](float x, float y, float z) {
+        EditableVertex v;
+        v.position = Ogre::Vector3(x, y, z);
+        v.normal = Ogre::Vector3::UNIT_Z;
+        v.hasNormal = true;
+        return v;
+    };
+    // Two tris sharing an edge — the shared-edge vertices have valence 2.
+    sub.vertices = { mkV(0, 0, 0), mkV(1, 0, 0), mkV(0, 1, 0), mkV(1, 1, 0) };
+    auto mkT = [](unsigned a, unsigned b, unsigned c) {
+        EditableTriangle t;
+        t.indices[0] = a; t.indices[1] = b; t.indices[2] = c;
+        return t;
+    };
+    sub.triangles = { mkT(0, 1, 2), mkT(1, 3, 2) };
+    em.subMeshes().push_back(sub);
+
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    // Vertex 1 is shared by both tris but has valence 2 internally AND
+    // it's on the mesh boundary — should be skipped by bevelVertices.
+    auto newVerts = he.bevelVertices({1}, 0.05f);
+    EXPECT_TRUE(newVerts.empty())
+        << "valence<3 / boundary vertex should be skipped";
+}
+
+TEST(HalfEdgeMeshStandalone, BevelVertexZeroWidthIsNoOp) {
+    auto em = makeCubeMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    auto newVerts = he.bevelVertices({5}, 0.0f);
+    EXPECT_TRUE(newVerts.empty());
+}
+
+TEST(HalfEdgeMeshStandalone, BevelVertexMultipleCorners) {
+    // Multi-vertex bevel runs one vertex at a time internally so shared
+    // edges get the shortened-edge topology correctly (each pass sees
+    // the already-bevelled neighbor).
+    auto em = makeCubeMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    std::vector<int> corners = {0, 1, 2, 3, 4, 5, 6, 7};
+    auto newVerts = he.bevelVertices(corners, 0.1f);
+    EXPECT_EQ(newVerts.size(), 24u);
+    EXPECT_TRUE(he.validate());
+    EditableMesh back;
+    ASSERT_TRUE(he.toEditableMesh(back));
+    EXPECT_TRUE(isManifold(back));
+    const auto stats = statsOf(back);
+    EXPECT_EQ(stats.boundaryEdges, 0u);
+}
+
+TEST(HalfEdgeMeshStandalone, BevelVertexAdjacentPair) {
+    // Two vertices sharing a cube edge (v4-v5). Sequential processing
+    // should leave the mesh manifold with the shared edge shortened
+    // between the two new corner offsets.
+    auto em = makeCubeMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    auto newVerts = he.bevelVertices({4, 5}, 0.1f);
+    EXPECT_TRUE(he.validate());
+    EditableMesh back;
+    ASSERT_TRUE(he.toEditableMesh(back));
+    EXPECT_TRUE(isManifold(back));
+    const auto stats = statsOf(back);
+    EXPECT_EQ(stats.boundaryEdges, 0u);
+}
+
+TEST(HalfEdgeMeshStandalone, BevelVertexSymmetricBudgetOnSharedEdge) {
+    // When two adjacent selected vertices' offsets would collide on
+    // the shared edge (width > edge_length / 2), each side should clamp
+    // to half the edge so both offsets land at the midpoint. Without a
+    // symmetric budget, the first-processed vertex gets the full
+    // requested offset and the second gets squeezed by the shortened
+    // edge, producing visually uneven offsets.
+    auto em = makeCubeMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    // v4 = (-1, 1, 1), v5 = (1, 1, 1). Edge length = 2. Request a
+    // width that would exceed half (i.e., collision territory).
+    const float requested = 100.0f; // huge → clamped to 0.49 * 1.0 = 0.49
+    auto newVerts = he.bevelVertices({4, 5}, requested);
+    EXPECT_TRUE(he.validate());
+
+    // Distance from v4 to v4's offsets should equal v5 to v5's offsets
+    // along the shared edge (both = 0.49 * 1.0 = 0.49). Pick the two
+    // offsets on the v4-v5 edge: they're the ones with y=1, z=1 and
+    // x in (-1, 1) range.
+    std::vector<Ogre::Vector3> onSharedEdge;
+    for (int v : newVerts) {
+        const auto& p = he.vertex(v).position;
+        if (std::abs(p.y - 1.0f) < 1e-4f
+            && std::abs(p.z - 1.0f) < 1e-4f
+            && std::abs(p.x) <= 1.0f - 1e-4f) {
+            onSharedEdge.push_back(p);
+        }
+    }
+    ASSERT_EQ(onSharedEdge.size(), 2u);
+    const Ogre::Vector3 v4(-1, 1, 1), v5(1, 1, 1);
+    // Each vertex's offset should be 0.49 along the shared edge.
+    float dist4 = std::min(onSharedEdge[0].distance(v4), onSharedEdge[1].distance(v4));
+    float dist5 = std::min(onSharedEdge[0].distance(v5), onSharedEdge[1].distance(v5));
+    EXPECT_NEAR(dist4, dist5, 1e-4f)
+        << "offsets at each end of shared edge should be symmetric";
+    EXPECT_NEAR(dist4, 0.49f, 1e-3f)
+        << "each side should claim half the 1.0 shared half-edge budget";
+}
+
+TEST(HalfEdgeMeshStandalone, BevelVertexOffsetIsClampedToHalfEdge) {
+    // Passing a huge width should clamp — the new offsets should never
+    // pass the midpoint of the shortest incident edge.
+    auto em = makeCubeMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    auto newVerts = he.bevelVertices({5}, 100.0f);
+    ASSERT_EQ(newVerts.size(), 3u);
+    const Ogre::Vector3 v5(1, 1, 1);
+    for (int v : newVerts) {
+        const auto& p = he.vertex(v).position;
+        EXPECT_LT(p.distance(v5), 1.01f)
+            << "offset must not exceed shortest incident edge (length 2 → half=1)";
+    }
+    EXPECT_TRUE(he.validate());
+}


### PR DESCRIPTION
## Summary
- Adds vertex-bevel: select a vertex in edit mode, press `Cmd+B` / `Ctrl+B`, drag the gizmo to cut that corner of the mesh. Like Blender's `Ctrl+Shift+B` / Maya's `polyBevel` on vertex input.
- Multi-vertex selection is supported — offsets on shared edges land symmetrically at the midpoint.

## Details
- `HalfEdgeMesh::bevelVertices(indices, width, segments, profile, profilePoints)` mirrors the edge-bevel signature. MVP emits a flat N-gon cap; `segments` / `profile` are reserved for a future rounded-dome extension.
- `EditModeController::bevelSession` now tracks a `Kind` enum (Edges | Vertices) and dispatches through a new `reapplyActiveBevel()` on drag/segment/profile updates.
- Multi-vertex pass is sequential with a per-vertex pre-clamp computed on the pristine mesh: if two selected vertices share an edge each side claims half, so they converge to the edge midpoint instead of pushing each other.
- Coplanar-sibling ring merging so a cube corner → triangle (3 offsets), not 4 offsets with one landing on a face diagonal.
- QML: Bevel button visible in vertex mode; segments/profile stay hidden for now since the MVP uses a flat cap.

## Tests
7 new unit tests + 1 E2E:
- Single cube corner → triangle cap, manifold.
- Valence < 3 / boundary vertex skipped.
- Zero-width is a no-op.
- All 8 cube corners beveled together stays manifold (24 new verts).
- Adjacent pair (shared edge) is manifold.
- Symmetric-budget: requesting a huge width on two adjacent corners clamps each to half the shared edge (offsets equidistant from each end).
- Offset clamp to half shortest incident edge.
- E2E: `BevelCubeCornerVertexProducesClosedManifold` runs the full session path through `EditModeController::bevelSelection()` in VertexMode.

## Test plan
- [x] `UnitTests --gtest_filter="*Bevel*"` — 46 bevel tests pass.
- [x] Interactive verification on cube corners (single + multi).
- [ ] CI: Linux / macOS / Windows builds, unit-tests-linux, SonarCloud, CodeRabbit.

## Known limitations (tracked for follow-up)
- `segments > 1` → rounded dome topology not yet implemented (segments hidden in UI until it lands).
- Boundary vertices skipped for this MVP.