### PR TITLE
feat(paint): QML falloff slider + vertex color preview toggle

### DIFF
--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -246,7 +246,6 @@ Rectangle {
             property int activeNormals: EditModeController.normalsMode
             property bool softSelOn: EditModeController.softSelectionEnabled
             property bool wireframeOn: EditModeController.wireframeEnabled
-            property bool vertexPaintOn: EditModeController.vertexPaintEnabled
             property bool vertexPreviewOn: EditModeController.vertexColorPreviewEnabled
 
             Connections {
@@ -256,7 +255,6 @@ Rectangle {
                 function onNormalsModeChanged() { editToolsCol.activeNormals = EditModeController.normalsMode }
                 function onSoftSelectionEnabledChanged() { editToolsCol.softSelOn = EditModeController.softSelectionEnabled }
                 function onWireframeChanged() { editToolsCol.wireframeOn = EditModeController.wireframeEnabled }
-                function onVertexPaintChanged() { editToolsCol.vertexPaintOn = EditModeController.vertexPaintEnabled }
                 function onVertexColorPreviewChanged() { editToolsCol.vertexPreviewOn = EditModeController.vertexColorPreviewEnabled }
             }
 
@@ -430,116 +428,22 @@ Rectangle {
                 Text { text: "Wireframe"; font.pixelSize: 11; color: PropertiesPanelController.textColor; anchors.verticalCenter: parent.verticalCenter }
             }
 
-            // Vertex paint controls (MVP)
-            Column {
-                width: parent.width - 16
+            // Vertex color preview toggle (keep in Inspector; brush settings live on the toolbar button).
+            Row {
                 spacing: 6
+                width: parent.width - 16
 
-                Row {
-                    spacing: 6
-                    width: parent.width
-
-                    // Enable paint
-                    Rectangle {
-                        width: 14; height: 14; anchors.verticalCenter: parent.verticalCenter
-                        border.color: PropertiesPanelController.borderColor; border.width: 1; radius: 2
-                        color: editToolsCol.vertexPaintOn ? PropertiesPanelController.highlightColor : "transparent"
-                        Behavior on color { ColorAnimation { duration: 50 } }
-                        Text { anchors.centerIn: parent; text: editToolsCol.vertexPaintOn ? "\u2713" : ""; color: "white"; font.pixelSize: 10 }
-                        MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor
-                            onClicked: { editToolsCol.vertexPaintOn = !editToolsCol.vertexPaintOn; EditModeController.vertexPaintEnabled = editToolsCol.vertexPaintOn }
-                        }
-                    }
-                    Text { text: "Vertex Paint"; font.pixelSize: 11; color: PropertiesPanelController.textColor; anchors.verticalCenter: parent.verticalCenter }
-
-                    // Preview toggle
-                    Rectangle {
-                        width: 14; height: 14; anchors.verticalCenter: parent.verticalCenter
-                        border.color: PropertiesPanelController.borderColor; border.width: 1; radius: 2
-                        color: editToolsCol.vertexPreviewOn ? PropertiesPanelController.highlightColor : "transparent"
-                        Behavior on color { ColorAnimation { duration: 50 } }
-                        Text { anchors.centerIn: parent; text: editToolsCol.vertexPreviewOn ? "\u2713" : ""; color: "white"; font.pixelSize: 10 }
-                        MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor
-                            onClicked: { editToolsCol.vertexPreviewOn = !editToolsCol.vertexPreviewOn; EditModeController.vertexColorPreviewEnabled = editToolsCol.vertexPreviewOn }
-                        }
-                    }
-                    Text { text: "Preview"; font.pixelSize: 11; color: PropertiesPanelController.textColor; anchors.verticalCenter: parent.verticalCenter; opacity: 0.9 }
-                }
-
-                // Color swatches
-                Row {
-                    spacing: 6
-                    width: parent.width
-                    visible: editToolsCol.vertexPaintOn
-
-                    Text { text: "Color"; font.pixelSize: 10; color: PropertiesPanelController.textColor; width: 36; anchors.verticalCenter: parent.verticalCenter }
-
-                    Repeater {
-                        model: ["#ff0000", "#00ff00", "#0000ff", "#ffff00", "#00ffff", "#ff00ff", "#ffffff", "#000000"]
-                        Rectangle {
-                            width: 16; height: 16; radius: 3
-                            color: modelData
-                            border.width: 1
-                            border.color: PropertiesPanelController.borderColor
-                            MouseArea {
-                                anchors.fill: parent
-                                cursorShape: Qt.PointingHandCursor
-                                onClicked: EditModeController.setVertexPaintBrushColor(modelData)
-                            }
-                        }
+                Rectangle {
+                    width: 14; height: 14; anchors.verticalCenter: parent.verticalCenter
+                    border.color: PropertiesPanelController.borderColor; border.width: 1; radius: 2
+                    color: editToolsCol.vertexPreviewOn ? PropertiesPanelController.highlightColor : "transparent"
+                    Behavior on color { ColorAnimation { duration: 50 } }
+                    Text { anchors.centerIn: parent; text: editToolsCol.vertexPreviewOn ? "\u2713" : ""; color: "white"; font.pixelSize: 10 }
+                    MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor
+                        onClicked: { editToolsCol.vertexPreviewOn = !editToolsCol.vertexPreviewOn; EditModeController.vertexColorPreviewEnabled = editToolsCol.vertexPreviewOn }
                     }
                 }
-
-                // Radius slider
-                Column {
-                    width: parent.width
-                    visible: editToolsCol.vertexPaintOn
-                    spacing: 2
-                    Text {
-                        text: "Radius: " + EditModeController.vertexPaintRadius.toFixed(3)
-                        color: PropertiesPanelController.textColor; font.pixelSize: 10
-                    }
-                    Slider {
-                        width: parent.width
-                        from: 0.01; to: 2.0; stepSize: 0.005
-                        value: EditModeController.vertexPaintRadius
-                        onValueChanged: EditModeController.vertexPaintRadius = value
-                    }
-                }
-
-                // Strength slider
-                Column {
-                    width: parent.width
-                    visible: editToolsCol.vertexPaintOn
-                    spacing: 2
-                    Text {
-                        text: "Strength: " + EditModeController.vertexPaintStrength.toFixed(2)
-                        color: PropertiesPanelController.textColor; font.pixelSize: 10
-                    }
-                    Slider {
-                        width: parent.width
-                        from: 0.0; to: 1.0; stepSize: 0.01
-                        value: EditModeController.vertexPaintStrength
-                        onValueChanged: EditModeController.vertexPaintStrength = value
-                    }
-                }
-
-                // Falloff slider (requested for issue #315)
-                Column {
-                    width: parent.width
-                    visible: editToolsCol.vertexPaintOn
-                    spacing: 2
-                    Text {
-                        text: "Falloff: " + EditModeController.vertexPaintFalloff.toFixed(2)
-                        color: PropertiesPanelController.textColor; font.pixelSize: 10
-                    }
-                    Slider {
-                        width: parent.width
-                        from: 0.0; to: 1.0; stepSize: 0.01
-                        value: EditModeController.vertexPaintFalloff
-                        onValueChanged: EditModeController.vertexPaintFalloff = value
-                    }
-                }
+                Text { text: "Vertex Color Preview"; font.pixelSize: 11; color: PropertiesPanelController.textColor; anchors.verticalCenter: parent.verticalCenter }
             }
 
             // Separator

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -246,6 +246,8 @@ Rectangle {
             property int activeNormals: EditModeController.normalsMode
             property bool softSelOn: EditModeController.softSelectionEnabled
             property bool wireframeOn: EditModeController.wireframeEnabled
+            property bool vertexPaintOn: EditModeController.vertexPaintEnabled
+            property bool vertexPreviewOn: EditModeController.vertexColorPreviewEnabled
 
             Connections {
                 target: EditModeController
@@ -254,6 +256,8 @@ Rectangle {
                 function onNormalsModeChanged() { editToolsCol.activeNormals = EditModeController.normalsMode }
                 function onSoftSelectionEnabledChanged() { editToolsCol.softSelOn = EditModeController.softSelectionEnabled }
                 function onWireframeChanged() { editToolsCol.wireframeOn = EditModeController.wireframeEnabled }
+                function onVertexPaintChanged() { editToolsCol.vertexPaintOn = EditModeController.vertexPaintEnabled }
+                function onVertexColorPreviewChanged() { editToolsCol.vertexPreviewOn = EditModeController.vertexColorPreviewEnabled }
             }
 
             // Selection mode buttons
@@ -424,6 +428,118 @@ Rectangle {
                     }
                 }
                 Text { text: "Wireframe"; font.pixelSize: 11; color: PropertiesPanelController.textColor; anchors.verticalCenter: parent.verticalCenter }
+            }
+
+            // Vertex paint controls (MVP)
+            Column {
+                width: parent.width - 16
+                spacing: 6
+
+                Row {
+                    spacing: 6
+                    width: parent.width
+
+                    // Enable paint
+                    Rectangle {
+                        width: 14; height: 14; anchors.verticalCenter: parent.verticalCenter
+                        border.color: PropertiesPanelController.borderColor; border.width: 1; radius: 2
+                        color: editToolsCol.vertexPaintOn ? PropertiesPanelController.highlightColor : "transparent"
+                        Behavior on color { ColorAnimation { duration: 50 } }
+                        Text { anchors.centerIn: parent; text: editToolsCol.vertexPaintOn ? "\u2713" : ""; color: "white"; font.pixelSize: 10 }
+                        MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor
+                            onClicked: { editToolsCol.vertexPaintOn = !editToolsCol.vertexPaintOn; EditModeController.vertexPaintEnabled = editToolsCol.vertexPaintOn }
+                        }
+                    }
+                    Text { text: "Vertex Paint"; font.pixelSize: 11; color: PropertiesPanelController.textColor; anchors.verticalCenter: parent.verticalCenter }
+
+                    // Preview toggle
+                    Rectangle {
+                        width: 14; height: 14; anchors.verticalCenter: parent.verticalCenter
+                        border.color: PropertiesPanelController.borderColor; border.width: 1; radius: 2
+                        color: editToolsCol.vertexPreviewOn ? PropertiesPanelController.highlightColor : "transparent"
+                        Behavior on color { ColorAnimation { duration: 50 } }
+                        Text { anchors.centerIn: parent; text: editToolsCol.vertexPreviewOn ? "\u2713" : ""; color: "white"; font.pixelSize: 10 }
+                        MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor
+                            onClicked: { editToolsCol.vertexPreviewOn = !editToolsCol.vertexPreviewOn; EditModeController.vertexColorPreviewEnabled = editToolsCol.vertexPreviewOn }
+                        }
+                    }
+                    Text { text: "Preview"; font.pixelSize: 11; color: PropertiesPanelController.textColor; anchors.verticalCenter: parent.verticalCenter; opacity: 0.9 }
+                }
+
+                // Color swatches
+                Row {
+                    spacing: 6
+                    width: parent.width
+                    visible: editToolsCol.vertexPaintOn
+
+                    Text { text: "Color"; font.pixelSize: 10; color: PropertiesPanelController.textColor; width: 36; anchors.verticalCenter: parent.verticalCenter }
+
+                    Repeater {
+                        model: ["#ff0000", "#00ff00", "#0000ff", "#ffff00", "#00ffff", "#ff00ff", "#ffffff", "#000000"]
+                        Rectangle {
+                            width: 16; height: 16; radius: 3
+                            color: modelData
+                            border.width: 1
+                            border.color: PropertiesPanelController.borderColor
+                            MouseArea {
+                                anchors.fill: parent
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: EditModeController.setVertexPaintBrushColor(modelData)
+                            }
+                        }
+                    }
+                }
+
+                // Radius slider
+                Column {
+                    width: parent.width
+                    visible: editToolsCol.vertexPaintOn
+                    spacing: 2
+                    Text {
+                        text: "Radius: " + EditModeController.vertexPaintRadius.toFixed(3)
+                        color: PropertiesPanelController.textColor; font.pixelSize: 10
+                    }
+                    Slider {
+                        width: parent.width
+                        from: 0.01; to: 2.0; stepSize: 0.005
+                        value: EditModeController.vertexPaintRadius
+                        onValueChanged: EditModeController.vertexPaintRadius = value
+                    }
+                }
+
+                // Strength slider
+                Column {
+                    width: parent.width
+                    visible: editToolsCol.vertexPaintOn
+                    spacing: 2
+                    Text {
+                        text: "Strength: " + EditModeController.vertexPaintStrength.toFixed(2)
+                        color: PropertiesPanelController.textColor; font.pixelSize: 10
+                    }
+                    Slider {
+                        width: parent.width
+                        from: 0.0; to: 1.0; stepSize: 0.01
+                        value: EditModeController.vertexPaintStrength
+                        onValueChanged: EditModeController.vertexPaintStrength = value
+                    }
+                }
+
+                // Falloff slider (requested for issue #315)
+                Column {
+                    width: parent.width
+                    visible: editToolsCol.vertexPaintOn
+                    spacing: 2
+                    Text {
+                        text: "Falloff: " + EditModeController.vertexPaintFalloff.toFixed(2)
+                        color: PropertiesPanelController.textColor; font.pixelSize: 10
+                    }
+                    Slider {
+                        width: parent.width
+                        from: 0.0; to: 1.0; stepSize: 0.01
+                        value: EditModeController.vertexPaintFalloff
+                        onValueChanged: EditModeController.vertexPaintFalloff = value
+                    }
+                }
             }
 
             // Separator

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -4839,8 +4839,10 @@ void EditModeController::createOverlayMaterials()
         pass->setLightingEnabled(false);
         pass->setVertexColourTracking(Ogre::TVC_DIFFUSE);
         pass->setDepthCheckEnabled(true);
