### PR TITLE
feat(export): vertex colors + .mesh sidecar materials

### DIFF
--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -1484,6 +1484,10 @@ void EditModeController::flushPendingVertexPaintForEntity(Ogre::Entity* entity)
 {
     if (!entity || !m_editModeActive || m_editEntity != entity || !m_editableMesh)
         return;
+    SentryReporter::addBreadcrumb(
+        "file.export",
+        QStringLiteral("Flushed pending vertex paint before export for entity '%1'")
+            .arg(QString::fromStdString(entity->getName())));
     m_vertexPaintFlushPending = false;
     m_editableMesh->commitVertexColorsToEntity(m_editEntity);
 }

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -1197,6 +1197,14 @@ void EditModeController::handleBoxSelect(const QPoint& startPos, const QPoint& e
 }
 // LCOV_EXCL_STOP
 
+void EditModeController::flushPendingVertexPaintForEntity(Ogre::Entity* entity)
+{
+    if (!entity || !m_editModeActive || m_editEntity != entity || !m_editableMesh)
+        return;
+    m_vertexPaintFlushPending = false;
+    m_editableMesh->commitVertexColorsToEntity(m_editEntity);
+}
+
 bool EditModeController::beginVertexPaintStroke(OgreWidget* widget, const QPoint& screenPos)
 {
     if (!m_vertexPaintEnabled || m_vertexPaintStrokeActive)

--- a/src/EditModeController.h
+++ b/src/EditModeController.h
@@ -209,8 +209,7 @@ public:
     double vertexPaintStrength() const { return m_vertexPaintStrength; }
     void setVertexPaintStrength(double s);
 
-    /// Push vertex colors from EditableMesh to the Ogre mesh immediately (used before file export;
-    /// paint coalescing otherwise defers GPU upload until the next event-loop tick).
+    /// Writes pending vertex paint from EditableMesh into the entity's GPU buffers (call before export).
     void flushPendingVertexPaintForEntity(Ogre::Entity* entity);
     /// @}
 

--- a/src/EditModeController.h
+++ b/src/EditModeController.h
@@ -214,7 +214,11 @@ public:
     double vertexPaintStrength() const { return m_vertexPaintStrength; }
     void setVertexPaintStrength(double s);
 
-    /// Writes pending vertex paint from EditableMesh into the entity's GPU buffers (call before export).
+    /**
+     * @brief Commits deferred vertex paint from EditableMesh into GPU vertex buffers.
+     * @param entity Must be the active edit target; otherwise this is a no-op.
+     * @note Call before mesh/FBX/glTF export so coalesced paint is not still pending on the event loop.
+     */
     void flushPendingVertexPaintForEntity(Ogre::Entity* entity);
     /// @}
 

--- a/src/EditModeController.h
+++ b/src/EditModeController.h
@@ -208,6 +208,10 @@ public:
     void setVertexPaintRadius(double r);
     double vertexPaintStrength() const { return m_vertexPaintStrength; }
     void setVertexPaintStrength(double s);
+
+    /// Push vertex colors from EditableMesh to the Ogre mesh immediately (used before file export;
+    /// paint coalescing otherwise defers GPU upload until the next event-loop tick).
+    void flushPendingVertexPaintForEntity(Ogre::Entity* entity);
     /// @}
 
     /// @name Topology operations

--- a/src/FBX/FBXExporter.cpp
+++ b/src/FBX/FBXExporter.cpp
@@ -1020,6 +1020,88 @@ private:
                 m_w.endNode(); // LayerElementUV
             }
 
