### PR TITLE
feat(quads): tris→quads converter + quad-aware wireframe

### DIFF
--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -3433,7 +3433,23 @@ int EditModeController::loopCutSelection()
     const auto preSelectedFaces = m_selectedFaces;
 
     const auto newHE = hm.loopCut(startEdge);
-    if (newHE.empty()) return 0;
+    if (newHE.empty()) {
+        // The walk failed — most often because both faces adjacent to
+        // the start edge are triangles (loop cut needs the opposite-edge
+        // correspondence, well-defined only on quads/n-gons). Surface a
+        // hint to the user pointing at the converter.
+        const auto [fa, fb] = hm.edgeFaces(startEdge);
+        const bool faTri = fa >= 0 && hm.faceVertices(fa).size() == 3;
+        const bool fbTri = fb >= 0 && hm.faceVertices(fb).size() == 3;
+        if (faTri || fbTri) {
+            const QString hint = QStringLiteral(
+                "Loop cut needs a quad mesh — try Mesh → Convert to Quads.");
+            emit editHintMessage(hint);
+            SentryReporter::addBreadcrumb("edit_mode",
+                "Loop Cut no-op (tri adjacency)");
+        }
+        return 0;
+    }
 
     EditableMesh updated;
     if (!hm.toEditableMesh(updated)) return 0;
@@ -3469,6 +3485,89 @@ int EditModeController::loopCutSelection()
     emit editSelectionChanged();
     emit meshDataChanged();
     return static_cast<int>(newHE.size());
+}
+
+int EditModeController::convertToQuads(float angleThresholdDeg)
+{
+    if (!m_editModeActive || !m_editableMesh || !m_editEntity) return 0;
+
+    if (m_bevelSession.active) cancelBevel();
+    if (m_knifeSession.active) cancelKnife();
+
+    auto originalSubMeshes = m_editableMesh->subMeshes();
+    const auto preSelectedVerts = m_selectedVertices;
+    const auto preSelectedEdges = m_selectedEdges;
+    const auto preSelectedFaces = m_selectedFaces;
+
+    int totalMerges = 0;
+    for (auto& sub : m_editableMesh->subMeshes()) {
+        // Promote first if the submesh is in legacy triangle-only mode
+        // so the n-gon path takes over even when no merges happen — the
+        // wireframe overlay etc. branch on .faces being non-empty.
+        if (sub.faces.empty()) promoteTrianglesToFaces(sub);
+        totalMerges += mergeCoplanarTrianglesToQuads(sub, angleThresholdDeg);
+    }
+
+    if (totalMerges == 0) {
+        // Promotion alone counts as a meaningful change (downstream
+        // n-gon-aware features start working) — but if every submesh
+        // already had .faces and no merges happened, this is a true
+        // no-op. Detect by comparing face counts pre/post.
+        bool topologyChanged = false;
+        const auto& cur = m_editableMesh->subMeshes();
+        if (cur.size() != originalSubMeshes.size()) {
+            topologyChanged = true;
+        } else {
+            for (size_t i = 0; i < cur.size(); ++i) {
+                if (cur[i].faces.size() != originalSubMeshes[i].faces.size()) {
+                    topologyChanged = true;
+                    break;
+                }
+            }
+        }
+        if (!topologyChanged) {
+            // Restore — promote was a no-op too.
+            m_editableMesh->subMeshes() = std::move(originalSubMeshes);
+            return 0;
+        }
+    }
+
+    if (m_normalsMode == 0) m_editableMesh->recalculateNormals();
+    else                     m_editableMesh->recalculateNormalsFlat();
+
+    m_editableMesh->resizeEntityBuffers(m_editEntity);
+    rewriteEntityAfterTopologyChange(m_editEntity);
+
+    // Vertex IDs are unchanged by the merge (we only restructured face
+    // groupings), so per-vertex selection survives. Edge/face IDs are
+    // not stable across the rebuild — clear them.
+    m_selectedEdges.clear();
+    m_selectedFaces.clear();
+
+    auto* cmd = new EditMeshTopologyCommand(
+        std::move(originalSubMeshes),
+        m_editableMesh->subMeshes(),
+        preSelectedVerts, preSelectedEdges, preSelectedFaces,
+        m_selectedVertices, m_selectedEdges, m_selectedFaces,
+        QStringLiteral("Convert to Quads"));
+    UndoManager::getSingleton()->push(cmd);
+
+    validateMesh();
+    SentryReporter::addBreadcrumb("edit_mode",
+        QString("Convert to Quads (merges=%1)").arg(totalMerges));
+
+    // Wireframe path may have flipped from PM_WIREFRAME to the n-gon
+    // boundary overlay (or back, if undo is invoked) — re-apply.
+    if (m_wireframeEnabled) {
+        removeWireframeMaterials();
+        applyWireframeMaterials();
+    }
+
+    updateSelectionOverlay();
+    refreshNormalVisualizer();
+    emit editSelectionChanged();
+    emit meshDataChanged();
+    return totalMerges;
 }
 
 int EditModeController::subdivideCatmullClarkAll()
