### PR TITLE
refactor: reduce duplication

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 2.29.1 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 2.29.0 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/cfg/plugins_d.cfg.in
+++ b/cfg/plugins_d.cfg.in
@@ -3,7 +3,8 @@
 # Define plugin folder
 PluginFolder=@PLUGIN_DIR@
 
-# Define plugins
+# Define plugins (keep aligned with plugins.cfg.in — Codec_STBI is required for common image formats)
 Plugin=RenderSystem_GL@PLUGIN_DEBUG_POSTFIX@
 Plugin=Plugin_OctreeSceneManager@PLUGIN_DEBUG_POSTFIX@
+Plugin=Codec_STBI@PLUGIN_DEBUG_POSTFIX@
 #Plugin=Plugin_CgProgramManager

--- a/cfg/resources.cfg.in
+++ b/cfg/resources.cfg.in
@@ -6,9 +6,12 @@
 
 
 # Resource locations to be added to the default path
+# Keep [General] in sync with resources_d.cfg.in so Release and Debug dev builds match install.
 [General]
 #FileSystem=media/models
-#FileSystem=media/materials/programs
-#FileSystem=media/materials/programs/GLSL
+# GLSL/CG sources for materials that declare vertex_program/fragment_program (e.g. Example_BumpMapping*)
+FileSystem=media/materials/programs/GLSL150
+FileSystem=media/materials/programs/GLSL
+FileSystem=media/materials/programs
 FileSystem=media/materials/scripts
 FileSystem=media/materials/textures

--- a/cfg/resources_d.cfg.in
+++ b/cfg/resources_d.cfg.in
@@ -6,9 +6,12 @@
 
 
 # Resource locations to be added to the default path
+# Keep [General] in sync with resources.cfg.in so Debug dev builds match Release/install.
 [General]
 #FileSystem=media/models
-#FileSystem=media/materials/programs
-#FileSystem=media/materials/programs/GLSL
+# GLSL/CG sources for materials that declare vertex_program/fragment_program (e.g. Example_BumpMapping*)
+FileSystem=media/materials/programs/GLSL150
+FileSystem=media/materials/programs/GLSL
+FileSystem=media/materials/programs
 FileSystem=media/materials/scripts
 FileSystem=media/materials/textures

--- a/media/RTShaderLib/FFPLib_Texturing.glsl
+++ b/media/RTShaderLib/FFPLib_Texturing.glsl
@@ -38,6 +38,8 @@ THE SOFTWARE.
 // see http://msdn.microsoft.com/en-us/library/bb206241.aspx
 //-----------------------------------------------------------------------------
 