-        pass->setDepthWriteEnabled(false);
-        pass->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
+        // Keep correct Z order so backfaces don't wash out frontfaces.
+        // (This is a preview override, not a translucent overlay.)
+        pass->setDepthWriteEnabled(true);
+        pass->setSceneBlending(Ogre::SBT_REPLACE);
         pass->setCullingMode(Ogre::CULL_NONE);
     }
 }

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -506,6 +506,16 @@ void EditModeController::exitEditMode(bool commitChanges)
         SentryReporter::addBreadcrumb("edit_mode", "Exited Edit Mode: changes discarded");
     }
 
+    // Restore material overrides (preview first, then wireframe).
+    // If preview was enabled while wireframe was on, the preview baseline can contain
+    // wireframe clone names; restoring preview after deleting those would reapply
+    // stale names. Always remove preview before tearing down wireframe.
+    if (m_vertexColorPreviewEnabled) {
+        removeVertexColorPreviewMaterials();
+        m_vertexColorPreviewEnabled = false;
+        emit vertexColorPreviewChanged();
+    }
+
     // Restore original materials (keep m_wireframeEnabled so it persists)
     if (!m_savedMaterials.empty())
         removeWireframeMaterials();
@@ -526,12 +536,6 @@ void EditModeController::exitEditMode(bool commitChanges)
         m_vertexPaintFlushScheduled = false;
         clearVertexPaintPreview();
         emit vertexPaintChanged();