@@ -4221,6 +4320,9 @@ void EditModeController::createOverlayMaterials()
         pass->setVertexColourTracking(Ogre::TVC_DIFFUSE);
         pass->setDepthCheckEnabled(false);
         pass->setDepthWriteEnabled(false);
+        // Thicker than the boundary-wireframe overlay (2px) so the
+        // selection still reads clearly when the two overlays overlap.
+        pass->setLineWidth(3.0f);
     }
 
     // Face selection material (semi-transparent overlay, no lighting)
@@ -4235,6 +4337,26 @@ void EditModeController::createOverlayMaterials()
         pass->setDepthCheckEnabled(true);
         pass->setDepthWriteEnabled(false);
         pass->setCullingMode(Ogre::CULL_NONE);
+    }
+
+    // Quad-aware wireframe overlay material — same render-mode profile
+    // as EditMode/EdgeSelection but kept distinct so its colour can
+    // diverge later (e.g. theme support, hover highlight).
+    if (!matMgr.getByName("EditMode/BoundaryWireframe"))
+    {
+        auto mat = matMgr.create("EditMode/BoundaryWireframe",
+                                 Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME);
+        auto* pass = mat->getTechnique(0)->getPass(0);
+        pass->setLightingEnabled(false);
+        pass->setVertexColourTracking(Ogre::TVC_DIFFUSE);
+        pass->setDepthCheckEnabled(true);
+        pass->setDepthWriteEnabled(false);
+        // Thicker boundary lines so the overlay reads cleanly against
+        // the underlying mesh shading. Note: many modern GL drivers
+        // cap line width to 1 in core profile — if this still looks
+        // hairline, the fallback is to extrude lines into camera-
+        // facing triangle strips (TODO if 2px is unreliable).
+        pass->setLineWidth(2.0f);
     }
 }
 
@@ -4262,7 +4384,8 @@ void EditModeController::updateSelectionOverlay()
     {
         m_overlayVertices = sceneMgr->createManualObject("EditMode_VertexOverlay");
         m_overlayVertices->setDynamic(true);
-        m_overlayVertices->setRenderQueueGroup(Ogre::RENDER_QUEUE_OVERLAY);
+        // Above the boundary wireframe so selected vertices read on top.
+        m_overlayVertices->setRenderQueueGroup(Ogre::RENDER_QUEUE_OVERLAY + 1);
         m_overlayNode->attachObject(m_overlayVertices);
     }
 
@@ -4307,7 +4430,9 @@ void EditModeController::updateSelectionOverlay()
     {
         m_overlayEdges = sceneMgr->createManualObject("EditMode_EdgeOverlay");
         m_overlayEdges->setDynamic(true);
-        m_overlayEdges->setRenderQueueGroup(Ogre::RENDER_QUEUE_OVERLAY);
+        // Draw selected edges AFTER the n-gon boundary wireframe overlay
+        // so the selection reads on top when the two coincide.
+        m_overlayEdges->setRenderQueueGroup(Ogre::RENDER_QUEUE_OVERLAY + 1);
         m_overlayNode->attachObject(m_overlayEdges);
     }
 
@@ -4389,6 +4514,9 @@ void EditModeController::updateSelectionOverlay()
         m_overlayFaces->end();
     }
 
+    // -- Quad-aware wireframe overlay (n-gon meshes only) --
+    updateBoundaryEdgeOverlay();
+
     // -- Soft selection radius sphere --
     if (m_softSelectionEnabled && !m_selectedVertices.empty()) {
         Ogre::Vector3 centroid = getSelectedVerticesCentroid();
@@ -4460,6 +4588,10 @@ void EditModeController::destroySelectionOverlay()
             sceneMgr->destroyManualObject(m_overlayFaces);
             m_overlayFaces = nullptr;
         }
