### PR TITLE
feat(knife): multi-point cut tool with live preview

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 2.28.3 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 2.29.0 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 2.29.0 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 2.29.1 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -2333,12 +2333,24 @@ bool EditModeController::commitKnife()
         return false;
     }
 
+    // Refuse the commit if any confirmed point isn't snapped to an edge.
+    // OnFace and OnVertex captures exist for the preview, but the MVP
+    // commit pipeline only knows how to cut along edges; silently
+    // dropping a face click would produce a mesh that doesn't match the
+    // line the user just drew, which is worse than failing the commit.
+    for (const auto& p : m_knifeSession.points) {
+        if (p.kind != KnifePoint::OnEdge) {
+            SentryReporter::addBreadcrumb("edit_mode",
+                "Knife: commit rejected (non-edge point — only edge cuts supported)");
+            cancelKnife();
+            return false;
+        }
+    }
+
     std::vector<HalfEdgeMesh::CutPoint> cpts;
     cpts.reserve(m_knifeSession.points.size());
     for (const auto& p : m_knifeSession.points) {
-        if (p.kind == KnifePoint::OnEdge && p.edgeIndex >= 0) {
-            cpts.push_back({p.edgeIndex, p.edgeT});
-        }
+        cpts.push_back({p.edgeIndex, p.edgeT});
     }
     if (cpts.size() < 2) {
         SentryReporter::addBreadcrumb("edit_mode",
@@ -2357,9 +2369,11 @@ bool EditModeController::commitKnife()
 
     // Write the modified mesh back. Topology changed (new verts and
     // tris), so we must resize the Ogre buffers and re-initialise the
-    // entity's subentity caches — same sequence EditMeshTopologyCommand
-    // uses on undo/redo. Without this the EditableMesh is updated but
-    // the GPU buffers still hold the pre-cut topology.
+    // entity's subentity caches — same sequence applyBevelTopology
+    // uses. Capture per-subentity material names first so the wireframe
+    // / MaterialEditor overrides survive the deinit/init round-trip;
+    // invalidate RTSS afterwards so its shader cache picks up the new
+    // vertex layout.
     EditableMesh updated;
     if (!hm.toEditableMesh(updated)) {
         cancelKnife();
@@ -2367,8 +2381,37 @@ bool EditModeController::commitKnife()
     }
     m_editableMesh->subMeshes() = std::move(updated.subMeshes());
     m_editableMesh->resizeEntityBuffers(m_editEntity);
+
+    std::vector<std::string> preMats;
+    preMats.reserve(m_editEntity->getNumSubEntities());
+    for (unsigned int i = 0; i < m_editEntity->getNumSubEntities(); ++i) {
+        preMats.push_back(m_editEntity->getSubEntity(i)->getMaterialName());
+    }
+
     m_editEntity->_deinitialise();
     m_editEntity->_initialise(true);
+
+    for (unsigned int i = 0;
+         i < m_editEntity->getNumSubEntities() && i < preMats.size(); ++i) {
+        if (!preMats[i].empty())
+            m_editEntity->getSubEntity(i)->setMaterialName(preMats[i]);
+    }
+
+    if (auto* shaderGen = Ogre::RTShader::ShaderGenerator::getSingletonPtr()) {
+        for (unsigned int i = 0; i < m_editEntity->getNumSubEntities(); ++i) {
+            const std::string& matName = m_editEntity->getSubEntity(i)->getMaterialName();
+            if (!matName.empty())
+                shaderGen->invalidateMaterial(
+                    Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME, matName);
+        }
+    }
+
+    // Clear edge/face selection — pre-cut IDs refer to retired topology
+    // slots and the walk added new vertices that aren't in any existing
+    // set. Leaving stale indices risks crashes in later overlay updates.
+    m_selectedVertices.clear();
+    m_selectedEdges.clear();
+    m_selectedFaces.clear();
 
     auto* cmd = new EditMeshTopologyCommand(
         std::move(originalSubMeshes),
@@ -2560,22 +2603,26 @@ void EditModeController::updateKnifePreviewOverlay()
     auto* sceneMgr = m_editEntity->_getManager();
     if (!sceneMgr) return;
 
-    if (!m_overlayNode) {
-        m_overlayNode = sceneMgr->getRootSceneNode()->createChildSceneNode();
+    // Knife preview owns its own scene node so updating its entity-
+    // mirror transform doesn't stomp on the selection overlay node's
+    // origin-parked / local-space geometry. Selection overlays live on
+    // m_overlayNode; knife on m_overlayKnifeNode.
+    if (!m_overlayKnifeNode) {
+        m_overlayKnifeNode = sceneMgr->getRootSceneNode()->createChildSceneNode();
     }
     if (!m_overlayKnife) {
         m_overlayKnife = sceneMgr->createManualObject("EditMode_KnifeOverlay");
         m_overlayKnife->setDynamic(true);
         m_overlayKnife->setRenderQueueGroup(Ogre::RENDER_QUEUE_OVERLAY);
-        m_overlayNode->attachObject(m_overlayKnife);
+        m_overlayKnifeNode->attachObject(m_overlayKnife);
     }
 
     // Mirror the entity's world transform so knife points drawn in local
     // space sit on the mesh.
     if (auto* entNode = m_editEntity->getParentSceneNode()) {
-        m_overlayNode->setPosition(entNode->_getDerivedPosition());
-        m_overlayNode->setOrientation(entNode->_getDerivedOrientation());
-        m_overlayNode->setScale(entNode->_getDerivedScale());
+        m_overlayKnifeNode->setPosition(entNode->_getDerivedPosition());
+        m_overlayKnifeNode->setOrientation(entNode->_getDerivedOrientation());
+        m_overlayKnifeNode->setScale(entNode->_getDerivedScale());
     }
 
     m_overlayKnife->clear();
@@ -2606,11 +2653,16 @@ void EditModeController::updateKnifePreviewOverlay()
 
 void EditModeController::destroyKnifePreviewOverlay()
 {
-    if (!m_overlayKnife) return;
     auto* sceneMgr = m_editEntity ? m_editEntity->_getManager() : nullptr;
-    if (m_overlayNode) m_overlayNode->detachObject(m_overlayKnife);
-    if (sceneMgr) sceneMgr->destroyManualObject(m_overlayKnife);
-    m_overlayKnife = nullptr;
+    if (m_overlayKnife) {
+        if (m_overlayKnifeNode) m_overlayKnifeNode->detachObject(m_overlayKnife);
+        if (sceneMgr) sceneMgr->destroyManualObject(m_overlayKnife);
+        m_overlayKnife = nullptr;
+    }
+    if (m_overlayKnifeNode) {
+        if (sceneMgr) sceneMgr->destroySceneNode(m_overlayKnifeNode);
+        m_overlayKnifeNode = nullptr;
+    }
 }
 
 // ===========================================================================

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -2260,6 +2260,45 @@ bool EditModeController::addKnifePoint(OgreWidget* widget, int screenX, int scre
     return true;
 }
 
+bool EditModeController::addKnifePointOnEdge(int heEdgeIndex, float t)
+{
+    if (!m_knifeSession.active || !m_editableMesh) return false;
+
+    // Resolve the edge's endpoint vertices from a fresh HE build; we need
+    // them to place the KnifePoint's localPosition for the preview overlay
+    // and to expose the same data the widget-based path produces.
+    HalfEdgeMesh hm;
+    if (!hm.buildFromEditableMesh(*m_editableMesh)) return false;
+    if (heEdgeIndex < 0 || heEdgeIndex >= static_cast<int>(hm.edgeCount())) return false;
+    const auto [ga, gb] = hm.edgeVertices(heEdgeIndex);
+    if (ga < 0 || gb < 0) return false;
+
+    auto [subA, locA] = globalToLocal(ga);
+    auto [subB, locB] = globalToLocal(gb);
+    const auto& subs = m_editableMesh->subMeshes();
+    if (subA >= subs.size() || subB >= subs.size()) return false;
+    if (locA >= subs[subA].vertices.size() || locB >= subs[subB].vertices.size()) return false;
+
+    const auto& p0 = subs[subA].vertices[locA].position;
+    const auto& p1 = subs[subB].vertices[locB].position;
+    const float clampT = std::clamp(t, 0.0f, 1.0f);
+
+    KnifePoint pt;
+    pt.kind = KnifePoint::OnEdge;
+    pt.edgeIndex = heEdgeIndex;
+    pt.edgeT = clampT;
+    pt.localPosition = p0 + (p1 - p0) * clampT;
+
+    m_knifeSession.points.push_back(pt);
+    m_knifeSession.hoverValid = false;
+    updateKnifePreviewOverlay();
+
+    SentryReporter::addBreadcrumb("edit_mode",
+        QString("Knife: point added programmatically (n=%1)").arg(m_knifeSession.points.size()));
+    emit knifeSessionChanged();
+    return true;
+}
+
 void EditModeController::updateKnifeHover(OgreWidget* widget, int screenX, int screenY)
 {
     if (!m_knifeSession.active || !widget) return;

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -320,6 +320,9 @@ void EditModeController::exitEditMode(bool commitChanges)
         if (commitChanges) commitBevel();
         else cancelBevel();
     }
+    // Knife session is always abandoned on exit — committing implicitly
+    // would be surprising mid-cut.
+    if (m_knifeSession.active) cancelKnife();
 
     if (commitChanges && m_editableMesh && m_editEntity) {
         bool ok = m_editableMesh->commitToEntity(m_editEntity);
@@ -1809,6 +1812,9 @@ bool EditModeController::beginBevel()
         return false;
     if (!m_editModeActive || !m_editableMesh || !m_editEntity)
         return false;
+    // Knife and bevel are mutually exclusive — a stray knife session would
+    // keep its preview overlay visible behind the bevel gizmo.
+    if (m_knifeSession.active) cancelKnife();
     const bool edgeValid = (m_selectionMode == EdgeMode && !m_selectedEdges.empty());
     const bool vertValid = (m_selectionMode == VertexMode && !m_selectedVertices.empty());
     if (!edgeValid && !vertValid) return false;
@@ -2216,6 +2222,303 @@ bool EditModeController::bevelSelection()
         return true;
     }
     return beginBevel();
+}
+
+// ===========================================================================
+// Knife tool
+// ===========================================================================
+
+bool EditModeController::beginKnife()
+{
+    if (!m_editModeActive || !m_editableMesh || !m_editEntity) return false;
+    if (m_knifeSession.active) return true;
+    // Knife lives alongside bevel but they shouldn't both be active.
+    if (m_bevelSession.active) cancelBevel();
+
+    m_knifeSession = {};
+    m_knifeSession.active = true;
+
+    SentryReporter::addBreadcrumb("edit_mode", "Knife: begin session");
+    emit knifeSessionChanged();
+    return true;
+}
+
+bool EditModeController::addKnifePoint(OgreWidget* widget, int screenX, int screenY)
+{
+    if (!m_knifeSession.active || !widget) return false;
+
+    KnifePoint pt;
+    if (!knifeHitTest(QPoint(screenX, screenY), widget, pt)) return false;
+
+    m_knifeSession.points.push_back(pt);
+    m_knifeSession.hoverValid = false;
+    updateKnifePreviewOverlay();
+
+    SentryReporter::addBreadcrumb("edit_mode",
+        QString("Knife: point added (n=%1)").arg(m_knifeSession.points.size()));
+    emit knifeSessionChanged();
+    return true;
+}
+
+void EditModeController::updateKnifeHover(OgreWidget* widget, int screenX, int screenY)
+{
+    if (!m_knifeSession.active || !widget) return;
+    m_knifeSession.hoverValid =
+        knifeHitTest(QPoint(screenX, screenY), widget, m_knifeSession.hover);
+    updateKnifePreviewOverlay();
+}
+
+bool EditModeController::commitKnife()
+{
+    if (!m_knifeSession.active) return false;
+    if (m_knifeSession.points.size() < 2) {
+        SentryReporter::addBreadcrumb("edit_mode",
+            "Knife: commit rejected (fewer than 2 points)");
+        cancelKnife();
+        return false;
+    }
+
+    // Snapshot for undo.
+    EditableMesh snapshot;
+    std::vector<EditableSubMesh> originalSubMeshes = m_editableMesh->subMeshes();
+
+    // Build an HE view once; each splitEdge mutates it in place. We walk
+    // the confirmed list and for each OnEdge point insert a vertex. OnFace
+    // and OnVertex points don't need a splitEdge — they either already
+    // exist (OnVertex) or land inside a face and would need a splitFace
+    // pairing, which the MVP doesn't yet handle, so we skip them.
+    HalfEdgeMesh hm;
+    if (!hm.buildFromEditableMesh(*m_editableMesh)) {
+        cancelKnife();
+        return false;
+    }
+
+    int inserted = 0;
+    for (const auto& p : m_knifeSession.points) {
+        if (p.kind == KnifePoint::OnEdge && p.edgeIndex >= 0) {
+            if (hm.splitEdge(p.edgeIndex, p.edgeT) >= 0) ++inserted;
+        }
+    }
+
+    if (inserted == 0) {
+        SentryReporter::addBreadcrumb("edit_mode",
+            "Knife: commit rejected (no edge cuts)");
+        cancelKnife();
+        return false;
+    }
+
+    // Write the modified mesh back and push undo.
+    EditableMesh updated;
+    if (!hm.toEditableMesh(updated)) {
+        cancelKnife();
+        return false;
+    }
+    m_editableMesh->subMeshes() = std::move(updated.subMeshes());
+
+    auto* cmd = new EditMeshTopologyCommand(
+        std::move(originalSubMeshes),
+        m_editableMesh->subMeshes(),
+        m_selectedVertices, m_selectedEdges, m_selectedFaces,
+        m_selectedVertices, m_selectedEdges, m_selectedFaces,
+        "Knife");
+    UndoManager::getSingleton()->push(cmd);
+
+    SentryReporter::addBreadcrumb("edit_mode",
+        QString("Knife: commit (points=%1, cuts=%2)")
+            .arg(m_knifeSession.points.size()).arg(inserted));
+
+    m_knifeSession = {};
+    destroyKnifePreviewOverlay();
+    emit knifeSessionChanged();
+    emit meshDataChanged();
+    return true;
+}
+
+void EditModeController::cancelKnife()
+{
+    if (!m_knifeSession.active) return;
+    SentryReporter::addBreadcrumb("edit_mode", "Knife: cancel");
+    m_knifeSession = {};
+    destroyKnifePreviewOverlay();
+    emit knifeSessionChanged();
+}
+
+bool EditModeController::knifeHitTest(const QPoint& screenPos, OgreWidget* widget,
+                                      KnifePoint& out) const
+{
+    if (!m_editableMesh || !m_editEntity || !widget) return false;
+    auto* spaceCam = widget->getSpaceCamera();
+    auto* camera = spaceCam ? spaceCam->getCamera() : nullptr;
+    if (!camera) return false;
+
+    const int vw = widget->width();
+    const int vh = widget->height();
+
+    // Priority 1: vertex snap. Uses the same radius as regular edit-mode
+    // vertex picking so the user's eye can predict the snap.
+    const int snapVert = hitTestVertex(screenPos, camera, vw, vh, 10.0f);
+    if (snapVert >= 0) {
+        auto [subIdx, localIdx] = globalToLocal(snapVert);
+        if (subIdx < m_editableMesh->subMeshes().size()
+         && localIdx < m_editableMesh->subMeshes()[subIdx].vertices.size()) {
+            out = {};
+            out.kind = KnifePoint::OnVertex;
+            out.vertexIndex = snapVert;
+            out.localPosition = m_editableMesh->subMeshes()[subIdx].vertices[localIdx].position;
+            return true;
+        }
+    }
+
+    // Priority 2: edge snap. hitTestEdge returns a pair of global vertex
+    // indices identifying the edge; translate it into an HE edge index
+    // and parametric position along it.
+    const auto edgePair = hitTestEdge(screenPos, camera, vw, vh, 10.0f);
+    if (edgePair.first >= 0 && edgePair.second >= 0) {
+        auto [sub0, loc0] = globalToLocal(edgePair.first);
+        auto [sub1, loc1] = globalToLocal(edgePair.second);
+        if (sub0 < m_editableMesh->subMeshes().size()
+         && sub1 < m_editableMesh->subMeshes().size()
+         && loc0 < m_editableMesh->subMeshes()[sub0].vertices.size()
+         && loc1 < m_editableMesh->subMeshes()[sub1].vertices.size()) {
+            const auto& p0 = m_editableMesh->subMeshes()[sub0].vertices[loc0].position;
+            const auto& p1 = m_editableMesh->subMeshes()[sub1].vertices[loc1].position;
+
+            // Project the click ray onto the edge line; use that parameter
+            // to place the midpoint. Clamp into [0,1] so we stay on the segment.
+            const Ogre::Real nx = static_cast<Ogre::Real>(screenPos.x()) / vw;
+            const Ogre::Real ny = static_cast<Ogre::Real>(screenPos.y()) / vh;
+            const Ogre::Ray ray = camera->getCameraToViewportRay(nx, ny);
+            Ogre::SceneNode* node = m_editEntity->getParentSceneNode();
+            Ogre::Vector3 localOrigin = p0;
+            Ogre::Vector3 localDir = (p1 - p0);
+            if (node) {
+                const Ogre::Affine3 worldToLocal = node->_getFullTransform().inverse();
+                localOrigin = worldToLocal * ray.getOrigin();
+                localDir = worldToLocal.linear() * ray.getDirection();
+            }
+
+            // Closest-point-on-line-segment against the ray in local space.
+            const Ogre::Vector3 d = p1 - p0;
+            const float dd = d.dotProduct(d);
+            if (dd > 1e-10f) {
+                const Ogre::Vector3 w = localOrigin - p0;
+                const float t = std::clamp(d.dotProduct(w) / dd, 0.0f, 1.0f);
+
+                // We still need the HE edge index. Build a quick lookup
+                // on the fly: iterate HE edges and match by vertex pair.
+                HalfEdgeMesh tmp;
+                if (tmp.buildFromEditableMesh(*m_editableMesh)) {
+                    for (size_t e = 0; e < tmp.edgeCount(); ++e) {
+                        auto [a, b] = tmp.edgeVertices(static_cast<int>(e));
+                        if ((a == edgePair.first && b == edgePair.second)
+                         || (a == edgePair.second && b == edgePair.first)) {
+                            out = {};
+                            out.kind = KnifePoint::OnEdge;
+                            out.edgeIndex = static_cast<int>(e);
+                            out.edgeT = t;
+                            out.localPosition = p0 + d * t;
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Priority 3: face ray-cast. Used for preview only in the MVP —
+    // commit pipeline doesn't yet handle on-face points.
+    const int triHit = hitTestFace(screenPos, camera, vw, vh);
+    if (triHit >= 0) {
+        out = {};
+        out.kind = KnifePoint::OnFace;
+        out.triangleIndex = triHit;
+        // Re-intersect the ray to get the local hit position for preview.
+        const Ogre::Real nx = static_cast<Ogre::Real>(screenPos.x()) / vw;
+        const Ogre::Real ny = static_cast<Ogre::Real>(screenPos.y()) / vh;
+        const Ogre::Ray ray = camera->getCameraToViewportRay(nx, ny);
+        Ogre::SceneNode* node = m_editEntity->getParentSceneNode();
+        Ogre::Affine3 worldToLocal = node ? node->_getFullTransform().inverse() : Ogre::Affine3::IDENTITY;
+        Ogre::Vector3 localOrigin = worldToLocal * ray.getOrigin();
+        Ogre::Vector3 localDir = worldToLocal.linear() * ray.getDirection();
+        localDir.normalise();
+
+        // Walk the mesh to find the tri and intersect.
+        int globalTriOffset = 0;
+        for (const auto& sub : m_editableMesh->subMeshes()) {
+            for (size_t ti = 0; ti < sub.triangles.size(); ++ti) {
+                if (globalTriOffset + static_cast<int>(ti) != triHit) continue;
+                const auto& tri = sub.triangles[ti];
+                const auto& v0 = sub.vertices[tri.indices[0]].position;
+                const auto& v1 = sub.vertices[tri.indices[1]].position;
+                const auto& v2 = sub.vertices[tri.indices[2]].position;
+                const float t = rayTriangleIntersect(localOrigin, localDir, v0, v1, v2);
+                if (t >= 0.0f) out.localPosition = localOrigin + localDir * t;
+            }
+            globalTriOffset += static_cast<int>(sub.triangles.size());
+        }
+        return true;
+    }
+
+    return false;
+}
+
+void EditModeController::updateKnifePreviewOverlay()
+{
+    if (!m_editModeActive || !m_editEntity) return;
+    auto* sceneMgr = m_editEntity->_getManager();
+    if (!sceneMgr) return;
+
+    if (!m_overlayNode) {
+        m_overlayNode = sceneMgr->getRootSceneNode()->createChildSceneNode();
+    }
+    if (!m_overlayKnife) {
+        m_overlayKnife = sceneMgr->createManualObject("EditMode_KnifeOverlay");
+        m_overlayKnife->setDynamic(true);
+        m_overlayKnife->setRenderQueueGroup(Ogre::RENDER_QUEUE_OVERLAY);
+        m_overlayNode->attachObject(m_overlayKnife);
+    }
+
+    // Mirror the entity's world transform so knife points drawn in local
+    // space sit on the mesh.
+    if (auto* entNode = m_editEntity->getParentSceneNode()) {
+        m_overlayNode->setPosition(entNode->_getDerivedPosition());
+        m_overlayNode->setOrientation(entNode->_getDerivedOrientation());
+        m_overlayNode->setScale(entNode->_getDerivedScale());
+    }
+
+    m_overlayKnife->clear();
+    if (m_knifeSession.points.empty() && !m_knifeSession.hoverValid) return;
+
+    const Ogre::ColourValue solid(1.0f, 0.85f, 0.2f, 1.0f);  // yellow for confirmed
+    const Ogre::ColourValue ghost(1.0f, 0.85f, 0.2f, 0.45f); // dimmer for hover
+
+    m_overlayKnife->begin("EditMode/EdgeSelection", Ogre::RenderOperation::OT_LINE_LIST);
+
+    // Confirmed polyline.
+    for (size_t i = 1; i < m_knifeSession.points.size(); ++i) {
+        m_overlayKnife->position(m_knifeSession.points[i - 1].localPosition);
+        m_overlayKnife->colour(solid);
+        m_overlayKnife->position(m_knifeSession.points[i].localPosition);
+        m_overlayKnife->colour(solid);
+    }
+    // Hover segment from last confirmed to cursor.
+    if (!m_knifeSession.points.empty() && m_knifeSession.hoverValid) {
+        m_overlayKnife->position(m_knifeSession.points.back().localPosition);
+        m_overlayKnife->colour(ghost);
+        m_overlayKnife->position(m_knifeSession.hover.localPosition);
+        m_overlayKnife->colour(ghost);
+    }
+
+    m_overlayKnife->end();
+}
+
+void EditModeController::destroyKnifePreviewOverlay()
+{
+    if (!m_overlayKnife) return;
+    auto* sceneMgr = m_editEntity ? m_editEntity->_getManager() : nullptr;
+    if (m_overlayNode) m_overlayNode->detachObject(m_overlayKnife);
+    if (sceneMgr) sceneMgr->destroyManualObject(m_overlayKnife);
+    m_overlayKnife = nullptr;
 }
 
 // ===========================================================================

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -2282,38 +2282,54 @@ bool EditModeController::commitKnife()
     EditableMesh snapshot;
     std::vector<EditableSubMesh> originalSubMeshes = m_editableMesh->subMeshes();
 
-    // Build an HE view once; each splitEdge mutates it in place. We walk
-    // the confirmed list and for each OnEdge point insert a vertex. OnFace
-    // and OnVertex points don't need a splitEdge — they either already
-    // exist (OnVertex) or land inside a face and would need a splitFace
-    // pairing, which the MVP doesn't yet handle, so we skip them.
+    // Build an HE view once and hand the confirmed-click list to cutPath,
+    // which runs the walk-and-cut algorithm: splits each click endpoint
+    // and every interior edge crossed by the straight-line cut between
+    // consecutive endpoints, so the visible preview becomes a real chain
+    // of mesh edges. OnFace/OnVertex clicks aren't yet in scope — the
+    // commit skips them and proceeds on the OnEdge subset.
     HalfEdgeMesh hm;
     if (!hm.buildFromEditableMesh(*m_editableMesh)) {
         cancelKnife();
         return false;
     }
 
-    int inserted = 0;
+    std::vector<HalfEdgeMesh::CutPoint> cpts;
+    cpts.reserve(m_knifeSession.points.size());
     for (const auto& p : m_knifeSession.points) {
         if (p.kind == KnifePoint::OnEdge && p.edgeIndex >= 0) {
-            if (hm.splitEdge(p.edgeIndex, p.edgeT) >= 0) ++inserted;
+            cpts.push_back({p.edgeIndex, p.edgeT});
         }
     }
-
-    if (inserted == 0) {
+    if (cpts.size() < 2) {
         SentryReporter::addBreadcrumb("edit_mode",
-            "Knife: commit rejected (no edge cuts)");
+            "Knife: commit rejected (fewer than 2 edge clicks)");
         cancelKnife();
         return false;
     }
+    const auto cutVerts = hm.cutPath(cpts);
+    if (cutVerts.empty()) {
+        SentryReporter::addBreadcrumb("edit_mode",
+            "Knife: commit rejected (cutPath failed)");
+        cancelKnife();
+        return false;
+    }
+    const int inserted = static_cast<int>(cutVerts.size());
 
-    // Write the modified mesh back and push undo.
+    // Write the modified mesh back. Topology changed (new verts and
+    // tris), so we must resize the Ogre buffers and re-initialise the
+    // entity's subentity caches — same sequence EditMeshTopologyCommand
+    // uses on undo/redo. Without this the EditableMesh is updated but
+    // the GPU buffers still hold the pre-cut topology.
     EditableMesh updated;
     if (!hm.toEditableMesh(updated)) {
         cancelKnife();
         return false;
     }
     m_editableMesh->subMeshes() = std::move(updated.subMeshes());
+    m_editableMesh->resizeEntityBuffers(m_editEntity);
+    m_editEntity->_deinitialise();
+    m_editEntity->_initialise(true);
 
     auto* cmd = new EditMeshTopologyCommand(
         std::move(originalSubMeshes),
@@ -2369,58 +2385,95 @@ bool EditModeController::knifeHitTest(const QPoint& screenPos, OgreWidget* widge
         }
     }
 
-    // Priority 2: edge snap. hitTestEdge returns a pair of global vertex
-    // indices identifying the edge; translate it into an HE edge index
-    // and parametric position along it.
-    const auto edgePair = hitTestEdge(screenPos, camera, vw, vh, 10.0f);
-    if (edgePair.first >= 0 && edgePair.second >= 0) {
-        auto [sub0, loc0] = globalToLocal(edgePair.first);
-        auto [sub1, loc1] = globalToLocal(edgePair.second);
-        if (sub0 < m_editableMesh->subMeshes().size()
-         && sub1 < m_editableMesh->subMeshes().size()
-         && loc0 < m_editableMesh->subMeshes()[sub0].vertices.size()
-         && loc1 < m_editableMesh->subMeshes()[sub1].vertices.size()) {
-            const auto& p0 = m_editableMesh->subMeshes()[sub0].vertices[loc0].position;
-            const auto& p1 = m_editableMesh->subMeshes()[sub1].vertices[loc1].position;
+    // Priority 2: edge snap. Knife needs a depth-aware variant of the
+    // regular edge hit-test: when front and back edges of a cube overlap
+    // in screen space, the generic hitTestEdge can pick either (iteration
+    // order decides). That lands the cut on an edge facing away from the
+    // camera, which the user experiences as "the vertex drops somewhere
+    // random on the edge I couldn't even see." Here we walk all edges,
+    // keep only those within the screen-space pixel radius, then pick the
+    // one whose closest-point sits nearest the camera.
+    {
+        const Ogre::Real nx = static_cast<Ogre::Real>(screenPos.x()) / vw;
+        const Ogre::Real ny = static_cast<Ogre::Real>(screenPos.y()) / vh;
+        const Ogre::Ray ray = camera->getCameraToViewportRay(nx, ny);
+        Ogre::SceneNode* node = m_editEntity->getParentSceneNode();
 
-            // Project the click ray onto the edge line; use that parameter
-            // to place the midpoint. Clamp into [0,1] so we stay on the segment.
-            const Ogre::Real nx = static_cast<Ogre::Real>(screenPos.x()) / vw;
-            const Ogre::Real ny = static_cast<Ogre::Real>(screenPos.y()) / vh;
-            const Ogre::Ray ray = camera->getCameraToViewportRay(nx, ny);
-            Ogre::SceneNode* node = m_editEntity->getParentSceneNode();
-            Ogre::Vector3 localOrigin = p0;
-            Ogre::Vector3 localDir = (p1 - p0);
-            if (node) {
-                const Ogre::Affine3 worldToLocal = node->_getFullTransform().inverse();
-                localOrigin = worldToLocal * ray.getOrigin();
-                localDir = worldToLocal.linear() * ray.getDirection();
+        Ogre::Vector3 rO = ray.getOrigin();
+        Ogre::Vector3 rD = ray.getDirection();
+        if (node) {
+            const Ogre::Affine3 worldToLocal = node->_getFullTransform().inverse();
+            rO = worldToLocal * rO;
+            rD = worldToLocal.linear() * rD;
+        }
+
+        HalfEdgeMesh tmp;
+        if (tmp.buildFromEditableMesh(*m_editableMesh)) {
+            const Ogre::Vector3 camPosWorld = camera->getDerivedPosition();
+            constexpr float kPixelRadius = 10.0f;
+            float bestDepth = std::numeric_limits<float>::infinity();
+            int bestEdgeIdx = -1;
+            float bestT = 0.5f;
+            Ogre::Vector3 bestLocal = Ogre::Vector3::ZERO;
+
+            for (size_t e = 0; e < tmp.edgeCount(); ++e) {
+                auto [gv0, gv1] = tmp.edgeVertices(static_cast<int>(e));
+                if (gv0 < 0 || gv1 < 0) continue;
+                auto [sub0, loc0] = globalToLocal(gv0);
+                auto [sub1, loc1] = globalToLocal(gv1);
+                if (sub0 >= m_editableMesh->subMeshes().size()) continue;
+                if (sub1 >= m_editableMesh->subMeshes().size()) continue;
+                const auto& sA = m_editableMesh->subMeshes()[sub0];
+                const auto& sB = m_editableMesh->subMeshes()[sub1];
+                if (loc0 >= sA.vertices.size() || loc1 >= sB.vertices.size()) continue;
+
+                const auto& p0 = sA.vertices[loc0].position;
+                const auto& p1 = sB.vertices[loc1].position;
+
+                // Screen-space pixel distance: reject edges outside the
+                // snap radius outright.
+                if (!node) continue;
+                const Ogre::Vector3 wp0 = node->convertLocalToWorldPosition(p0);
+                const Ogre::Vector3 wp1 = node->convertLocalToWorldPosition(p1);
+                const QPoint sp0 = worldToScreen(wp0, camera, vw, vh);
+                const QPoint sp1 = worldToScreen(wp1, camera, vw, vh);
+                if (pointToSegmentDistance(screenPos, sp0, sp1) > kPixelRadius)
+                    continue;
+
+                // Closest point on the edge segment to the click ray, in
+                // local mesh space. Solves the 2x2 system for the edge
+                // parameter s and ray parameter u that minimize |P(s)-R(u)|².
+                const Ogre::Vector3 d = p1 - p0;
+                const float a = d.dotProduct(d);
+                const float b = d.dotProduct(rD);
+                const float c = rD.dotProduct(rD);
+                const float det = a * c - b * b;
+                float t = 0.5f;
+                if (a > 1e-10f && det > 1e-10f) {
+                    const Ogre::Vector3 w0 = p0 - rO;
+                    const float dW = d.dotProduct(w0);
+                    const float rW = rD.dotProduct(w0);
+                    t = std::clamp((b * rW - c * dW) / det, 0.0f, 1.0f);
+                }
+                const Ogre::Vector3 local = p0 + d * t;
+                const Ogre::Vector3 world = node->convertLocalToWorldPosition(local);
+                const float depth = (world - camPosWorld).dotProduct(camera->getDerivedDirection());
+                if (depth <= 0.0f) continue; // behind camera
+                if (depth < bestDepth) {
+                    bestDepth = depth;
+                    bestEdgeIdx = static_cast<int>(e);
+                    bestT = t;
+                    bestLocal = local;
+                }
             }
 
-            // Closest-point-on-line-segment against the ray in local space.
-            const Ogre::Vector3 d = p1 - p0;
-            const float dd = d.dotProduct(d);
-            if (dd > 1e-10f) {
-                const Ogre::Vector3 w = localOrigin - p0;
-                const float t = std::clamp(d.dotProduct(w) / dd, 0.0f, 1.0f);
-
-                // We still need the HE edge index. Build a quick lookup
-                // on the fly: iterate HE edges and match by vertex pair.
-                HalfEdgeMesh tmp;
-                if (tmp.buildFromEditableMesh(*m_editableMesh)) {
-                    for (size_t e = 0; e < tmp.edgeCount(); ++e) {
-                        auto [a, b] = tmp.edgeVertices(static_cast<int>(e));
-                        if ((a == edgePair.first && b == edgePair.second)
-                         || (a == edgePair.second && b == edgePair.first)) {
-                            out = {};
-                            out.kind = KnifePoint::OnEdge;
-                            out.edgeIndex = static_cast<int>(e);
-                            out.edgeT = t;
-                            out.localPosition = p0 + d * t;
-                            return true;
-                        }
-                    }
-                }
+            if (bestEdgeIdx >= 0) {
+                out = {};
+                out.kind = KnifePoint::OnEdge;
+                out.edgeIndex = bestEdgeIdx;
+                out.edgeT = bestT;
+                out.localPosition = bestLocal;
+                return true;
             }
         }
     }

--- a/src/EditModeController.h
+++ b/src/EditModeController.h
@@ -289,6 +289,57 @@ public:
     Q_INVOKABLE void resetBevelProfile();
     /// @}
 
+    /// @name Knife tool
+    /// @{
+    /**
+     * @brief Enter knife mode. The user places cut points along mesh
+     *        surface (left-click), commits with commitKnife (Enter or
+     *        double-click) or cancels with cancelKnife (Esc). While
+     *        active, knifeSessionActive() returns true and the viewport
+     *        draws a live preview of the pending cut line.
+     */
+    Q_INVOKABLE bool beginKnife();
+
+    /**
+     * @brief Record a cut point from a viewport click. The hit-test
+     *        priority is vertex → edge → face (so snaps are sticky at
+     *        geometry boundaries). Called from TransformOperator's
+     *        mouse handler when the knife session is active.
+     */
+    bool addKnifePoint(OgreWidget* widget, int screenX, int screenY);
+
+    /**
+     * @brief Update the hover preview. Called from the mouse-move path
+     *        while knife is active; redraws the provisional segment
+     *        between the last confirmed point and the cursor.
+     */
+    void updateKnifeHover(OgreWidget* widget, int screenX, int screenY);
+
+    /**
+     * @brief Apply the current cut point list as splitEdge operations and
+     *        push one undo command. Clears the session afterwards.
+     *        No-op (returns false) if fewer than 2 points are confirmed.
+     */
+    Q_INVOKABLE bool commitKnife();
+
+    /// @brief Abandon the current knife session without mutating the mesh.
+    Q_INVOKABLE void cancelKnife();
+
+    /// @brief Whether a knife session is active. Exposed as a Q_PROPERTY
+    ///        so QML bindings get a real bool.
+    Q_PROPERTY(bool knifeSessionActiveValue READ knifeSessionActive
+               NOTIFY knifeSessionChanged)
+    bool knifeSessionActive() const { return m_knifeSession.active; }
+
+    /// @brief Count of confirmed cut points. QML uses this to decide
+    ///        whether Enter would commit or is a no-op.
+    Q_PROPERTY(int knifePointCountValue READ knifePointCount
+               NOTIFY knifeSessionChanged)
+    int knifePointCount() const {
+        return static_cast<int>(m_knifeSession.points.size());
+    }
+    /// @}
+
     /// @name Vertex transform support
     /// @{
     /// Get the centroid of selected vertices in local mesh space.
@@ -493,6 +544,9 @@ signals:
     void validationChanged();
     /// Emitted when the bevel profile points vector changes (size or value).
     void bevelProfilePointsChanged();
+    /// Emitted whenever the knife session starts, gains a point, or ends —
+    /// so QML toolbar state and preview overlay refresh together.
+    void knifeSessionChanged();
 
 private slots:
     void onSelectionChanged();
@@ -562,6 +616,48 @@ private:
     };
     BevelSession m_bevelSession;
     std::unique_ptr<class BevelGizmo> m_bevelGizmo;
+
+    // Knife session state — populated on beginKnife, mutated by each
+    // addKnifePoint / updateKnifeHover, consumed on commitKnife.
+    struct KnifePoint {
+        enum Kind { OnVertex, OnEdge, OnFace };
+        Kind kind = OnFace;
+        // OnVertex: vertexIndex. OnEdge: edgeIndex + edgeT. OnFace:
+        // triangleIndex + world-space position (no splitEdge needed for
+        // on-face points — they land inside a face and the commit
+        // pipeline handles them separately).
+        int vertexIndex = -1;
+        int edgeIndex = -1;
+        float edgeT = 0.5f;
+        int triangleIndex = -1;
+        // Local-space position of the point (for preview rendering and
+        // on-face fallback placement).
+        Ogre::Vector3 localPosition = Ogre::Vector3::ZERO;
+    };
+
+    struct KnifeSession {
+        bool active = false;
+        std::vector<KnifePoint> points;      ///< Confirmed points in click order.
+        bool hoverValid = false;             ///< True while cursor hit-test is hitting the mesh.
+        KnifePoint hover;                    ///< Preview point under the cursor.
+    };
+    KnifeSession m_knifeSession;
+
+    /// Hit-test a screen-space point for knife placement. Priority:
+    /// snap to existing vertex within pixelRadius, else snap to edge
+    /// within pixelRadius, else ray-cast to a face. Writes the result
+    /// into `out` and returns true on a successful hit.
+    bool knifeHitTest(const QPoint& screenPos, OgreWidget* widget,
+                      KnifePoint& out) const;
+
+    /// Rebuild the knife preview overlay from the current session
+    /// (confirmed points + hover), creating it on first use.
+    void updateKnifePreviewOverlay();
+
+    /// Destroy the knife preview overlay at session end.
+    void destroyKnifePreviewOverlay();
+
+    Ogre::ManualObject* m_overlayKnife = nullptr;
 
     /// Apply a bevel at `width` to `edges` assuming the mesh is at its
     /// pre-bevel snapshot state. Updates selection to the new chamfer verts.

--- a/src/EditModeController.h
+++ b/src/EditModeController.h
@@ -667,6 +667,10 @@ private:
     void destroyKnifePreviewOverlay();
 
     Ogre::ManualObject* m_overlayKnife = nullptr;
+    // Independent scene node for the knife preview so its entity-mirror
+    // transform doesn't fight with selection overlays, which expect
+    // m_overlayNode parked at the origin with local-space geometry.
+    Ogre::SceneNode* m_overlayKnifeNode = nullptr;
 
     /// Apply a bevel at `width` to `edges` assuming the mesh is at its
     /// pre-bevel snapshot state. Updates selection to the new chamfer verts.

--- a/src/EditModeController.h
+++ b/src/EditModeController.h
@@ -316,6 +316,15 @@ public:
     void updateKnifeHover(OgreWidget* widget, int screenX, int screenY);
 
     /**
+     * @brief Programmatic cut-point entry: append a knife click at
+     *        parametric position `t` on an existing HE edge, resolved
+     *        against the current mesh. Used by scripted/automated knife
+     *        flows and by unit tests that can't run the widget-based
+     *        hit-test (headless CI, macOS without plugins).
+     */
+    bool addKnifePointOnEdge(int heEdgeIndex, float t);
+
+    /**
      * @brief Apply the current cut point list as splitEdge operations and
      *        push one undo command. Clears the session afterwards.
      *        No-op (returns false) if fewer than 2 points are confirmed.

--- a/src/EditModeController_test.cpp
+++ b/src/EditModeController_test.cpp
@@ -14,6 +14,7 @@ The MIT License
 #include "TestHelpers.h"
 #include "Manager.h"
 #include "SelectionSet.h"
+#include "UndoManager.h"
 #include <Ogre.h>
 #include <set>
 #include <utility>
@@ -1273,5 +1274,89 @@ TEST_F(EditModeControllerBevelE2ETest, KnifeBeginOutsideEditModeFails) {
     // Fresh fixture: edit mode is off. beginKnife should be a no-op.
     EXPECT_FALSE(ctrl->beginKnife());
     EXPECT_FALSE(ctrl->knifeSessionActive());
+}
+
+TEST_F(EditModeControllerBevelE2ETest, KnifeCommitWalkAndCutGrowsMeshManifoldly) {
+    // End-to-end: open a knife session, programmatically push two OnEdge
+    // clicks on distinct edges of the welded cube, commit. The walk-and-
+    // cut commit pipeline should splitEdge at both endpoints and (for
+    // this topology) potentially at interior crossings, leaving the
+    // mesh manifold with more vertices than before.
+    auto* ctrl = EditModeController::instance();
+    ctrl->enterEditMode();
+    ASSERT_TRUE(ctrl->beginKnife());
+
+    // Capture pre-commit vertex count directly from the entity's buffers
+    // so we're comparing against what Ogre actually holds, not just the
+    // EditableMesh snapshot.
+    std::vector<Ogre::Vector3> posBefore;
+    std::vector<std::array<unsigned, 3>> trisBefore;
+    extractEntityBuffers(m_entity, posBefore, trisBefore);
+    const size_t vertsBefore = posBefore.size();
+
+    // Push two edge clicks. Edge indices 0 and 5 land on different edges
+    // of the welded cube; the exact topology is an implementation
+    // detail but as long as they resolve to distinct edges the cut
+    // has something to do. (If either call fails the assert surfaces
+    // the mismatch immediately.)
+    ASSERT_TRUE(ctrl->addKnifePointOnEdge(0, 0.4f));
+    ASSERT_TRUE(ctrl->addKnifePointOnEdge(5, 0.6f));
+    ASSERT_EQ(ctrl->knifePointCount(), 2);
+
+    ASSERT_TRUE(ctrl->commitKnife());
+    EXPECT_FALSE(ctrl->knifeSessionActive());
+
+    std::vector<Ogre::Vector3> posAfter;
+    std::vector<std::array<unsigned, 3>> trisAfter;
+    extractEntityBuffers(m_entity, posAfter, trisAfter);
+    EXPECT_GT(posAfter.size(), vertsBefore)
+        << "knife commit should have inserted new vertices into the GPU mesh";
+
+    // Manifold check: every edge is used by exactly 1 or 2 triangles;
+    // no edge should be used more than twice (would be non-manifold).
+    std::map<std::pair<unsigned, unsigned>, int> edgeUse;
+    for (const auto& t : trisAfter) {
+        for (int k = 0; k < 3; ++k) {
+            unsigned u = t[k], v = t[(k + 1) % 3];
+            auto key = std::make_pair(std::min(u, v), std::max(u, v));
+            ++edgeUse[key];
+        }
+    }
+    for (auto& [key, count] : edgeUse) {
+        EXPECT_LE(count, 2) << "non-manifold edge in post-knife mesh";
+    }
+}
+
+TEST_F(EditModeControllerBevelE2ETest, KnifeCommitUndoRestoresOriginalVertexCount) {
+    auto* ctrl = EditModeController::instance();
+    ctrl->enterEditMode();
+
+    std::vector<Ogre::Vector3> posBefore;
+    std::vector<std::array<unsigned, 3>> trisBefore;
+    extractEntityBuffers(m_entity, posBefore, trisBefore);
+    const size_t vertsBefore = posBefore.size();
+
+    ASSERT_TRUE(ctrl->beginKnife());
+    ASSERT_TRUE(ctrl->addKnifePointOnEdge(0, 0.5f));
+    ASSERT_TRUE(ctrl->addKnifePointOnEdge(5, 0.5f));
+    ASSERT_TRUE(ctrl->commitKnife());
+
+    UndoManager::getSingleton()->undo();
+
+    std::vector<Ogre::Vector3> posAfterUndo;
+    std::vector<std::array<unsigned, 3>> trisAfterUndo;
+    extractEntityBuffers(m_entity, posAfterUndo, trisAfterUndo);
+    EXPECT_EQ(posAfterUndo.size(), vertsBefore)
+        << "undo after knife commit should restore original vertex count";
+}
+
+TEST_F(EditModeControllerBevelE2ETest, KnifePointOnInvalidEdgeRefused) {
+    auto* ctrl = EditModeController::instance();
+    ctrl->enterEditMode();
+    ASSERT_TRUE(ctrl->beginKnife());
+
+    EXPECT_FALSE(ctrl->addKnifePointOnEdge(-1, 0.5f));
+    EXPECT_FALSE(ctrl->addKnifePointOnEdge(9999, 0.5f));
+    EXPECT_EQ(ctrl->knifePointCount(), 0);
 }
 

--- a/src/EditModeController_test.cpp
+++ b/src/EditModeController_test.cpp
@@ -15,6 +15,7 @@ The MIT License
 #include "Manager.h"
 #include "SelectionSet.h"
 #include "UndoManager.h"
+#include "HalfEdgeMesh.h"
 #include <Ogre.h>
 #include <QSignalSpy>
 #include <set>
@@ -1430,6 +1431,23 @@ TEST_F(EditModeControllerBevelE2ETest, KnifeBeginOutsideEditModeFails) {
     EXPECT_FALSE(ctrl->knifeSessionActive());
 }
 
+// Resolve an HE edge index for an edge connecting two global vertex
+// indices in the controller's current EditableMesh. HE indices are an
+// internal-rebuild detail; the knife tests resolve by vertex pair so
+// harmless topology-order changes don't flake the assertions.
+static int resolveEdgeByVerts(int va, int vb) {
+    auto* mesh = EditModeController::instance()->currentMesh();
+    if (!mesh) return -1;
+    HalfEdgeMesh hm;
+    if (!hm.buildFromEditableMesh(*mesh)) return -1;
+    for (size_t e = 0; e < hm.edgeCount(); ++e) {
+        auto [a, b] = hm.edgeVertices(static_cast<int>(e));
+        if ((a == va && b == vb) || (a == vb && b == va))
+            return static_cast<int>(e);
+    }
+    return -1;
+}
+
 TEST_F(EditModeControllerBevelE2ETest, KnifeCommitWalkAndCutGrowsMeshManifoldly) {
     // End-to-end: open a knife session, programmatically push two OnEdge
     // clicks on distinct edges of the welded cube, commit. The walk-and-
@@ -1448,13 +1466,17 @@ TEST_F(EditModeControllerBevelE2ETest, KnifeCommitWalkAndCutGrowsMeshManifoldly)
     extractEntityBuffers(m_entity, posBefore, trisBefore);
     const size_t vertsBefore = posBefore.size();
 
-    // Push two edge clicks. Edge indices 0 and 5 land on different edges
-    // of the welded cube; the exact topology is an implementation
-    // detail but as long as they resolve to distinct edges the cut
-    // has something to do. (If either call fails the assert surfaces
-    // the mismatch immediately.)
-    ASSERT_TRUE(ctrl->addKnifePointOnEdge(0, 0.4f));
-    ASSERT_TRUE(ctrl->addKnifePointOnEdge(5, 0.6f));
+    // Welded cube verts 2..5 bound the top face (y=+1). Picking two
+    // perimeter edges of that face gives a knife cut that's guaranteed
+    // to land on the same coplanar region — the walk has something to
+    // do, and the topology is fixed regardless of HE-edge numbering.
+    const int edgeA = resolveEdgeByVerts(2, 3); // back-top edge
+    const int edgeB = resolveEdgeByVerts(4, 5); // front-top edge
+    ASSERT_GE(edgeA, 0);
+    ASSERT_GE(edgeB, 0);
+
+    ASSERT_TRUE(ctrl->addKnifePointOnEdge(edgeA, 0.4f));
+    ASSERT_TRUE(ctrl->addKnifePointOnEdge(edgeB, 0.6f));
     ASSERT_EQ(ctrl->knifePointCount(), 2);
 
     ASSERT_TRUE(ctrl->commitKnife());
@@ -1490,9 +1512,14 @@ TEST_F(EditModeControllerBevelE2ETest, KnifeCommitUndoRestoresOriginalVertexCoun
     extractEntityBuffers(m_entity, posBefore, trisBefore);
     const size_t vertsBefore = posBefore.size();
 
+    const int edgeA = resolveEdgeByVerts(2, 3);
+    const int edgeB = resolveEdgeByVerts(4, 5);
+    ASSERT_GE(edgeA, 0);
+    ASSERT_GE(edgeB, 0);
+
     ASSERT_TRUE(ctrl->beginKnife());
-    ASSERT_TRUE(ctrl->addKnifePointOnEdge(0, 0.5f));
-    ASSERT_TRUE(ctrl->addKnifePointOnEdge(5, 0.5f));
+    ASSERT_TRUE(ctrl->addKnifePointOnEdge(edgeA, 0.5f));
+    ASSERT_TRUE(ctrl->addKnifePointOnEdge(edgeB, 0.5f));
     ASSERT_TRUE(ctrl->commitKnife());
 
     UndoManager::getSingleton()->undo();

--- a/src/EditModeController_test.cpp
+++ b/src/EditModeController_test.cpp
@@ -1194,3 +1194,84 @@ TEST_F(EditModeControllerBevelE2ETest, BevelCubeCornerVertexProducesClosedManifo
     EXPECT_EQ(boundaryEdges, 0u) << "vertex bevel leaves " << boundaryEdges << " boundary edges";
 }
 
+// ===========================================================================
+// Knife tool — session lifecycle (hit-test-free tests)
+//
+// The hit-test paths depend on an OgreWidget, which isn't available headless.
+// These tests drive the controller API directly by pushing synthetic
+// KnifePoint records through the commit pipeline, exercising the bits that
+// do run in CI: enter/cancel/commit state transitions, short-circuit on
+// zero-cut commits, breadcrumb emission via the active bevel guard, etc.
+// ===========================================================================
+
+TEST_F(EditModeControllerBevelE2ETest, KnifeBeginThenCancelRestoresIdleState) {
+    auto* ctrl = EditModeController::instance();
+    ctrl->enterEditMode();
+
+    EXPECT_FALSE(ctrl->knifeSessionActive());
+    EXPECT_TRUE(ctrl->beginKnife());
+    EXPECT_TRUE(ctrl->knifeSessionActive());
+    EXPECT_EQ(ctrl->knifePointCount(), 0);
+
+    ctrl->cancelKnife();
+    EXPECT_FALSE(ctrl->knifeSessionActive());
+    EXPECT_EQ(ctrl->knifePointCount(), 0);
+}
+
+TEST_F(EditModeControllerBevelE2ETest, KnifeCommitWithoutPointsRejectsAndCleansUp) {
+    auto* ctrl = EditModeController::instance();
+    ctrl->enterEditMode();
+    ASSERT_TRUE(ctrl->beginKnife());
+
+    // Zero confirmed points — commit should refuse and tidy up.
+    EXPECT_FALSE(ctrl->commitKnife());
+    EXPECT_FALSE(ctrl->knifeSessionActive());
+}
+
+TEST_F(EditModeControllerBevelE2ETest, KnifeBeginCancelsActiveBevelFirst) {
+    auto* ctrl = EditModeController::instance();
+    ctrl->enterEditMode();
+    ctrl->setSelectionMode(EditModeController::VertexMode);
+    ctrl->selectVertex(5, false);
+    ASSERT_TRUE(ctrl->bevelSelection());
+    ASSERT_TRUE(ctrl->bevelSessionActive());
+
+    // Opening the knife should cancel the bevel session first.
+    ASSERT_TRUE(ctrl->beginKnife());
+    EXPECT_TRUE(ctrl->knifeSessionActive());
+    EXPECT_FALSE(ctrl->bevelSessionActive());
+}
+
+TEST_F(EditModeControllerBevelE2ETest, BeginBevelCancelsActiveKnifeFirst) {
+    auto* ctrl = EditModeController::instance();
+    ctrl->enterEditMode();
+    ASSERT_TRUE(ctrl->beginKnife());
+
+    // Now the user invokes a vertex bevel — the knife session should get
+    // cancelled rather than leaving a stale preview behind the gizmo.
+    ctrl->setSelectionMode(EditModeController::VertexMode);
+    ctrl->selectVertex(5, false);
+    ASSERT_TRUE(ctrl->bevelSelection());
+
+    EXPECT_TRUE(ctrl->bevelSessionActive());
+    EXPECT_FALSE(ctrl->knifeSessionActive());
+}
+
+TEST_F(EditModeControllerBevelE2ETest, ExitEditModeCancelsKnifeSession) {
+    auto* ctrl = EditModeController::instance();
+    ctrl->enterEditMode();
+    ASSERT_TRUE(ctrl->beginKnife());
+    ASSERT_TRUE(ctrl->knifeSessionActive());
+
+    ctrl->exitEditMode(false);
+    EXPECT_FALSE(ctrl->knifeSessionActive());
+    EXPECT_FALSE(ctrl->isEditModeActive());
+}
+
+TEST_F(EditModeControllerBevelE2ETest, KnifeBeginOutsideEditModeFails) {
+    auto* ctrl = EditModeController::instance();
+    // Fresh fixture: edit mode is off. beginKnife should be a no-op.
+    EXPECT_FALSE(ctrl->beginKnife());
+    EXPECT_FALSE(ctrl->knifeSessionActive());
+}
+

--- a/src/HalfEdgeMesh.cpp
+++ b/src/HalfEdgeMesh.cpp
@@ -125,19 +125,26 @@ bool HalfEdgeMesh::buildFromEditableMesh(const EditableMesh& editableMesh)
 
 int HalfEdgeMesh::appendTriangle(int v0, int v1, int v2, int subMeshIndex)
 {
-    int fIdx = static_cast<int>(m_faces.size());
+    return appendFace({v0, v1, v2}, subMeshIndex);
+}
+
+int HalfEdgeMesh::appendFace(const std::vector<int>& vertices, int subMeshIndex)
+{
+    const int n = static_cast<int>(vertices.size());
+    if (n < 3) return -1;
+
+    const int fIdx = static_cast<int>(m_faces.size());
     HEFace f;
     f.subMeshIndex = subMeshIndex;
     m_faces.push_back(f);
 
-    int he0 = static_cast<int>(m_halfEdges.size());
-    int verts[3] = {v0, v1, v2};
-    for (int i = 0; i < 3; ++i) {
+    const int he0 = static_cast<int>(m_halfEdges.size());
+    for (int i = 0; i < n; ++i) {
         HalfEdge he;
-        he.vertex = verts[(i + 1) % 3]; // points TO the next vertex
+        he.vertex = vertices[(i + 1) % n]; // points TO the next vertex in the loop
         he.face = fIdx;
-        he.next = he0 + (i + 1) % 3;
-        he.prev = he0 + (i + 2) % 3;
+        he.next = he0 + (i + 1) % n;
+        he.prev = he0 + (i + n - 1) % n;
         m_halfEdges.push_back(he);
     }
     m_faces[fIdx].halfEdge = he0;
@@ -3580,6 +3587,219 @@ std::vector<int> HalfEdgeMesh::bevelVertices(
     fixVertexHalfEdges();
 
     return newVertices;
+}
+
+namespace {
+
+// Interpolate a new vertex between two existing ones at parameter t.
+// Position / normal / UV / color / tangent / bone weights are lerped by t,
+// with an eps safety margin so an exactly-on-endpoint t doesn't collapse
+// the source face into degeneracy.
+HEVertex interpolateVertex(const HEVertex& a, const HEVertex& b, float t)
+{
+    HEVertex r;
+    r.position = a.position * (1.0f - t) + b.position * t;
+    r.normal   = a.normal   * (1.0f - t) + b.normal   * t;
+    if (r.normal.squaredLength() > 1e-12f) r.normal.normalise();
+    r.uv       = a.uv       * (1.0f - t) + b.uv       * t;
+    r.color    = a.color    * (1.0f - t) + b.color    * t;
+    r.tangent  = a.tangent  * (1.0f - t) + b.tangent  * t;
+    r.hasNormal  = a.hasNormal && b.hasNormal;
+    r.hasUV      = a.hasUV && b.hasUV;
+    r.hasColor   = a.hasColor && b.hasColor;
+    r.hasTangent = a.hasTangent && b.hasTangent;
+
+    // Union of bone influences by index, weights blended by t. Skip zero-
+    // weight entries so the list stays short on typical rigs.
+    auto addOrBlend = [&](unsigned short idx, float w) {
+        if (w <= 1e-6f) return;
+        for (auto& ba : r.boneAssignments) {
+            if (ba.first == idx) { ba.second += w; return; }
+        }
+        r.boneAssignments.emplace_back(idx, w);
+    };
+    for (const auto& ba : a.boneAssignments) addOrBlend(ba.first, ba.second * (1.0f - t));
+    for (const auto& ba : b.boneAssignments) addOrBlend(ba.first, ba.second * t);
+    return r;
+}
+
+} // namespace
+
+int HalfEdgeMesh::splitEdge(int edgeIdx, float t)
+{
+    if (edgeIdx < 0 || edgeIdx >= static_cast<int>(m_edges.size())) return -1;
+    const int heA = m_edges[edgeIdx].halfEdge;
+    if (heA < 0 || heA >= static_cast<int>(m_halfEdges.size())) return -1;
+
+    // Clamp t off the endpoints so neither new face degenerates to a sliver.
+    constexpr float kEps = 1e-4f;
+    t = std::clamp(t, kEps, 1.0f - kEps);
+
+    // Collect the two adjacent triangle descriptions while the old
+    // topology is still intact. Both faces must be triangles for this
+    // MVP; n-gon splitting needs ear-clip-aware rewiring.
+    struct TriFace {
+        int face;           // face index (for submesh lookup)
+        int subMeshIndex;
+        int vFrom;          // edge endpoint (start)
+        int vTo;            // edge endpoint (end)
+        int vOpp;           // third triangle vertex
+        int heFrom, heTo, heOpp; // the three half-edges of the triangle
+    };
+
+    auto describeFace = [&](int he, TriFace& out) -> bool {
+        if (he < 0 || he >= static_cast<int>(m_halfEdges.size())) return false;
+        if (m_halfEdges[he].face < 0) return false;
+        const int fIdx = m_halfEdges[he].face;
+        const auto verts = faceVertices(fIdx);
+        if (verts.size() != 3) return false;
+
+        // Identify which HE of the triangle is the one carrying `edgeIdx`.
+        // Traverse the face loop starting at the face's HE; the HE pointing
+        // "to" heVertex of `he` is the one sharing edgeIdx. Fill TriFace
+        // in face-loop order so we keep winding.
+        const int startHE = m_faces[fIdx].halfEdge;
+        int he0 = startHE;
+        int he1 = m_halfEdges[he0].next;
+        int he2 = m_halfEdges[he1].next;
+        int heIndices[3] = {he0, he1, he2};
+
+        int shareIdx = -1;
+        for (int i = 0; i < 3; ++i) {
+            if (heIndices[i] == he) { shareIdx = i; break; }
+        }
+        if (shareIdx < 0) return false;
+
+        out.face = fIdx;
+        out.subMeshIndex = m_faces[fIdx].subMeshIndex;
+        out.heFrom = heIndices[shareIdx];
+        out.heTo   = heIndices[(shareIdx + 1) % 3];
+        out.heOpp  = heIndices[(shareIdx + 2) % 3];
+
+        // Vertex layout: heFrom.prev.vertex -> heFrom.vertex -> heTo.vertex.
+        // The shared edge goes vFrom -> vTo. The third vertex is heTo.vertex.
+        out.vFrom = m_halfEdges[out.heOpp].vertex;
+        out.vTo   = m_halfEdges[out.heFrom].vertex;
+        out.vOpp  = m_halfEdges[out.heTo].vertex;
+        return true;
+    };
+
+    TriFace fA{}, fB{};
+    const bool hasA = describeFace(heA, fA);
+    const int heB = m_halfEdges[heA].twin;
+    const bool hasB = (heB >= 0) && describeFace(heB, fB);
+
+    if (!hasA && !hasB) return -1;
+
+    // Edge direction is fA.vFrom -> fA.vTo (with t measured from vFrom).
+    // If only fB exists (the edge sits on the boundary on the A side),
+    // fB.vFrom / fB.vTo run in the opposite direction, so re-measure t.
+    int vFrom = hasA ? fA.vFrom : fB.vTo;
+    int vTo   = hasA ? fA.vTo   : fB.vFrom;
+
+    // Create the midpoint vertex.
+    HEVertex mid = interpolateVertex(m_vertices[vFrom], m_vertices[vTo], t);
+    mid.halfEdge = -1;
+    const int vMid = static_cast<int>(m_vertices.size());
+    m_vertices.push_back(std::move(mid));
+
+    // Retire a face: set each of its half-edges' face to -1 and clear the
+    // face slot's halfEdge pointer so the four-call cleanup drops them.
+    auto retireFace = [&](const TriFace& tf) {
+        m_halfEdges[tf.heFrom].face = -1;
+        m_halfEdges[tf.heTo].face = -1;
+        m_halfEdges[tf.heOpp].face = -1;
+        m_faces[tf.face].halfEdge = -1;
+    };
+
+    if (hasA) {
+        retireFace(fA);
+        // Old triangle [vFrom, vTo, vOpp] wound as
+        // heOpp: vOpp -> vFrom, heFrom: vFrom -> vTo, heTo: vTo -> vOpp.
+        // New triangles share the vMid → vOpp diagonal and keep the same winding.
+        appendFace({fA.vFrom, vMid, fA.vOpp}, fA.subMeshIndex);
+        appendFace({vMid, fA.vTo, fA.vOpp}, fA.subMeshIndex);
+    }
+    if (hasB) {
+        retireFace(fB);
+        // fB's winding is reversed relative to fA (opposite twin). Using
+        // fB's own vFrom/vTo keeps its orientation intact.
+        appendFace({fB.vFrom, vMid, fB.vOpp}, fB.subMeshIndex);
+        appendFace({vMid, fB.vTo, fB.vOpp}, fB.subMeshIndex);
+    }
+
+    rebuildEdgesAndTwins();
+    compactBoundaryHalfEdges();
+    buildBoundaryHalfEdges();
+    fixVertexHalfEdges();
+    return vMid;
+}
+
+bool HalfEdgeMesh::splitFace(int faceIdx, int vA, int vB)
+{
+    if (faceIdx < 0 || faceIdx >= static_cast<int>(m_faces.size())) return false;
+    if (vA == vB) return false;
+    if (vA < 0 || vB < 0) return false;
+    if (vA >= static_cast<int>(m_vertices.size())) return false;
+    if (vB >= static_cast<int>(m_vertices.size())) return false;
+    if (m_faces[faceIdx].halfEdge < 0) return false;
+
+    const auto verts = faceVertices(faceIdx);
+    if (verts.size() < 3 || verts.size() > 4) return false;
+
+    // Require both vA and vB to be on the boundary loop.
+    int posA = -1;
+    int posB = -1;
+    for (int i = 0; i < static_cast<int>(verts.size()); ++i) {
+        if (verts[i] == vA) posA = i;
+        if (verts[i] == vB) posB = i;
+    }
+    if (posA < 0 || posB < 0) return false;
+
+    // Reject splits that don't actually cut the face: adjacent boundary
+    // vertices are already connected by an edge, so a "diagonal" between
+    // them would be a duplicate.
+    const int n = static_cast<int>(verts.size());
+    const int gap = std::abs(posA - posB);
+    if (gap == 1 || gap == n - 1) return false;
+
+    const int subMeshIndex = m_faces[faceIdx].subMeshIndex;
+
+    // Retire the old face.
+    {
+        const int startHE = m_faces[faceIdx].halfEdge;
+        int he = startHE;
+        do {
+            const int next = m_halfEdges[he].next;
+            m_halfEdges[he].face = -1;
+            he = next;
+        } while (he != startHE);
+        m_faces[faceIdx].halfEdge = -1;
+    }
+
+    // Walk the old loop from vA to vB to collect one side, then from vB
+    // to vA for the other. appendFace needs at least 3 vertices, so a
+    // degenerate side (empty) bails the whole operation.
+    std::vector<int> sideAB;
+    for (int i = posA; ; i = (i + 1) % n) {
+        sideAB.push_back(verts[i]);
+        if (i == posB) break;
+    }
+    std::vector<int> sideBA;
+    for (int i = posB; ; i = (i + 1) % n) {
+        sideBA.push_back(verts[i]);
+        if (i == posA) break;
+    }
+    if (sideAB.size() < 3 || sideBA.size() < 3) return false;
+
+    appendFace(sideAB, subMeshIndex);
+    appendFace(sideBA, subMeshIndex);
+
+    rebuildEdgesAndTwins();
+    compactBoundaryHalfEdges();
+    buildBoundaryHalfEdges();
+    fixVertexHalfEdges();
+    return true;
 }
 
 bool HalfEdgeMesh::validate() const

--- a/src/HalfEdgeMesh.cpp
+++ b/src/HalfEdgeMesh.cpp
@@ -3687,9 +3687,19 @@ int HalfEdgeMesh::splitEdge(int edgeIdx, float t)
     TriFace fA{}, fB{};
     const bool hasA = describeFace(heA, fA);
     const int heB = m_halfEdges[heA].twin;
-    const bool hasB = (heB >= 0) && describeFace(heB, fB);
+    const bool hasValidB = (heB >= 0);
+    const bool hasB = hasValidB && describeFace(heB, fB);
 
     if (!hasA && !hasB) return -1;
+
+    // splitEdge is a triangle-only MVP: if either adjacent face exists
+    // and isn't a triangle, bail before we mutate. Partially splitting
+    // would desync the other side's half-edge pointers against a face
+    // that's still an n-gon, producing silent topology corruption.
+    // (A face "exists" here means its twin is non-boundary. Boundary
+    // half-edges — face == -1 — are fine.)
+    if (!hasA && m_halfEdges[heA].face >= 0) return -1;
+    if (!hasB && hasValidB && m_halfEdges[heB].face >= 0) return -1;
 
     // Edge direction is fA.vFrom -> fA.vTo (with t measured from vFrom).
     // If only fB exists (the edge sits on the boundary on the A side),
@@ -3880,15 +3890,30 @@ std::vector<int> HalfEdgeMesh::cutPath(const std::vector<CutPoint>& points)
         return -1;
     };
 
+    // Snapshot the whole HE representation so partial failures can roll
+    // back cleanly (e.g. two CutPoints referencing the same underlying
+    // edge: the first split removes it, the second findEdgeByVerts
+    // returns -1). Without this the caller sees a half-mutated mesh.
+    const auto snapHalfEdges = m_halfEdges;
+    const auto snapVertices = m_vertices;
+    const auto snapFaces = m_faces;
+    const auto snapEdges = m_edges;
+    auto restore = [&]() {
+        m_halfEdges = snapHalfEdges;
+        m_vertices = snapVertices;
+        m_faces = snapFaces;
+        m_edges = snapEdges;
+    };
+
     // Step 1: insert vertices at every click endpoint, re-resolving the
     // edge each time because the previous split may have renumbered them.
     std::vector<int> clickVerts(points.size(), -1);
     for (size_t i = 0; i < points.size(); ++i) {
         const int resolvedEdge = findEdgeByVerts(clickEdgeVerts[i].first,
                                                  clickEdgeVerts[i].second);
-        if (resolvedEdge < 0) return newVertices;
+        if (resolvedEdge < 0) { restore(); newVertices.clear(); return newVertices; }
         const int v = splitEdge(resolvedEdge, clickT[i]);
-        if (v < 0) return newVertices;
+        if (v < 0) { restore(); newVertices.clear(); return newVertices; }
         clickVerts[i] = v;
         newVertices.push_back(v);
     }

--- a/src/HalfEdgeMesh.cpp
+++ b/src/HalfEdgeMesh.cpp
@@ -3802,6 +3802,189 @@ bool HalfEdgeMesh::splitFace(int faceIdx, int vA, int vB)
     return true;
 }
 
+namespace {
+
+// Intersect two line segments in 3D, parameterised as
+//   A(sA) = a0 + sA * (a1 - a0),
+//   B(sB) = b0 + sB * (b1 - b0),
+// minimising |A(sA) - B(sB)|². Returns the parameter pair plus the
+// squared separation; callers decide whether that separation is small
+// enough to call the segments "coincident" for cut purposes.
+struct SegmentSegmentClosest {
+    float sA = 0.0f;
+    float sB = 0.0f;
+    float squaredSeparation = 0.0f;
+    bool degenerate = false; // true if either segment has ~zero length
+};
+
+SegmentSegmentClosest closestOnSegments(const Ogre::Vector3& a0, const Ogre::Vector3& a1,
+                                        const Ogre::Vector3& b0, const Ogre::Vector3& b1)
+{
+    SegmentSegmentClosest r;
+    const Ogre::Vector3 dA = a1 - a0;
+    const Ogre::Vector3 dB = b1 - b0;
+    const Ogre::Vector3 w0 = a0 - b0;
+    const float aa = dA.dotProduct(dA);
+    const float bb = dB.dotProduct(dB);
+    const float ab = dA.dotProduct(dB);
+    const float aw = dA.dotProduct(w0);
+    const float bw = dB.dotProduct(w0);
+    const float det = aa * bb - ab * ab;
+    if (aa < 1e-12f || bb < 1e-12f) { r.degenerate = true; return r; }
+    if (det < 1e-12f) {
+        // Parallel — pick the middle of the overlap on A.
+        r.sA = 0.5f;
+        r.sB = std::clamp((r.sA * ab + bw) / bb, 0.0f, 1.0f);
+    } else {
+        r.sA = (ab * bw - bb * aw) / det;
+        r.sB = (aa * bw - ab * aw) / det;
+    }
+    r.sA = std::clamp(r.sA, 0.0f, 1.0f);
+    r.sB = std::clamp(r.sB, 0.0f, 1.0f);
+    const Ogre::Vector3 pA = a0 + dA * r.sA;
+    const Ogre::Vector3 pB = b0 + dB * r.sB;
+    r.squaredSeparation = (pA - pB).squaredLength();
+    return r;
+}
+
+} // namespace
+
+std::vector<int> HalfEdgeMesh::cutPath(const std::vector<CutPoint>& points)
+{
+    std::vector<int> newVertices;
+    if (points.size() < 2) return newVertices;
+
+    // Resolve every click's edge to a stable (vA, vB) vertex pair BEFORE
+    // touching the mesh. Edge indices aren't stable across splitEdge
+    // (rebuildEdgesAndTwins reorders them) but vertex indices are append-
+    // only, so we can re-find the edge each time by its endpoints.
+    std::vector<std::pair<int, int>> clickEdgeVerts(points.size(), {-1, -1});
+    std::vector<float> clickT(points.size(), 0.0f);
+    for (size_t i = 0; i < points.size(); ++i) {
+        const int eIdx = points[i].edgeIndex;
+        if (eIdx < 0 || eIdx >= static_cast<int>(m_edges.size())) return newVertices;
+        clickEdgeVerts[i] = edgeVertices(eIdx);
+        clickT[i] = points[i].t;
+        if (clickEdgeVerts[i].first < 0 || clickEdgeVerts[i].second < 0) return newVertices;
+    }
+
+    // Helper: re-find the HE edge index whose endpoints are {va, vb}
+    // against the current mesh. Returns -1 if either vertex has been
+    // removed or the pair is no longer a logical edge.
+    auto findEdgeByVerts = [this](int va, int vb) -> int {
+        for (size_t e = 0; e < m_edges.size(); ++e) {
+            const auto [a, b] = edgeVertices(static_cast<int>(e));
+            if ((a == va && b == vb) || (a == vb && b == va))
+                return static_cast<int>(e);
+        }
+        return -1;
+    };
+
+    // Step 1: insert vertices at every click endpoint, re-resolving the
+    // edge each time because the previous split may have renumbered them.
+    std::vector<int> clickVerts(points.size(), -1);
+    for (size_t i = 0; i < points.size(); ++i) {
+        const int resolvedEdge = findEdgeByVerts(clickEdgeVerts[i].first,
+                                                 clickEdgeVerts[i].second);
+        if (resolvedEdge < 0) return newVertices;
+        const int v = splitEdge(resolvedEdge, clickT[i]);
+        if (v < 0) return newVertices;
+        clickVerts[i] = v;
+        newVertices.push_back(v);
+    }
+
+    // Step 2: for each consecutive pair, walk from one click vertex to the
+    // next through the tris between them. Every edge the straight-line
+    // cut crosses gets splitEdge'd so the cut materialises as real mesh
+    // edges.
+    constexpr int kMaxWalkSteps = 256;    // safety: real cuts visit <~10 tris
+    constexpr float kNearZero = 1e-5f;    // close-to-vertex tolerance
+    constexpr float kMinStep = 1e-4f;     // reject crossings that don't advance
+
+    for (size_t i = 0; i + 1 < clickVerts.size(); ++i) {
+        int vA = clickVerts[i];
+        const int vTarget = clickVerts[i + 1];
+        if (vA < 0 || vTarget < 0 || vA == vTarget) continue;
+
+        for (int step = 0; step < kMaxWalkSteps; ++step) {
+            if (vA == vTarget) break;
+
+            // Does vA already share a triangle with vTarget? Then the
+            // existing splitEdge semantics (two click splits on one tri
+            // produce the connecting edge automatically) already created
+            // the final cut edge — nothing more to do for this pair.
+            const auto facesAtA = facesAroundVertex(vA);
+            bool shareFace = false;
+            for (int f : facesAtA) {
+                const auto fv = faceVertices(f);
+                if (std::find(fv.begin(), fv.end(), vTarget) != fv.end()) {
+                    shareFace = true; break;
+                }
+            }
+            if (shareFace) break;
+
+            const Ogre::Vector3 pA = m_vertices[vA].position;
+            const Ogre::Vector3 pT = m_vertices[vTarget].position;
+
+            // Pick the face adjacent to vA whose straight-line to vTarget
+            // exits through an interior edge. For each candidate face,
+            // consider only edges not incident to vA: if the closest-point
+            // pair sits strictly inside the edge and advances us toward
+            // vTarget (sCut > kMinStep), that's an exit candidate. Among
+            // candidates, choose the smallest sCut (closest crossing).
+            int bestFace = -1;
+            int bestEdge = -1;
+            float bestT = 0.0f;
+            float bestSA = std::numeric_limits<float>::infinity();
+
+            for (int f : facesAtA) {
+                const auto fe = faceEdges(f);
+                for (int eIdx : fe) {
+                    const auto [ev0, ev1] = edgeVertices(eIdx);
+                    if (ev0 == vA || ev1 == vA) continue; // entry edge
+                    const Ogre::Vector3& b0 = m_vertices[ev0].position;
+                    const Ogre::Vector3& b1 = m_vertices[ev1].position;
+                    const auto hit = closestOnSegments(pA, pT, b0, b1);
+                    if (hit.degenerate) continue;
+                    if (hit.squaredSeparation > 1e-4f) continue;
+                    // Must actually advance from vA toward vTarget.
+                    if (hit.sA < kMinStep) continue;
+                    // Exit edge parameter must be strictly inside the
+                    // segment (endpoint-snap is a TODO).
+                    if (hit.sB < kNearZero || hit.sB > 1.0f - kNearZero) continue;
+                    if (hit.sA < bestSA) {
+                        bestSA = hit.sA;
+                        bestEdge = eIdx;
+                        bestT = hit.sB;
+                        bestFace = f;
+                    }
+                }
+            }
+
+            if (bestEdge < 0) {
+                // No valid forward exit found. Either the cut's ray went
+                // off the surface (click span not on a coplanar region)
+                // or the target sits on a face we don't share — give up
+                // on this pair and move on.
+                break;
+            }
+            (void)bestFace;
+
+            // Split the exit edge; the new vertex becomes the entry point
+            // for the next triangle. Because the previous iteration's vA
+            // and the new vertex now both live on the same triangle, the
+            // splitEdge pass already leaves the segment between them as a
+            // real mesh edge.
+            const int vMid = splitEdge(bestEdge, bestT);
+            if (vMid < 0) break;
+            newVertices.push_back(vMid);
+            vA = vMid;
+        }
+    }
+
+    return newVertices;
+}
+
 bool HalfEdgeMesh::validate() const
 {
     // Check 1: Twin symmetry

--- a/src/HalfEdgeMesh.h
+++ b/src/HalfEdgeMesh.h
@@ -408,6 +408,45 @@ public:
      */
     bool splitFace(int faceIdx, int vA, int vB);
 
+    /**
+     * @brief A single click on a mesh edge, given as the edge index plus the
+     *        parametric position along it in [0,1]. The walk-and-cut knife
+     *        algorithm takes a list of these and produces a continuous chain
+     *        of real mesh edges between consecutive clicks.
+     */
+    struct CutPoint {
+        int edgeIndex = -1;
+        float t = 0.5f;
+    };
+
+    /**
+     * @brief Apply a knife cut defined by a sequence of edge clicks.
+     *
+     * For each pair of consecutive `CutPoint`s the algorithm:
+     *  - runs `splitEdge` at both endpoints (skipping duplicates the second
+     *    time an endpoint is encountered),
+     *  - walks triangles between the two new vertices along the 3D line that
+     *    connects them, running `splitEdge` at every interior edge the line
+     *    crosses,
+     *  - stops when the current triangle contains both the previous cut
+     *    vertex and the next endpoint — at that point the existing
+     *    splitEdge semantics already produce the closing cut edge.
+     *
+     * MVP scope:
+     *  - All intersections must land strictly inside edge segments. Cuts
+     *    that graze a vertex are not yet snapped.
+     *  - The algorithm walks only one face at a time; it doesn't bridge
+     *    disconnected submeshes.
+     *
+     * @param points Ordered clicks. Each must reference a currently-valid
+     *               edge of the mesh (indices are NOT re-validated against
+     *               mutations inside this call — callers must pass the list
+     *               resolved against the pre-cut mesh).
+     * @return Indices of every newly created vertex (endpoints + interior
+     *         crossings), in creation order. Empty on failure.
+     */
+    std::vector<int> cutPath(const std::vector<CutPoint>& points);
+
     /// @}
 
     /// @name Validation

--- a/src/HalfEdgeMesh.h
+++ b/src/HalfEdgeMesh.h
@@ -367,6 +367,47 @@ public:
                                    float profile = 0.5f,
                                    const std::vector<float>& profilePoints = {});
 
+    /**
+     * @brief Insert a new vertex on an edge at parametric position t, then
+     *        split each triangle that used the edge into two triangles.
+     *
+     * Interpolates the new vertex's position, normal, UV, color, tangent,
+     * and bone weights between the edge's endpoints using t. After the call
+     * the edge is replaced by two edges meeting at the new vertex, and
+     * each of the 1–2 adjacent triangles has been replaced by two
+     * triangles sharing the split point.
+     *
+     * MVP limits: works only on edges whose adjacent faces are triangles
+     * (n-gons would need ear-clip-aware splitting). Returns -1 on failure.
+     *
+     * @param edgeIdx The edge to split.
+     * @param t Parametric position along the edge in [0, 1]. Clamped into
+     *          the (epsilon, 1 - epsilon) interior so the resulting faces
+     *          aren't degenerate.
+     * @return The newly created vertex's index, or -1 on failure.
+     */
+    int splitEdge(int edgeIdx, float t);
+
+    /**
+     * @brief Split a face by inserting a diagonal edge between two of its
+     *        boundary vertices.
+     *
+     * Retires the old face and appends two new faces sharing the new
+     * diagonal edge. Vertices must both be on the face's boundary loop
+     * and must not already be adjacent (connected by a face-boundary
+     * edge), or the split would be degenerate.
+     *
+     * MVP limits: only splits triangles and quads (faces with 3 or 4
+     * boundary vertices). Higher n-gons aren't produced by the current
+     * pipeline.
+     *
+     * @param faceIdx The face to split.
+     * @param vA First boundary vertex.
+     * @param vB Second boundary vertex.
+     * @return true on success.
+     */
+    bool splitFace(int faceIdx, int vA, int vB);
+
     /// @}
 
     /// @name Validation
@@ -406,6 +447,12 @@ private:
     /// Returns the new face index. Does NOT update vertex or edge data —
     /// callers must rebuild edges/twins after adding all triangles.
     int appendTriangle(int v0, int v1, int v2, int subMeshIndex);
+
+    /// Append a polygon with N vertices (N >= 3) as a single face with
+    /// N half-edges. Returns the new face index, or -1 if vertices.size()
+    /// is invalid. Like appendTriangle, callers must run the
+    /// rebuild/compact/boundary/fix-vertex cleanup afterwards.
+    int appendFace(const std::vector<int>& vertices, int subMeshIndex);
 
     /// Rebuild m_edges, half-edge twin/edge fields, and clear edge state.
     /// Skips half-edges with face < 0. After this, every interior HE has

--- a/src/HalfEdgeMesh.h
+++ b/src/HalfEdgeMesh.h
@@ -389,17 +389,26 @@ public:
     int splitEdge(int edgeIdx, float t);
 
     /**
-     * @brief Split a face by inserting a diagonal edge between two of its
-     *        boundary vertices.
+     * @brief Split an n-gon face by inserting a diagonal edge between two
+     *        of its boundary vertices, where n ∈ {3, 4}.
      *
      * Retires the old face and appends two new faces sharing the new
-     * diagonal edge. Vertices must both be on the face's boundary loop
-     * and must not already be adjacent (connected by a face-boundary
-     * edge), or the split would be degenerate.
+     * diagonal edge. Both vertices must be on the face's boundary loop
+     * and must NOT already be adjacent on that loop (connected by a
+     * boundary edge of the face) — either would duplicate an existing
+     * edge or collapse one of the new faces.
      *
-     * MVP limits: only splits triangles and quads (faces with 3 or 4
-     * boundary vertices). Higher n-gons aren't produced by the current
-     * pipeline.
+     * Consequence: on a triangle every pair of vertices is adjacent, so
+     * splitFace always rejects triangles. The knife pipeline doesn't
+     * need that case anyway — two splitEdges on one triangle already
+     * leave the cut segment as a real edge (see the
+     * TwoSplitEdgesOnOneTriangleProduceMidpointEdge invariant).
+     *
+     * Faces with more than 4 boundary vertices are also rejected: the
+     * current pipeline doesn't produce them, and splitting them cleanly
+     * would need an ear-clip-aware rewire. appendFace itself accepts
+     * any n ≥ 3, so the cap here is a scope choice and can be lifted
+     * later without changing this method's contract.
      *
      * @param faceIdx The face to split.
      * @param vA First boundary vertex.

--- a/src/HalfEdgeMesh_test.cpp
+++ b/src/HalfEdgeMesh_test.cpp
@@ -3397,3 +3397,27 @@ TEST(HalfEdgeMeshStandalone, CutPathFailsOnInvalidEdgeIndex) {
     // Negative / out-of-range edge indices short-circuit the walk.
     EXPECT_TRUE(he.cutPath({{edge, 0.5f}, {-1, 0.5f}}).empty());
 }
+
+TEST(HalfEdgeMeshStandalone, CutPathRollsBackWhenSecondEdgeDuplicatesFirst) {
+    // If two CutPoints reference the same underlying edge (same
+    // endpoint vertex pair), the first splitEdge removes that edge and
+    // the second lookup fails. cutPath must roll back, leaving the
+    // mesh byte-identical to its pre-call state — otherwise callers
+    // see a half-applied cut.
+    auto em = makeQuadMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    const size_t vertsBefore = he.vertexCount();
+    const size_t facesBefore = he.faceCount();
+    const size_t edgesBefore = he.edgeCount();
+
+    const int edge = findEdge(he, 1, 2); // shared diagonal
+    ASSERT_GE(edge, 0);
+    const auto result = he.cutPath({{edge, 0.3f}, {edge, 0.7f}});
+    EXPECT_TRUE(result.empty()) << "duplicate-edge cutPath must fail";
+
+    EXPECT_EQ(he.vertexCount(), vertsBefore);
+    EXPECT_EQ(he.faceCount(), facesBefore);
+    EXPECT_EQ(he.edgeCount(), edgesBefore);
+    EXPECT_TRUE(he.validate());
+}

--- a/src/HalfEdgeMesh_test.cpp
+++ b/src/HalfEdgeMesh_test.cpp
@@ -3308,3 +3308,92 @@ TEST(HalfEdgeMeshStandalone, SplitEdgePreservesSubmeshCount) {
     ASSERT_TRUE(he.toEditableMesh(back));
     EXPECT_EQ(back.subMeshes().size(), static_cast<size_t>(beforeSubCount));
 }
+
+// ===========================================================================
+// cutPath — knife walk-and-cut along a polyline
+// ===========================================================================
+
+TEST(HalfEdgeMeshStandalone, CutPathCrossesInteriorDiagonalAndLinksEndpoints) {
+    // Two triangles share a diagonal v1-v2. A horizontal cut from the
+    // midpoint of v0-v1 to the midpoint of v2-v3 crosses the diagonal at
+    // its midpoint, so the final mesh must have:
+    //   - 3 new vertices (both endpoints plus one on the diagonal),
+    //   - the cut visible as a chain of real edges end-to-end.
+    auto em = makeQuadMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+
+    const int edgeBottom = findEdge(he, 0, 1);
+    const int edgeTop = findEdge(he, 2, 3);
+    ASSERT_GE(edgeBottom, 0);
+    ASSERT_GE(edgeTop, 0);
+
+    const auto newVerts = he.cutPath({{edgeBottom, 0.5f}, {edgeTop, 0.5f}});
+    ASSERT_EQ(newVerts.size(), 3u)
+        << "expected 2 endpoint verts + 1 diagonal-crossing vert";
+    EXPECT_TRUE(he.validate());
+
+    // All three new vertices should sit on the x=0.5 cut line.
+    for (int v : newVerts) {
+        EXPECT_NEAR(he.vertex(v).position.x, 0.5f, 1e-3f);
+    }
+
+    // The cut must exist as real edges: every consecutive pair of cut
+    // vertices (sorted by y) should be connected by an HE edge.
+    std::vector<int> orderedCutVerts = newVerts;
+    std::sort(orderedCutVerts.begin(), orderedCutVerts.end(),
+              [&](int a, int b) {
+                  return he.vertex(a).position.y < he.vertex(b).position.y;
+              });
+    for (size_t i = 0; i + 1 < orderedCutVerts.size(); ++i) {
+        EXPECT_GE(findEdge(he, orderedCutVerts[i], orderedCutVerts[i + 1]), 0)
+            << "consecutive cut vertices should be connected by a real edge";
+    }
+
+    EditableMesh back;
+    ASSERT_TRUE(he.toEditableMesh(back));
+    EXPECT_TRUE(isManifold(back));
+}
+
+TEST(HalfEdgeMeshStandalone, CutPathSingleTriangleStillProducesEndpointEdge) {
+    // Cutting both clicks onto edges of a single triangle doesn't need an
+    // interior edge crossing — two splitEdges already leave the M1↔M2
+    // segment as a real edge. cutPath should return exactly the two
+    // endpoint vertices in that case.
+    auto em = makeTriangleMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+
+    const int edgeA = findEdge(he, 0, 1);
+    const int edgeB = findEdge(he, 1, 2);
+    ASSERT_GE(edgeA, 0);
+    ASSERT_GE(edgeB, 0);
+
+    const auto newVerts = he.cutPath({{edgeA, 0.5f}, {edgeB, 0.5f}});
+    ASSERT_EQ(newVerts.size(), 2u);
+    EXPECT_TRUE(he.validate());
+    EXPECT_GE(findEdge(he, newVerts[0], newVerts[1]), 0)
+        << "single-triangle cut should connect both endpoints directly";
+}
+
+TEST(HalfEdgeMeshStandalone, CutPathBailsOnFewerThanTwoPoints) {
+    auto em = makeQuadMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+
+    EXPECT_TRUE(he.cutPath({}).empty());
+    const int edge = findEdge(he, 0, 1);
+    ASSERT_GE(edge, 0);
+    EXPECT_TRUE(he.cutPath({{edge, 0.5f}}).empty());
+}
+
+TEST(HalfEdgeMeshStandalone, CutPathFailsOnInvalidEdgeIndex) {
+    auto em = makeQuadMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+
+    const int edge = findEdge(he, 0, 1);
+    ASSERT_GE(edge, 0);
+    // Negative / out-of-range edge indices short-circuit the walk.
+    EXPECT_TRUE(he.cutPath({{edge, 0.5f}, {-1, 0.5f}}).empty());
+}

--- a/src/HalfEdgeMesh_test.cpp
+++ b/src/HalfEdgeMesh_test.cpp
@@ -3181,6 +3181,17 @@ TEST(HalfEdgeMeshStandalone, SplitEdgeInterpolatesNormalAndUV) {
 
     // Both endpoints share normal +Z; midpoint should too.
     EXPECT_NEAR(v.normal.z, 1.0f, 1e-4f);
+
+    // UV lerp: v1=(1,0), v2=(0,1). Any linear blend between them falls
+    // on the x+y=1 line regardless of the split direction, so check
+    // that invariant plus the correct distance from either endpoint.
+    // A broken `v.uv` lerp (e.g. zeroed out) fails both.
+    EXPECT_NEAR(v.uv.x + v.uv.y, 1.0f, 1e-4f)
+        << "UV lerp should stay on the segment between endpoints";
+    const float uvDist1 = std::hypot(v.uv.x - 1.0f, v.uv.y - 0.0f);
+    const float uvDist2 = std::hypot(v.uv.x - 0.0f, v.uv.y - 1.0f);
+    const float uvSeg = std::hypot(1.0f, 1.0f);
+    EXPECT_NEAR(std::min(uvDist1, uvDist2) / uvSeg, 0.25f, 1e-3f);
 }
 
 TEST(HalfEdgeMeshStandalone, SplitEdgeBoundaryEdgeProducesOneExtraTriangle) {
@@ -3279,12 +3290,31 @@ TEST(HalfEdgeMeshStandalone, SplitFaceRejectsAdjacentBoundaryVertices) {
 }
 
 TEST(HalfEdgeMeshStandalone, SplitFaceRejectsInvalidVertexIndices) {
+    // These guard paths run BEFORE the triangle-rejection in splitFace
+    // (see the ordered checks at the top of the implementation), so the
+    // assertions hit the invalid-vertex branches directly rather than
+    // getting short-circuited by the "every tri vertex pair is
+    // adjacent" rule. Covers: same-vertex, negative, out-of-range,
+    // and in-range-but-not-on-this-face.
     auto em = makeQuadMesh();
     HalfEdgeMesh he;
     ASSERT_TRUE(he.buildFromEditableMesh(em));
-    EXPECT_FALSE(he.splitFace(0, -1, 1));
-    EXPECT_FALSE(he.splitFace(0, 0, 999));
-    EXPECT_FALSE(he.splitFace(0, 2, 2)); // same vertex
+
+    EXPECT_FALSE(he.splitFace(0, 2, 2))
+        << "same-vertex pair should fail (check 2 — first guard)";
+    EXPECT_FALSE(he.splitFace(0, -1, 1))
+        << "negative index should fail (check 3)";
+    EXPECT_FALSE(he.splitFace(0, 0, 999))
+        << "out-of-range index should fail (check 5)";
+    EXPECT_FALSE(he.splitFace(-1, 0, 1))
+        << "invalid face index should fail (check 1)";
+
+    // Also verify the "vertex exists but isn't on this face" path.
+    // Triangle 0 of makeQuadMesh contains verts {0,1,2}; vertex 3
+    // exists in the mesh but is on triangle 1, so splitFace should
+    // reject before getting to adjacency checks.
+    EXPECT_FALSE(he.splitFace(0, 0, 3))
+        << "off-face valid vertex should fail the boundary-loop check";
 }
 
 TEST(HalfEdgeMeshStandalone, SplitEdgePreservesSubmeshCount) {

--- a/src/HalfEdgeMesh_test.cpp
+++ b/src/HalfEdgeMesh_test.cpp
@@ -3104,3 +3104,207 @@ TEST(HalfEdgeMeshStandalone, BevelVertexSegmentsClampsOverUpperLimit) {
     ASSERT_TRUE(he.toEditableMesh(back));
     EXPECT_TRUE(isManifold(back));
 }
+
+// ===========================================================================
+// splitEdge / splitFace — knife-tool topology primitives
+// ===========================================================================
+
+// Count active (non-retired) faces. After a topology op some face slots have
+// halfEdge == -1 — they'll be compacted out of toEditableMesh but still
+// contribute to faceCount(), so tests that want the visible triangle count
+// need the active count here.
+static int activeFaceCount(const HalfEdgeMesh& he)
+{
+    int n = 0;
+    for (size_t f = 0; f < he.faceCount(); ++f) {
+        if (he.face(static_cast<int>(f)).halfEdge >= 0) ++n;
+    }
+    return n;
+}
+
+TEST(HalfEdgeMeshStandalone, SplitEdgeMidpointOfInteriorEdgeDoublesTriangles) {
+    // The quad mesh has two triangles sharing the v1↔v2 diagonal. Splitting
+    // that edge at t=0.5 should insert one new vertex, replace both triangles
+    // with two each (four tris total), and keep the mesh manifold.
+    auto em = makeQuadMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+
+    const int sharedEdge = findEdge(he, 1, 2);
+    ASSERT_GE(sharedEdge, 0);
+
+    const int vMid = he.splitEdge(sharedEdge, 0.5f);
+    ASSERT_GE(vMid, 0);
+    EXPECT_TRUE(he.validate());
+
+    EXPECT_EQ(he.vertexCount(), 5u);
+    EXPECT_EQ(activeFaceCount(he), 4);
+
+    // Midpoint position should be the average of the endpoints.
+    const auto mid = he.vertex(vMid).position;
+    EXPECT_NEAR(mid.x, 0.5f, 1e-4f);
+    EXPECT_NEAR(mid.y, 0.5f, 1e-4f);
+    EXPECT_NEAR(mid.z, 0.0f, 1e-4f);
+
+    EditableMesh back;
+    ASSERT_TRUE(he.toEditableMesh(back));
+    EXPECT_TRUE(isManifold(back));
+}
+
+TEST(HalfEdgeMeshStandalone, SplitEdgeInterpolatesNormalAndUV) {
+    // Interpolation at t=0.25 should place the new vertex a quarter of the
+    // way from v1 to v2 and carry weighted normal / UV attributes.
+    auto em = makeQuadMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+
+    const int sharedEdge = findEdge(he, 1, 2);
+    ASSERT_GE(sharedEdge, 0);
+
+    const int vMid = he.splitEdge(sharedEdge, 0.25f);
+    ASSERT_GE(vMid, 0);
+
+    const auto& v = he.vertex(vMid);
+    EXPECT_TRUE(v.hasNormal);
+    EXPECT_TRUE(v.hasUV);
+
+    // Position lies on the v1↔v2 segment at parameter ~0.25 (direction
+    // depends on which endpoint splitEdge treats as the "from"; check
+    // distance ratio rather than exact coords).
+    const auto& p1 = he.vertex(1).position;
+    const auto& p2 = he.vertex(2).position;
+    const float segLen = p1.distance(p2);
+    const float d1 = v.position.distance(p1);
+    const float d2 = v.position.distance(p2);
+    const float frac = std::min(d1, d2) / segLen;
+    EXPECT_NEAR(frac, 0.25f, 1e-3f);
+
+    // Both endpoints share normal +Z; midpoint should too.
+    EXPECT_NEAR(v.normal.z, 1.0f, 1e-4f);
+}
+
+TEST(HalfEdgeMeshStandalone, SplitEdgeBoundaryEdgeProducesOneExtraTriangle) {
+    // A triangle's perimeter edge is a boundary edge (only one adjacent face).
+    // Splitting it should turn the single triangle into two triangles without
+    // creating any phantom face on the outside.
+    auto em = makeTriangleMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+
+    // Pick the edge between v0 (0,0,0) and v1 (1,0,0).
+    const int edge = findEdge(he, 0, 1);
+    ASSERT_GE(edge, 0);
+
+    const int vMid = he.splitEdge(edge, 0.5f);
+    ASSERT_GE(vMid, 0);
+    EXPECT_TRUE(he.validate());
+
+    EXPECT_EQ(he.vertexCount(), 4u);
+    EXPECT_EQ(activeFaceCount(he), 2);
+}
+
+TEST(HalfEdgeMeshStandalone, SplitEdgeClampsExtremeT) {
+    // t=0 or t=1 would collapse one of the new triangles; splitEdge should
+    // nudge the parameter inside the (0,1) interior rather than fail or
+    // produce a zero-area face.
+    auto em = makeQuadMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+
+    const int sharedEdge = findEdge(he, 1, 2);
+    ASSERT_GE(sharedEdge, 0);
+
+    const int vMid = he.splitEdge(sharedEdge, 0.0f);
+    ASSERT_GE(vMid, 0);
+    EXPECT_TRUE(he.validate());
+
+    EditableMesh back;
+    ASSERT_TRUE(he.toEditableMesh(back));
+    EXPECT_TRUE(isManifold(back));
+}
+
+TEST(HalfEdgeMeshStandalone, SplitEdgeInvalidIndexReturnsMinusOne) {
+    auto em = makeQuadMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    EXPECT_EQ(he.splitEdge(-1, 0.5f), -1);
+    EXPECT_EQ(he.splitEdge(999, 0.5f), -1);
+}
+
+TEST(HalfEdgeMeshStandalone, TwoSplitEdgesOnOneTriangleProduceMidpointEdge) {
+    // Real knife-tool scenario: the user cuts a triangle by clicking two of
+    // its edges. Two splitEdge calls on the same triangle should leave the
+    // M1↔M2 segment as a real edge of the resulting mesh — no follow-up
+    // splitFace needed. This is the invariant the knife commit pipeline
+    // relies on for the common "cut one face" case.
+    auto em = makeTriangleMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    ASSERT_EQ(activeFaceCount(he), 1);
+
+    const int edgeA = findEdge(he, 0, 1);
+    ASSERT_GE(edgeA, 0);
+    const int m1 = he.splitEdge(edgeA, 0.5f);
+    ASSERT_GE(m1, 0);
+    EXPECT_TRUE(he.validate());
+
+    const int edgeB = findEdge(he, 1, 2);
+    ASSERT_GE(edgeB, 0);
+    const int m2 = he.splitEdge(edgeB, 0.5f);
+    ASSERT_GE(m2, 0);
+    EXPECT_TRUE(he.validate());
+
+    // The knife cut ran from M1 to M2; that segment must now be an edge.
+    EXPECT_GE(findEdge(he, m1, m2), 0)
+        << "M1-M2 should be a real edge after two splitEdges on the same triangle";
+
+    EditableMesh back;
+    ASSERT_TRUE(he.toEditableMesh(back));
+    EXPECT_TRUE(isManifold(back));
+}
+
+TEST(HalfEdgeMeshStandalone, SplitFaceRejectsAdjacentBoundaryVertices) {
+    // A "diagonal" between two vertices that are already edge-adjacent on a
+    // face boundary would duplicate the existing edge. splitFace should
+    // refuse rather than produce a degenerate split. On a triangle every
+    // pair of boundary vertices is edge-adjacent so every call should fail.
+    auto em = makeTriangleMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+
+    EXPECT_FALSE(he.splitFace(0, 0, 1));
+    EXPECT_FALSE(he.splitFace(0, 1, 2));
+    EXPECT_FALSE(he.splitFace(0, 0, 2));
+    EXPECT_EQ(activeFaceCount(he), 1);
+}
+
+TEST(HalfEdgeMeshStandalone, SplitFaceRejectsInvalidVertexIndices) {
+    auto em = makeQuadMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    EXPECT_FALSE(he.splitFace(0, -1, 1));
+    EXPECT_FALSE(he.splitFace(0, 0, 999));
+    EXPECT_FALSE(he.splitFace(0, 2, 2)); // same vertex
+}
+
+TEST(HalfEdgeMeshStandalone, SplitEdgePreservesSubmeshCount) {
+    // splitEdge operating on one submesh's edge should leave the submesh
+    // count unchanged. Attribute correctness across submeshes is covered
+    // by the roundtrip test below.
+    auto em = makeTwoSubMeshMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+
+    const auto beforeSubCount = he.subMeshCount();
+    const int edge = findEdge(he, 0, 1);
+    if (edge < 0) GTEST_SKIP() << "v0-v1 edge not present in mesh";
+
+    const int vMid = he.splitEdge(edge, 0.5f);
+    ASSERT_GE(vMid, 0);
+    EXPECT_TRUE(he.validate());
+    EXPECT_EQ(he.subMeshCount(), beforeSubCount);
+
+    EditableMesh back;
+    ASSERT_TRUE(he.toEditableMesh(back));
+    EXPECT_EQ(back.subMeshes().size(), static_cast<size_t>(beforeSubCount));
+}

--- a/src/TransformOperator.cpp
+++ b/src/TransformOperator.cpp
@@ -892,10 +892,22 @@ void TransformOperator::mousePressEvent(QMouseEvent *e)
 {
     if (e->button()==Qt::LeftButton)
     {
+        auto* editCtrl = EditModeController::instance();
+
+        // Knife session is active: left-click adds a cut point at the
+        // hovered position. Nothing else (selection, bevel, transform)
+        // fires while the knife is open — the session is dismissed with
+        // Enter (commit) or Esc (cancel), or automatically on edit-mode
+        // exit.
+        if (editCtrl->knifeSessionActive())
+        {
+            editCtrl->addKnifePoint(m_pActiveWidget, e->pos().x(), e->pos().y());
+            return;
+        }
+
         // Bevel session is active: priority path. If the click hits the
         // gizmo handle → start a width-drag; anywhere else → commit the
         // current width and fall through to normal selection.
-        auto* editCtrl = EditModeController::instance();
         if (editCtrl->bevelSessionActive())
         {
             auto* hit = performRaySelection(e->pos(), /*findGizmo=*/true);
@@ -1039,6 +1051,16 @@ void TransformOperator::mousePressEvent(QMouseEvent *e)
 
 void TransformOperator::mouseMoveEvent(QMouseEvent *e)
 {
+    // Knife hover preview: cheap to update on every move while the session
+    // is active, and draws the ghost segment from the last confirmed
+    // point to the cursor. Does not consume the event — other handlers
+    // (camera, gizmo drag) still run below.
+    if (auto* editCtrl = EditModeController::instance();
+        editCtrl->knifeSessionActive() && m_pActiveWidget)
+    {
+        editCtrl->updateKnifeHover(m_pActiveWidget, e->pos().x(), e->pos().y());
+    }
+
     // Bevel gizmo drag: priority path.
     if (mBevelDragActive && EditModeController::instance()->bevelSessionActive())
     {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1062,8 +1062,12 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
         return;
     }
 
-    // Knife session: Esc cancels, Enter commits. These override selection
-    // mode shortcuts while the session is open.
+    // Knife session: Esc cancels, Enter commits. Every other key is
+    // swallowed while the session is open — otherwise selection-mode
+    // shortcuts (1/2/3), Ctrl+E/B, Ctrl+A, and friends would silently
+    // mutate state mid-cut and leave the user with a preview that no
+    // longer matches the tool they're in. The user can't mean those
+    // keys while the knife preview is on screen.
     if (editCtrl->knifeSessionActive()) {
         if (event->key() == Qt::Key_Escape) {
             SentryReporter::addBreadcrumb("ui.shortcut", "Esc — cancel knife");
@@ -1077,6 +1081,9 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
             event->accept();
             return;
         }
+        // Swallow everything else so fall-through handlers don't fire.
+        event->accept();
+        return;
     }
 
     if (editCtrl->isEditModeActive()) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -656,17 +656,36 @@ void MainWindow::initToolBar()
     });
     QAction* bevelAction = ui->objectsToolbar->addWidget(bevelButton);
 
+    // Knife: opens a multi-point cut session. Available in edit mode
+    // regardless of selection component (vertex/edge/face), because
+    // the knife's own hit-test snaps to geometry.
+    auto knifeButton = new QToolButton(ui->objectsToolbar);
+    knifeButton->setText(QStringLiteral("\u2702"));  // ✂ scissors
+    knifeButton->setToolTip(tr("Knife — place cut points, Enter to commit, Esc to cancel (K)"));
+    knifeButton->setFont(topoFont);
+    knifeButton->setStyleSheet(topoBtnStyle);
+    connect(knifeButton, &QToolButton::clicked, this, []() {
+        SentryReporter::addBreadcrumb("ui.action", "Toolbar: Knife");
+        auto* c = EditModeController::instance();
+        // Pressing the button while a session is already open commits
+        // it — matches the bevel button pattern (click = open / commit).
+        if (c->knifeSessionActive()) c->commitKnife();
+        else                         c->beginKnife();
+    });
+    QAction* knifeAction = ui->objectsToolbar->addWidget(knifeButton);
+
     // Context-aware visibility + enabled:
     //  - Hidden entirely when NOT in edit mode.
     //  - In edit mode: stay visible but only enable when the current
     //    mode matches AND the relevant element type actually has a
     //    non-empty selection.
-    auto refreshTopoButtons = [extrudeButton, bevelButton,
-                               extrudeAction, bevelAction]() {
+    auto refreshTopoButtons = [extrudeButton, bevelButton, knifeButton,
+                               extrudeAction, bevelAction, knifeAction]() {
         auto* c = EditModeController::instance();
         const bool active = c->isEditModeActive();
         extrudeAction->setVisible(active);
         bevelAction->setVisible(active);
+        knifeAction->setVisible(active);
         if (!active) return;
         const int mode = c->selectionMode();  // 0 vertex, 1 edge, 2 face
         const bool hasFaces = c->selectedFaceCount() > 0;
@@ -675,6 +694,9 @@ void MainWindow::initToolBar()
         extrudeButton->setEnabled(mode == 2 && hasFaces);
         bevelButton->setEnabled((mode == 1 && hasEdges)
                              || (mode == 0 && hasVerts));
+        // Knife is always enabled in edit mode; the session has its own
+        // point-based hit-tests and doesn't need a pre-existing selection.
+        knifeButton->setEnabled(true);
     };
     refreshTopoButtons();
     connect(editCtrlForTopo, &EditModeController::editModeChanged,
@@ -1035,6 +1057,23 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
         return;
     }
 
+    // Knife session: Esc cancels, Enter commits. These override selection
+    // mode shortcuts while the session is open.
+    if (editCtrl->knifeSessionActive()) {
+        if (event->key() == Qt::Key_Escape) {
+            SentryReporter::addBreadcrumb("ui.shortcut", "Esc — cancel knife");
+            editCtrl->cancelKnife();
+            event->accept();
+            return;
+        }
+        if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter) {
+            SentryReporter::addBreadcrumb("ui.shortcut", "Enter — commit knife");
+            editCtrl->commitKnife();
+            event->accept();
+            return;
+        }
+    }
+
     if (editCtrl->isEditModeActive()) {
         switch (event->key()) {
         case Qt::Key_1:
@@ -1080,6 +1119,16 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
             if (event->modifiers() & (Qt::ControlModifier | Qt::MetaModifier)) {
                 SentryReporter::addBreadcrumb("ui.shortcut", "Cmd+B — Bevel (edit mode)");
                 editCtrl->bevelSelection();
+                event->accept();
+                return;
+            }
+            break;
+        case Qt::Key_K:
+            // K: enter knife mode. No modifier required — follows the
+            // Blender convention for topology tools.
+            if (!(event->modifiers() & (Qt::ControlModifier | Qt::MetaModifier | Qt::AltModifier))) {
+                SentryReporter::addBreadcrumb("ui.shortcut", "K — Knife (edit mode)");
+                editCtrl->beginKnife();
                 event->accept();
                 return;
             }


### PR DESCRIPTION
## Summary

Adds the knife topology tool that was scoped when we decided against starting with loop-cut: unlike loop-cut, the knife doesn't care about manifold ring walks, so it works cleanly on both primitives and arbitrary imported meshes.

- **Core primitives** (`HalfEdgeMesh`): `splitEdge(edgeIdx, t)` inserts a vertex at parametric `t` on an edge and splits each adjacent triangle into two; `splitFace(faceIdx, vA, vB)` adds a diagonal between two boundary vertices of an n-gon; `appendFace(vector<int>, subMeshIndex)` is the n-gon generalization of `appendTriangle`. `splitEdge` interpolates position, normal, UV, color, tangent, and bone weights between the endpoints. Boundary edges handled (one face splits instead of two).
- **Knife state machine** (`EditModeController`): `beginKnife` / `addKnifePoint` / `updateKnifeHover` / `commitKnife` / `cancelKnife`. A `KnifeSession` holds the confirmed point list + the live hover snap. Points are typed — `OnVertex`, `OnEdge(edgeIdx, t)`, or `OnFace(triIdx, localPos)`.
- **Hit-test with snap priority**: vertex within 10px → edge within 10px → ray-cast against faces. Edge parameter `t` is computed via closest-point-on-line-segment against the click ray in local mesh space, so the placement tracks the cursor even on oblique edges.
- **Live preview overlay**: a dynamic `ManualObject` draws the confirmed polyline in solid yellow and the pending segment (last-confirmed → cursor snap) in a dimmer ghost yellow, using the existing `EditMode/EdgeSelection` material.
- **Commit pipeline**: walks the point list, calls `splitEdge` for each `OnEdge` point, pushes one `EditMeshTopologyCommand` so undo/redo rewinds the whole cut in one step. The `M1↔M2` edge across a single triangle falls out of two `splitEdge` calls automatically — no `splitFace` needed in the common case.
- **UX wiring**: `K` enters knife mode, `Esc` cancels, `Enter`/`Return` commits, scissors button on the edit-mode toolbar next to Extrude/Bevel. Mutual exclusion with bevel in both directions. Knife always tears down on edit-mode exit (committing a stale mid-cut would be surprising).
- **Sentry breadcrumbs**: `edit_mode` for session lifecycle with point counts (`Knife: point added (n=3)`, `Knife: commit (points=3, cuts=2)`), `ui.action` for toolbar click, `ui.shortcut` for K / Esc / Enter.

## Scope limits (deliberate)

- `splitEdge` requires adjacent faces to already be triangles — our entire pipeline feeds triangles through Assimp, so this matches reality.
- `splitFace` is a correct primitive but not used by the commit pipeline yet; it'll become relevant if we add a loop-cut or knife-project tool.
- On-face cut points are captured in the preview overlay but the commit skips them for now (they'd need `splitFace` + a new vertex on the face interior, which is a real project but not v1).

## Tests

- **9 new unit tests** for `splitEdge`/`splitFace` (pure topology, no Ogre): midpoint split of an interior edge, attribute interpolation (UV/normal), boundary-edge split, t-clamping, invalid-index rejection, submesh preservation, bad-hint fallback, adjacent-vertex rejection, `M1↔M2` edge invariant after two `splitEdges`. Full `HalfEdgeMeshStandalone` suite: **106/106**.
- **6 new E2E tests** (`EditModeControllerBevelE2ETest`): begin→cancel lifecycle, commit-without-points rejection, mutual exclusion with bevel (both directions), `exitEditMode` tears down the session, `beginKnife` outside edit mode refuses. Skip on macOS (Ogre headless limitation) and run on Linux CI.

## Test plan

- [x] `./build_local/bin/UnitTests --gtest_filter="HalfEdgeMeshStandalone.*"` → 106/106 pass
- [x] `./build_local/bin/UnitTests --gtest_filter="*Standalone*:*Geometry*"` → 181 pass, 3 pre-existing skips
- [x] App builds clean on macOS arm64 (release target).
- [ ] Manual: create a Cube, enter edit mode, press K, click two different edges, press Enter, confirm new vertex + edges exist and undo rewinds.
- [ ] CI: Linux build + test, macOS build, Windows build, SonarCloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive Knife tool with live preview overlay, K shortcut, toolbar button, Enter to commit and Esc to cancel; knife cancels when leaving edit mode or starting bevel.
  * More robust multi-point mesh cuts with reliable undo/redo and preserved materials.
* **Tests**
  * Added unit and integration tests for Knife workflow, split/cut operations, and undo behavior.
* **Chores**
  * Project version updated to 2.29.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->