+            // ── LayerElementColor (vertex colors) ──
+            const auto* colElem = vData->vertexDeclaration->findElementBySemantic(Ogre::VES_DIFFUSE);
+            if (colElem)
+            {
+                std::vector<double> colors(vData->vertexCount * 4);
+                auto vbuf = vData->vertexBufferBinding->getBuffer(colElem->getSource());
+                auto* base = static_cast<const unsigned char*>(
+                    vbuf->lock(Ogre::HardwareBuffer::HBL_READ_ONLY));
+                for (size_t j = 0; j < vData->vertexCount; ++j)
+                {
+                    const Ogre::RGBA* p;
+                    colElem->baseVertexPointerToElement(
+                        const_cast<unsigned char*>(base + j * vbuf->getVertexSize()), &p);
+                    Ogre::ColourValue cv;
+                    if (colElem->getType() == Ogre::VET_COLOUR_ABGR)
+                        cv.setAsABGR(*p);
+                    else
+                        cv.setAsARGB(*p);
+                    colors[j * 4 + 0] = cv.r;
+                    colors[j * 4 + 1] = cv.g;
+                    colors[j * 4 + 2] = cv.b;
+                    colors[j * 4 + 3] = cv.a;
+                }
+                vbuf->unlock();
+
+                // Expand to per-polygon-vertex with reversed winding to match PolygonVertexIndex
+                std::vector<double> expandedColors;
+                if (iData && iData->indexCount > 0)
+                {
+                    expandedColors.resize(iData->indexCount * 4);
+                    auto ibuf = iData->indexBuffer;
+                    auto* ibase2 = static_cast<const unsigned char*>(
+                        ibuf->lock(Ogre::HardwareBuffer::HBL_READ_ONLY));
+                    bool use32 = ibuf->getType() == Ogre::HardwareIndexBuffer::IT_32BIT;
+                    for (size_t f = 0; f < iData->indexCount / 3; ++f)
+                    {
+                        uint32_t vi0 = use32
+                            ? reinterpret_cast<const uint32_t*>(ibase2)[f * 3 + 0]
+                            : reinterpret_cast<const uint16_t*>(ibase2)[f * 3 + 0];
+                        uint32_t vi1 = use32
+                            ? reinterpret_cast<const uint32_t*>(ibase2)[f * 3 + 1]
+                            : reinterpret_cast<const uint16_t*>(ibase2)[f * 3 + 1];
+                        uint32_t vi2 = use32
+                            ? reinterpret_cast<const uint32_t*>(ibase2)[f * 3 + 2]
+                            : reinterpret_cast<const uint16_t*>(ibase2)[f * 3 + 2];
+
+                        // Reversed winding: (v0, v2, v1)
+                        size_t base = f * 12;
+                        auto copy = [&](size_t outVertex, uint32_t vi) {
+                            expandedColors[outVertex + 0] = colors[vi * 4 + 0];
+                            expandedColors[outVertex + 1] = colors[vi * 4 + 1];
+                            expandedColors[outVertex + 2] = colors[vi * 4 + 2];
+                            expandedColors[outVertex + 3] = colors[vi * 4 + 3];
+                        };
+                        copy(base + 0, vi0);
+                        copy(base + 4, vi2);
+                        copy(base + 8, vi1);
+                    }
+                    ibuf->unlock();
+                }
+                else
+                {
+                    expandedColors = colors;
+                }
+
+                m_w.beginNode("LayerElementColor");
+                m_w.writePropertyI(0);
+                m_w.endProperties();
+
+                m_w.beginNode("Version"); m_w.writePropertyI(101); m_w.endProperties(); m_w.endNodeLeaf();
+                m_w.beginNode("Name"); m_w.writePropertyS(""); m_w.endProperties(); m_w.endNodeLeaf();
+                m_w.beginNode("MappingInformationType"); m_w.writePropertyS("ByPolygonVertex"); m_w.endProperties(); m_w.endNodeLeaf();
+                m_w.beginNode("ReferenceInformationType"); m_w.writePropertyS("Direct"); m_w.endProperties(); m_w.endNodeLeaf();
+
+                m_w.beginNode("Colors");
+                m_w.writePropertyArrayD(expandedColors);
+                m_w.endProperties();
+                m_w.endNodeLeaf();
+
+                m_w.endNode(); // LayerElementColor
+            }
+
             // ── LayerElementMaterial ──
             {
                 // Each Model has exactly one material connected, so index is always 0
@@ -1062,6 +1144,14 @@ private:
                 m_w.beginNode("LayerElement");
                 m_w.endProperties();
                 m_w.beginNode("Type"); m_w.writePropertyS("LayerElementUV"); m_w.endProperties(); m_w.endNodeLeaf();
+                m_w.beginNode("TypedIndex"); m_w.writePropertyI(0); m_w.endProperties(); m_w.endNodeLeaf();
+                m_w.endNode();
+            }
+            if (colElem)
+            {
+                m_w.beginNode("LayerElement");
+                m_w.endProperties();
+                m_w.beginNode("Type"); m_w.writePropertyS("LayerElementColor"); m_w.endProperties(); m_w.endNodeLeaf();
                 m_w.beginNode("TypedIndex"); m_w.writePropertyI(0); m_w.endProperties(); m_w.endNodeLeaf();
                 m_w.endNode();
             }

--- a/src/FBX/FBXExporter_test.cpp
+++ b/src/FBX/FBXExporter_test.cpp
@@ -1271,6 +1271,37 @@ TEST_F(FBXExporterCoverageTest, UVs_VFlipped) {
     cleanup(r);
 }
 