+        if (m_overlayBoundaryEdges) {
+            sceneMgr->destroyManualObject(m_overlayBoundaryEdges);
+            m_overlayBoundaryEdges = nullptr;
+        }
         if (m_softSelSphere) {
             if (m_softSelSphereNode)
                 m_softSelSphereNode->detachAllObjects();
@@ -4481,10 +4613,33 @@ void EditModeController::destroySelectionOverlay()
 // Wireframe toggle
 // ===========================================================================
 
+bool EditModeController::meshHasNgonFaces() const
+{
+    return isMeshQuadBased();
+}
+
+bool EditModeController::isMeshQuadBased() const
+{
+    if (!m_editableMesh) return false;
+    for (const auto& sub : m_editableMesh->subMeshes()) {
+        if (!sub.faces.empty()) return true;
+    }
+    return false;
+}
+
 void EditModeController::applyWireframeMaterials()
 {
     if (!m_editEntity)
         return;
+
+    // n-gon mesh: keep solid material, use the boundary-edge overlay
+    // (drawn from updateSelectionOverlay) to show face boundaries
+    // without the fan-triangulation diagonals.
+    if (meshHasNgonFaces()) {
+        m_savedMaterials.clear();
+        updateBoundaryEdgeOverlay();
+        return;
+    }
 
     m_savedMaterials.clear();
     for (unsigned int i = 0; i < m_editEntity->getNumSubEntities(); ++i) {
@@ -4521,6 +4676,61 @@ void EditModeController::removeWireframeMaterials()
         }
     }
     m_savedMaterials.clear();
+
+    // Clear the n-gon boundary overlay too — the user toggled wireframe
+    // off, no PM_WIREFRAME or boundary lines should remain visible.
+    if (m_overlayBoundaryEdges)
+        m_overlayBoundaryEdges->clear();
+}
+
+void EditModeController::updateBoundaryEdgeOverlay()
+{
+    if (!m_editModeActive || !m_editableMesh || !m_editEntity) return;
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    if (!sceneMgr) return;
+    if (!m_overlayNode) return; // overlay setup hasn't run yet
+
+    if (!m_overlayBoundaryEdges) {
+        m_overlayBoundaryEdges = sceneMgr->createManualObject(
+            "EditMode_BoundaryEdgeOverlay");
+        m_overlayBoundaryEdges->setDynamic(true);
+        m_overlayBoundaryEdges->setRenderQueueGroup(Ogre::RENDER_QUEUE_OVERLAY);
+        m_overlayNode->attachObject(m_overlayBoundaryEdges);
+    }
+
+    m_overlayBoundaryEdges->clear();
+    if (!m_wireframeEnabled || !meshHasNgonFaces()) return;
+
+    m_overlayBoundaryEdges->begin("EditMode/BoundaryWireframe",
+                                  Ogre::RenderOperation::OT_LINE_LIST);
+    const Ogre::ColourValue lineColor(0.85f, 0.85f, 0.85f, 1.0f);
+
+    // Build a deduped set of (min,max) vertex-pair edges from each
+    // submesh's n-gon faces. Submesh-local indexing — different
+    // submeshes don't share vertices.
+    for (const auto& sub : m_editableMesh->subMeshes()) {
+        if (sub.faces.empty()) continue;
+        std::set<std::pair<unsigned int, unsigned int>> emitted;
+        for (const auto& face : sub.faces) {
+            if (!face.isValid()) continue;
+            const auto& idx = face.indices;
+            const size_t n = idx.size();
+            for (size_t i = 0; i < n; ++i) {
+                const unsigned int a = idx[i];
+                const unsigned int b = idx[(i + 1) % n];
+                const auto key = std::make_pair(std::min(a, b), std::max(a, b));
+                if (!emitted.insert(key).second) continue;
+                if (a >= sub.vertices.size() || b >= sub.vertices.size())
+                    continue;
+                m_overlayBoundaryEdges->position(sub.vertices[a].position);
+                m_overlayBoundaryEdges->colour(lineColor);
+                m_overlayBoundaryEdges->position(sub.vertices[b].position);
+                m_overlayBoundaryEdges->colour(lineColor);
+            }
+        }
+    }
+
+    m_overlayBoundaryEdges->end();
 }
 
 void EditModeController::setWireframeEnabled(bool enabled)

--- a/src/EditModeController.h
+++ b/src/EditModeController.h
@@ -122,6 +122,11 @@ public:
     Q_PROPERTY(bool wireframeEnabled READ wireframeEnabled WRITE setWireframeEnabled NOTIFY wireframeChanged)
     bool wireframeEnabled() const { return m_wireframeEnabled; }
     void setWireframeEnabled(bool enabled);
+
+    /// True if any submesh of the current edit mesh has non-empty
+    /// n-gon `.faces` — i.e. quad-based already. Drives the
+    /// "Convert to Quads" toolbar button enable state.
+    Q_INVOKABLE bool isMeshQuadBased() const;
     /// @}
 
     /// @name Mesh info (only valid when in edit mode)
@@ -501,6 +506,28 @@ public:
      * @return Number of triangles created (0 on no-op or rejection).
      */
     Q_INVOKABLE int fillSelection();
+
+    /**
+     * @brief Merge coplanar adjacent triangle pairs into quads.
+     *
+     * Whole-mesh operation: walks every submesh, looks for triangle pairs
+     * that share an edge and are within `angleThresholdDeg` of coplanar
+     * (default 1°), and merges each qualifying pair into a single quad
+     * face. Promotes the legacy triangle-only representation into the
+     * n-gon canonical form. After the operation, downstream features
+     * that branch on n-gon `.faces` (loop cut, n-gon-aware bevel,
+     * quad-aware wireframe) start working.
+     *
+     * No-op when nothing qualifies (all tris are non-coplanar, or the
+     * mesh is already quad-dominant). Pushes one undo command labeled
+     * "Convert to Quads" iff merges happened.
+     *
+     * @param angleThresholdDeg Maximum dihedral angle (deg) to treat as
+     *        coplanar. 0 = strict, ~5 = forgiving for float-quantised
+     *        imports. Defaults to 1°.
+     * @return Number of triangle pairs merged across all submeshes.
+     */
+    Q_INVOKABLE int convertToQuads(float angleThresholdDeg = 1.0f);
     /// @}
 
     /// @name Vertex transform support