-    }
-
-    if (m_vertexColorPreviewEnabled) {
-        removeVertexColorPreviewMaterials();
-        m_vertexColorPreviewEnabled = false;
-        emit vertexColorPreviewChanged();
     }
 
     m_editableMesh.reset();
@@ -5255,14 +5259,20 @@ void EditModeController::setWireframeEnabled(bool enabled)
     m_wireframeEnabled = enabled;
 
     if (m_editModeActive && m_editEntity) {
+        const bool previewWasOn = m_vertexColorPreviewEnabled;
+        // If preview is active, temporarily restore underlying materials before
+        // toggling wireframe so we don't snapshot from the preview override.
+        if (previewWasOn)
+            removeVertexColorPreviewMaterials();
+
         if (enabled)
             applyWireframeMaterials();
         else
             removeWireframeMaterials();
 
-        // If preview is on, re-apply after toggling wireframe so we snapshot/restore
-        // the current (wireframe or solid) material state correctly.
-        if (m_vertexColorPreviewEnabled)
+        // Re-apply preview after wireframe toggle so preview remains visible and the
+        // baseline becomes the current wireframe/solid state.
+        if (previewWasOn)
             applyVertexColorPreviewMaterials();
     }
 

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -238,6 +238,23 @@ void EditModeController::setVertexPaintEnabled(bool enabled)
     emit vertexPaintChanged();
 }
 
