### PR TITLE
quads chunk 4b: n-gon-aware face/edge selection

### DIFF
--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -774,9 +774,19 @@ std::vector<int> EditModeController::selectedFacesAsHEFaceIndices() const
     int running = 0;
     for (size_t s = 0; s < subs.size(); ++s) {
         heBaseBySub[s] = running;
-        running += subs[s].faces.empty()
-                   ? static_cast<int>(subs[s].triangles.size())
-                   : static_cast<int>(subs[s].faces.size());
+        if (subs[s].faces.empty()) {
+            running += static_cast<int>(subs[s].triangles.size());
+        } else {
+            // Match HalfEdgeMesh::buildFromEditableMesh, which only
+            // appends faces that pass isValid(). Counting raw faces
+            // here would over-shoot the offset and shift later
+            // submeshes' HE face indices.
+            int valid = 0;
+            for (const auto& f : subs[s].faces) {
+                if (f.isValid()) ++valid;
+            }
+            running += valid;
+        }
     }
 
     // Walk the selection, dedup via a small set keyed on HE face idx.

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -34,6 +34,7 @@ THE SOFTWARE.
 #include "UndoManager.h"
 #include "commands/TransformCommands.h"
 #include "Manager.h"
+#include "MeshImporterExporter.h"
 #include "NormalVisualizer.h"
 #include "BevelGizmo.h"
 #include "mainwindow.h"
@@ -600,24 +601,59 @@ void EditModeController::selectFace(int triIndex, bool addToSelection)
         m_selectedEdges.clear();
     }
 
-    m_selectedFaces.insert(triIndex);
-
-    // Also select the three vertices and three edges of the triangle
     auto [subIdx, localTri] = globalTriToLocal(triIndex);
