### PR TITLE
test(quads): native-quad coverage for topology ops (audit #326)

### DIFF
--- a/src/HalfEdgeMesh_test.cpp
+++ b/src/HalfEdgeMesh_test.cpp
@@ -105,6 +105,36 @@ static EditableMesh makeQuadMesh()
     return mesh;
 }
 
+/// Two-quad strip in the n-gon canonical form (sub.faces is populated).
+/// Topology:
+///   3---2---5
+///   |q1 |q2 |
+///   0---1---4
+/// Both quads are coplanar in XY at z=0, share edge (1,2). Used by the
+/// quad-mesh topology-op test audit (#326 acceptance criterion).
+static EditableMesh makeNativeQuadMesh()
+{
+    EditableMesh mesh;
+    EditableSubMesh sub;
+    sub.materialName = "QuadStripMat";
+    auto mkV = [](float x, float y) {
+        EditableVertex v;
+        v.position = Ogre::Vector3(x, y, 0);
+        v.normal = Ogre::Vector3(0, 0, 1); v.hasNormal = true;
+        v.uv = Ogre::Vector2(x, y); v.hasUV = true;
+        return v;
+    };
+    sub.vertices = { mkV(0, 0), mkV(1, 0), mkV(1, 1), mkV(0, 1),
+                     mkV(2, 0), mkV(2, 1) };
+    EditableFace q1, q2;
+    q1.indices = {0, 1, 2, 3};
+    q2.indices = {1, 4, 5, 2};
+    sub.faces = { q1, q2 };
+    triangulateFaces(sub);
+    mesh.subMeshes().push_back(std::move(sub));
+    return mesh;
+}
+
 /**
  * Creates a two-submesh mesh (one triangle each, sharing no vertices):
  *   Submesh 0: triangle at z=0
@@ -5705,4 +5735,151 @@ TEST(HalfEdgeMeshStandalone, CatmullClarkRoundTripsThroughEditableMesh) {
     EXPECT_TRUE(he2.validate());
     // 2 input tris × 3 quads each = 6 output quads.
     EXPECT_EQ(activeFaceCount(he2), 6);
+}
+
+// ===========================================================================
+// Native-quad-mesh coverage for #326 acceptance criterion: every existing
+// topology op should have at least one test that exercises a quad input
+// via the n-gon canonical path (sub.faces non-empty), not just the legacy
+// 2-triangle quad fixture.
+//
+// These tests use makeNativeQuadMesh() which populates sub.faces with two
+// 4-vertex EditableFace entries. buildFromEditableMesh respects the n-gon
+// path when faces is non-empty, so the HE mesh has 2 quad faces (not 4
+// fan-triangulated tris).
+// ===========================================================================
+
+TEST(HalfEdgeMeshStandalone, ExtrudeNativeQuadFacePreservesCapArity) {
+    // Extrude on an n-gon face preserves the cap arity (the lifted copy
+    // of the original face stays a quad). Side walls are currently
+    // fan-triangulated by extrudeFaces — that's a known limitation of
+    // the chunk-4 extrude path, tracked for follow-up; this test only
+    // pins the cap-arity invariant which is what users see top-down.
+    auto em = makeNativeQuadMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    ASSERT_EQ(he.faceCount(), 2u);
+    ASSERT_EQ(he.faceVertices(0).size(), 4u) << "input is a native quad face";
+
+    auto newVerts = he.extrudeFaces({0});
+    EXPECT_EQ(newVerts.size(), 4u) << "one new vertex per face corner";
+    EXPECT_TRUE(he.validate());
+
+    // Among active faces:
+    //   - lifted cap (quad — invariant we care about)
+    //   - untouched neighbour q2 (still a quad)
+    //   - 8 fan-triangulated side walls (4 sides × 2 tris each)
+    int active = 0, quads = 0;
+    for (size_t f = 0; f < he.faceCount(); ++f) {
+        if (he.face(static_cast<int>(f)).halfEdge < 0) continue;
+        ++active;
+        if (he.faceVertices(static_cast<int>(f)).size() == 4) ++quads;
+    }
+    EXPECT_GE(active, 6);
+    EXPECT_GE(quads, 2)
+        << "lifted cap + untouched q2 must remain quads";
+}
+
+TEST(HalfEdgeMeshStandalone, CutPathOnNativeQuadCrossesInterior) {
+    // Cut horizontally through both quads — start on the bottom edge of
+    // q1, end on the bottom edge of q2 (no, that's parallel — go vertical
+    // instead): start on left edge of q1, exit on right edge of q2,
+    // crossing the shared (1,2) edge in between.
+    auto em = makeNativeQuadMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+
+    const int leftEdge  = findEdge(he, 0, 3); // left of q1 (x=0)
+    const int rightEdge = findEdge(he, 4, 5); // right of q2 (x=2)
+    ASSERT_GE(leftEdge, 0);
+    ASSERT_GE(rightEdge, 0);
+
+    // Cut at y=0.5 across both quads. The shared edge (1,2) is also
+    // horizontal (x=1, y from 0→1) — wait no, (1,2) goes (1,0)→(1,1) so
+    // it's vertical at x=1. The cut line y=0.5 will cross it at (1, 0.5).
+    auto newVerts = he.cutPath({{leftEdge, 0.5f}, {rightEdge, 0.5f}});
+    EXPECT_GE(newVerts.size(), 3u) << "endpoint splits + interior crossing";
+    EXPECT_TRUE(he.validate());
+}
+
+TEST(HalfEdgeMeshStandalone, MergeVerticesOnNativeQuadCollapsesCorner) {
+    // Merge two adjacent corners of q1 (verts 0 and 1) — that collapses
+    // the bottom edge of q1, turning it into a degenerate triangle (the
+    // two merged endpoints become one). q2 is untouched (it shares only
+    // vertex 1 with q1).
+    auto em = makeNativeQuadMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    ASSERT_EQ(he.faceCount(), 2u);
+
+    const Ogre::Vector3 mid(0.5f, 0.0f, 0.0f);
+    const int retired = he.mergeVertices({0, 1}, mid);
+    EXPECT_EQ(retired, 1) << "one of the two collapses to the survivor";
+    EXPECT_TRUE(he.validate());
+
+    // q1 collapsed from a quad to a triangle (one of its edges fused).
+    // q2 must still be a quad — it contained vertex 1 but lost a neighbour
+    // and gained the survivor in its place, still 4 distinct corners.
+    int active = 0, quads = 0, tris = 0;
+    for (size_t f = 0; f < he.faceCount(); ++f) {
+        if (he.face(static_cast<int>(f)).halfEdge < 0) continue;
+        ++active;
+        const auto sz = he.faceVertices(static_cast<int>(f)).size();
+        if (sz == 3) ++tris;
+        if (sz == 4) ++quads;
+    }
+    EXPECT_GE(active, 1) << "at least q2 should survive";
+    EXPECT_GE(tris + quads, 1);
+}
+
+TEST(HalfEdgeMeshStandalone, DeleteFacesNativeQuadRetiresWholeQuad) {
+    // Delete the whole q1 quad face. Pre-quad-aware delete operated on
+    // single triangles inside a fan-triangulated quad — only half the
+    // visible face went. With native quads, deleting face 0 retires
+    // exactly one face and leaves q2 untouched.
+    auto em = makeNativeQuadMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    ASSERT_EQ(activeFaceCount(he), 2);
+
+    he.deleteFaces({0});
+    EXPECT_EQ(activeFaceCount(he), 1) << "q1 retired, q2 alive";
+    EXPECT_TRUE(he.validate());
+
+    // The surviving face must still be a quad (not a triangle from a
+    // half-deleted fan).
+    for (size_t f = 0; f < he.faceCount(); ++f) {
+        if (he.face(static_cast<int>(f)).halfEdge < 0) continue;
+        EXPECT_EQ(he.faceVertices(static_cast<int>(f)).size(), 4u);
+    }
+}
+
+TEST(HalfEdgeMeshStandalone, DissolveEdgesOnNativeQuadInteriorMergesQuads) {
+    // Dissolve the shared edge (1,2) between q1 and q2. The two adjacent
+    // quads should merge into a single 6-vertex hexagonal n-gon.
+    // Pre-quad-aware dissolve tested this on a 4-tri pair (Quad +
+    // Diagonal) producing a quad output; here we verify the n-gon path
+    // produces a hexagon from two quads.
+    auto em = makeNativeQuadMesh();
+    HalfEdgeMesh he;
+    ASSERT_TRUE(he.buildFromEditableMesh(em));
+    ASSERT_EQ(activeFaceCount(he), 2);
+
+    const int sharedEdge = findEdge(he, 1, 2);
+    ASSERT_GE(sharedEdge, 0);
+
+    he.dissolveEdges({sharedEdge});
+    EXPECT_TRUE(he.validate());
+
+    // After dissolve: 1 active face, with 6 vertices (the union of q1's
+    // 4 corners and q2's 4 corners, minus the 2 shared).
+    int active = 0;
+    size_t outerArity = 0;
+    for (size_t f = 0; f < he.faceCount(); ++f) {
+        if (he.face(static_cast<int>(f)).halfEdge < 0) continue;
+        ++active;
+        outerArity = he.faceVertices(static_cast<int>(f)).size();
+    }
+    EXPECT_EQ(active, 1) << "two quads merged into one";
+    EXPECT_EQ(outerArity, 6u) << "merged hexagon: 4+4-2 corners";
 }


### PR DESCRIPTION
## Summary
Closes the **\"every existing topology op has at least one quad-mesh unit test\"** acceptance criterion from the quad-migration epic (#326).

Audited the 8 ops listed in the epic body. Five had no native-n-gon test (their existing \"Quad\" tests used the legacy 2-triangle \`makeQuadMesh()\` fixture, where \`sub.faces\` is empty). Added one test per gap, using a new \`makeNativeQuadMesh()\` fixture that populates \`sub.faces\` with two 4-vertex \`EditableFace\` entries — exercises the n-gon canonical path directly.

## Audit results
| Op | Native-n-gon test before | After |
|---|---|---|
| extrude | ❌ legacy tri fixture only | ✅ \`ExtrudeNativeQuadFacePreservesCapArity\` |
| bevel | ✅ several \`BevelEdgesNgon...\` | (unchanged) |
| knife (cutPath) | ❌ legacy tri fixture only | ✅ \`CutPathOnNativeQuadCrossesInterior\` |
| merge | ❌ legacy tri fixture only | ✅ \`MergeVerticesOnNativeQuadCollapsesCorner\` |
| delete | ❌ legacy tri fixture only | ✅ \`DeleteFacesNativeQuadRetiresWholeQuad\` |
| dissolve | ❌ legacy tri fixture only | ✅ \`DissolveEdgesOnNativeQuadInteriorMergesQuads\` |
| subdivide | ✅ \`SubdivideFacesToQuadsOnQuad...\` | (unchanged) |
| fill | ✅ \`FillSelectionFourVerticesEmitsTwoTriangles\` (emits a quad) | (unchanged) |

## Notes
- The extrude test pins only the cap-arity invariant. Side walls are currently fan-triangulated by \`extrudeFaces\` — that's a known chunk-4 limitation, tracked for a future \"n-gon-preserving extrude side walls\" PR.
- The merge test asserts \`>= 1\` surviving face rather than exact counts, since the precise post-merge topology depends on which adjacent face survives — both legitimate outcomes are accepted.

## Test plan
- [x] All 5 new tests pass on macOS (\`238/238\` standalone)
- [x] No regression on existing tests (233 → 238)
- [x] Build clean (UnitTests target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)