+TEST_F(FBXExporterCoverageTest, VertexColors_WritesLayerElementColor) {
+    auto meshPtr = createInMemoryTriangleMeshWithVertexColors("fbx_colors");
+    ASSERT_TRUE(!!meshPtr);
+    auto* node = Manager::getSingleton()->addSceneNode("fbx_colors_node");
+    auto* entity = Manager::getSingleton()->createEntity(node, meshPtr);
+    ASSERT_NE(entity, nullptr);
+
+    auto r = exportAndParse(entity);
+    ASSERT_TRUE(r.success);
+
+    auto* objects = findTopLevel(r.nodes, "Objects");
+    auto geomNodes = objects->findAll("Geometry");
+    ASSERT_EQ(geomNodes.size(), 1u);
+
+    EXPECT_NE(geomNodes[0]->find("LayerElementColor"), nullptr);
+    auto* layer = geomNodes[0]->find("Layer");
+    ASSERT_NE(layer, nullptr);
+    bool hasColor = false;
+    for (const auto* le : layer->findAll("LayerElement")) {
+        auto* typeNode = le->find("Type");
+        if (typeNode && !typeNode->properties.empty()
+            && typeNode->properties[0].stringVal == "LayerElementColor") {
+            hasColor = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(hasColor);
+
+    cleanup(r);
+}
+
 TEST_F(FBXExporterCoverageTest, NoNormals_SkipsNormalLayer) {
     auto name = uniqueName("nonorm");
     auto* entity = createMeshNoNormalsNoUVs(name);

--- a/src/FBX/FBXExporter_test.cpp
+++ b/src/FBX/FBXExporter_test.cpp
@@ -1272,9 +1272,10 @@ TEST_F(FBXExporterCoverageTest, UVs_VFlipped) {
 }
 
 TEST_F(FBXExporterCoverageTest, VertexColors_WritesLayerElementColor) {
-    auto meshPtr = createInMemoryTriangleMeshWithVertexColors("fbx_colors");
+    const std::string name = uniqueName("fbx_colors");
+    auto meshPtr = createInMemoryTriangleMeshWithVertexColors(name);
     ASSERT_TRUE(!!meshPtr);
-    auto* node = Manager::getSingleton()->addSceneNode("fbx_colors_node");
+    auto* node = Manager::getSingleton()->addSceneNode(QString::fromStdString(name + "_node"));
     auto* entity = Manager::getSingleton()->createEntity(node, meshPtr);
     ASSERT_NE(entity, nullptr);
 
@@ -1282,6 +1283,7 @@ TEST_F(FBXExporterCoverageTest, VertexColors_WritesLayerElementColor) {
     ASSERT_TRUE(r.success);
 
     auto* objects = findTopLevel(r.nodes, "Objects");
+    ASSERT_NE(objects, nullptr);
     auto geomNodes = objects->findAll("Geometry");
     ASSERT_EQ(geomNodes.size(), 1u);
 

--- a/src/FBX/FBXExporter_test.cpp
+++ b/src/FBX/FBXExporter_test.cpp
@@ -1285,7 +1285,33 @@ TEST_F(FBXExporterCoverageTest, VertexColors_WritesLayerElementColor) {
     auto geomNodes = objects->findAll("Geometry");
     ASSERT_EQ(geomNodes.size(), 1u);
 
-    EXPECT_NE(geomNodes[0]->find("LayerElementColor"), nullptr);
+    auto* colorLayer = geomNodes[0]->find("LayerElementColor");
+    ASSERT_NE(colorLayer, nullptr);
+    auto* mapType = colorLayer->find("MappingInformationType");
+    ASSERT_NE(mapType, nullptr);
+    EXPECT_EQ(mapType->properties[0].stringVal, "ByPolygonVertex");
+    auto* refType = colorLayer->find("ReferenceInformationType");
+    ASSERT_NE(refType, nullptr);
+    EXPECT_EQ(refType->properties[0].stringVal, "Direct");
+
+    auto* colors = colorLayer->find("Colors");
+    ASSERT_NE(colors, nullptr);
+    // One tri × 3 polygon-vertices × 4 components (exporter reverses winding: v0, v2, v1).
+    ASSERT_EQ(colors->properties[0].doubleArray.size(), 12u);
+    const auto& c = colors->properties[0].doubleArray;
+    EXPECT_NEAR(c[0], 1.0, 1e-4);
+    EXPECT_NEAR(c[1], 0.0, 1e-4);
+    EXPECT_NEAR(c[2], 0.0, 1e-4);
+    EXPECT_NEAR(c[3], 1.0, 1e-4); // red corner (vi0)
+    EXPECT_NEAR(c[4], 0.0, 1e-4);
+    EXPECT_NEAR(c[5], 0.0, 1e-4);
+    EXPECT_NEAR(c[6], 1.0, 1e-4);
+    EXPECT_NEAR(c[7], 1.0, 1e-4); // blue corner (vi2)
+    EXPECT_NEAR(c[8], 0.0, 1e-4);
+    EXPECT_NEAR(c[9], 1.0, 1e-4);
+    EXPECT_NEAR(c[10], 0.0, 1e-4);
+    EXPECT_NEAR(c[11], 1.0, 1e-4); // green corner (vi1)
+
     auto* layer = geomNodes[0]->find("Layer");
     ASSERT_NE(layer, nullptr);
     bool hasColor = false;

--- a/src/MeshImporterExporter.cpp
+++ b/src/MeshImporterExporter.cpp
@@ -1489,6 +1489,35 @@ int MeshImporterExporter::exportCurrentPose(Ogre::Entity* entity, const QString&
             }
         }
 
+        // Vertex colors live on bind-pose buffers (unchanged by skinning), like UVs.
+        if (bindData)
+        {
+            const auto* colElem = bindData->vertexDeclaration->findElementBySemantic(Ogre::VES_DIFFUSE);
+            if (colElem)
+            {
+                const unsigned int n = std::min(
+                    aiM->mNumVertices,
+                    static_cast<unsigned int>(bindData->vertexCount));
+                aiM->mColors[0] = new aiColor4D[aiM->mNumVertices];
+                for (unsigned int j = 0; j < aiM->mNumVertices; ++j)
+                    aiM->mColors[0][j] = aiColor4D(1, 1, 1, 1);
+                auto vbuf = bindData->vertexBufferBinding->getBuffer(colElem->getSource());
+                auto* base = static_cast<const unsigned char*>(vbuf->lock(Ogre::HardwareBuffer::HBL_READ_ONLY));
+                for (unsigned int j = 0; j < n; ++j)
+                {
+                    const Ogre::RGBA* p;
+                    colElem->baseVertexPointerToElement(const_cast<unsigned char*>(base + j * vbuf->getVertexSize()), &p);
+                    Ogre::ColourValue cv;
+                    if (colElem->getType() == Ogre::VET_COLOUR_ABGR)
+                        cv.setAsABGR(*p);
+                    else
+                        cv.setAsARGB(*p);
+                    aiM->mColors[0][j] = aiColor4D(cv.r, cv.g, cv.b, cv.a);
+                }
+                vbuf->unlock();
+            }
+        }
+
         // Read indices from the original submesh
         const Ogre::IndexData* iData = subMesh->indexData;
         if (iData && iData->indexCount > 0)

--- a/src/MeshImporterExporter.cpp
+++ b/src/MeshImporterExporter.cpp
@@ -1022,10 +1022,12 @@ static void loadMaterialsDeclaredInOgreMaterialScript(const QByteArray& script, 
         if (end <= 0)
             continue;
 
-        const QByteArray matName = rest.left(end);
+        const QByteArray matName = rest.left(end).trimmed();
+        if (matName.isEmpty())
+            continue;
         Ogre::MaterialPtr m = Ogre::MaterialManager::getSingleton().getByName(
             Ogre::String(matName.constData(), matName.size()), group);
-        if (m && m->getLoadingState() == Ogre::Resource::LOADSTATE_UNLOADED)
+        if (m)
             m->load();
     }
 }
@@ -1058,11 +1060,25 @@ static void tryLoadSidecarMaterialScript(const QFileInfo& meshFile)
         // ensureResourceGroup() may have already initialised this group; a second
         // initialiseResourceGroup() is a no-op and leaves parseScript materials unloaded.
         auto& rgm = Ogre::ResourceGroupManager::getSingleton();
-        if (!rgm.isResourceGroupInitialised(group))
+        if (rgm.isResourceGroupInitialised(group))
+            rgm.loadResourceGroup(group);
+        else
             rgm.initialiseResourceGroup(group);
-        // Do not call loadResourceGroup() here: it loads every resource in the directory.
-        // Only load materials declared in this sidecar script.
+        // Explicitly load materials named in this script (parseScript can leave them UNLOADED).
         loadMaterialsDeclaredInOgreMaterialScript(scriptBytes, group);
+        // Catch any other UNLOADED materials in this folder group (same as pre-review behavior).
+        {
+            Ogre::ResourceManager::ResourceMapIterator mit =
+                Ogre::MaterialManager::getSingleton().getResourceIterator();
+            while (mit.hasMoreElements())
+            {
+                Ogre::ResourcePtr res = mit.peekNextValue();
+                if (res->getGroup() == group
+                    && res->getLoadingState() == Ogre::Resource::LOADSTATE_UNLOADED)
+                    res->load();
+                mit.moveNext();
+            }
+        }
         SentryReporter::addBreadcrumb("file.import",
             QStringLiteral("Loaded sidecar material: %1").arg(sidecar));
     } catch (const Ogre::Exception& e) {

--- a/src/MeshImporterExporter.cpp
+++ b/src/MeshImporterExporter.cpp
@@ -990,25 +990,53 @@ static void ensureResourceGroup(const QString &path)
     }
 }
 
-static void loadUnloadedOgreMaterialsInGroup(const Ogre::String& group)
+/** Loads only materials declared in script text (`material <name>` lines), not every resource in the folder. */
+static void loadMaterialsDeclaredInOgreMaterialScript(const QByteArray& script, const Ogre::String& group)
 {
-    Ogre::ResourceManager::ResourceMapIterator mit =
-        Ogre::MaterialManager::getSingleton().getResourceIterator();
-    while (mit.hasMoreElements())
+    const QList<QByteArray> lines = script.split('\n');
+    for (QByteArray raw : lines)
     {
-        Ogre::ResourcePtr res = mit.peekNextValue();
-        if (res->getGroup() == group
-            && res->getLoadingState() == Ogre::Resource::LOADSTATE_UNLOADED)
-            res->load();
-        mit.moveNext();
+        QByteArray line = raw.trimmed();
+        if (line.isEmpty() || line.startsWith("//"))
+            continue;
+        if (line.size() < 10)
+            continue;
+        if (line.left(8).compare(QByteArrayLiteral("material"), Qt::CaseInsensitive) != 0)
+            continue;
+        const char boundary = line[8];
+        if (boundary != ' ' && boundary != '\t')
+            continue; // e.g. "materials" must not match
+
+        QByteArray rest = line.mid(9).trimmed();
+        if (rest.isEmpty())
+            continue;
+
+        int end = 0;
+        while (end < rest.size())
+        {
+            const char c = rest[end];
+            if (c == ' ' || c == '\t' || c == ':' || c == '{')
+                break;
+            ++end;
+        }
+        if (end <= 0)
+            continue;
+
+        const QByteArray matName = rest.left(end);
+        Ogre::MaterialPtr m = Ogre::MaterialManager::getSingleton().getByName(
+            Ogre::String(matName.constData(), matName.size()), group);
+        if (m && m->getLoadingState() == Ogre::Resource::LOADSTATE_UNLOADED)
+            m->load();
     }
 }
 
+/** Parse `<mesh-complete-basename>.material` next to the `.mesh` file (uses completeBaseName so `a.v2.mesh` → `a.v2.material`). */
 static void tryLoadSidecarMaterialScript(const QFileInfo& meshFile)
 {
     // `.mesh` stores material names, but not the script definitions. If the
     // corresponding `.material` isn't loaded, Ogre falls back to BaseWhite.
-    const QString sidecar = meshFile.path() + "/" + meshFile.baseName() + ".material";
+    const QString sidecar =
+        meshFile.path() + "/" + meshFile.completeBaseName() + ".material";
     QFile f(sidecar);
     if (!f.exists() || !f.open(QIODevice::ReadOnly))
         return;
@@ -1030,13 +1058,11 @@ static void tryLoadSidecarMaterialScript(const QFileInfo& meshFile)
         // ensureResourceGroup() may have already initialised this group; a second
         // initialiseResourceGroup() is a no-op and leaves parseScript materials unloaded.
         auto& rgm = Ogre::ResourceGroupManager::getSingleton();
-        if (rgm.isResourceGroupInitialised(group))
-            rgm.loadResourceGroup(group);
-        else
+        if (!rgm.isResourceGroupInitialised(group))
             rgm.initialiseResourceGroup(group);
-        // Materials created only via parseScript can remain in LOADSTATE_UNLOADED
-        // until explicitly loaded (loadResourceGroup does not always pick them up).
-        loadUnloadedOgreMaterialsInGroup(group);
+        // Do not call loadResourceGroup() here: it loads every resource in the directory.
+        // Only load materials declared in this sidecar script.
+        loadMaterialsDeclaredInOgreMaterialScript(scriptBytes, group);
         SentryReporter::addBreadcrumb("file.import",
             QStringLiteral("Loaded sidecar material: %1").arg(sidecar));
     } catch (const Ogre::Exception& e) {

--- a/src/MeshImporterExporter.cpp
+++ b/src/MeshImporterExporter.cpp
@@ -990,6 +990,20 @@ static void ensureResourceGroup(const QString &path)
     }
 }
 
+static void loadUnloadedOgreMaterialsInGroup(const Ogre::String& group)
+{
+    Ogre::ResourceManager::ResourceMapIterator mit =
+        Ogre::MaterialManager::getSingleton().getResourceIterator();
+    while (mit.hasMoreElements())
+    {
+        Ogre::ResourcePtr res = mit.peekNextValue();
+        if (res->getGroup() == group
+            && res->getLoadingState() == Ogre::Resource::LOADSTATE_UNLOADED)
+            res->load();
+        mit.moveNext();
+    }
+}
+
 static void tryLoadSidecarMaterialScript(const QFileInfo& meshFile)
 {
     // `.mesh` stores material names, but not the script definitions. If the
@@ -999,15 +1013,18 @@ static void tryLoadSidecarMaterialScript(const QFileInfo& meshFile)
     if (!f.exists() || !f.open(QIODevice::ReadOnly))
         return;
 
-    const QByteArray bytes = f.readAll();
-    if (bytes.isEmpty())
+    QByteArray scriptBytes = f.readAll();
+    if (scriptBytes.isEmpty())
         return;
 
     try {
+        // Mutable QByteArray buffer + read-only stream (no constData → void* cast).
+        void* scriptMem = scriptBytes.data();
         Ogre::DataStreamPtr ds(new Ogre::MemoryDataStream(
-            (void*)bytes.constData(),
-            static_cast<size_t>(bytes.size()),
-            false));
+            scriptMem,
+            static_cast<size_t>(scriptBytes.size()),
+            false,
+            true));
         const Ogre::String group = meshFile.path().toStdString();
         Ogre::MaterialManager::getSingleton().parseScript(ds, group);
         // ensureResourceGroup() may have already initialised this group; a second
@@ -1017,6 +1034,9 @@ static void tryLoadSidecarMaterialScript(const QFileInfo& meshFile)
             rgm.loadResourceGroup(group);
         else
             rgm.initialiseResourceGroup(group);
+        // Materials created only via parseScript can remain in LOADSTATE_UNLOADED
+        // until explicitly loaded (loadResourceGroup does not always pick them up).
+        loadUnloadedOgreMaterialsInGroup(group);
         SentryReporter::addBreadcrumb("file.import",
             QStringLiteral("Loaded sidecar material: %1").arg(sidecar));
     } catch (const Ogre::Exception& e) {

--- a/src/MeshImporterExporter.cpp
+++ b/src/MeshImporterExporter.cpp
@@ -990,9 +990,10 @@ static void ensureResourceGroup(const QString &path)
     }
 }
 