@@ -723,6 +750,12 @@ signals:
     /// so QML toolbar state and preview overlay refresh together.
     void knifeSessionChanged();
 
+    /// Emitted when an edit-mode op short-circuits and wants to surface
+    /// a one-line explanation to the user (e.g. "Loop cut requires a
+    /// quad mesh — try Mesh → Convert to Quads"). QML overlays /
+    /// status-bar widgets can subscribe.
+    void editHintMessage(const QString& message);
+
 private slots:
     void onSelectionChanged();
 
@@ -765,6 +798,12 @@ private:
     Ogre::ManualObject* m_overlayVertices = nullptr;
     Ogre::ManualObject* m_overlayEdges = nullptr;
     Ogre::ManualObject* m_overlayFaces = nullptr;
+    /// Quad-aware wireframe: lines along n-gon face boundaries only,
+    /// hiding the diagonals introduced by `triangulateFaces()`. Active
+    /// when `m_wireframeEnabled` AND any submesh has non-empty `.faces`.
+    /// On legacy triangle-only meshes this stays empty and the
+    /// PM_WIREFRAME material override does the work instead.
+    Ogre::ManualObject* m_overlayBoundaryEdges = nullptr;
     Ogre::SceneNode* m_overlayNode = nullptr;
 
     // Bevel session state — populated on beginBevel, consumed on commit/cancel.
@@ -903,6 +942,14 @@ private:
     // Wireframe helpers
     void applyWireframeMaterials();
     void removeWireframeMaterials();
+    /// True if any submesh has non-empty `.faces` (n-gon canonical).
+    /// Drives the choice between PM_WIREFRAME (all submeshes pure tris)
+    /// and the boundary-edge overlay (any n-gon faces present).
+    bool meshHasNgonFaces() const;
+    /// (Re)build the n-gon boundary-edge overlay from `m_editableMesh`.
+    /// Active when `m_wireframeEnabled` AND `meshHasNgonFaces()` —
+    /// otherwise clears the overlay so it draws nothing.
+    void updateBoundaryEdgeOverlay();
 
 public:
     /// Refresh an entity after a topology mutation: rebuild tangents

--- a/src/EditableMesh.cpp
+++ b/src/EditableMesh.cpp
@@ -30,10 +30,12 @@ THE SOFTWARE.
 #include "SubMeshTransform.h"
 #include <OgreSubEntity.h>
 #include <algorithm>
+#include <climits>
 #include <iterator>
 #include <limits>
 #include <cmath>
 #include <cstring>
+#include <map>
 
 // Assimp re-import path (loadFromAssimpFile) — drops aiProcess_Triangulate
 // so source n-gons survive into EditableSubMesh::faces. Quad migration #326,
@@ -79,6 +81,158 @@ void promoteTrianglesToFaces(EditableSubMesh& sub)
     // existing `triangles` already mirrors what `faces` would generate
     // (each face is a single triangle), so the canonical-faces invariant
     // already holds.