+#include "RTSLib_Colour.glsl"
+
 //-----------------------------------------------------------------------------
 void FFP_TransformTexCoord(in mat4 m, in vec2 v, out vec2 vOut)
 {

--- a/qml/PreferencesDialog.qml
+++ b/qml/PreferencesDialog.qml
@@ -294,9 +294,17 @@ Rectangle {
 
                     // --- Viewport Tab ---
                     Column {
+                        id: viewportTabColumn
                         width: parent.width - 32
                         spacing: 12
                         visible: currentTab === 2
+
+                        property int msaaSelection: 4
+                        Component.onCompleted: {
+                            var v = parseInt(readSetting("Viewport/fsaaSamples", 4))
+                            if (v === 0 || v === 2 || v === 4 || v === 8)
+                                msaaSelection = v
+                        }
 
                         // Grid visibility (themed checkbox)
                         Row {
@@ -316,6 +324,72 @@ Rectangle {
                                 }
                             }
                             Text { text: "Show Grid"; font.pixelSize: 12; color: textColor; anchors.verticalCenter: parent.verticalCenter }
+                        }
+
+                        // MSAA (applied immediately; render windows are recreated)
+                        Column {
+                            width: parent.width
+                            spacing: 4
+
+                            Text {
+                                text: "Anti-aliasing (MSAA)"
+                                font.pixelSize: 12
+                                font.bold: true
+                                color: textColor
+                            }
+
+                            Flow {
+                                spacing: 3
+                                width: parent.width
+
+                                Repeater {
+                                    model: [
+                                        { "label": "Off", "value": 0 },
+                                        { "label": "2×", "value": 2 },
+                                        { "label": "4×", "value": 4 },
+                                        { "label": "8×", "value": 8 }
+                                    ]
+
+                                    Rectangle {
+                                        width: Math.max(44, (parent.width - 9) / 4)
+                                        height: 24
+                                        radius: 3
+                                        color: modelData.value === viewportTabColumn.msaaSelection ? highlightColor
+                                             : msaaBtnMa.containsMouse ? Qt.lighter(panelColor, 1.5)
+                                             : Qt.darker(panelColor, 1.1)
+                                        border.color: borderColor
+                                        border.width: 1
+                                        Behavior on color { ColorAnimation { duration: 50 } }
+
+                                        Text {
+                                            anchors.centerIn: parent
+                                            text: modelData.label
+                                            color: textColor
+                                            font.pixelSize: 11
+                                        }
+
+                                        MouseArea {
+                                            id: msaaBtnMa
+                                            anchors.fill: parent
+                                            hoverEnabled: true
+                                            cursorShape: Qt.PointingHandCursor
+                                            onClicked: {
+                                                viewportTabColumn.msaaSelection = modelData.value
+                                                writeSetting("Viewport/fsaaSamples", modelData.value)
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            Text {
+                                text: "Higher values smooth edges but cost more GPU time. Off may look jagged on high-DPI displays."
+                                font.pixelSize: 11
+                                font.italic: true
+                                color: dimTextColor
+                                wrapMode: Text.WordWrap
+                                width: parent.width
+                            }
                         }
 
                         // Camera speed

--- a/qtmesh.example.yml
+++ b/qtmesh.example.yml
@@ -23,6 +23,7 @@ scan:
     - "**/*.fbx"
     - "**/*.glb"
     - "**/*.gltf"
+    - "**/*.vrm"
     - "**/*.obj"
   exclude:
     - "**/third_party/**"
@@ -32,7 +33,7 @@ scan:
 
 rules:
   # Format restrictions
-  allowed_formats: [fbx, glb, gltf, obj]
+  allowed_formats: [fbx, glb, gltf, vrm, obj]
   forbidden_extensions: [dae, 3ds]
 
   # Size & complexity limits

--- a/qtmesh.yml
+++ b/qtmesh.yml
@@ -10,6 +10,7 @@ scan:
     - "**/*.fbx"
     - "**/*.glb"
     - "**/*.gltf"
+    - "**/*.vrm"
     - "**/*.obj"
     - "**/*.mesh"
   exclude:

--- a/src/AppSettingsKeys.h
+++ b/src/AppSettingsKeys.h
@@ -1,0 +1,70 @@
+/*
+-----------------------------------------------------------------------------------
+A QtMeshEditor file
+
+Copyright (c) Fernando Tonon (https://github.com/fernandotonon)
+
+The MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software
+without restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies of the
+Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+-----------------------------------------------------------------------------------
+*/
+
+#ifndef APP_SETTINGS_KEYS_H
+#define APP_SETTINGS_KEYS_H
+
+#include <QString>
+
+namespace AppSettingsKeys
+{
+
+/** @brief Sentry on/off in Preferences (must match QML and SentryReporter). */
+inline const QString& sentryEnabled()
+{
+    static const QString k(QStringLiteral("Sentry/enabled"));
+    return k;
+}
+
+/** @brief Telemetry on/off. */
+inline const QString& telemetryEnabled()
+{
+    static const QString k(QStringLiteral("Telemetry/enabled"));
+    return k;
+}
+
+/** @brief Light/dark/system from Preferences. */
+inline const QString& appearanceTheme()
+{
+    static const QString k(QStringLiteral("Appearance/theme"));
+    return k;
+}
+
+/**
+ * @brief Legacy / alternate key for theme (some paths write "palette").
+ */
+inline const QString& palette()
+{
+    static const QString k(QStringLiteral("palette"));
+    return k;
+}
+
+} // namespace AppSettingsKeys
+
+#endif // APP_SETTINGS_KEYS_H

--- a/src/AssetBrowserController.cpp
+++ b/src/AssetBrowserController.cpp
@@ -12,7 +12,7 @@
 AssetBrowserController* AssetBrowserController::m_pSingleton = nullptr;
 
 const QStringList AssetBrowserController::s_meshExtensions = {
-    "fbx", "gltf", "glb", "gltf2", "obj", "dae", "stl", "mesh", "3ds", "blend", "ply",
+    "fbx", "gltf", "glb", "gltf2", "vrm", "obj", "dae", "stl", "mesh", "3ds", "blend", "ply",
     "x", "x3d", "lwo", "lws", "ac", "ms3d", "cob", "scn", "bvh", "irrmesh", "irr",
     "mdl", "md2", "md3", "md5mesh", "smd", "ogex", "b3d", "q3d", "nff", "off",
     "raw", "ter", "hmp", "assbin", "mesh.xml"

--- a/src/AssetBrowserController_test.cpp
+++ b/src/AssetBrowserController_test.cpp
@@ -226,6 +226,7 @@ TEST_F(AssetBrowserControllerTests, FileTypeClassification) {
     auto* abc = AssetBrowserController::instance();
     EXPECT_EQ(abc->fileTypeForPath("/foo/bar.fbx"), "mesh");
     EXPECT_EQ(abc->fileTypeForPath("/foo/bar.gltf"), "mesh");
+    EXPECT_EQ(abc->fileTypeForPath("/foo/bar.vrm"), "mesh");
     EXPECT_EQ(abc->fileTypeForPath("/foo/bar.obj"), "mesh");
     EXPECT_EQ(abc->fileTypeForPath("/foo/bar.png"), "texture");
     EXPECT_EQ(abc->fileTypeForPath("/foo/bar.jpg"), "texture");

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -336,6 +336,7 @@ QString CLIPipeline::formatForExtension(const QString& path)
         {".glb2", "glTF 2.0 Binary (*.glb2)"},
         {".gltf", "glTF 2.0 (*.gltf)"},
         {".gltf2", "glTF 2.0 (*.gltf2)"},
+        {".vrm", "VRM / glTF 2.0 (*.vrm)"},
         {".dae", "Collada (*.dae)"},
         {".obj", "OBJ (*.obj)"},
         {".stl", "STL (*.stl)"},

--- a/src/CLIPipeline_test.cpp
+++ b/src/CLIPipeline_test.cpp
@@ -497,6 +497,7 @@ TEST(CLIPipelineFormatForExtension, PathWithDirectories)
     EXPECT_EQ(CLIPipeline::formatForExtension("/tmp/dir/model.glb"), "glTF 2.0 Binary (*.glb)");
     EXPECT_EQ(CLIPipeline::formatForExtension("/tmp/dir/model.gltf"), "glTF 2.0 (*.gltf)");
     EXPECT_EQ(CLIPipeline::formatForExtension("C:\\dir\\model.gltf2"), "glTF 2.0 (*.gltf2)");
+    EXPECT_EQ(CLIPipeline::formatForExtension("model.vrm"), "VRM / glTF 2.0 (*.vrm)");
 }
 
 // --- printUsage / printVersion smoke tests ---

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -100,6 +100,7 @@ TransformOperator.h
 PrimitivesWidget.h
 PrimitiveObject.h
 ViewportGrid.h
+ViewportSettingsKeys.h
 AnimationWidget.h
 SelectionSet.h
 SelectionBoxObject.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,6 +78,7 @@ AnimationControlController.h
 GlobalDefinitions.h
 Euler.h
 about.h
+AppSettingsKeys.h
 mainwindow.h
 Manager.h
 material.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -354,6 +354,16 @@ else()
     )
 endif()
 
+# Dev runs expect `media/` beside the executable: resources.cfg uses
+# media/materials/* and RTShaderHelper adds media/RTShaderLib + media/Main
+# (OgreUnifiedShader.h). Without this copy the viewport can stay black.
+add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_SOURCE_DIR}/media
+        $<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>/media
+    COMMENT "Copying media/ next to QtMeshEditor (materials + RTSS)"
+)
+
 ##############################################################
 #  Linking the executable
 ##############################################################

--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -3501,7 +3501,7 @@ QJsonArray MCPServer::buildToolsList()
     // open_scene
     {
         QJsonObject props;
-        props["file_path"] = QJsonObject{{"type", "string"}, {"description", "Absolute path to a scene file to open (*.scene.glb, *.scene.gltf, *.glb, *.gltf)"}};
+        props["file_path"] = QJsonObject{{"type", "string"}, {"description", "Absolute path to a scene file to open (*.scene.glb, *.scene.gltf, *.glb, *.gltf, *.vrm)"}};
         appendTool(
             "open_scene",
             "Open a scene file, replacing the current scene. Loads all meshes with their transforms, materials, skeletons, and animations. "

--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -80,7 +80,7 @@ Manager* Manager:: m_pSingleton = nullptr;
 
 QString Manager::mValidFileExtention = ".mesh .dae .blend .3ds .ase .obj .ifc .xgl .zgl .ply .dxf .lwo "\
         ".lws .lxo .stl .x .ac .ms3d .cob .scn .bvh .csm .xml .irrmesh .irr .mdl .md2 .md3 "\
-        ".pk3 .mdc .md5 .txt .smd .vta .m3 .3d .b3d .q3d .q3s .nff .nff .off .raw .ter .mdl .hmp .ndo .fbx .glb .gltf";
+        ".pk3 .mdc .md5 .txt .smd .vta .m3 .3d .b3d .q3d .q3s .nff .nff .off .raw .ter .mdl .hmp .ndo .fbx .glb .gltf .vrm";
 
 ////////////////////////////////////////
 /// Static Member to build & destroy

--- a/src/Manager_test.cpp
+++ b/src/Manager_test.cpp
@@ -261,6 +261,9 @@ TEST_F(ManagerHeadlessTest, IsValidFileExtention)
     QString glbFile = "model.glb";
     EXPECT_TRUE(mgr->isValidFileExtention(glbFile));
 
+    QString vrmFile = "avatar.vrm";
+    EXPECT_TRUE(mgr->isValidFileExtention(vrmFile));
+
     QString stlFile = "print.stl";
     EXPECT_TRUE(mgr->isValidFileExtention(stlFile));
 
@@ -282,6 +285,7 @@ TEST_F(ManagerHeadlessTest, IsValidFileExtention)
     EXPECT_FALSE(validExts.isEmpty());
     EXPECT_TRUE(validExts.contains(".mesh"));
     EXPECT_TRUE(validExts.contains(".fbx"));
+    EXPECT_TRUE(validExts.contains(".vrm"));
 }
 
 TEST_F(ManagerHeadlessTest, CreateEmptyScene)

--- a/src/MeshImporterExporter.cpp
+++ b/src/MeshImporterExporter.cpp
@@ -1027,6 +1027,11 @@ void MeshImporterExporter::importer(const QStringList &_uriList, unsigned int ad
                 if (en->getMesh() && en->getMesh()->getSkeleton())
                     AnimationMerger::registerSkeletonUpAxis(
                         en->getMesh()->getSkeleton()->getName(), importer.getSceneUpAxis());
+
+                // Same as .mesh/.xml path: ensure tangents exist and RTSS normal maps are
+                // applied after the Entity exists (import-time material setup can run before
+                // mesh data is finalized; Assimp sometimes omits tangents on awkward assets).
+                applyNormalMapsToEntity(en);
             }
 
             sn->setPosition(0,0,0);

--- a/src/MeshTransform.cpp
+++ b/src/MeshTransform.cpp
@@ -31,19 +31,9 @@ THE SOFTWARE.
 #include <limits>
 #include "Manager.h"
 #include "SkeletonTransform.h"
+#include "TransformMath.h"
 
 namespace {
-
-Ogre::Quaternion buildRotationQuat(const Ogre::Vector3 &rotate)
-{
-    if(rotate.x != 0)
-        return {Ogre::Degree(rotate.x), Ogre::Vector3::UNIT_Y};
-    if(rotate.y != 0)
-        return {Ogre::Degree(rotate.y), Ogre::Vector3::UNIT_Z};
-    if(rotate.z != 0)
-        return {Ogre::Degree(rotate.z), Ogre::Vector3::UNIT_X};
-    return Ogre::Quaternion::IDENTITY;
-}
 
 // Iterates all unique vertex data blocks in a mesh, calling transformFn(pos) for each
 // vertex position. Writes back the transformed position and updates mesh bounds.
@@ -143,7 +133,7 @@ void MeshTransform::translateMesh(const Ogre::Entity *_ent, const Ogre::Vector3 
 
 void MeshTransform::rotateMesh(const Ogre::Entity *_ent, const Ogre::Vector3 &_rotate)
 {
-    rotateMesh(_ent, buildRotationQuat(_rotate));
+    rotateMesh(_ent, TransformMath::buildRotationQuat(_rotate));
 }
 
 void MeshTransform::rotateMesh(const Ogre::Entity *_ent, const Ogre::Quaternion &_quat)

--- a/src/OgreWidget.cpp
+++ b/src/OgreWidget.cpp
@@ -36,6 +36,7 @@ THE SOFTWARE.
 #include <Ogre.h>
 
 #include "GlobalDefinitions.h"
+#include "ViewportSettingsKeys.h"
 
 #include "OgreWidget.h"
 #include "Manager.h"
@@ -51,13 +52,13 @@ void applyViewportCameraFromSettings(SpaceCamera* cam)
     if (!cam || !cam->getCamera())
         return;
     QSettings settings;
-    Ogre::Real speed = settings.value(QStringLiteral("Viewport/cameraSpeed"), 1.0).toReal();
+    Ogre::Real speed = settings.value(ViewportSettingsKeys::cameraSpeed(), 1.0).toReal();
     if (speed > 0)
         cam->setCameraSpeed(speed);
     cam->getCamera()->setNearClipDistance(
-        settings.value(QStringLiteral("Viewport/nearClip"), 0.1).toDouble());
+        settings.value(ViewportSettingsKeys::nearClip(), 0.1).toDouble());
     cam->getCamera()->setFarClipDistance(
-        settings.value(QStringLiteral("Viewport/farClip"), 10000.0).toDouble());
+        settings.value(ViewportSettingsKeys::farClip(), 10000.0).toDouble());
 }
 }
 
@@ -151,6 +152,11 @@ QColor OgreWidget::getBackgroundColor() const
 const Ogre::Viewport* OgreWidget::getViewport() const
 {   return mViewport;   }
 
+unsigned int OgreWidget::fsaaSamples() const
+{
+    return mOgreWindow ? mOgreWindow->getFSAA() : 0u;
+}
+
 void OgreWidget::setBackgroundColor(const QColor& c)
 {
     Ogre::ColourValue ogreColour;
@@ -184,7 +190,7 @@ void OgreWidget::initOgreWindow(void)
 
     {
         QSettings settings;
-        const int fsaa = settings.value(QStringLiteral("Viewport/fsaaSamples"), 4).toInt();
+        const int fsaa = settings.value(ViewportSettingsKeys::fsaaSamples(), 4).toInt();
         if (fsaa > 0)
             params["FSAA"] = Ogre::StringConverter::toString(fsaa);
     }
@@ -264,7 +270,7 @@ void OgreWidget::rebuildRenderWindow()
     Ogre::Vector3 targetW, camW;
     Ogre::Quaternion orientW;
     bool restorePose = false;
-    if (mCamera && mCamera->getCamera())
+    if (mCamera && mCamera->getCamera() && mViewport)
     {
         restorePose = true;
         mCamera->getViewportPose(targetW, camW, orientW);

--- a/src/OgreWidget.cpp
+++ b/src/OgreWidget.cpp
@@ -31,6 +31,7 @@ THE SOFTWARE.
 #include <QCoreApplication>
 #include <QTimer>
 #include <QNativeGestureEvent>
+#include <QSettings>
 
 #include <Ogre.h>
 
@@ -43,6 +44,22 @@ THE SOFTWARE.
 #include "QtInputManager.h"
 #include "EditModeController.h"
 #include "TransformOperator.h"
+
+namespace {
+void applyViewportCameraFromSettings(SpaceCamera* cam)
+{
+    if (!cam || !cam->getCamera())
+        return;
+    QSettings settings;
+    Ogre::Real speed = settings.value(QStringLiteral("Viewport/cameraSpeed"), 1.0).toReal();
+    if (speed > 0)
+        cam->setCameraSpeed(speed);
+    cam->getCamera()->setNearClipDistance(
+        settings.value(QStringLiteral("Viewport/nearClip"), 0.1).toDouble());
+    cam->getCamera()->setFarClipDistance(
+        settings.value(QStringLiteral("Viewport/farClip"), 10000.0).toDouble());
+}
+}
 
 OgreWidget::OgreWidget( QWidget *parent ):
     QWidget( parent )
@@ -165,6 +182,13 @@ void OgreWidget::initOgreWindow(void)
     params["macAPICocoaUseNSView"] = "true";
 #endif
 
+    {
+        QSettings settings;
+        const int fsaa = settings.value(QStringLiteral("Viewport/fsaaSamples"), 4).toInt();
+        if (fsaa > 0)
+            params["FSAA"] = Ogre::StringConverter::toString(fsaa);
+    }
+
     QString name = "Viewport " + QString::number(getIndex());
     while (mOgreRoot->getRenderTarget(name.toStdString())) {
         name+=".";
@@ -186,6 +210,85 @@ void OgreWidget::initOgreWindow(void)
     mViewport->setMaterialScheme(Ogre::MSN_SHADERGEN);
 
     mOgreRoot->addFrameListener(this);
+
+    if (mCamera)
+        applyViewportCameraFromSettings(mCamera.get());
+}
+
+void OgreWidget::teardownOgreWindow()
+{
+    if (mOgreRoot)
+    {
+        try {
+            mOgreRoot->removeFrameListener(this);
+        } catch (...) {
+        }
+    }
+
+    mCamera.reset();
+
+    if (mOgreWindow)
+    {
+        try {
+            try {
+                mOgreWindow->removeAllViewports();
+            } catch (...) {
+            }
+
+            if (mOgreRoot)
+            {
+                try {
+                    mOgreRoot->detachRenderTarget(mOgreWindow);
+                } catch (...) {
+                }
+            }
+
+            try {
+                mOgreWindow->setActive(false);
+            } catch (...) {
+            }
+
+            mViewport = nullptr;
+            mOgreWindow = nullptr;
+        } catch (...) {
+            mViewport = nullptr;
+            mOgreWindow = nullptr;
+        }
+    }
+}
+
+void OgreWidget::rebuildRenderWindow()
+{
+    QColor bg = getBackgroundColor();
+    uint visMask = SCENE_VISIBILITY_FLAGS;
+    Ogre::Vector3 targetW, camW;
+    Ogre::Quaternion orientW;
+    bool restorePose = false;
+    if (mCamera && mCamera->getCamera())
+    {
+        restorePose = true;
+        mCamera->getViewportPose(targetW, camW, orientW);
+        visMask = mViewport->getVisibilityMask();
+    }
+
+    teardownOgreWindow();
+    initOgreWindow();
+
+    setBackgroundColor(bg);
+    if (mViewport)
+        mViewport->setVisibilityMask(visMask);
+
+    if (restorePose && mCamera)
+        mCamera->applyViewportPose(targetW, camW, orientW);
+
+    if (mOgreWindow)
+    {
+        mOgreWindow->resize(width(), height());
+        mOgreWindow->windowMovedOrResized();
+    }
+    if (mCamera)
+        mCamera->setAspectRatio((Ogre::Real)width() / (Ogre::Real)height());
+    update();
 }
 
 bool OgreWidget::frameStarted(const Ogre::FrameEvent& e)

--- a/src/OgreWidget.h
+++ b/src/OgreWidget.h
@@ -56,6 +56,9 @@ class OgreWidget : public QWidget, public Ogre::FrameListener
   void setBackgroundColor(const QColor& c);
   SpaceCamera* getSpaceCamera() const { return mCamera.get(); }
 
+  /// MSAA sample count reported by the render target (0 if off / no window).
+  unsigned int fsaaSamples() const;
+
   /// Recreate the Ogre render window (e.g. after MSAA / FSAA settings change).
   void rebuildRenderWindow();
 

--- a/src/OgreWidget.h
+++ b/src/OgreWidget.h
@@ -56,8 +56,12 @@ class OgreWidget : public QWidget, public Ogre::FrameListener
   void setBackgroundColor(const QColor& c);
   SpaceCamera* getSpaceCamera() const { return mCamera.get(); }
 
+  /// Recreate the Ogre render window (e.g. after MSAA / FSAA settings change).
+  void rebuildRenderWindow();
+
 protected:
   /*virtual*/ void initOgreWindow(void);
+  void teardownOgreWindow();
 
   QPaintEngine* paintEngine() const override;
   void resizeEvent(QResizeEvent *e) override;

--- a/src/OgreWidget_test.cpp
+++ b/src/OgreWidget_test.cpp
@@ -4,11 +4,13 @@
 #include <QFocusEvent>
 #include <QSignalSpy>
 #include <QThread>
+#include <QSettings>
 #include <QWheelEvent>
 #include <exception>
 
 #include "EditorViewport.h"
 #include "GlobalDefinitions.h"
+#include "ViewportSettingsKeys.h"
 #include "Manager.h"
 #include "SpaceCamera.h"
 #include "mainwindow.h"
@@ -213,4 +215,34 @@ TEST_F(OgreWidgetTest, FocusEventsEmitSignalAndToggleVisibilityMask)
     widget->focusOutEvent(&focusOut);
     EXPECT_TRUE(focusOut.isAccepted());
     EXPECT_EQ(widget->getViewport()->getVisibilityMask(), SCENE_VISIBILITY_FLAGS);
+}
+
+TEST_F(OgreWidgetTest, FsaaSamplesMatchesRenderTarget)
+{
+    ASSERT_NE(widget->getViewport(), nullptr);
+    Ogre::RenderTarget* target = widget->getViewport()->getTarget();
+    ASSERT_NE(target, nullptr);
+    EXPECT_EQ(widget->fsaaSamples(), target->getFSAA());
+}
+
+TEST_F(OgreWidgetTest, RebuildRenderWindowPreservesBackgroundAndKeepsCamera)
+{
+    QSettings settings;
+    settings.setValue(ViewportSettingsKeys::fsaaSamples(), 2);
+    settings.setValue(ViewportSettingsKeys::cameraSpeed(), 1.5);
+    settings.setValue(ViewportSettingsKeys::nearClip(), 0.05);
+    settings.setValue(ViewportSettingsKeys::farClip(), 5000.0);
+
+    const QColor bg(18, 52, 86);
+    widget->setBackgroundColor(bg);
+
+    EXPECT_NO_THROW(widget->rebuildRenderWindow());
+    app->processEvents();
+
+    EXPECT_EQ(widget->getBackgroundColor(), bg);
+    ASSERT_NE(widget->getSpaceCamera(), nullptr);
+    ASSERT_NE(widget->getSpaceCamera()->getCamera(), nullptr);
+    EXPECT_FLOAT_EQ(widget->getSpaceCamera()->getCameraSpeed(), 1.5f);
+    EXPECT_DOUBLE_EQ(widget->getSpaceCamera()->getCamera()->getNearClipDistance(), 0.05);
+    EXPECT_DOUBLE_EQ(widget->getSpaceCamera()->getCamera()->getFarClipDistance(), 5000.0);
 }

--- a/src/OgreWidget_test.cpp
+++ b/src/OgreWidget_test.cpp
@@ -243,6 +243,7 @@ TEST_F(OgreWidgetTest, RebuildRenderWindowPreservesBackgroundAndKeepsCamera)
     ASSERT_NE(widget->getSpaceCamera(), nullptr);
     ASSERT_NE(widget->getSpaceCamera()->getCamera(), nullptr);
     EXPECT_FLOAT_EQ(widget->getSpaceCamera()->getCameraSpeed(), 1.5f);
-    EXPECT_DOUBLE_EQ(widget->getSpaceCamera()->getCamera()->getNearClipDistance(), 0.05);
-    EXPECT_DOUBLE_EQ(widget->getSpaceCamera()->getCamera()->getFarClipDistance(), 5000.0);
+    // QSettings/Ogre path can introduce tiny float error vs exact literals (CI Linux).
+    EXPECT_NEAR(widget->getSpaceCamera()->getCamera()->getNearClipDistance(), 0.05, 1e-5);
+    EXPECT_NEAR(widget->getSpaceCamera()->getCamera()->getFarClipDistance(), 5000.0, 1e-3);
 }

--- a/src/PrimitivesWidget.cpp
+++ b/src/PrimitivesWidget.cpp
@@ -143,359 +143,151 @@ void PrimitivesWidget::setUVTileVisible(bool visible)
     pb_switchUV->setVisible(visible);
 }
 
-void PrimitivesWidget::setUiCube()
+void PrimitivesWidget::applyPrimitiveUiConfig(const QString &type,
+                                              bool sizeX, bool sizeY, bool sizeZ,
+                                              bool radius, bool radius2, bool height,
+                                              const QString &radiusText, const QString &radius2Text,
+                                              bool segX, bool segY, bool segZ,
+                                              const QString &segXText, const QString &segYText, const QString &segZText,
+                                              bool uvTileVisible, bool switchUvVisible)
 {
-
-    edit_type->setText(tr("Cube"));
+    edit_type->setText(type);
 
     gb_Geometry->show();
     gb_Mesh->show();
 
-    edit_sizeX->show();
-    edit_sizeY->show();
-    edit_sizeZ->show();
+    edit_sizeX->setVisible(sizeX);
+    edit_sizeY->setVisible(sizeY);
+    edit_sizeZ->setVisible(sizeZ);
 
-    label_sizeX->show();
-    label_sizeY->show();
-    label_sizeZ->show();
+    label_sizeX->setVisible(sizeX);
+    label_sizeY->setVisible(sizeY);
+    label_sizeZ->setVisible(sizeZ);
 
-    label_radius->hide();
-    label_radius2->hide();
-    label_height->hide();
+    label_radius->setVisible(radius);
+    label_radius2->setVisible(radius2);
+    label_height->setVisible(height);
 
-    edit_radius->hide();
-    edit_radius2->hide();
-    edit_height->hide();
+    edit_radius->setVisible(radius);
+    edit_radius2->setVisible(radius2);
+    edit_height->setVisible(height);
 
-    label_numSegX->show();
-    label_numSegY->show();
-    label_numSegZ->show();
+    if(!radiusText.isEmpty())  label_radius->setText(radiusText);
+    if(!radius2Text.isEmpty()) label_radius2->setText(radius2Text);
 
-    edit_numSegX->show();
-    edit_numSegY->show();
-    edit_numSegZ->show();
+    label_numSegX->setVisible(segX);
+    label_numSegY->setVisible(segY);
+    label_numSegZ->setVisible(segZ);
 
-    setUVTileVisible(true);
-    pb_switchUV->setVisible(false);
+    edit_numSegX->setVisible(segX);
+    edit_numSegY->setVisible(segY);
+    edit_numSegZ->setVisible(segZ);
 
-    label_numSegX->setText(tr("Seg X"));
-    label_numSegY->setText(tr("Seg Y"));
-    label_numSegZ->setText(tr("Seg Z"));
+    setUVTileVisible(uvTileVisible);
+    pb_switchUV->setVisible(switchUvVisible && uvTileVisible);
 
+    if(!segXText.isEmpty()) label_numSegX->setText(segXText);
+    if(!segYText.isEmpty()) label_numSegY->setText(segYText);
+    if(!segZText.isEmpty()) label_numSegZ->setText(segZText);
+}
+
+void PrimitivesWidget::setUiCube()
+{
+    applyPrimitiveUiConfig(tr("Cube"),
+                           true, true, true,
+                           false, false, false,
+                           QString(), QString(),
+                           true, true, true,
+                           tr("Seg X"), tr("Seg Y"), tr("Seg Z"),
+                           true, false);
 }
 
 void PrimitivesWidget::setUiSphere()
 {
-    edit_type->setText(tr("Sphere"));
-
-    gb_Geometry->show();
-    gb_Mesh->show();
-
-    edit_sizeX->hide();
-    edit_sizeY->hide();
-    edit_sizeZ->hide();
-
-    label_sizeX->hide();
-    label_sizeY->hide();
-    label_sizeZ->hide();
-
-    label_radius->show();
-    label_radius2->hide();
-    label_height->hide();
-
-    edit_radius->show();
-    edit_radius2->hide();
-    edit_height->hide();
-
-    label_radius->setText(tr("Radius"));
-
-    label_numSegX->show();
-    label_numSegY->show();
-    label_numSegZ->hide();
-
-    edit_numSegX->show();
-    edit_numSegY->show();
-    edit_numSegZ->hide();
-
-    setUVTileVisible(true);
-
-    label_numSegX->setText(tr("Seg Ring"));
-    label_numSegY->setText(tr("Seg Loop"));
-
+    applyPrimitiveUiConfig(tr("Sphere"),
+                           false, false, false,
+                           true, false, false,
+                           tr("Radius"), QString(),
+                           true, true, false,
+                           tr("Seg Ring"), tr("Seg Loop"), QString(),
+                           true);
 }
 
 void PrimitivesWidget::setUiPlane()
 {
-    edit_type->setText(tr("Plane"));
-
-    gb_Geometry->show();
-    gb_Mesh->show();
-
-    edit_sizeX->show();
-    edit_sizeY->show();
-    edit_sizeZ->hide();
-
-    label_sizeX->show();
-    label_sizeY->show();
-    label_sizeZ->hide();
-
-    label_radius->hide();
-    label_radius2->hide();
-    label_height->hide();
-
-    edit_radius->hide();
-    edit_radius2->hide();
-    edit_height->hide();
-
-    label_numSegX->show();
-    label_numSegY->show();
-    label_numSegZ->hide();
-
-    edit_numSegX->show();
-    edit_numSegY->show();
-    edit_numSegZ->hide();
-
-    setUVTileVisible(true);
-
-    label_numSegX->setText(tr("Seg X"));
-    label_numSegY->setText(tr("Seg Y"));
-
+    applyPrimitiveUiConfig(tr("Plane"),
+                           true, true, false,
+                           false, false, false,
+                           QString(), QString(),
+                           true, true, false,
+                           tr("Seg X"), tr("Seg Y"), QString(),
+                           true);
 }
 
 void PrimitivesWidget::setUiCylinder()
 {
-    edit_type->setText(tr("Cylinder"));
-
-    gb_Geometry->show();
-    gb_Mesh->show();
-
-    edit_sizeX->hide();
-    edit_sizeY->hide();
-    edit_sizeZ->hide();
-
-    label_sizeX->hide();
-    label_sizeY->hide();
-    label_sizeZ->hide();
-
-    label_radius->show();
-    label_radius2->hide();
-    label_height->show();
-
-    edit_radius->show();
-    edit_radius2->hide();
-    edit_height->show();
-
-    label_radius->setText(tr("Radius"));
-
-    label_numSegX->show();
-    label_numSegY->hide();
-    label_numSegZ->show();
-
-    edit_numSegX->show();
-    edit_numSegY->hide();
-    edit_numSegZ->show();
-
-    setUVTileVisible(true);
-
-    label_numSegX->setText(tr("Seg Base"));
-    label_numSegZ->setText(tr("Seg Height"));
+    applyPrimitiveUiConfig(tr("Cylinder"),
+                           false, false, false,
+                           true, false, true,
+                           tr("Radius"), QString(),
+                           true, false, true,
+                           tr("Seg Base"), QString(), tr("Seg Height"),
+                           true);
 }
 
 void PrimitivesWidget::setUiCone()
 {
-    edit_type->setText(tr("Cone"));
-
-    gb_Geometry->show();
-    gb_Mesh->show();
-
-    edit_sizeX->hide();
-    edit_sizeY->hide();
-    edit_sizeZ->hide();
-
-    label_sizeX->hide();
-    label_sizeY->hide();
-    label_sizeZ->hide();
-
-    label_radius->show();
-    label_radius2->hide();
-    label_height->show();
-
-    edit_radius->show();
-    edit_radius2->hide();
-    edit_height->show();
-
-    label_radius->setText(tr("Radius"));
-
-    label_numSegX->show();
-    label_numSegY->hide();
-    label_numSegZ->show();
-
-    edit_numSegX->show();
-    edit_numSegY->hide();
-    edit_numSegZ->show();
-
-    setUVTileVisible(true);
-
-    label_numSegX->setText(tr("Seg Base"));
-    label_numSegZ->setText(tr("Seg Height"));
+    applyPrimitiveUiConfig(tr("Cone"),
+                           false, false, false,
+                           true, false, true,
+                           tr("Radius"), QString(),
+                           true, false, true,
+                           tr("Seg Base"), QString(), tr("Seg Height"),
+                           true);
 }
 
 void PrimitivesWidget::setUiTorus()
 {
-    edit_type->setText(tr("Torus"));
-
-    gb_Geometry->show();
-    gb_Mesh->show();
-
-    edit_sizeX->hide();
-    edit_sizeY->hide();
-    edit_sizeZ->hide();
-
-    label_sizeX->hide();
-    label_sizeY->hide();
-    label_sizeZ->hide();
-
-    label_radius->show();
-    label_radius2->show();
-    label_height->hide();
-
-    edit_radius->show();
-    edit_radius2->show();
-    edit_height->hide();
-
-    label_radius->setText(tr("Radius"));
-    label_radius2->setText(tr("Section Radius"));
-
-    label_numSegX->show();
-    label_numSegY->show();
-    label_numSegZ->hide();
-
-    edit_numSegX->show();
-    edit_numSegY->show();
-    edit_numSegZ->hide();
-
-    setUVTileVisible(true);
-
-    label_numSegX->setText(tr("Seg Circle"));
-    label_numSegY->setText(tr("Seg Section"));
+    applyPrimitiveUiConfig(tr("Torus"),
+                           false, false, false,
+                           true, true, false,
+                           tr("Radius"), tr("Section Radius"),
+                           true, true, false,
+                           tr("Seg Circle"), tr("Seg Section"), QString(),
+                           true);
 }
 
 void PrimitivesWidget::setUiTube()
 {
-    edit_type->setText(tr("Tube"));
-
-    gb_Geometry->show();
-    gb_Mesh->show();
-
-    edit_sizeX->hide();
-    edit_sizeY->hide();
-    edit_sizeZ->hide();
-
-    label_sizeX->hide();
-    label_sizeY->hide();
-    label_sizeZ->hide();
-
-    label_radius->show();
-    label_radius2->show();
-    label_height->show();
-
-    edit_radius->show();
-    edit_radius2->show();
-    edit_height->show();
-
-    label_radius->setText(tr("Outer Radius"));
-    label_radius2->setText(tr("Inner Radius"));
-
-    label_numSegX->show();
-    label_numSegY->hide();
-    label_numSegZ->show();
-
-    edit_numSegX->show();
-    edit_numSegY->hide();
-    edit_numSegZ->show();
-
-    setUVTileVisible(true);
-
-    label_numSegX->setText(tr("Seg Base"));
-    label_numSegZ->setText(tr("Seg Height"));
+    applyPrimitiveUiConfig(tr("Tube"),
+                           false, false, false,
+                           true, true, true,
+                           tr("Outer Radius"), tr("Inner Radius"),
+                           true, false, true,
+                           tr("Seg Base"), QString(), tr("Seg Height"),
+                           true);
 }
 
 void PrimitivesWidget::setUiCapsule()
 {
-    edit_type->setText(tr("Capsule"));
-
-    gb_Geometry->show();
-    gb_Mesh->show();
-
-    edit_sizeX->hide();
-    edit_sizeY->hide();
-    edit_sizeZ->hide();
-
-    label_sizeX->hide();
-    label_sizeY->hide();
-    label_sizeZ->hide();
-
-    label_radius->show();
-    label_radius2->hide();
-    label_height->show();
-
-    edit_radius->show();
-    edit_radius2->hide();
-    edit_height->show();
-
-    label_radius->setText(tr("Radius"));
-
-    label_numSegX->show();
-    label_numSegY->show();
-    label_numSegZ->show();
-
-    edit_numSegX->show();
-    edit_numSegY->show();
-    edit_numSegZ->show();
-
-    setUVTileVisible(true);
-
-    label_numSegX->setText(tr("Seg Ring"));
-    label_numSegY->setText(tr("Seg Loop"));
-    label_numSegZ->setText(tr("Seg Height"));
+    applyPrimitiveUiConfig(tr("Capsule"),
+                           false, false, false,
+                           true, false, true,
+                           tr("Radius"), QString(),
+                           true, true, true,
+                           tr("Seg Ring"), tr("Seg Loop"), tr("Seg Height"),
+                           true);
 }
 
 void PrimitivesWidget::setUiIcoSphere()
 {
-    edit_type->setText(tr("IcoSphere"));
-
-    gb_Geometry->show();
-    gb_Mesh->show();
-
-    edit_sizeX->hide();
-    edit_sizeY->hide();
-    edit_sizeZ->hide();
-
-    label_sizeX->hide();
-    label_sizeY->hide();
-    label_sizeZ->hide();
-
-    label_radius->show();
-    label_radius2->hide();
-    label_height->hide();
-
-    edit_radius->show();
-    edit_radius2->hide();
-    edit_height->hide();
-
-    label_radius->setText(tr("Radius"));
-
-    label_numSegX->show();
-    label_numSegY->hide();
-    label_numSegZ->hide();
-
-    edit_numSegX->show();
-    edit_numSegY->hide();
-    edit_numSegZ->hide();
-
-    setUVTileVisible(true);
-
-    label_numSegX->setText(tr("Iterations"));
+    applyPrimitiveUiConfig(tr("IcoSphere"),
+                           false, false, false,
+                           true, false, false,
+                           tr("Radius"), QString(),
+                           true, false, false,
+                           tr("Iterations"), QString(), QString(),
+                           true);
 }
 
 void PrimitivesWidget::setUiRoundedBox()

--- a/src/PrimitivesWidget.h
+++ b/src/PrimitivesWidget.h
@@ -2,6 +2,7 @@
 #define PRIMITIVES_WIDGET_H
 
 #include <QWidget>
+#include <QString>
 #include <OgrePrerequisites.h>
 #include "PrimitiveObject.h"
 
@@ -34,6 +35,13 @@ public slots:
 protected:
     void setUiEmpty();
     void setUiMesh();
+    void applyPrimitiveUiConfig(const QString &type,
+                                bool sizeX, bool sizeY, bool sizeZ,
+                                bool radius, bool radius2, bool height,
+                                const QString &radiusText, const QString &radius2Text,
+                                bool segX, bool segY, bool segZ,
+                                const QString &segXText, const QString &segYText, const QString &segZText,
+                                bool uvTileVisible, bool switchUvVisible = true);
     void setUiCube();
     void setUiSphere();
     void setUiPlane();

--- a/src/PropertiesPanelController.cpp
+++ b/src/PropertiesPanelController.cpp
@@ -13,6 +13,7 @@
 #include "SpaceCamera.h"
 #include "EditorViewport.h"
 #include "ViewportGrid.h"
+#include "mainwindow.h"
 #include <QApplication>
 #include <QFileDialog>
 #include <QSettings>
@@ -801,6 +802,9 @@ void PropertiesPanelController::setSetting(const QString& key, const QVariant& v
                 }
             }
         }
+    } else if (key == "Viewport/fsaaSamples") {
+        if (auto* mainWin = Manager::getSingleton()->getMainWindow())
+            mainWin->rebuildAllOgreViewports();
     } else if (key == "Sentry/enabled" || key == "Telemetry/enabled") {
         SentryReporter::setEnabled(value.toBool());
     } else if (key == "Appearance/theme" || key == "palette") {

--- a/src/PropertiesPanelController.cpp
+++ b/src/PropertiesPanelController.cpp
@@ -14,6 +14,7 @@
 #include "EditorViewport.h"
 #include "ViewportGrid.h"
 #include "ViewportSettingsKeys.h"
+#include "AppSettingsKeys.h"
 #include "mainwindow.h"
 #include <QApplication>
 #include <QFileDialog>
@@ -760,59 +761,109 @@ QVariantList PropertiesPanelController::scaleStepPresets() const
 
 namespace
 {
-/// Handles Viewport/* keys for setSetting; returns true if @p key was handled.
+void applyGridVisibleFromSettings(const QVariant& value)
+{
+    auto* grid = Manager::getSingleton()->getViewportGrid();
+    if (grid) {
+        grid->setVisible(value.toBool());
+    }
+}
+
+void applyCameraSpeedToAllViewports(Ogre::Real speed)
+{
+    if (speed <= 0) {
+        speed = 0.5f;
+    }
+    auto* activeWidget = TransformOperator::getSingleton()->getActiveWidget();
+    if (activeWidget && activeWidget->getSpaceCamera()) {
+        activeWidget->getSpaceCamera()->setCameraSpeed(speed);
+    }
+    auto* mainWin = Manager::getSingleton()->getMainWindow();
+    if (!mainWin) {
+        return;
+    }
+    for (auto* ow : mainWin->findChildren<OgreWidget*>()) {
+        if (ow->getSpaceCamera()) {
+            ow->getSpaceCamera()->setCameraSpeed(speed);
+        }
+    }
+}
+
+void applyClipPlaneToAllViewports(const QString& key, const QVariant& value)
+{
+    const bool isNear = (key == ViewportSettingsKeys::nearClip());
+    const Ogre::Real v = value.toReal();
+    auto* mainWin = Manager::getSingleton()->getMainWindow();
+    if (!mainWin) {
+        return;
+    }
+    for (auto* ow : mainWin->findChildren<OgreWidget*>()) {
+        Ogre::Camera* cam = nullptr;
+        if (ow->getSpaceCamera()) {
+            cam = ow->getSpaceCamera()->getCamera();
+        }
+        if (!cam) {
+            continue;
+        }
+        if (isNear) {
+            cam->setNearClipDistance(v);
+        } else {
+            cam->setFarClipDistance(v);
+        }
+    }
+}
+
+void applyFsaaByRebuildingViewports()
+{
+    if (auto* mainWin = Manager::getSingleton()->getMainWindow()) {
+        mainWin->rebuildAllOgreViewports();
+    }
+}
+
 bool tryApplyViewportSetting(const QString& key, const QVariant& value)
 {
     if (key == ViewportSettingsKeys::gridVisible()) {
-        auto* grid = Manager::getSingleton()->getViewportGrid();
-        if (grid) {
-            grid->setVisible(value.toBool());
-        }
+        applyGridVisibleFromSettings(value);
         return true;
     }
     if (key == ViewportSettingsKeys::cameraSpeed()) {
-        Ogre::Real speed = value.toReal();
-        if (speed <= 0) {
-            speed = 0.5f;
-        }
-        // Apply to the active viewport (TransformOperator tracks it)
-        auto* activeWidget = TransformOperator::getSingleton()->getActiveWidget();
-        if (activeWidget && activeWidget->getSpaceCamera()) {
-            activeWidget->getSpaceCamera()->setCameraSpeed(speed);
-        }
-        // Also apply to all viewports
-        auto* mainWin = Manager::getSingleton()->getMainWindow();
-        if (mainWin) {
-            for (auto* ow : mainWin->findChildren<OgreWidget*>()) {
-                if (ow->getSpaceCamera()) {
-                    ow->getSpaceCamera()->setCameraSpeed(speed);
-                }
-            }
-        }
+        applyCameraSpeedToAllViewports(value.toReal());
         return true;
     }
     if (key == ViewportSettingsKeys::nearClip() || key == ViewportSettingsKeys::farClip()) {
-        auto* mainWin = Manager::getSingleton()->getMainWindow();
-        if (mainWin) {
-            for (auto* ow : mainWin->findChildren<OgreWidget*>()) {
-                if (ow->getSpaceCamera() && ow->getSpaceCamera()->getCamera()) {
-                    if (key == ViewportSettingsKeys::nearClip()) {
-                        ow->getSpaceCamera()->getCamera()->setNearClipDistance(value.toReal());
-                    } else {
-                        ow->getSpaceCamera()->getCamera()->setFarClipDistance(value.toReal());
-                    }
-                }
-            }
-        }
+        applyClipPlaneToAllViewports(key, value);
         return true;
     }
     if (key == ViewportSettingsKeys::fsaaSamples()) {
-        if (auto* mainWin = Manager::getSingleton()->getMainWindow()) {
-            mainWin->rebuildAllOgreViewports();
-        }
+        applyFsaaByRebuildingViewports();
         return true;
     }
     return false;
+}
+
+void applyEditorThemeFromString(const QString& themeLower)
+{
+    if (themeLower == QStringLiteral("dark")) {
+        QPalette dark;
+        dark.setColor(QPalette::Window, QColor(53, 53, 53));
+        dark.setColor(QPalette::WindowText, Qt::white);
+        dark.setColor(QPalette::Base, QColor(35, 35, 35));
+        dark.setColor(QPalette::AlternateBase, QColor(53, 53, 53));
+        dark.setColor(QPalette::ToolTipBase, QColor(25, 25, 25));
+        dark.setColor(QPalette::ToolTipText, Qt::white);
+        dark.setColor(QPalette::Text, Qt::white);
+        dark.setColor(QPalette::Button, QColor(53, 53, 53));
+        dark.setColor(QPalette::ButtonText, Qt::white);
+        dark.setColor(QPalette::Link, QColor(42, 130, 218));
+        dark.setColor(QPalette::Highlight, QColor(42, 130, 218));
+        dark.setColor(QPalette::HighlightedText, Qt::black);
+        QApplication::setPalette(dark);
+        return;
+    }
+    if (themeLower == QStringLiteral("light")) {
+        QApplication::setPalette(QColor(QStringLiteral("ghostwhite")));
+    }
+    // "system" = use platform default (may require restart)
 }
 } // namespace
 
@@ -833,29 +884,11 @@ void PropertiesPanelController::setSetting(const QString& key, const QVariant& v
     if (tryApplyViewportSetting(key, value)) {
         return;
     }
-    if (key == "Sentry/enabled" || key == "Telemetry/enabled") {
+    if (key == AppSettingsKeys::sentryEnabled() || key == AppSettingsKeys::telemetryEnabled()) {
         SentryReporter::setEnabled(value.toBool());
-    } else if (key == "Appearance/theme" || key == "palette") {
-        QString theme = value.toString().toLower();
-        if (theme == "dark") {
-            // Match MainWindow::on_actionDark_toggled — use dark palette
-            QPalette dark;
-            dark.setColor(QPalette::Window, QColor(53, 53, 53));
-            dark.setColor(QPalette::WindowText, Qt::white);
-            dark.setColor(QPalette::Base, QColor(35, 35, 35));
-            dark.setColor(QPalette::AlternateBase, QColor(53, 53, 53));
-            dark.setColor(QPalette::ToolTipBase, QColor(25, 25, 25));
-            dark.setColor(QPalette::ToolTipText, Qt::white);
-            dark.setColor(QPalette::Text, Qt::white);
-            dark.setColor(QPalette::Button, QColor(53, 53, 53));
-            dark.setColor(QPalette::ButtonText, Qt::white);
-            dark.setColor(QPalette::Link, QColor(42, 130, 218));
-            dark.setColor(QPalette::Highlight, QColor(42, 130, 218));
-            dark.setColor(QPalette::HighlightedText, Qt::black);
-            QApplication::setPalette(dark);
-        } else if (theme == "light") {
-            QApplication::setPalette(QColor("ghostwhite"));
-        }
-        // System = use platform default (requires restart)
+        return;
+    }
+    if (key == AppSettingsKeys::appearanceTheme() || key == AppSettingsKeys::palette()) {
+        applyEditorThemeFromString(value.toString().toLower());
     }
 }

--- a/src/PropertiesPanelController.cpp
+++ b/src/PropertiesPanelController.cpp
@@ -13,6 +13,7 @@
 #include "SpaceCamera.h"
 #include "EditorViewport.h"
 #include "ViewportGrid.h"
+#include "ViewportSettingsKeys.h"
 #include "mainwindow.h"
 #include <QApplication>
 #include <QFileDialog>
@@ -757,6 +758,64 @@ QVariantList PropertiesPanelController::scaleStepPresets() const
     return result;
 }
 
+namespace
+{
+/// Handles Viewport/* keys for setSetting; returns true if @p key was handled.
+bool tryApplyViewportSetting(const QString& key, const QVariant& value)
+{
+    if (key == ViewportSettingsKeys::gridVisible()) {
+        auto* grid = Manager::getSingleton()->getViewportGrid();
+        if (grid) {
+            grid->setVisible(value.toBool());
+        }
+        return true;
+    }
+    if (key == ViewportSettingsKeys::cameraSpeed()) {
+        Ogre::Real speed = value.toReal();
+        if (speed <= 0) {
+            speed = 0.5f;
+        }
+        // Apply to the active viewport (TransformOperator tracks it)
+        auto* activeWidget = TransformOperator::getSingleton()->getActiveWidget();
+        if (activeWidget && activeWidget->getSpaceCamera()) {
+            activeWidget->getSpaceCamera()->setCameraSpeed(speed);
+        }
+        // Also apply to all viewports
+        auto* mainWin = Manager::getSingleton()->getMainWindow();
+        if (mainWin) {
+            for (auto* ow : mainWin->findChildren<OgreWidget*>()) {
+                if (ow->getSpaceCamera()) {
+                    ow->getSpaceCamera()->setCameraSpeed(speed);
+                }
+            }
+        }
+        return true;
+    }
+    if (key == ViewportSettingsKeys::nearClip() || key == ViewportSettingsKeys::farClip()) {
+        auto* mainWin = Manager::getSingleton()->getMainWindow();
+        if (mainWin) {
+            for (auto* ow : mainWin->findChildren<OgreWidget*>()) {
+                if (ow->getSpaceCamera() && ow->getSpaceCamera()->getCamera()) {
+                    if (key == ViewportSettingsKeys::nearClip()) {
+                        ow->getSpaceCamera()->getCamera()->setNearClipDistance(value.toReal());
+                    } else {
+                        ow->getSpaceCamera()->getCamera()->setFarClipDistance(value.toReal());
+                    }
+                }
+            }
+        }
+        return true;
+    }
+    if (key == ViewportSettingsKeys::fsaaSamples()) {
+        if (auto* mainWin = Manager::getSingleton()->getMainWindow()) {
+            mainWin->rebuildAllOgreViewports();
+        }
+        return true;
+    }
+    return false;
+}
+} // namespace
+
 // Generic QSettings accessors for Preferences dialog
 QVariant PropertiesPanelController::getSetting(const QString& key, const QVariant& defaultValue) const
 {
@@ -771,41 +830,10 @@ void PropertiesPanelController::setSetting(const QString& key, const QVariant& v
     SentryReporter::addBreadcrumb("ui.action",
         QString("Preference changed: %1").arg(key));
 
-    // Apply settings immediately to the running app
-    if (key == "Viewport/gridVisible") {
-        auto* grid = Manager::getSingleton()->getViewportGrid();
-        if (grid) grid->setVisible(value.toBool());
-    } else if (key == "Viewport/cameraSpeed") {
-        Ogre::Real speed = value.toReal();
-        if (speed <= 0) speed = 0.5f;
-        // Apply to the active viewport (TransformOperator tracks it)
-        auto* activeWidget = TransformOperator::getSingleton()->getActiveWidget();
-        if (activeWidget && activeWidget->getSpaceCamera())
-            activeWidget->getSpaceCamera()->setCameraSpeed(speed);
-        // Also apply to all viewports
-        auto* mainWin = Manager::getSingleton()->getMainWindow();
-        if (mainWin) {
-            for (auto* ow : mainWin->findChildren<OgreWidget*>()) {
-                if (ow->getSpaceCamera())
-                    ow->getSpaceCamera()->setCameraSpeed(speed);
-            }
-        }
-    } else if (key == "Viewport/nearClip" || key == "Viewport/farClip") {
-        auto* mainWin = Manager::getSingleton()->getMainWindow();
-        if (mainWin) {
-            for (auto* ow : mainWin->findChildren<OgreWidget*>()) {
-                if (ow->getSpaceCamera() && ow->getSpaceCamera()->getCamera()) {
-                    if (key == "Viewport/nearClip")
-                        ow->getSpaceCamera()->getCamera()->setNearClipDistance(value.toReal());
-                    else
-                        ow->getSpaceCamera()->getCamera()->setFarClipDistance(value.toReal());
-                }
-            }
-        }
-    } else if (key == "Viewport/fsaaSamples") {
-        if (auto* mainWin = Manager::getSingleton()->getMainWindow())
-            mainWin->rebuildAllOgreViewports();
-    } else if (key == "Sentry/enabled" || key == "Telemetry/enabled") {
+    if (tryApplyViewportSetting(key, value)) {
+        return;
+    }
+    if (key == "Sentry/enabled" || key == "Telemetry/enabled") {
         SentryReporter::setEnabled(value.toBool());
     } else if (key == "Appearance/theme" || key == "palette") {
         QString theme = value.toString().toLower();

--- a/src/PropertiesPanelController_test.cpp
+++ b/src/PropertiesPanelController_test.cpp
@@ -19,6 +19,7 @@
 #include "TransformOperator.h"
 #include "UndoManager.h"
 #include "ViewportSettingsKeys.h"
+#include "AppSettingsKeys.h"
 
 class PropertiesPanelControllerTests : public ::testing::Test
 {
@@ -594,13 +595,13 @@ TEST_F(PropertiesPanelControllerTests, SetSettingCoversViewportSentryAndThemeBra
     controller->setSetting(ViewportSettingsKeys::cameraSpeed(), 2.0);
     controller->setSetting(ViewportSettingsKeys::nearClip(), 0.1);
     controller->setSetting(ViewportSettingsKeys::farClip(), 5000.0);
-    controller->setSetting("Sentry/enabled", false);
-    controller->setSetting("Telemetry/enabled", true);
+    controller->setSetting(AppSettingsKeys::sentryEnabled(), false);
+    controller->setSetting(AppSettingsKeys::telemetryEnabled(), true);
 
-    controller->setSetting("Appearance/theme", "dark");
+    controller->setSetting(AppSettingsKeys::appearanceTheme(), "dark");
     EXPECT_EQ(app->palette().color(QPalette::Window), QColor(53, 53, 53));
 
-    controller->setSetting("palette", "light");
+    controller->setSetting(AppSettingsKeys::palette(), "light");
     EXPECT_EQ(app->palette().color(QPalette::Window), QColor("ghostwhite"));
 }
 

--- a/src/PropertiesPanelController_test.cpp
+++ b/src/PropertiesPanelController_test.cpp
@@ -18,6 +18,7 @@
 #include "TestHelpers.h"
 #include "TransformOperator.h"
 #include "UndoManager.h"
+#include "ViewportSettingsKeys.h"
 
 class PropertiesPanelControllerTests : public ::testing::Test
 {
@@ -587,12 +588,12 @@ TEST_F(PropertiesPanelControllerTests, SetSettingCoversViewportSentryAndThemeBra
     ASSERT_NE(mgr, nullptr);
 
     mgr->CreateEmptyScene();
-    controller->setSetting("Viewport/gridVisible", false);
-    controller->setSetting("Viewport/gridVisible", true);
-    controller->setSetting("Viewport/cameraSpeed", 0.0);
-    controller->setSetting("Viewport/cameraSpeed", 2.0);
-    controller->setSetting("Viewport/nearClip", 0.1);
-    controller->setSetting("Viewport/farClip", 5000.0);
+    controller->setSetting(ViewportSettingsKeys::gridVisible(), false);
+    controller->setSetting(ViewportSettingsKeys::gridVisible(), true);
+    controller->setSetting(ViewportSettingsKeys::cameraSpeed(), 0.0);
+    controller->setSetting(ViewportSettingsKeys::cameraSpeed(), 2.0);
+    controller->setSetting(ViewportSettingsKeys::nearClip(), 0.1);
+    controller->setSetting(ViewportSettingsKeys::farClip(), 5000.0);
     controller->setSetting("Sentry/enabled", false);
     controller->setSetting("Telemetry/enabled", true);
 
@@ -875,6 +876,24 @@ TEST_F(PropertiesPanelControllerTests, GetSettingReturnsDefaultWhenKeyMissing)
     EXPECT_EQ(controller->getSetting(key, QVariant("defaultVal")).toString(), "defaultVal");
     EXPECT_EQ(controller->getSetting(key, QVariant(99)).toInt(), 99);
     EXPECT_EQ(controller->getSetting(key, QVariant(true)).toBool(), true);
+}
+
+TEST_F(PropertiesPanelControllerTests, FsaaSamplesSetSettingPersists)
+{
+    const QString& key = ViewportSettingsKeys::fsaaSamples();
+    QSettings settings;
+    const QVariant saved = settings.value(key);
+
+    controller->setSetting(key, 8);
+    EXPECT_EQ(controller->getSetting(key, 0).toInt(), 8);
+
+    controller->setSetting(key, 0);
+    EXPECT_EQ(controller->getSetting(key, 99).toInt(), 0);
+
+    if (saved.isValid())
+        settings.setValue(key, saved);
+    else
+        settings.remove(key);
 }
 
 // ---- undoHistory / undoIndex / clearUndoHistory (additional tests) ----

--- a/src/RTShaderHelper.cpp
+++ b/src/RTShaderHelper.cpp
@@ -284,9 +284,10 @@ void RTShaderHelper::applyNormalMap(Ogre::MaterialPtr& mat, const std::string& n
             return;
         }
 
-        auto* perPixelSRS = shaderGen->createSubRenderState(
-            Ogre::RTShader::SRS_PER_PIXEL_LIGHTING);
-        renderState->addTemplateSubRenderState(perPixelSRS);
+        // Do not add SRS_PER_PIXEL_LIGHTING here: the ShaderGenerator scheme's global
+        // RenderState already includes it (resetToBuiltinSubRenderStates). Adding another
+        // replaces that instance during TargetRenderState::link() with a fresh default,
+        // which breaks lighting + normal map generation.
 
         auto* normalMapSRS = shaderGen->createSubRenderState(
             Ogre::RTShader::SRS_NORMALMAP);

--- a/src/ScanEngine.cpp
+++ b/src/ScanEngine.cpp
@@ -102,6 +102,28 @@ QStringList ScanEngine::enumerateFiles(const ScanConfig& config, const QString& 
 // Asset inspection via Assimp (lightweight — no Ogre needed)
 // ---------------------------------------------------------------------------
 
+bool ScanEngine::isAssimpResultLoadFailure(const aiScene* scene, const char* assimpErrorString,
+                                            QString* outErrorMessage)
+{
+    if (!scene) {
+        QString e = assimpErrorString ? QString::fromUtf8(assimpErrorString) : QString();
+        if (e.isEmpty())
+            e = QStringLiteral("Assimp failed to read file");
+        if (outErrorMessage)
+            *outErrorMessage = e;
+        return true;
+    }
+    if (scene->mNumMeshes == 0 && !scene->HasAnimations()) {
+        QString e = assimpErrorString ? QString::fromUtf8(assimpErrorString) : QString();
+        if (e.isEmpty())
+            e = QStringLiteral("Scene has no meshes and no animations");
+        if (outErrorMessage)
+            *outErrorMessage = e;
+        return true;
+    }
+    return false;
+}
+
 AssetInfo ScanEngine::inspectAsset(const QString& filePath, const QString& scanRoot)
 {
     AssetInfo info;
@@ -111,14 +133,19 @@ AssetInfo ScanEngine::inspectAsset(const QString& filePath, const QString& scanR
     info.fileSize = QFileInfo(filePath).size();
 
     Assimp::Importer importer;
+    importer.SetPropertyBool(AI_CONFIG_IMPORT_FBX_PRESERVE_PIVOTS, false);
+
     // Triangulate for consistent vertex/face counts; otherwise minimal processing.
     const aiScene* scene = importer.ReadFile(
         filePath.toStdString(),
         aiProcess_Triangulate | aiProcess_ValidateDataStructure);
 
-    if (!scene || (scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE)) {
+    // A null scene is a true load failure.  Do NOT treat AI_SCENE_FLAGS_INCOMPLETE
+    // as fatal: Assimp sets it on many valid FBX files (e.g. Unreal/ Mixamo
+    // animation takes with no mesh geometry).  Match AssimpToOgreImporter: use
+    // mesh/animation presence as the authoritative check.
+    if (isAssimpResultLoadFailure(scene, importer.GetErrorString(), &info.errorMessage)) {
         info.loadError = true;
-        info.errorMessage = QString::fromUtf8(importer.GetErrorString());
         return info;
     }
 

--- a/src/ScanEngine.h
+++ b/src/ScanEngine.h
@@ -8,6 +8,8 @@
 #include <QStringList>
 #include <functional>
 
+struct aiScene;
+
 enum class Severity { Info, Warning, Error };
 
 struct Finding {
@@ -83,6 +85,12 @@ public:
 
     /// Inspect a single asset file using Assimp (lightweight, no Ogre needed).
     static AssetInfo inspectAsset(const QString& filePath, const QString& scanRoot);
+
+    /// After `Assimp::Importer::ReadFile`, whether the result would make `inspectAsset` set
+    /// `loadError` (e.g. null scene, or no mesh and no animations). A scene may have
+    /// the incomplete flag set and still be acceptable if it has animations. Unit-tested.
+    static bool isAssimpResultLoadFailure(const aiScene* scene, const char* assimpErrorString,
+                                         QString* outErrorMessage = nullptr);
 
     /// Evaluate all configured rules against one asset.
     static QList<Finding> evaluateRules(const AssetInfo& asset, const ScanConfig& config);

--- a/src/ScanEngine_test.cpp
+++ b/src/ScanEngine_test.cpp
@@ -2,6 +2,8 @@
 #include "ScanConfig.h"
 #include "ScanEngine.h"
 
+#include <assimp/scene.h>
+
 #include <QCoreApplication>
 #include <QDateTime>
 #include <QDir>
@@ -1439,6 +1441,48 @@ TEST(ScanEngineTest, InspectAsset_AnimatedFixtureCollectsAnimationMetadata)
     EXPECT_FALSE(info.animationDurations.isEmpty());
     EXPECT_FALSE(info.animationKeyframeCounts.isEmpty());
     EXPECT_EQ(info.animationNames.size(), info.animationDurations.size());
+}
+
+TEST(ScanEngineTest, AssimpReadPolicy_NullSceneIsLoadFailure)
+{
+    QString err;
+    EXPECT_TRUE(ScanEngine::isAssimpResultLoadFailure(nullptr, "read failed", &err));
+    EXPECT_EQ(err, QStringLiteral("read failed"));
+}
+
+TEST(ScanEngineTest, AssimpReadPolicy_NullSceneUsesDefaultMessage)
+{
+    QString err;
+    EXPECT_TRUE(ScanEngine::isAssimpResultLoadFailure(nullptr, "", &err));
+    EXPECT_EQ(err, QStringLiteral("Assimp failed to read file"));
+}
+
+TEST(ScanEngineTest, AssimpReadPolicy_EmptyContentNoMeshNoAnimIsLoadFailure)
+{
+    aiScene scene {};
+    EXPECT_EQ(scene.mNumMeshes, 0u);
+    EXPECT_FALSE(scene.HasAnimations());
+    QString err;
+    EXPECT_TRUE(ScanEngine::isAssimpResultLoadFailure(&scene, nullptr, &err));
+    EXPECT_EQ(err, QStringLiteral("Scene has no meshes and no animations"));
+}
+
+TEST(ScanEngineTest, AssimpReadPolicy_IncompleteFlagWithAnimIsNotLoadFailure)
+{
+    // Mimics Assimp: animation-only FBX often sets AI_SCENE_FLAGS_INCOMPLETE; scan must still
+    // accept the scene if HasAnimations() is true.  Use heap arrays so ~aiScene can delete[]
+    // them the same way Importer-owned scenes do.
+    aiScene* scene = new aiScene();
+    scene->mNumMeshes     = 0;
+    scene->mNumAnimations = 1;
+    scene->mAnimations    = new aiAnimation*[1];
+    scene->mAnimations[0]   = new aiAnimation();
+    scene->mFlags         = AI_SCENE_FLAGS_INCOMPLETE;
+
+    ASSERT_TRUE(scene->HasAnimations());
+    QString err;
+    EXPECT_FALSE(ScanEngine::isAssimpResultLoadFailure(scene, "", &err)) << qPrintable(err);
+    delete scene;
 }
 
 namespace {

--- a/src/SentryReporter.cpp
+++ b/src/SentryReporter.cpp
@@ -1,4 +1,5 @@
 #include "SentryReporter.h"
+#include "AppSettingsKeys.h"
 #include <QSettings>
 #include <QMessageBox>
 #include <QCoreApplication>
@@ -59,19 +60,19 @@ void SentryReporter::shutdown()
 bool SentryReporter::isEnabled()
 {
     QSettings settings;
-    return settings.value("Sentry/enabled", true).toBool();
+    return settings.value(AppSettingsKeys::sentryEnabled(), true).toBool();
 }
 
 void SentryReporter::setEnabled(bool enabled)
 {
     QSettings settings;
-    settings.setValue("Sentry/enabled", enabled);
+    settings.setValue(AppSettingsKeys::sentryEnabled(), enabled);
 }
 
 bool SentryReporter::isFirstLaunch()
 {
     QSettings settings;
-    return !settings.contains("Sentry/enabled");
+    return !settings.contains(AppSettingsKeys::sentryEnabled());
 }
 
 void SentryReporter::showConsentDialog()

--- a/src/SentryReporter_test.cpp
+++ b/src/SentryReporter_test.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <QSettings>
+#include "AppSettingsKeys.h"
 #include "SentryReporter.h"
 
 class SentryReporterTest : public ::testing::Test {
@@ -7,12 +8,12 @@ protected:
     void SetUp() override {
         // Clear any previous Sentry settings
         QSettings settings;
-        settings.remove("Sentry/enabled");
+        settings.remove(AppSettingsKeys::sentryEnabled());
     }
 
     void TearDown() override {
         QSettings settings;
-        settings.remove("Sentry/enabled");
+        settings.remove(AppSettingsKeys::sentryEnabled());
     }
 };
 

--- a/src/SkeletonTransform.cpp
+++ b/src/SkeletonTransform.cpp
@@ -39,21 +39,7 @@ THE SOFTWARE.
 #include <vector>
 
 #include "Manager.h"
-
-namespace {
-
-Ogre::Quaternion buildRotationQuat(const Ogre::Vector3 &rotate)
-{
-    if(rotate.x != 0)
-        return {Ogre::Degree(rotate.x), Ogre::Vector3::UNIT_Y};
-    if(rotate.y != 0)
-        return {Ogre::Degree(rotate.y), Ogre::Vector3::UNIT_Z};
-    if(rotate.z != 0)
-        return {Ogre::Degree(rotate.z), Ogre::Vector3::UNIT_X};
-    return Ogre::Quaternion::IDENTITY;
-}
-
-} // anonymous namespace
+#include "TransformMath.h"
 
 void SkeletonTransform::scaleSkeleton(const Ogre::Entity *_ent, const Ogre::Vector3 &_scale)
 {
@@ -97,7 +83,7 @@ void SkeletonTransform::translateSkeleton(const Ogre::Entity *_ent, const Ogre::
 void SkeletonTransform::rotateSkeleton(const Ogre::Entity *_ent, const Ogre::Vector3 &_rotate)
 {
     auto pivot = _ent->getMesh()->getBounds().getCenter();
-    rotateSkeleton(_ent, buildRotationQuat(_rotate), pivot);
+    rotateSkeleton(_ent, TransformMath::buildRotationQuat(_rotate), pivot);
 }
 
 void SkeletonTransform::rotateSkeleton(const Ogre::Entity *_ent, const Ogre::Quaternion &_quat,

--- a/src/SpaceCamera.cpp
+++ b/src/SpaceCamera.cpp
@@ -137,6 +137,30 @@ void SpaceCamera::setTargetPosition(const Ogre::Vector3 &pos)
 void SpaceCamera::setAspectRatio(const Ogre::Real& ratio)
 {    mCamera->setAspectRatio(ratio); }
 
+void SpaceCamera::getViewportPose(Ogre::Vector3& outTargetWorld, Ogre::Vector3& outCamWorld,
+                                  Ogre::Quaternion& outTargetOrient) const
+{
+    if (!mTarget || !mCamera)
+        return;
+    outTargetWorld = mTarget->_getDerivedPosition();
+    outCamWorld = mCamera->getDerivedPosition();
+    outTargetOrient = mTarget->getOrientation();
+}
+
+void SpaceCamera::applyViewportPose(const Ogre::Vector3& targetWorld, const Ogre::Vector3& camWorld,
+                                    const Ogre::Quaternion& targetOrient)
+{
+    if (!mTarget || !mCameraNode || !mCamera)
+        return;
+    Ogre::SceneNode* parent = mTarget->getParentSceneNode();
+    if (parent)
+        mTarget->setPosition(parent->convertWorldToLocalPosition(targetWorld));
+    else
+        mTarget->setPosition(targetWorld);
+    mTarget->setOrientation(targetOrient);
+    setCameraPosition(camWorld);
+}
+
 //////////////////////////////////////////////////////////////////////////////////
 //Frame listener
 

--- a/src/SpaceCamera.h
+++ b/src/SpaceCamera.h
@@ -65,6 +65,12 @@ class SpaceCamera : Ogre::FrameListener
         void setTargetPosition(const Ogre::Vector3 &pos);
         void setAspectRatio(const Ogre::Real& ratio);
 
+        /// Save/restore camera rig for rebuild (e.g. MSAA toggle) without losing the view.
+        void getViewportPose(Ogre::Vector3& outTargetWorld, Ogre::Vector3& outCamWorld,
+                             Ogre::Quaternion& outTargetOrient) const;
+        void applyViewportPose(const Ogre::Vector3& targetWorld, const Ogre::Vector3& camWorld,
+                               const Ogre::Quaternion& targetOrient);
+
         /// FrameListener
         bool frameStarted(const Ogre::FrameEvent& event);
         bool frameEnded(const Ogre::FrameEvent& event);

--- a/src/SpaceCamera_test.cpp
+++ b/src/SpaceCamera_test.cpp
@@ -812,6 +812,34 @@ TEST_F(SpaceCameraWidgetIntegrationTest, SetCameraPositionAdjustsCameraNodeDista
     EXPECT_LT(afterZ, 0.0f);
 }
 
+TEST_F(SpaceCameraWidgetIntegrationTest, ViewportPoseRoundTripRestoresTargetAndCamera)
+{
+    Ogre::Vector3 t0, c0, t1, c1;
+    Ogre::Quaternion q0, q1;
+
+    camera->setTargetPosition(Ogre::Vector3(1.0f, 2.0f, -3.0f));
+    camera->setCameraPosition(Ogre::Vector3(10.0f, 11.0f, 50.0f));
+    camera->getViewportPose(t0, c0, q0);
+
+    camera->setTargetPosition(Ogre::Vector3(0.0f, 0.0f, 0.0f));
+    camera->setCameraPosition(Ogre::Vector3(0.0f, 1.0f, -25.0f));
+
+    camera->applyViewportPose(t0, c0, q0);
+    camera->getViewportPose(t1, c1, q1);
+
+    const Ogre::Real eps = 0.08f;
+    EXPECT_NEAR(t0.x, t1.x, eps);
+    EXPECT_NEAR(t0.y, t1.y, eps);
+    EXPECT_NEAR(t0.z, t1.z, eps);
+    EXPECT_NEAR(c0.x, c1.x, eps);
+    EXPECT_NEAR(c0.y, c1.y, eps);
+    EXPECT_NEAR(c0.z, c1.z, eps);
+    EXPECT_NEAR(q0.w, q1.w, eps);
+    EXPECT_NEAR(q0.x, q1.x, eps);
+    EXPECT_NEAR(q0.y, q1.y, eps);
+    EXPECT_NEAR(q0.z, q1.z, eps);
+}
+
 TEST_F(SpaceCameraWidgetIntegrationTest, WheelEventControlModifierUsesZoomPath)
 {
     Ogre::SceneNode* cameraNode = camera->getCamera()->getParentSceneNode();

--- a/src/TransformMath.h
+++ b/src/TransformMath.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <OgreQuaternion.h>
+#include <OgreVector3.h>
+
+namespace TransformMath {
+
+// Builds a quaternion matching the editor's rotate-vector convention:
+// only one axis is expected to be non-zero at a time (X->UNIT_Y, Y->UNIT_Z, Z->UNIT_X).
+inline Ogre::Quaternion buildRotationQuat(const Ogre::Vector3 &rotate)
+{
+    if(rotate.x != 0)
+        return {Ogre::Degree(rotate.x), Ogre::Vector3::UNIT_Y};
+    if(rotate.y != 0)
+        return {Ogre::Degree(rotate.y), Ogre::Vector3::UNIT_Z};
+    if(rotate.z != 0)
+        return {Ogre::Degree(rotate.z), Ogre::Vector3::UNIT_X};
+    return Ogre::Quaternion::IDENTITY;
+}
+
+} // namespace TransformMath
+

--- a/src/ViewportSettingsKeys.h
+++ b/src/ViewportSettingsKeys.h
@@ -1,0 +1,76 @@
+/*
+-----------------------------------------------------------------------------------
+A QtMeshEditor file
+
+Copyright (c) Fernando Tonon (https://github.com/fernandotonon)
+
+The MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software
+without restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies of the
+Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+-----------------------------------------------------------------------------------
+*/
+
+#ifndef VIEWPORT_SETTINGS_KEYS_H
+#define VIEWPORT_SETTINGS_KEYS_H
+
+#include <QString>
+
+namespace ViewportSettingsKeys
+{
+
+/**
+ * @brief QSettings key strings for Viewport/ preferences (single source of truth).
+ *
+ * C++ and QML must stay aligned: PreferencesDialog.qml uses the same
+ * string values for readSetting/writeSetting.
+ */
+inline const QString& gridVisible()
+{
+    static const QString k(QStringLiteral("Viewport/gridVisible"));
+    return k;
+}
+
+inline const QString& cameraSpeed()
+{
+    static const QString k(QStringLiteral("Viewport/cameraSpeed"));
+    return k;
+}
+
+inline const QString& nearClip()
+{
+    static const QString k(QStringLiteral("Viewport/nearClip"));
+    return k;
+}
+
+inline const QString& farClip()
+{
+    static const QString k(QStringLiteral("Viewport/farClip"));
+    return k;
+}
+
+inline const QString& fsaaSamples()
+{
+    static const QString k(QStringLiteral("Viewport/fsaaSamples"));
+    return k;
+}
+
+} // namespace ViewportSettingsKeys
+
+#endif // VIEWPORT_SETTINGS_KEYS_H

--- a/src/WelcomeDialog.cpp
+++ b/src/WelcomeDialog.cpp
@@ -68,7 +68,7 @@ WelcomeDialog::WelcomeDialog(QWidget* parent)
     connect(openFileBtn, &QPushButton::clicked, this, [this]() {
         QString file = QFileDialog::getOpenFileName(
             this, "Open 3D File", QString(),
-            "3D Files (*.fbx *.gltf *.glb *.obj *.dae *.stl *.mesh *.3ds *.x);;All Files (*)");
+            "3D Files (*.fbx *.gltf *.glb *.vrm *.obj *.dae *.stl *.mesh *.3ds *.x);;All Files (*)");
         if (!file.isEmpty()) {
             m_action = OpenFile;
             m_selectedFile = file;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1707,6 +1707,14 @@ void MainWindow::createEditorViewport(/*TODO add the type of view (perspective, 
     ui->action2x2_Grid->blockSignals(false);
 }
 
+void MainWindow::rebuildAllOgreViewports()
+{
+    for (EditorViewport* vp : mDockWidgetList) {
+        if (OgreWidget* w = vp->getOgreWidget())
+            w->rebuildRenderWindow();
+    }
+}
+
 void MainWindow::onWidgetClosing(EditorViewport* const& widget)
 {
     // Artificial MUTEX !!! don't know if required

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1355,7 +1355,7 @@ void MainWindow::on_actionOpen_Scene_triggered()
 
     QString fileName = QFileDialog::getOpenFileName(this, tr("Open Scene"),
                                                     "",
-                                                    tr("Scene Files (*.scene.glb *.scene.gltf);;glTF Files (*.gltf *.glb);;All Files (*)"),
+                                                    tr("Scene Files (*.scene.glb *.scene.gltf);;glTF / VRM (*.gltf *.glb *.vrm);;All Files (*)"),
                                                     nullptr, QFileDialog::DontUseNativeDialog);
     if (fileName.isEmpty()) return;
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -49,6 +49,9 @@ public:
     void loadFile(const QString& filePath);
     void setMCPServer(MCPServer* server);
 
+    /// Recreate Ogre render windows (e.g. after MSAA samples change in Preferences).
+    void rebuildAllOgreViewports();
+
     void keyPressEvent(QKeyEvent *event) override;
     void dropEvent(QDropEvent *event) override;
     

--- a/src/mainwindow_test.cpp
+++ b/src/mainwindow_test.cpp
@@ -32,6 +32,9 @@
 #include "TransformOperator.h"
 #include "EditModeController.h"
 #include "TestHelpers.h"
+#include "EditorViewport.h"
+#include "ViewportSettingsKeys.h"
+#include "OgreWidget.h"
 #include "ui_mainwindow.h"
 
 class MainWindowTest : public ::testing::Test {
@@ -187,6 +190,18 @@ TEST_F(MainWindowTest, SetPlayingFalse) {
     window->setPlaying(true);
     window->setPlaying(false);
     EXPECT_FALSE(window->isPlaying);
+}
+
+TEST_F(MainWindowTest, RebuildAllOgreViewportsDoesNotCrash)
+{
+    ASSERT_FALSE(window->mDockWidgetList.isEmpty());
+    QSettings settings;
+    settings.setValue(ViewportSettingsKeys::fsaaSamples(), 4);
+    EXPECT_NO_THROW(window->rebuildAllOgreViewports());
+    app->processEvents();
+    auto* ow = window->mDockWidgetList.first()->getOgreWidget();
+    ASSERT_NE(ow, nullptr);
+    EXPECT_NO_THROW(ow->fsaaSamples());
 }
 
 // ---- Cycle all transform states via keyboard ----


### PR DESCRIPTION
## Summary
- Extract shared rotation quaternion builder into `src/TransformMath.h` and reuse from mesh/skeleton transforms.
- Consolidate repeated primitive UI show/hide/label logic via `PrimitivesWidget::applyPrimitiveUiConfig(...)`.

## Why
Sonar duplication is above target; this removes a few of the larger repeated blocks and should lower overall duplication percentage.

## Test plan
- CI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Stage media/shader assets beside the executable and enable shader/material search paths.
  * Add STBI image codec support.
* **New Features**
  * MSAA preference UI with persistent setting, query API, and render-window rebuild support.
  * Expose centralized viewport and app settings keys and a global viewport rebuild entry point.
* **Refactor**
  * Centralized primitive editor UI and unified rotation math; viewport preference application consolidated.
* **Bug Fixes**
  * Ensure imported meshes get tangents and preserve lighting during shader generation.
* **Tests**
  * Added tests for MSAA, render-window rebuilds, camera pose round-trips, and settings persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->