+void EditModeController::setVertexColorPreviewEnabled(bool enabled)
+{
+    if (m_vertexColorPreviewEnabled == enabled)
+        return;
+
+    m_vertexColorPreviewEnabled = enabled;
+    if (enabled)
+        applyVertexColorPreviewMaterials();
+    else
+        removeVertexColorPreviewMaterials();
+
+    SentryReporter::addBreadcrumb(
+        "ui.action",
+        QStringLiteral("Vertex color preview %1").arg(enabled ? "enabled" : "disabled"));
+    emit vertexColorPreviewChanged();
+}
+
 void EditModeController::setVertexPaintColor(const QColor& c)
 {
     if (!c.isValid())
@@ -295,6 +312,18 @@ void EditModeController::setVertexPaintStrength(double s)
     SentryReporter::addBreadcrumb(
         "ui.action",
         QStringLiteral("Vertex paint strength: %1").arg(m_vertexPaintStrength, 0, 'f', 3));
+    emit vertexPaintChanged();
+}
+
+void EditModeController::setVertexPaintFalloff(double f)
+{
+    const double clamped = std::max(0.0, std::min(1.0, f));
+    if (m_vertexPaintFalloff == clamped)
+        return;
+    m_vertexPaintFalloff = clamped;
+    SentryReporter::addBreadcrumb(
+        "ui.action",
+        QStringLiteral("Vertex paint falloff: %1").arg(m_vertexPaintFalloff, 0, 'f', 3));
     emit vertexPaintChanged();
 }
 
