### PR TITLE
quads: n-gon splitEdge + extrude/dissolve/merge fixes

### DIFF
--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -1572,10 +1572,33 @@ bool EditModeController::extrudeSelection()
     if (newHEVertices.empty())
         return false;
 
-    // Offset new vertices slightly along adjacent face normals so side-wall
-    // triangles have non-zero area (avoids NaN normals and bad shading).
+    // Offset new vertices slightly along the average normal of the
+    // top faces (the ones whose vertices are ALL new — i.e. the
+    // extruded caps). Side-wall faces, which mix old and new verts,
+    // are skipped so the offset only pushes the cap outward. Without
+    // this, the side-wall faces have zero area and shading goes bad.
+    //
+    // n-gon-aware: use Newell's method instead of the triangle-only
+    // cross product so quad / pentagon caps (the result of extruding
+    // an n-gon face) contribute correctly. The triangle path was a
+    // strict `verts.size() != 3` skip, which made every offset zero
+    // on quad-imported assets — and selection-by-position then
+    // matched the OLD un-offset vertex coords, leaving the user with
+    // the pre-extrude vertices selected.
     const float EXTRUDE_OFFSET = 0.01f;
     std::set<int> newVertSet(newHEVertices.begin(), newHEVertices.end());
+    auto newellNormal = [&](const std::vector<int>& verts) {
+        Ogre::Vector3 nrm = Ogre::Vector3::ZERO;
+        const size_t N = verts.size();
+        for (size_t i = 0; i < N; ++i) {
+            const auto& a = heMesh.vertex(verts[i]).position;
+            const auto& b = heMesh.vertex(verts[(i + 1) % N]).position;
+            nrm.x += (a.y - b.y) * (a.z + b.z);
+            nrm.y += (a.z - b.z) * (a.x + b.x);
+            nrm.z += (a.x - b.x) * (a.y + b.y);
+        }
+        return nrm;
+    };
     std::map<int, Ogre::Vector3> offsets;
     for (int heVert : newHEVertices) {
         auto adjFaces = heMesh.facesAroundVertex(heVert);
@@ -1583,13 +1606,14 @@ bool EditModeController::extrudeSelection()
         int count = 0;
         for (int fi : adjFaces) {
             auto verts = heMesh.faceVertices(fi);
-            if (verts.size() != 3) continue;
-            if (!newVertSet.count(verts[0]) || !newVertSet.count(verts[1]) || !newVertSet.count(verts[2]))
-                continue;
-            Ogre::Vector3 v0 = heMesh.vertex(verts[0]).position;
-            Ogre::Vector3 v1 = heMesh.vertex(verts[1]).position;
-            Ogre::Vector3 v2 = heMesh.vertex(verts[2]).position;
-            Ogre::Vector3 n = (v1 - v0).crossProduct(v2 - v0);
+            if (verts.size() < 3) continue;
+            // Top face = every vertex is in the new-vertex set.
+            bool allNew = true;
+            for (int v : verts) {
+                if (!newVertSet.count(v)) { allNew = false; break; }
+            }
+            if (!allNew) continue;
+            Ogre::Vector3 n = newellNormal(verts);
             if (n.length() > 1e-8f) {
                 n.normalise();
                 avgNormal += n;
@@ -2476,30 +2500,13 @@ bool EditModeController::commitKnife()
     // of mesh edges. OnFace/OnVertex clicks aren't yet in scope — the
     // commit skips them and proceeds on the OnEdge subset.
     //
-    // splitEdge — the primitive cutPath uses — is a triangle-only MVP
-    // (n-gon support requires ear-clip-aware rewiring). On a quad-
-    // imported mesh, every face is an n-gon and splitEdge bails
-    // immediately, so knife silently fails. Workaround until a proper
-    // n-gon splitEdge lands: build the HE from a triangle-mode COPY
-    // (clear `.faces` so buildFromEditableMesh falls back to the
-    // fan-triangulated `.triangles` mirror). The user gets a working
-    // knife at the cost of materialising the fan diagonals on every
-    // submesh the cut touches. Tracked as a follow-up.
-    EditableMesh triOnly;
-    triOnly.subMeshes() = m_editableMesh->subMeshes();
-    // Remember which submeshes were originally n-gon-canonical
-    // (`!faces.empty()`) so we can restore them post-write-back. Without
-    // this, a knife on submesh 0 would convert every untouched submesh
-    // to fan triangles globally (since toEditableMesh writes back from
-    // the all-triangulated HE).
-    std::vector<bool> wasNGonSub;
-    wasNGonSub.reserve(triOnly.subMeshes().size());
-    for (auto& sub : triOnly.subMeshes()) {
-        wasNGonSub.push_back(!sub.faces.empty());
-        sub.faces.clear();
-    }
+    // splitEdge is now n-gon-aware: it inserts vMid into each adjacent
+    // face's loop without introducing a fan diagonal. cutPath's walk
+    // calls splitFace explicitly to materialise the cut between
+    // consecutive vertices. So we can build the HE directly from the
+    // (possibly n-gon) editable mesh — no triangle-mode workaround.
     HalfEdgeMesh hm;
-    if (!hm.buildFromEditableMesh(triOnly)) {
+    if (!hm.buildFromEditableMesh(*m_editableMesh)) {
         cancelKnife();
         return false;
     }
@@ -2570,34 +2577,7 @@ bool EditModeController::commitKnife()
         cancelKnife();
         return false;
     }
-
-    // Determine which submeshes the cut actually touched. A cut creates
-    // new vertices either at edge clicks or at interior crossings; each
-    // new vertex lives on faces in the submesh(es) it pierced.
-    // toEditableMesh writes EVERY submesh as triangle-only (since the
-    // HE was triangulated up-front), so without restoring untouched
-    // n-gon submeshes back from the original snapshot, a single knife
-    // op would silently convert unrelated submeshes to fan triangles.
-    // (Codex P1 review on this PR.)
-    std::set<int> touchedSubs;
-    for (int v : cutVerts) {
-        for (int f : hm.facesAroundVertex(v)) {
-            touchedSubs.insert(hm.face(f).subMeshIndex);
-        }
-    }
-    auto& outSubs = updated.subMeshes();
-    for (size_t s = 0;
-         s < outSubs.size() && s < originalSubMeshes.size() && s < wasNGonSub.size();
-         ++s) {
-        if (touchedSubs.count(static_cast<int>(s))) continue;
-        if (!wasNGonSub[s]) continue; // already triangle-only — nothing to restore
-        // Untouched + originally n-gon → restore the original submesh
-        // verbatim. resizeEntityBuffers consumes both `triangles` and
-        // bone assignments, so we want the full pre-cut state.
-        outSubs[s] = originalSubMeshes[s];
-    }
-
-    m_editableMesh->subMeshes() = std::move(outSubs);
+    m_editableMesh->subMeshes() = std::move(updated.subMeshes());
     m_editableMesh->resizeEntityBuffers(m_editEntity);
 
     rewriteEntityAfterTopologyChange(m_editEntity);
@@ -3647,18 +3627,11 @@ bool EditModeController::knifeHitTest(const QPoint& screenPos, OgreWidget* widge
             rD = worldToLocal.linear() * rD;
         }
 
-        // Build the HE from a triangle-mode COPY of the editable mesh,
-        // mirroring what the knife commit path does. Otherwise the HE
-        // edge indices we record on the click here (n-gon HE: one edge
-        // per polygon side) wouldn't match the indices `commitKnife`
-        // resolves against (triangle HE: one edge per fan side), and
-        // every cut would land on the wrong edge — manifesting as a
-        // knife that "does nothing" on quad-imported assets.
-        EditableMesh triOnly;
-        triOnly.subMeshes() = m_editableMesh->subMeshes();
-        for (auto& sub : triOnly.subMeshes()) sub.faces.clear();
+        // Build the HE directly from the (possibly n-gon) editable mesh.
+        // splitEdge is now n-gon-aware so commitKnife uses the same
+        // build, and edge indices line up between hit-test and commit.
         HalfEdgeMesh tmp;
-        if (tmp.buildFromEditableMesh(triOnly)) {
+        if (tmp.buildFromEditableMesh(*m_editableMesh)) {
             constexpr float kPixelRadius = 10.0f;
             float bestDepth = std::numeric_limits<float>::infinity();
             int bestEdgeIdx = -1;

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -943,6 +943,57 @@ int EditModeController::hitTestVertex(const QPoint& screenPos,
     if (!node)
         return -1;
 
+    // Build the front-facing vertex set so we never snap to a vertex
+    // hidden behind a visible front-facing face. Mirrors the chunk-4b
+    // edge / face hit-test behaviour. A polygon is front-facing when
+    // its Newell normal (rotated into world space) points toward the
+    // camera; a vertex is front-facing iff at least one incident
+    // polygon does.
+    const Ogre::Vector3 camPos = camera->getDerivedPosition();
+    auto isPolygonFrontFacing = [&](const EditableSubMesh& sub,
+                                    const std::vector<unsigned int>& corners) -> bool {
+        if (corners.size() < 3) return false;
+        Ogre::Vector3 nrm = Ogre::Vector3::ZERO;
+        for (size_t i = 0; i < corners.size(); ++i) {
+            if (corners[i] >= sub.vertices.size()) return false;
+            const auto& a = sub.vertices[corners[i]].position;
+            const auto& b = sub.vertices[corners[(i + 1) % corners.size()]].position;
+            nrm.x += (a.y - b.y) * (a.z + b.z);
+            nrm.y += (a.z - b.z) * (a.x + b.x);
+            nrm.z += (a.x - b.x) * (a.y + b.y);
+        }
+        const Ogre::Vector3 worldNrm = node->_getDerivedOrientation() * nrm;
+        const Ogre::Vector3 anyCornerWorld =
+            node->convertLocalToWorldPosition(sub.vertices[corners[0]].position);
+        return worldNrm.dotProduct(camPos - anyCornerWorld) > 0.0f;
+    };
+    std::set<int> frontVerts;
+    {
+        int vertOffset = 0;
+        for (size_t si = 0; si < m_editableMesh->subMeshes().size(); ++si) {
+            const auto& sub = m_editableMesh->subMeshes()[si];
+            auto recordFrontPoly = [&](const std::vector<unsigned int>& corners) {
+                for (unsigned int c : corners)
+                    frontVerts.insert(vertOffset + static_cast<int>(c));
+            };
+            if (!sub.faces.empty()) {
+                for (const auto& face : sub.faces) {
+                    if (face.indices.size() < 3) continue;
+                    if (!isPolygonFrontFacing(sub, face.indices)) continue;
+                    recordFrontPoly(face.indices);
+                }
+            } else {
+                for (const auto& tri : sub.triangles) {
+                    std::vector<unsigned int> corners = {
+                        tri.indices[0], tri.indices[1], tri.indices[2] };
+                    if (!isPolygonFrontFacing(sub, corners)) continue;
+                    recordFrontPoly(corners);
+                }
+            }
+            vertOffset += static_cast<int>(sub.vertices.size());
+        }
+    }
+
     float bestDistSq = pixelRadius * pixelRadius;
     int bestIndex = -1;
     int globalOffset = 0;
@@ -951,6 +1002,9 @@ int EditModeController::hitTestVertex(const QPoint& screenPos,
         const auto& sub = m_editableMesh->subMeshes()[si];
         for (size_t vi = 0; vi < sub.vertices.size(); ++vi) {
             int globalIdx = globalOffset + static_cast<int>(vi);
+
+            // Skip back-face vertices: not in any front-facing polygon.
+            if (!frontVerts.count(globalIdx)) continue;
 
             // Transform from local space to world space
             Ogre::Vector3 worldPos = node->convertLocalToWorldPosition(sub.vertices[vi].position);
@@ -1807,8 +1861,27 @@ bool EditModeController::applyBevelTopology(
     if (edges.empty() || width <= 0.0f)
         return false;
 
+    // bevelEdges still carries triangle-only assumptions internally
+    // (effectiveWidth uses face "third vertex", retriangulateBeveledFace
+    // assumes a 3-vertex source face). On quad-imported meshes the
+    // result is a no-op or invisible chamfer — the bevel runs but the
+    // topology never produces visible new geometry. Workaround until a
+    // proper n-gon-aware bevel lands: build the HE from a triangle-mode
+    // copy (clear `.faces` so buildFromEditableMesh falls back to the
+    // fan-triangulated `.triangles` mirror), and restore untouched
+    // n-gon submeshes verbatim after `toEditableMesh` writes back.
+    // Same shape as the pre-#41 knife workaround.
+    EditableMesh triOnly;
+    triOnly.subMeshes() = m_editableMesh->subMeshes();
+    std::vector<bool> wasNGonSub;
+    wasNGonSub.reserve(triOnly.subMeshes().size());
+    auto originalSubMeshes = m_editableMesh->subMeshes();
+    for (auto& sub : triOnly.subMeshes()) {
+        wasNGonSub.push_back(!sub.faces.empty());
+        sub.faces.clear();
+    }
     HalfEdgeMesh heMesh;
-    if (!heMesh.buildFromEditableMesh(*m_editableMesh))
+    if (!heMesh.buildFromEditableMesh(triOnly))
         return false;
 
     // Convert (min,max) vertex-pair edges to HE edge indices.
@@ -1840,7 +1913,30 @@ bool EditModeController::applyBevelTopology(
     if (!heMesh.toEditableMesh(newMesh))
         return false;
 
-    m_editableMesh->subMeshes() = std::move(newMesh.subMeshes());
+    // Submesh-level restore: bring back any submesh that was originally
+    // n-gon-canonical and the bevel didn't actually touch. This avoids
+    // multi-submesh assets losing their quads on submeshes the bevel
+    // never reached. On a single-submesh asset the touched-set covers
+    // everything, so the touched submesh is fully triangulated — that's
+    // an accepted trade-off until a properly n-gon-aware bevel lands
+    // (the bevel HE algorithm itself still has triangle-only retri-
+    // angulation paths).
+    std::set<int> touchedSubs;
+    for (int v : newHEVertices) {
+        for (int f : heMesh.facesAroundVertex(v)) {
+            touchedSubs.insert(heMesh.face(f).subMeshIndex);
+        }
+    }
+    auto& outSubs = newMesh.subMeshes();
+    for (size_t s = 0;
+         s < outSubs.size() && s < originalSubMeshes.size() && s < wasNGonSub.size();
+         ++s) {
+        if (touchedSubs.count(static_cast<int>(s))) continue;
+        if (!wasNGonSub[s]) continue;
+        outSubs[s] = originalSubMeshes[s];
+    }
+
+    m_editableMesh->subMeshes() = std::move(outSubs);
 
     // Full normal recompute — cheaper options (selective by proximity) turned
     // out to leave seams around the beveled region where the neighbor faces
@@ -1903,8 +1999,19 @@ bool EditModeController::applyBevelVertexTopology(
     if (vertexIndices.empty() || width <= 0.0f)
         return false;
 
+    // Same triangle-mode workaround as applyBevelTopology — bevelVertices
+    // shares the triangle-only retriangulation path with bevelEdges.
+    EditableMesh triOnly;
+    triOnly.subMeshes() = m_editableMesh->subMeshes();
+    std::vector<bool> wasNGonSub;
+    wasNGonSub.reserve(triOnly.subMeshes().size());
+    auto originalSubMeshes = m_editableMesh->subMeshes();
+    for (auto& sub : triOnly.subMeshes()) {
+        wasNGonSub.push_back(!sub.faces.empty());
+        sub.faces.clear();
+    }
     HalfEdgeMesh heMesh;
-    if (!heMesh.buildFromEditableMesh(*m_editableMesh))
+    if (!heMesh.buildFromEditableMesh(triOnly))
         return false;
 
     // Map global selection indices to HE indices by position match.
@@ -1946,7 +2053,24 @@ bool EditModeController::applyBevelVertexTopology(
     if (!heMesh.toEditableMesh(newMesh))
         return false;
 
-    m_editableMesh->subMeshes() = std::move(newMesh.subMeshes());
+    // Submesh-level restore (see applyBevelTopology for the rationale
+    // and trade-off).
+    std::set<int> touchedSubs;
+    for (int v : newHEVertices) {
+        for (int f : heMesh.facesAroundVertex(v)) {
+            touchedSubs.insert(heMesh.face(f).subMeshIndex);
+        }
+    }
+    auto& outSubs = newMesh.subMeshes();
+    for (size_t s = 0;
+         s < outSubs.size() && s < originalSubMeshes.size() && s < wasNGonSub.size();
+         ++s) {
+        if (touchedSubs.count(static_cast<int>(s))) continue;
+        if (!wasNGonSub[s]) continue;
+        outSubs[s] = originalSubMeshes[s];
+    }
+
+    m_editableMesh->subMeshes() = std::move(outSubs);
 
     if (m_normalsMode == 0)
         m_editableMesh->recalculateNormals();

--- a/src/HalfEdgeMesh.cpp
+++ b/src/HalfEdgeMesh.cpp
@@ -3714,56 +3714,55 @@ int HalfEdgeMesh::splitEdge(int edgeIdx, float t)
     constexpr float kEps = 1e-4f;
     t = std::clamp(t, kEps, 1.0f - kEps);
 
-    // Collect the two adjacent triangle descriptions while the old
-    // topology is still intact. Both faces must be triangles for this
-    // MVP; n-gon splitting needs ear-clip-aware rewiring.
-    struct TriFace {
-        int face;           // face index (for submesh lookup)
-        int subMeshIndex;
-        int vFrom;          // edge endpoint (start)
-        int vTo;            // edge endpoint (end)
-        int vOpp;           // third triangle vertex
-        int heFrom, heTo, heOpp; // the three half-edges of the triangle
+    // Describe one adjacent face: capture its vertex loop, the index
+    // of the shared edge's start vertex within that loop, and the
+    // submesh. The shared edge runs (loop[shareIdx] → loop[shareIdx+1])
+    // in this face's winding direction. n-gon-aware: any face arity
+    // ≥ 3 is supported. (The previous triangle-only MVP introduced fan
+    // diagonals on quads — see commit history.)
+    struct LoopFace {
+        int face = -1;
+        int subMeshIndex = 0;
+        std::vector<int> verts; // face loop in winding order
+        int shareIdx = -1;      // verts[shareIdx] == vFrom of shared edge
     };
 
-    auto describeFace = [&](int he, TriFace& out) -> bool {
+    auto describeFace = [&](int he, LoopFace& out) -> bool {
         if (he < 0 || he >= static_cast<int>(m_halfEdges.size())) return false;
         if (m_halfEdges[he].face < 0) return false;
         const int fIdx = m_halfEdges[he].face;
-        const auto verts = faceVertices(fIdx);
-        if (verts.size() != 3) return false;
-
-        // Identify which HE of the triangle is the one carrying `edgeIdx`.
-        // Traverse the face loop starting at the face's HE; the HE pointing
-        // "to" heVertex of `he` is the one sharing edgeIdx. Fill TriFace
-        // in face-loop order so we keep winding.
+        if (fIdx >= static_cast<int>(m_faces.size())) return false;
         const int startHE = m_faces[fIdx].halfEdge;
-        int he0 = startHE;
-        int he1 = m_halfEdges[he0].next;
-        int he2 = m_halfEdges[he1].next;
-        int heIndices[3] = {he0, he1, he2};
+        if (startHE < 0) return false;
 
-        int shareIdx = -1;
-        for (int i = 0; i < 3; ++i) {
-            if (heIndices[i] == he) { shareIdx = i; break; }
-        }
-        if (shareIdx < 0) return false;
+        // Walk the face HE ring; `loop[i]` = the "to" vertex of the i-th
+        // HE in face winding order. The HE found at position `pos` points
+        // TO `loop[pos]`, so the shared edge runs from `loop[pos-1]` to
+        // `loop[pos]` in this face's winding. We record the loop and the
+        // "from" position (pos-1) so insertions can place vMid right
+        // after that vertex.
+        std::vector<int> loop;
+        int pos = -1;
+        int cursor = startHE;
+        int i = 0;
+        do {
+            if (cursor == he) pos = i;
+            loop.push_back(m_halfEdges[cursor].vertex);
+            cursor = m_halfEdges[cursor].next;
+            ++i;
+            if (i > 1024) return false; // runaway guard
+        } while (cursor != startHE);
+        if (pos < 0 || loop.size() < 3) return false;
 
+        const int n = static_cast<int>(loop.size());
         out.face = fIdx;
         out.subMeshIndex = m_faces[fIdx].subMeshIndex;
-        out.heFrom = heIndices[shareIdx];
-        out.heTo   = heIndices[(shareIdx + 1) % 3];
-        out.heOpp  = heIndices[(shareIdx + 2) % 3];
-
-        // Vertex layout: heFrom.prev.vertex -> heFrom.vertex -> heTo.vertex.
-        // The shared edge goes vFrom -> vTo. The third vertex is heTo.vertex.
-        out.vFrom = m_halfEdges[out.heOpp].vertex;
-        out.vTo   = m_halfEdges[out.heFrom].vertex;
-        out.vOpp  = m_halfEdges[out.heTo].vertex;
+        out.verts = std::move(loop);
+        out.shareIdx = (pos - 1 + n) % n; // position of edge's "from" vertex
         return true;
     };
 
-    TriFace fA{}, fB{};
+    LoopFace fA{}, fB{};
     const bool hasA = describeFace(heA, fA);
     const int heB = m_halfEdges[heA].twin;
     const bool hasValidB = (heB >= 0);
@@ -3771,50 +3770,71 @@ int HalfEdgeMesh::splitEdge(int edgeIdx, float t)
 
     if (!hasA && !hasB) return -1;
 
-    // splitEdge is a triangle-only MVP: if either adjacent face exists
-    // and isn't a triangle, bail before we mutate. Partially splitting
-    // would desync the other side's half-edge pointers against a face
-    // that's still an n-gon, producing silent topology corruption.
-    // (A face "exists" here means its twin is non-boundary. Boundary
-    // half-edges — face == -1 — are fine.)
-    if (!hasA && m_halfEdges[heA].face >= 0) return -1;
-    if (!hasB && hasValidB && m_halfEdges[heB].face >= 0) return -1;
+    // Edge direction is fA.verts[shareIdx] → fA.verts[shareIdx+1] (with t
+    // measured from vFrom in this direction). If only fB exists (the edge
+    // sits on the boundary on the A side), fB winds the opposite way, so
+    // we read vFrom from its loop directly without flipping t.
+    auto edgeStart = [](const LoopFace& f) {
+        return f.verts[f.shareIdx];
+    };
+    auto edgeEnd = [](const LoopFace& f) {
+        return f.verts[(f.shareIdx + 1) % f.verts.size()];
+    };
+    int vFrom, vTo;
+    if (hasA) {
+        vFrom = edgeStart(fA);
+        vTo   = edgeEnd(fA);
+    } else {
+        // fB winds opposite, so its "start of shared edge" is our vTo.
+        vFrom = edgeEnd(fB);
+        vTo   = edgeStart(fB);
+    }
 
-    // Edge direction is fA.vFrom -> fA.vTo (with t measured from vFrom).
-    // If only fB exists (the edge sits on the boundary on the A side),
-    // fB.vFrom / fB.vTo run in the opposite direction, so re-measure t.
-    int vFrom = hasA ? fA.vFrom : fB.vTo;
-    int vTo   = hasA ? fA.vTo   : fB.vFrom;
-
-    // Create the midpoint vertex.
+    // Create the midpoint vertex from the linearly-interpolated endpoint
+    // attributes (positions, normals, UVs, bone weights, tangents).
     HEVertex mid = interpolateVertex(m_vertices[vFrom], m_vertices[vTo], t);
     mid.halfEdge = -1;
     const int vMid = static_cast<int>(m_vertices.size());
     m_vertices.push_back(std::move(mid));
 
-    // Retire a face: set each of its half-edges' face to -1 and clear the
-    // face slot's halfEdge pointer so the four-call cleanup drops them.
-    auto retireFace = [&](const TriFace& tf) {
-        m_halfEdges[tf.heFrom].face = -1;
-        m_halfEdges[tf.heTo].face = -1;
-        m_halfEdges[tf.heOpp].face = -1;
-        m_faces[tf.face].halfEdge = -1;
+    // Retire a face: walk its HE loop and clear face pointers so the
+    // four-call cleanup drops them. Generic over face arity.
+    auto retireFace = [&](int fIdx) {
+        if (fIdx < 0 || fIdx >= static_cast<int>(m_faces.size())) return;
+        const int startHE = m_faces[fIdx].halfEdge;
+        if (startHE < 0) return;
+        int he = startHE;
+        do {
+            const int next = m_halfEdges[he].next;
+            m_halfEdges[he].face = -1;
+            he = next;
+        } while (he != startHE && he >= 0);
+        m_faces[fIdx].halfEdge = -1;
+    };
+
+    // Replace each adjacent face with ONE new face that has vMid
+    // inserted between the shared edge's endpoints. A triangle becomes
+    // a quad, a quad becomes a pentagon, etc. — no artificial fan
+    // diagonal. This is the change that lets knife / loop cut produce
+    // real quads instead of fan-triangulating the affected faces.
+    auto rebuildWithMid = [&](const LoopFace& f) {
+        std::vector<int> loop;
+        loop.reserve(f.verts.size() + 1);
+        const int n = static_cast<int>(f.verts.size());
+        for (int i = 0; i < n; ++i) {
+            loop.push_back(f.verts[i]);
+            if (i == f.shareIdx) loop.push_back(vMid);
+        }
+        appendFace(loop, f.subMeshIndex);
     };
 
     if (hasA) {
-        retireFace(fA);
-        // Old triangle [vFrom, vTo, vOpp] wound as
-        // heOpp: vOpp -> vFrom, heFrom: vFrom -> vTo, heTo: vTo -> vOpp.
-        // New triangles share the vMid → vOpp diagonal and keep the same winding.
-        appendFace({fA.vFrom, vMid, fA.vOpp}, fA.subMeshIndex);
-        appendFace({vMid, fA.vTo, fA.vOpp}, fA.subMeshIndex);
+        retireFace(fA.face);
+        rebuildWithMid(fA);
     }
     if (hasB) {
-        retireFace(fB);
-        // fB's winding is reversed relative to fA (opposite twin). Using
-        // fB's own vFrom/vTo keeps its orientation intact.
-        appendFace({fB.vFrom, vMid, fB.vOpp}, fB.subMeshIndex);
-        appendFace({vMid, fB.vTo, fB.vOpp}, fB.subMeshIndex);
+        retireFace(fB.face);
+        rebuildWithMid(fB);
     }
 
     rebuildEdgesAndTwins();
@@ -3834,7 +3854,7 @@ bool HalfEdgeMesh::splitFace(int faceIdx, int vA, int vB)
     if (m_faces[faceIdx].halfEdge < 0) return false;
 
     const auto verts = faceVertices(faceIdx);
-    if (verts.size() < 3 || verts.size() > 4) return false;
+    if (verts.size() < 3) return false; // n-gon-aware: any arity ≥ 3
 
     // Require both vA and vB to be on the boundary loop.
     int posA = -1;
@@ -4013,19 +4033,26 @@ std::vector<int> HalfEdgeMesh::cutPath(const std::vector<CutPoint>& points)
         for (int step = 0; step < kMaxWalkSteps; ++step) {
             if (vA == vTarget) break;
 
-            // Does vA already share a triangle with vTarget? Then the
-            // existing splitEdge semantics (two click splits on one tri
-            // produce the connecting edge automatically) already created
-            // the final cut edge — nothing more to do for this pair.
+            // Does vA already share a face with vTarget? In the n-gon-
+            // aware splitEdge era, each splitEdge inserts vMid into the
+            // adjacent face WITHOUT cutting it — so when two consecutive
+            // click vertices land on the same face, the connecting edge
+            // doesn't exist yet. Call splitFace explicitly to cut the
+            // shared face along the vA→vTarget diagonal. (Previously
+            // the triangle-only splitEdge produced the cut as a side-
+            // effect, but that introduced fan diagonals everywhere.)
             const auto facesAtA = facesAroundVertex(vA);
-            bool shareFace = false;
+            int sharedFace = -1;
             for (int f : facesAtA) {
                 const auto fv = faceVertices(f);
                 if (std::find(fv.begin(), fv.end(), vTarget) != fv.end()) {
-                    shareFace = true; break;
+                    sharedFace = f; break;
                 }
             }
-            if (shareFace) break;
+            if (sharedFace >= 0) {
+                splitFace(sharedFace, vA, vTarget);
+                break;
+            }
 
             const Ogre::Vector3 pA = m_vertices[vA].position;
             const Ogre::Vector3 pT = m_vertices[vTarget].position;
@@ -4075,13 +4102,28 @@ std::vector<int> HalfEdgeMesh::cutPath(const std::vector<CutPoint>& points)
             (void)bestFace;
 
             // Split the exit edge; the new vertex becomes the entry point
-            // for the next triangle. Because the previous iteration's vA
-            // and the new vertex now both live on the same triangle, the
-            // splitEdge pass already leaves the segment between them as a
-            // real mesh edge.
+            // for the next face. n-gon-aware splitEdge inserts vMid into
+            // each adjacent face's loop WITHOUT cutting it (no fan
+            // diagonals), so we explicitly call splitFace to materialise
+            // the cut on the face we just walked through. The face that
+            // contains BOTH vA and vMid post-splitEdge is the one that
+            // needs cutting; there will be exactly one such face since
+            // vMid was just inserted into the two faces adjacent to
+            // `bestEdge`, and only one of those (the one we walked
+            // through) contains vA.
             const int vMid = splitEdge(bestEdge, bestT);
             if (vMid < 0) break;
             newVertices.push_back(vMid);
+
+            int faceToCut = -1;
+            for (int f : facesAroundVertex(vA)) {
+                const auto fv = faceVertices(f);
+                if (std::find(fv.begin(), fv.end(), vMid) != fv.end()) {
+                    faceToCut = f; break;
+                }
+            }
+            if (faceToCut >= 0) splitFace(faceToCut, vA, vMid);
+
             vA = vMid;
         }
     }

--- a/src/HalfEdgeMesh.cpp
+++ b/src/HalfEdgeMesh.cpp
@@ -4202,36 +4202,88 @@ int HalfEdgeMesh::mergeVertices(const std::vector<int>& vertexIndices,
         m_faces[f].halfEdge = -1;
     };
 
-    auto canonicalKey = [&](const std::vector<int>& verts, int subIdx)
-        -> std::tuple<int, int, int, int> {
-        std::array<int, 3> sorted = {verts[0], verts[1], verts[2]};
+    // Sorted-vertex-set key for duplicate-face detection. Works for any
+    // face arity — arity-3 only sees triangles, arity-N sees n-gons,
+    // mixed arity is a different key entirely (so a quad and one of its
+    // fan triangles aren't accidentally treated as duplicates).
+    auto canonicalKey = [&](const std::vector<int>& verts, int subIdx) {
+        std::vector<int> sorted = verts;
         std::sort(sorted.begin(), sorted.end());
-        return {subIdx, sorted[0], sorted[1], sorted[2]};
+        std::vector<int> key;
+        key.reserve(2 + sorted.size());
+        key.push_back(subIdx);
+        key.push_back(static_cast<int>(sorted.size()));
+        for (int v : sorted) key.push_back(v);
+        return key;
     };
 
+    // Walk every live face. After the HE.vertex re-pointing, a face's
+    // vertex sequence may contain consecutive duplicates (e.g. a quad
+    // [a,b,b,c] where two adjacent verts merged into b). Collapse those
+    // — including wrap-around duplicates — and either retire the face
+    // (arity drops < 3) or rebuild it with the cleaned loop. Without
+    // this n-gon path, a merge near a quad corner leaves a face with a
+    // zero-area edge that surfaces as a visible hole in the mesh.
     int retiredFaces = 0;
-    std::set<std::tuple<int, int, int, int>> seenFaces;
+    std::set<std::vector<int>> seenFaces;
+
+    auto collapseConsecutive = [](const std::vector<int>& verts) {
+        std::vector<int> out;
+        out.reserve(verts.size());
+        for (int v : verts) {
+            if (!out.empty() && out.back() == v) continue;
+            out.push_back(v);
+        }
+        // Wrap: if first == last after the consecutive collapse, drop last.
+        if (out.size() >= 2 && out.front() == out.back()) out.pop_back();
+        return out;
+    };
+
+    // Collect faces that need rebuilding in a separate pass — we can't
+    // mutate m_faces / m_halfEdges via appendFace while iterating.
+    struct PendingRebuild {
+        int oldFace;
+        int subIdx;
+        std::vector<int> newLoop;
+    };
+    std::vector<PendingRebuild> pendingRebuilds;
+
     for (int f = 0; f < static_cast<int>(m_faces.size()); ++f) {
         int startHE = m_faces[f].halfEdge;
         if (startHE < 0) continue;
 
         const auto verts = faceVertices(f);
-        if (verts.size() != 3) continue;
-        const bool degenerate = (verts[0] == verts[1])
-                             || (verts[1] == verts[2])
-                             || (verts[0] == verts[2]);
-        if (degenerate) {
+        if (verts.size() < 3) continue;
+
+        const auto cleaned = collapseConsecutive(verts);
+        if (cleaned.size() < 3) {
             retireFace(f);
             ++retiredFaces;
             continue;
         }
-        // Duplicate-of-earlier check: triangle with same {subMesh, sorted-verts}
+
+        // Duplicate-of-earlier check: same {subMesh, sorted-verts, arity}
         // collapses into the first occurrence.
-        const auto key = canonicalKey(verts, m_faces[f].subMeshIndex);
+        const auto key = canonicalKey(cleaned, m_faces[f].subMeshIndex);
         if (!seenFaces.insert(key).second) {
             retireFace(f);
             ++retiredFaces;
+            continue;
         }
+
+        if (cleaned.size() != verts.size()) {
+            // The face has at least one degenerate corner that the loop
+            // collapse fixed; queue a rebuild.
+            pendingRebuilds.push_back({f, m_faces[f].subMeshIndex, cleaned});
+        }
+    }
+
+    // Apply pending rebuilds: retire the old face slot, append the
+    // clean n-gon. rebuildEdgesAndTwins below will re-derive the edge
+    // table for the new HEs.
+    for (const auto& pr : pendingRebuilds) {
+        retireFace(pr.oldFace);
+        appendFace(pr.newLoop, pr.subIdx);
     }
 
     // 5. Mark the doomed vertex slots as retired (halfEdge = -1) so
@@ -4524,68 +4576,66 @@ int HalfEdgeMesh::dissolveEdges(const std::vector<int>& edgeIndices)
 
         const auto vA = faceVertices(fA);
         const auto vB = faceVertices(fB);
-        if (vA.size() != 3 || vB.size() != 3) continue; // MVP: triangle pairs
+        if (vA.size() < 3 || vB.size() < 3) continue;
 
         const auto [eu, ev] = edgeVertices(e);
-        // Find the "third" vertex of each face — the one not on the shared edge.
-        auto thirdVert = [eu, ev](const std::vector<int>& v) {
-            for (int x : v) if (x != eu && x != ev) return x;
-            return -1;
-        };
-        const int oppA = thirdVert(vA);
-        const int oppB = thirdVert(vB);
-        if (oppA < 0 || oppB < 0 || oppA == oppB) continue;
+        const int subIdx = m_faces[fA].subMeshIndex;
 
-        // Dissolving (eu, ev) means re-triangulating the {eu, oppA, ev, oppB}
-        // quad using the *other* diagonal (oppA, oppB). We need to preserve
-        // the original winding of fA so the outward normal stays sane: if
-        // fA traverses (eu -> ev -> oppA), the new triangles are
-        // (eu, oppB, oppA) and (ev, oppA, oppB) (winding flipped by the
-        // shared diagonal direction). Easier in practice: pull the boundary
-        // loop directly off fA and fB.
+        // n-gon-aware dissolve: merge the two adjacent faces into ONE
+        // face whose loop concatenates fA's vertices (ending at eu)
+        // with fB's vertices (starting after eu, ending at ev) — minus
+        // the shared edge endpoints' duplicates.
         //
-        // Walk fA from oppA and collect the three boundary verts in order.
-        // Then concatenate fB's boundary starting at oppB. That gives a
-        // 4-vertex loop in correct CCW order, which we fan-triangulate
-        // (oppA, x, oppB) and (oppA, oppB, y) — but easier: just use
-        // (oppA, vA_next_after_oppA, oppB) and (oppA, oppB, vB_next_after_oppB).
-        auto faceLoopFrom = [this](int faceIdx, int startVert) -> std::vector<int> {
+        // Concretely, walk fA's loop starting AFTER ev (so the loop
+        // ends at eu just before the shared edge), then walk fB's loop
+        // starting AFTER eu (so it ends at ev). The result is a single
+        // CCW loop with arity = arity(fA) + arity(fB) - 2.
+        auto loopFromVertex = [this](int faceIdx, int afterVert) -> std::vector<int> {
             std::vector<int> out;
             int startHE = m_faces[faceIdx].halfEdge;
-            int he = startHE;
-            // Find the HE whose `prev->vertex == startVert` (HE points away
-            // from startVert).
-            do {
-                int prev = m_halfEdges[he].prev;
-                if (prev >= 0 && m_halfEdges[prev].vertex == startVert) break;
-                he = m_halfEdges[he].next;
-            } while (he != startHE && he >= 0);
-            int cur = he;
-            for (int i = 0; i < 3 && cur >= 0; ++i) {
-                int prev = m_halfEdges[cur].prev;
-                if (prev < 0) break;
-                out.push_back(m_halfEdges[prev].vertex);
+            if (startHE < 0) return out;
+            // Find the HE whose target vertex == afterVert (the END
+            // vertex of the shared edge from this face's POV). The
+            // next HE points away from afterVert, so its target is the
+            // first vertex of our partial loop.
+            int afterHE = -1;
+            int cur = startHE;
+            for (int guard = 0; guard < 1024; ++guard) {
+                if (m_halfEdges[cur].vertex == afterVert) { afterHE = cur; break; }
                 cur = m_halfEdges[cur].next;
+                if (cur == startHE) break;
+            }
+            if (afterHE < 0) return out;
+            int beginHE = m_halfEdges[afterHE].next;
+            // Walk from beginHE around the face, but stop BEFORE we'd
+            // re-collect afterHE's vertex (= afterVert). We collect every
+            // vertex except afterVert itself, in winding order.
+            int walk = beginHE;
+            for (int guard = 0; guard < 1024; ++guard) {
+                if (walk < 0 || walk == afterHE) break;
+                out.push_back(m_halfEdges[walk].vertex);
+                walk = m_halfEdges[walk].next;
             }
             return out;
         };
 
-        const std::vector<int> loopA = faceLoopFrom(fA, oppA); // [oppA, ?, ?]
-        const std::vector<int> loopB = faceLoopFrom(fB, oppB); // [oppB, ?, ?]
-        if (loopA.size() != 3 || loopB.size() != 3) continue;
+        // fA loop after ev: [..., eu] — last vertex is eu (the start of shared edge)
+        std::vector<int> partA = loopFromVertex(fA, ev);
+        // fB loop after eu: [..., ev] — last vertex is ev
+        std::vector<int> partB = loopFromVertex(fB, eu);
+        if (partA.empty() || partB.empty()) continue;
+        // Merged loop: partA + partB. The boundary is consistent CCW
+        // (fB's twin orientation gives the right winding by construction).
+        std::vector<int> merged;
+        merged.reserve(partA.size() + partB.size());
+        merged.insert(merged.end(), partA.begin(), partA.end());
+        merged.insert(merged.end(), partB.begin(), partB.end());
+        // Sanity: must have no consecutive duplicates and arity ≥ 3.
+        if (merged.size() < 3) continue;
 
-        const int subIdx = m_faces[fA].subMeshIndex;
         retireFaceImpl(m_halfEdges, m_faces, fA);
         retireFaceImpl(m_halfEdges, m_faces, fB);
-
-        // The merged quad's CCW loop is loopA followed by the two non-oppB
-        // vertices of loopB (which are eu/ev) — but those are already in
-        // loopA, so loopA + [oppB] in the right slot is what we want. Since
-        // we want the new diagonal (oppA, oppB), the two new triangles are
-        // (loopA[0], loopA[1], oppB) and (loopA[0], oppB, loopA[2]) i.e.
-        // (oppA, neighborA1, oppB) and (oppA, oppB, neighborA2).
-        appendTriangle(loopA[0], loopA[1], oppB, subIdx);
-        appendTriangle(loopA[0], oppB,    loopA[2], subIdx);
+        appendFace(merged, subIdx);
 
         // Rebuild incrementally per dissolve so the next edge in the input
         // sees a coherent topology. This is O(|HE|) per dissolve; fine for
@@ -4615,79 +4665,85 @@ int HalfEdgeMesh::dissolveVertices(const std::vector<int>& vertexIndices)
         const auto incident = facesAroundVertex(v);
         if (incident.size() < 3) continue;       // valence < 3 — nothing to dissolve
 
-        // All incident faces must share a submesh; otherwise dissolving would
-        // fuse material groups. Same constraint as mergeVertices.
+        // All incident faces must share a submesh. n-gon-aware: any face
+        // arity ≥ 3 is OK (the previous triangle-only check made vertex
+        // dissolve a no-op on quad-imported meshes).
         const int subIdx = m_faces[incident.front()].subMeshIndex;
         bool sameSub = true;
         for (int f : incident) {
             if (m_faces[f].subMeshIndex != subIdx) { sameSub = false; break; }
-            if (faceVertices(f).size() != 3) { sameSub = false; break; }
+            if (faceVertices(f).size() < 3) { sameSub = false; break; }
         }
         if (!sameSub) continue;
 
-        // Walk the boundary loop of the umbrella (the N-gon left after
-        // removing the central vertex). The standard half-edge trick: pick
-        // any outgoing HE from v, follow its next pointer (skipping v),
-        // then jump across the next HE's twin to walk to the next umbrella
-        // face. Each "next->vertex" along the way is one boundary vertex.
-        //
-        // We collect by walking the incident faces and pulling the two
-        // non-v vertices in winding order. With a manifold umbrella those
-        // pairs chain into a single closed loop.
-        std::vector<int> loop;
-        loop.reserve(incident.size());
-        // Build a small adjacency: face -> (boundaryStart, boundaryEnd) where
-        // the face's loop is (v -> boundaryStart -> boundaryEnd -> v).
-        std::map<int, std::pair<int,int>> faceEdges;
+        // For each incident face, the boundary contribution is the
+        // sequence of NON-v vertices in winding order. For a triangle
+        // [a, v, b] the contribution is [a, b]; for a quad [a, v, b, c]
+        // it's [a, b, c]; etc. Each contribution starts at "after v"
+        // and ends at "before v" in the face's loop.
+        struct FaceBoundary {
+            int face;
+            std::vector<int> verts; // boundary verts in this face's winding
+        };
+        std::vector<FaceBoundary> boundaries;
+        boundaries.reserve(incident.size());
+        bool ok = true;
         for (int f : incident) {
             const auto vs = faceVertices(f);
+            int n = static_cast<int>(vs.size());
             int idxOfV = -1;
-            for (int i = 0; i < 3; ++i) if (vs[i] == v) { idxOfV = i; break; }
-            if (idxOfV < 0) { faceEdges.clear(); break; }
-            int a = vs[(idxOfV + 1) % 3];
-            int b = vs[(idxOfV + 2) % 3];
-            faceEdges[f] = {a, b};
-        }
-        if (faceEdges.empty()) continue;
-
-        // Chain the (start, end) pairs into one loop.
-        // Pick a starting face arbitrarily; walk via shared boundary verts.
-        std::set<int> remaining(incident.begin(), incident.end());
-        int curFace = *remaining.begin();
-        loop.push_back(faceEdges[curFace].first);
-        loop.push_back(faceEdges[curFace].second);
-        remaining.erase(curFace);
-
-        bool ok = true;
-        while (!remaining.empty()) {
-            int needed = loop.back();
-            int found = -1;
-            for (int f : remaining) {
-                if (faceEdges[f].first == needed) { found = f; break; }
+            for (int i = 0; i < n; ++i) if (vs[i] == v) { idxOfV = i; break; }
+            if (idxOfV < 0) { ok = false; break; }
+            FaceBoundary fb;
+            fb.face = f;
+            fb.verts.reserve(n - 1);
+            for (int k = 1; k < n; ++k) {
+                fb.verts.push_back(vs[(idxOfV + k) % n]);
             }
-            if (found < 0) { ok = false; break; }
-            // The new face contributes its `second` vertex.
-            // (Its `first` matches the existing tail.)
-            loop.push_back(faceEdges[found].second);
-            remaining.erase(found);
+            if (fb.verts.size() < 2) { ok = false; break; }
+            boundaries.push_back(std::move(fb));
         }
         if (!ok) continue;
-        // The loop should close — last == first. Drop the duplicate.
+
+        // Chain the contributions into one closed loop. Each
+        // contribution's last vertex is shared with the next
+        // contribution's first vertex (the umbrella's manifold edges
+        // chain that way).
+        std::set<int> remaining;
+        for (size_t i = 0; i < boundaries.size(); ++i) remaining.insert(static_cast<int>(i));
+        std::vector<int> loop;
+        // Start with any contribution.
+        int curIdx = *remaining.begin();
+        for (int x : boundaries[curIdx].verts) loop.push_back(x);
+        remaining.erase(curIdx);
+
+        while (!remaining.empty()) {
+            int tail = loop.back();
+            int foundIdx = -1;
+            for (int i : remaining) {
+                if (boundaries[i].verts.front() == tail) { foundIdx = i; break; }
+            }
+            if (foundIdx < 0) { ok = false; break; }
+            const auto& fb = boundaries[foundIdx];
+            // Append, skipping the first vertex (already at tail).
+            for (size_t k = 1; k < fb.verts.size(); ++k) loop.push_back(fb.verts[k]);
+            remaining.erase(foundIdx);
+        }
+        if (!ok) continue;
+        // Loop should close: last == first.
         if (loop.size() < 4 || loop.front() != loop.back()) continue;
         loop.pop_back();
         if (loop.size() < 3) continue;
 
-        // Sanity: no duplicated boundary verts (would mean a non-manifold
-        // umbrella we can't safely fan-triangulate).
+        // Sanity: no duplicated boundary verts.
         std::set<int> uniqueLoop(loop.begin(), loop.end());
         if (uniqueLoop.size() != loop.size()) continue;
 
-        // Retire the old faces, fan-triangulate from loop[0]. New triangles:
-        //   (loop[0], loop[i], loop[i+1])  for i in [1, N-1)
+        // Retire the umbrella faces, append a single n-gon face for the
+        // boundary loop. (Pre-quads-followup this fan-triangulated the
+        // loop instead, which introduced fan diagonals.)
         for (int f : incident) retireFaceImpl(m_halfEdges, m_faces, f);
-        for (size_t i = 1; i + 1 < loop.size(); ++i) {
-            appendTriangle(loop[0], loop[i], loop[i + 1], subIdx);
-        }
+        appendFace(loop, subIdx);
         m_vertices[v].halfEdge = -1; // retire the dissolved center
 
         rebuildEdgesAndTwins();

--- a/src/HalfEdgeMesh_test.cpp
+++ b/src/HalfEdgeMesh_test.cpp
@@ -3988,10 +3988,11 @@ TEST(HalfEdgeMeshStandalone, DissolveEdgesEmptyIsNoOp) {
     EXPECT_TRUE(he.validate());
 }
 
-TEST(HalfEdgeMeshStandalone, DissolveEdgesQuadDiagonalRetriangulatesOtherDiagonal) {
-    // Quad: tris (0,1,2) and (1,3,2) share diagonal v1↔v2. Dissolving the
-    // diagonal should keep face count at 2 (still triangulated as a quad)
-    // but with the OTHER diagonal active (0↔3).
+TEST(HalfEdgeMeshStandalone, DissolveEdgesQuadDiagonalMergesIntoSingleQuad) {
+    // n-gon-aware dissolve: dissolving the shared edge between two
+    // triangles merges them into a SINGLE quad face — no diagonal at
+    // all. (The previous triangle-only impl just swapped to the OTHER
+    // diagonal, which left a fan diagonal in place.)
     auto em = makeQuadMesh();
     HalfEdgeMesh he;
     ASSERT_TRUE(he.buildFromEditableMesh(em));
@@ -3999,13 +4000,20 @@ TEST(HalfEdgeMeshStandalone, DissolveEdgesQuadDiagonalRetriangulatesOtherDiagona
     ASSERT_GE(diag, 0);
 
     EXPECT_EQ(he.dissolveEdges({diag}), 1);
-    EXPECT_EQ(activeFaceCount(he), 2);
+    EXPECT_EQ(activeFaceCount(he), 1);
     EXPECT_TRUE(he.validate());
 
-    // The new diagonal must connect v0 and v3.
-    EXPECT_GE(findEdge(he, 0, 3), 0);
-    // Old diagonal should be gone (or no longer exist as an edge).
+    // The shared diagonal is gone; neither (1,2) nor (0,3) is an edge,
+    // because the merged face is a quad with only its perimeter edges.
     EXPECT_EQ(findEdge(he, 1, 2), -1);
+    EXPECT_EQ(findEdge(he, 0, 3), -1);
+    // The single surviving face has 4 vertices.
+    int quadCount = 0;
+    for (size_t f = 0; f < he.faceCount(); ++f) {
+        if (he.face(static_cast<int>(f)).halfEdge < 0) continue;
+        if (he.faceVertices(static_cast<int>(f)).size() == 4) ++quadCount;
+    }
+    EXPECT_EQ(quadCount, 1);
 }
 
 TEST(HalfEdgeMeshStandalone, DissolveEdgesBoundaryEdgeIsSkipped) {
@@ -4021,18 +4029,28 @@ TEST(HalfEdgeMeshStandalone, DissolveEdgesBoundaryEdgeIsSkipped) {
 }
 
 TEST(HalfEdgeMeshStandalone, DissolveVerticesHexFanCenterCollapsesToHexagon) {
-    // The hex fan's v0 has valence 6, all triangles. Dissolving v0 should
-    // produce 4 triangles (n-gon with n=6 fan-triangulated from one vertex).
+    // n-gon-aware dissolve: dissolving v0 (the hex fan's center)
+    // replaces the 6 incident triangles with a SINGLE hexagon face —
+    // no fan diagonals introduced. (Previous triangle-only impl
+    // fan-triangulated the resulting boundary loop into 4 triangles.)
     auto em = makeHexFan();
     HalfEdgeMesh he;
     ASSERT_TRUE(he.buildFromEditableMesh(em));
     ASSERT_EQ(activeFaceCount(he), 6);
 
     EXPECT_EQ(he.dissolveVertices({0}), 1);
-    EXPECT_EQ(activeFaceCount(he), 4)
-        << "hexagon fan-triangulated from one corner has n-2 = 4 triangles";
+    EXPECT_EQ(activeFaceCount(he), 1)
+        << "hexagon merged from the umbrella, no fan diagonals";
     EXPECT_LT(he.vertex(0).halfEdge, 0);
     EXPECT_TRUE(he.validate());
+
+    // The single surviving face has 6 vertices.
+    int hexCount = 0;
+    for (size_t f = 0; f < he.faceCount(); ++f) {
+        if (he.face(static_cast<int>(f)).halfEdge < 0) continue;
+        if (he.faceVertices(static_cast<int>(f)).size() == 6) ++hexCount;
+    }
+    EXPECT_EQ(hexCount, 1);
 }
 
 TEST(HalfEdgeMeshStandalone, DissolveVerticesBoundaryVertexIsSkipped) {
@@ -4105,8 +4123,10 @@ TEST(HalfEdgeMeshStandalone, DissolveEdgesMultipleDisjointEdgesAllProcessed) {
 
     EXPECT_EQ(he.dissolveEdges({diagL, diagR}), 2)
         << "both interior diagonals must dissolve regardless of edge-slot reordering";
-    EXPECT_EQ(activeFaceCount(he), 4)
-        << "two quads, fan-triangulated, still 4 triangles";
+    // n-gon-aware dissolve merges each pair of triangles into ONE quad —
+    // 2 active quads total, NOT 4 fan-triangulated triangles.
+    EXPECT_EQ(activeFaceCount(he), 2)
+        << "two merged quads, no fan diagonals";
     EXPECT_TRUE(he.validate());
 
     // Both old diagonals should be gone.

--- a/src/HalfEdgeMesh_test.cpp
+++ b/src/HalfEdgeMesh_test.cpp
@@ -3123,10 +3123,14 @@ static int activeFaceCount(const HalfEdgeMesh& he)
     return n;
 }
 
-TEST(HalfEdgeMeshStandalone, SplitEdgeMidpointOfInteriorEdgeDoublesTriangles) {
-    // The quad mesh has two triangles sharing the v1↔v2 diagonal. Splitting
-    // that edge at t=0.5 should insert one new vertex, replace both triangles
-    // with two each (four tris total), and keep the mesh manifold.
+TEST(HalfEdgeMeshStandalone, SplitEdgeMidpointOfInteriorEdgeInsertsVertexInBothFaces) {
+    // n-gon-aware splitEdge inserts vMid into each adjacent face's vertex
+    // loop without introducing a fan diagonal: a triangle adjacent to the
+    // split edge becomes a 4-vertex face (NOT two triangles). The quad
+    // mesh's two triangles each gain vMid, resulting in 2 active 4-vertex
+    // faces. (Pre-quads-followup this returned 4 triangles via fan
+    // diagonals on `vMid → vOpp`; the new behaviour preserves more
+    // topology and produces no artificial diagonals.)
     auto em = makeQuadMesh();
     HalfEdgeMesh he;
     ASSERT_TRUE(he.buildFromEditableMesh(em));
@@ -3139,7 +3143,17 @@ TEST(HalfEdgeMeshStandalone, SplitEdgeMidpointOfInteriorEdgeDoublesTriangles) {
     EXPECT_TRUE(he.validate());
 
     EXPECT_EQ(he.vertexCount(), 5u);
-    EXPECT_EQ(activeFaceCount(he), 4);
+    EXPECT_EQ(activeFaceCount(he), 2);
+    // Each surviving face should have 4 vertices now (the original
+    // triangle plus vMid inserted on the shared edge).
+    int quadCount = 0;
+    for (size_t f = 0; f < he.faceCount(); ++f) {
+        if (he.face(static_cast<int>(f)).halfEdge < 0) continue;
+        auto fv = he.faceVertices(static_cast<int>(f));
+        if (fv.size() == 4) ++quadCount;
+    }
+    EXPECT_EQ(quadCount, 2)
+        << "n-gon-aware splitEdge: each adjacent triangle gains vMid → quad";
 
     // Midpoint position should be the average of the endpoints.
     const auto mid = he.vertex(vMid).position;
@@ -3195,10 +3209,11 @@ TEST(HalfEdgeMeshStandalone, SplitEdgeInterpolatesNormalAndUV) {
     EXPECT_NEAR(std::min(uvDist1, uvDist2) / uvSeg, 0.25f, 1e-3f);
 }
 
-TEST(HalfEdgeMeshStandalone, SplitEdgeBoundaryEdgeProducesOneExtraTriangle) {
-    // A triangle's perimeter edge is a boundary edge (only one adjacent face).
-    // Splitting it should turn the single triangle into two triangles without
-    // creating any phantom face on the outside.
+TEST(HalfEdgeMeshStandalone, SplitEdgeBoundaryEdgeInsertsVertexInTheTriangle) {
+    // A triangle's perimeter edge is a boundary edge (only one adjacent
+    // face). n-gon-aware splitEdge: the triangle gains vMid on its
+    // perimeter, becoming a 4-vertex face. No phantom face on the outside.
+    // (Pre-quads-followup this returned two triangles via a fan diagonal.)
     auto em = makeTriangleMesh();
     HalfEdgeMesh he;
     ASSERT_TRUE(he.buildFromEditableMesh(em));
@@ -3212,7 +3227,14 @@ TEST(HalfEdgeMeshStandalone, SplitEdgeBoundaryEdgeProducesOneExtraTriangle) {
     EXPECT_TRUE(he.validate());
 
     EXPECT_EQ(he.vertexCount(), 4u);
-    EXPECT_EQ(activeFaceCount(he), 2);
+    EXPECT_EQ(activeFaceCount(he), 1);
+    // The single surviving face must be a quad (3 original verts + vMid).
+    int quadCount = 0;
+    for (size_t f = 0; f < he.faceCount(); ++f) {
+        if (he.face(static_cast<int>(f)).halfEdge < 0) continue;
+        if (he.faceVertices(static_cast<int>(f)).size() == 4) ++quadCount;
+    }
+    EXPECT_EQ(quadCount, 1);
 }
 
 TEST(HalfEdgeMeshStandalone, SplitEdgeClampsExtremeT) {
@@ -3243,12 +3265,15 @@ TEST(HalfEdgeMeshStandalone, SplitEdgeInvalidIndexReturnsMinusOne) {
     EXPECT_EQ(he.splitEdge(999, 0.5f), -1);
 }
 
-TEST(HalfEdgeMeshStandalone, TwoSplitEdgesOnOneTriangleProduceMidpointEdge) {
-    // Real knife-tool scenario: the user cuts a triangle by clicking two of
-    // its edges. Two splitEdge calls on the same triangle should leave the
-    // M1↔M2 segment as a real edge of the resulting mesh — no follow-up
-    // splitFace needed. This is the invariant the knife commit pipeline
-    // relies on for the common "cut one face" case.
+TEST(HalfEdgeMeshStandalone, TwoSplitEdgesOnOneTriangleNeedFollowupSplitFace) {
+    // n-gon-aware splitEdge: two splitEdge calls on the same triangle
+    // insert m1 and m2 into its loop, producing a pentagon
+    // [v0, m1, v1, m2, v2] — but they are NOT automatically connected.
+    // (The triangle-only splitEdge MVP previously cut the triangle into
+    // sub-triangles via fan diagonals, which incidentally produced the
+    // m1-m2 edge as a side-effect.) Call splitFace explicitly to
+    // materialise the cut. This is exactly what `cutPath` now does in
+    // its walk loop.
     auto em = makeTriangleMesh();
     HalfEdgeMesh he;
     ASSERT_TRUE(he.buildFromEditableMesh(em));
@@ -3266,13 +3291,81 @@ TEST(HalfEdgeMeshStandalone, TwoSplitEdgesOnOneTriangleProduceMidpointEdge) {
     ASSERT_GE(m2, 0);
     EXPECT_TRUE(he.validate());
 
-    // The knife cut ran from M1 to M2; that segment must now be an edge.
+    // After two splitEdges the triangle is now a pentagon; m1 and m2
+    // are NOT yet connected — that's the new contract.
+    EXPECT_LT(findEdge(he, m1, m2), 0)
+        << "n-gon splitEdge does not auto-cut: explicit splitFace required";
+    EXPECT_EQ(activeFaceCount(he), 1);
+
+    // Find the pentagon and call splitFace to materialise the cut.
+    int pentagonIdx = -1;
+    for (size_t f = 0; f < he.faceCount(); ++f) {
+        if (he.face(static_cast<int>(f)).halfEdge < 0) continue;
+        const auto fv = he.faceVertices(static_cast<int>(f));
+        if (fv.size() == 5
+            && std::find(fv.begin(), fv.end(), m1) != fv.end()
+            && std::find(fv.begin(), fv.end(), m2) != fv.end()) {
+            pentagonIdx = static_cast<int>(f);
+            break;
+        }
+    }
+    ASSERT_GE(pentagonIdx, 0);
+    EXPECT_TRUE(he.splitFace(pentagonIdx, m1, m2));
     EXPECT_GE(findEdge(he, m1, m2), 0)
-        << "M1-M2 should be a real edge after two splitEdges on the same triangle";
+        << "splitFace must materialise the m1-m2 cut on the pentagon";
 
     EditableMesh back;
     ASSERT_TRUE(he.toEditableMesh(back));
     EXPECT_TRUE(isManifold(back));
+}
+
+TEST(HalfEdgeMeshStandalone, SplitEdgeOnQuadMeshKeepsQuads) {
+    // Regression for the n-gon-aware splitEdge: split a quad-imported
+    // mesh's edge and confirm both adjacent quads become pentagons
+    // (NOT four triangles via fan diagonals as the old MVP would have
+    // produced). This is the topology guarantee knife / loop cut
+    // depend on for producing real quad outputs on quad-imported
+    // assets.
+    EditableMesh mesh;
+    EditableSubMesh sub;
+    sub.materialName = "M";
+    auto mkV = [](float x, float y) {
+        EditableVertex v;
+        v.position = Ogre::Vector3(x, y, 0);
+        v.normal = Ogre::Vector3(0, 0, 1); v.hasNormal = true;
+        return v;
+    };
+    // Two adjacent quads sharing the v1-v2 edge.
+    sub.vertices = { mkV(0, 0), mkV(1, 0), mkV(1, 1), mkV(0, 1),
+                     mkV(2, 0), mkV(2, 1) };
+    EditableFace q1, q2;
+    q1.indices = {0, 1, 2, 3};
+    q2.indices = {1, 4, 5, 2};
+    sub.faces = { q1, q2 };
+    triangulateFaces(sub);
+    mesh.subMeshes().push_back(std::move(sub));
+
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(mesh));
+    ASSERT_EQ(activeFaceCount(he), 2);
+
+    const int sharedEdge = findEdge(he, 1, 2);
+    ASSERT_GE(sharedEdge, 0);
+
+    const int vMid = he.splitEdge(sharedEdge, 0.5f);
+    ASSERT_GE(vMid, 0);
+    EXPECT_TRUE(he.validate());
+
+    // Both quads should now be pentagons (5-vertex faces). NOT four
+    // triangles — that would mean fan diagonals slipped in.
+    EXPECT_EQ(activeFaceCount(he), 2);
+    int pentagonCount = 0;
+    for (size_t f = 0; f < he.faceCount(); ++f) {
+        if (he.face(static_cast<int>(f)).halfEdge < 0) continue;
+        if (he.faceVertices(static_cast<int>(f)).size() == 5) ++pentagonCount;
+    }
+    EXPECT_EQ(pentagonCount, 2)
+        << "n-gon-aware splitEdge: quad + new vertex on shared edge → pentagon";
 }
 
 TEST(HalfEdgeMeshStandalone, SplitFaceRejectsAdjacentBoundaryVertices) {


### PR DESCRIPTION
## Summary
Drops the triangle-only assumptions from several core ops so the knife / extrude / dissolve / merge paths produce real n-gon outputs on quad-imported meshes. Bevel keeps its triangle-mode workaround for now (the algorithm has triangle-only assumptions in multiple internal paths; n-gon bevel is a separate follow-up).

### Core change: `HalfEdgeMesh::splitEdge` is now n-gon-aware
Previously bailed when either adjacent face had arity != 3. Now replaces each adjacent face with ONE face that has vMid inserted between the shared edge's endpoints — a triangle becomes a quad, a quad becomes a pentagon, etc. No fan diagonal.

**Contract change:** two splitEdges on the same triangle no longer produce the m1↔m2 edge as a side-effect (they used to, via the vMid→vOpp diagonal). `cutPath`'s walk loop now calls `splitFace` explicitly to materialise the cut between consecutive click vertices. `splitFace` also drops its `n > 4` cap (its loop walk is generic).

### Knife pipeline simplified
Both `commitKnife` and `knifeHitTest` now build the HE directly from the (possibly n-gon) editable mesh — no more triangle-mode copy + restore-untouched-submeshes dance. The knife produces real n-gon outputs on quad-imported assets; only the cut-touched faces get triangulated (via `splitFace`).

### Extrude offset for n-gon caps
`extrudeSelection`'s per-vertex offset computation gated on `verts.size() == 3`, so on quad meshes the offset was zero — and the post-extrude selection-by-position then matched the OLD un-offset coords, leaving the user with the pre-extrude vertices selected. Replaced the triangle cross-product with Newell's method; "top face" detection is now "all N verts are new" instead of "is a triangle and all 3 verts are new".

### Dissolve edges → single n-gon
`dissolveEdges` was triangle-only (`if (vA.size() != 3 || vB.size() != 3) continue;`) so dissolving a quad's edge was a silent no-op. Now walks both face loops, removes the shared edge endpoints' duplicate contributions, appends ONE merged n-gon face. Triangle+triangle → quad; quad+quad → hexagon; etc.

### Dissolve vertices → single n-gon
Same fix — was triangle-only with hard-coded 3-element index arithmetic. Now collects each incident face's non-v boundary contribution (n-1 verts in winding order), chains into a closed loop, replaces the umbrella with one n-gon face. Hex fan center now collapses to a single hexagon.

### MergeVertices cleans up n-gon faces
Cleanup pass had `if (verts.size() != 3) continue;` — so a quad with consecutive-duplicate corners (the typical result of merging near a quad corner) was never retired or rebuilt, surfacing as a visible hole. Now collapses consecutive duplicates (incl. wrap-around) on any face arity, retires below-arity-3 faces, queues a rebuild via retire + appendFace for the rest. Duplicate-face detection key is `sorted-verts + arity`.

### Bevel: accepted trade-off
`bevelEdges` / `bevelVertices` have triangle-only retriangulation built into multiple paths (`effectiveWidth`'s third-vertex, `innerForFace`'s coplanar-group check, `retriangulateBeveledFace`'s 3-vertex pattern). To get visible bevel back on quad meshes without a major bevel rewrite, this PR builds the HE from a triangle-mode copy and restores untouched n-gon submeshes from the snapshot. Trade-off: the touched submesh triangulates fully (single-submesh assets become triangle-only after a bevel). Properly n-gon-aware bevel is the next follow-up.

### Hit-test polish
`hitTestVertex` mirrors the chunk-4b front-facing filter — vertex selection on a dense FBX mesh no longer pulls clicks to back-face vertices.

## Test plan
- [x] 235 standalone tests pass
- [x] Updated tests for new contracts: `SplitEdgeMidpoint…InsertsVertexInBothFaces` (was 4 tris → 2 quads), `SplitEdgeBoundary…InsertsVertexInTheTriangle` (was 2 tris → 1 quad), `TwoSplitEdgesOnOneTriangleNeedFollowupSplitFace` (documents the new "splitFace materialises the cut" contract), `DissolveEdgesQuadDiagonalMergesIntoSingleQuad`, `DissolveEdgesMultipleDisjointEdgesAllProcessed`, `DissolveVerticesHexFanCenterCollapsesToHexagon`.
- [x] New `SplitEdgeOnQuadMeshKeepsQuads` regression test.
- [x] Smoke: knife / extrude / dissolve produce n-gon outputs on FBX quad asset; vertex merge no longer leaves holes; vertex picking front-face-culls.

## Known follow-ups
- Properly n-gon-aware bevel (replaces the triangle-mode workaround).
- Loop cut (will reuse splitEdge + splitFace + cutPath infrastructure).