+}
+
+namespace {
+
+Ogre::Vector3 triangleNormal(const EditableSubMesh& sub,
+                             const EditableTriangle& tri)
+{
+    if (tri.indices[0] >= sub.vertices.size()
+        || tri.indices[1] >= sub.vertices.size()
+        || tri.indices[2] >= sub.vertices.size())
+        return Ogre::Vector3::ZERO;
+    const auto& a = sub.vertices[tri.indices[0]].position;
+    const auto& b = sub.vertices[tri.indices[1]].position;
+    const auto& c = sub.vertices[tri.indices[2]].position;
+    Ogre::Vector3 n = (b - a).crossProduct(c - a);
+    if (n.squaredLength() < 1e-12f) return Ogre::Vector3::ZERO;
+    n.normalise();
+    return n;
+}
+
+// Build the merged quad winding from two adjacent triangles sharing
+// edge (sharedA, sharedB). Returns the 4-vertex loop in the winding of
+// the first triangle, or empty if the merge would produce a degenerate
+// or non-convex result.
+std::vector<unsigned int> buildQuadLoop(const EditableSubMesh& sub,
+                                        const EditableTriangle& t1,
+                                        const EditableTriangle& t2,
+                                        unsigned int sharedA,
+                                        unsigned int sharedB)
+{
+    // Find the apex (non-shared vertex) of each triangle.
+    auto apexOf = [&](const EditableTriangle& t) -> unsigned int {
+        for (int i = 0; i < 3; ++i) {
+            if (t.indices[i] != sharedA && t.indices[i] != sharedB)
+                return t.indices[i];
+        }
+        return UINT_MAX;
+    };
+    const unsigned int apex1 = apexOf(t1);
+    const unsigned int apex2 = apexOf(t2);
+    if (apex1 == UINT_MAX || apex2 == UINT_MAX) return {};
+    if (apex1 == apex2) return {}; // degenerate
+
+    // Walk t1's winding to figure out the order: starting from apex1,
+    // is the next vertex sharedA or sharedB? That determines whether
+    // the quad is [apex1, sharedA, apex2, sharedB] or [apex1, sharedB,
+    // apex2, sharedA]. The diagonal we drop is (sharedA, sharedB).
+    int apexPos = -1;
+    for (int i = 0; i < 3; ++i) {
+        if (t1.indices[i] == apex1) { apexPos = i; break; }
+    }
+    if (apexPos < 0) return {};
+    const unsigned int after = t1.indices[(apexPos + 1) % 3];
+
+    std::vector<unsigned int> loop;
+    loop.reserve(4);
+    loop.push_back(apex1);
+    loop.push_back(after);                  // sharedA or sharedB
+    loop.push_back(apex2);
+    loop.push_back(after == sharedA ? sharedB : sharedA);
+
+    // Convexity check: for each consecutive triple in the loop, the
+    // cross product (next - cur) × (prev - cur) must point in the same
+    // direction as the triangle normal. If any flips, the quad is
+    // non-convex (or self-intersecting) — reject the merge.
+    const Ogre::Vector3 nRef = triangleNormal(sub, t1);
+    if (nRef == Ogre::Vector3::ZERO) return {};
+    for (int i = 0; i < 4; ++i) {
+        const auto& a = sub.vertices[loop[(i + 3) % 4]].position;
+        const auto& b = sub.vertices[loop[i]].position;
+        const auto& c = sub.vertices[loop[(i + 1) % 4]].position;
+        const Ogre::Vector3 cross = (c - b).crossProduct(a - b);
+        if (cross.dotProduct(nRef) <= 0.0f) return {};
+    }
+
+    return loop;
+}
+
+} // namespace
+
+int mergeCoplanarTrianglesToQuads(EditableSubMesh& sub,
+                                  float angleThresholdDeg)
+{
+    if (sub.triangles.empty()) return 0;
+
+    // Edge → list of triangle indices. An interior edge between two
+    // triangles has exactly two entries.
+    using EdgeKey = std::pair<unsigned int, unsigned int>;
+    auto makeKey = [](unsigned int a, unsigned int b) {
+        return EdgeKey{ std::min(a, b), std::max(a, b) };
+    };
+    std::map<EdgeKey, std::vector<size_t>> edgeToTris;
+    for (size_t ti = 0; ti < sub.triangles.size(); ++ti) {
+        const auto& t = sub.triangles[ti];
+        for (int e = 0; e < 3; ++e) {
+            edgeToTris[makeKey(t.indices[e], t.indices[(e + 1) % 3])]
+                .push_back(ti);
+        }
+    }
+
+    const float cosThreshold = std::cos(
+        Ogre::Math::DegreesToRadians(std::max(0.0f, angleThresholdDeg)));
+
+    std::vector<bool> consumed(sub.triangles.size(), false);
+    std::vector<EditableFace> outFaces;
+    outFaces.reserve(sub.triangles.size());
+    int merges = 0;
+
+    for (size_t ti = 0; ti < sub.triangles.size(); ++ti) {
+        if (consumed[ti]) continue;
+        const auto& t = sub.triangles[ti];
+
+        bool merged = false;
+        for (int e = 0; e < 3 && !merged; ++e) {
+            const unsigned int a = t.indices[e];
+            const unsigned int b = t.indices[(e + 1) % 3];
+            const auto& neighbours = edgeToTris[makeKey(a, b)];
+            if (neighbours.size() != 2) continue; // boundary or non-manifold
+
+            const size_t other = (neighbours[0] == ti) ? neighbours[1]
+                                                       : neighbours[0];
+            if (other == ti || consumed[other]) continue;
+
+            const Ogre::Vector3 n1 = triangleNormal(sub, t);
+            const Ogre::Vector3 n2 = triangleNormal(sub, sub.triangles[other]);
+            if (n1 == Ogre::Vector3::ZERO || n2 == Ogre::Vector3::ZERO)
+                continue;
+            if (n1.dotProduct(n2) < cosThreshold) continue;
+
+            const auto loop = buildQuadLoop(sub, t, sub.triangles[other], a, b);
+            if (loop.size() != 4) continue;
+
+            EditableFace face;
+            face.indices.assign(loop.begin(), loop.end());
+            outFaces.push_back(std::move(face));
+            consumed[ti] = true;
+            consumed[other] = true;
+            ++merges;
+            merged = true;
+        }
+
+        if (!merged) {
+            EditableFace face;
+            face.indices = {t.indices[0], t.indices[1], t.indices[2]};
+            outFaces.push_back(std::move(face));
+            consumed[ti] = true;
+        }
+    }
+
+    sub.faces = std::move(outFaces);
+    triangulateFaces(sub);
+    return merges;
 }
 
 bool EditableMesh::loadFromEntity(Ogre::Entity* entity)

