### PR TITLE
feat(edit): merge vertices (Phase 4 topology op)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1629,8 +1629,11 @@ jobs:
             sudo cp -R ${{github.workspace}}/resources/icon.icns ${{github.workspace}}/bin/QtMeshEditor.app/Contents/MacOS/media
             sudo mkdir -p ${{github.workspace}}/bin/QtMeshEditor.app/Contents/Resources
 
-            # Create qt.conf to help Qt find plugins in the bundle
-            echo -e "[Paths]\nPlugins = PlugIns\nQml2Imports = PlugIns/qml" | sudo tee ${{github.workspace}}/bin/QtMeshEditor.app/Contents/Resources/qt.conf
+            # Create qt.conf to help Qt find plugins in the bundle.
+            # QmlImports (Qt 6.5+) supersedes Qml2Imports (deprecated), but
+            # we set both for compat with anything still keying off the older
+            # name during plugin discovery.
+            echo -e "[Paths]\nPlugins = PlugIns\nQmlImports = PlugIns/qml\nQml2Imports = PlugIns/qml" | sudo tee ${{github.workspace}}/bin/QtMeshEditor.app/Contents/Resources/qt.conf
             sudo cp -R ${{github.workspace}}/resources/icon.icns ${{github.workspace}}/bin/QtMeshEditor.app/Contents/Resources
             sudo cp -R ${{github.workspace}}/bin/Info.plist ${{github.workspace}}/bin/QtMeshEditor.app/Contents/
             

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 2.30.0 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 2.31.0 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/qml/AIChatPanel.qml
+++ b/qml/AIChatPanel.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import AIChatPanel 1.0
 import PropertiesPanel 1.0
 

--- a/qml/AISettingsDialog.qml
+++ b/qml/AISettingsDialog.qml
@@ -1,6 +1,6 @@
-import QtQuick 6.0
-import QtQuick.Controls 6.0
-import QtQuick.Layouts 6.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import MaterialEditorQML 1.0
 import "." as Local
 