@@ -432,6 +461,9 @@ bool EditModeController::enterEditMode()
     if (m_wireframeEnabled)
         applyWireframeMaterials();
 
+    if (m_vertexColorPreviewEnabled)
+        applyVertexColorPreviewMaterials();
+
     SentryReporter::addBreadcrumb("edit_mode",
         QString("Entered Edit Mode: %1 vertices, %2 triangles, %3 submeshes")
             .arg(m_editableMesh->totalVertexCount())
@@ -494,6 +526,12 @@ void EditModeController::exitEditMode(bool commitChanges)
         m_vertexPaintFlushScheduled = false;
         clearVertexPaintPreview();
         emit vertexPaintChanged();
+    }
+
+    if (m_vertexColorPreviewEnabled) {
+        removeVertexColorPreviewMaterials();
+        m_vertexColorPreviewEnabled = false;
+        emit vertexColorPreviewChanged();
     }
 
     m_editableMesh.reset();
@@ -1017,7 +1055,8 @@ bool EditModeController::applyVertexColorBrush(EditableMesh& mesh,
                                                const Ogre::Vector3& localCenter,
                                                float radius,
                                                const Ogre::ColourValue& color,
-                                               float strength)
+                                               float strength,
+                                               float falloff)
 {
     if (radius <= 0.0f)
         return false;
@@ -1025,6 +1064,10 @@ bool EditModeController::applyVertexColorBrush(EditableMesh& mesh,
     strength = std::clamp(strength, 0.0f, 1.0f);
     if (strength <= 0.0f)
         return false;
+
+    falloff = std::clamp(falloff, 0.0f, 1.0f);
+    // Map [0..1] to an exponent curve [1..6]. Larger exponent = harder center / faster edge drop.
+    const float exp = 1.0f + falloff * 5.0f;
 
     bool changed = false;
     const float invR = 1.0f / radius;
@@ -1037,9 +1080,9 @@ bool EditModeController::applyVertexColorBrush(EditableMesh& mesh,
             if (d > radius)
                 continue;
 
-            // Smooth falloff: w = (1 - d/r)^2
+            // Distance falloff: w = (1 - d/r)^exp
             const float t = 1.0f - (d * invR);
-            const float w = t * t;
+            const float w = std::pow(std::max(0.0f, t), exp);
             const float a = strength * w;
             if (a <= 0.0f)
                 continue;
@@ -1559,7 +1602,8 @@ void EditModeController::updateVertexPaintStroke(OgreWidget* widget, const QPoin
         localHit,
         static_cast<float>(m_vertexPaintRadius),
         paint,
-        static_cast<float>(m_vertexPaintStrength));
+        static_cast<float>(m_vertexPaintStrength),
+        static_cast<float>(m_vertexPaintFalloff));
 
     if (changed) {
         m_vertexPaintStrokeDirty = true;
@@ -4781,6 +4825,20 @@ void EditModeController::createOverlayMaterials()
         // facing triangle strips (TODO if 2px is unreliable).
         pass->setLineWidth(2.0f);
     }
+
+    // Vertex color preview material (unlit, uses diffuse vertex color).
+    if (!matMgr.getByName("EditMode/VertexColorPreview"))
+    {
+        auto mat = matMgr.create("EditMode/VertexColorPreview",
+                                 Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME);
+        auto* pass = mat->getTechnique(0)->getPass(0);
+        pass->setLightingEnabled(false);
+        pass->setVertexColourTracking(Ogre::TVC_DIFFUSE);
+        pass->setDepthCheckEnabled(true);
+        pass->setDepthWriteEnabled(false);
+        pass->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
+        pass->setCullingMode(Ogre::CULL_NONE);
+    }
 }
 
 void EditModeController::updateSelectionOverlay()
@@ -5106,6 +5164,39 @@ void EditModeController::removeWireframeMaterials()
         m_overlayBoundaryEdges->clear();
 }
 