--- a/src/EditableMesh.h
+++ b/src/EditableMesh.h
@@ -162,6 +162,34 @@ void triangulateFaces(EditableSubMesh& sub);
 void promoteTrianglesToFaces(EditableSubMesh& sub);
 
 /**
+ * @brief Merge coplanar adjacent triangle pairs into quads in `faces`.
+ *
+ * Walks the submesh's triangles, builds an edge→triangle adjacency map,
+ * and for each interior edge between two unmerged triangles checks whether
+ * the pair is coplanar (face normals' dot product ≥ cos(angleThresholdDeg))
+ * and forms a convex quad. Matching pairs are written to `sub.faces` as
+ * 4-vertex EditableFace entries; unmerged triangles are written as 3-vertex
+ * faces. After the call, `sub.faces` is canonical and `sub.triangles` is
+ * resynced via `triangulateFaces(sub)`.
+ *
+ * Each triangle is merged at most once. A greedy first-fit scan is used:
+ * when multiple neighbours qualify, the first one walked wins. This is
+ * good enough for axis-aligned tessellated quads and tri-pair-strip
+ * imports — the typical "I exported a quad mesh as triangles" case.
+ *
+ * @param sub Submesh to convert. Read-write — `sub.faces` is overwritten,
+ *            `sub.triangles` is rebuilt.
+ * @param angleThresholdDeg Maximum dihedral angle (degrees) between the
+ *            two triangle normals for them to be considered coplanar.
+ *            Defaults to 1° (very strict). Pass 0 to require perfect
+ *            coplanarity, or e.g. 5° to merge near-coplanar imports
+ *            from float-quantised exporters.
+ * @return Number of triangle pairs merged into quads.
+ */
+int mergeCoplanarTrianglesToQuads(EditableSubMesh& sub,
+                                  float angleThresholdDeg = 1.0f);
+
+/**
  * @brief Re-triangulate every submesh whose `faces` is non-empty.
  *
  * Convenience over `triangulateFaces(sub)` for a whole mesh: walks the

--- a/src/EditableMesh_test.cpp
+++ b/src/EditableMesh_test.cpp
@@ -1309,3 +1309,119 @@ TEST(EditableMeshStandalone, FaceIndexForTriangleSkipsInvalidFaces) {
     EXPECT_EQ(firstTri, 0u);
     EXPECT_EQ(count, 2u);
 }
+
+// ============================================================================
+// mergeCoplanarTrianglesToQuads
+// ============================================================================
+
+namespace {
+EditableVertex mkPosV(float x, float y, float z) {
+    EditableVertex v;
+    v.position = Ogre::Vector3(x, y, z);
+    v.normal = Ogre::Vector3::UNIT_Z;
+    v.hasNormal = true;
+    return v;
+}
+} // namespace
+
+TEST(EditableMeshStandalone, MergeCoplanarTrianglesProducesQuad) {
+    // Two triangles forming a planar unit quad on the XY plane.
+    EditableSubMesh sub;
+    sub.vertices = {
+        mkPosV(0, 0, 0), mkPosV(1, 0, 0), mkPosV(1, 1, 0), mkPosV(0, 1, 0),
+    };
+    EditableTriangle t1{}, t2{};
+    t1.indices[0] = 0; t1.indices[1] = 1; t1.indices[2] = 2;
+    t2.indices[0] = 0; t2.indices[1] = 2; t2.indices[2] = 3;
+    sub.triangles = {t1, t2};
+
+    const int merged = mergeCoplanarTrianglesToQuads(sub);
+    EXPECT_EQ(merged, 1);
+    ASSERT_EQ(sub.faces.size(), 1u);
+    EXPECT_EQ(sub.faces[0].indices.size(), 4u);
+    // triangulation mirror is rebuilt
+    EXPECT_EQ(sub.triangles.size(), 2u);
+}
+
+TEST(EditableMeshStandalone, MergeCoplanarLeavesNonCoplanarAsTris) {
+    // Two triangles sharing edge (0,1) but bent at 90°.
+    EditableSubMesh sub;
+    sub.vertices = {
+        mkPosV(0, 0, 0), mkPosV(1, 0, 0), mkPosV(0, 1, 0), mkPosV(0, 0, 1),
+    };
+    EditableTriangle t1{}, t2{};
+    t1.indices[0] = 0; t1.indices[1] = 1; t1.indices[2] = 2;
+    // Second tri lifted off the XY plane along Z — 90° dihedral.
+    t2.indices[0] = 1; t2.indices[1] = 0; t2.indices[2] = 3;
+    sub.triangles = {t1, t2};
+
+    const int merged = mergeCoplanarTrianglesToQuads(sub, 1.0f);
+    EXPECT_EQ(merged, 0);
+    ASSERT_EQ(sub.faces.size(), 2u);
+    EXPECT_EQ(sub.faces[0].indices.size(), 3u);
+    EXPECT_EQ(sub.faces[1].indices.size(), 3u);
+}
+
+TEST(EditableMeshStandalone, MergeCoplanarHandlesTriangulatedCube) {
+    // Standard 8-vert cube triangulated as 12 tris (2 per face).
+    // mergeCoplanarTrianglesToQuads should reconstruct 6 quads.
+    EditableSubMesh sub;
+    sub.vertices = {
+        mkPosV(-1,-1,-1), mkPosV( 1,-1,-1), mkPosV( 1, 1,-1), mkPosV(-1, 1,-1),
+        mkPosV(-1,-1, 1), mkPosV( 1,-1, 1), mkPosV( 1, 1, 1), mkPosV(-1, 1, 1),
+    };
+    auto T = [](unsigned a, unsigned b, unsigned c) {
+        EditableTriangle t{}; t.indices[0]=a; t.indices[1]=b; t.indices[2]=c;
+        return t;
+    };
+    // Each face split along a single diagonal — winding outward.
+    sub.triangles = {
+        T(0,2,1), T(0,3,2),    // back  (-Z)
+        T(4,5,6), T(4,6,7),    // front (+Z)
+        T(0,1,5), T(0,5,4),    // bottom (-Y)
+        T(2,3,7), T(2,7,6),    // top    (+Y)
+        T(0,4,7), T(0,7,3),    // left   (-X)
+        T(1,2,6), T(1,6,5),    // right  (+X)
+    };
+
+    const int merged = mergeCoplanarTrianglesToQuads(sub, 1.0f);
+    EXPECT_EQ(merged, 6);
+    EXPECT_EQ(sub.faces.size(), 6u);
+    for (const auto& f : sub.faces) {
+        EXPECT_EQ(f.indices.size(), 4u);
+    }
+    // 6 quads × 2 fan tris = 12 — same as input.
+    EXPECT_EQ(sub.triangles.size(), 12u);
+}
+
+TEST(EditableMeshStandalone, MergeCoplanarRespectsAngleThreshold) {
+    // Two triangles bent by ~5° dihedral. With strict threshold (1°),
+    // they don't merge; with loose threshold (10°), they do.
+    EditableSubMesh sub;
+    sub.vertices = {
+        mkPosV(0, 0, 0),
+        mkPosV(1, 0, 0),
+        mkPosV(1, 1, 0),
+        // 4th vertex tilted up in z by tan(5°) ≈ 0.0875
+        mkPosV(0, 1, 0.0875f),
+    };
+    EditableTriangle t1{}, t2{};
+    t1.indices[0] = 0; t1.indices[1] = 1; t1.indices[2] = 2;
+    t2.indices[0] = 0; t2.indices[1] = 2; t2.indices[2] = 3;
+    sub.triangles = {t1, t2};
+
+    EditableSubMesh strict = sub;
+    EXPECT_EQ(mergeCoplanarTrianglesToQuads(strict, 1.0f), 0);
+    EXPECT_EQ(strict.faces.size(), 2u);
+
+    EditableSubMesh loose = sub;
+    EXPECT_EQ(mergeCoplanarTrianglesToQuads(loose, 10.0f), 1);
+    EXPECT_EQ(loose.faces.size(), 1u);
+}
+
+TEST(EditableMeshStandalone, MergeCoplanarEmptySubMesh) {
+    EditableSubMesh sub;
+    EXPECT_EQ(mergeCoplanarTrianglesToQuads(sub), 0);
+    EXPECT_TRUE(sub.faces.empty());
+    EXPECT_TRUE(sub.triangles.empty());
+}

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -162,6 +162,13 @@ MainWindow::MainWindow(QWidget *parent) :
             this, &MainWindow::updateEditModeIndicator);
     updateEditModeIndicator();
 
+    // Surface edit-mode hint messages (e.g. "Loop cut needs a quad mesh") in
+    // the status bar for ~5s.
+    connect(EditModeController::instance(), &EditModeController::editHintMessage,
+            this, [this](const QString& msg) {
+                statusBar()->showMessage(msg, 5000);
+            });
+
     // Auto-start MCP HTTP server if enabled in settings
     QSettings mcpSettings;
     bool mcpEnabled = mcpSettings.value("MCP/enabled", false).toBool();
@@ -799,15 +806,29 @@ void MainWindow::initToolBar()
     });
     QAction* loopCutAction = ui->objectsToolbar->addWidget(loopCutButton);
 
+    // Convert to Quads: walks the mesh and merges coplanar adjacent
+    // triangle pairs into n-gon quads. Useful when an imported tri
+    // mesh blocks loop cut / n-gon-aware bevel.
+    auto convertToQuadsButton = new QToolButton(ui->objectsToolbar);
+    convertToQuadsButton->setText(QStringLiteral("\u25A6"));  // ▦ — "tessellated/quad grid"
+    convertToQuadsButton->setToolTip(tr("Convert to Quads — merge coplanar triangle pairs into quads"));
+    convertToQuadsButton->setFont(topoFont);
+    convertToQuadsButton->setStyleSheet(topoBtnStyle);
+    connect(convertToQuadsButton, &QToolButton::clicked, this, []() {
+        SentryReporter::addBreadcrumb("ui.action", "Toolbar: Convert to Quads");
+        EditModeController::instance()->convertToQuads();
+    });
+    QAction* convertToQuadsAction = ui->objectsToolbar->addWidget(convertToQuadsButton);
+
     // Context-aware visibility + enabled:
     //  - Hidden entirely when NOT in edit mode.
     //  - In edit mode: stay visible but only enable when the current
     //    mode matches AND the relevant element type actually has a
     //    non-empty selection.
     auto refreshTopoButtons = [extrudeButton, bevelButton, knifeButton, mergeButton, deleteButton,
-                               subdivideButton, fillButton, loopCutButton,
+                               subdivideButton, fillButton, loopCutButton, convertToQuadsButton,
                                extrudeAction, bevelAction, knifeAction, mergeAction, deleteAction,
-                               subdivideAction, fillAction, loopCutAction]() {
+                               subdivideAction, fillAction, loopCutAction, convertToQuadsAction]() {
         auto* c = EditModeController::instance();
         const bool active = c->isEditModeActive();
         extrudeAction->setVisible(active);
@@ -818,6 +839,7 @@ void MainWindow::initToolBar()
         subdivideAction->setVisible(active);
         fillAction->setVisible(active);
         loopCutAction->setVisible(active);
+        convertToQuadsAction->setVisible(active);
         if (!active) return;
         const int mode = c->selectionMode();  // 0 vertex, 1 edge, 2 face
         const bool hasFaces = c->selectedFaceCount() > 0;
@@ -850,6 +872,9 @@ void MainWindow::initToolBar()
         // uses the first selected edge as the start; multi-edge loop
         // cuts aren't in scope for the MVP.
         loopCutButton->setEnabled(mode == 1 && hasEdges);
+        // Convert to Quads: whole-mesh; disable once the mesh already
+        // has n-gon canonical faces (no work to do).
+        convertToQuadsButton->setEnabled(!c->isMeshQuadBased());
     };
     refreshTopoButtons();
     connect(editCtrlForTopo, &EditModeController::editModeChanged,
@@ -857,6 +882,11 @@ void MainWindow::initToolBar()
     connect(editCtrlForTopo, &EditModeController::selectionModeChanged,
             this, refreshTopoButtons);
     connect(editCtrlForTopo, &EditModeController::editSelectionChanged,
+            this, refreshTopoButtons);
+    // Mesh-data changes (extrude/bevel/convertToQuads/undo) flip the
+    // n-gon-vs-tri state — refresh so "Convert to Quads" disables once
+    // the mesh has been promoted.
+    connect(editCtrlForTopo, &EditModeController::meshDataChanged,
             this, refreshTopoButtons);
 
     connect(pAddCube,       SIGNAL(triggered()),m_pPrimitivesWidget,SLOT(createCube()));


### PR DESCRIPTION
## Summary
- New whole-mesh **Convert to Quads** action (▦ toolbar in Edit Mode): walks each submesh, merges coplanar adjacent triangle pairs into n-gon canonical faces. Auto-disables once the mesh is already quad-based. Promotes legacy tri-only submeshes into the n-gon path even when no merges happen, so downstream quad features (loop cut, n-gon-aware bevel, quad wireframe) start working.
- **Loop cut hint**: when triggered on a tri mesh the op now emits `editHintMessage` so the status bar reads "Loop cut needs a quad mesh — try Mesh → Convert to Quads." instead of silently doing nothing.
- **Quad-aware wireframe**: in edit mode with a quad-based mesh, the wireframe overlay draws lines along n-gon face boundaries only — no fan-triangulation diagonals. Pure-tri meshes keep PM_WIREFRAME so behavior is unchanged.

## Why
Closes the "quad mesh from tri import" gap discovered while smoke-testing PR #341 (loop cut). Loop cut + n-gon-aware bevel only activate when a submesh has `.faces` populated; imported tri-only meshes never do. Convert to Quads gives users a one-click path; the wireframe makes the resulting quad topology visually obvious.

## Implementation
- `mergeCoplanarTrianglesToQuads(EditableSubMesh&, angleThresholdDeg=1°)` in `EditableMesh.cpp` — greedy first-fit, edge-adjacency map, normal-dot coplanarity test, convexity check on the merged loop. Each tri merged at most once.
- `EditModeController::convertToQuads` Q_INVOKABLE — runs the merge per submesh, pushes an `EditMeshTopologyCommand` (undo-able), re-applies wireframe (PM_WIREFRAME→overlay flip).
- `EditModeController::isMeshQuadBased()` predicate drives the toolbar enable state. Toolbar refresh now also subscribes to `meshDataChanged` so undo correctly re-enables.
- Quad-aware wireframe in `updateBoundaryEdgeOverlay()` — separate ManualObject on `RENDER_QUEUE_OVERLAY` driven from `updateSelectionOverlay`. Selected vertex/edge overlays moved to `RENDER_QUEUE_OVERLAY+1` and edge selection lines bumped to 3px so selection reads on top of the 2px boundary wireframe.

## Test plan
- [x] `mergeCoplanarTrianglesToQuads` standalone tests: planar quad, 90° dihedral rejection, triangulated cube → 6 quads, angle threshold respected, empty submesh
- [x] All 250 EditMode/EditableMesh/HalfEdge tests pass locally
- [x] Build clean on macOS (Linux/Windows via CI)
- [x] Manual smoke: imported tri cube → Convert to Quads → 6 quads in Inspector → wireframe shows clean quad boundaries → loop cut works → undo restores tri state
- [x] Selected edge visibility verified on top of boundary wireframe

🤖 Generated with [Claude Code](https://claude.com/claude-code)