--- a/qml/AnimationControlPanel.qml
+++ b/qml/AnimationControlPanel.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import AnimationControl 1.0
 
 Column {

--- a/qml/AssetBrowser.qml
+++ b/qml/AssetBrowser.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import AssetBrowser 1.0
 import PropertiesPanel 1.0
 

--- a/qml/CollapsibleSection.qml
+++ b/qml/CollapsibleSection.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import PropertiesPanel 1.0
 
 Column {

--- a/qml/MaterialEditorWindow.qml
+++ b/qml/MaterialEditorWindow.qml
@@ -1,6 +1,6 @@
-import QtQuick 6.0
-import QtQuick.Controls 6.0
-import QtQuick.Layouts 6.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import MaterialEditorQML 1.0
 
 ApplicationWindow {

--- a/qml/MaterialListModal.qml
+++ b/qml/MaterialListModal.qml
@@ -1,6 +1,6 @@
-import QtQuick 6.0
-import QtQuick.Controls 6.0
-import QtQuick.Layouts 6.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import MaterialEditorQML 1.0
 
 ApplicationWindow {

--- a/qml/PassPropertiesPanel.qml
+++ b/qml/PassPropertiesPanel.qml
@@ -1,6 +1,6 @@
-import QtQuick 6.0
-import QtQuick.Controls 6.0
-import QtQuick.Layouts 6.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import MaterialEditorQML 1.0
 
 GroupBox {

--- a/qml/PreferencesDialog.qml
+++ b/qml/PreferencesDialog.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import PropertiesPanel 1.0
 
 Rectangle {

--- a/qml/ProfileGraph.qml
+++ b/qml/ProfileGraph.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.15
+import QtQuick
 
 // 2D graph control for the bevel profile. Displays N-1 vertically-
 // draggable control points for N segments; endpoints are fixed on the

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import PropertiesPanel 1.0
 import AnimationControl 1.0
 

--- a/qml/SceneTreeNode.qml
+++ b/qml/SceneTreeNode.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick
+import QtQuick.Controls
 import PropertiesPanel 1.0
 
 Column {

--- a/qml/ShortcutReference.qml
+++ b/qml/ShortcutReference.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import PropertiesPanel 1.0
 
 Rectangle {

--- a/qml/TexturePropertiesPanel.qml
+++ b/qml/TexturePropertiesPanel.qml
@@ -1,6 +1,6 @@
-import QtQuick 6.0
-import QtQuick.Controls 6.0
-import QtQuick.Layouts 6.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import MaterialEditorQML 1.0
 
 GroupBox {

--- a/qml/ThemedButton.qml
+++ b/qml/ThemedButton.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick
+import QtQuick.Controls
 
 Button {
     background: Rectangle {

--- a/qml/ThemedComboBox.qml
+++ b/qml/ThemedComboBox.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick
+import QtQuick.Controls
 import ThemeManager 1.0
 
 // Themed ComboBox matching the look of the typeahead dropdowns elsewhere

--- a/qml/ThemedLabel.qml
+++ b/qml/ThemedLabel.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick
+import QtQuick.Controls
 
 Label {
     color: enabled ? MaterialEditorQML.textColor : MaterialEditorQML.disabledTextColor

--- a/qml/ThemedSpinBox.qml
+++ b/qml/ThemedSpinBox.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick
+import QtQuick.Controls
 
 SpinBox {
     contentItem: TextInput {

--- a/qml/ThemedTextArea.qml
+++ b/qml/ThemedTextArea.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick
+import QtQuick.Controls
 
 TextArea {
     color: MaterialEditorQML.textColor

--- a/qml/ThemedTextField.qml
+++ b/qml/ThemedTextField.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick
+import QtQuick.Controls
 
 TextField {
     color: MaterialEditorQML.textColor

--- a/qml/TransformField.qml
+++ b/qml/TransformField.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick
+import QtQuick.Controls
 import PropertiesPanel 1.0
 
 Row {

--- a/qml/WelcomeScreen.qml
+++ b/qml/WelcomeScreen.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import WelcomeScreen 1.0
 import PropertiesPanel 1.0
 

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -2517,6 +2517,11 @@ int EditModeController::mergeAtCenter()
 
     SentryReporter::addBreadcrumb("edit_mode",
         QString("Merge: At Center (removed=%1)").arg(retired));
+    // Selection sets were cleared above (vertex IDs are stale post-merge).
+    // Redraw the overlay so the previously-selected highlights stop
+    // showing — the live geometry has new index order and the old
+    // markers point at unrelated verts.
+    updateSelectionOverlay();
     emit editSelectionChanged();
     emit meshDataChanged();
     return retired;
@@ -2559,6 +2564,7 @@ int EditModeController::mergeAtFirst()
 
     SentryReporter::addBreadcrumb("edit_mode",
         QString("Merge: At First (removed=%1)").arg(retired));
+    updateSelectionOverlay();
     emit editSelectionChanged();
     emit meshDataChanged();
     return retired;
@@ -2603,6 +2609,7 @@ int EditModeController::mergeAtLast()
 
     SentryReporter::addBreadcrumb("edit_mode",
         QString("Merge: At Last (removed=%1)").arg(retired));
+    updateSelectionOverlay();
     emit editSelectionChanged();
     emit meshDataChanged();
     return retired;
@@ -2645,6 +2652,7 @@ int EditModeController::mergeByDistance(float threshold)
     SentryReporter::addBreadcrumb("edit_mode",
         QString("Merge: By Distance (threshold=%1, removed=%2)")
             .arg(threshold).arg(retired));
+    updateSelectionOverlay();
     emit editSelectionChanged();
     emit meshDataChanged();
     return retired;

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -2432,6 +2432,224 @@ bool EditModeController::commitKnife()
     return true;
 }
 
+// ---------------------------------------------------------------------------
+// Merge vertices
+//
+// All four public entry points share the same plumbing: take the current
+// VertexMode selection, run an HEMesh transform, write the result back. The
+// only thing that changes between them is which target position we hand to
+// the HE primitive (centroid / first / last / per-cluster centroid for
+// by-distance). `applyMergeOp` factors that boilerplate.
+// ---------------------------------------------------------------------------
+namespace {
+// Shared post-mesh-mutation hook used by knife + merge: rewrite the entity's
+// Ogre buffers, save / restore per-subentity material overrides, and tell
+// RTSS to re-link shaders against the new vertex layout. Captures locally
+// to avoid a public helper just for this.
+inline void rewriteEntityAfterTopologyChange(Ogre::Entity* ent) {
+    std::vector<std::string> preMats;
+    preMats.reserve(ent->getNumSubEntities());
+    for (unsigned int i = 0; i < ent->getNumSubEntities(); ++i)
+        preMats.push_back(ent->getSubEntity(i)->getMaterialName());
+
+    ent->_deinitialise();
+    ent->_initialise(true);
+
+    for (unsigned int i = 0;
+         i < ent->getNumSubEntities() && i < preMats.size(); ++i) {
+        if (!preMats[i].empty())
+            ent->getSubEntity(i)->setMaterialName(preMats[i]);
+    }
+
+    if (auto* sg = Ogre::RTShader::ShaderGenerator::getSingletonPtr()) {
+        for (unsigned int i = 0; i < ent->getNumSubEntities(); ++i) {
+            const std::string& m = ent->getSubEntity(i)->getMaterialName();
+            if (!m.empty())
+                sg->invalidateMaterial(
+                    Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME, m);
+        }
+    }
+}
+} // namespace
+
+int EditModeController::mergeAtCenter()
+{
+    if (!m_editModeActive || !m_editableMesh || !m_editEntity) return 0;
+    if (m_selectionMode != VertexMode) return 0;
+    if (m_selectedVertices.size() < 2) return 0;
+
+    HalfEdgeMesh hm;
+    if (!hm.buildFromEditableMesh(*m_editableMesh)) return 0;
+
+    // m_selectedVertices already holds HE-aligned indices (build is
+    // submesh-contiguous, matching localToGlobal).
+    std::vector<int> verts(m_selectedVertices.begin(), m_selectedVertices.end());
+
+    Ogre::Vector3 centroid = Ogre::Vector3::ZERO;
+    for (int v : verts) centroid += hm.vertex(v).position;
+    centroid /= static_cast<float>(verts.size());
+
+    auto originalSubMeshes = m_editableMesh->subMeshes();
+    const int retired = hm.mergeVertices(verts, centroid);
+    if (retired == 0) return 0;
+
+    EditableMesh updated;
+    if (!hm.toEditableMesh(updated)) return 0;
+    m_editableMesh->subMeshes() = std::move(updated.subMeshes());
+    m_editableMesh->resizeEntityBuffers(m_editEntity);
+    rewriteEntityAfterTopologyChange(m_editEntity);
+
+    // Vertex indices have shifted (toEditableMesh re-packs per submesh).
+    // Clear all selections — safer than trying to map the survivor's new
+    // index, since the user's intent post-merge is usually a fresh
+    // selection on the merged-up cluster anyway.
+    m_selectedVertices.clear();
+    m_selectedEdges.clear();
+    m_selectedFaces.clear();
+
+    auto* cmd = new EditMeshTopologyCommand(
+        std::move(originalSubMeshes),
+        m_editableMesh->subMeshes(),
+        m_selectedVertices, m_selectedEdges, m_selectedFaces,
+        m_selectedVertices, m_selectedEdges, m_selectedFaces,
+        "Merge At Center");
+    UndoManager::getSingleton()->push(cmd);
+
+    SentryReporter::addBreadcrumb("edit_mode",
+        QString("Merge: At Center (removed=%1)").arg(retired));
+    emit editSelectionChanged();
+    emit meshDataChanged();
+    return retired;
+}
+
+int EditModeController::mergeAtFirst()
+{
+    if (!m_editModeActive || !m_editableMesh || !m_editEntity) return 0;
+    if (m_selectionMode != VertexMode) return 0;
+    if (m_selectedVertices.size() < 2) return 0;
+
+    HalfEdgeMesh hm;
+    if (!hm.buildFromEditableMesh(*m_editableMesh)) return 0;
+
+    std::vector<int> verts(m_selectedVertices.begin(), m_selectedVertices.end());
+    // std::set iteration is sorted, so verts.front() is the lowest index.
+    const Ogre::Vector3 target = hm.vertex(verts.front()).position;
+
+    auto originalSubMeshes = m_editableMesh->subMeshes();
+    const int retired = hm.mergeVertices(verts, target);
+    if (retired == 0) return 0;
+
+    EditableMesh updated;
+    if (!hm.toEditableMesh(updated)) return 0;
+    m_editableMesh->subMeshes() = std::move(updated.subMeshes());
+    m_editableMesh->resizeEntityBuffers(m_editEntity);
+    rewriteEntityAfterTopologyChange(m_editEntity);
+
+    m_selectedVertices.clear();
+    m_selectedEdges.clear();
+    m_selectedFaces.clear();
+
+    auto* cmd = new EditMeshTopologyCommand(
+        std::move(originalSubMeshes),
+        m_editableMesh->subMeshes(),
+        m_selectedVertices, m_selectedEdges, m_selectedFaces,
+        m_selectedVertices, m_selectedEdges, m_selectedFaces,
+        "Merge At First");
+    UndoManager::getSingleton()->push(cmd);
+
+    SentryReporter::addBreadcrumb("edit_mode",
+        QString("Merge: At First (removed=%1)").arg(retired));
+    emit editSelectionChanged();
+    emit meshDataChanged();
+    return retired;
+}
+
+int EditModeController::mergeAtLast()
+{
+    if (!m_editModeActive || !m_editableMesh || !m_editEntity) return 0;
+    if (m_selectionMode != VertexMode) return 0;
+    if (m_selectedVertices.size() < 2) return 0;
+
+    HalfEdgeMesh hm;
+    if (!hm.buildFromEditableMesh(*m_editableMesh)) return 0;
+
+    std::vector<int> verts(m_selectedVertices.begin(), m_selectedVertices.end());
+    // verts.back() is the highest index (set is sorted ascending).
+    // mergeVertices uses index 0 as the survivor, so move the desired
+    // anchor to the front and re-target manually.
+    const Ogre::Vector3 target = hm.vertex(verts.back()).position;
+
+    auto originalSubMeshes = m_editableMesh->subMeshes();
+    const int retired = hm.mergeVertices(verts, target);
+    if (retired == 0) return 0;
+
+    EditableMesh updated;
+    if (!hm.toEditableMesh(updated)) return 0;
+    m_editableMesh->subMeshes() = std::move(updated.subMeshes());
+    m_editableMesh->resizeEntityBuffers(m_editEntity);
+    rewriteEntityAfterTopologyChange(m_editEntity);
+
+    m_selectedVertices.clear();
+    m_selectedEdges.clear();
+    m_selectedFaces.clear();
+
+    auto* cmd = new EditMeshTopologyCommand(
+        std::move(originalSubMeshes),
+        m_editableMesh->subMeshes(),
+        m_selectedVertices, m_selectedEdges, m_selectedFaces,
+        m_selectedVertices, m_selectedEdges, m_selectedFaces,
+        "Merge At Last");
+    UndoManager::getSingleton()->push(cmd);
+
+    SentryReporter::addBreadcrumb("edit_mode",
+        QString("Merge: At Last (removed=%1)").arg(retired));
+    emit editSelectionChanged();
+    emit meshDataChanged();
+    return retired;
+}
+
+int EditModeController::mergeByDistance(float threshold)
+{
+    if (!m_editModeActive || !m_editableMesh || !m_editEntity) return 0;
+    if (m_selectionMode != VertexMode) return 0;
+    if (m_selectedVertices.size() < 2) return 0;
+    if (threshold <= 0.0f) return 0;
+
+    HalfEdgeMesh hm;
+    if (!hm.buildFromEditableMesh(*m_editableMesh)) return 0;
+
+    std::vector<int> verts(m_selectedVertices.begin(), m_selectedVertices.end());
+
+    auto originalSubMeshes = m_editableMesh->subMeshes();
+    const int retired = hm.mergeVerticesByDistance(verts, threshold);
+    if (retired == 0) return 0;
+
+    EditableMesh updated;
+    if (!hm.toEditableMesh(updated)) return 0;
+    m_editableMesh->subMeshes() = std::move(updated.subMeshes());
+    m_editableMesh->resizeEntityBuffers(m_editEntity);
+    rewriteEntityAfterTopologyChange(m_editEntity);
+
+    m_selectedVertices.clear();
+    m_selectedEdges.clear();
+    m_selectedFaces.clear();
+
+    auto* cmd = new EditMeshTopologyCommand(
+        std::move(originalSubMeshes),
+        m_editableMesh->subMeshes(),
+        m_selectedVertices, m_selectedEdges, m_selectedFaces,
+        m_selectedVertices, m_selectedEdges, m_selectedFaces,
+        "Merge By Distance");
+    UndoManager::getSingleton()->push(cmd);
+
+    SentryReporter::addBreadcrumb("edit_mode",
+        QString("Merge: By Distance (threshold=%1, removed=%2)")
+            .arg(threshold).arg(retired));
+    emit editSelectionChanged();
+    emit meshDataChanged();
+    return retired;
+}
+
 void EditModeController::cancelKnife()
 {
     if (!m_knifeSession.active) return;

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -44,6 +44,7 @@ THE SOFTWARE.
 #include <ProceduralSphereGenerator.h>
 #include <cmath>
 #include <algorithm>
+#include <numeric>
 #include <limits>
 
 namespace {
@@ -2472,7 +2473,47 @@ inline void rewriteEntityAfterTopologyChange(Ogre::Entity* ent) {
 }
 } // namespace
 
-int EditModeController::mergeAtCenter()
+// Find global vertex indices of the survivor positions after toEditableMesh
+// re-packed the per-submesh arrays. Each survivor is the unique vertex at
+// `pos` (within `eps`) in the post-merge mesh. Mirrors the pattern bevel
+// uses to re-select its newly-created vertices.
+static std::set<int> findGlobalVertsByPosition(
+    const EditableMesh* mesh, const std::vector<Ogre::Vector3>& targets)
+{
+    std::set<int> result;
+    if (!mesh || targets.empty()) return result;
+
+    constexpr float eps2 = 1e-8f;
+    int globalIdx = 0;
+    for (const auto& sub : mesh->subMeshes()) {
+        for (size_t v = 0; v < sub.vertices.size(); ++v) {
+            for (const auto& pos : targets) {
+                if (sub.vertices[v].position.squaredDistance(pos) < eps2) {
+                    result.insert(globalIdx + static_cast<int>(v));
+                    break;
+                }
+            }
+        }
+        globalIdx += static_cast<int>(sub.vertices.size());
+    }
+    return result;
+}
+
+// Shared post-merge plumbing for all four merge ops. Captures pre-merge
+// selection for undo, runs the supplied HE-side merge, writes the new
+// submeshes back, recomputes normals, refreshes the entity, and re-selects
+// the survivor vertex (or vertices, for By Distance) by hunting the target
+// position(s) in the re-packed mesh.
+//
+// `mergeFn` does the actual HE mutation; it gets the prepared HEMesh and
+// must return the number of retired vertices (0 = no-op, abort).
+//
+// `survivorTargets` is the world-space position(s) the user expected the
+// survivor to land at — used to re-select after toEditableMesh re-packs.
+int EditModeController::applyMergeAndRefresh(
+    const QString& opLabel,
+    const std::function<int(HalfEdgeMesh&)>& mergeFn,
+    const std::vector<Ogre::Vector3>& survivorTargets)
 {
     if (!m_editModeActive || !m_editableMesh || !m_editEntity) return 0;
     if (m_selectionMode != VertexMode) return 0;
@@ -2481,181 +2522,184 @@ int EditModeController::mergeAtCenter()
     HalfEdgeMesh hm;
     if (!hm.buildFromEditableMesh(*m_editableMesh)) return 0;
 
-    // m_selectedVertices already holds HE-aligned indices (build is
-    // submesh-contiguous, matching localToGlobal).
-    std::vector<int> verts(m_selectedVertices.begin(), m_selectedVertices.end());
-
-    Ogre::Vector3 centroid = Ogre::Vector3::ZERO;
-    for (int v : verts) centroid += hm.vertex(v).position;
-    centroid /= static_cast<float>(verts.size());
-
+    // Snapshot mesh + selection BEFORE the mutation so undo restores both
+    // (CodeRabbit critical: previously the cleared selection was passed
+    // for both old and new state, leaving undo with an empty selection).
     auto originalSubMeshes = m_editableMesh->subMeshes();
-    const int retired = hm.mergeVertices(verts, centroid);
+    const auto preSelectedVerts = m_selectedVertices;
+    const auto preSelectedEdges = m_selectedEdges;
+    const auto preSelectedFaces = m_selectedFaces;
+
+    const int retired = mergeFn(hm);
     if (retired == 0) return 0;
 
     EditableMesh updated;
     if (!hm.toEditableMesh(updated)) return 0;
     m_editableMesh->subMeshes() = std::move(updated.subMeshes());
+
+    // Recompute normals so shading stays right across the new topology —
+    // bevel/extrude do this for the same reason. Respect the current
+    // smooth/flat mode so the user doesn't lose their setting on merge.
+    if (m_normalsMode == 0)
+        m_editableMesh->recalculateNormals();
+    else
+        m_editableMesh->recalculateNormalsFlat();
+
     m_editableMesh->resizeEntityBuffers(m_editEntity);
     rewriteEntityAfterTopologyChange(m_editEntity);
 
-    // Vertex indices have shifted (toEditableMesh re-packs per submesh).
-    // Clear all selections — safer than trying to map the survivor's new
-    // index, since the user's intent post-merge is usually a fresh
-    // selection on the merged-up cluster anyway.
-    m_selectedVertices.clear();
+    // Re-select survivor(s) by position. toEditableMesh re-packs per
+    // submesh so old indices are dead, but the position is stable —
+    // matches the bevel post-op refresh pattern.
+    m_selectedVertices = findGlobalVertsByPosition(m_editableMesh.get(),
+                                                   survivorTargets);
     m_selectedEdges.clear();
     m_selectedFaces.clear();
 
     auto* cmd = new EditMeshTopologyCommand(
         std::move(originalSubMeshes),
         m_editableMesh->subMeshes(),
+        preSelectedVerts, preSelectedEdges, preSelectedFaces,
         m_selectedVertices, m_selectedEdges, m_selectedFaces,
-        m_selectedVertices, m_selectedEdges, m_selectedFaces,
-        "Merge At Center");
+        opLabel);
     UndoManager::getSingleton()->push(cmd);
 
     SentryReporter::addBreadcrumb("edit_mode",
-        QString("Merge: At Center (removed=%1)").arg(retired));
-    // Selection sets were cleared above (vertex IDs are stale post-merge).
-    // Redraw the overlay so the previously-selected highlights stop
-    // showing — the live geometry has new index order and the old
-    // markers point at unrelated verts.
+        QString("%1 (removed=%2)").arg(opLabel).arg(retired));
+
     updateSelectionOverlay();
+    refreshNormalVisualizer();
     emit editSelectionChanged();
     emit meshDataChanged();
     return retired;
+}
+
+int EditModeController::mergeAtCenter()
+{
+    if (m_selectedVertices.empty()) return 0;
+    HalfEdgeMesh probe; // peek at positions before the real run
+    if (!probe.buildFromEditableMesh(*m_editableMesh)) return 0;
+
+    std::vector<int> verts(m_selectedVertices.begin(), m_selectedVertices.end());
+    Ogre::Vector3 centroid = Ogre::Vector3::ZERO;
+    for (int v : verts) centroid += probe.vertex(v).position;
+    centroid /= static_cast<float>(verts.size());
+
+    return applyMergeAndRefresh("Merge At Center",
+        [&verts, centroid](HalfEdgeMesh& hm) {
+            return hm.mergeVertices(verts, centroid);
+        },
+        {centroid});
 }
 
 int EditModeController::mergeAtFirst()
 {
-    if (!m_editModeActive || !m_editableMesh || !m_editEntity) return 0;
-    if (m_selectionMode != VertexMode) return 0;
-    if (m_selectedVertices.size() < 2) return 0;
-
-    HalfEdgeMesh hm;
-    if (!hm.buildFromEditableMesh(*m_editableMesh)) return 0;
+    if (m_selectedVertices.empty()) return 0;
+    HalfEdgeMesh probe;
+    if (!probe.buildFromEditableMesh(*m_editableMesh)) return 0;
 
     std::vector<int> verts(m_selectedVertices.begin(), m_selectedVertices.end());
-    // std::set iteration is sorted, so verts.front() is the lowest index.
-    const Ogre::Vector3 target = hm.vertex(verts.front()).position;
+    // std::set iteration is sorted ascending — verts[0] is the lowest index.
+    const Ogre::Vector3 target = probe.vertex(verts.front()).position;
 
-    auto originalSubMeshes = m_editableMesh->subMeshes();
-    const int retired = hm.mergeVertices(verts, target);
-    if (retired == 0) return 0;
-
-    EditableMesh updated;
-    if (!hm.toEditableMesh(updated)) return 0;
-    m_editableMesh->subMeshes() = std::move(updated.subMeshes());
-    m_editableMesh->resizeEntityBuffers(m_editEntity);
-    rewriteEntityAfterTopologyChange(m_editEntity);
-
-    m_selectedVertices.clear();
-    m_selectedEdges.clear();
-    m_selectedFaces.clear();
-
-    auto* cmd = new EditMeshTopologyCommand(
-        std::move(originalSubMeshes),
-        m_editableMesh->subMeshes(),
-        m_selectedVertices, m_selectedEdges, m_selectedFaces,
-        m_selectedVertices, m_selectedEdges, m_selectedFaces,
-        "Merge At First");
-    UndoManager::getSingleton()->push(cmd);
-
-    SentryReporter::addBreadcrumb("edit_mode",
-        QString("Merge: At First (removed=%1)").arg(retired));
-    updateSelectionOverlay();
-    emit editSelectionChanged();
-    emit meshDataChanged();
-    return retired;
+    return applyMergeAndRefresh("Merge At First",
+        [&verts, target](HalfEdgeMesh& hm) {
+            return hm.mergeVertices(verts, target);
+        },
+        {target});
 }
 
 int EditModeController::mergeAtLast()
 {
-    if (!m_editModeActive || !m_editableMesh || !m_editEntity) return 0;
-    if (m_selectionMode != VertexMode) return 0;
-    if (m_selectedVertices.size() < 2) return 0;
-
-    HalfEdgeMesh hm;
-    if (!hm.buildFromEditableMesh(*m_editableMesh)) return 0;
+    if (m_selectedVertices.empty()) return 0;
+    HalfEdgeMesh probe;
+    if (!probe.buildFromEditableMesh(*m_editableMesh)) return 0;
 
     std::vector<int> verts(m_selectedVertices.begin(), m_selectedVertices.end());
-    // verts.back() is the highest index (set is sorted ascending).
-    // mergeVertices uses index 0 as the survivor, so move the desired
-    // anchor to the front and re-target manually.
-    const Ogre::Vector3 target = hm.vertex(verts.back()).position;
+    // Move the highest-index vert to the front so HEMesh::mergeVertices
+    // picks it as the survivor. Without this swap, the survivor is the
+    // lowest index (verts[0]) and only its *position* would be retargeted
+    // — semantically that's "Merge At First, with last's position", not
+    // "Merge At Last". Caught by Codex P1 + CodeRabbit.
+    std::swap(verts.front(), verts.back());
+    const Ogre::Vector3 target = probe.vertex(verts.front()).position;
 
-    auto originalSubMeshes = m_editableMesh->subMeshes();
-    const int retired = hm.mergeVertices(verts, target);
-    if (retired == 0) return 0;
-
-    EditableMesh updated;
-    if (!hm.toEditableMesh(updated)) return 0;
-    m_editableMesh->subMeshes() = std::move(updated.subMeshes());
-    m_editableMesh->resizeEntityBuffers(m_editEntity);
-    rewriteEntityAfterTopologyChange(m_editEntity);
-
-    m_selectedVertices.clear();
-    m_selectedEdges.clear();
-    m_selectedFaces.clear();
-
-    auto* cmd = new EditMeshTopologyCommand(
-        std::move(originalSubMeshes),
-        m_editableMesh->subMeshes(),
-        m_selectedVertices, m_selectedEdges, m_selectedFaces,
-        m_selectedVertices, m_selectedEdges, m_selectedFaces,
-        "Merge At Last");
-    UndoManager::getSingleton()->push(cmd);
-
-    SentryReporter::addBreadcrumb("edit_mode",
-        QString("Merge: At Last (removed=%1)").arg(retired));
-    updateSelectionOverlay();
-    emit editSelectionChanged();
-    emit meshDataChanged();
-    return retired;
+    return applyMergeAndRefresh("Merge At Last",
+        [&verts, target](HalfEdgeMesh& hm) {
+            return hm.mergeVertices(verts, target);
+        },
+        {target});
 }
 
 int EditModeController::mergeByDistance(float threshold)
 {
-    if (!m_editModeActive || !m_editableMesh || !m_editEntity) return 0;
-    if (m_selectionMode != VertexMode) return 0;
-    if (m_selectedVertices.size() < 2) return 0;
-    if (threshold <= 0.0f) return 0;
+    if (m_selectedVertices.empty()) return 0;
 
-    HalfEdgeMesh hm;
-    if (!hm.buildFromEditableMesh(*m_editableMesh)) return 0;
+    // Defensive clamp: very large thresholds (or finite-but-massive caller
+    // input) make t² overflow to +∞ in HEMesh, collapsing the entire
+    // selection into one cluster. 1e6 world units is well past anything
+    // realistic on a meter-scale mesh and stays safely under sqrt(FLT_MAX).
+    if (threshold <= 0.0f) return 0;
+    threshold = std::min(threshold, 1.0e6f);
+
+    HalfEdgeMesh probe;
+    if (!probe.buildFromEditableMesh(*m_editableMesh)) return 0;
 
     std::vector<int> verts(m_selectedVertices.begin(), m_selectedVertices.end());
 
-    auto originalSubMeshes = m_editableMesh->subMeshes();
-    const int retired = hm.mergeVerticesByDistance(verts, threshold);
-    if (retired == 0) return 0;
+    // Pre-compute the cluster centroids so we know what positions to
+    // re-select after the operation. Mirrors HEMesh's internal grouping
+    // (union-find by distance) but stays per-submesh because cross-submesh
+    // pairs are never fused — including them in the union step inflates
+    // clusters and causes the whole cluster to be rejected at HE level.
+    // Codex P2.
+    std::vector<Ogre::Vector3> survivorTargets;
+    {
+        // Group verts by submesh first.
+        std::map<int, std::vector<int>> bySubmesh;
+        for (int v : verts) {
+            const auto faces = probe.facesAroundVertex(v);
+            if (faces.empty()) continue;
+            int sub = probe.face(faces.front()).subMeshIndex;
+            bySubmesh[sub].push_back(v);
+        }
+        // Within each submesh, union by distance.
+        const float t2 = threshold * threshold;
+        for (auto& [sub, members] : bySubmesh) {
+            std::vector<int> parent(members.size());
+            std::iota(parent.begin(), parent.end(), 0);
+            std::function<int(int)> find = [&](int i) {
+                while (parent[i] != i) { parent[i] = parent[parent[i]]; i = parent[i]; }
+                return i;
+            };
+            for (size_t i = 0; i < members.size(); ++i) {
+                for (size_t j = i + 1; j < members.size(); ++j) {
+                    if (probe.vertex(members[i]).position.squaredDistance(
+                            probe.vertex(members[j]).position) <= t2) {
+                        int ri = find(static_cast<int>(i));
+                        int rj = find(static_cast<int>(j));
+                        if (ri != rj) parent[std::max(ri, rj)] = std::min(ri, rj);
+                    }
+                }
+            }
+            std::map<int, std::vector<int>> clusters;
+            for (size_t i = 0; i < members.size(); ++i)
+                clusters[find(static_cast<int>(i))].push_back(members[i]);
+            for (auto& [_, clusterMembers] : clusters) {
+                if (clusterMembers.size() < 2) continue;
+                Ogre::Vector3 c = Ogre::Vector3::ZERO;
+                for (int m : clusterMembers) c += probe.vertex(m).position;
+                c /= static_cast<float>(clusterMembers.size());
+                survivorTargets.push_back(c);
+            }
+        }
+    }
 
-    EditableMesh updated;
-    if (!hm.toEditableMesh(updated)) return 0;
-    m_editableMesh->subMeshes() = std::move(updated.subMeshes());
-    m_editableMesh->resizeEntityBuffers(m_editEntity);
-    rewriteEntityAfterTopologyChange(m_editEntity);
-
-    m_selectedVertices.clear();
-    m_selectedEdges.clear();
-    m_selectedFaces.clear();
-
-    auto* cmd = new EditMeshTopologyCommand(
-        std::move(originalSubMeshes),
-        m_editableMesh->subMeshes(),
-        m_selectedVertices, m_selectedEdges, m_selectedFaces,
-        m_selectedVertices, m_selectedEdges, m_selectedFaces,
-        "Merge By Distance");
-    UndoManager::getSingleton()->push(cmd);
-
-    SentryReporter::addBreadcrumb("edit_mode",
-        QString("Merge: By Distance (threshold=%1, removed=%2)")
-            .arg(threshold).arg(retired));
-    updateSelectionOverlay();
-    emit editSelectionChanged();
-    emit meshDataChanged();
-    return retired;
+    return applyMergeAndRefresh("Merge By Distance",
+        [&verts, threshold](HalfEdgeMesh& hm) {
+            return hm.mergeVerticesByDistance(verts, threshold);
+        },
+        survivorTargets);
 }
 
 void EditModeController::cancelKnife()

--- a/src/EditModeController.h
+++ b/src/EditModeController.h
@@ -36,6 +36,7 @@ THE SOFTWARE.
 #include <QVariantList>
 #include <limits>
 #include <memory>
+#include <functional>
 #include <set>
 #include <map>
 #include <utility>
@@ -46,6 +47,7 @@ THE SOFTWARE.
 #include "EditableMesh.h" // BevelSession stores std::vector<EditableSubMesh> by value
 
 class OgreWidget;
+class HalfEdgeMesh;
 
 namespace Ogre {
     class Entity;
@@ -599,6 +601,16 @@ private slots:
 private:
     EditModeController();
     ~EditModeController() override;
+
+    /// Shared post-merge plumbing: snapshot mesh + selection, run the
+    /// HE-side `mergeFn`, write back, recompute normals, refresh entity,
+    /// re-select the survivor(s) by hunting `survivorTargets` positions
+    /// in the re-packed mesh, and push one EditMeshTopologyCommand.
+    /// Returns the retired-vertex count (0 on no-op / refusal).
+    int applyMergeAndRefresh(
+        const QString& opLabel,
+        const std::function<int(HalfEdgeMesh&)>& mergeFn,
+        const std::vector<Ogre::Vector3>& survivorTargets);
 
     /// Build or rebuild the selection overlay ManualObject.
     void updateSelectionOverlay();

--- a/src/EditModeController.h
+++ b/src/EditModeController.h
@@ -349,6 +349,42 @@ public:
     }
     /// @}
 
+    /// @name Merge vertices
+    /// @{
+    /**
+     * @brief Collapse the current vertex selection into a single survivor at
+     *        their centroid. No-op if fewer than 2 vertices are selected or
+     *        the selection spans submeshes (HE refuses cross-submesh merges
+     *        to preserve UV seams). Pushes one undo command labeled
+     *        "Merge At Center". Returns the count of removed vertices
+     *        (selection size minus 1) on success, 0 otherwise.
+     */
+    Q_INVOKABLE int mergeAtCenter();
+
+    /**
+     * @brief Collapse selected vertices to the position of the first
+     *        (lowest-index) vertex in the selection. Same constraints and
+     *        behavior as mergeAtCenter() otherwise.
+     */
+    Q_INVOKABLE int mergeAtFirst();
+
+    /**
+     * @brief Collapse selected vertices to the position of the last
+     *        (highest-index) vertex in the selection.
+     */
+    Q_INVOKABLE int mergeAtLast();
+
+    /**
+     * @brief Fuse any pair of selected vertices that lie within `threshold`
+     *        of each other (default 1e-4 ≈ 0.1 mm at meter scale). Each
+     *        cluster collapses to its centroid. Useful for cleaning up
+     *        duplicate vertices left by extrudes / mirror operations.
+     *
+     * @return Total vertices retired across all clusters.
+     */
+    Q_INVOKABLE int mergeByDistance(float threshold = 1e-4f);
+    /// @}
+
     /// @name Vertex transform support
     /// @{
     /// Get the centroid of selected vertices in local mesh space.

--- a/src/HalfEdgeMesh.cpp
+++ b/src/HalfEdgeMesh.cpp
@@ -29,10 +29,12 @@ THE SOFTWARE.
 #include "HalfEdgeMesh.h"
 #include "EditableMesh.h"
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cmath>
 #include <functional>
 #include <set>
+#include <tuple>
 #include <unordered_set>
 
 bool HalfEdgeMesh::buildFromEditableMesh(const EditableMesh& editableMesh)
@@ -4008,6 +4010,188 @@ std::vector<int> HalfEdgeMesh::cutPath(const std::vector<CutPoint>& points)
     }
 
     return newVertices;
+}
+
+int HalfEdgeMesh::mergeVertices(const std::vector<int>& vertexIndices,
+                                const Ogre::Vector3& targetPos)
+{
+    // 1. Pick a survivor and build the doomed set, filtering out invalid /
+    //    out-of-range indices and dedup'ing along the way. Anything < 2
+    //    valid distinct verts is a no-op.
+    int survivor = -1;
+    std::set<int> doomed;
+    for (int v : vertexIndices) {
+        if (v < 0 || v >= static_cast<int>(m_vertices.size())) continue;
+        if (m_vertices[v].halfEdge < 0) continue; // already retired
+        if (survivor == -1) {
+            survivor = v;
+            continue;
+        }
+        if (v == survivor) continue;
+        doomed.insert(v);
+    }
+    if (survivor == -1 || doomed.empty()) return 0;
+
+    // 2. Refuse cross-submesh merges. The HE build pipeline keeps a
+    //    distinct HEVertex per (submesh, localVert) pair so UV seams and
+    //    material boundaries survive; collapsing across that boundary
+    //    would silently fuse them. Cheap check: every face touching the
+    //    merge set must agree on subMeshIndex with the survivor's faces.
+    auto collectSubmeshes = [&](int v, std::set<int>& out) {
+        const auto faces = facesAroundVertex(v);
+        for (int f : faces) {
+            if (f >= 0 && f < static_cast<int>(m_faces.size())
+                && m_faces[f].halfEdge >= 0) {
+                out.insert(m_faces[f].subMeshIndex);
+            }
+        }
+    };
+    std::set<int> mergeSubs;
+    collectSubmeshes(survivor, mergeSubs);
+    for (int v : doomed) collectSubmeshes(v, mergeSubs);
+    if (mergeSubs.size() > 1) return 0;
+
+    // 3. Move the survivor to targetPos and re-point every half-edge
+    //    that pointed TO a doomed vertex so it now points to the survivor.
+    m_vertices[survivor].position = targetPos;
+
+    for (auto& he : m_halfEdges) {
+        if (he.face < 0) continue;            // skip retired / boundary HEs
+        if (doomed.count(he.vertex))
+            he.vertex = survivor;
+    }
+
+    // 4. Retire every triangle that is now degenerate (any two of its
+    //    three vertices identical) OR a duplicate of an earlier surviving
+    //    triangle. Mergers commonly produce duplicates: e.g. two
+    //    coincident-vertex pairs each collapse to a single vert and the
+    //    two triangles that used to differ only by those two indices end
+    //    up with identical vertex sets. We compare unordered vertex sets
+    //    (sub-mesh agnostic — same trio in the same submesh is a dup).
+    auto retireFace = [&](int f) {
+        int startHE = m_faces[f].halfEdge;
+        if (startHE < 0) return;
+        int he = startHE;
+        do {
+            int next = m_halfEdges[he].next;
+            m_halfEdges[he].face = -1;
+            m_halfEdges[he].twin = -1;
+            m_halfEdges[he].next = -1;
+            m_halfEdges[he].prev = -1;
+            he = next;
+        } while (he != startHE && he >= 0);
+        m_faces[f].halfEdge = -1;
+    };
+
+    auto canonicalKey = [&](const std::vector<int>& verts, int subIdx)
+        -> std::tuple<int, int, int, int> {
+        std::array<int, 3> sorted = {verts[0], verts[1], verts[2]};
+        std::sort(sorted.begin(), sorted.end());
+        return {subIdx, sorted[0], sorted[1], sorted[2]};
+    };
+
+    int retiredFaces = 0;
+    std::set<std::tuple<int, int, int, int>> seenFaces;
+    for (int f = 0; f < static_cast<int>(m_faces.size()); ++f) {
+        int startHE = m_faces[f].halfEdge;
+        if (startHE < 0) continue;
+
+        const auto verts = faceVertices(f);
+        if (verts.size() != 3) continue;
+        const bool degenerate = (verts[0] == verts[1])
+                             || (verts[1] == verts[2])
+                             || (verts[0] == verts[2]);
+        if (degenerate) {
+            retireFace(f);
+            ++retiredFaces;
+            continue;
+        }
+        // Duplicate-of-earlier check: triangle with same {subMesh, sorted-verts}
+        // collapses into the first occurrence.
+        const auto key = canonicalKey(verts, m_faces[f].subMeshIndex);
+        if (!seenFaces.insert(key).second) {
+            retireFace(f);
+            ++retiredFaces;
+        }
+    }
+
+    // 5. Mark the doomed vertex slots as retired (halfEdge = -1) so
+    //    later operations skip them. Their physical entries stay in
+    //    m_vertices but become inert.
+    for (int v : doomed) {
+        m_vertices[v].halfEdge = -1;
+    }
+
+    // 6. Rebuild edge tables. After the rewrite, two formerly-distinct
+    //    edges may now share endpoints, and twin links need to be
+    //    recomputed. The standard trio mirrors splitFace / extrude.
+    rebuildEdgesAndTwins();
+    compactBoundaryHalfEdges();
+    buildBoundaryHalfEdges();
+    fixVertexHalfEdges();
+
+    return static_cast<int>(doomed.size());
+}
+
+int HalfEdgeMesh::mergeVerticesByDistance(const std::vector<int>& vertexIndices,
+                                          float threshold)
+{
+    if (vertexIndices.size() < 2 || threshold <= 0.0f) return 0;
+
+    // Filter to live vertices, keep original ordering — the first vertex
+    // of each cluster becomes the survivor (matches Blender's "Merge By
+    // Distance" deterministic-survivor behavior).
+    std::vector<int> alive;
+    alive.reserve(vertexIndices.size());
+    for (int v : vertexIndices) {
+        if (v >= 0 && v < static_cast<int>(m_vertices.size())
+            && m_vertices[v].halfEdge >= 0) {
+            alive.push_back(v);
+        }
+    }
+    if (alive.size() < 2) return 0;
+
+    // Union-find over alive[]: pair-scan in O(N²). N is the selected-
+    // vertex count, which is small in practice (hundreds at most). If
+    // this becomes a bottleneck, swap in a uniform spatial hash.
+    std::vector<int> parent(alive.size());
+    for (size_t i = 0; i < parent.size(); ++i) parent[i] = static_cast<int>(i);
+    std::function<int(int)> find = [&](int i) {
+        while (parent[i] != i) { parent[i] = parent[parent[i]]; i = parent[i]; }
+        return i;
+    };
+    auto unite = [&](int a, int b) {
+        int ra = find(a), rb = find(b);
+        if (ra == rb) return;
+        // Lower index wins so cluster.front() == oldest selection slot.
+        if (ra < rb) parent[rb] = ra; else parent[ra] = rb;
+    };
+
+    const float t2 = threshold * threshold;
+    for (size_t i = 0; i < alive.size(); ++i) {
+        for (size_t j = i + 1; j < alive.size(); ++j) {
+            const auto& pa = m_vertices[alive[i]].position;
+            const auto& pb = m_vertices[alive[j]].position;
+            if (pa.squaredDistance(pb) <= t2)
+                unite(static_cast<int>(i), static_cast<int>(j));
+        }
+    }
+
+    // Group cluster members and dispatch one mergeVertices() per cluster
+    // with cluster centroid as the target. Clusters of size 1 are skipped.
+    std::map<int, std::vector<int>> clusters;
+    for (size_t i = 0; i < alive.size(); ++i)
+        clusters[find(static_cast<int>(i))].push_back(alive[i]);
+
+    int totalRetired = 0;
+    for (auto& [root, members] : clusters) {
+        if (members.size() < 2) continue;
+        Ogre::Vector3 centroid = Ogre::Vector3::ZERO;
+        for (int v : members) centroid += m_vertices[v].position;
+        centroid /= static_cast<float>(members.size());
+        totalRetired += mergeVertices(members, centroid);
+    }
+    return totalRetired;
 }
 
 bool HalfEdgeMesh::validate() const

--- a/src/HalfEdgeMesh.cpp
+++ b/src/HalfEdgeMesh.cpp
@@ -4138,6 +4138,15 @@ int HalfEdgeMesh::mergeVerticesByDistance(const std::vector<int>& vertexIndices,
 {
     if (vertexIndices.size() < 2 || threshold <= 0.0f) return 0;
 
+    // Defensive clamp on the squared-distance comparand: if a caller
+    // passes a huge threshold (or one mis-converted from world to mesh
+    // units), `threshold * threshold` overflows to +∞ and every pair
+    // satisfies the comparison, collapsing the entire selection into one
+    // cluster. Cap at sqrt(FLT_MAX/2) — well past any realistic mesh
+    // diagonal and still leaves headroom in the squared form.
+    constexpr float kMaxThreshold = 1.0e18f;
+    if (threshold > kMaxThreshold) threshold = kMaxThreshold;
+
     // Filter to live vertices, keep original ordering — the first vertex
     // of each cluster becomes the survivor (matches Blender's "Merge By
     // Distance" deterministic-survivor behavior).
@@ -4150,6 +4159,17 @@ int HalfEdgeMesh::mergeVerticesByDistance(const std::vector<int>& vertexIndices,
         }
     }
     if (alive.size() < 2) return 0;
+
+    // Compute each candidate vertex's submesh up front so the union step
+    // only fuses pairs in the same submesh. mergeVertices() refuses
+    // cross-submesh inputs anyway, so a mixed cluster would silently
+    // drop everything; pre-partitioning preserves the same-submesh
+    // pairs the user actually wanted to fuse. (Codex P2)
+    auto vertexSubmesh = [&](int v) -> int {
+        const auto faces = facesAroundVertex(v);
+        if (faces.empty()) return -1;
+        return m_faces[faces.front()].subMeshIndex;
+    };
 
     // Union-find over alive[]: pair-scan in O(N²). N is the selected-
     // vertex count, which is small in practice (hundreds at most). If
@@ -4167,9 +4187,16 @@ int HalfEdgeMesh::mergeVerticesByDistance(const std::vector<int>& vertexIndices,
         if (ra < rb) parent[rb] = ra; else parent[ra] = rb;
     };
 
+    std::vector<int> aliveSubs;
+    aliveSubs.reserve(alive.size());
+    for (int v : alive) aliveSubs.push_back(vertexSubmesh(v));
+
     const float t2 = threshold * threshold;
     for (size_t i = 0; i < alive.size(); ++i) {
         for (size_t j = i + 1; j < alive.size(); ++j) {
+            // Skip cross-submesh pairs entirely — UV seams / material
+            // boundaries must survive.
+            if (aliveSubs[i] != aliveSubs[j]) continue;
             const auto& pa = m_vertices[alive[i]].position;
             const auto& pb = m_vertices[alive[j]].position;
             if (pa.squaredDistance(pb) <= t2)

--- a/src/HalfEdgeMesh.h
+++ b/src/HalfEdgeMesh.h
@@ -456,6 +456,50 @@ public:
      */
     std::vector<int> cutPath(const std::vector<CutPoint>& points);
 
+    /**
+     * @brief Merge a set of vertices into a single survivor at `targetPos`.
+     *
+     * Picks `vertexIndices[0]` as the survivor, copies `targetPos` into its
+     * position, re-points every half-edge that referenced a doomed vertex
+     * to the survivor, retires triangles that become degenerate (two of
+     * their three vertices identical after the rewrite), then rebuilds the
+     * edge/twin/boundary tables. UVs/normals/bone weights/tangents on the
+     * survivor are kept as-is so the user gets a deterministic outcome —
+     * pre-merge attribute interpolation is a follow-up concern.
+     *
+     * Refuses any merge that would cross a submesh boundary, since
+     * dropping a vertex per submesh would silently fuse UV seams /
+     * material groups. Caller can group selections per-submesh upfront.
+     *
+     * @param vertexIndices The HE-vertex indices to merge. Order matters
+     *        only in that vertexIndices[0] becomes the survivor; the rest
+     *        are retired. Duplicates and invalid indices are ignored.
+     * @param targetPos The local-space position assigned to the survivor.
+     * @return Number of vertices that were actually retired (0 on no-op
+     *         or refusal). The survivor is not counted.
+     */
+    int mergeVertices(const std::vector<int>& vertexIndices,
+                      const Ogre::Vector3& targetPos);
+
+    /**
+     * @brief Find pairs of vertices within `threshold` of each other and
+     *        merge each cluster to its centroid. Operates only on the
+     *        provided candidate set (so the caller controls scope —
+     *        usually the current selection). Cross-submesh pairs are
+     *        skipped, same as `mergeVertices`.
+     *
+     * Implementation: union-find by spatial proximity. A vertex landing
+     * in two clusters joins both; the merged cluster collapses to the
+     * combined centroid.
+     *
+     * @param vertexIndices Candidate vertices.
+     * @param threshold World-space distance under which a pair fuses.
+     *        Defaults to 1e-4 (≈0.1 mm at meter scale).
+     * @return Number of vertices retired across all clusters.
+     */
+    int mergeVerticesByDistance(const std::vector<int>& vertexIndices,
+                                float threshold = 1e-4f);
+
     /// @}
 
     /// @name Validation

--- a/src/HalfEdgeMesh_test.cpp
+++ b/src/HalfEdgeMesh_test.cpp
@@ -3609,3 +3609,145 @@ TEST(HalfEdgeMeshStandalone, MergeVerticesByDistanceIgnoresVertsBeyondThreshold)
     EXPECT_EQ(he.vertexCount(), vertsBefore);
     EXPECT_TRUE(he.validate());
 }
+
+TEST(HalfEdgeMeshStandalone, MergeVerticesSurvivorTakesTargetPosition) {
+    // Verify the explicit target position is written to the survivor —
+    // independently of whether the target equals any input vertex's
+    // pre-merge position. Important for "Merge At Cursor" futures.
+    auto em = makeQuadMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+
+    // Pick (10, 20, 30) — far from any quad vert — so we can spot-check the
+    // write rather than confusing it with an existing position.
+    const Ogre::Vector3 target(10.0f, 20.0f, 30.0f);
+    const int retired = he.mergeVertices({0, 3}, target);
+    EXPECT_EQ(retired, 1);
+    // Survivor is the first input (index 0).
+    EXPECT_NEAR(he.vertex(0).position.x, target.x, 1e-5f);
+    EXPECT_NEAR(he.vertex(0).position.y, target.y, 1e-5f);
+    EXPECT_NEAR(he.vertex(0).position.z, target.z, 1e-5f);
+    EXPECT_TRUE(he.validate());
+}
+
+TEST(HalfEdgeMeshStandalone, MergeVerticesPreservesSurvivorBoneWeights) {
+    // The merge keeps the survivor's attributes verbatim and discards the
+    // doomed verts'. Pin that contract: survivor's bone weights must be
+    // unchanged after merge so skinned meshes don't deform unexpectedly.
+    EditableMesh em;
+    EditableSubMesh sub;
+    sub.materialName = "Skinned";
+
+    auto mkV = [](float x, float y, unsigned short bone, float weight) {
+        EditableVertex v;
+        v.position = Ogre::Vector3(x, y, 0);
+        v.normal = Ogre::Vector3(0, 0, 1); v.hasNormal = true;
+        EditableBoneAssignment ba;
+        ba.boneIndex = bone;
+        ba.weight = weight;
+        v.boneAssignments.push_back(ba);
+        return v;
+    };
+    sub.vertices = {
+        mkV(0, 0, /*bone=*/3, /*weight=*/0.7f),  // survivor
+        mkV(1, 0, /*bone=*/8, /*weight=*/0.4f),  // doomed
+        mkV(0, 1, /*bone=*/8, /*weight=*/0.5f),
+    };
+    EditableTriangle tri;
+    tri.indices[0] = 0; tri.indices[1] = 1; tri.indices[2] = 2;
+    sub.triangles = {tri};
+    em.subMeshes().push_back(std::move(sub));
+
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+
+    // Survivor vert 0 has bone 3 / weight 0.7. Merging in vert 1 (bone 8)
+    // must NOT overwrite — survivor wins.
+    he.mergeVertices({0, 1}, Ogre::Vector3::ZERO);
+    ASSERT_EQ(he.vertex(0).boneAssignments.size(), 1u);
+    EXPECT_EQ(he.vertex(0).boneAssignments[0].first, 3);
+    EXPECT_FLOAT_EQ(he.vertex(0).boneAssignments[0].second, 0.7f);
+}
+
+TEST(HalfEdgeMeshStandalone, MergeVerticesThreeVertCluster) {
+    // Merging three verts in one call: one survivor, two retired. All three
+    // verts share the only triangle, which collapses entirely.
+    auto em = makeQuadMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    ASSERT_EQ(activeFaceCount(he), 2);
+
+    // Verts 0, 1, 2 form one triangle. Merging all three retires that
+    // triangle and leaves the other (1,3,2) — but its verts 1 and 2 also
+    // collapsed onto survivor 0, so it becomes (0,3,0) → degenerate.
+    const int retired = he.mergeVertices({0, 1, 2}, Ogre::Vector3(0.5f, 0.5f, 0));
+    EXPECT_EQ(retired, 2) << "two doomed verts retire";
+    EXPECT_EQ(activeFaceCount(he), 0)
+        << "every triangle had at least two of {0,1,2} so all collapse";
+    EXPECT_TRUE(he.validate());
+}
+
+TEST(HalfEdgeMeshStandalone, MergeVerticesInvalidIndicesAreFiltered) {
+    auto em = makeQuadMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    const auto vertsBefore = he.vertexCount();
+
+    // Mix valid indices, out-of-range indices, and a duplicate. The
+    // duplicate and out-of-range entries are silently filtered, leaving
+    // {0, 1} as the actual merge set.
+    const int retired = he.mergeVertices({0, 1, -1, 9999, 1, 0},
+                                          Ogre::Vector3::ZERO);
+    EXPECT_EQ(retired, 1) << "{-1, 9999} dropped, dup {0, 1} dedup'd";
+    EXPECT_EQ(he.vertex(1).halfEdge, -1)
+        << "vert 1 retired";
+    EXPECT_TRUE(he.validate());
+    Q_UNUSED(vertsBefore);
+}
+
+TEST(HalfEdgeMeshStandalone, MergeVerticesAlreadyRetiredVertsAreSkipped) {
+    // Run a first merge to retire vert 1, then call merge again with a
+    // selection that includes the now-retired vert 1. It must be filtered
+    // out without crashing or producing junk topology.
+    auto em = makeQuadMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+
+    // First pass: merge 1 + 2 (collapses both quad triangles).
+    ASSERT_EQ(he.mergeVertices({1, 2}, Ogre::Vector3(0.5f, 0.5f, 0)), 1);
+    // vert 1 is retired (m_vertices[1].halfEdge == -1) but vert 2 absorbed
+    // into vert 1 via doomed=2; verify the second merge call doesn't choke
+    // when we hand it the retired index.
+    const int retired = he.mergeVertices({0, 2, 3}, Ogre::Vector3::ZERO);
+    EXPECT_GE(retired, 0) << "retired-input filter must not crash";
+    EXPECT_TRUE(he.validate());
+}
+
+TEST(HalfEdgeMeshStandalone, MergeVerticesByDistanceEmptyInputIsNoOp) {
+    auto em = makeQuadMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    const auto vertsBefore = he.vertexCount();
+    EXPECT_EQ(he.mergeVerticesByDistance({}, 1e-3f), 0);
+    EXPECT_EQ(he.mergeVerticesByDistance({0}, 1e-3f), 0);
+    EXPECT_EQ(he.mergeVerticesByDistance({0, 1}, -1.0f), 0)
+        << "negative threshold is rejected";
+    EXPECT_EQ(he.vertexCount(), vertsBefore);
+    EXPECT_TRUE(he.validate());
+}
+
+TEST(HalfEdgeMeshStandalone, MergeVerticesOnBoundaryEdge) {
+    // One-triangle mesh — every edge is a boundary. Merging two of its
+    // verts must retire the triangle and leave the survivor without
+    // crashing the boundary half-edge bookkeeping.
+    auto em = makeTriangleMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    ASSERT_EQ(activeFaceCount(he), 1);
+
+    const int retired = he.mergeVertices({0, 1}, Ogre::Vector3(0.5f, 0, 0));
+    EXPECT_EQ(retired, 1);
+    EXPECT_EQ(activeFaceCount(he), 0)
+        << "the single tri collapses since 0 and 1 fused";
+    EXPECT_TRUE(he.validate());
+}

--- a/src/HalfEdgeMesh_test.cpp
+++ b/src/HalfEdgeMesh_test.cpp
@@ -3451,3 +3451,161 @@ TEST(HalfEdgeMeshStandalone, CutPathRollsBackWhenSecondEdgeDuplicatesFirst) {
     EXPECT_EQ(he.edgeCount(), edgesBefore);
     EXPECT_TRUE(he.validate());
 }
+
+// ===========================================================================
+// Merge vertices
+// ===========================================================================
+
+TEST(HalfEdgeMeshStandalone, MergeVerticesNoOpOnLessThanTwoInputs) {
+    auto em = makeQuadMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    const auto vertsBefore = he.vertexCount();
+    EXPECT_EQ(he.mergeVertices({}, Ogre::Vector3::ZERO), 0);
+    EXPECT_EQ(he.mergeVertices({0}, Ogre::Vector3::ZERO), 0);
+    EXPECT_EQ(he.vertexCount(), vertsBefore);
+    EXPECT_TRUE(he.validate());
+}
+
+TEST(HalfEdgeMeshStandalone, MergeVerticesCollapsesSharedEdgeRetiringBothTriangles) {
+    // The quad mesh has two triangles sharing the v1↔v2 diagonal. Merging
+    // those two endpoints fuses the diagonal into one vertex and both
+    // triangles become degenerate (two of their three verts collapse).
+    auto em = makeQuadMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    ASSERT_EQ(activeFaceCount(he), 2);
+
+    const Ogre::Vector3 mid(0.5f, 0.5f, 0.0f);
+    const int retired = he.mergeVertices({1, 2}, mid);
+    EXPECT_EQ(retired, 1) << "one vertex retires; the other becomes the survivor";
+    EXPECT_EQ(activeFaceCount(he), 0)
+        << "both triangles collapsed because they each touched both merged verts";
+    EXPECT_TRUE(he.validate());
+
+    // Survivor moved to the requested centroid.
+    EXPECT_NEAR(he.vertex(1).position.x, mid.x, 1e-5f);
+    EXPECT_NEAR(he.vertex(1).position.y, mid.y, 1e-5f);
+}
+
+TEST(HalfEdgeMeshStandalone, MergeVerticesNonAdjacentPairKeepsTriangleAlive) {
+    // Build a strip of three triangles where merging two non-adjacent verts
+    // doesn't make any triangle a duplicate. Layout (top-down):
+    //
+    //   v0─v1─v2─v3
+    //    \ /\ /\ /
+    //    v4─v5─v6
+    //
+    // Triangles: (0,1,4), (1,5,4), (1,2,5), (2,6,5), (2,3,6).
+    // Merging v0 and v3 doesn't affect any triangle's vertex set since
+    // v0 only appears in tri (0,1,4) and v3 only in tri (2,3,6) — both
+    // survive with distinct sorted-vert keys.
+    EditableMesh em;
+    EditableSubMesh sub;
+    sub.materialName = "Strip";
+    auto mkV = [](float x, float y) {
+        EditableVertex v;
+        v.position = Ogre::Vector3(x, y, 0);
+        v.normal = Ogre::Vector3(0, 0, 1); v.hasNormal = true;
+        v.uv = Ogre::Vector2(x * 0.25f, y); v.hasUV = true;
+        return v;
+    };
+    sub.vertices = {
+        mkV(0, 1), mkV(1, 1), mkV(2, 1), mkV(3, 1),  // 0..3 top row
+        mkV(0.5f, 0), mkV(1.5f, 0), mkV(2.5f, 0),    // 4..6 bottom row
+    };
+    auto mkT = [](int a, int b, int c) {
+        EditableTriangle t;
+        t.indices[0] = a; t.indices[1] = b; t.indices[2] = c;
+        return t;
+    };
+    sub.triangles = {
+        mkT(0, 1, 4), mkT(1, 5, 4), mkT(1, 2, 5),
+        mkT(2, 6, 5), mkT(2, 3, 6),
+    };
+    em.subMeshes().push_back(std::move(sub));
+
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    ASSERT_EQ(activeFaceCount(he), 5);
+
+    // Move v0 onto v3's position so the survivor sits at the strip's right
+    // edge. v0 and v3 share no triangle, so neither face becomes degenerate
+    // nor a duplicate.
+    const int retired = he.mergeVertices({0, 3}, Ogre::Vector3(3, 1, 0));
+    EXPECT_EQ(retired, 1);
+    EXPECT_EQ(activeFaceCount(he), 5)
+        << "non-adjacent merge on this strip keeps every triangle distinct";
+    EXPECT_TRUE(he.validate());
+}
+
+TEST(HalfEdgeMeshStandalone, MergeVerticesByDistanceFusesCoincidentVerts) {
+    // Build a mesh with two pairs of near-coincident vertices and confirm
+    // mergeVerticesByDistance picks them up.
+    EditableMesh em;
+    EditableSubMesh sub;
+    sub.materialName = "Mat";
+    auto mkV = [](float x, float y, float z) {
+        EditableVertex v;
+        v.position = Ogre::Vector3(x, y, z);
+        v.normal = Ogre::Vector3(0, 0, 1); v.hasNormal = true;
+        v.uv = Ogre::Vector2(0, 0); v.hasUV = true;
+        return v;
+    };
+    // Two nearly-coincident pairs (within 1e-5 of each other) plus a far one,
+    // arranged so distinct triangles cover all of them.
+    sub.vertices = {
+        mkV(0, 0, 0),                       // 0
+        mkV(1e-6f, 0, 0),                   // 1 — coincident with 0
+        mkV(1, 0, 0),                       // 2
+        mkV(1.0f + 1e-6f, 0, 0),            // 3 — coincident with 2
+        mkV(0.5f, 1, 0),                    // 4 — far apex
+    };
+    auto mkT = [](int a, int b, int c) {
+        EditableTriangle t;
+        t.indices[0] = a; t.indices[1] = b; t.indices[2] = c;
+        return t;
+    };
+    sub.triangles = { mkT(0, 2, 4), mkT(1, 3, 4) };
+    em.subMeshes().push_back(std::move(sub));
+
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    EXPECT_EQ(activeFaceCount(he), 2);
+
+    // Loose threshold catches both pairs; they fuse to a single triangle.
+    const int retired = he.mergeVerticesByDistance({0, 1, 2, 3, 4}, 1e-3f);
+    EXPECT_EQ(retired, 2);
+    EXPECT_EQ(activeFaceCount(he), 1)
+        << "the two near-duplicate triangles collapse to one";
+    EXPECT_TRUE(he.validate());
+}
+
+TEST(HalfEdgeMeshStandalone, MergeVerticesRefusesCrossSubmeshSelection) {
+    // Same-position verts in different submeshes must NOT fuse — that
+    // would silently bridge a UV seam / material boundary.
+    auto em = makeTwoSubMeshMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    const auto vertsBefore = he.vertexCount();
+
+    // Pick one vertex from each submesh (sub0 has indices 0..2, sub1 has 3..5).
+    const int retired = he.mergeVertices({0, 3}, Ogre::Vector3::ZERO);
+    EXPECT_EQ(retired, 0) << "cross-submesh merge must be refused";
+    EXPECT_EQ(he.vertexCount(), vertsBefore);
+    EXPECT_TRUE(he.validate());
+}
+
+TEST(HalfEdgeMeshStandalone, MergeVerticesByDistanceIgnoresVertsBeyondThreshold) {
+    auto em = makeQuadMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    const auto vertsBefore = he.vertexCount();
+
+    // Quad verts are 1.0 apart on either axis — a 1e-3 threshold is far
+    // tighter than any real spacing here, so nothing should fuse.
+    const int retired = he.mergeVerticesByDistance({0, 1, 2, 3}, 1e-3f);
+    EXPECT_EQ(retired, 0);
+    EXPECT_EQ(he.vertexCount(), vertsBefore);
+    EXPECT_TRUE(he.validate());
+}

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -675,18 +675,59 @@ void MainWindow::initToolBar()
     });
     QAction* knifeAction = ui->objectsToolbar->addWidget(knifeButton);
 
+    // Merge: vertex-mode-only collapse of the current selection. Drops a
+    // small popup so the user can pick the survivor target (Center / First
+    // / Last / By Distance) without having to memorise a four-key chord.
+    auto mergeButton = new QToolButton(ui->objectsToolbar);
+    mergeButton->setText(QStringLiteral("\u2A00"));   // ⨀ circled-dot — fuse
+    mergeButton->setToolTip(tr("Merge vertices… — collapse selection (M)"));
+    mergeButton->setFont(topoFont);
+    mergeButton->setStyleSheet(topoBtnStyle);
+    mergeButton->setPopupMode(QToolButton::InstantPopup);
+
+    auto mergeMenu = new QMenu(mergeButton);
+    auto* actAtCenter   = mergeMenu->addAction(tr("At Center"));
+    auto* actAtFirst    = mergeMenu->addAction(tr("At First"));
+    auto* actAtLast     = mergeMenu->addAction(tr("At Last"));
+    mergeMenu->addSeparator();
+    auto* actByDistance = mergeMenu->addAction(tr("By Distance"));
+    mergeButton->setMenu(mergeMenu);
+
+    auto runMerge = [](int (EditModeController::*op)(), const char* label) {
+        SentryReporter::addBreadcrumb("ui.action",
+            QString("Toolbar: Merge %1").arg(label));
+        auto* c = EditModeController::instance();
+        const int removed = (c->*op)();
+        Q_UNUSED(removed); // status reporting handled by Sentry breadcrumb for now
+    };
+    connect(actAtCenter, &QAction::triggered, this, [runMerge]() {
+        runMerge(&EditModeController::mergeAtCenter, "At Center");
+    });
+    connect(actAtFirst, &QAction::triggered, this, [runMerge]() {
+        runMerge(&EditModeController::mergeAtFirst, "At First");
+    });
+    connect(actAtLast, &QAction::triggered, this, [runMerge]() {
+        runMerge(&EditModeController::mergeAtLast, "At Last");
+    });
+    connect(actByDistance, &QAction::triggered, this, []() {
+        SentryReporter::addBreadcrumb("ui.action", "Toolbar: Merge By Distance");
+        EditModeController::instance()->mergeByDistance(1e-4f);
+    });
+    QAction* mergeAction = ui->objectsToolbar->addWidget(mergeButton);
+
     // Context-aware visibility + enabled:
     //  - Hidden entirely when NOT in edit mode.
     //  - In edit mode: stay visible but only enable when the current
     //    mode matches AND the relevant element type actually has a
     //    non-empty selection.
-    auto refreshTopoButtons = [extrudeButton, bevelButton, knifeButton,
-                               extrudeAction, bevelAction, knifeAction]() {
+    auto refreshTopoButtons = [extrudeButton, bevelButton, knifeButton, mergeButton,
+                               extrudeAction, bevelAction, knifeAction, mergeAction]() {
         auto* c = EditModeController::instance();
         const bool active = c->isEditModeActive();
         extrudeAction->setVisible(active);
         bevelAction->setVisible(active);
         knifeAction->setVisible(active);
+        mergeAction->setVisible(active);
         if (!active) return;
         const int mode = c->selectionMode();  // 0 vertex, 1 edge, 2 face
         const bool hasFaces = c->selectedFaceCount() > 0;
@@ -698,6 +739,9 @@ void MainWindow::initToolBar()
         // Knife is always enabled in edit mode; the session has its own
         // point-based hit-tests and doesn't need a pre-existing selection.
         knifeButton->setEnabled(true);
+        // Merge needs a multi-vertex selection in vertex mode — the four
+        // operations (Center/First/Last/ByDistance) all require ≥2 verts.
+        mergeButton->setEnabled(mode == 0 && c->selectedVertexCount() >= 2);
     };
     refreshTopoButtons();
     connect(editCtrlForTopo, &EditModeController::editModeChanged,
@@ -1141,6 +1185,21 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
             if (!(event->modifiers() & (Qt::ControlModifier | Qt::MetaModifier | Qt::AltModifier))) {
                 SentryReporter::addBreadcrumb("ui.shortcut", "K — Knife (edit mode)");
                 editCtrl->beginKnife();
+                event->accept();
+                return;
+            }
+            break;
+        case Qt::Key_M:
+            // M: Merge At Center on the current vertex selection. Phase-4
+            // issue spec calls this out as the headline merge gesture; the
+            // other targets (First / Last / By Distance) remain on the
+            // toolbar dropdown. No modifier so it doesn't collide with
+            // platform shortcuts (Cmd+M minimises on macOS — guarded).
+            if (!(event->modifiers() & (Qt::ControlModifier | Qt::MetaModifier | Qt::AltModifier))
+                && editCtrl->selectionMode() == EditModeController::VertexMode
+                && editCtrl->selectedVertexCount() >= 2) {
+                SentryReporter::addBreadcrumb("ui.shortcut", "M — Merge At Center (edit mode)");
+                editCtrl->mergeAtCenter();
                 event->accept();
                 return;
             }


### PR DESCRIPTION
Phase 4 (#259) — merge vertices.

## Summary

Implements the four standard merge variants from Blender:

- **Merge At Center** — selection collapses to its centroid
- **Merge At First** — collapses to the lowest-index selected vertex
- **Merge At Last** — collapses to the highest-index selected vertex
- **Merge By Distance** — auto-fuse pairs within a threshold (1e-4 world units default); each cluster collapses to its centroid

## Core primitive

\`HalfEdgeMesh::mergeVertices(verts, targetPos)\`:

- Picks \`verts[0]\` as survivor, retires the rest
- Re-points half-edges that referenced doomed verts
- Retires triangles that become degenerate after the rewrite
- Retires triangles that become *duplicates* of an earlier survivor (same \`{submesh, sorted-vert-set}\` key) — common after pair-merging
- Refuses cross-submesh merges to preserve UV seams + material groups
- Standard rebuild trio: edges/twins → compact boundaries → fix vertex half-edge pointers (mirrors \`splitFace\` / extrude pattern)

\`mergeVerticesByDistance\` is union-find by spatial proximity, O(N²) on the candidate set — fine for UI-selection sizes.

## Controller surface

\`EditModeController::mergeAtCenter / mergeAtFirst / mergeAtLast / mergeByDistance\`. All four push a single \`EditMeshTopologyCommand\` so undo/redo is one step, and all refuse outside vertex mode or with <2 verts selected.

A shared \`rewriteEntityAfterTopologyChange\` helper was extracted from the existing knife commit path — handles Ogre buffer resize, material preservation, and RTSS shader invalidation.

## UI

- Toolbar button (⨀ glyph) with a four-item dropdown menu, placed next to the existing Knife scissor button
- Visibility tied to edit mode; enabled only when ≥2 verts selected in vertex mode
- **M key shortcut** runs Merge At Center directly (the headline path from the issue spec); the other three targets are on the dropdown

## Tests

- Less-than-two inputs is a no-op
- Merging both ends of a shared edge retires both adjacent triangles
- Non-adjacent merge on a tri-strip leaves all faces alive
- By-distance fuses near-coincident pairs and collapses duplicate tris
- Cross-submesh merge is refused
- Tight by-distance threshold ignores well-separated verts

All 117 active HalfEdgeMesh tests pass on macOS. Full suite has the same 6 pre-existing macOS-Ogre-init failures as master baseline (no new regressions).

## Test plan

- [ ] Linux CI (full suite incl. Ogre-dependent)
- [ ] Manual: cube → vertex mode → select two corners → press M → centered merge → undo → redo
- [ ] Manual: dropdown — At First / At Last / By Distance — each lands on a sensible position
- [ ] Manual: select verts across two submeshes → trigger merge → no-op (refused, breadcrumb logged)

Closes part of #259 (Merge Vertices section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Four vertex-merge actions: merge at center, merge to first/last selected vertex, and distance-threshold clustering merge
  * Merge options in a new toolbar dropdown and a keyboard shortcut (M) for "merge at center"
  * Merges only in vertex edit mode with ≥2 vertices selected; selections and overlays update after merge
  * Full undo/redo and activity/breadcrumb recording for merge operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->