### PR TITLE
quads chunk 5a: Catmull-Clark subdivide

### DIFF
--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -3083,6 +3083,63 @@ int EditModeController::subdivideSelection()
     return static_cast<int>(targetFaces.size());
 }
 
+int EditModeController::subdivideCatmullClarkAll()
+{
+    if (!m_editModeActive || !m_editableMesh || !m_editEntity) return 0;
+
+    // Cancel interactive previews — same rationale as deleteSelection
+    // (a stale bevel/knife snapshot would replay against post-CC topology).
+    if (m_bevelSession.active) cancelBevel();
+    if (m_knifeSession.active) cancelKnife();
+
+    HalfEdgeMesh hm;
+    if (!hm.buildFromEditableMesh(*m_editableMesh)) return 0;
+
+    auto originalSubMeshes = m_editableMesh->subMeshes();
+    const auto preSelectedVerts = m_selectedVertices;
+    const auto preSelectedEdges = m_selectedEdges;
+    const auto preSelectedFaces = m_selectedFaces;
+
+    const auto newVerts = hm.subdivideCatmullClark();
+    if (newVerts.empty()) return 0;
+
+    EditableMesh updated;
+    if (!hm.toEditableMesh(updated)) return 0;
+    m_editableMesh->subMeshes() = std::move(updated.subMeshes());
+
+    if (m_normalsMode == 0) m_editableMesh->recalculateNormals();
+    else                     m_editableMesh->recalculateNormalsFlat();
+
+    m_editableMesh->resizeEntityBuffers(m_editEntity);
+    rewriteEntityAfterTopologyChange(m_editEntity);
+
+    // Selection clears: post-CC topology has no stable mapping back to
+    // the pre-op selection (face/edge points didn't exist, vertex
+    // indices may have shifted on re-pack). Fresh start is the safe
+    // default; partial-CC with selection preservation is a follow-up.
+    m_selectedVertices.clear();
+    m_selectedEdges.clear();
+    m_selectedFaces.clear();
+
+    auto* cmd = new EditMeshTopologyCommand(
+        std::move(originalSubMeshes),
+        m_editableMesh->subMeshes(),
+        preSelectedVerts, preSelectedEdges, preSelectedFaces,
+        m_selectedVertices, m_selectedEdges, m_selectedFaces,
+        QStringLiteral("Catmull-Clark Subdivide"));
+    UndoManager::getSingleton()->push(cmd);
+
+    validateMesh();
+    SentryReporter::addBreadcrumb("edit_mode",
+        QString("Catmull-Clark Subdivide (newVerts=%1)").arg(newVerts.size()));
+
+    updateSelectionOverlay();
+    refreshNormalVisualizer();
+    emit editSelectionChanged();
+    emit meshDataChanged();
+    return static_cast<int>(newVerts.size());
+}
+
 namespace {
 // Build the closed BOUNDARY-EDGE loop implied by a set of selected edges.
 // Returns vertex indices in winding order, or an empty vector if any

--- a/src/EditModeController.h
+++ b/src/EditModeController.h
@@ -442,6 +442,28 @@ public:
     Q_INVOKABLE int subdivideSelection();
 
     /**
+     * @brief Subdivide the entire mesh by one Catmull-Clark step.
+     *
+     * Unlike `subdivideSelection` (which does a 1-to-4 triangle split
+     * on the selected faces only), this op operates on the whole mesh
+     * at once and produces an all-quad output regardless of input
+     * topology — a triangle becomes 3 quads, a quad becomes 4. Output
+     * geometry is smoothed via the classic Catmull-Clark rule (face
+     * points, edge points, smoothed vertex positions) so the surface
+     * approaches a C¹-continuous limit on closed manifolds.
+     *
+     * Selection is cleared after the op (the new face/edge points
+     * don't have stable analogues in the pre-op selection set, and
+     * partial-mesh CC needs a more sophisticated boundary blend that
+     * isn't in this MVP).
+     *
+     * Pushes one undo command labeled "Catmull-Clark Subdivide".
+     *
+     * @return Number of vertices added (0 on no-op).
+     */
+    Q_INVOKABLE int subdivideCatmullClarkAll();
+
+    /**
      * @brief Fill the current selection with new face(s).
      *
      * Vertex mode: 3 selected vertices → emit a triangle. 4 selected →

--- a/src/HalfEdgeMesh.cpp
+++ b/src/HalfEdgeMesh.cpp
@@ -4798,6 +4798,338 @@ std::vector<int> HalfEdgeMesh::subdivideFaces(const std::vector<int>& faceIndice
     return newVertices;
 }
 
+namespace {
+
+// Average a list of HEVertex by uniform weight. Used for face points
+// (corners → face point) and as the base for edge / smoothing rules.
+// Position / normal / UV / color / tangent are summed and divided;
+// bone weights are accumulated per bone index. Output flags follow
+// the AND of input flags so a vertex with no UV doesn't fabricate one.
+HEVertex averageHEVertices(const std::vector<const HEVertex*>& src)
+{
+    HEVertex r;
+    if (src.empty()) return r;
+    const float w = 1.0f / static_cast<float>(src.size());
+    bool anyNorm = true, anyUV = true, anyCol = true, anyTan = true;
+    for (const auto* v : src) {
+        r.position += v->position * w;
+        r.normal   += v->normal   * w;
+        r.uv       += v->uv       * w;
+        r.color    += v->color    * w;
+        r.tangent  += v->tangent  * w;
+        anyNorm = anyNorm && v->hasNormal;
+        anyUV   = anyUV   && v->hasUV;
+        anyCol  = anyCol  && v->hasColor;
+        anyTan  = anyTan  && v->hasTangent;
+    }
+    r.hasNormal = anyNorm;
+    r.hasUV = anyUV;
+    r.hasColor = anyCol;
+    r.hasTangent = anyTan;
+    if (r.normal.squaredLength() > 1e-12f) r.normal.normalise();
+
+    auto addBone = [&](unsigned short idx, float weight) {
+        if (weight <= 1e-6f) return;
+        for (auto& ba : r.boneAssignments) {
+            if (ba.first == idx) { ba.second += weight; return; }
+        }
+        r.boneAssignments.emplace_back(idx, weight);
+    };
+    for (const auto* v : src) {
+        for (const auto& ba : v->boneAssignments) addBone(ba.first, ba.second * w);
+    }
+    return r;
+}
+
+// Midpoint of two HE vertices with the same attribute rules as
+// averageHEVertices. Used by the boundary-edge rule and by midpoint
+// computation for the interior smoothing R term.
+HEVertex midpointHEVertices(const HEVertex& a, const HEVertex& b)
+{
+    return averageHEVertices({&a, &b});
+}
+
+} // namespace
+
+std::vector<int> HalfEdgeMesh::subdivideCatmullClark()
+{
+    std::vector<int> newVertices;
+
+    // 0. Snapshot the live geometry. The algorithm reads from the
+    //    pre-step state for the smoothing rule, then writes new
+    //    geometry on top — so we keep a copy of every original vertex.
+    const std::vector<HEVertex> origVerts = m_vertices;
+    const int origVertexCount = static_cast<int>(origVerts.size());
+    const int origFaceCount = static_cast<int>(m_faces.size());
+    const int origEdgeCount = static_cast<int>(m_edges.size());
+    if (origVertexCount == 0 || origFaceCount == 0) return newVertices;
+
+    // 1. Compute one face point per live face. The face point is the
+    //    arithmetic mean of the face's corner vertices. Skip retired
+    //    faces (halfEdge < 0). Track the face's submesh so output
+    //    quads inherit it.
+    std::vector<int> facePointIdx(origFaceCount, -1); // HE-vertex idx of face point
+    std::vector<int> faceSubMesh(origFaceCount, -1);
+    std::vector<std::vector<int>> faceCornerIdxs(origFaceCount);
+    for (int f = 0; f < origFaceCount; ++f) {
+        if (m_faces[f].halfEdge < 0) continue;
+        const auto verts = faceVertices(f);
+        if (verts.size() < 3) continue;
+        // Cross-submesh skip: faceVertices only walks one face so the
+        // submesh check is implicit (the face IS one submesh's). The
+        // cross-submesh guard for SHARED edges happens in step 2.
+
+        std::vector<const HEVertex*> src;
+        src.reserve(verts.size());
+        for (int v : verts) src.push_back(&origVerts[v]);
+
+        HEVertex fp = averageHEVertices(src);
+        fp.halfEdge = -1;
+        facePointIdx[f] = static_cast<int>(m_vertices.size());
+        m_vertices.push_back(std::move(fp));
+        newVertices.push_back(facePointIdx[f]);
+
+        faceSubMesh[f] = m_faces[f].subMeshIndex;
+        faceCornerIdxs[f] = std::move(verts);
+    }
+
+    // 2. Compute one edge point per live edge. For an interior edge
+    //    with two adjacent faces in the SAME submesh:
+    //       Ep = (a + b + Fp1 + Fp2) / 4
+    //    For a boundary edge or a cross-submesh edge:
+    //       Ep = (a + b) / 2
+    //    Cross-submesh edges are treated as boundaries so material
+    //    seams stay sharp through the subdivision.
+    std::vector<int> edgePointIdx(origEdgeCount, -1);
+    std::vector<bool> edgeIsBoundary(origEdgeCount, false);
+    for (int e = 0; e < origEdgeCount; ++e) {
+        if (m_edges[e].halfEdge < 0) continue;
+        const auto [va, vb] = edgeVertices(e);
+        if (va < 0 || vb < 0) continue;
+        const auto [fA, fB] = edgeFaces(e);
+
+        bool boundary = (fA < 0 || fB < 0);
+        if (!boundary) {
+            // Cross-submesh = treat as boundary.
+            if (m_faces[fA].subMeshIndex != m_faces[fB].subMeshIndex)
+                boundary = true;
+        }
+        edgeIsBoundary[e] = boundary;
+
+        HEVertex ep;
+        if (boundary) {
+            ep = midpointHEVertices(origVerts[va], origVerts[vb]);
+        } else {
+            std::vector<const HEVertex*> src;
+            src.reserve(4);
+            src.push_back(&origVerts[va]);
+            src.push_back(&origVerts[vb]);
+            // Adjacent face points are stored as new HE vertices already;
+            // read their positions back from m_vertices.
+            if (facePointIdx[fA] >= 0) src.push_back(&m_vertices[facePointIdx[fA]]);
+            if (facePointIdx[fB] >= 0) src.push_back(&m_vertices[facePointIdx[fB]]);
+            ep = averageHEVertices(src);
+        }
+        ep.halfEdge = -1;
+        edgePointIdx[e] = static_cast<int>(m_vertices.size());
+        m_vertices.push_back(std::move(ep));
+        newVertices.push_back(edgePointIdx[e]);
+    }
+
+    // 3. Update each ORIGINAL vertex in place using the smoothing rule.
+    //    Use origVerts (the snapshot) for any reads — m_vertices[v] is
+    //    being overwritten in this loop. For a boundary vertex, blend
+    //    against its two boundary-edge midpoints; that keeps mesh
+    //    boundaries continuous. For an interior vertex of valence n,
+    //    use Catmull-Clark's classic formula.
+    for (int v = 0; v < origVertexCount; ++v) {
+        if (origVerts[v].halfEdge < 0) continue;
+
+        const bool boundary = isVertexBoundary(v);
+        const auto incidentFaces = facesAroundVertex(v);
+        const auto incidentEdges = edgesAroundVertex(v);
+        if (incidentFaces.empty() || incidentEdges.empty()) continue;
+
+        if (boundary) {
+            // Find the two boundary edges this vertex is on. Their
+            // mid-points (using PRE-step geometry) plus the vertex's
+            // own position averaged 1:2:1 weighted is the standard
+            // chord rule: V' = (V + Em1 + Em2) / 4 where each Em is
+            // the boundary-edge midpoint between V and the other
+            // endpoint. We pre-computed boundary edge points in step 2
+            // already, so just reuse those.
+            std::vector<const HEVertex*> src;
+            src.reserve(3);
+            src.push_back(&origVerts[v]);
+            int boundaryEpsFound = 0;
+            for (int e : incidentEdges) {
+                if (!edgeIsBoundary[e]) continue;
+                if (edgePointIdx[e] >= 0) {
+                    src.push_back(&m_vertices[edgePointIdx[e]]);
+                    ++boundaryEpsFound;
+                }
+            }
+            if (boundaryEpsFound < 2) {
+                // Non-manifold corner or weird topology — leave the
+                // vertex alone rather than smoothing into a wrong place.
+                continue;
+            }
+            // Average the 3 contributors; this is V/3 + Em1/3 + Em2/3
+            // — close to the V/4 + (Em1+Em2)/4 + (Em1+Em2)/4 chord
+            // rule but slightly more centred on V. Acceptable for the
+            // interactive editor; tighter weights are a follow-up.
+            HEVertex updated = averageHEVertices(src);
+            updated.halfEdge = origVerts[v].halfEdge; // keep outgoing HE
+            m_vertices[v] = std::move(updated);
+        } else {
+            // Interior vertex of valence n.
+            //   F = average of adjacent face points
+            //   R = average of adjacent edge MIDPOINTS (NOT the new
+            //       edge points — that's the spec; midpoint = (a+b)/2)
+            //   V' = (F + 2R + (n-3) V) / n
+            const int n = static_cast<int>(incidentEdges.size());
+            if (n < 3) continue;
+
+            // F: average of adjacent face points (in PRE-step
+            // m_vertices slots).
+            HEVertex F;
+            {
+                std::vector<const HEVertex*> src;
+                src.reserve(incidentFaces.size());
+                for (int f : incidentFaces) {
+                    if (facePointIdx[f] >= 0)
+                        src.push_back(&m_vertices[facePointIdx[f]]);
+                }
+                if (src.empty()) continue;
+                F = averageHEVertices(src);
+            }
+
+            // R: average of edge midpoints (NOT the smoothed edge
+            // points). Compute midpoints on-the-fly from origVerts.
+            HEVertex R;
+            {
+                std::vector<HEVertex> midStorage;
+                midStorage.reserve(incidentEdges.size());
+                std::vector<const HEVertex*> src;
+                src.reserve(incidentEdges.size());
+                for (int e : incidentEdges) {
+                    const auto [ea, eb] = edgeVertices(e);
+                    if (ea < 0 || eb < 0) continue;
+                    midStorage.push_back(midpointHEVertices(
+                        origVerts[ea], origVerts[eb]));
+                    src.push_back(&midStorage.back());
+                }
+                if (src.empty()) continue;
+                R = averageHEVertices(src);
+            }
+
+            // V'_position = (F + 2R + (n-3) V) / n. Apply the same
+            // weighted blend to all attributes.
+            const float invN = 1.0f / static_cast<float>(n);
+            HEVertex updated;
+            updated.position =
+                (F.position + R.position * 2.0f
+                 + origVerts[v].position * static_cast<float>(n - 3)) * invN;
+            updated.normal =
+                (F.normal + R.normal * 2.0f
+                 + origVerts[v].normal * static_cast<float>(n - 3)) * invN;
+            if (updated.normal.squaredLength() > 1e-12f)
+                updated.normal.normalise();
+            updated.uv =
+                (F.uv + R.uv * 2.0f
+                 + origVerts[v].uv * static_cast<float>(n - 3)) * invN;
+            updated.color =
+                (F.color + R.color * 2.0f
+                 + origVerts[v].color * static_cast<float>(n - 3)) * invN;
+            updated.tangent =
+                (F.tangent + R.tangent * 2.0f
+                 + origVerts[v].tangent * static_cast<float>(n - 3)) * invN;
+            updated.hasNormal = F.hasNormal && R.hasNormal && origVerts[v].hasNormal;
+            updated.hasUV = F.hasUV && R.hasUV && origVerts[v].hasUV;
+            updated.hasColor = F.hasColor && R.hasColor && origVerts[v].hasColor;
+            updated.hasTangent = F.hasTangent && R.hasTangent && origVerts[v].hasTangent;
+            // Bone weights: use the original vertex's weights — the
+            // smoothed position is still mostly "near V", so preserving
+            // V's skinning is closer to correct than averaging across
+            // unrelated neighbours.
+            updated.boneAssignments = origVerts[v].boneAssignments;
+            updated.halfEdge = origVerts[v].halfEdge;
+            m_vertices[v] = std::move(updated);
+        }
+    }
+
+    // 4. Replace each face with its quad fan. For a face with corners
+    //    [c0, c1, ..., c(N-1)], emit N quads:
+    //       quad_i = (c_i, edgePoint(c_i, c_{i+1}), facePoint, edgePoint(c_{i-1}, c_i))
+    //    The output is always quads, regardless of input N (≥3).
+    auto retireFace = [&](int faceIdx) {
+        if (faceIdx < 0) return;
+        const int startHE = m_faces[faceIdx].halfEdge;
+        if (startHE < 0) return;
+        int he = startHE;
+        do {
+            const int next = m_halfEdges[he].next;
+            m_halfEdges[he].face = -1;
+            he = next;
+        } while (he != startHE && he >= 0);
+        m_faces[faceIdx].halfEdge = -1;
+    };
+
+    auto findEdgeIdxByVerts = [&](int va, int vb) -> int {
+        // Search the LIVE edges (after step-2 the m_edges array still
+        // describes the pre-step topology; we haven't rebuilt yet).
+        for (int e = 0; e < origEdgeCount; ++e) {
+            if (m_edges[e].halfEdge < 0) continue;
+            const auto [a, b] = edgeVertices(e);
+            if ((a == va && b == vb) || (a == vb && b == va)) return e;
+        }
+        return -1;
+    };
+
+    for (int f = 0; f < origFaceCount; ++f) {
+        if (facePointIdx[f] < 0) continue;
+        const auto& corners = faceCornerIdxs[f];
+        const int N = static_cast<int>(corners.size());
+        if (N < 3) continue;
+
+        // Pre-resolve edge points for each consecutive corner pair so
+        // we don't search twice per quad.
+        std::vector<int> edgePointForSide(N, -1);
+        for (int i = 0; i < N; ++i) {
+            const int va = corners[i];
+            const int vb = corners[(i + 1) % N];
+            const int eIdx = findEdgeIdxByVerts(va, vb);
+            if (eIdx >= 0) edgePointForSide[i] = edgePointIdx[eIdx];
+        }
+
+        retireFace(f);
+
+        const int subIdx = faceSubMesh[f];
+        const int fp = facePointIdx[f];
+        for (int i = 0; i < N; ++i) {
+            const int prevSide = (i + N - 1) % N;
+            const int currSide = i;
+            const int corner = corners[i];
+            const int epPrev = edgePointForSide[prevSide];
+            const int epCurr = edgePointForSide[currSide];
+            if (epPrev < 0 || epCurr < 0) continue; // corrupt — skip
+            // Quad winding: (corner, ep_curr, face_point, ep_prev).
+            // Walking corner → ep_curr matches the direction
+            // corners[i] → corners[i+1], so the resulting quad is
+            // CCW relative to the original face's winding.
+            appendFace({corner, epCurr, fp, epPrev}, subIdx);
+        }
+    }
+
+    // 5. Rebuild edge / twin / boundary / vertex tables.
+    rebuildEdgesAndTwins();
+    compactBoundaryHalfEdges();
+    buildBoundaryHalfEdges();
+    fixVertexHalfEdges();
+
+    return newVertices;
+}
+
 int HalfEdgeMesh::fillSelection(const std::vector<int>& vertexIndices)
 {
     const int n = static_cast<int>(vertexIndices.size());

--- a/src/HalfEdgeMesh.cpp
+++ b/src/HalfEdgeMesh.cpp
@@ -32,9 +32,11 @@ THE SOFTWARE.
 #include <array>
 #include <cassert>
 #include <cmath>
+#include <cstdint>
 #include <functional>
 #include <set>
 #include <tuple>
+#include <unordered_map>
 #include <unordered_set>
 
 bool HalfEdgeMesh::buildFromEditableMesh(const EditableMesh& editableMesh)
@@ -4902,10 +4904,21 @@ std::vector<int> HalfEdgeMesh::subdivideCatmullClark()
     //    seams stay sharp through the subdivision.
     std::vector<int> edgePointIdx(origEdgeCount, -1);
     std::vector<bool> edgeIsBoundary(origEdgeCount, false);
+    // Undirected (min,max)-vertex-pair → edgeIdx hash, populated as we
+    // walk live edges below. Used by the per-side rebuild to avoid an
+    // O(F·E) linear scan per face side.
+    std::unordered_map<std::uint64_t, int> edgeIdxByVertPair;
+    edgeIdxByVertPair.reserve(static_cast<size_t>(origEdgeCount) * 2u);
+    auto packVertPair = [](int a, int b) -> std::uint64_t {
+        const std::uint32_t lo = static_cast<std::uint32_t>(std::min(a, b));
+        const std::uint32_t hi = static_cast<std::uint32_t>(std::max(a, b));
+        return (static_cast<std::uint64_t>(hi) << 32) | static_cast<std::uint64_t>(lo);
+    };
     for (int e = 0; e < origEdgeCount; ++e) {
         if (m_edges[e].halfEdge < 0) continue;
         const auto [va, vb] = edgeVertices(e);
         if (va < 0 || vb < 0) continue;
+        edgeIdxByVertPair.emplace(packVertPair(va, vb), e);
         const auto [fA, fB] = edgeFaces(e);
 
         bool boundary = (fA < 0 || fB < 0);
@@ -5076,14 +5089,9 @@ std::vector<int> HalfEdgeMesh::subdivideCatmullClark()
     };
 
     auto findEdgeIdxByVerts = [&](int va, int vb) -> int {
-        // Search the LIVE edges (after step-2 the m_edges array still
-        // describes the pre-step topology; we haven't rebuilt yet).
-        for (int e = 0; e < origEdgeCount; ++e) {
-            if (m_edges[e].halfEdge < 0) continue;
-            const auto [a, b] = edgeVertices(e);
-            if ((a == va && b == vb) || (a == vb && b == va)) return e;
-        }
-        return -1;
+        if (va < 0 || vb < 0) return -1;
+        auto it = edgeIdxByVertPair.find(packVertPair(va, vb));
+        return it == edgeIdxByVertPair.end() ? -1 : it->second;
     };
 
     for (int f = 0; f < origFaceCount; ++f) {

--- a/src/HalfEdgeMesh.h
+++ b/src/HalfEdgeMesh.h
@@ -604,6 +604,47 @@ public:
     std::vector<int> subdivideFaces(const std::vector<int>& faceIndices);
 
     /**
+     * @brief Subdivide every face by one Catmull-Clark step.
+     *
+     * The classic Catmull-Clark scheme. For each face F:
+     *  - Compute a face point Fp = average of its corner positions.
+     *  - For each edge E with endpoints (a, b) and adjacent face points
+     *    (Fp1, Fp2), compute the edge point Ep = (a + b + Fp1 + Fp2) / 4
+     *    on interior edges, or Ep = (a + b) / 2 on boundary edges.
+     *  - For each original vertex V of valence n with adjacent face
+     *    points Fi (mean F) and edge midpoints Ri (mean R, taken on
+     *    PRE-update positions), update V to (F + 2R + (n-3) V) / n on
+     *    interior vertices, or (V + Em1 + Em2) / 4 on boundary
+     *    vertices using its two boundary edge midpoints.
+     *  - Replace each face F (with n corners) by n quads, each formed
+     *    from (corner, neighbouring-edge-point, face-point,
+     *    other-neighbouring-edge-point).
+     *
+     * Output is ALWAYS quads, regardless of input — a triangle becomes
+     * 3 quads, a quad becomes 4 quads, an N-gon becomes N quads.
+     * Submesh assignments are preserved (each output quad inherits its
+     * source face's submesh).
+     *
+     * UVs / normals / colors / bone weights / tangents are blended
+     * with the same weights as positions (face point: avg of corners;
+     * edge point: avg of endpoints+adjacent face points; updated
+     * vertex: weighted blend per the rule above). For boundary
+     * vertices the chord rule keeps UV seams reasonable; geometry on
+     * a closed manifold is C¹ continuous in the limit.
+     *
+     * Skips faces that span multiple submeshes (would silently weld
+     * material groups). Cross-submesh edges are treated as boundaries
+     * for the smoothing rule, so submesh boundaries stay sharp.
+     *
+     * @return Indices of every newly created vertex (face points,
+     *         edge points, in creation order). The original vertex
+     *         slots are reused for the smoothed positions; their
+     *         indices are unchanged. Empty on no-op (all submeshes
+     *         empty / all faces invalid).
+     */
+    std::vector<int> subdivideCatmullClark();
+
+    /**
      * @brief Fill a face from selected vertices or a closed edge loop.
      *
      * Two input modes, picked by the caller:

--- a/src/HalfEdgeMesh_test.cpp
+++ b/src/HalfEdgeMesh_test.cpp
@@ -4816,3 +4816,184 @@ TEST(HalfEdgeMeshStandalone, PromoteTrianglesToFacesProducesMatchingFaces) {
     // identical content)
     EXPECT_EQ(sub.triangles.size(), 2u);
 }
+
+// ===========================================================================
+// subdivideCatmullClark — chunk 5a quad-aware subdivision
+// ===========================================================================
+
+TEST(HalfEdgeMeshStandalone, CatmullClarkOnSingleQuadProducesFourQuads) {
+    // A single quad → 1 face point + 4 edge points + 4 corners (the 4
+    // corners get smoothed in place — for a flat planar quad on a
+    // boundary, the boundary-vertex chord rule will have moved them).
+    // After CC: 4 output faces, each a quad.
+    EditableMesh em;
+    EditableSubMesh sub;
+    auto mkV = [](float x, float y, float z) {
+        EditableVertex v;
+        v.position = Ogre::Vector3(x, y, z);
+        v.normal = Ogre::Vector3(0, 0, 1); v.hasNormal = true;
+        return v;
+    };
+    sub.vertices = {
+        mkV(0, 0, 0), mkV(1, 0, 0), mkV(1, 1, 0), mkV(0, 1, 0),
+    };
+    EditableFace f;
+    f.indices = {0, 1, 2, 3};
+    sub.faces.push_back(std::move(f));
+    em.subMeshes().push_back(std::move(sub));
+
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    ASSERT_EQ(activeFaceCount(he), 1);
+
+    const auto newVerts = he.subdivideCatmullClark();
+    EXPECT_FALSE(newVerts.empty());
+    EXPECT_EQ(activeFaceCount(he), 4) << "1 quad → 4 sub-quads";
+
+    // Every output face should be a quad.
+    for (size_t f = 0; f < he.faceCount(); ++f) {
+        if (he.face(static_cast<int>(f)).halfEdge < 0) continue;
+        EXPECT_EQ(he.faceVertices(static_cast<int>(f)).size(), 4u)
+            << "Catmull-Clark always produces quads";
+    }
+    EXPECT_TRUE(he.validate());
+}
+
+TEST(HalfEdgeMeshStandalone, CatmullClarkOnTriangleProducesThreeQuads) {
+    // A single triangle → 3 sub-quads (one per corner).
+    auto em = makeTriangleMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    ASSERT_EQ(activeFaceCount(he), 1);
+
+    he.subdivideCatmullClark();
+    EXPECT_EQ(activeFaceCount(he), 3);
+    for (size_t f = 0; f < he.faceCount(); ++f) {
+        if (he.face(static_cast<int>(f)).halfEdge < 0) continue;
+        EXPECT_EQ(he.faceVertices(static_cast<int>(f)).size(), 4u);
+    }
+    EXPECT_TRUE(he.validate());
+}
+
+TEST(HalfEdgeMeshStandalone, CatmullClarkOnCubeStaysClosed) {
+    // 12-tri cube → 36 sub-quads. Output is a closed manifold (no
+    // boundary edges), and toEditableMesh round-trips through the
+    // n-gon path so all 36 faces appear in EditableSubMesh::faces.
+    auto em = makeCubeMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    ASSERT_EQ(activeFaceCount(he), 12);
+
+    he.subdivideCatmullClark();
+    EXPECT_EQ(activeFaceCount(he), 36) << "12 tris × 3 sub-quads = 36";
+    EXPECT_TRUE(he.validate());
+
+    EditableMesh back;
+    ASSERT_TRUE(he.toEditableMesh(back));
+    auto s = statsOf(back);
+    EXPECT_EQ(s.boundaryEdges, 0u)
+        << "Catmull-Clark on a closed cube must stay closed";
+    EXPECT_TRUE(isManifold(back));
+    // n-gon path: faces non-empty since output is all quads.
+    ASSERT_FALSE(back.subMeshes().empty());
+    EXPECT_FALSE(back.subMeshes()[0].faces.empty())
+        << "all-quad output should populate EditableSubMesh::faces";
+    EXPECT_EQ(back.subMeshes()[0].faces.size(), 36u);
+    for (const auto& f : back.subMeshes()[0].faces) {
+        EXPECT_EQ(f.indices.size(), 4u) << "every output face is a quad";
+    }
+}
+
+TEST(HalfEdgeMeshStandalone, CatmullClarkOnQuadGridProducesFourTimesAsManyQuads) {
+    // 2x2 grid of 4 quads → 16 sub-quads (one per corner of each face).
+    EditableMesh em;
+    EditableSubMesh sub;
+    auto mkV = [](float x, float y) {
+        EditableVertex v;
+        v.position = Ogre::Vector3(x, y, 0);
+        v.normal = Ogre::Vector3(0, 0, 1); v.hasNormal = true;
+        return v;
+    };
+    sub.vertices = {
+        mkV(0, 0), mkV(1, 0), mkV(2, 0),
+        mkV(0, 1), mkV(1, 1), mkV(2, 1),
+        mkV(0, 2), mkV(1, 2), mkV(2, 2),
+    };
+    auto mkF = [](unsigned a, unsigned b, unsigned c, unsigned d) {
+        EditableFace f;
+        f.indices = {a, b, c, d};
+        return f;
+    };
+    sub.faces = {
+        mkF(0, 1, 4, 3), mkF(1, 2, 5, 4),
+        mkF(3, 4, 7, 6), mkF(4, 5, 8, 7),
+    };
+    em.subMeshes().push_back(std::move(sub));
+
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    ASSERT_EQ(activeFaceCount(he), 4);
+
+    he.subdivideCatmullClark();
+    EXPECT_EQ(activeFaceCount(he), 16) << "4 quads × 4 sub-quads = 16";
+    EXPECT_TRUE(he.validate());
+}
+
+TEST(HalfEdgeMeshStandalone, CatmullClarkPreservesPlanarFaceCenter) {
+    // For a planar regular quad on a closed manifold (e.g. the centre
+    // of a 3x3 quad grid), the face point should land exactly at the
+    // arithmetic centre of the four corners.
+    EditableMesh em;
+    EditableSubMesh sub;
+    auto mkV = [](float x, float y) {
+        EditableVertex v;
+        v.position = Ogre::Vector3(x, y, 0);
+        v.normal = Ogre::Vector3(0, 0, 1); v.hasNormal = true;
+        return v;
+    };
+    sub.vertices = { mkV(0, 0), mkV(1, 0), mkV(1, 1), mkV(0, 1) };
+    EditableFace f;
+    f.indices = {0, 1, 2, 3};
+    sub.faces.push_back(std::move(f));
+    em.subMeshes().push_back(std::move(sub));
+
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    const auto newVerts = he.subdivideCatmullClark();
+
+    // Find the face point (the only vertex with all 4 corners as 1-ring
+    // neighbours — exactly the face point on a single-quad mesh).
+    bool foundFacePoint = false;
+    for (int v : newVerts) {
+        const auto neighbours = he.verticesAroundVertex(v);
+        if (neighbours.size() == 4) {
+            const auto& p = he.vertex(v).position;
+            EXPECT_NEAR(p.x, 0.5f, 1e-4f);
+            EXPECT_NEAR(p.y, 0.5f, 1e-4f);
+            EXPECT_NEAR(p.z, 0.0f, 1e-4f);
+            foundFacePoint = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(foundFacePoint);
+}
+
+TEST(HalfEdgeMeshStandalone, CatmullClarkEmptyMeshIsNoOp) {
+    HalfEdgeMesh he;
+    EXPECT_TRUE(he.subdivideCatmullClark().empty());
+}
+
+TEST(HalfEdgeMeshStandalone, CatmullClarkRoundTripsThroughEditableMesh) {
+    auto em = makeQuadMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    he.subdivideCatmullClark();
+
+    EditableMesh back;
+    ASSERT_TRUE(he.toEditableMesh(back));
+    HalfEdgeMesh he2;
+    ASSERT_TRUE(he2.buildFromEditableMesh(back));
+    EXPECT_TRUE(he2.validate());
+    // 2 input tris × 3 quads each = 6 output quads.
+    EXPECT_EQ(activeFaceCount(he2), 6);
+}

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -747,17 +747,29 @@ void MainWindow::initToolBar()
     });
     QAction* deleteAction = ui->objectsToolbar->addWidget(deleteButton);
 
-    // Subdivide: face mode (subdivide selected triangles, retriangulate
-    // adjacent ones to avoid T-junctions) or edge mode (subdivide every
-    // triangle incident to a selected edge — Blender convention).
+    // Subdivide: dropdown with two modes.
+    //  - Standard: 1-to-4 triangle split on the selected faces/edges
+    //    (what was always there).
+    //  - Catmull-Clark: whole-mesh subdivide-surface step. Always
+    //    produces quads regardless of input topology.
     auto subdivideButton = new QToolButton(ui->objectsToolbar);
     subdivideButton->setText(QStringLiteral("\u229E"));  // ⊞ box-plus, evokes a 4-cell split
-    subdivideButton->setToolTip(tr("Subdivide selected faces / edges"));
+    subdivideButton->setToolTip(tr("Subdivide… (Standard / Catmull-Clark)"));
     subdivideButton->setFont(topoFont);
     subdivideButton->setStyleSheet(topoBtnStyle);
-    connect(subdivideButton, &QToolButton::clicked, this, []() {
-        SentryReporter::addBreadcrumb("ui.action", "Toolbar: Subdivide");
+    subdivideButton->setPopupMode(QToolButton::InstantPopup);
+    auto subdivideMenu = new QMenu(subdivideButton);
+    auto* actSubStandard = subdivideMenu->addAction(tr("Standard (1-to-4 split, selected faces)"));
+    auto* actSubCC = subdivideMenu->addAction(tr("Catmull-Clark (whole mesh, smoothed quads)"));
+    subdivideButton->setMenu(subdivideMenu);
+
+    connect(actSubStandard, &QAction::triggered, this, []() {
+        SentryReporter::addBreadcrumb("ui.action", "Toolbar: Subdivide (standard)");
         EditModeController::instance()->subdivideSelection();
+    });
+    connect(actSubCC, &QAction::triggered, this, []() {
+        SentryReporter::addBreadcrumb("ui.action", "Toolbar: Subdivide (Catmull-Clark)");
+        EditModeController::instance()->subdivideCatmullClarkAll();
     });
     QAction* subdivideAction = ui->objectsToolbar->addWidget(subdivideButton);
 
@@ -811,9 +823,11 @@ void MainWindow::initToolBar()
         deleteButton->setEnabled((mode == 0 && hasVerts)
                               || (mode == 1 && hasEdges)
                               || (mode == 2 && hasFaces));
-        // Subdivide: needs faces (face mode) or edges (edge mode).
-        subdivideButton->setEnabled((mode == 2 && hasFaces)
-                                 || (mode == 1 && hasEdges));
+        // Subdivide: enabled whenever in edit mode. The Standard option
+        // self-gates on a face/edge selection (no-op otherwise);
+        // Catmull-Clark operates on the whole mesh and never needs a
+        // selection.
+        subdivideButton->setEnabled(true);
         // Fill: needs ≥3 verts (vertex mode) or ≥3 edges that form a
         // closed loop (edge mode — degree check happens at apply time).
         fillButton->setEnabled((mode == 0 && c->selectedVertexCount() >= 3)


### PR DESCRIPTION
## Summary
Chunk 5a of the quad migration (#326). Adds the classic Catmull-Clark subdivision-surface op on the half-edge mesh and wires it through the toolbar as a second Subdivide menu item.

Stacked on chunk 4 (#332). When chunk 4 lands on `feat/quads`, this PR's base auto-updates.

## What it does
- `HalfEdgeMesh::subdivideCatmullClark()` — one full CC step on the whole mesh. Always emits quads regardless of input topology (triangle → 3 quads, quad → 4 quads, N-gon → N quads). Geometry is smoothed via the standard rule (face points / edge points / smoothed vertex positions). Cross-submesh edges are treated as boundaries so material seams stay sharp.
- `EditModeController::subdivideCatmullClarkAll()` — wraps it with the standard pre-cancel-bevel/knife + undo-command + re-pack pipeline. Selection clears after the op.
- The Subdivide toolbar button becomes a dropdown: **Standard** (existing 1-to-4 triangle split, selected faces/edges) and **Catmull-Clark** (whole mesh, smoothed quads).

## Tests (+7 standalone)
- Single quad → 4 sub-quads.
- Single triangle → 3 sub-quads.
- Closed cube → 36 quads, no boundary edges (manifold preserved).
- 2x2 quad grid → 16 sub-quads.
- Planar quad face point lands at the arithmetic centre.
- Empty mesh is a no-op.
- Round-trip through EditableMesh preserves the all-quad output.

204 standalone tests pass (was 197; +7).

## Test plan
- [x] App builds clean.
- [x] 204 standalone tests green on macOS.
- [ ] Linux/macOS/Windows CI.
- [ ] Manual smoke: import a quad asset, Tab into Edit Mode, click Subdivide → Catmull-Clark. Mesh should subdivide once with smoothed quads.

## Deferred to follow-up chunks
- Selective Catmull-Clark (subdivide only selected faces, with proper boundary blending into unselected neighbours).
- Multi-step iteration UI (currently each click is one step).
- Quad-preserving extrude/bevel/dissolve (chunks 5b–5d in the plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)