### PR TITLE
feat(ui): move Extrude/Bevel to main toolbar, slim Inspector

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1921,9 +1921,26 @@ jobs:
             $userResp = Invoke-WebRequest -Uri "https://api.github.com/user" -Headers $headers -UseBasicParsing
             $scopes = $userResp.Headers['X-OAuth-Scopes']
             $login  = ($userResp.Content | ConvertFrom-Json).login
-            Write-Host "Token OK for user '$login' with scopes: $scopes"
-            if ($scopes -and ($scopes -notmatch 'public_repo') -and ($scopes -notmatch '\brepo\b')) {
-              Write-Host "::warning::WINGET_TOKEN has scopes '$scopes'; wingetcreate --submit needs 'public_repo' or 'repo'."
+            # X-OAuth-Scopes is only populated for classic PATs.
+            # Fine-grained PATs return an empty / missing scopes header.
+            # wingetcreate --submit has consistently been observed to
+            # fail with "Resource not accessible by personal access token"
+            # when given a fine-grained PAT, regardless of its
+            # configured fine-grained permissions on microsoft/winget-pkgs
+            # (the fork step uses an API endpoint fine-grained tokens
+            # can't reach). Fail fast with a clear remediation.
+            if ($scopes) {
+              Write-Host "Token OK for user '$login' with classic PAT scopes: $scopes"
+              if (($scopes -notmatch 'public_repo') -and ($scopes -notmatch '\brepo\b')) {
+                Write-Host "::error::WINGET_TOKEN is a classic PAT but has scopes '$scopes'; wingetcreate --submit needs 'public_repo' or 'repo'."
+                Write-Host "::error::Regenerate the token at https://github.com/settings/tokens/new with 'public_repo' checked and update the WINGET_TOKEN repo secret."
+                exit 1
+              }
+            } else {
+              Write-Host "::error::WINGET_TOKEN validates as user '$login' but reports NO X-OAuth-Scopes — this is a fine-grained PAT."
+              Write-Host "::error::wingetcreate --submit requires a CLASSIC PAT with 'public_repo' scope; fine-grained PATs cannot fork / open PRs against microsoft/winget-pkgs."
+              Write-Host "::error::Regenerate at https://github.com/settings/tokens/new (NOT /tokens/new?type=beta) with 'public_repo' checked and update WINGET_TOKEN."
+              exit 1
             }
           } catch {
             Write-Host "::error::Token validation failed: $($_.Exception.Message). Rotate WINGET_TOKEN (classic PAT with 'public_repo')."
@@ -1968,16 +1985,26 @@ jobs:
           # Retry up to three times on transient failures — wingetcreate's
           # "Failed to connect to GitHub" sometimes hits during runner DNS
           # flakes or microsoft/winget-pkgs being under load after a release.
+          # We capture stderr so we can detect the "Resource not accessible
+          # by personal access token" auth failure and bail immediately
+          # (retrying that is pointless; the token lacks permissions).
           $submitOk = $false
+          $authErrorSeen = $false
           for ($attempt = 1; $attempt -le 3; $attempt++) {
             Write-Host "Submitting WinGet manifest for version $ver (attempt $attempt)..."
-            .\wingetcreate.exe update FernandoTonon.QtMeshEditor `
+            $output = & .\wingetcreate.exe update FernandoTonon.QtMeshEditor `
               --version $ver `
               --urls $url `
               --submit `
-              --token $env:WINGET_TOKEN
+              --token $env:WINGET_TOKEN 2>&1
+            # Echo the tool's output so users can read it in the logs.
+            $output | ForEach-Object { Write-Host $_ }
             if ($LASTEXITCODE -eq 0) {
               $submitOk = $true
+              break
+            }
+            if ($output -match 'Resource not accessible by personal access token') {
+              $authErrorSeen = $true
               break
             }
             Write-Host "::warning::wingetcreate exited $LASTEXITCODE on attempt $attempt."
@@ -1986,10 +2013,16 @@ jobs:
             }
           }
           if (-not $submitOk) {
-            Write-Host "::error::wingetcreate submit failed after 3 attempts. Check:"
-            Write-Host "::error:: 1. WINGET_TOKEN is still valid and has 'public_repo' scope."
-            Write-Host "::error:: 2. The user's fork of microsoft/winget-pkgs hasn't diverged."
-            Write-Host "::error:: 3. https://www.githubstatus.com for GitHub API availability."
+            if ($authErrorSeen) {
+              Write-Host "::error::wingetcreate reported 'Resource not accessible by personal access token'."
+              Write-Host "::error::This means WINGET_TOKEN lacks the required scope to fork microsoft/winget-pkgs and open a PR."
+              Write-Host "::error::Fix: regenerate a CLASSIC PAT at https://github.com/settings/tokens/new with 'public_repo' checked, update the WINGET_TOKEN repo secret, then re-run this job."
+            } else {
+              Write-Host "::error::wingetcreate submit failed after 3 attempts. Check:"
+              Write-Host "::error:: 1. WINGET_TOKEN is still valid and has 'public_repo' scope."
+              Write-Host "::error:: 2. The user's fork of microsoft/winget-pkgs hasn't diverged."
+              Write-Host "::error:: 3. https://www.githubstatus.com for GitHub API availability."
+            }
             exit 1
           }
           Write-Host "WinGet PR submitted successfully."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2029,48 +2029,16 @@ jobs:
           }
           Write-Host "WinGet PR submitted successfully."
 
-          # Parse the PR number out of wingetcreate's success output and
-          # post a follow-up comment on the winget-pkgs PR. The default
-          # body is Microsoft's contributor checklist (same for every
-          # submission); this comment gives the reviewer a pointer to
-          # the QtMeshEditor release notes + flags the PR as automated.
-          $prUrl = $null
+          # Echo the created PR's URL at the top of our own action log
+          # so it's easy to find from the release build later. We do NOT
+          # post a comment on the winget-pkgs PR itself: winget's review
+          # flow is driven by wingetbot and Microsoft maintainers, and
+          # external contributor comments don't add value (and could
+          # risk tripping keyword-based automation).
           foreach ($line in $lastOutput) {
-            if ($line -match 'Pull request.*?(https://github\.com/microsoft/winget-pkgs/pull/(\d+))') {
-              $prUrl    = $Matches[1]
-              $prNumber = [int]$Matches[2]
+            if ($line -match 'Pull request.*?(https://github\.com/microsoft/winget-pkgs/pull/\d+)') {
+              Write-Host "::notice::WinGet PR created: $($Matches[1])"
               break
-            }
-          }
-          if (-not $prUrl) {
-            Write-Host "::warning::Submit succeeded but no PR URL was parsed from wingetcreate output — skipping context comment."
-          } else {
-            Write-Host "Posting context comment on $prUrl ..."
-            $releaseUrl = "https://github.com/fernandotonon/QtMeshEditor/releases/tag/$rawTag"
-            $commentBody = @"
-Automated by the QtMeshEditor release workflow ([run]($($env:GITHUB_SERVER_URL + '/' + $env:GITHUB_REPOSITORY + '/actions/runs/' + $env:GITHUB_RUN_ID))).
-
-Release notes: [$rawTag]($releaseUrl)
-
-The default checklist above is the microsoft/winget-pkgs PR template; the manifest passed `wingetcreate`'s local validation before submission.
-"@
-            $payload = @{ body = $commentBody } | ConvertTo-Json -Compress
-            $commentHeaders = @{
-              Authorization = "token $env:WINGET_TOKEN"
-              Accept        = "application/vnd.github+json"
-              "User-Agent"  = "QtMeshEditor-CI"
-            }
-            try {
-              $null = Invoke-WebRequest `
-                -Uri "https://api.github.com/repos/microsoft/winget-pkgs/issues/$prNumber/comments" `
-                -Method POST `
-                -Headers $commentHeaders `
-                -ContentType "application/json; charset=utf-8" `
-                -Body ([System.Text.Encoding]::UTF8.GetBytes($payload)) `
-                -UseBasicParsing
-              Write-Host "Context comment posted on $prUrl."
-            } catch {
-              Write-Host "::warning::Failed to post context comment: $($_.Exception.Message). The PR itself is still submitted at $prUrl."
             }
           }
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1990,6 +1990,7 @@ jobs:
           # (retrying that is pointless; the token lacks permissions).
           $submitOk = $false
           $authErrorSeen = $false
+          $lastOutput = @()
           for ($attempt = 1; $attempt -le 3; $attempt++) {
             Write-Host "Submitting WinGet manifest for version $ver (attempt $attempt)..."
             $output = & .\wingetcreate.exe update FernandoTonon.QtMeshEditor `
@@ -1997,6 +1998,7 @@ jobs:
               --urls $url `
               --submit `
               --token $env:WINGET_TOKEN 2>&1
+            $lastOutput = $output
             # Echo the tool's output so users can read it in the logs.
             $output | ForEach-Object { Write-Host $_ }
             if ($LASTEXITCODE -eq 0) {
@@ -2026,6 +2028,51 @@ jobs:
             exit 1
           }
           Write-Host "WinGet PR submitted successfully."
+
+          # Parse the PR number out of wingetcreate's success output and
+          # post a follow-up comment on the winget-pkgs PR. The default
+          # body is Microsoft's contributor checklist (same for every
+          # submission); this comment gives the reviewer a pointer to
+          # the QtMeshEditor release notes + flags the PR as automated.
+          $prUrl = $null
+          foreach ($line in $lastOutput) {
+            if ($line -match 'Pull request.*?(https://github\.com/microsoft/winget-pkgs/pull/(\d+))') {
+              $prUrl    = $Matches[1]
+              $prNumber = [int]$Matches[2]
+              break
+            }
+          }
+          if (-not $prUrl) {
+            Write-Host "::warning::Submit succeeded but no PR URL was parsed from wingetcreate output — skipping context comment."
+          } else {
+            Write-Host "Posting context comment on $prUrl ..."
+            $releaseUrl = "https://github.com/fernandotonon/QtMeshEditor/releases/tag/$rawTag"
+            $commentBody = @"
+Automated by the QtMeshEditor release workflow ([run]($($env:GITHUB_SERVER_URL + '/' + $env:GITHUB_REPOSITORY + '/actions/runs/' + $env:GITHUB_RUN_ID))).
+
+Release notes: [$rawTag]($releaseUrl)
+
+The default checklist above is the microsoft/winget-pkgs PR template; the manifest passed `wingetcreate`'s local validation before submission.
+"@
+            $payload = @{ body = $commentBody } | ConvertTo-Json -Compress
+            $commentHeaders = @{
+              Authorization = "token $env:WINGET_TOKEN"
+              Accept        = "application/vnd.github+json"
+              "User-Agent"  = "QtMeshEditor-CI"
+            }
+            try {
+              $null = Invoke-WebRequest `
+                -Uri "https://api.github.com/repos/microsoft/winget-pkgs/issues/$prNumber/comments" `
+                -Method POST `
+                -Headers $commentHeaders `
+                -ContentType "application/json; charset=utf-8" `
+                -Body ([System.Text.Encoding]::UTF8.GetBytes($payload)) `
+                -UseBasicParsing
+              Write-Host "Context comment posted on $prUrl."
+            } catch {
+              Write-Host "::warning::Failed to post context comment: $($_.Exception.Message). The PR itself is still submitted at $prUrl."
+            }
+          }
 
 ####################################################################
 # Snap Store Publish (after Linux .deb is built)

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -480,45 +480,10 @@ Rectangle {
                 }
             }
 
-            // Topology tools
-            Text {
-                width: parent.width - 16
-                text: "Topology"
-                color: PropertiesPanelController.textColor; font.pixelSize: 11; font.bold: true
-                visible: EditModeController.editModeActive
-            }
-
-            // Extrude button (face mode only)
-            Rectangle {
-                property string shortcutLabel: Qt.platform.os === "osx" ? "Cmd+E" : "Ctrl+E"
-                width: parent.width - 16; height: 26; radius: 3
-                visible: EditModeController.editModeActive && EditModeController.selectionMode === 2
-                color: extrudeMouse.pressed ? Qt.darker(PropertiesPanelController.highlightColor, 1.2)
-                     : extrudeMouse.containsMouse ? Qt.lighter(PropertiesPanelController.highlightColor, 1.1)
-                     : PropertiesPanelController.highlightColor
-                Text { anchors.centerIn: parent; text: "Extrude (" + parent.shortcutLabel + ")"; color: "white"; font.pixelSize: 11 }
-                MouseArea {
-                    id: extrudeMouse; anchors.fill: parent; hoverEnabled: true
-                    onClicked: EditModeController.extrudeSelection()
-                }
-            }
-
-            // Bevel button (edge or vertex mode)
-            Rectangle {
-                property string shortcutLabel: Qt.platform.os === "osx" ? "Cmd+B" : "Ctrl+B"
-                width: parent.width - 16; height: 26; radius: 3
-                visible: EditModeController.editModeActive
-                      && (EditModeController.selectionMode === 1
-                          || EditModeController.selectionMode === 0)
-                color: bevelMouse.pressed ? Qt.darker(PropertiesPanelController.highlightColor, 1.2)
-                     : bevelMouse.containsMouse ? Qt.lighter(PropertiesPanelController.highlightColor, 1.1)
-                     : PropertiesPanelController.highlightColor
-                Text { anchors.centerIn: parent; text: "Bevel (" + parent.shortcutLabel + ")"; color: "white"; font.pixelSize: 11 }
-                MouseArea {
-                    id: bevelMouse; anchors.fill: parent; hoverEnabled: true
-                    onClicked: EditModeController.bevelSelection()
-                }
-            }
+            // Topology triggers (Extrude / Bevel) live on the main
+            // objects toolbar now — see mainwindow.cpp. The Inspector
+            // keeps only the operation parameters below (bevel session
+            // segments + profile) which are only relevant mid-drag.
 
             // Bevel session controls (visible only while a bevel session is
             // active — i.e., between Cmd+B and the commit/cancel click).

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -627,6 +627,7 @@ void MainWindow::initToolBar()
     // On successful extrude, auto-switch to the Translate tool so the
     // user can immediately move the freshly-extruded geometry.
     connect(extrudeButton, &QToolButton::clicked, this, [this]() {
+        SentryReporter::addBreadcrumb("ui.action", "Toolbar: Extrude");
         auto* c = EditModeController::instance();
         if (c->extrudeSelection()) {
             setTransformState(TransformOperator::TS_TRANSLATE);
@@ -649,8 +650,10 @@ void MainWindow::initToolBar()
     bevelButton->setToolTip(tr("Bevel selected edges / vertices (%1)").arg(bevelShortcutLabel));
     bevelButton->setFont(topoFont);
     bevelButton->setStyleSheet(topoBtnStyle);
-    connect(bevelButton, &QToolButton::clicked,
-            editCtrlForTopo, &EditModeController::bevelSelection);
+    connect(bevelButton, &QToolButton::clicked, this, []() {
+        SentryReporter::addBreadcrumb("ui.action", "Toolbar: Bevel");
+        EditModeController::instance()->bevelSelection();
+    });
     QAction* bevelAction = ui->objectsToolbar->addWidget(bevelButton);
 
     // Context-aware visibility + enabled:

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -577,6 +577,110 @@ void MainWindow::initToolBar()
     });
     ui->objectsToolbar->addWidget(aiChatButton);
 
+    // Topology tools — toolbar shortcuts for Extrude / Bevel. They
+    // delegate to the same EditModeController actions the Inspector
+    // buttons used to trigger, and enable/disable themselves based on
+    // the current edit-mode state so the Inspector can be slimmed down.
+    //
+    // Styling: matches the primitive icons' light-green gradient look.
+    // Disabled state desaturates to a subtle gray so the buttons don't
+    // shout when they're not actionable (e.g., Extrude in vertex mode).
+    auto* editCtrlForTopo = EditModeController::instance();
+
+    // Shared stylesheet for the glyph buttons. Uses a CSS linear-gradient
+    // on the text color (via color: qlineargradient isn't supported in
+    // widgets — Qt clips to a single color — so we pick the midtone
+    // green of the icon family for the enabled state and a muted gray
+    // for the disabled state).
+    const char* topoBtnStyle = R"(
+        QToolButton {
+            color: #7bbd2a;
+            border: none;
+            padding: 2px 4px;
+        }
+        QToolButton:hover:enabled {
+            color: #9adc4a;
+        }
+        QToolButton:pressed:enabled {
+            color: #5a9a1a;
+        }
+        QToolButton:disabled {
+            color: #b8b8b8;
+        }
+    )";
+
+    // Extrude: face mode only.
+    auto extrudeButton = new QToolButton(ui->objectsToolbar);
+    extrudeButton->setText("\u2B06");  // ⬆ (extrude = push outward)
+    const QString extrudeShortcutLabel =
+#ifdef Q_OS_MACOS
+        QStringLiteral("Cmd+E");
+#else
+        QStringLiteral("Ctrl+E");
+#endif
+    extrudeButton->setToolTip(tr("Extrude selected faces (%1)").arg(extrudeShortcutLabel));
+    QFont topoFont = extrudeButton->font();
+    topoFont.setPixelSize(16);
+    topoFont.setBold(true);
+    extrudeButton->setFont(topoFont);
+    extrudeButton->setStyleSheet(topoBtnStyle);
+    // On successful extrude, auto-switch to the Translate tool so the
+    // user can immediately move the freshly-extruded geometry.
+    connect(extrudeButton, &QToolButton::clicked, this, [this]() {
+        auto* c = EditModeController::instance();
+        if (c->extrudeSelection()) {
+            setTransformState(TransformOperator::TS_TRANSLATE);
+        }
+    });
+    // QToolBar::addWidget returns the QAction that wraps the widget.
+    // Hiding the widget directly doesn't affect the toolbar's layout —
+    // we have to toggle the action's visibility instead.
+    QAction* extrudeAction = ui->objectsToolbar->addWidget(extrudeButton);
+
+    // Bevel: edge OR vertex mode.
+    auto bevelButton = new QToolButton(ui->objectsToolbar);
+    bevelButton->setText("\u25E2");  // ◢ (cut corner)
+    const QString bevelShortcutLabel =
+#ifdef Q_OS_MACOS
+        QStringLiteral("Cmd+B");
+#else
+        QStringLiteral("Ctrl+B");
+#endif
+    bevelButton->setToolTip(tr("Bevel selected edges / vertices (%1)").arg(bevelShortcutLabel));
+    bevelButton->setFont(topoFont);
+    bevelButton->setStyleSheet(topoBtnStyle);
+    connect(bevelButton, &QToolButton::clicked,
+            editCtrlForTopo, &EditModeController::bevelSelection);
+    QAction* bevelAction = ui->objectsToolbar->addWidget(bevelButton);
+
+    // Context-aware visibility + enabled:
+    //  - Hidden entirely when NOT in edit mode.
+    //  - In edit mode: stay visible but only enable when the current
+    //    mode matches AND the relevant element type actually has a
+    //    non-empty selection.
+    auto refreshTopoButtons = [extrudeButton, bevelButton,
+                               extrudeAction, bevelAction]() {
+        auto* c = EditModeController::instance();
+        const bool active = c->isEditModeActive();
+        extrudeAction->setVisible(active);
+        bevelAction->setVisible(active);
+        if (!active) return;
+        const int mode = c->selectionMode();  // 0 vertex, 1 edge, 2 face
+        const bool hasFaces = c->selectedFaceCount() > 0;
+        const bool hasEdges = c->selectedEdgeCount() > 0;
+        const bool hasVerts = c->selectedVertexCount() > 0;
+        extrudeButton->setEnabled(mode == 2 && hasFaces);
+        bevelButton->setEnabled((mode == 1 && hasEdges)
+                             || (mode == 0 && hasVerts));
+    };
+    refreshTopoButtons();
+    connect(editCtrlForTopo, &EditModeController::editModeChanged,
+            this, refreshTopoButtons);
+    connect(editCtrlForTopo, &EditModeController::selectionModeChanged,
+            this, refreshTopoButtons);
+    connect(editCtrlForTopo, &EditModeController::editSelectionChanged,
+            this, refreshTopoButtons);
+
     connect(pAddCube,       SIGNAL(triggered()),m_pPrimitivesWidget,SLOT(createCube()));
     connect(pAddSphere,     SIGNAL(triggered()),m_pPrimitivesWidget,SLOT(createSphere()));
     connect(pAddPlane,      SIGNAL(triggered()),m_pPrimitivesWidget,SLOT(createPlane()));


### PR DESCRIPTION
## Summary
Addresses the \"Inspector is getting overloaded\" feedback by moving the topology action triggers (Extrude / Bevel) out of the Inspector and onto the main objects toolbar, next to the Primitives menu and AI Chat button.

## Details
**Toolbar buttons (new)**
- **⬆ Extrude** — face mode only. On successful extrude, auto-switches to the Translate tool so the user can immediately move the new geometry.
- **◢ Bevel** — edge mode or vertex mode. Opens the existing bevel session (gizmo + Inspector session panel).

**States**
- **Hidden entirely when not in edit mode** (the toolbar reclaims the space). Uses the `QAction` returned by `QToolBar::addWidget()` — hiding the `QToolButton` directly leaves a gap.
- **Enabled** only when the current selection mode matches AND the relevant element type has a non-empty selection (face count > 0 for Extrude, edge or vertex count > 0 for Bevel).
- **Colors** match the primitive icons' green palette: `#7bbd2a` idle, `#9adc4a` hover, `#5a9a1a` pressed. Disabled state: `#b8b8b8` muted gray.

**Inspector (updated)**
The Topology section (Extrude button + Bevel button) is removed from `PropertiesPanel.qml`'s `editModeToolsComponent`. The bevel session panel (segments + profile graph) stays in the Inspector since those parameters are only relevant mid-drag.

## Test plan
- [x] Manual: enter edit mode → buttons appear green; leave edit mode → buttons hidden, toolbar tight.
- [x] Manual: select a face with Extrude enabled → click → cube face extruded, translation gizmo appears automatically.
- [x] Manual: select an edge in Edge mode → Bevel enables green; switch to Face mode with only faces selected → Bevel goes gray.
- [x] Manual: select a vertex → Bevel enables (vertex-mode bevel still works via the same action).
- [ ] CI: Linux / macOS / Windows builds, unit-tests-linux, SonarCloud, CodeRabbit.

## Notes
- No new unit tests added — the change is pure UI wiring on top of existing `EditModeController` Q_INVOKABLE actions. The underlying selection-count properties are already covered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Changes**
  * Extrude and Bevel topology tools moved out of the Inspector and into the main objects toolbar; visibility and enabled state are context-aware (edit mode, selection type/content).
  * Inspector now only shows bevel session parameters during an active bevel drag; toolbar tooltips include platform-specific shortcut labels.

* **Chores**
  * Deployment workflow improved to better detect token types and surface targeted authentication guidance when publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->