### PR TITLE
Vertex paint: coalesce vertex color uploads during stroke

### DIFF
--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -39,6 +39,7 @@ THE SOFTWARE.
 #include "mainwindow.h"
 #include "OgreWidget.h"
 #include "SpaceCamera.h"
+#include <QTimer>
 #include <Ogre.h>
 #include <OgreRTShaderSystem.h>
 #include <ProceduralSphereGenerator.h>
@@ -426,6 +427,8 @@ void EditModeController::exitEditMode(bool commitChanges)
         if (m_vertexPaintStrokeActive)
             endVertexPaintStroke(/*commitUndo=*/commitChanges);
         m_vertexPaintEnabled = false;
+        m_vertexPaintFlushPending = false;
+        m_vertexPaintFlushScheduled = false;
         clearVertexPaintPreview();
         emit vertexPaintChanged();
     }
@@ -1258,8 +1261,20 @@ void EditModeController::updateVertexPaintStroke(OgreWidget* widget, const QPoin
 
     if (changed) {
         m_vertexPaintStrokeDirty = true;
-        m_editableMesh->commitVertexColorsToEntity(m_editEntity);
-        emit meshDataChanged();
+        m_vertexPaintFlushPending = true;
+        if (!m_vertexPaintFlushScheduled) {
+            m_vertexPaintFlushScheduled = true;
+            QTimer::singleShot(0, this, [this]() {
+                m_vertexPaintFlushScheduled = false;
+                if (!m_vertexPaintFlushPending)
+                    return;
+                if (!m_editModeActive || !m_editableMesh || !m_editEntity)
+                    return;
+                m_vertexPaintFlushPending = false;
+                m_editableMesh->commitVertexColorsToEntity(m_editEntity);
+                emit meshDataChanged();
+            });
+        }
     }
 }
 
@@ -1343,6 +1358,13 @@ void EditModeController::endVertexPaintStroke(bool commitUndo)
     if (!m_vertexPaintStrokeDirty) {
         m_vertexPaintStrokeOriginalSubMeshes.clear();
         return;
+    }
+
+    // Ensure the final sample is visible before we snapshot undo state.
+    if (m_vertexPaintFlushPending && m_editModeActive && m_editableMesh && m_editEntity) {
+        m_vertexPaintFlushPending = false;
+        m_editableMesh->commitVertexColorsToEntity(m_editEntity);
+        emit meshDataChanged();
     }
 
     const auto newSubMeshes = m_editableMesh->subMeshes();

--- a/src/EditModeController.h
+++ b/src/EditModeController.h
@@ -824,6 +824,8 @@ private:
     Ogre::Vector3 m_vertexPaintLastLocal = Ogre::Vector3::ZERO;
     bool m_vertexPaintHaveLastLocal = false;
     bool m_vertexPaintStrokeDirty = false;
+    bool m_vertexPaintFlushScheduled = false;
+    bool m_vertexPaintFlushPending = false;
     std::vector<EditableSubMesh> m_vertexPaintStrokeOriginalSubMeshes;
 
     /// Hit-test a screen-space point for knife placement. Priority:


### PR DESCRIPTION
## Summary
- Improve vertex paint stroke performance by coalescing vertex color uploads.
- Instead of committing colors on every mouse-move, schedule a single-shot flush and upload at most once per event loop tick.
- Force a final flush on stroke end to ensure the last sample is visible and captured.

## Rationale
On dense meshes, uploading vertex colors every mouse-move can dominate frame time and make the brush feel sticky. This keeps the painting math unchanged while reducing buffer churn.

## Test plan
- Enter Edit Mode, enable Vertex Paint.
- Paint continuously over a dense mesh: brush should feel smoother and colors should still update interactively.
- Release mouse: last painted sample should be visible immediately and undo should revert the stroke.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vertex painting performance by deferring color updates instead of processing them immediately on each brush sample.
  * Enhanced reliability of undo snapshots to ensure painted states are properly captured before editing completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->