### PR TITLE
Release 2.32.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 2.32.0 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 2.32.1 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run QtMesh scan
-        uses: fernandotonon/QtMeshEditor@2.32.0
+        uses: fernandotonon/QtMeshEditor@2.32.1
         with:
           command: scan
         env:
@@ -64,20 +64,20 @@ Use the latest action release tag from the [releases page](https://github.com/fe
 
 ```yaml
 # Validate a specific mesh
-- uses: fernandotonon/QtMeshEditor@2.32.0
+- uses: fernandotonon/QtMeshEditor@2.32.1
   with:
     command: validate
     input-file: ./models/character.fbx
 
 # Convert FBX → glTF
-- uses: fernandotonon/QtMeshEditor@2.32.0
+- uses: fernandotonon/QtMeshEditor@2.32.1
   with:
     command: convert
     input-file: ./models/character.fbx
     output-file: ./output/character.gltf2
 
 # Resample Mixamo animations (200+ keyframes → 30)
-- uses: fernandotonon/QtMeshEditor@2.32.0
+- uses: fernandotonon/QtMeshEditor@2.32.1
   with:
     command: anim
     input-file: ./animations/dance.fbx
@@ -85,7 +85,7 @@ Use the latest action release tag from the [releases page](https://github.com/fe
     options: --resample 30
 
 # Get mesh info as JSON
-- uses: fernandotonon/QtMeshEditor@2.32.0
+- uses: fernandotonon/QtMeshEditor@2.32.1
   id: info
   with:
     command: info

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -1220,6 +1220,13 @@ bool EditModeController::beginVertexPaintStroke(OgreWidget* widget, const QPoint
     m_vertexPaintStrokeDirty = false;
     m_vertexPaintHaveLastLocal = false;
 
+    SentryReporter::addBreadcrumb(
+        "ui.action",
+        QStringLiteral("Vertex paint stroke begin (radius=%1 strength=%2 color=%3)")
+            .arg(m_vertexPaintRadius, 0, 'f', 3)
+            .arg(m_vertexPaintStrength, 0, 'f', 3)
+            .arg(m_vertexPaintColor.name(QColor::HexRgb)));
+
     updateVertexPaintStroke(widget, screenPos);
     return true;
 }
@@ -1352,11 +1359,13 @@ void EditModeController::endVertexPaintStroke(bool commitUndo)
 
     if (!commitUndo || !m_editModeActive || !m_editableMesh || !m_editEntity) {
         m_vertexPaintStrokeOriginalSubMeshes.clear();
+        SentryReporter::addBreadcrumb("ui.action", "Vertex paint stroke end (discarded)");
         return;
     }
 
     if (!m_vertexPaintStrokeDirty) {
         m_vertexPaintStrokeOriginalSubMeshes.clear();
+        SentryReporter::addBreadcrumb("ui.action", "Vertex paint stroke end (no changes)");
         return;
     }
 
@@ -1366,6 +1375,10 @@ void EditModeController::endVertexPaintStroke(bool commitUndo)
         m_editableMesh->commitVertexColorsToEntity(m_editEntity);
         emit meshDataChanged();
     }
+
+    SentryReporter::addBreadcrumb("ui.action",
+        QStringLiteral("Vertex paint stroke end (%1)")
+            .arg(commitUndo ? QStringLiteral("committed") : QStringLiteral("discarded")));
 
     const auto newSubMeshes = m_editableMesh->subMeshes();
     auto* cmd = new EditMeshTopologyCommand(

--- a/website/src/hooks/useQtmeshActionRef.js
+++ b/website/src/hooks/useQtmeshActionRef.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 const QTMESH_RELEASES_LATEST_API = 'https://api.github.com/repos/fernandotonon/QtMeshEditor/releases/latest';
-const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@2.32.0';
+const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@2.32.1';
 const CACHE_KEY = 'qtmesh.actionRef.cache.v1';
 const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 


### PR DESCRIPTION
## Summary
- Bump version to `2.32.1`.
- Update README + website action reference fallback.
- Add Sentry breadcrumbs for vertex paint brush usage (stroke begin/end), in addition to existing toggle/parameter breadcrumbs.

## Test plan
- Build `QtMeshEditor`.
- Run `UnitTests --gtest_filter=EditModeControllerGeometry.*`.
- Enter Edit Mode and confirm vertex paint works.


Made with [Cursor](https://cursor.com)