+void EditModeController::applyVertexColorPreviewMaterials()
+{
+    if (!m_editModeActive || !m_editEntity || !m_editableMesh)
+        return;
+
+    // Ensure the mesh actually has vertex color buffers; default-initialize to white if missing.
+    m_editableMesh->ensureVertexColorBuffers(m_editEntity);
+
+    m_vertexColorPreviewSavedMaterials.clear();
+    for (unsigned int i = 0; i < m_editEntity->getNumSubEntities(); ++i) {
+        auto* subEnt = m_editEntity->getSubEntity(i);
+        if (!subEnt)
+            continue;
+        m_vertexColorPreviewSavedMaterials[i] = subEnt->getMaterialName();
+        subEnt->setMaterialName(
+            "EditMode/VertexColorPreview",
+            Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME);
+    }
+}
+
+void EditModeController::removeVertexColorPreviewMaterials()
+{
+    if (!m_editEntity)
+        return;
+
+    for (const auto& [idx, matName] : m_vertexColorPreviewSavedMaterials) {
+        if (idx < m_editEntity->getNumSubEntities()) {
+            m_editEntity->getSubEntity(idx)->setMaterialName(matName);
+        }
+    }
+    m_vertexColorPreviewSavedMaterials.clear();
+}
+
 void EditModeController::updateBoundaryEdgeOverlay()
 {
     if (!m_editModeActive || !m_editableMesh || !m_editEntity) return;
@@ -5168,6 +5259,11 @@ void EditModeController::setWireframeEnabled(bool enabled)
             applyWireframeMaterials();
         else
             removeWireframeMaterials();
+
+        // If preview is on, re-apply after toggling wireframe so we snapshot/restore
+        // the current (wireframe or solid) material state correctly.
+        if (m_vertexColorPreviewEnabled)
+            applyVertexColorPreviewMaterials();
     }
 
     SentryReporter::addBreadcrumb("edit_mode",

--- a/src/EditModeController.h
+++ b/src/EditModeController.h
@@ -106,6 +106,8 @@ class EditModeController : public QObject
     Q_PROPERTY(QColor vertexPaintColor READ vertexPaintColor WRITE setVertexPaintColor NOTIFY vertexPaintChanged)
     Q_PROPERTY(double vertexPaintRadius READ vertexPaintRadius WRITE setVertexPaintRadius NOTIFY vertexPaintChanged)
     Q_PROPERTY(double vertexPaintStrength READ vertexPaintStrength WRITE setVertexPaintStrength NOTIFY vertexPaintChanged)
+    Q_PROPERTY(double vertexPaintFalloff READ vertexPaintFalloff WRITE setVertexPaintFalloff NOTIFY vertexPaintChanged)
+    Q_PROPERTY(bool vertexColorPreviewEnabled READ vertexColorPreviewEnabled WRITE setVertexColorPreviewEnabled NOTIFY vertexColorPreviewChanged)
 
 public:
     /// Selection component mode for edit mode.
@@ -213,6 +215,13 @@ public:
     void setVertexPaintRadius(double r);
     double vertexPaintStrength() const { return m_vertexPaintStrength; }
     void setVertexPaintStrength(double s);
+    /// Brush falloff [0..1]. Internally mapped to an exponent curve.
+    double vertexPaintFalloff() const { return m_vertexPaintFalloff; }
+    void setVertexPaintFalloff(double f);
+
+    /// Render-time material override to preview vertex colors (Edit Mode only).
+    bool vertexColorPreviewEnabled() const { return m_vertexColorPreviewEnabled; }
+    void setVertexColorPreviewEnabled(bool enabled);
 
     /**
      * @brief Commits deferred vertex paint from EditableMesh into GPU vertex buffers.
@@ -743,7 +752,8 @@ public:
                                       const Ogre::Vector3& localCenter,
                                       float radius,
                                       const Ogre::ColourValue& color,
-                                      float strength);
+                                      float strength,
+                                      float falloff);
 
     /// Convert a global vertex index to (subMeshIndex, localVertexIndex) pair.
     std::pair<size_t, size_t> globalToLocal(int globalIndex) const;
@@ -795,6 +805,7 @@ signals:
     /// so QML toolbar state and preview overlay refresh together.
     void knifeSessionChanged();
     void vertexPaintChanged();
+    void vertexColorPreviewChanged();
 
     /// Emitted when an edit-mode op short-circuits and wants to surface
     /// a one-line explanation to the user (e.g. "Loop cut requires a
@@ -918,6 +929,7 @@ private:
     QColor m_vertexPaintColor = QColor(255, 0, 0);
     double m_vertexPaintRadius = 0.25;   // local units
     double m_vertexPaintStrength = 0.5;  // 0..1
+    double m_vertexPaintFalloff = 0.5;   // 0..1
     bool m_vertexPaintStrokeActive = false;
     OgreWidget* m_vertexPaintWidget = nullptr;
     Ogre::Vector3 m_vertexPaintLastLocal = Ogre::Vector3::ZERO;
@@ -926,6 +938,12 @@ private:
     bool m_vertexPaintFlushScheduled = false;
     bool m_vertexPaintFlushPending = false;
     std::vector<EditableSubMesh> m_vertexPaintStrokeOriginalSubMeshes;
+
+    // Vertex color preview material override (Edit Mode only)
+    bool m_vertexColorPreviewEnabled = false;
+    std::map<unsigned int, Ogre::String> m_vertexColorPreviewSavedMaterials;
+    void applyVertexColorPreviewMaterials();
+    void removeVertexColorPreviewMaterials();
 
     /// Hit-test a screen-space point for knife placement. Priority:
     /// snap to existing vertex within pixelRadius, else snap to edge

--- a/src/EditModeController_test.cpp
+++ b/src/EditModeController_test.cpp
@@ -166,7 +166,7 @@ TEST(EditModeControllerGeometry, ApplyVertexColorBrushAffectsVerticesWithinRadiu
 
     const Ogre::ColourValue paint(1.0f, 0.0f, 0.0f, 1.0f); // red
     const bool changed = EditModeController::applyVertexColorBrush(
-        mesh, Ogre::Vector3(0.0f, 0.0f, 0.0f), /*radius=*/1.1f, paint, /*strength=*/1.0f);
+        mesh, Ogre::Vector3(0.0f, 0.0f, 0.0f), /*radius=*/1.1f, paint, /*strength=*/1.0f, /*falloff=*/0.5f);
     EXPECT_TRUE(changed);
 
     // v0 should become red-ish (exact red because distance 0 => w=1).