-/** Loads only materials declared in script text (`material <name>` lines), not every resource in the folder. */
-static void loadMaterialsDeclaredInOgreMaterialScript(const QByteArray& script, const Ogre::String& group)
+/** @return true if at least one declared material exists in the manager for this group. */
+static bool loadMaterialsDeclaredInOgreMaterialScript(const QByteArray& script, const Ogre::String& group)
 {
+    bool anyFound = false;
     const QList<QByteArray> lines = script.split('\n');
     for (QByteArray raw : lines)
     {
@@ -1028,8 +1029,12 @@ static void loadMaterialsDeclaredInOgreMaterialScript(const QByteArray& script, 
         Ogre::MaterialPtr m = Ogre::MaterialManager::getSingleton().getByName(
             Ogre::String(matName.constData(), matName.size()), group);
         if (m)
+        {
+            anyFound = true;
             m->load();
+        }
     }
+    return anyFound;
 }
 
 /** Parse `<mesh-complete-basename>.material` next to the `.mesh` file (uses completeBaseName so `a.v2.mesh` → `a.v2.material`). */
@@ -1047,27 +1052,15 @@ static void tryLoadSidecarMaterialScript(const QFileInfo& meshFile)
     if (scriptBytes.isEmpty())
         return;
 
+    const Ogre::String group = meshFile.path().toStdString();
     try {
-        // Mutable QByteArray buffer + read-only stream (no constData → void* cast).
-        void* scriptMem = scriptBytes.data();
-        Ogre::DataStreamPtr ds(new Ogre::MemoryDataStream(
-            scriptMem,
-            static_cast<size_t>(scriptBytes.size()),
-            false,
-            true));
-        const Ogre::String group = meshFile.path().toStdString();
-        Ogre::MaterialManager::getSingleton().parseScript(ds, group);
-        // ensureResourceGroup() may have already initialised this group; a second
-        // initialiseResourceGroup() is a no-op and leaves parseScript materials unloaded.
         auto& rgm = Ogre::ResourceGroupManager::getSingleton();
         if (rgm.isResourceGroupInitialised(group))
             rgm.loadResourceGroup(group);
         else
             rgm.initialiseResourceGroup(group);
-        // Explicitly load materials named in this script (parseScript can leave them UNLOADED).
-        loadMaterialsDeclaredInOgreMaterialScript(scriptBytes, group);
-        // Catch any other UNLOADED materials in this folder group (same as pre-review behavior).
-        {
+
+        auto sweepUnloadedInGroup = [&group]() {
             Ogre::ResourceManager::ResourceMapIterator mit =
                 Ogre::MaterialManager::getSingleton().getResourceIterator();
             while (mit.hasMoreElements())
@@ -1078,12 +1071,34 @@ static void tryLoadSidecarMaterialScript(const QFileInfo& meshFile)
                     res->load();
                 mit.moveNext();
             }
+        };
+
+        bool haveDeclared = loadMaterialsDeclaredInOgreMaterialScript(scriptBytes, group);
+        sweepUnloadedInGroup();
+
+        // If the folder was initialised before the .material existed, or the filesystem
+        // parser skipped it, inject the script once from memory (avoid when already declared
+        // — duplicate parse throws and would skip loadResourceGroup if caught too broadly).
+        if (!haveDeclared)
+        {
+            void* scriptMem = scriptBytes.data();
+            Ogre::DataStreamPtr ds(new Ogre::MemoryDataStream(
+                scriptMem,
+                static_cast<size_t>(scriptBytes.size()),
+                false,
+                true));
+            Ogre::MaterialManager::getSingleton().parseScript(ds, group);
+            if (rgm.isResourceGroupInitialised(group))
+                rgm.loadResourceGroup(group);
+            loadMaterialsDeclaredInOgreMaterialScript(scriptBytes, group);
+            sweepUnloadedInGroup();
         }
+
         SentryReporter::addBreadcrumb("file.import",
             QStringLiteral("Loaded sidecar material: %1").arg(sidecar));
     } catch (const Ogre::Exception& e) {
         Ogre::LogManager::getSingleton().logMessage(
-            "Warning: failed to parse sidecar .material: " + e.getFullDescription());
+            "Warning: sidecar material load: " + e.getFullDescription());
     }
 }
 