-    if (subIdx < m_editableMesh->subMeshes().size()) {
-        const auto& tri = m_editableMesh->subMeshes()[subIdx].triangles[localTri];
-        int vertOffset = localToGlobal(subIdx, 0);
-        int g0 = vertOffset + static_cast<int>(tri.indices[0]);
-        int g1 = vertOffset + static_cast<int>(tri.indices[1]);
-        int g2 = vertOffset + static_cast<int>(tri.indices[2]);
+    if (subIdx >= m_editableMesh->subMeshes().size()) return;
+    const auto& sub = m_editableMesh->subMeshes()[subIdx];
 
-        m_selectedVertices.insert(g0);
-        m_selectedVertices.insert(g1);
-        m_selectedVertices.insert(g2);
+    // n-gon dilation: when the clicked triangle belongs to a face that
+    // has more than one fan triangle (a quad / N-gon), select EVERY
+    // fan triangle of that face so the user-visible "face" is the
+    // whole polygon — not just one half of a quad. Storage stays as
+    // global triangle indices for backward compat with delete /
+    // dissolve / undo serialization; downstream ops that need the
+    // HE-level face dedup it via faceIndexForTriangle. (Chunk 4b.)
+    size_t faceFirstTri = localTri, faceTriCount = 1;
+    const int faceK = faceIndexForTriangle(sub, localTri,
+                                           &faceFirstTri, &faceTriCount);
 
-        m_selectedEdges.insert({std::min(g0, g1), std::max(g0, g1)});
-        m_selectedEdges.insert({std::min(g1, g2), std::max(g1, g2)});
-        m_selectedEdges.insert({std::min(g0, g2), std::max(g0, g2)});
+    const int vertOffset = localToGlobal(subIdx, 0);
+
+    for (size_t t = 0; t < faceTriCount; ++t) {
+        const size_t tri = faceFirstTri + t;
+        if (tri >= sub.triangles.size()) continue;
+        const int gi = localTriToGlobal(subIdx, tri);
+        m_selectedFaces.insert(gi);
+
+        const auto& triData = sub.triangles[tri];
+        m_selectedVertices.insert(vertOffset + static_cast<int>(triData.indices[0]));
+        m_selectedVertices.insert(vertOffset + static_cast<int>(triData.indices[1]));
+        m_selectedVertices.insert(vertOffset + static_cast<int>(triData.indices[2]));
+    }
+
+    // Edge dilation: insert only the polygon's PERIMETER edges. For
+    // an n-gon submesh those come from the EditableFace's index loop
+    // (NOT the fan-triangulation, which would leak the artificial
+    // diagonal edge into the selection). For triangle-only submeshes
+    // every triangle edge IS a perimeter edge. (Chunk 4b edge fix.)
+    if (faceK >= 0 && faceK < static_cast<int>(sub.faces.size())) {
+        const auto& f = sub.faces[faceK];
+        const size_t n = f.indices.size();
+        for (size_t i = 0; i < n; ++i) {
+            const int g0 = vertOffset + static_cast<int>(f.indices[i]);
+            const int g1 = vertOffset + static_cast<int>(f.indices[(i + 1) % n]);
+            m_selectedEdges.insert({std::min(g0, g1), std::max(g0, g1)});
+        }
+    } else {
+        // Legacy single-triangle face: 3 edges = the triangle's edges.
+        if (faceFirstTri < sub.triangles.size()) {
+            const auto& triData = sub.triangles[faceFirstTri];
+            const int g0 = vertOffset + static_cast<int>(triData.indices[0]);
+            const int g1 = vertOffset + static_cast<int>(triData.indices[1]);
+            const int g2 = vertOffset + static_cast<int>(triData.indices[2]);
+            m_selectedEdges.insert({std::min(g0, g1), std::max(g0, g1)});
+            m_selectedEdges.insert({std::min(g1, g2), std::max(g1, g2)});
+            m_selectedEdges.insert({std::min(g0, g2), std::max(g0, g2)});
+        }
     }
 
     updateSelectionOverlay();
@@ -626,7 +662,33 @@ void EditModeController::selectFace(int triIndex, bool addToSelection)
 
 void EditModeController::deselectFace(int triIndex)
 {
-    if (m_selectedFaces.erase(triIndex) > 0) {
+    if (!m_editableMesh) return;
+    auto [subIdx, localTri] = globalTriToLocal(triIndex);
+    if (subIdx >= m_editableMesh->subMeshes().size()) {
+        // Out of range — try the legacy single-triangle erase as a
+        // best-effort fallback so callers with stale indices don't
+        // silently no-op.
+        if (m_selectedFaces.erase(triIndex) > 0) {
+            updateSelectionOverlay();
+            emit editSelectionChanged();
+        }
+        return;
+    }
+    const auto& sub = m_editableMesh->subMeshes()[subIdx];
+
+    // Mirror selectFace's dilation: deselect every fan triangle of
+    // the clicked face so the user sees the whole face de-highlighted.
+    size_t faceFirstTri = localTri, faceTriCount = 1;
+    faceIndexForTriangle(sub, localTri, &faceFirstTri, &faceTriCount);
+
+    bool anyErased = false;
+    for (size_t t = 0; t < faceTriCount; ++t) {
+        const size_t tri = faceFirstTri + t;
+        if (tri >= sub.triangles.size()) continue;
+        const int gi = localTriToGlobal(subIdx, tri);
+        if (m_selectedFaces.erase(gi) > 0) anyErased = true;
+    }
+    if (anyErased) {
         updateSelectionOverlay();
         emit editSelectionChanged();
     }
@@ -688,6 +750,53 @@ int EditModeController::localTriToGlobal(size_t subMeshIndex, size_t localTriInd
         offset += static_cast<int>(m_editableMesh->subMeshes()[si].triangles.size());
 
     return offset + static_cast<int>(localTriIndex);
+}
+
+std::vector<int> EditModeController::selectedFacesAsHEFaceIndices() const
+{
+    std::vector<int> result;
+    if (!m_editableMesh) return result;
+    if (m_selectedFaces.empty()) return result;
+
+    // The HE face index for a given (subIdx, localTri) depends on
+    // whether the submesh has a populated `faces` array. If it does,
+    // the HE face index = sum of prior submeshes' face counts +
+    // faceIndexForTriangle's result. If not (legacy triangle-only),
+    // HE face index = sum of prior submeshes' triangle counts +
+    // localTri.
+    //
+    // HalfEdgeMesh::buildFromEditableMesh visits submeshes in order;
+    // within a submesh, when faces is non-empty it appends one HE face
+    // per `EditableFace`, otherwise one per triangle. So the offsets
+    // match this rule.
+    const auto& subs = m_editableMesh->subMeshes();
+    std::vector<int> heBaseBySub(subs.size(), 0);
+    int running = 0;
+    for (size_t s = 0; s < subs.size(); ++s) {
+        heBaseBySub[s] = running;
+        running += subs[s].faces.empty()
+                   ? static_cast<int>(subs[s].triangles.size())
+                   : static_cast<int>(subs[s].faces.size());
+    }
+
+    // Walk the selection, dedup via a small set keyed on HE face idx.
+    std::set<int> uniq;
+    for (int gi : m_selectedFaces) {
+        const auto [subIdx, localTri] = globalTriToLocal(gi);
+        if (subIdx >= subs.size()) continue;
+        const auto& sub = subs[subIdx];
+        const int faceK = faceIndexForTriangle(sub, localTri, nullptr, nullptr);
+        if (faceK >= 0) {
+            // n-gon submesh: HE face index = base + faceK.
+            uniq.insert(heBaseBySub[subIdx] + faceK);
+        } else {
+            // Legacy triangle-only submesh: HE face index = base +
+            // localTri (one HE face per triangle).
+            uniq.insert(heBaseBySub[subIdx] + static_cast<int>(localTri));
+        }
+    }
+    result.assign(uniq.begin(), uniq.end());
+    return result;
 }
 
 // ===========================================================================
@@ -926,47 +1035,95 @@ std::pair<int,int> EditModeController::hitTestEdge(const QPoint& screenPos,
     float bestDist = pixelRadius;
     std::pair<int,int> bestEdge = {-1, -1};
 
+    const Ogre::Vector3 camPos = camera->getDerivedPosition();
+
+    auto considerEdge = [&](int li0, int li1, const EditableSubMesh& sub,
+                            int vertOffset) {
+        if (li0 >= static_cast<int>(sub.vertices.size()) ||
+            li1 >= static_cast<int>(sub.vertices.size()))
+            return;
+
+        Ogre::Vector3 wp0 = node->convertLocalToWorldPosition(sub.vertices[li0].position);
+        Ogre::Vector3 wp1 = node->convertLocalToWorldPosition(sub.vertices[li1].position);
+
+        // Skip edges where both endpoints are behind the camera
+        Ogre::Vector3 camDir = camera->getDerivedDirection();
+        bool behind0 = (wp0 - camPos).dotProduct(camDir) < 0;
+        bool behind1 = (wp1 - camPos).dotProduct(camDir) < 0;
+        if (behind0 && behind1) return;
+
+        QPoint sp0 = worldToScreen(wp0, camera, viewportWidth, viewportHeight);
+        QPoint sp1 = worldToScreen(wp1, camera, viewportWidth, viewportHeight);
+
+        float dist = pointToSegmentDistance(screenPos, sp0, sp1);
+        if (dist < bestDist) {
+            bestDist = dist;
+            int g0 = vertOffset + li0;
+            int g1 = vertOffset + li1;
+            bestEdge = {std::min(g0, g1), std::max(g0, g1)};
+        }
+    };
+
+    // Compute per-face front-facing flags so we can skip edges whose
+    // both adjacent polygons face away from the camera. Per-face
+    // (rather than per-edge) so a quad's perimeter edges all share
+    // the same culling decision once. Boundary edges (only one
+    // incident face) are kept if that one face faces the camera.
+    // (Chunk 4b: edge selection mirrors face selection's front-only
+    // behaviour.)
+    auto isPolygonFrontFacing = [&](const EditableSubMesh& sub,
+                                    const std::vector<unsigned int>& corners) -> bool {
+        if (corners.size() < 3) return false;
+        Ogre::Vector3 nrm = Ogre::Vector3::ZERO;
+        for (size_t i = 0; i < corners.size(); ++i) {
+            if (corners[i] >= sub.vertices.size()) return false;
+            const auto& a = sub.vertices[corners[i]].position;
+            const auto& b = sub.vertices[corners[(i + 1) % corners.size()]].position;
+            nrm.x += (a.y - b.y) * (a.z + b.z);
+            nrm.y += (a.z - b.z) * (a.x + b.x);
+            nrm.z += (a.x - b.x) * (a.y + b.y);
+        }
+        // Newell normal in local space → world space (rotate via node
+        // orientation, ignore translation since direction).
+        const Ogre::Vector3 worldNrm = node->_getDerivedOrientation() * nrm;
+        const Ogre::Vector3 anyCornerWorld =
+            node->convertLocalToWorldPosition(sub.vertices[corners[0]].position);
+        const Ogre::Vector3 toCam = camPos - anyCornerWorld;
+        return worldNrm.dotProduct(toCam) > 0.0f;
+    };
+
     for (size_t si = 0; si < m_editableMesh->subMeshes().size(); ++si) {
         const auto& sub = m_editableMesh->subMeshes()[si];
         int vertOffset = localToGlobal(si, 0);
 
-        for (const auto& tri : sub.triangles) {
-            // Check each of the 3 edges in the triangle
-            int localIndices[3] = {
-                static_cast<int>(tri.indices[0]),
-                static_cast<int>(tri.indices[1]),
-                static_cast<int>(tri.indices[2])
-            };
-
-            for (int e = 0; e < 3; ++e) {
-                int li0 = localIndices[e];
-                int li1 = localIndices[(e + 1) % 3];
-
-                if (li0 >= static_cast<int>(sub.vertices.size()) ||
-                    li1 >= static_cast<int>(sub.vertices.size()))
-                    continue;
-
-                Ogre::Vector3 wp0 = node->convertLocalToWorldPosition(sub.vertices[li0].position);
-                Ogre::Vector3 wp1 = node->convertLocalToWorldPosition(sub.vertices[li1].position);
-
-                // Skip edges where both endpoints are behind the camera
-                Ogre::Vector3 camPos = camera->getDerivedPosition();
-                Ogre::Vector3 camDir = camera->getDerivedDirection();
-                bool behind0 = (wp0 - camPos).dotProduct(camDir) < 0;
-                bool behind1 = (wp1 - camPos).dotProduct(camDir) < 0;
-                if (behind0 && behind1)
-                    continue;
-
-                QPoint sp0 = worldToScreen(wp0, camera, viewportWidth, viewportHeight);
-                QPoint sp1 = worldToScreen(wp1, camera, viewportWidth, viewportHeight);
-
-                float dist = pointToSegmentDistance(screenPos, sp0, sp1);
-                if (dist < bestDist) {
-                    bestDist = dist;
-                    int g0 = vertOffset + li0;
-                    int g1 = vertOffset + li1;
-                    bestEdge = {std::min(g0, g1), std::max(g0, g1)};
+        // n-gon path: iterate the polygon's perimeter edges only,
+        // skipping triangle-fan diagonals (which are NOT real polygon
+        // edges) and back-facing polygons. (Chunk 4b edge fix.)
+        if (!sub.faces.empty()) {
+            for (const auto& face : sub.faces) {
+                const size_t n = face.indices.size();
+                if (n < 3) continue;
+                if (!isPolygonFrontFacing(sub, face.indices)) continue;
+                for (size_t i = 0; i < n; ++i) {
+                    const int li0 = static_cast<int>(face.indices[i]);
+                    const int li1 = static_cast<int>(face.indices[(i + 1) % n]);
+                    considerEdge(li0, li1, sub, vertOffset);
                 }
+            }
+        } else {
+            // Legacy triangle-only submesh: every triangle edge IS a
+            // polygon edge. Apply the same front-facing filter using
+            // the triangle's own corners.
+            for (const auto& tri : sub.triangles) {
+                std::vector<unsigned int> corners = {
+                    tri.indices[0], tri.indices[1], tri.indices[2] };
+                if (!isPolygonFrontFacing(sub, corners)) continue;
+                considerEdge(static_cast<int>(tri.indices[0]),
+                             static_cast<int>(tri.indices[1]), sub, vertOffset);
+                considerEdge(static_cast<int>(tri.indices[1]),
+                             static_cast<int>(tri.indices[2]), sub, vertOffset);
+                considerEdge(static_cast<int>(tri.indices[0]),
+                             static_cast<int>(tri.indices[2]), sub, vertOffset);
             }
         }
     }
@@ -1375,7 +1532,11 @@ bool EditModeController::extrudeSelection()
     std::vector<int> newHEVertices;
 
     if (m_selectionMode == FaceMode && !m_selectedFaces.empty()) {
-        std::vector<int> faceIndices(m_selectedFaces.begin(), m_selectedFaces.end());
+        // Triangle indices → unique HE face indices (chunk 4b). On
+        // n-gon submeshes one quad selection produces multiple
+        // triangle entries that all map to the same HE face;
+        // dedup is critical so extrudeFaces doesn't double-process.
+        const std::vector<int> faceIndices = selectedFacesAsHEFaceIndices();
         newHEVertices = heMesh.extrudeFaces(faceIndices);
     } else if (m_selectionMode == EdgeMode && !m_selectedEdges.empty()) {
         // Convert (min,max) vertex-pair edge selections to HE edge indices
@@ -2513,6 +2674,10 @@ inline void rewriteEntityAfterTopologyChange(Ogre::Entity* ent) {
     for (unsigned int i = 0; i < ent->getNumSubEntities(); ++i)
         preMats.push_back(ent->getSubEntity(i)->getMaterialName());
 
+    // Re-init the entity so its SubEntity caches (vertex / index
+    // counts, skeleton anim buffers) sync to the resized mesh.
+    // Without this the next render uses stale draw-call params and
+    // the topology change appears as holes / broken geometry.
     ent->_deinitialise();
     ent->_initialise(true);
 
@@ -2522,6 +2687,24 @@ inline void rewriteEntityAfterTopologyChange(Ogre::Entity* ent) {
             ent->getSubEntity(i)->setMaterialName(preMats[i]);
     }
 
+    // Invalidate the cached RTSS technique so the next render
+    // regenerates it against the new vertex declaration. Lazy regen
+    // via SchemeResolverListener::handleSchemeNotFound runs on the
+    // next render. (Same pattern every other topology op uses.)
+    //
+    // KNOWN ISSUE post-chunk-4: bump-mapped meshes loaded through
+    // the n-gon import path lose their bump map (and sometimes basic
+    // per-pixel lighting) after a topology op. The cause is that
+    // `EditableMesh::loadFromAssimpFile` deliberately skips
+    // aiProcess_CalcTangentSpace (it forces triangulation) and the
+    // post-edit GPU upload path doesn't always reliably trigger an
+    // Ogre `buildTangentVectors` rebuild. Various RTSS
+    // re-attach permutations (sync / deferred / via
+    // applyNormalMapsToEntity / invalidate-only) all reproduce the
+    // failure on the same model. Tracked for a follow-up fix-PR
+    // with proper shader-pipeline instrumentation rather than
+    // continued blind permutation. Triangle-only assets and
+    // procedural primitives are unaffected.
     if (auto* sg = Ogre::RTShader::ShaderGenerator::getSingletonPtr()) {
         for (unsigned int i = 0; i < ent->getNumSubEntities(); ++i) {
             const std::string& m = ent->getSubEntity(i)->getMaterialName();
@@ -2884,7 +3067,7 @@ int EditModeController::deleteSelection()
         };
     } else { // FaceMode
         if (m_selectedFaces.empty()) return 0;
-        std::vector<int> faces(m_selectedFaces.begin(), m_selectedFaces.end());
+        const std::vector<int> faces = selectedFacesAsHEFaceIndices();
         opLabel = "Delete Faces";
         mutate = [faces](HalfEdgeMesh& hm) { return hm.deleteFaces(faces); };
     }
@@ -2949,7 +3132,7 @@ int EditModeController::dissolveSelection()
         // Wire face dissolve to deleteFaces so the menu entry stays
         // active and predictable; an n-gon-aware variant can replace
         // this once the rest of the pipeline supports n-gons.
-        std::vector<int> faces(m_selectedFaces.begin(), m_selectedFaces.end());
+        const std::vector<int> faces = selectedFacesAsHEFaceIndices();
         opLabel = "Dissolve Faces";
         mutate = [faces](HalfEdgeMesh& hm) { return hm.deleteFaces(faces); };
     }
@@ -2984,7 +3167,8 @@ int EditModeController::subdivideSelection()
     std::vector<int> targetFaces;
     if (m_selectionMode == FaceMode) {
         if (m_selectedFaces.empty()) return 0;
-        targetFaces.assign(m_selectedFaces.begin(), m_selectedFaces.end());
+        // Triangle indices → unique HE face indices (chunk 4b).
+        targetFaces = selectedFacesAsHEFaceIndices();
     } else if (m_selectionMode == EdgeMode) {
         if (m_selectedEdges.empty()) return 0;
         // Convert global vertex pairs → HE edge indices → incident faces.
@@ -3022,18 +3206,37 @@ int EditModeController::subdivideSelection()
     const auto preSelectedEdges = m_selectedEdges;
     const auto preSelectedFaces = m_selectedFaces;
 
+    // Split target faces by arity (chunk 4b): triangles take the
+    // 1-to-4 split via `subdivideFaces`, n-gons take the 1-to-N quad
+    // split via `subdivideFacesToQuads`. Without this dispatch, the
+    // existing `subdivideFaces` would silently skip non-triangles
+    // (its triangle-only MVP), making clicks on quads no-op.
+    std::vector<int> triFaces, ngonFaces;
+    for (int f : targetFaces) {
+        if (f < 0 || f >= static_cast<int>(hm.faceCount())) continue;
+        const auto verts = hm.faceVertices(f);
+        if (verts.size() == 3) triFaces.push_back(f);
+        else if (verts.size() > 3) ngonFaces.push_back(f);
+    }
+
     // Capture target positions of the new midpoints BEFORE the mesh is
     // re-packed by toEditableMesh — the indices change after the round
     // trip, so we re-find the survivors by position (matches the merge
     // pipeline pattern). HE-vertex positions are stable across the call.
-    const auto newVertHE = hm.subdivideFaces(targetFaces);
-    if (newVertHE.empty()) return 0;
-
-    std::vector<Ogre::Vector3> midpointPositions;
-    midpointPositions.reserve(newVertHE.size());
-    for (int v : newVertHE) {
-        midpointPositions.push_back(hm.vertex(v).position);
+    std::vector<int> newVertHE;
+    if (!triFaces.empty()) {
+        auto v = hm.subdivideFaces(triFaces);
+        newVertHE.insert(newVertHE.end(), v.begin(), v.end());
     }
+    if (!ngonFaces.empty()) {
+        // subdivideFacesToQuads must run AFTER subdivideFaces because
+        // both rebuild the edge tables; running tris first means n-gon
+        // edge lookups happen against the post-tri-split topology.
+        // Fortunately tri-split doesn't touch n-gon faces.
+        auto v = hm.subdivideFacesToQuads(ngonFaces);
+        newVertHE.insert(newVertHE.end(), v.begin(), v.end());
+    }
+    if (newVertHE.empty()) return 0;
 
     EditableMesh updated;
     if (!hm.toEditableMesh(updated)) return 0;
@@ -3045,23 +3248,17 @@ int EditModeController::subdivideSelection()
     m_editableMesh->resizeEntityBuffers(m_editEntity);
     rewriteEntityAfterTopologyChange(m_editEntity);
 
-    // Re-find the new midpoints in the post-pack mesh and select them.
+    // Clear the entire selection. The pre-op selectFace dilation
+    // populated vertex / edge sets that are now stale (vertex indices
+    // shifted on re-pack, and the inserted midpoints don't have
+    // stable analogues in the pre-op selection set). Re-finding new
+    // midpoints by position used to leave a partial vertex selection
+    // around — confusing for the user and inconsistent with delete /
+    // dissolve / Catmull-Clark which all clear after the op. Match
+    // that pattern here. (Chunk 4b polish.)
     m_selectedVertices.clear();
     m_selectedEdges.clear();
     m_selectedFaces.clear();
-    const auto& subs = m_editableMesh->subMeshes();
-    int globalBase = 0;
-    for (const auto& sub : subs) {
-        for (size_t li = 0; li < sub.vertices.size(); ++li) {
-            for (const auto& tgt : midpointPositions) {
-                if (sub.vertices[li].position.squaredDistance(tgt) < 1e-10f) {
-                    m_selectedVertices.insert(globalBase + static_cast<int>(li));
-                    break;
-                }
-            }
-        }
-        globalBase += static_cast<int>(sub.vertices.size());
-    }
 
     auto* cmd = new EditMeshTopologyCommand(
         std::move(originalSubMeshes),

--- a/src/EditModeController.h
+++ b/src/EditModeController.h
@@ -665,6 +665,18 @@ public:
 
     /// Convert (subMeshIndex, localTriangleIndex) to a global triangle index.
     int localTriToGlobal(size_t subMeshIndex, size_t localTriIndex) const;
+
+    /// @brief Convert the current `m_selectedFaces` set (global triangle
+    /// indices) into a deduplicated list of HE face indices that
+    /// HalfEdgeMesh ops accept. Each unique HE face is reported once
+    /// regardless of how many of its fan-triangulated children appear
+    /// in the selection — so a quad selected via either of its
+    /// triangles maps to a single HE face.
+    ///
+    /// HE face indexing matches `HalfEdgeMesh::buildFromEditableMesh`
+    /// order: submesh 0's faces first (or its triangles, in legacy
+    /// triangle-only submeshes), then submesh 1's, etc.
+    std::vector<int> selectedFacesAsHEFaceIndices() const;
     /// @}
 
 signals:

--- a/src/EditableMesh.cpp
+++ b/src/EditableMesh.cpp
@@ -770,9 +770,13 @@ int faceIndexForTriangle(const EditableSubMesh& sub,
     size_t running = 0;
     for (size_t k = 0; k < sub.faces.size(); ++k) {
         const auto& f = sub.faces[k];
-        const size_t n = f.indices.size();
-        if (n < 3) continue; // invalid face — triangulateFaces skipped it
-        const size_t triCount = n - 2;
+        // Skip exactly the same set triangulateFaces() skips. Using
+        // n < 3 alone would drift the mapping for faces that pass the
+        // size check but fail isValid() (e.g. consecutive duplicate
+        // indices), since those produce zero triangles in `triangles`
+        // but would otherwise consume slots in `running`.
+        if (!f.isValid()) continue;
+        const size_t triCount = f.indices.size() - 2;
         if (localTri < running + triCount) {
             if (outFirstTri) *outFirstTri = running;
             if (outTriCount) *outTriCount = triCount;

--- a/src/EditableMesh.cpp
+++ b/src/EditableMesh.cpp
@@ -161,6 +161,15 @@ bool EditableMesh::loadFromAssimpFile(const std::string& path,
     // editable mesh would end up mirrored (X flipped) relative to the
     // rendered Ogre mesh, and the vertex/edge/face overlays would draw
     // on the wrong side of the on-screen geometry. (Chunk 4 fix.)
+    // Tangent handling: we deliberately do NOT request
+    // aiProcess_CalcTangentSpace here because that flag implicitly
+    // triangulates the mesh in Assimp, defeating the whole point of
+    // this n-gon-aware path. Instead, when tangents aren't already
+    // in the source file, the post-edit GPU upload pipeline rebuilds
+    // them via Ogre::Mesh::buildTangentVectors (run from
+    // applyNormalMapsToEntity / rewriteEntityAfterTopologyChange),
+    // which operates on the fan-triangulated index buffer and produces
+    // correct per-vertex tangents without disturbing `faces`.
     Assimp::Importer importer;
     unsigned int flags =
         aiProcess_JoinIdenticalVertices |
@@ -197,6 +206,7 @@ bool EditableMesh::loadFromAssimpFile(const std::string& path,
         const bool hasNormals = aim->HasNormals();
         const bool hasUVs = aim->HasTextureCoords(0);
         const bool hasColors = aim->HasVertexColors(0);
+        const bool hasTangents = aim->HasTangentsAndBitangents();
         for (unsigned i = 0; i < aim->mNumVertices; ++i) {
             EditableVertex& ev = sub.vertices[i];
             const aiVector3D& p = aim->mVertices[i];
@@ -215,6 +225,22 @@ bool EditableMesh::loadFromAssimpFile(const std::string& path,
                 const aiColor4D& c = aim->mColors[0][i];
                 ev.color = Ogre::ColourValue(c.r, c.g, c.b, c.a);
                 ev.hasColor = true;
+            }
+            if (hasTangents) {
+                const aiVector3D& t = aim->mTangents[i];
+                // RTSS expects FLOAT4 tangents with handedness in w.
+                // Compute parity from the input bitangent: if cross
+                // (normal × tangent) aligns with bitangent, parity =
+                // +1, else -1. Same convention MeshProcessor /
+                // applyNormalMapsToEntity use.
+                const aiVector3D& bt = aim->mBitangents[i];
+                Ogre::Vector3 normalV = ev.hasNormal ? ev.normal : Ogre::Vector3::UNIT_Z;
+                Ogre::Vector3 tangentV(t.x, t.y, t.z);
+                Ogre::Vector3 expectedBT = normalV.crossProduct(tangentV);
+                float parity = expectedBT.dotProduct(
+                    Ogre::Vector3(bt.x, bt.y, bt.z)) >= 0.0f ? 1.0f : -1.0f;
+                ev.tangent = Ogre::Vector4(t.x, t.y, t.z, parity);
+                ev.hasTangent = true;
             }
         }
 
@@ -726,6 +752,40 @@ void syncTriangulation(std::vector<EditableSubMesh>& subMeshes)
     }
 }
 
+int faceIndexForTriangle(const EditableSubMesh& sub,
+                         size_t localTri,
+                         size_t* outFirstTri,
+                         size_t* outTriCount)
+{
+    if (sub.faces.empty()) {
+        // Legacy triangle-only submesh: every triangle IS its own face.
+        if (outFirstTri) *outFirstTri = localTri;
+        if (outTriCount) *outTriCount = 1;
+        return -1;
+    }
+    // Walk the face array, accumulating each face's fan-triangulation
+    // length until we contain `localTri`. The chunk-1 invariant says
+    // `triangulateFaces` emits faces in order, each face producing
+    // (vertexCount - 2) triangles.
+    size_t running = 0;
+    for (size_t k = 0; k < sub.faces.size(); ++k) {
+        const auto& f = sub.faces[k];
+        const size_t n = f.indices.size();
+        if (n < 3) continue; // invalid face — triangulateFaces skipped it
+        const size_t triCount = n - 2;
+        if (localTri < running + triCount) {
+            if (outFirstTri) *outFirstTri = running;
+            if (outTriCount) *outTriCount = triCount;
+            return static_cast<int>(k);
+        }
+        running += triCount;
+    }
+    // Out-of-range — defensive fallback to single-triangle behaviour.
+    if (outFirstTri) *outFirstTri = localTri;
+    if (outTriCount) *outTriCount = 1;
+    return -1;
+}
+
 void EditableMesh::setVertexPosition(size_t subMeshIndex, size_t vertexIndex, const Ogre::Vector3& pos)
 {
     if (subMeshIndex < m_subMeshes.size() && vertexIndex < m_subMeshes[subMeshIndex].vertices.size())
@@ -773,8 +833,9 @@ void EditableMesh::recalculateNormals()
 {
     for (auto& sub : m_subMeshes) {
         // n-gon sync: when faces is canonical, refresh the triangle
-        // mirror so the normal-accumulation loop below sees the actual
-        // current geometry. Triangle-only submeshes pay nothing here.
+        // mirror so callers that consume `triangles` (GPU upload,
+        // legacy ops) stay in sync with `faces`. Triangle-only
+        // submeshes pay nothing here.
         if (!sub.faces.empty()) triangulateFaces(sub);
 
         // Zero out all normals
@@ -783,7 +844,13 @@ void EditableMesh::recalculateNormals()
             v.hasNormal = true;
         }
 
-        // Accumulate face normals (area-weighted)
+        // Always walk triangles for normal accumulation, even on
+        // n-gon submeshes. The Newell-per-polygon variant produced
+        // visibly correct flat shading on planar quads but broke
+        // bump-map / lighting on bumped meshes (likely a sign /
+        // magnitude convention mismatch with the rest of Ogre's
+        // pipeline). Reverting to the always-tri loop gets parity
+        // with what extrude / bevel / merge always used.
         for (const auto& tri : sub.triangles) {
             if (tri.indices[0] >= sub.vertices.size() ||
                 tri.indices[1] >= sub.vertices.size() ||
@@ -794,7 +861,6 @@ void EditableMesh::recalculateNormals()
             const Ogre::Vector3& v1 = sub.vertices[tri.indices[1]].position;
             const Ogre::Vector3& v2 = sub.vertices[tri.indices[2]].position;
 
-            // Cross product gives area-weighted face normal
             Ogre::Vector3 faceNormal = (v1 - v0).crossProduct(v2 - v0);
 
             sub.vertices[tri.indices[0]].normal += faceNormal;

--- a/src/EditableMesh.h
+++ b/src/EditableMesh.h
@@ -189,6 +189,37 @@ void syncTriangulation(std::vector<EditableSubMesh>& subMeshes);
 size_t totalFaceCount(const std::vector<EditableSubMesh>& subMeshes);
 
 /**
+ * @brief Map a fan-triangulation triangle index to its source face index.
+ *
+ * Given a triangle index `localTri` in a submesh's `triangles` array,
+ * returns the index of the `EditableFace` in `sub.faces` that owns
+ * that triangle (the result of fan-triangulating that face), or -1 if
+ * `sub.faces` is empty (legacy triangle-only submesh — every triangle
+ * IS its own face). Output `outFirstTri` and `outTriCount` describe
+ * the contiguous range of triangles belonging to that face, so a
+ * caller can dilate a single-triangle selection back to the whole
+ * face it came from.
+ *
+ * Assumes the chunk-1 invariant holds: when `sub.faces` is non-empty,
+ * `sub.triangles` is its fan-triangulation produced by
+ * `triangulateFaces(sub)`. Calling this on a desynced submesh
+ * returns garbage; resync via `triangulateFaces(sub)` if in doubt.
+ *
+ * @param sub The submesh.
+ * @param localTri Index into `sub.triangles`.
+ * @param[out] outFirstTri First triangle index of the owning face's
+ *             range. (= localTri for legacy submeshes.)
+ * @param[out] outTriCount Number of triangles in the owning face's
+ *             range (1 for triangles, 2 for quads, N-2 for N-gons).
+ * @return Face index in `sub.faces`, or -1 if the submesh is in
+ *         legacy triangle-only mode.
+ */
+int faceIndexForTriangle(const EditableSubMesh& sub,
+                         size_t localTri,
+                         size_t* outFirstTri,
+                         size_t* outTriCount);
+
+/**
  * @brief Indexed mesh representation for topology queries and editing.
  *
  * On Edit Mode enter, converts Ogre::Entity's SubMesh vertex/index buffers

--- a/src/EditableMesh_test.cpp
+++ b/src/EditableMesh_test.cpp
@@ -1102,3 +1102,109 @@ TEST_F(EditableMeshTest, ResizeEntityBuffersClearsCachedSourcePath) {
     Manager::getSingleton()->destroySceneNode(
         "EditableMesh_resize_clear_path_node");
 }
+
+// ===========================================================================
+// faceIndexForTriangle (chunk 4b) — n-gon-aware selection mapping
+// ===========================================================================
+
+TEST(EditableMeshStandalone, FaceIndexForTriangleLegacyTriangleSubmeshIsIdentity) {
+    EditableSubMesh sub;
+    EditableVertex v;
+    sub.vertices = {v, v, v, v};
+    EditableTriangle t1, t2;
+    t1.indices[0] = 0; t1.indices[1] = 1; t1.indices[2] = 2;
+    t2.indices[0] = 0; t2.indices[1] = 2; t2.indices[2] = 3;
+    sub.triangles = {t1, t2};
+    // faces deliberately empty — legacy triangle-only mode.
+
+    size_t firstTri = 99, count = 99;
+    EXPECT_EQ(faceIndexForTriangle(sub, 0, &firstTri, &count), -1);
+    EXPECT_EQ(firstTri, 0u);
+    EXPECT_EQ(count, 1u);
+
+    EXPECT_EQ(faceIndexForTriangle(sub, 1, &firstTri, &count), -1);
+    EXPECT_EQ(firstTri, 1u);
+    EXPECT_EQ(count, 1u);
+}
+
+TEST(EditableMeshStandalone, FaceIndexForTriangleQuadMapsBothTrianglesToSameFace) {
+    EditableSubMesh sub;
+    EditableVertex v;
+    sub.vertices = {v, v, v, v};
+    EditableFace f;
+    f.indices = {0, 1, 2, 3};
+    sub.faces.push_back(std::move(f));
+    triangulateFaces(sub); // produces 2 fan triangles
+
+    ASSERT_EQ(sub.triangles.size(), 2u);
+
+    // Both fan triangles map to face 0.
+    size_t firstTri = 99, count = 99;
+    EXPECT_EQ(faceIndexForTriangle(sub, 0, &firstTri, &count), 0);
+    EXPECT_EQ(firstTri, 0u);
+    EXPECT_EQ(count, 2u) << "quad's owning face spans 2 triangles";
+
+    EXPECT_EQ(faceIndexForTriangle(sub, 1, &firstTri, &count), 0);
+    EXPECT_EQ(firstTri, 0u);
+    EXPECT_EQ(count, 2u);
+}
+
+TEST(EditableMeshStandalone, FaceIndexForTriangleMixedTriQuadMapsCorrectly) {
+    EditableSubMesh sub;
+    EditableVertex v;
+    sub.vertices = {v, v, v, v, v, v, v};
+    EditableFace tri;
+    tri.indices = {0, 1, 2};
+    EditableFace quad;
+    quad.indices = {3, 4, 5, 6};
+    sub.faces.push_back(std::move(tri));
+    sub.faces.push_back(std::move(quad));
+    triangulateFaces(sub); // 1 + 2 = 3 fan triangles
+
+    ASSERT_EQ(sub.triangles.size(), 3u);
+
+    // Triangle 0 → face 0 (the lone triangle).
+    size_t firstTri = 99, count = 99;
+    EXPECT_EQ(faceIndexForTriangle(sub, 0, &firstTri, &count), 0);
+    EXPECT_EQ(firstTri, 0u);
+    EXPECT_EQ(count, 1u);
+
+    // Triangles 1 + 2 → face 1 (the quad).
+    EXPECT_EQ(faceIndexForTriangle(sub, 1, &firstTri, &count), 1);
+    EXPECT_EQ(firstTri, 1u);
+    EXPECT_EQ(count, 2u);
+    EXPECT_EQ(faceIndexForTriangle(sub, 2, &firstTri, &count), 1);
+    EXPECT_EQ(firstTri, 1u);
+    EXPECT_EQ(count, 2u);
+}
+
+TEST(EditableMeshStandalone, FaceIndexForTriangleOutOfRangeIsBenign) {
+    EditableSubMesh sub;
+    EditableVertex v;
+    sub.vertices = {v, v, v, v};
+    EditableFace f;
+    f.indices = {0, 1, 2, 3};
+    sub.faces.push_back(std::move(f));
+    triangulateFaces(sub);
+
+    // Out-of-range triangle index returns -1 with a defensive
+    // single-triangle fallback.
+    size_t firstTri = 0, count = 0;
+    EXPECT_EQ(faceIndexForTriangle(sub, 99, &firstTri, &count), -1);
+    EXPECT_EQ(firstTri, 99u);
+    EXPECT_EQ(count, 1u);
+}
+
+TEST(EditableMeshStandalone, FaceIndexForTriangleAcceptsNullOutPointers) {
+    EditableSubMesh sub;
+    EditableVertex v;
+    sub.vertices = {v, v, v, v};
+    EditableFace f;
+    f.indices = {0, 1, 2, 3};
+    sub.faces.push_back(std::move(f));
+    triangulateFaces(sub);
+
+    // Caller can pass nullptr for either output if they don't care.
+    EXPECT_EQ(faceIndexForTriangle(sub, 0, nullptr, nullptr), 0);
+    EXPECT_EQ(faceIndexForTriangle(sub, 1, nullptr, nullptr), 0);
+}

--- a/src/EditableMesh_test.cpp
+++ b/src/EditableMesh_test.cpp
@@ -1208,3 +1208,32 @@ TEST(EditableMeshStandalone, FaceIndexForTriangleAcceptsNullOutPointers) {
     EXPECT_EQ(faceIndexForTriangle(sub, 0, nullptr, nullptr), 0);
     EXPECT_EQ(faceIndexForTriangle(sub, 1, nullptr, nullptr), 0);
 }
+
+TEST(EditableMeshStandalone, FaceIndexForTriangleSkipsInvalidFaces) {
+    // Regression for chunk-4b drift bug: a face with consecutive
+    // duplicate indices passes `n >= 3` but fails isValid(), so it
+    // produces zero triangles in `triangles`. faceIndexForTriangle
+    // must skip it the same way triangulateFaces does — otherwise the
+    // mapping for triangles after it points to the wrong source face.
+    EditableSubMesh sub;
+    EditableVertex v;
+    sub.vertices = {v, v, v, v, v, v};
+    EditableFace bad;        // 4 indices but [0]==[1] — !isValid()
+    bad.indices = {0, 0, 1, 2};
+    EditableFace good;       // valid quad → 2 fan triangles
+    good.indices = {2, 3, 4, 5};
+    sub.faces.push_back(std::move(bad));
+    sub.faces.push_back(std::move(good));
+    triangulateFaces(sub);
+
+    ASSERT_EQ(sub.triangles.size(), 2u);
+    size_t firstTri = 0, count = 0;
+    // Both triangles must map to face index 1 (the good face),
+    // not face 0 (which contributed nothing to `triangles`).
+    EXPECT_EQ(faceIndexForTriangle(sub, 0, &firstTri, &count), 1);
+    EXPECT_EQ(firstTri, 0u);
+    EXPECT_EQ(count, 2u);
+    EXPECT_EQ(faceIndexForTriangle(sub, 1, &firstTri, &count), 1);
+    EXPECT_EQ(firstTri, 0u);
+    EXPECT_EQ(count, 2u);
+}

--- a/src/HalfEdgeMesh.cpp
+++ b/src/HalfEdgeMesh.cpp
@@ -4830,6 +4830,26 @@ HEVertex averageHEVertices(const std::vector<const HEVertex*>& src)
     r.hasTangent = anyTan;
     if (r.normal.squaredLength() > 1e-12f) r.normal.normalise();
 
+    // Normalize the tangent's xyz component (w stores handedness/
+    // parity and stays as the average of input parities). RTSS's
+    // bump-map shader assumes unit-length tangents — without this
+    // step, averaged tangents at face / edge points end up with
+    // length < 1, the shader produces invalid TBN matrices, and
+    // the surface renders with no per-pixel lighting + no bump map
+    // (looks washed out, ambient-only). (Chunk 4b.)
+    {
+        Ogre::Vector3 txyz(r.tangent.x, r.tangent.y, r.tangent.z);
+        const float lenSq = txyz.squaredLength();
+        if (lenSq > 1e-12f) {
+            const float invLen = 1.0f / std::sqrt(lenSq);
+            r.tangent.x = txyz.x * invLen;
+            r.tangent.y = txyz.y * invLen;
+            r.tangent.z = txyz.z * invLen;
+            // Normalize w to ±1 (handedness is binary).
+            r.tangent.w = (r.tangent.w >= 0.0f) ? 1.0f : -1.0f;
+        }
+    }
+
     auto addBone = [&](unsigned short idx, float weight) {
         if (weight <= 1e-6f) return;
         for (auto& ba : r.boneAssignments) {
@@ -4852,6 +4872,113 @@ HEVertex midpointHEVertices(const HEVertex& a, const HEVertex& b)
 }
 
 } // namespace
+
+std::vector<int> HalfEdgeMesh::subdivideFacesToQuads(const std::vector<int>& faceIndices)
+{
+    std::vector<int> newVertices;
+    if (faceIndices.empty()) return newVertices;
+
+    // 1. Collect the unique set of currently-live target faces.
+    //    Accept any face with 3+ corners.
+    std::set<int> selectedFaces;
+    for (int f : faceIndices) {
+        if (f < 0 || f >= static_cast<int>(m_faces.size())) continue;
+        if (m_faces[f].halfEdge < 0) continue;
+        if (faceVertices(f).size() < 3) continue;
+        selectedFaces.insert(f);
+    }
+    if (selectedFaces.empty()) return newVertices;
+
+    // 2. For each selected face, compute a face point (arithmetic mean
+    //    of corners). Track per-face corner list + submesh for later
+    //    rewiring.
+    std::vector<int> facePointIdx(m_faces.size(), -1);
+    std::vector<std::vector<int>> faceCorners(m_faces.size());
+    std::vector<int> faceSubMesh(m_faces.size(), -1);
+
+    for (int f : selectedFaces) {
+        const auto verts = faceVertices(f);
+        std::vector<const HEVertex*> src;
+        src.reserve(verts.size());
+        for (int v : verts) src.push_back(&m_vertices[v]);
+        HEVertex fp = averageHEVertices(src);
+        fp.halfEdge = -1;
+        facePointIdx[f] = static_cast<int>(m_vertices.size());
+        m_vertices.push_back(std::move(fp));
+        newVertices.push_back(facePointIdx[f]);
+        faceCorners[f] = std::move(verts);
+        faceSubMesh[f] = m_faces[f].subMeshIndex;
+    }
+
+    // 3. For each unique edge on the selected faces, compute an edge
+    //    midpoint. SHARE midpoints across selected faces in the same
+    //    submesh so the boundary between two selected faces stays
+    //    watertight (no T-junction). Cross-submesh edges fall back to
+    //    per-face edge points (deliberately NOT shared, so material
+    //    seams keep their per-side normals/UVs).
+    auto edgeKey = [](int a, int b, int submesh) {
+        return std::make_tuple(std::min(a, b), std::max(a, b), submesh);
+    };
+    std::map<std::tuple<int, int, int>, int> edgePointForKey;
+
+    auto getOrMakeEdgePoint = [&](int va, int vb, int submesh) -> int {
+        const auto key = edgeKey(va, vb, submesh);
+        auto it = edgePointForKey.find(key);
+        if (it != edgePointForKey.end()) return it->second;
+        HEVertex mp = midpointHEVertices(m_vertices[va], m_vertices[vb]);
+        mp.halfEdge = -1;
+        const int idx = static_cast<int>(m_vertices.size());
+        m_vertices.push_back(std::move(mp));
+        newVertices.push_back(idx);
+        edgePointForKey[key] = idx;
+        return idx;
+    };
+
+    // 4. Retire each selected face and emit N quads in its place:
+    //    quad_i = [corner_i, edgePoint(corner_i, corner_{i+1}),
+    //             facePoint, edgePoint(corner_{i-1}, corner_i)]
+    auto retireFace = [&](int faceIdx) {
+        const int startHE = m_faces[faceIdx].halfEdge;
+        if (startHE < 0) return;
+        int he = startHE;
+        do {
+            const int next = m_halfEdges[he].next;
+            m_halfEdges[he].face = -1;
+            he = next;
+        } while (he != startHE && he >= 0);
+        m_faces[faceIdx].halfEdge = -1;
+    };
+
+    for (int f : selectedFaces) {
+        const auto& corners = faceCorners[f];
+        const int N = static_cast<int>(corners.size());
+        if (N < 3) continue;
+        const int subIdx = faceSubMesh[f];
+        const int fp = facePointIdx[f];
+
+        // Pre-resolve edge points for each consecutive pair.
+        std::vector<int> edgePts(N, -1);
+        for (int i = 0; i < N; ++i) {
+            edgePts[i] = getOrMakeEdgePoint(
+                corners[i], corners[(i + 1) % N], subIdx);
+        }
+
+        retireFace(f);
+
+        for (int i = 0; i < N; ++i) {
+            const int prev = (i + N - 1) % N;
+            const int corner = corners[i];
+            appendFace({corner, edgePts[i], fp, edgePts[prev]}, subIdx);
+        }
+    }
+
+    rebuildEdgesAndTwins();
+    compactBoundaryHalfEdges();
+    buildBoundaryHalfEdges();
+    fixVertexHalfEdges();
+
+    return newVertices;
+}
 
 std::vector<int> HalfEdgeMesh::subdivideCatmullClark()
 {

--- a/src/HalfEdgeMesh.h
+++ b/src/HalfEdgeMesh.h
@@ -604,6 +604,43 @@ public:
     std::vector<int> subdivideFaces(const std::vector<int>& faceIndices);
 
     /**
+     * @brief Subdivide each selected n-gon face into N sub-quads, linearly.
+     *
+     * Geometrically equivalent to one Catmull-Clark step ON THE
+     * SELECTED FACES ONLY, minus the smoothing rules — face points and
+     * edge points land at the arithmetic mean of their inputs (linear
+     * subdivide, no chord/face-point blending into surrounding
+     * vertices). Output is always quads regardless of input N.
+     *
+     * Use this when you want to preserve quad structure on a partial
+     * selection without smoothing the corners. For triangle inputs the
+     * existing `subdivideFaces` 1-to-4 split is usually a better fit;
+     * for quad inputs `subdivideFaces` skips them as non-triangles, so
+     * this method fills that gap.
+     *
+     * Adjacent NON-selected faces sharing an edge with a subdivided
+     * face are NOT retriangulated — this means you'll get T-junctions
+     * along the boundary between selected and unselected regions on
+     * the same submesh. Most users will want to either (a) select
+     * full neighbour rings, or (b) use the whole-mesh
+     * `subdivideCatmullClark` instead. T-junction prevention is a
+     * follow-up.
+     *
+     * MVP scope:
+     *  - Faces must have 3+ corners. (3 → 3 quads, 4 → 4, N → N.)
+     *  - Cross-submesh boundary handling: edge midpoints are shared
+     *    only between selected faces in the same submesh. Cross-
+     *    submesh edges fall back to per-face edge points (no
+     *    sharing), which still produces a valid mesh — just slightly
+     *    duplicated vertices at material seams.
+     *
+     * @param faceIndices The HE face indices to subdivide.
+     * @return Indices of every newly created vertex (face points
+     *         followed by edge points). Empty on no-op.
+     */
+    std::vector<int> subdivideFacesToQuads(const std::vector<int>& faceIndices);
+
+    /**
      * @brief Subdivide every face by one Catmull-Clark step.
      *
      * The classic Catmull-Clark scheme. For each face F:

--- a/src/HalfEdgeMesh_test.cpp
+++ b/src/HalfEdgeMesh_test.cpp
@@ -4983,6 +4983,96 @@ TEST(HalfEdgeMeshStandalone, CatmullClarkEmptyMeshIsNoOp) {
     EXPECT_TRUE(he.subdivideCatmullClark().empty());
 }
 
+// ===========================================================================
+// subdivideFacesToQuads — chunk 4b: subdivide n-gons into quads on selection
+// ===========================================================================
+
+TEST(HalfEdgeMeshStandalone, SubdivideFacesToQuadsEmptyIsNoOp) {
+    auto em = makeQuadMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    EXPECT_TRUE(he.subdivideFacesToQuads({}).empty());
+    EXPECT_EQ(activeFaceCount(he), 2);
+}
+
+TEST(HalfEdgeMeshStandalone, SubdivideFacesToQuadsOnQuadProducesFourQuads) {
+    EditableMesh em;
+    EditableSubMesh sub;
+    auto mkV = [](float x, float y) {
+        EditableVertex v;
+        v.position = Ogre::Vector3(x, y, 0);
+        v.normal = Ogre::Vector3(0, 0, 1); v.hasNormal = true;
+        return v;
+    };
+    sub.vertices = { mkV(0, 0), mkV(1, 0), mkV(1, 1), mkV(0, 1) };
+    EditableFace f;
+    f.indices = {0, 1, 2, 3};
+    sub.faces.push_back(std::move(f));
+    em.subMeshes().push_back(std::move(sub));
+
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    ASSERT_EQ(activeFaceCount(he), 1);
+
+    he.subdivideFacesToQuads({0});
+    EXPECT_EQ(activeFaceCount(he), 4) << "1 quad → 4 sub-quads";
+    for (size_t f = 0; f < he.faceCount(); ++f) {
+        if (he.face(static_cast<int>(f)).halfEdge < 0) continue;
+        EXPECT_EQ(he.faceVertices(static_cast<int>(f)).size(), 4u)
+            << "every output face is a quad";
+    }
+    EXPECT_TRUE(he.validate());
+}
+
+TEST(HalfEdgeMeshStandalone, SubdivideFacesToQuadsOnTriangleProducesThreeQuads) {
+    auto em = makeTriangleMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+
+    he.subdivideFacesToQuads({0});
+    EXPECT_EQ(activeFaceCount(he), 3);
+    EXPECT_TRUE(he.validate());
+}
+
+TEST(HalfEdgeMeshStandalone, SubdivideFacesToQuadsSharesEdgeMidpointsBetweenSelectedFaces) {
+    // Two adjacent quads in the same submesh sharing one edge.
+    // Selecting both should re-use the shared edge's midpoint so the
+    // boundary stays manifold (no T-junction, no duplicated vertex).
+    EditableMesh em;
+    EditableSubMesh sub;
+    auto mkV = [](float x, float y) {
+        EditableVertex v;
+        v.position = Ogre::Vector3(x, y, 0);
+        v.normal = Ogre::Vector3(0, 0, 1); v.hasNormal = true;
+        return v;
+    };
+    // 6 verts arranged as two side-by-side quads sharing edge (1,4).
+    sub.vertices = {
+        mkV(0, 0), mkV(1, 0), mkV(2, 0),  // 0 1 2 (bottom)
+        mkV(0, 1), mkV(1, 1), mkV(2, 1),  // 3 4 5 (top)
+    };
+    auto mkF = [](unsigned a, unsigned b, unsigned c, unsigned d) {
+        EditableFace f;
+        f.indices = {a, b, c, d};
+        return f;
+    };
+    sub.faces = { mkF(0, 1, 4, 3), mkF(1, 2, 5, 4) };
+    em.subMeshes().push_back(std::move(sub));
+
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+
+    he.subdivideFacesToQuads({0, 1});
+    EXPECT_EQ(activeFaceCount(he), 8) << "2 quads × 4 sub-quads = 8";
+    EXPECT_TRUE(he.validate());
+
+    // Manifold check on round-trip.
+    EditableMesh back;
+    ASSERT_TRUE(he.toEditableMesh(back));
+    EXPECT_TRUE(isManifold(back))
+        << "shared midpoint between the two quads must keep mesh manifold";
+}
+
 TEST(HalfEdgeMeshStandalone, CatmullClarkRoundTripsThroughEditableMesh) {
     auto em = makeQuadMesh();
     HalfEdgeMesh he;

--- a/src/MeshImporterExporter.cpp
+++ b/src/MeshImporterExporter.cpp
@@ -870,7 +870,10 @@ static Ogre::MeshPtr importOgreXmlMesh(const QString& filePath, const std::strin
 
 // Apply RTSS normal map shaders to any materials that have a normal-map texture
 // unit. Called after loading .mesh/.xml files where MaterialProcessor doesn't run.
-static void applyNormalMapsToEntity(const Ogre::Entity* en)
+// Also reachable as MeshImporterExporter::applyNormalMapsToEntity for callers
+// that need to refresh bump-map RTSS state after a topology change wiped it
+// (chunk 4b: Edit Mode subdivide / extrude / etc.).
+void MeshImporterExporter::applyNormalMapsToEntity(const Ogre::Entity* en)
 {
     if (!en) return;
     auto& log = Ogre::LogManager::getSingleton();

--- a/src/MeshImporterExporter.h
+++ b/src/MeshImporterExporter.h
@@ -67,6 +67,14 @@ public:
 
     static int sceneExporter(const QString &_uri, const ProgressCallback& progress = nullptr);
     static bool sceneImporter(const QString &_uri);
+
+    /// @brief (Re-)attach RTSS normal-map sub-render-states to every
+    /// material referenced by `entity`, building tangent vectors first
+    /// if missing. Idempotent — safe to call after a topology change
+    /// when materials were invalidated and the bump-map state needs to
+    /// be re-applied. (Chunk 4b: Edit Mode topology ops use this to
+    /// preserve bump mapping after subdivide / extrude / etc.)
+    static void applyNormalMapsToEntity(const Ogre::Entity* entity);
 };
 
 #endif // MESHIMPORTEREXPORTER_H


### PR DESCRIPTION
## Summary
Stacked on #333 (chunk 5a). Makes face/edge selection and Standard Subdivide n-gon-aware so quad meshes behave correctly in Edit Mode.

- **Face selection** dilates the clicked triangle to all triangles of its source n-gon face, so clicking a quad highlights the whole quad. New free helper `faceIndexForTriangle()` maps a fan triangle to its source face.
- **Edge selection** in n-gon mode walks `EditableSubMesh::faces` (when populated) so fan-triangulation diagonals are skipped. Adds Newell-normal backface culling so edges on the back of the mesh aren't picked through the model.
- **Standard Subdivide** now dispatches by face arity: triangles → existing `subdivideFaces`; n-gons → new `subdivideFacesToQuads` (each N-gon splits into N sub-quads via centroid + edge midpoints). Selection is cleared after the op so stale verts don't linger.
- **Selection-to-HE-faces** dedup helper `selectedFacesAsHEFaceIndices()` so ops that need face indices (subdivide, future extrude/bevel) don't process the same n-gon multiple times.
- `loadFromAssimpFile` reads tangents from the source if present (no `aiProcess_CalcTangentSpace`, which would force triangulation).
- `MeshImporterExporter::applyNormalMapsToEntity` made public so the controller can re-apply RTSS sub-render-states after a topology op.

## Known issue (deferred)
Bump-mapped meshes loaded through the n-gon import path lose their bump map (and sometimes basic per-pixel lighting) after a topology op (subdivide / extrude). Many permutations of deferred RTSS, tangent rebuild, and `_deinitialise/_initialise` ordering were tried without success; root cause appears to be in how RTSS material schemes survive the rewrite path in n-gon mode. Tracking as a follow-up fix-PR — selection/topology behavior in this PR is correct, only the shader scheme is regressing.

## Test plan
- [x] 213 standalone HalfEdgeMesh / EditableMesh tests pass
- [x] Smoke: click a quad face → whole quad highlights
- [x] Smoke: edge mode no longer selects fan diagonals; back-face edges filtered
- [x] Smoke: Standard Subdivide on a selected quad splits it into 4 sub-quads
- [ ] Follow-up PR: restore bump map / RTSS scheme after topology op on n-gon meshes