--- a/src/EditableMesh.cpp
+++ b/src/EditableMesh.cpp
@@ -1553,19 +1553,6 @@ bool EditableMesh::writeVertexColors(Ogre::VertexData* vertexData, const std::ve
     const size_t vertexSize = vbuf->getVertexSize();
     const size_t count = std::min(vertices.size(), static_cast<size_t>(vertexData->vertexCount));
 
-    // Upgrade static → dynamic for immediate GPU visibility.
-    if (vbuf->getUsage() & Ogre::HardwareBuffer::HBU_STATIC) {
-        std::vector<unsigned char> oldData(bufSize);
-        vbuf->readData(0, bufSize, oldData.data());
-
-        auto newBuf = Ogre::HardwareBufferManager::getSingleton().createVertexBuffer(
-            vertexSize, vertexData->vertexCount,
-            Ogre::HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY, true);
-        newBuf->writeData(0, bufSize, oldData.data(), true);
-        binding->setBinding(source, newBuf);
-        vbuf = newBuf;
-    }
-
     std::vector<unsigned char> bufCopy(bufSize);
     vbuf->readData(0, bufSize, bufCopy.data());
 

--- a/src/EditableMesh_test.cpp
+++ b/src/EditableMesh_test.cpp
@@ -282,6 +282,42 @@ TEST_F(EditableMeshTest, VertexColorsRoundTripThroughCommitAndResize)
     Manager::getSingleton()->destroySceneNode("EditableMesh_colors_node");
 }
 