--- a/src/MeshImporterExporter.cpp
+++ b/src/MeshImporterExporter.cpp
@@ -995,7 +995,13 @@ static void tryLoadSidecarMaterialScript(const QFileInfo& meshFile)
             false));
         const Ogre::String group = meshFile.path().toStdString();
         Ogre::MaterialManager::getSingleton().parseScript(ds, group);
-        Ogre::ResourceGroupManager::getSingleton().initialiseResourceGroup(group);
+        // ensureResourceGroup() may have already initialised this group; a second
+        // initialiseResourceGroup() is a no-op and leaves parseScript materials unloaded.
+        auto& rgm = Ogre::ResourceGroupManager::getSingleton();
+        if (rgm.isResourceGroupInitialised(group))
+            rgm.loadResourceGroup(group);
+        else
+            rgm.initialiseResourceGroup(group);
         SentryReporter::addBreadcrumb("file.import",
             QStringLiteral("Loaded sidecar material: %1").arg(sidecar));
     } catch (const Ogre::Exception& e) {

--- a/src/MeshImporterExporter.cpp
+++ b/src/MeshImporterExporter.cpp
@@ -52,6 +52,7 @@ THE SOFTWARE.
 #include "Assimp/BoneProcessor.h"
 #include "Assimp/AnimationProcessor.h"
 #include "CLIPipeline.h"
+#include "EditModeController.h"
 #include <OgreMaterialManager.h>
 #include <OgreDataStream.h>
 
@@ -1156,6 +1157,10 @@ int MeshImporterExporter::exporter(const Ogre::SceneNode *_sn, const QString &_u
     const Ogre::Entity *e = Manager::getSingleton()->getSceneMgr()->getEntity(_sn->getName());
     if(!e) return -1;
 
+    // Vertex paint defers GPU upload; export reads Ogre buffers — sync first.
+    EditModeController::instance()->flushPendingVertexPaintForEntity(
+        const_cast<Ogre::Entity*>(e));
+
     if(_format=="Ogre XML (*.mesh.xml)")
     {
         Ogre::XMLMeshSerializer xmlMS;
@@ -1344,6 +1349,8 @@ int MeshImporterExporter::exportCurrentPose(Ogre::Entity* entity, const QString&
 {
     if (!entity) return -1;
     if (outputPath.isEmpty()) return -1;
+
+    EditModeController::instance()->flushPendingVertexPaintForEntity(entity);
 
     SentryReporter::addBreadcrumb("file.export", QString("Export pose: %1").arg(outputPath));
 
@@ -1662,6 +1669,7 @@ static aiScene* buildSceneAiScene()
     {
         auto* sn = nodeEntities[ni].sceneNode;
         auto* entity = nodeEntities[ni].entity;
+        EditModeController::instance()->flushPendingVertexPaintForEntity(entity);
         const Ogre::MeshPtr mesh = entity->getMesh();
         const unsigned int numSub = mesh->getNumSubMeshes();
         const bool hasSkeleton = entity->hasSkeleton();

--- a/src/MeshImporterExporter.cpp
+++ b/src/MeshImporterExporter.cpp
@@ -34,6 +34,7 @@ THE SOFTWARE.
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QDebug>
+#include <QFile>
 #include <set>
 
 #include "OgreXML/OgreXMLMeshSerializer.h"
@@ -51,6 +52,8 @@ THE SOFTWARE.
 #include "Assimp/BoneProcessor.h"
 #include "Assimp/AnimationProcessor.h"
 #include "CLIPipeline.h"
+#include <OgreMaterialManager.h>
+#include <OgreDataStream.h>
 
 #ifndef WIN32
     #include <unistd.h>
@@ -304,6 +307,28 @@ static void readSubmeshGeometry(
             const Ogre::Real* p;
             tcElem->baseVertexPointerToElement(const_cast<unsigned char*>(base + j * vbuf->getVertexSize()), &p);
             aiM->mTextureCoords[0][j] = aiVector3D(p[0], p[1], 0.0f);
+        }
+        vbuf->unlock();
+    }
+
+    // Read vertex colors (diffuse) into Assimp color set 0
+    const auto* colElem = vData->vertexDeclaration->findElementBySemantic(Ogre::VES_DIFFUSE);
+    if (colElem)
+    {
+        aiM->mColors[0] = new aiColor4D[aiM->mNumVertices];
+        auto vbuf = vData->vertexBufferBinding->getBuffer(colElem->getSource());
+        auto* base = static_cast<const unsigned char*>(vbuf->lock(Ogre::HardwareBuffer::HBL_READ_ONLY));
+        for (unsigned int j = 0; j < aiM->mNumVertices; ++j)
+        {
+            const Ogre::RGBA* p;
+            colElem->baseVertexPointerToElement(const_cast<unsigned char*>(base + j * vbuf->getVertexSize()), &p);
+            Ogre::ColourValue cv;
+            // Ogre's VET_COLOUR backing varies by render system; respect the declared element type.
+            if (colElem->getType() == Ogre::VET_COLOUR_ABGR)
+                cv.setAsABGR(*p);
+            else
+                cv.setAsARGB(*p);
+            aiM->mColors[0][j] = aiColor4D(cv.r, cv.g, cv.b, cv.a);
         }
         vbuf->unlock();
     }
@@ -949,6 +974,35 @@ static void ensureResourceGroup(const QString &path)
     }
 }
 
+static void tryLoadSidecarMaterialScript(const QFileInfo& meshFile)
+{
+    // `.mesh` stores material names, but not the script definitions. If the
+    // corresponding `.material` isn't loaded, Ogre falls back to BaseWhite.
+    const QString sidecar = meshFile.path() + "/" + meshFile.baseName() + ".material";
+    QFile f(sidecar);
+    if (!f.exists() || !f.open(QIODevice::ReadOnly))
+        return;
+
+    const QByteArray bytes = f.readAll();
+    if (bytes.isEmpty())
+        return;
+
+    try {
+        Ogre::DataStreamPtr ds(new Ogre::MemoryDataStream(
+            (void*)bytes.constData(),
+            static_cast<size_t>(bytes.size()),
+            false));
+        const Ogre::String group = meshFile.path().toStdString();
+        Ogre::MaterialManager::getSingleton().parseScript(ds, group);
+        Ogre::ResourceGroupManager::getSingleton().initialiseResourceGroup(group);
+        SentryReporter::addBreadcrumb("file.import",
+            QStringLiteral("Loaded sidecar material: %1").arg(sidecar));
+    } catch (const Ogre::Exception& e) {
+        Ogre::LogManager::getSingleton().logMessage(
+            "Warning: failed to parse sidecar .material: " + e.getFullDescription());
+    }
+}
+
 void MeshImporterExporter::importer(const QStringList &_uriList, unsigned int additionalFlags,
                                      QList<Ogre::SkeletonPtr>* outAnimOnlySkeletons,
                                      int* outUpAxis)
@@ -967,6 +1021,7 @@ void MeshImporterExporter::importer(const QStringList &_uriList, unsigned int ad
 
             if(!file.suffix().compare("mesh",Qt::CaseInsensitive))
             {
+                tryLoadSidecarMaterialScript(file);
                 Ogre::MeshPtr mesh = Ogre::MeshManager::getSingleton().load(
                     file.fileName().toStdString().data(),
                     file.path().toStdString().data());

--- a/src/MeshImporterExporter_test.cpp
+++ b/src/MeshImporterExporter_test.cpp
@@ -329,6 +329,56 @@ TEST_F(MeshImporterExporterTest, Importer_MissingMeshFile_IsIgnored) {
     EXPECT_TRUE(Manager::getSingleton()->getSceneNodes().isEmpty());
 }
 
+TEST_F(MeshImporterExporterTest, Importer_MeshLoadsSidecarMaterialScript) {
+    if (!canLoadMeshFiles()) {
+        GTEST_SKIP() << "Skipping: no GL context / hardware buffers available";
+    }
+    // Create a mesh with a custom material, export both .mesh and .material,
+    // then reimport and ensure the material isn't falling back to BaseWhite.
+    auto* manager = Manager::getSingleton();
+    auto mesh = createInMemoryTriangleMesh("sidecar_mat_mesh");
+    ASSERT_NE(mesh, nullptr);
+
+    Ogre::MaterialPtr mat = Ogre::MaterialManager::getSingleton().create(
+        "SidecarMaterial", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+    ASSERT_TRUE(!!mat);
+    mat->compile();
+
+    Ogre::SceneNode* sn = manager->addSceneNode("SidecarMatNode");
+    ASSERT_NE(sn, nullptr);
+    Ogre::Entity* e = manager->createEntity(sn, mesh);
+    ASSERT_NE(e, nullptr);
+    e->getSubEntity(0)->setMaterial(mat);
+
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+    const QString outMesh = tmpDir.path() + "/sidecar_roundtrip.mesh";
+
+    // Export the Ogre mesh.
+    Ogre::MeshSerializer ser;
+    ser.exportMesh(e->getMesh().get(), outMesh.toStdString());
+
+    // Write a minimal sidecar material script using the exporter's naming convention.
+    const QString sidecarMat = tmpDir.path() + "/sidecar_roundtrip.material";
+    QFile matFile(sidecarMat);
+    ASSERT_TRUE(matFile.open(QIODevice::WriteOnly | QIODevice::Truncate));
+    matFile.write("material SidecarMaterial\n{\n  technique\n  {\n    pass\n    {\n    }\n  }\n}\n");
+    matFile.close();
+    ASSERT_TRUE(QFileInfo::exists(sidecarMat));
+
+    // Reimport from disk.
+    MeshImporterExporter::importer({outMesh});
+    ASSERT_FALSE(manager->getSceneNodes().isEmpty());
+    auto* importedNode = manager->getSceneNodes().last();
+    ASSERT_TRUE(manager->getSceneMgr()->hasEntity(importedNode->getName()));
+    auto* importedEntity = manager->getSceneMgr()->getEntity(importedNode->getName());
+    ASSERT_GE(importedEntity->getNumSubEntities(), 1u);
+
+    const Ogre::String importedMat = importedEntity->getSubEntity(0)->getMaterialName();
+    EXPECT_NE(importedMat, "BaseWhite");
+    EXPECT_EQ(importedMat, "SidecarMaterial");
+}
+
 TEST_F(MeshImporterExporterTest, Importer_MissingMeshXmlFile_IsIgnored) {
     MeshImporterExporter::importer(QStringList{"/tmp/nonexistent_mesh_importer_12345.mesh.xml"});
     EXPECT_TRUE(Manager::getSingleton()->getSceneNodes().isEmpty());

--- a/src/MeshImporterExporter_test.cpp
+++ b/src/MeshImporterExporter_test.cpp
@@ -349,6 +349,8 @@ TEST_F(MeshImporterExporterTest, Importer_MeshLoadsSidecarMaterialScript) {
     Ogre::Entity* e = manager->createEntity(sn, mesh);
     ASSERT_NE(e, nullptr);
     e->getSubEntity(0)->setMaterial(mat);
+    // MeshSerializer exports SubMesh::getMaterialName(), not the SubEntity override.
+    e->getMesh()->getSubMesh(0)->setMaterialName("SidecarMaterial");
 
     QTemporaryDir tmpDir;
     ASSERT_TRUE(tmpDir.isValid());

--- a/src/MeshImporterExporter_test.cpp
+++ b/src/MeshImporterExporter_test.cpp
@@ -366,6 +366,17 @@ TEST_F(MeshImporterExporterTest, Importer_MeshLoadsSidecarMaterialScript) {
     matFile.close();
     ASSERT_TRUE(QFileInfo::exists(sidecarMat));
 
+    // Tear down the export entity and drop our material handle so reimport cannot
+    // succeed from an in-memory material alone — it must parse the sidecar script.
+    manager->destroySceneNode(sn);
+    mat.reset();
+    if (Ogre::MaterialManager::getSingleton().getByName(
+            "SidecarMaterial", Ogre::ResourceGroupManager::AUTODETECT_RESOURCE_GROUP_NAME))
+    {
+        Ogre::MaterialManager::getSingleton().remove(
+            "SidecarMaterial", Ogre::ResourceGroupManager::AUTODETECT_RESOURCE_GROUP_NAME);
+    }
+
     // Reimport from disk.
     MeshImporterExporter::importer({outMesh});
     ASSERT_FALSE(manager->getSceneNodes().isEmpty());


### PR DESCRIPTION
## Summary
- Export vertex colors to Assimp-based formats (glTF/GLB/OBJ/DAE/PLY/...) from Ogre `VES_DIFFUSE`.
- Export vertex colors to FBX by writing `LayerElementColor` (ByPolygonVertex/Direct).
- Fix `.mesh` reimport material fallback by auto-loading `<basename>.material` sidecar when present (prevents `BaseWhite`).

## Test plan
- `UnitTests` (CI) — added coverage tests:
  - `MeshImporterExporterTest.Importer_MeshLoadsSidecarMaterialScript`
  - `FBXExporterCoverageTest.VertexColors_WritesLayerElementColor`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-vertex colors are preserved and exported to FBX (including from bind/pose data) and included in mesh exports.
  * Mesh import now detects and loads accompanying material sidecar files.
  * New API to flush pending vertex-paint into the active mesh/entity before export.

* **Tests**
  * Added tests for vertex-color FBX export and round-trip import with sidecar material files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->