### PR TITLE
feat(quads): loop cut on quad meshes

### DIFF
--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -3398,6 +3398,79 @@ int EditModeController::subdivideSelection()
     return static_cast<int>(targetFaces.size());
 }
 
+int EditModeController::loopCutSelection()
+{
+    if (!m_editModeActive || !m_editableMesh || !m_editEntity) return 0;
+    if (m_selectionMode != EdgeMode) return 0;
+    if (m_selectedEdges.empty()) return 0;
+
+    // Cancel any active interactive preview before mutating topology.
+    if (m_bevelSession.active) cancelBevel();
+    if (m_knifeSession.active) cancelKnife();
+
+    // Loop cut takes a SINGLE start edge — the first one in the
+    // selection if multiple are selected. Convert (min, max) global
+    // vertex pair to an HE edge index against the live mesh.
+    const auto firstEdge = *m_selectedEdges.begin();
+    const int targetMinV = firstEdge.first;
+    const int targetMaxV = firstEdge.second;
+
+    HalfEdgeMesh hm;
+    if (!hm.buildFromEditableMesh(*m_editableMesh)) return 0;
+    int startEdge = -1;
+    for (size_t e = 0; e < hm.edgeCount(); ++e) {
+        const auto [a, b] = hm.edgeVertices(static_cast<int>(e));
+        if (std::min(a, b) == targetMinV && std::max(a, b) == targetMaxV) {
+            startEdge = static_cast<int>(e);
+            break;
+        }
+    }
+    if (startEdge < 0) return 0;
+
+    auto originalSubMeshes = m_editableMesh->subMeshes();
+    const auto preSelectedVerts = m_selectedVertices;
+    const auto preSelectedEdges = m_selectedEdges;
+    const auto preSelectedFaces = m_selectedFaces;
+
+    const auto newHE = hm.loopCut(startEdge);
+    if (newHE.empty()) return 0;
+
+    EditableMesh updated;
+    if (!hm.toEditableMesh(updated)) return 0;
+    m_editableMesh->subMeshes() = std::move(updated.subMeshes());
+
+    if (m_normalsMode == 0) m_editableMesh->recalculateNormals();
+    else                     m_editableMesh->recalculateNormalsFlat();
+
+    m_editableMesh->resizeEntityBuffers(m_editEntity);
+    rewriteEntityAfterTopologyChange(m_editEntity);
+
+    // Clear selection — pre-op edge IDs are stale after the topology
+    // mutation. The user can hit-test the new loop directly if they
+    // want to chain operations.
+    m_selectedVertices.clear();
+    m_selectedEdges.clear();
+    m_selectedFaces.clear();
+
+    auto* cmd = new EditMeshTopologyCommand(
+        std::move(originalSubMeshes),
+        m_editableMesh->subMeshes(),
+        preSelectedVerts, preSelectedEdges, preSelectedFaces,
+        m_selectedVertices, m_selectedEdges, m_selectedFaces,
+        QStringLiteral("Loop Cut"));
+    UndoManager::getSingleton()->push(cmd);
+
+    validateMesh();
+    SentryReporter::addBreadcrumb("edit_mode",
+        QString("Loop Cut (midpoints=%1)").arg(newHE.size()));
+
+    updateSelectionOverlay();
+    refreshNormalVisualizer();
+    emit editSelectionChanged();
+    emit meshDataChanged();
+    return static_cast<int>(newHE.size());
+}
+
 int EditModeController::subdivideCatmullClarkAll()
 {
     if (!m_editModeActive || !m_editableMesh || !m_editEntity) return 0;

--- a/src/EditModeController.h
+++ b/src/EditModeController.h
@@ -442,6 +442,25 @@ public:
     Q_INVOKABLE int subdivideSelection();
 
     /**
+     * @brief Insert a loop cut starting from the first selected edge.
+     *
+     * Walks the chain of quads adjacent to the start edge via the
+     * "opposite edge" relation. Each quad in the ring is bisected by
+     * splitting two parallel edges at their midpoints and connecting
+     * the new midpoints with a new edge. The walk terminates at
+     * boundaries, non-quad faces, or when it loops back to the start.
+     *
+     * Requires Edge selection mode and at least one selected edge.
+     * Uses the FIRST selected edge as the start; multi-edge loop cuts
+     * are out of scope for the MVP (each cut is independent).
+     *
+     * Pushes one undo command labeled "Loop Cut".
+     *
+     * @return Number of new vertices inserted (0 on no-op / failure).
+     */
+    Q_INVOKABLE int loopCutSelection();
+
+    /**
      * @brief Subdivide the entire mesh by one Catmull-Clark step.
      *
      * Unlike `subdivideSelection` (which does a 1-to-4 triangle split

--- a/src/HalfEdgeMesh.cpp
+++ b/src/HalfEdgeMesh.cpp
@@ -4828,6 +4828,158 @@ std::vector<int> HalfEdgeMesh::cutPath(const std::vector<CutPoint>& points)
     return newVertices;
 }
 
+// ===========================================================================
+// loopCut — insert a perpendicular cut through a ring of quads.
+// ===========================================================================
+//
+// Given a starting edge, walk the chain of quads adjacent to it via the
+// "opposite edge" relation. In each quad [v0, v1, v2, v3] (where the
+// shared edge with the previous step is one of its four edges, e.g.
+// (v0, v1)), the OPPOSITE edge is (v2, v3). The loop cut splits both
+// edges at their midpoints and connects the new midpoint vertices,
+// bisecting the quad.
+//
+// The walk continues across each opposite edge into the NEXT quad in
+// the ring (the second face adjacent to that edge). It stops when:
+//   - the walk returns to the starting edge (closed loop), OR
+//   - it encounters a non-quad face (loop cut needs the opposite-edge
+//     correspondence, only well-defined on quads), OR
+//   - it encounters a boundary edge (no second face to walk into).
+//
+// MVP: cuts at midpoint (t = 0.5) on each rail edge. A future
+// extension can take a `t` parameter so the cut shifts along the
+// loop. Profile / multi-cuts are out of scope.
+//
+// Returns the indices of every newly created vertex (in walk order).
+// Empty on failure (bad start edge, immediate non-quad neighbor, etc).
+std::vector<int> HalfEdgeMesh::loopCut(int startEdgeIdx)
+{
+    std::vector<int> newVertices;
+    if (startEdgeIdx < 0
+        || startEdgeIdx >= static_cast<int>(m_edges.size()))
+        return newVertices;
+    if (m_edges[startEdgeIdx].halfEdge < 0) return newVertices;
+
+    auto oppositeEdgeInQuad = [this](int faceIdx, int va, int vb)
+        -> std::pair<int, int> {
+        // For a quad face [w0, w1, w2, w3], the edge (va, vb) is one
+        // of its four sides. The opposite edge is two positions away
+        // in the loop. Return its endpoints in winding order.
+        const auto loop = faceVertices(faceIdx);
+        if (loop.size() != 4) return {-1, -1};
+        for (int i = 0; i < 4; ++i) {
+            const int a = loop[i];
+            const int b = loop[(i + 1) % 4];
+            if ((a == va && b == vb) || (a == vb && b == va)) {
+                return { loop[(i + 2) % 4], loop[(i + 3) % 4] };
+            }
+        }
+        return {-1, -1};
+    };
+
+    auto findEdgeByVerts = [this](int va, int vb) -> int {
+        for (size_t e = 0; e < m_edges.size(); ++e) {
+            if (m_edges[e].halfEdge < 0) continue;
+            const auto [ea, eb] = edgeVertices(static_cast<int>(e));
+            if ((ea == va && eb == vb) || (ea == vb && eb == va))
+                return static_cast<int>(e);
+        }
+        return -1;
+    };
+
+    // Walk the ring up-front (vertex-pair-keyed, no edge-index
+    // dependence) and collect each quad's rail pair (entry edge +
+    // opposite edge). Two passes: across f1 from the starting edge,
+    // then across f2. visitedFaces handles closed loops.
+    struct WalkStep {
+        int face;
+        std::pair<int, int> railA;
+        std::pair<int, int> railB;
+    };
+    std::vector<WalkStep> walk;
+    std::set<int> visitedFaces;
+
+    const auto [startA, startB] = edgeVertices(startEdgeIdx);
+    if (startA < 0 || startB < 0) return newVertices;
+
+    auto walkDirection = [&](int firstFace, int entryA, int entryB) {
+        if (firstFace < 0) return;
+        int curFace = firstFace;
+        int curA = entryA, curB = entryB;
+        for (int guard = 0; guard < 4096; ++guard) {
+            if (curFace < 0) return;
+            if (m_faces[curFace].halfEdge < 0) return;
+            if (!visitedFaces.insert(curFace).second) return;
+            const auto opp = oppositeEdgeInQuad(curFace, curA, curB);
+            if (opp.first < 0) return; // non-quad / not found
+            WalkStep step;
+            step.face = curFace;
+            step.railA = { curA, curB };
+            step.railB = opp;
+            walk.push_back(step);
+            const int oppEdge = findEdgeByVerts(opp.first, opp.second);
+            if (oppEdge < 0) return;
+            const auto [fa, fb] = edgeFaces(oppEdge);
+            int nextFace = -1;
+            if (fa == curFace) nextFace = fb;
+            else if (fb == curFace) nextFace = fa;
+            if (nextFace < 0) return; // boundary
+            curFace = nextFace;
+            curA = opp.first;
+            curB = opp.second;
+            if ((curA == startA && curB == startB)
+                || (curA == startB && curB == startA)) {
+                return;
+            }
+        }
+    };
+
+    const auto [f1, f2] = edgeFaces(startEdgeIdx);
+    walkDirection(f1, startA, startB);
+    walkDirection(f2, startA, startB);
+
+    if (walk.empty()) return newVertices;
+
+    // Materialise the cut. Rails shared between consecutive steps must
+    // produce the SAME midpoint, so cache by vertex-pair.
+    auto pairKey = [](int a, int b) {
+        return std::make_pair(std::min(a, b), std::max(a, b));
+    };
+    std::map<std::pair<int, int>, int> railMidpoints;
+
+    auto ensureMidpoint = [&](const std::pair<int, int>& rail) -> int {
+        const auto k = pairKey(rail.first, rail.second);
+        auto it = railMidpoints.find(k);
+        if (it != railMidpoints.end()) return it->second;
+        const int eIdx = findEdgeByVerts(rail.first, rail.second);
+        if (eIdx < 0) return -1;
+        const int vMid = splitEdge(eIdx, 0.5f);
+        if (vMid < 0) return -1;
+        railMidpoints[k] = vMid;
+        newVertices.push_back(vMid);
+        return vMid;
+    };
+
+    for (const auto& step : walk) {
+        const int vMidA = ensureMidpoint(step.railA);
+        const int vMidB = ensureMidpoint(step.railB);
+        if (vMidA < 0 || vMidB < 0) continue;
+        // Re-resolve the face: splitEdge may have created replacement
+        // face slots. Find the live face that contains both midpoints.
+        int liveFace = -1;
+        for (int f : facesAroundVertex(vMidA)) {
+            const auto fv = faceVertices(f);
+            if (std::find(fv.begin(), fv.end(), vMidB) != fv.end()) {
+                liveFace = f; break;
+            }
+        }
+        if (liveFace < 0) continue;
+        splitFace(liveFace, vMidA, vMidB);
+    }
+
+    return newVertices;
+}
+
 int HalfEdgeMesh::mergeVertices(const std::vector<int>& vertexIndices,
                                 const Ogre::Vector3& targetPos)
 {

--- a/src/HalfEdgeMesh.h
+++ b/src/HalfEdgeMesh.h
@@ -501,6 +501,34 @@ public:
     std::vector<int> cutPath(const std::vector<CutPoint>& points);
 
     /**
+     * @brief Loop cut: insert a perpendicular cut through a ring of quads.
+     *
+     * Given a starting edge, walks the chain of quads adjacent to it
+     * via the "opposite edge" relation. In each quad [v0, v1, v2, v3]
+     * (where the entry edge is one of its sides, e.g. (v0, v1)), the
+     * OPPOSITE edge is (v2, v3). The loop cut splits both edges at
+     * their midpoints and bisects the quad along the new diagonal.
+     *
+     * The walk continues across each opposite edge into the next
+     * quad in the ring. It terminates when:
+     *   - the walk returns to the starting edge (closed loop),
+     *   - it encounters a non-quad face (loop cut requires the
+     *     opposite-edge correspondence, only well-defined on quads),
+     *   - it encounters a boundary edge (no second face to cross).
+     *
+     * MVP scope: cuts at midpoint (t = 0.5) on each rail. A future
+     * extension can take a `t` parameter to slide the cut along
+     * the loop. Profile / multi-cuts are out of scope.
+     *
+     * @param startEdgeIdx The HE edge index to start from. Must be
+     *                     an interior edge whose adjacent faces are
+     *                     both quads; otherwise returns empty.
+     * @return Indices of every newly created vertex (in walk order).
+     *         Empty on failure.
+     */
+    std::vector<int> loopCut(int startEdgeIdx);
+
+    /**
      * @brief Merge a set of vertices into a single survivor at `targetPos`.
      *
      * Picks `vertexIndices[0]` as the survivor, copies `targetPos` into its

--- a/src/HalfEdgeMesh_test.cpp
+++ b/src/HalfEdgeMesh_test.cpp
@@ -3836,6 +3836,136 @@ TEST(HalfEdgeMeshStandalone, CutPathRollsBackWhenSecondEdgeDuplicatesFirst) {
 }
 
 // ===========================================================================
+// loopCut — perpendicular ring cut through quads
+// ===========================================================================
+
+TEST(HalfEdgeMeshStandalone, LoopCutOnQuadStripCutsEachQuadOnce) {
+    // 3-quad strip: q1=(0,1,5,4), q2=(1,2,6,5), q3=(2,3,7,6).
+    //
+    //   v0─v1─v2─v3
+    //   │ q1│q2│q3│
+    //   v4─v5─v6─v7
+    //
+    // Loop-cutting the (1,5) interior edge starts from q1, the
+    // opposite-edge walk crosses (1,5) into q2 then (2,6) into q3,
+    // terminates at the q3 boundary (3,7). 3 quads × 1 cut each =
+    // 3 new midpoints, 6 quads total after the cut.
+    EditableMesh mesh;
+    EditableSubMesh sub;
+    sub.materialName = "M";
+    auto mkV = [](float x, float y) {
+        EditableVertex v;
+        v.position = Ogre::Vector3(x, y, 0);
+        v.normal = Ogre::Vector3(0, 0, 1); v.hasNormal = true;
+        return v;
+    };
+    sub.vertices = {
+        mkV(0, 1), mkV(1, 1), mkV(2, 1), mkV(3, 1),
+        mkV(0, 0), mkV(1, 0), mkV(2, 0), mkV(3, 0),
+    };
+    EditableFace q1, q2, q3;
+    q1.indices = {0, 1, 5, 4};
+    q2.indices = {1, 2, 6, 5};
+    q3.indices = {2, 3, 7, 6};
+    sub.faces = { q1, q2, q3 };
+    triangulateFaces(sub);
+    mesh.subMeshes().push_back(std::move(sub));
+
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(mesh));
+    const int startEdge = findEdge(he, 1, 5);
+    ASSERT_GE(startEdge, 0);
+
+    auto newVerts = he.loopCut(startEdge);
+    // 4 rails get midpoints: (1,5) start, (0,4) on q1's other side,
+    // (2,6) interior, (3,7) on q3's other side. So 4 new vertices.
+    EXPECT_EQ(newVerts.size(), 4u)
+        << "open-ended loop cut: 4 rail midpoints across 3 quads";
+    EXPECT_TRUE(he.validate());
+
+    int active = 0, quads = 0;
+    for (size_t f = 0; f < he.faceCount(); ++f) {
+        if (he.face(static_cast<int>(f)).halfEdge < 0) continue;
+        ++active;
+        if (he.faceVertices(static_cast<int>(f)).size() == 4) ++quads;
+    }
+    EXPECT_EQ(active, 6) << "each of the 3 original quads bisected → 6 quads";
+    EXPECT_EQ(quads, 6) << "loop cut preserves quad topology";
+}
+
+TEST(HalfEdgeMeshStandalone, LoopCutFailsOnNonQuadAdjacency) {
+    // Triangles can't loop-cut: there's no opposite-edge correspondence.
+    // Starting from any edge of a triangle pair returns empty.
+    auto em = makeQuadMesh(); // two triangles, NOT quads
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    const int diag = findEdge(he, 1, 2);
+    ASSERT_GE(diag, 0);
+    auto newVerts = he.loopCut(diag);
+    EXPECT_TRUE(newVerts.empty());
+    EXPECT_TRUE(he.validate());
+}
+
+TEST(HalfEdgeMeshStandalone, LoopCutClosedRingOnQuadCubeReturnsToStart) {
+    // Quad cube: 6 quad faces forming a closed manifold. Loop-cutting
+    // any edge produces a closed ring of cuts (4 rails total since
+    // the walk returns to the starting edge after traversing 4 faces).
+    EditableMesh em;
+    EditableSubMesh sub;
+    sub.materialName = "M";
+    auto mkV = [](float x, float y, float z) {
+        EditableVertex v;
+        v.position = Ogre::Vector3(x, y, z);
+        v.normal = Ogre::Vector3::UNIT_Y; v.hasNormal = true;
+        return v;
+    };
+    sub.vertices = {
+        mkV(-1,-1,-1), mkV(1,-1,-1), mkV(-1,1,-1), mkV(1,1,-1),
+        mkV(-1,-1, 1), mkV(1,-1, 1), mkV(-1,1, 1), mkV(1,1, 1),
+    };
+    EditableFace fBack, fFront, fTop, fBottom, fLeft, fRight;
+    fBack.indices   = {0, 2, 3, 1};
+    fFront.indices  = {5, 7, 6, 4};
+    fBottom.indices = {0, 1, 5, 4};
+    fTop.indices    = {2, 6, 7, 3};
+    fLeft.indices   = {0, 4, 6, 2};
+    fRight.indices  = {1, 3, 7, 5};
+    sub.faces = { fBack, fFront, fBottom, fTop, fLeft, fRight };
+    triangulateFaces(sub);
+    em.subMeshes().push_back(std::move(sub));
+
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    // Pick the front-bottom edge (4,5). Its perpendicular ring runs
+    // around the cube via Bottom → Right → Top → Left and closes.
+    const int startEdge = findEdge(he, 4, 5);
+    ASSERT_GE(startEdge, 0);
+
+    auto newVerts = he.loopCut(startEdge);
+    EXPECT_EQ(newVerts.size(), 4u)
+        << "closed cube ring: 4 rails (one per traversed face), shared midpoints";
+    EXPECT_TRUE(he.validate());
+
+    // 6 original faces + 4 cuts (one per cube face crossed) → 10 quads.
+    int active = 0, quads = 0;
+    for (size_t f = 0; f < he.faceCount(); ++f) {
+        if (he.face(static_cast<int>(f)).halfEdge < 0) continue;
+        ++active;
+        if (he.faceVertices(static_cast<int>(f)).size() == 4) ++quads;
+    }
+    EXPECT_EQ(active, 10);
+    EXPECT_EQ(quads, 10) << "loop cut preserves quad topology on closed manifolds";
+}
+
+TEST(HalfEdgeMeshStandalone, LoopCutFailsOnInvalidEdgeIndex) {
+    auto em = makeQuadMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    EXPECT_TRUE(he.loopCut(-1).empty());
+    EXPECT_TRUE(he.loopCut(999).empty());
+}
+
+// ===========================================================================
 // Merge vertices
 // ===========================================================================
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -786,15 +786,28 @@ void MainWindow::initToolBar()
     });
     QAction* fillAction = ui->objectsToolbar->addWidget(fillButton);
 
+    // Loop cut: edge mode only — pick one edge, the op walks the
+    // perpendicular ring of quads and bisects each one.
+    auto loopCutButton = new QToolButton(ui->objectsToolbar);
+    loopCutButton->setText(QStringLiteral("\u2551"));  // ‖ double vertical line — "loop"
+    loopCutButton->setToolTip(tr("Loop Cut (Ctrl+R) — bisect quads perpendicular to the selected edge"));
+    loopCutButton->setFont(topoFont);
+    loopCutButton->setStyleSheet(topoBtnStyle);
+    connect(loopCutButton, &QToolButton::clicked, this, []() {
+        SentryReporter::addBreadcrumb("ui.action", "Toolbar: Loop Cut");
+        EditModeController::instance()->loopCutSelection();
+    });
+    QAction* loopCutAction = ui->objectsToolbar->addWidget(loopCutButton);
+
     // Context-aware visibility + enabled:
     //  - Hidden entirely when NOT in edit mode.
     //  - In edit mode: stay visible but only enable when the current
     //    mode matches AND the relevant element type actually has a
     //    non-empty selection.
     auto refreshTopoButtons = [extrudeButton, bevelButton, knifeButton, mergeButton, deleteButton,
-                               subdivideButton, fillButton,
+                               subdivideButton, fillButton, loopCutButton,
                                extrudeAction, bevelAction, knifeAction, mergeAction, deleteAction,
-                               subdivideAction, fillAction]() {
+                               subdivideAction, fillAction, loopCutAction]() {
         auto* c = EditModeController::instance();
         const bool active = c->isEditModeActive();
         extrudeAction->setVisible(active);
@@ -804,6 +817,7 @@ void MainWindow::initToolBar()
         deleteAction->setVisible(active);
         subdivideAction->setVisible(active);
         fillAction->setVisible(active);
+        loopCutAction->setVisible(active);
         if (!active) return;
         const int mode = c->selectionMode();  // 0 vertex, 1 edge, 2 face
         const bool hasFaces = c->selectedFaceCount() > 0;
@@ -832,6 +846,10 @@ void MainWindow::initToolBar()
         // closed loop (edge mode — degree check happens at apply time).
         fillButton->setEnabled((mode == 0 && c->selectedVertexCount() >= 3)
                             || (mode == 1 && c->selectedEdgeCount() >= 3));
+        // Loop cut: edge mode with at least one selected edge. The op
+        // uses the first selected edge as the start; multi-edge loop
+        // cuts aren't in scope for the MVP.
+        loopCutButton->setEnabled(mode == 1 && hasEdges);
     };
     refreshTopoButtons();
     connect(editCtrlForTopo, &EditModeController::editModeChanged,
@@ -1343,6 +1361,21 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
         setTransformState(TransformOperator::TS_ROTATE);
        break;
     case Qt::Key_R:
+        // Ctrl+R in edit-mode + edge-selection: loop cut. Otherwise R
+        // is Scale mode (Unity convention). The Ctrl modifier
+        // disambiguates without disturbing the existing shortcut.
+        if (event->modifiers() & Qt::ControlModifier) {
+            auto* editCtrl = EditModeController::instance();
+            if (editCtrl->isEditModeActive()
+                && editCtrl->selectionMode() == EditModeController::EdgeMode
+                && editCtrl->selectedEdgeCount() > 0) {
+                if (editCtrl->loopCutSelection() > 0) {
+                    SentryReporter::addBreadcrumb("ui.shortcut", "Ctrl+R — Loop Cut");
+                    event->accept();
+                    return;
+                }
+            }
+        }
         SentryReporter::addBreadcrumb("ui.shortcut", "R — Scale mode");
         setTransformState(TransformOperator::TS_SCALE);
        break;


### PR DESCRIPTION
## Summary
Implements **loop cut** — the original target that started the quad-migration epic. Walks the perpendicular ring of quads adjacent to a selected edge and bisects each one with a midpoint chain.

### `HalfEdgeMesh::loopCut(startEdgeIdx)`
- Starts at the two faces adjacent to `startEdgeIdx`.
- In each quad, finds the opposite edge (two positions away in the loop) and crosses through it into the next face.
- Stops on: closed loop (back to start), boundary edge, or non-quad face.
- Walks both directions from the start so an interior edge of an open mesh produces cuts on both sides.
- Materialisation phase: vertex-pair-keyed midpoint cache (shared between consecutive steps), `splitFace` bisects each step's face.

### `EditModeController::loopCutSelection()`
Edge-mode only; uses first selected edge. Pushes "Loop Cut" undo command.

### UI
- Toolbar button (‖ double vertical line) next to Fill.
- **Ctrl+R** shortcut — disambiguates from R=Scale (Unity convention). Falls through to Scale when loop cut returns 0, so Ctrl+R is harmless outside Edit/Edge mode.

### Quad-only behaviour
Loop cut is geometrically a quad operation — triangles have no opposite-edge correspondence, so there's no well-defined "loop". MVP returns empty on triangle adjacency, matching Blender's behaviour. A tri-pair fallback (treat coplanar triangle pairs as quads for the walk) could be added later if needed.

## Test plan
- [x] 244 standalone tests pass
- [x] `LoopCutOnQuadStripCutsEachQuadOnce` — 3-quad strip → 4 rail midpoints, 6 quads after cut, no fan diagonals.
- [x] `LoopCutClosedRingOnQuadCubeReturnsToStart` — quad cube → 4 rail midpoints (closed ring), 10 quads (6 + 4 cuts).
- [x] `LoopCutFailsOnNonQuadAdjacency` — triangle pair → empty.
- [x] `LoopCutFailsOnInvalidEdgeIndex` — -1 / out-of-range → empty.
- [x] Smoke: FBX quad asset — Ctrl+R on an interior edge produces a perpendicular cut chain through the quad ring.
- [x] Smoke: triangle cube — Ctrl+R is a no-op (expected).

## Known follow-ups
- Triangle-pair fallback (treat tri+tri sharing a diagonal as a logical quad).
- Slide / `t` parameter to position the cut along the loop instead of always at midpoint.
- Multi-cut loops (insert N parallel cuts in one op).