+TEST_F(EditableMeshTest, VertexColorsCommitDoesNotSwapDiffuseVertexBuffer)
+{
+    // Regression test: freshly imported meshes may not show paint until a full buffer
+    // rebuild if we replace the VES_DIFFUSE vertex buffer binding (VAO caching).
+    auto meshPtr = createInMemoryTriangleMesh("EditableMesh_colors_no_swap");
+    auto* node = Manager::getSingleton()->addSceneNode("EditableMesh_colors_no_swap_node");
+    auto* entity = Manager::getSingleton()->createEntity(node, meshPtr);
+
+    EditableMesh editMesh;
+    ASSERT_TRUE(editMesh.loadFromEntity(entity));
+    ASSERT_TRUE(editMesh.ensureVertexColorBuffers(entity));
+
+    Ogre::Mesh* mesh = entity->getMesh().get();
+    ASSERT_NE(mesh, nullptr);
+    ASSERT_GE(mesh->getNumSubMeshes(), 1u);
+    Ogre::SubMesh* sm = mesh->getSubMesh(0);
+    ASSERT_NE(sm, nullptr);
+    ASSERT_TRUE(!sm->useSharedVertices);
+    ASSERT_NE(sm->vertexData, nullptr);
+    const auto* elem = sm->vertexData->vertexDeclaration->findElementBySemantic(Ogre::VES_DIFFUSE);
+    ASSERT_NE(elem, nullptr);
+    const unsigned short src = elem->getSource();
+    const auto before = sm->vertexData->vertexBufferBinding->getBuffer(src);
+    ASSERT_TRUE(!!before);
+
+    // Change one vertex color and commit.
+    editMesh.setVertexColor(0, 0, Ogre::ColourValue(0.2f, 0.8f, 0.1f, 1.0f));
+    ASSERT_TRUE(editMesh.commitVertexColorsToEntity(entity));
+
+    const auto after = sm->vertexData->vertexBufferBinding->getBuffer(src);
+    ASSERT_TRUE(!!after);
+    EXPECT_EQ(before.get(), after.get());
+
+    Manager::getSingleton()->destroySceneNode("EditableMesh_colors_no_swap_node");
+}
+
 TEST_F(EditableMeshTest, RecalculateNormals) {
     auto meshPtr = createInMemoryTriangleMesh("EditableMesh_normals");
     auto* node = Manager::getSingleton()->addSceneNode("EditableMesh_normals_node");

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -983,15 +983,34 @@ void MainWindow::initToolBar()
     paintLay->addWidget(strLabel);
     paintLay->addWidget(strSlider);
 
+    // Falloff slider (0..1)
+    auto* falloffLabel = new QLabel(paintSettings);
+    auto* falloffSlider = new QSlider(Qt::Horizontal, paintSettings);
+    falloffSlider->setRange(0, 100);
+    auto syncFalloff = [falloffLabel, falloffSlider, emPaint]() {
+        QSignalBlocker b(falloffSlider);
+        falloffSlider->setValue(qBound(0, static_cast<int>(qRound(emPaint->vertexPaintFalloff() * 100.0)), 100));
+        falloffLabel->setText(tr("Falloff: %1").arg(emPaint->vertexPaintFalloff(), 0, 'f', 2));
+    };
+    syncFalloff();
+    connect(falloffSlider, &QSlider::valueChanged, this, [this, emPaint, falloffLabel](int v) {
+        emPaint->setVertexPaintFalloff(v / 100.0);
+        falloffLabel->setText(tr("Falloff: %1").arg(emPaint->vertexPaintFalloff(), 0, 'f', 2));
+    });
+    connect(emPaint, &EditModeController::vertexPaintChanged, this, syncFalloff);
+    paintLay->addWidget(falloffLabel);
+    paintLay->addWidget(falloffSlider);
+
     auto* paintWa = new QWidgetAction(vertexPaintMenu);
     paintWa->setDefaultWidget(paintSettings);
     vertexPaintMenu->addAction(paintWa);
     vertexPaintButton->setMenu(vertexPaintMenu);
 
-    connect(vertexPaintMenu, &QMenu::aboutToShow, this, [syncPaintColorBtn, syncRad, syncStr]() {
+    connect(vertexPaintMenu, &QMenu::aboutToShow, this, [syncPaintColorBtn, syncRad, syncStr, syncFalloff]() {
         syncPaintColorBtn();
         syncRad();
         syncStr();
+        syncFalloff();
     });
 
     connect(vertexPaintButton, &QToolButton::toggled, this, [this](bool on) {


### PR DESCRIPTION
## Summary
- Add Vertex Paint controls to the QML Inspector (Edit Mode Tools): radius, strength, **falloff**.
- Add a **Vertex Color Preview** toggle that applies a non-destructive per-entity material override in Edit Mode.
- Make brush falloff configurable (distance weight exponent).

Closes #315.

## Test plan
- Build `UnitTests` and run `EditModeControllerGeometry.ApplyVertexColorBrushAffectsVerticesWithinRadius`.
- In GUI: enter Edit Mode, enable Vertex Paint, adjust radius/strength/falloff and paint; toggle preview on/off and verify original materials restore.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vertex Color Preview toggle in edit mode for real-time color visualization.
  * Configurable Paint Falloff slider in brush settings to control gradient behavior.
  * Toolbar/menu controls synced with the new preview and falloff settings.

* **Bug Fixes**
  * Preserve existing vertex color buffers when committing edits to avoid replacing buffer bindings.

* **Tests**
  * Added regression tests verifying vertex color commit behavior and brush falloff application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->