### PR TITLE
FBX export: embed textures (no sidecar .material/.png)

### DIFF
--- a/src/FBX/FBXExporter.cpp
+++ b/src/FBX/FBXExporter.cpp
@@ -1586,35 +1586,15 @@ private:
     // ── Texture objects ─────────────────────────────────────────
     static std::vector<uint8_t> readOgreResourceBytes(const std::string& resourceName)
     {
-        try {
-            auto& rgm = Ogre::ResourceGroupManager::getSingleton();
-            Ogre::DataStreamPtr stream;
-
-            // Prefer the group Assimp/Ogre says contains the resource, but fall back to scanning
-            // all groups. (Some pipelines create dynamic groups with non-trivial names, e.g. paths.)
-            Ogre::String preferred = rgm.findGroupContainingResource(resourceName);
-            if (!preferred.empty() && rgm.resourceExists(preferred, resourceName))
-                stream = rgm.openResource(resourceName, preferred);
-            if (stream.isNull() && rgm.resourceExists(Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME, resourceName))
-                stream = rgm.openResource(resourceName, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-            if (stream.isNull()) {
-                const auto groups = rgm.getResourceGroups();
-                for (const auto& g : groups) {
-                    if (rgm.resourceExists(g, resourceName)) {
-                        stream = rgm.openResource(resourceName, g);
-                        if (!stream.isNull()) break;
-                    }
-                }
-            }
-            if (stream.isNull())
+        const auto readAll = [](const Ogre::DataStreamPtr& stream) -> std::vector<uint8_t> {
+            if (!stream)
                 return {};
 
             std::vector<uint8_t> data;
-            const size_t sz = stream->size();
-            if (sz > 0 && sz != static_cast<size_t>(-1)) {
+            if (const size_t sz = stream->size(); sz > 0 && sz != static_cast<size_t>(-1)) {
                 data.resize(sz);
-                const size_t read = stream->read(data.data(), sz);
-                data.resize(read);
+                const size_t n = stream->read(data.data(), sz);
+                data.resize(n);
                 return data;
             }
 
@@ -1623,11 +1603,41 @@ private:
             std::vector<uint8_t> chunk(kChunk);
             while (!stream->eof()) {
                 const size_t n = stream->read(chunk.data(), kChunk);
-                if (n == 0) break;
+                if (n == 0)
+                    break;
                 data.insert(data.end(), chunk.begin(), chunk.begin() + static_cast<std::ptrdiff_t>(n));
             }
             return data;
-        } catch (...) {
+        };
+
+        try {
+            const auto& rgm = Ogre::ResourceGroupManager::getSingleton();
+            const auto openInGroup = [&](const Ogre::String& group) -> Ogre::DataStreamPtr {
+                if (group.empty() || !rgm.resourceExists(group, resourceName))
+                    return {};
+                return rgm.openResource(resourceName, group);
+            };
+
+            // Prefer the group Ogre says contains it.
+            if (const Ogre::String preferred = rgm.findGroupContainingResource(resourceName); !preferred.empty()) {
+                if (auto stream = openInGroup(preferred))
+                    return readAll(stream);
+            }
+
+            // Then try default group.
+            if (auto stream = openInGroup(Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME))
+                return readAll(stream);
+
+            // Finally scan all groups (dynamic groups may exist, e.g. path-based groups).
+            for (const auto& g : rgm.getResourceGroups()) {
+                if (auto stream = openInGroup(g))
+                    return readAll(stream);
+            }
+
+            return {};
+        } catch (const Ogre::Exception&) {
+            return {};
+        } catch (const std::exception&) {
             return {};
         }
     }
@@ -1688,8 +1698,7 @@ private:
 
                 // Embed texture bytes when the resource is available. Many tools (e.g. Mixamo exports)
                 // expect texture payloads to be embedded via Video.Content.
-                const auto bytes = readOgreResourceBytes(texName);
-                if (!bytes.empty()) {
+                if (const auto bytes = readOgreResourceBytes(texName); !bytes.empty()) {
                     m_w.beginNode("Content");
                     m_w.writePropertyR(bytes);
                     m_w.endProperties();

--- a/src/FBX/FBXExporter.cpp
+++ b/src/FBX/FBXExporter.cpp
@@ -40,6 +40,8 @@ THE SOFTWARE.
 #include <OgreMaterialManager.h>
 #include <OgreTechnique.h>
 #include <OgrePass.h>
+#include <OgreResourceGroupManager.h>
+#include <OgreDataStream.h>
 
 #include <fstream>
 #include <vector>
@@ -1582,6 +1584,54 @@ private:
     }
 
     // ── Texture objects ─────────────────────────────────────────
+    static std::vector<uint8_t> readOgreResourceBytes(const std::string& resourceName)
+    {
+        try {
+            auto& rgm = Ogre::ResourceGroupManager::getSingleton();
+            Ogre::DataStreamPtr stream;
+
+            // Prefer the group Assimp/Ogre says contains the resource, but fall back to scanning
+            // all groups. (Some pipelines create dynamic groups with non-trivial names, e.g. paths.)
+            Ogre::String preferred = rgm.findGroupContainingResource(resourceName);
+            if (!preferred.empty() && rgm.resourceExists(preferred, resourceName))
+                stream = rgm.openResource(resourceName, preferred);
+            if (stream.isNull() && rgm.resourceExists(Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME, resourceName))
+                stream = rgm.openResource(resourceName, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+            if (stream.isNull()) {
+                const auto groups = rgm.getResourceGroups();
+                for (const auto& g : groups) {
+                    if (rgm.resourceExists(g, resourceName)) {
+                        stream = rgm.openResource(resourceName, g);
+                        if (!stream.isNull()) break;
+                    }
+                }
+            }
+            if (stream.isNull())
+                return {};
+
+            std::vector<uint8_t> data;
+            const size_t sz = stream->size();
+            if (sz > 0 && sz != static_cast<size_t>(-1)) {
+                data.resize(sz);
+                const size_t read = stream->read(data.data(), sz);
+                data.resize(read);
+                return data;
+            }
+
+            // Fallback if size is unknown: read in chunks
+            constexpr size_t kChunk = 64 * 1024;
+            std::vector<uint8_t> chunk(kChunk);
+            while (!stream->eof()) {
+                const size_t n = stream->read(chunk.data(), kChunk);
+                if (n == 0) break;
+                data.insert(data.end(), chunk.begin(), chunk.begin() + static_cast<std::ptrdiff_t>(n));
+            }
+            return data;
+        } catch (...) {
+            return {};
+        }
+    }
+
     void writeTextureObjects()
     {
         std::set<std::string> seen;
@@ -1635,6 +1685,16 @@ private:
                 m_w.beginNode("Type"); m_w.writePropertyS("Clip"); m_w.endProperties(); m_w.endNodeLeaf();
                 m_w.beginNode("FileName"); m_w.writePropertyS(texName); m_w.endProperties(); m_w.endNodeLeaf();
                 m_w.beginNode("RelativeFilename"); m_w.writePropertyS(texName); m_w.endProperties(); m_w.endNodeLeaf();
+
+                // Embed texture bytes when the resource is available. Many tools (e.g. Mixamo exports)
+                // expect texture payloads to be embedded via Video.Content.
+                const auto bytes = readOgreResourceBytes(texName);
+                if (!bytes.empty()) {
+                    m_w.beginNode("Content");
+                    m_w.writePropertyR(bytes);
+                    m_w.endProperties();
+                    m_w.endNodeLeaf();
+                }
 
                 m_w.endNode(); // Video
             }

--- a/src/FBX/FBXExporter_test.cpp
+++ b/src/FBX/FBXExporter_test.cpp
@@ -7,6 +7,7 @@
 #include <QFile>
 #include <QDir>
 #include <QTemporaryFile>
+#include <QTemporaryDir>
 #include <QCoreApplication>
 #include <QApplication>
 #include <QThread>
@@ -452,6 +453,7 @@ class FBXExporterCoverageTest : public ::testing::Test {
 protected:
     QApplication* app = nullptr;
     int meshCounter = 0;
+    QTemporaryDir textureDir;
 
     void SetUp() override {
         SelectionSet::kill();
@@ -464,7 +466,38 @@ protected:
         if (!tryInitOgre()) {
             GTEST_SKIP() << "Skipping: Ogre initialization failed";
         }
+        if (!canLoadMeshFiles()) {
+            GTEST_SKIP() << "Skipping: no GL context / hardware buffers available";
+        }
         createStandardOgreMaterials();
+
+        // Provide a real texture file so FBXExporter can embed Video.Content.
+        ASSERT_TRUE(textureDir.isValid());
+        const QString texPath = QDir(textureDir.path()).filePath("diffuse_tex.png");
+        QFile tex(texPath);
+        ASSERT_TRUE(tex.open(QIODevice::WriteOnly));
+        // 1x1 transparent PNG
+        const QByteArray png =
+            QByteArray::fromHex(
+                "89504E470D0A1A0A"
+                "0000000D49484452"
+                "0000000100000001"
+                "08060000001F15C489"
+                "0000000A49444154"
+                "789C63600000020001"
+                "E221BC3300000000"
+                "49454E44AE426082");
+        tex.write(png);
+        tex.close();
+
+        auto& rgm = Ogre::ResourceGroupManager::getSingleton();
+        const Ogre::String texGroup = "FBXExporterTestTextures";
+        if (!rgm.resourceGroupExists(texGroup))
+            rgm.createResourceGroup(texGroup);
+        rgm.addResourceLocation(textureDir.path().toStdString(), "FileSystem", texGroup, false);
+        // Don't touch the DEFAULT group (it may already be initialized by the engine).
+        // Initialize only our dedicated test group so openResource() can find the texture.
+        try { rgm.initialiseResourceGroup(texGroup); } catch (...) {}
     }
 
     void TearDown() override {
@@ -1884,6 +1917,13 @@ TEST_F(FBXExporterCoverageTest, TextureAndVideo) {
     auto* vidType = vidNodes[0]->find("Type");
     ASSERT_NE(vidType, nullptr);
     EXPECT_EQ(vidType->properties[0].stringVal, "Clip");
+
+    // Embedded payload should exist
+    auto* content = vidNodes[0]->find("Content");
+    ASSERT_NE(content, nullptr);
+    ASSERT_FALSE(content->properties.empty());
+    EXPECT_EQ(content->properties[0].type, 'R');
+    EXPECT_GT(content->properties[0].stringVal.size(), 0u);
 
     cleanup(r);
 }

--- a/src/MeshImporterExporter.cpp
+++ b/src/MeshImporterExporter.cpp
@@ -1167,9 +1167,9 @@ int MeshImporterExporter::exporter(const Ogre::SceneNode *_sn, const QString &_u
         exportMaterial(e, file);
     } else if (_format == "FBX Binary (*.fbx)") {
         bool ok = FBXExporter::exportFBX(e, _uri);
-        if (ok)
-            exportMaterial(e, file);
-        else
+        // FBXExporter embeds textures (Video.Content) so avoid emitting sidecar
+        // .material and extracted image files next to the FBX.
+        if (!ok)
             return -1;
     } else {
         // Export using Assimp — build aiScene directly from Ogre mesh data
@@ -1263,8 +1263,10 @@ int MeshImporterExporter::exporter(const Ogre::SceneNode *_sn, const QString &_u
             }
             else
             {
-                // Export texture files alongside the model
-                exportMaterial(e, file);
+                // Export texture files alongside the model.
+                // For FBX we aim for a single-file export (embedded textures), so skip sidecars.
+                if (_format != "FBX Binary (*.fbx)")
+                    exportMaterial(e, file);
             }
 
             delete scene;
@@ -1499,7 +1501,11 @@ int MeshImporterExporter::exportCurrentPose(Ogre::Entity* entity, const QString&
                                                 exportFlags);
             if (aiResult == AI_SUCCESS) {
                 result = 0;
-                exportMaterial(entity, file);
+                // For FBX, prefer a single-file export. Assimp FBX export may still
+                // reference textures by name, but our current expectation for FBX is
+                // "no sidecar dumps" (materials/textures are embedded or handled by importer).
+                if (fmt != "FBX Binary (*.fbx)")
+                    exportMaterial(entity, file);
             } else {
                 auto msg = QString("Assimp export (pose) to %1 failed: %2")
                     .arg(formatId).arg(exporter.GetErrorString());


### PR DESCRIPTION
## Summary
- Embed texture payloads directly into exported FBX via `Video.Content` so exports are single-file (Mixamo-style).
- Improve texture resource resolution by scanning Ogre resource groups.
- Stop emitting sidecar `.material` and extracted texture images for FBX exports.

## Test plan
- Run: `QtMeshEditor --cli convert <textured_asset> -o out.fbx` and verify no `.material`/`.png` sidecars are created.
- Verify FBX contains `Objects/Video/Content` (raw `R` payload).
- Run: `UnitTests --gtest_filter=FBXExporter*`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FBX exports now embed texture data directly within the FBX file, eliminating separate texture files and material sidecars for FBX outputs.

* **Tests**
  * Added tests to verify embedded texture payloads are present, non-empty, and correctly formatted in FBX exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->