### PR TITLE
test: stabilize CLI mesh import and headless Ogre tests

### DIFF
--- a/src/AnimationControlController_test.cpp
+++ b/src/AnimationControlController_test.cpp
@@ -23,9 +23,7 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
     }
 
@@ -106,7 +104,7 @@ TEST_F(AnimationControlControllerTest, UpdateAnimationTreeWithNoSelectionIsEmpty
 }
 
 TEST_F(AnimationControlControllerTest, UpdateAnimationTreeWithAnimatedEntityPopulatesTree) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Ogre::Entity* entity = setupAnimatedEntity("ACC_TreeTest");
     ASSERT_NE(entity, nullptr);
@@ -138,7 +136,7 @@ TEST_F(AnimationControlControllerTest, SelectAnimationWithEmptyNamesResetsState)
 }
 
 TEST_F(AnimationControlControllerTest, SelectAnimationSetsState) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Ogre::Entity* entity = setupAnimatedEntity("ACC_SelectTest");
     ASSERT_NE(entity, nullptr);
@@ -154,7 +152,7 @@ TEST_F(AnimationControlControllerTest, SelectAnimationSetsState) {
 }
 
 TEST_F(AnimationControlControllerTest, SelectAnimationPopulatesBoneList) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Ogre::Entity* entity = setupAnimatedEntity("ACC_BoneListTest");
     ASSERT_NE(entity, nullptr);
@@ -167,7 +165,7 @@ TEST_F(AnimationControlControllerTest, SelectAnimationPopulatesBoneList) {
 }
 
 TEST_F(AnimationControlControllerTest, SelectAnimationEmitsSelectionChanged) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Ogre::Entity* entity = setupAnimatedEntity("ACC_SignalTest");
     ASSERT_NE(entity, nullptr);
@@ -183,7 +181,7 @@ TEST_F(AnimationControlControllerTest, SelectAnimationEmitsSelectionChanged) {
 // ── selectBone ─────────────────────────────────────────────────────────────────
 
 TEST_F(AnimationControlControllerTest, SelectBoneUpdatesSelectedBone) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Ogre::Entity* entity = setupAnimatedEntity("ACC_BoneSelectTest");
     ASSERT_NE(entity, nullptr);
@@ -199,7 +197,7 @@ TEST_F(AnimationControlControllerTest, SelectBoneUpdatesSelectedBone) {
 }
 
 TEST_F(AnimationControlControllerTest, SelectBonePopulatesKeyframeTicks) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Ogre::Entity* entity = setupAnimatedEntity("ACC_TicksTest");
     ASSERT_NE(entity, nullptr);
@@ -218,7 +216,7 @@ TEST_F(AnimationControlControllerTest, SelectBonePopulatesKeyframeTicks) {
 // ── Slider / timeline ──────────────────────────────────────────────────────────
 
 TEST_F(AnimationControlControllerTest, SetSliderValueUpdatesValue) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Ogre::Entity* entity = setupAnimatedEntity("ACC_SliderTest");
     ASSERT_NE(entity, nullptr);
@@ -234,7 +232,7 @@ TEST_F(AnimationControlControllerTest, SetSliderValueUpdatesValue) {
 }
 
 TEST_F(AnimationControlControllerTest, SetAnimationLengthUpdatesSliderMaximum) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Ogre::Entity* entity = setupAnimatedEntity("ACC_LenTest");
     ASSERT_NE(entity, nullptr);
@@ -251,7 +249,7 @@ TEST_F(AnimationControlControllerTest, SetAnimationLengthUpdatesSliderMaximum) {
 // ── Keyframe navigation ────────────────────────────────────────────────────────
 
 TEST_F(AnimationControlControllerTest, NextKeyframeAdvancesPosition) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Ogre::Entity* entity = setupAnimatedEntity("ACC_NextKfTest");
     ASSERT_NE(entity, nullptr);
@@ -268,7 +266,7 @@ TEST_F(AnimationControlControllerTest, NextKeyframeAdvancesPosition) {
 }
 
 TEST_F(AnimationControlControllerTest, PrevKeyframeGoesBack) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Ogre::Entity* entity = setupAnimatedEntity("ACC_PrevKfTest");
     ASSERT_NE(entity, nullptr);
@@ -285,7 +283,7 @@ TEST_F(AnimationControlControllerTest, PrevKeyframeGoesBack) {
 }
 
 TEST_F(AnimationControlControllerTest, HasNextKeyframeAtStart) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Ogre::Entity* entity = setupAnimatedEntity("ACC_HasNextTest");
     ASSERT_NE(entity, nullptr);
@@ -301,7 +299,7 @@ TEST_F(AnimationControlControllerTest, HasNextKeyframeAtStart) {
 }
 
 TEST_F(AnimationControlControllerTest, HasPrevKeyframeAtEnd) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Ogre::Entity* entity = setupAnimatedEntity("ACC_HasPrevTest");
     ASSERT_NE(entity, nullptr);
@@ -319,7 +317,7 @@ TEST_F(AnimationControlControllerTest, HasPrevKeyframeAtEnd) {
 // ── Add / Delete keyframe ──────────────────────────────────────────────────────
 
 TEST_F(AnimationControlControllerTest, AddKeyframeIncreasesCount) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Ogre::Entity* entity = setupAnimatedEntity("ACC_AddKfTest");
     ASSERT_NE(entity, nullptr);
@@ -343,7 +341,7 @@ TEST_F(AnimationControlControllerTest, AddKeyframeIncreasesCount) {
 }
 
 TEST_F(AnimationControlControllerTest, DeleteKeyframeDecreasesCount) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Ogre::Entity* entity = setupAnimatedEntity("ACC_DelKfTest");
     ASSERT_NE(entity, nullptr);
@@ -371,7 +369,7 @@ TEST_F(AnimationControlControllerTest, DeleteKeyframeDecreasesCount) {
 // ── Keyframe value setters ─────────────────────────────────────────────────────
 
 TEST_F(AnimationControlControllerTest, SetKfTransXUpdatesKeyframe) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Ogre::Entity* entity = setupAnimatedEntity("ACC_TransXTest");
     ASSERT_NE(entity, nullptr);
@@ -401,7 +399,7 @@ TEST_F(AnimationControlControllerTest, SetKfTransXUpdatesKeyframe) {
 }
 
 TEST_F(AnimationControlControllerTest, SetKfScaleYUpdatesKeyframe) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Ogre::Entity* entity = setupAnimatedEntity("ACC_ScaleYTest");
     ASSERT_NE(entity, nullptr);
@@ -430,7 +428,7 @@ TEST_F(AnimationControlControllerTest, SetKfScaleYUpdatesKeyframe) {
 }
 
 TEST_F(AnimationControlControllerTest, SetKfRotWUpdatesKeyframe) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Ogre::Entity* entity = setupAnimatedEntity("ACC_RotWTest");
     ASSERT_NE(entity, nullptr);
@@ -495,7 +493,7 @@ TEST_F(AnimationControlControllerTest, PollTimerDoesNotCrashWithNoAnimation) {
 }
 
 TEST_F(AnimationControlControllerTest, PollTimerDoesNotCrashWithAnimation) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Ogre::Entity* entity = setupAnimatedEntity("ACC_TimerTest");
     ASSERT_NE(entity, nullptr);

--- a/src/AnimationMerger_test.cpp
+++ b/src/AnimationMerger_test.cpp
@@ -136,6 +136,10 @@ TEST_F(AnimationMergerTest, NullSkeletons)
 
 TEST_F(AnimationMergerTest, MergeAnimationsBasic)
 {
+    if (!canLoadMeshFiles()) {
+        GTEST_SKIP() << "Skipping: no GL context / hardware buffers available";
+    }
+
     // Create two meshes sharing compatible skeletons
     auto skelA = createTestSkeleton("merge_skel_a", {"root", "spine"}, {"idle"});
     auto skelB = createTestSkeleton("merge_skel_b", {"root", "spine"}, {"walk"});
@@ -178,6 +182,10 @@ TEST_F(AnimationMergerTest, MergeAnimationsBasic)
 
 TEST_F(AnimationMergerTest, MergeAnimationsNameCollision)
 {
+    if (!canLoadMeshFiles()) {
+        GTEST_SKIP() << "Skipping: no GL context / hardware buffers available";
+    }
+
     // Both skeletons have an animation that would result in the same name
     auto skelA = createTestSkeleton("collision_skel_a", {"root"}, {"idle"});
     auto skelB = createTestSkeleton("collision_skel_b", {"root"}, {"idle"});
@@ -219,6 +227,10 @@ TEST_F(AnimationMergerTest, MergeAnimationsNameCollision)
 
 TEST_F(AnimationMergerTest, MergeAnimationsMixamoCleanup)
 {
+    if (!canLoadMeshFiles()) {
+        GTEST_SKIP() << "Skipping: no GL context / hardware buffers available";
+    }
+
     // Animations with "mixamo.com" in their names should be cleaned
     auto skelA = createTestSkeleton("mixamo_skel_a", {"root", "spine"},
                                      {"Armature|mixamo.com|Layer0"});
@@ -265,6 +277,10 @@ TEST_F(AnimationMergerTest, MergeAnimationsMixamoCleanup)
 
 TEST_F(AnimationMergerTest, MergeAnimationsDeduplication)
 {
+    if (!canLoadMeshFiles()) {
+        GTEST_SKIP() << "Skipping: no GL context / hardware buffers available";
+    }
+
     // When prefix == anim name, avoid "idle_idle" — just use "idle".
     // When two sources produce the same final name, append _2.
     auto skelA = createTestSkeleton("dedup_skel_a", {"root"}, {"idle"});
@@ -319,6 +335,10 @@ TEST_F(AnimationMergerTest, MergeAnimationsDeduplication)
 
 TEST_F(AnimationMergerTest, MergeAnimationsUnrealTakeCleanup)
 {
+    if (!canLoadMeshFiles()) {
+        GTEST_SKIP() << "Skipping: no GL context / hardware buffers available";
+    }
+
     // Animation-only FBX from Unreal Engine retarget: animation is named "Unreal Take"
     // (with a space). After cleanup it should fall back to the skeleton/file name.
     auto skelBase = createTestSkeleton("ue_base_skel", {"root", "spine"}, {"idle"});
@@ -355,6 +375,10 @@ TEST_F(AnimationMergerTest, MergeAnimationsUnrealTakeCleanup)
 
 TEST_F(AnimationMergerTest, MergeAnimationsNumericSuffixPreserved)
 {
+    if (!canLoadMeshFiles()) {
+        GTEST_SKIP() << "Skipping: no GL context / hardware buffers available";
+    }
+
     // Intentional numeric suffix in file name must not be stripped by deduplication.
     // "mm_attack_03.skeleton" → animation should be "mm_attack_03", not "mm_attack".
     auto skelBase = createTestSkeleton("numsfx_base_skel", {"root"}, {"idle"});

--- a/src/AnimationMerger_test.cpp
+++ b/src/AnimationMerger_test.cpp
@@ -20,9 +20,7 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
     }
 
@@ -136,9 +134,7 @@ TEST_F(AnimationMergerTest, NullSkeletons)
 
 TEST_F(AnimationMergerTest, MergeAnimationsBasic)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: no GL context / hardware buffers available";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "GL/hardware buffers required (Xvfb in CI)";
 
     // Create two meshes sharing compatible skeletons
     auto skelA = createTestSkeleton("merge_skel_a", {"root", "spine"}, {"idle"});
@@ -182,9 +178,7 @@ TEST_F(AnimationMergerTest, MergeAnimationsBasic)
 
 TEST_F(AnimationMergerTest, MergeAnimationsNameCollision)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: no GL context / hardware buffers available";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "GL/hardware buffers required (Xvfb in CI)";
 
     // Both skeletons have an animation that would result in the same name
     auto skelA = createTestSkeleton("collision_skel_a", {"root"}, {"idle"});
@@ -227,9 +221,7 @@ TEST_F(AnimationMergerTest, MergeAnimationsNameCollision)
 
 TEST_F(AnimationMergerTest, MergeAnimationsMixamoCleanup)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: no GL context / hardware buffers available";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "GL/hardware buffers required (Xvfb in CI)";
 
     // Animations with "mixamo.com" in their names should be cleaned
     auto skelA = createTestSkeleton("mixamo_skel_a", {"root", "spine"},
@@ -277,9 +269,7 @@ TEST_F(AnimationMergerTest, MergeAnimationsMixamoCleanup)
 
 TEST_F(AnimationMergerTest, MergeAnimationsDeduplication)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: no GL context / hardware buffers available";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "GL/hardware buffers required (Xvfb in CI)";
 
     // When prefix == anim name, avoid "idle_idle" — just use "idle".
     // When two sources produce the same final name, append _2.
@@ -335,9 +325,7 @@ TEST_F(AnimationMergerTest, MergeAnimationsDeduplication)
 
 TEST_F(AnimationMergerTest, MergeAnimationsUnrealTakeCleanup)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: no GL context / hardware buffers available";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "GL/hardware buffers required (Xvfb in CI)";
 
     // Animation-only FBX from Unreal Engine retarget: animation is named "Unreal Take"
     // (with a space). After cleanup it should fall back to the skeleton/file name.
@@ -375,9 +363,7 @@ TEST_F(AnimationMergerTest, MergeAnimationsUnrealTakeCleanup)
 
 TEST_F(AnimationMergerTest, MergeAnimationsNumericSuffixPreserved)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: no GL context / hardware buffers available";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "GL/hardware buffers required (Xvfb in CI)";
 
     // Intentional numeric suffix in file name must not be stripped by deduplication.
     // "mm_attack_03.skeleton" → animation should be "mm_attack_03", not "mm_attack".

--- a/src/AnimationWidget_test.cpp
+++ b/src/AnimationWidget_test.cpp
@@ -23,9 +23,7 @@ protected:
         QThread::msleep(50);
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
         // Start with a clean selection
         SelectionSet::getSingleton()->clear();
@@ -51,9 +49,7 @@ protected:
         if (::testing::Test::IsSkipped()) return;
 
         // Loading .mesh files can crash in headless/offscreen mode (no GPU context)
-        if (!canLoadMeshFiles()) {
-            GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-        }
+        ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
 
         entity = createAnimatedTestEntity("AnimationWidgetWithMeshEntity");
         ASSERT_NE(entity, nullptr);
@@ -160,9 +156,8 @@ TEST_F(AnimationWidgetWithMeshTest, AnimationTablePopulatedAfterSelection)
 
     // robot.mesh has animations so the table should have at least one row
     const Ogre::AnimationStateSet* set = entity->getAllAnimationStates();
-    if (!set || set->getAnimationStates().empty()) {
-        GTEST_SKIP() << "Skipping: entity has no animation states";
-    }
+    ASSERT_NE(set, nullptr);
+    ASSERT_FALSE(set->getAnimationStates().empty());
 
     EXPECT_GT(animTable->rowCount(), 0);
 }
@@ -176,9 +171,7 @@ TEST_F(AnimationWidgetWithMeshTest, AnimationTableHasCorrectColumns)
     QTableWidget* animTable = widget.findChild<QTableWidget*>("animTable");
     ASSERT_NE(animTable, nullptr);
 
-    if (animTable->rowCount() == 0) {
-        GTEST_SKIP() << "Skipping: no animation rows";
-    }
+    ASSERT_GT(animTable->rowCount(), 0);
 
     // Column 0: Entity name, Column 1: Animation name,
     // Column 2: Enabled checkbox, Column 3: Loop checkbox
@@ -224,9 +217,7 @@ TEST_F(AnimationWidgetWithMeshTest, SkeletonTableEntityName)
     QTableWidget* skeletonTable = widget.findChild<QTableWidget*>("skeletonTable");
     ASSERT_NE(skeletonTable, nullptr);
 
-    if (skeletonTable->rowCount() == 0) {
-        GTEST_SKIP() << "Skipping: skeleton table empty";
-    }
+    ASSERT_GE(skeletonTable->rowCount(), 1);
 
     auto* entityItem = skeletonTable->item(0, 0);
     ASSERT_NE(entityItem, nullptr);
@@ -244,9 +235,7 @@ TEST_F(AnimationWidgetWithMeshTest, SkeletonTableCheckboxInitiallyUnchecked)
     QTableWidget* skeletonTable = widget.findChild<QTableWidget*>("skeletonTable");
     ASSERT_NE(skeletonTable, nullptr);
 
-    if (skeletonTable->rowCount() == 0) {
-        GTEST_SKIP() << "Skipping: skeleton table empty";
-    }
+    ASSERT_GE(skeletonTable->rowCount(), 1);
 
     // Display Skeleton checkbox should default to unchecked
     auto* showSkeletonItem = skeletonTable->item(0, 1);
@@ -347,9 +336,7 @@ TEST_F(AnimationWidgetWithMeshTest, AnimationItemsAreNonEditable)
     QTableWidget* animTable = widget.findChild<QTableWidget*>("animTable");
     ASSERT_NE(animTable, nullptr);
 
-    if (animTable->rowCount() == 0) {
-        GTEST_SKIP() << "Skipping: no animation rows";
-    }
+    ASSERT_GT(animTable->rowCount(), 0);
 
     // All four columns should have the non-editable flag
     for (int col = 0; col < 4; ++col) {
@@ -369,9 +356,7 @@ TEST_F(AnimationWidgetWithMeshTest, SkeletonItemsAreNonEditable)
     QTableWidget* skeletonTable = widget.findChild<QTableWidget*>("skeletonTable");
     ASSERT_NE(skeletonTable, nullptr);
 
-    if (skeletonTable->rowCount() == 0) {
-        GTEST_SKIP() << "Skipping: no skeleton rows";
-    }
+    ASSERT_GE(skeletonTable->rowCount(), 1);
 
     for (int col = 0; col < 2; ++col) {
         auto* item = skeletonTable->item(0, col);
@@ -549,9 +534,7 @@ TEST_F(AnimationWidgetTest, MultipleWidgetDestructionOrder)
 TEST_F(AnimationWidgetTest, TriangleMeshEntityShowsNoAnimations)
 {
     // A simple triangle mesh with no skeleton should show 0 animation rows
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
 
     auto mesh = createInMemoryTriangleMesh("animwidget_tri");
     auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
@@ -581,9 +564,7 @@ TEST_F(AnimationWidgetTest, SkeletonMeshEntityWithoutAnimations)
 {
     // A mesh with a skeleton but no animations should show in skeleton table
     // but have 0 animation rows.
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
 
     auto mesh = createInMemorySkeletonMesh("animwidget_skel_noanim");
     auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
@@ -612,9 +593,7 @@ TEST_F(AnimationWidgetTest, SkeletonMeshEntityWithoutAnimations)
 TEST_F(AnimationWidgetTest, AnimatedEntityShowsAnimationRow)
 {
     // An entity created via createAnimatedTestEntity has "TestAnim" animation.
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
 
     auto* entity = createAnimatedTestEntity("animwidget_animated");
     ASSERT_NE(entity, nullptr);
@@ -649,9 +628,7 @@ TEST_F(AnimationWidgetTest, AnimatedEntityShowsAnimationRow)
 TEST_F(AnimationWidgetTest, PollAnimationStateUpdatesCheckbox)
 {
     // Verify that pollAnimationState picks up externally-changed animation state.
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
 
     auto* entity = createAnimatedTestEntity("animwidget_poll");
     ASSERT_NE(entity, nullptr);
@@ -703,9 +680,7 @@ TEST_F(AnimationWidgetTest, PollAnimationStateUpdatesCheckbox)
 TEST_F(AnimationWidgetTest, MultipleWidgetsSyncOnSelectionChange)
 {
     // Two AnimationWidget instances should both update when selection changes.
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
 
     auto* entity = createAnimatedTestEntity("animwidget_sync");
     ASSERT_NE(entity, nullptr);
@@ -746,9 +721,7 @@ TEST_F(AnimationWidgetTest, MultipleWidgetsSyncOnSelectionChange)
 TEST_F(AnimationWidgetTest, SkeletonTableWeightsColumnDisabledForNoSkeleton)
 {
     // For an entity without a skeleton, the "Show Weights" checkbox should be disabled.
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
 
     auto mesh = createInMemoryTriangleMesh("animwidget_noskel_weights");
     auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
@@ -789,9 +762,7 @@ TEST_F(AnimationWidgetTest, PlayPauseButtonInitiallyUnchecked)
 TEST_F(AnimationWidgetTest, AnimTableClicked_EnableColumn)
 {
     // Test clicking on the enable column (col 2) to toggle animation enabled state
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
 
     auto* entity = createAnimatedTestEntity("animwidget_enable_click");
     ASSERT_NE(entity, nullptr);
@@ -838,9 +809,7 @@ TEST_F(AnimationWidgetTest, AnimTableClicked_EnableColumn)
 TEST_F(AnimationWidgetTest, AnimTableClicked_LoopColumn)
 {
     // Test clicking on the loop column (col 3) to toggle animation loop state
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
 
     auto* entity = createAnimatedTestEntity("animwidget_loop_click");
     ASSERT_NE(entity, nullptr);
@@ -885,9 +854,7 @@ TEST_F(AnimationWidgetTest, AnimTableClicked_LoopColumn)
 TEST_F(AnimationWidgetTest, AnimTableClicked_Column0And1_NoEffect)
 {
     // Clicking on column 0 or 1 should NOT change animation state
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
 
     auto* entity = createAnimatedTestEntity("animwidget_col01_click");
     ASSERT_NE(entity, nullptr);
@@ -932,9 +899,7 @@ TEST_F(AnimationWidgetTest, AnimTableClicked_Column0And1_NoEffect)
 
 TEST_F(AnimationWidgetTest, SkeletonTableClicked_Column0_NoEffect)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
 
     auto* entity = createAnimatedTestEntity("animwidget_skel_col0");
     ASSERT_NE(entity, nullptr);
@@ -964,9 +929,7 @@ TEST_F(AnimationWidgetTest, SkeletonTableClicked_Column0_NoEffect)
 
 TEST_F(AnimationWidgetTest, AnimTableCellDoubleClicked_Column0_NoEffect)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
 
     auto* entity = createAnimatedTestEntity("animwidget_dblclick_col0");
     ASSERT_NE(entity, nullptr);
@@ -995,9 +958,7 @@ TEST_F(AnimationWidgetTest, AnimTableCellDoubleClicked_Column0_NoEffect)
 
 TEST_F(AnimationWidgetToggleBoneWeightsTest, ToggleBoneWeightsOnOffAndIdempotent)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
 
     auto* entity = createAnimatedTestEntity("animwidget_toggle_weights");
     ASSERT_NE(entity, nullptr);
@@ -1022,9 +983,7 @@ TEST_F(AnimationWidgetToggleBoneWeightsTest, ToggleBoneWeightsOnOffAndIdempotent
 
 TEST_F(AnimationWidgetSkeletonTableBoneWeightsClickTest, SkeletonTableClicked_Column2_TogglesBoneWeights)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
 
     auto* entity = createAnimatedTestEntity("animwidget_skel_click_col2");
     ASSERT_NE(entity, nullptr);
@@ -1058,9 +1017,7 @@ TEST_F(AnimationWidgetSkeletonTableBoneWeightsClickTest, SkeletonTableClicked_Co
 
 TEST_F(AnimationWidgetTest, SkeletonTableClicked_NoSkeletonEntityIsIgnored)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
 
     auto mesh = createInMemoryTriangleMesh("animwidget_skel_click_noskel");
     auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
@@ -1093,9 +1050,7 @@ TEST_F(AnimationWidgetTest, SkeletonTableClicked_NoSkeletonEntityIsIgnored)
 
 TEST_F(AnimationWidgetSceneNodeDestroyedCleanupTest, SceneNodeDestroyedSignalCleansEntityDebugOverlays)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
 
     auto* entity = createAnimatedTestEntity("animwidget_scene_node_destroyed");
     ASSERT_NE(entity, nullptr);
@@ -1117,9 +1072,7 @@ TEST_F(AnimationWidgetSceneNodeDestroyedCleanupTest, SceneNodeDestroyedSignalCle
 
 TEST_F(AnimationWidgetSceneClearingCleanupTest, SceneClearingSignalDisablesAllDebugOverlays)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
 
     auto* entity = createAnimatedTestEntity("animwidget_scene_clearing");
     ASSERT_NE(entity, nullptr);
@@ -1139,9 +1092,7 @@ TEST_F(AnimationWidgetSceneClearingCleanupTest, SceneClearingSignalDisablesAllDe
 
 TEST_F(AnimationWidgetTest, AnimTableClicked_NullEntityDataIsIgnored)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
 
     auto* entity = createAnimatedTestEntity("animwidget_click_null_entity");
     ASSERT_NE(entity, nullptr);
@@ -1169,9 +1120,7 @@ TEST_F(AnimationWidgetTest, AnimTableClicked_NullEntityDataIsIgnored)
 
 TEST_F(AnimationWidgetTest, PollAnimationStateSkipsRowsWithMissingCells)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
 
     auto* entity = createAnimatedTestEntity("animwidget_poll_missing_cells");
     ASSERT_NE(entity, nullptr);

--- a/src/BoneWeightOverlay_test.cpp
+++ b/src/BoneWeightOverlay_test.cpp
@@ -24,14 +24,10 @@ protected:
         QThread::msleep(50);
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
 
-        if (!canLoadMeshFiles())
-            GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-
+        ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
         // Remove leftover material so createMaterial() runs fresh
         auto existing = Ogre::MaterialManager::getSingleton().getByName(
             "BoneWeightOverlay/Material");
@@ -39,12 +35,8 @@ protected:
             Ogre::MaterialManager::getSingleton().remove(existing);
 
         QStringList uris{"./media/models/robot.mesh"};
-        try { MeshImporterExporter::importer(uris); }
-        catch (...) { GTEST_SKIP() << "Skipping: failed to import robot.mesh"; }
-
-        if (Manager::getSingleton()->getEntities().isEmpty())
-            GTEST_SKIP() << "Skipping: no entity after import";
-
+        ASSERT_NO_THROW(MeshImporterExporter::importer(uris));
+        ASSERT_FALSE(Manager::getSingleton()->getEntities().isEmpty());
         entity = Manager::getSingleton()->getEntities().last();
         ASSERT_NE(entity, nullptr);
     }
@@ -178,14 +170,10 @@ protected:
         QThread::msleep(50);
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
 
-        if (!canLoadMeshFiles())
-            GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-
+        ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
         // Remove leftover material so createMaterial() runs fresh
         auto existing = Ogre::MaterialManager::getSingleton().getByName(
             "BoneWeightOverlay/Material");
@@ -212,8 +200,7 @@ protected:
 TEST_F(BoneWeightOverlayInMemoryTest, SetVisibleTogglesTimerAndOverlay)
 {
     Ogre::Entity* entity = createAnimatedTestEntity("BWO_VisToggle");
-    if (!entity)
-        GTEST_SKIP() << "Skipping: could not create animated test entity";
+    ASSERT_NE(entity, nullptr);
 
     BoneWeightOverlay overlay(entity, Manager::getSingleton()->getSceneMgr());
 
@@ -240,8 +227,7 @@ TEST_F(BoneWeightOverlayInMemoryTest, SetVisibleTogglesTimerAndOverlay)
 TEST_F(BoneWeightOverlayInMemoryTest, SetSelectedBoneWithValidIndex)
 {
     Ogre::Entity* entity = createAnimatedTestEntity("BWO_BoneValid");
-    if (!entity)
-        GTEST_SKIP() << "Skipping: could not create animated test entity";
+    ASSERT_NE(entity, nullptr);
 
     ASSERT_TRUE(entity->hasSkeleton());
     ASSERT_GE(entity->getSkeleton()->getNumBones(), 2u);
@@ -270,8 +256,7 @@ TEST_F(BoneWeightOverlayInMemoryTest, SetSelectedBoneWithValidIndex)
 TEST_F(BoneWeightOverlayInMemoryTest, SetSelectedBoneWithInvalidIndex)
 {
     Ogre::Entity* entity = createAnimatedTestEntity("BWO_BoneInvalid");
-    if (!entity)
-        GTEST_SKIP() << "Skipping: could not create animated test entity";
+    ASSERT_NE(entity, nullptr);
 
     BoneWeightOverlay overlay(entity, Manager::getSingleton()->getSceneMgr());
     overlay.setVisible(true);
@@ -292,8 +277,7 @@ TEST_F(BoneWeightOverlayInMemoryTest, SetSelectedBoneWithInvalidIndex)
 TEST_F(BoneWeightOverlayInMemoryTest, BuildOverlayOnAnimatedEntity)
 {
     Ogre::Entity* entity = createAnimatedTestEntity("BWO_AnimBuild");
-    if (!entity)
-        GTEST_SKIP() << "Skipping: could not create animated test entity";
+    ASSERT_NE(entity, nullptr);
 
     ASSERT_TRUE(entity->hasSkeleton());
 
@@ -319,8 +303,7 @@ TEST_F(BoneWeightOverlayInMemoryTest, BuildOverlayOnAnimatedEntity)
 TEST_F(BoneWeightOverlayInMemoryTest, DestroyOverlayOnDeselect)
 {
     Ogre::Entity* entity = createAnimatedTestEntity("BWO_Destroy");
-    if (!entity)
-        GTEST_SKIP() << "Skipping: could not create animated test entity";
+    ASSERT_NE(entity, nullptr);
 
     Ogre::SceneNode* node = entity->getParentSceneNode();
     ASSERT_NE(node, nullptr);
@@ -342,8 +325,7 @@ TEST_F(BoneWeightOverlayInMemoryTest, DestroyOverlayOnDeselect)
 TEST_F(BoneWeightOverlayInMemoryTest, MultipleShowHideCycles)
 {
     Ogre::Entity* entity = createAnimatedTestEntity("BWO_MultiCycle");
-    if (!entity)
-        GTEST_SKIP() << "Skipping: could not create animated test entity";
+    ASSERT_NE(entity, nullptr);
 
     BoneWeightOverlay overlay(entity, Manager::getSingleton()->getSceneMgr());
     Ogre::SceneNode* node = entity->getParentSceneNode();
@@ -402,8 +384,7 @@ TEST_F(BoneWeightOverlayInMemoryTest, NonSkeletalEntityDoesNotCrash)
 TEST_F(BoneWeightOverlayInMemoryTest, TimerBasedUpdatePositions)
 {
     Ogre::Entity* entity = createAnimatedTestEntity("BWO_TimerUpdate");
-    if (!entity)
-        GTEST_SKIP() << "Skipping: could not create animated test entity";
+    ASSERT_NE(entity, nullptr);
 
     ASSERT_TRUE(entity->hasSkeleton());
 
@@ -438,8 +419,7 @@ TEST_F(BoneWeightOverlayInMemoryTest, TimerBasedUpdatePositions)
 TEST_F(BoneWeightOverlayInMemoryTest, PollBoneSelectionChanges)
 {
     Ogre::Entity* entity = createAnimatedTestEntity("BWO_PollBone");
-    if (!entity)
-        GTEST_SKIP() << "Skipping: could not create animated test entity";
+    ASSERT_NE(entity, nullptr);
 
     ASSERT_TRUE(entity->hasSkeleton());
     ASSERT_GE(entity->getSkeleton()->getNumBones(), 2u);
@@ -484,8 +464,7 @@ TEST_F(BoneWeightOverlayInMemoryTest, PollBoneSelectionChanges)
 TEST_F(BoneWeightOverlayInMemoryTest, RapidBoneSelectionChanges)
 {
     Ogre::Entity* entity = createAnimatedTestEntity("BWO_RapidBone");
-    if (!entity)
-        GTEST_SKIP() << "Skipping: could not create animated test entity";
+    ASSERT_NE(entity, nullptr);
 
     ASSERT_TRUE(entity->hasSkeleton());
     ASSERT_GE(entity->getSkeleton()->getNumBones(), 2u);
@@ -515,8 +494,7 @@ TEST_F(BoneWeightOverlayInMemoryTest, RapidBoneSelectionChanges)
 TEST_F(BoneWeightOverlayInMemoryTest, DoubleSetVisibleTrueNoDuplicate)
 {
     Ogre::Entity* entity = createAnimatedTestEntity("BWO_DblShow");
-    if (!entity)
-        GTEST_SKIP() << "Skipping: could not create animated test entity";
+    ASSERT_NE(entity, nullptr);
 
     BoneWeightOverlay overlay(entity, Manager::getSingleton()->getSceneMgr());
     Ogre::SceneNode* node = entity->getParentSceneNode();

--- a/src/BoneWeightOverlay_test.cpp
+++ b/src/BoneWeightOverlay_test.cpp
@@ -34,7 +34,9 @@ protected:
         if (existing)
             Ogre::MaterialManager::getSingleton().remove(existing);
 
-        QStringList uris{"./media/models/robot.mesh"};
+        const QString robotPath = testRobotMeshPath();
+        ASSERT_FALSE(robotPath.isEmpty()) << "robot.mesh not found under media/models";
+        QStringList uris{robotPath};
         ASSERT_NO_THROW(MeshImporterExporter::importer(uris));
         ASSERT_FALSE(Manager::getSingleton()->getEntities().isEmpty());
         entity = Manager::getSingleton()->getEntities().last();

--- a/src/CLIPipeline_test.cpp
+++ b/src/CLIPipeline_test.cpp
@@ -1,11 +1,13 @@
 #include <gtest/gtest.h>
 #include <QDir>
 #include <QFile>
+#include <QFileInfo>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
 #include <QSettings>
 #include <QTemporaryDir>
+#include <QUuid>
 #include <QCoreApplication>
 #include <vector>
 #include <OgreMeshManager.h>
@@ -743,6 +745,13 @@ static QString exportGeneratedTriangleMesh(const QString& baseName)
     if (!manager)
         return QString();
 
+    // Isolate each export under its own directory so the Ogre resource group (dir path)
+    // is never shared with stale FileSystem listings from other tests or earlier runs.
+    const QString exportRoot = QDir::tempPath() + "/qtmesh_cli_exp_" +
+        QUuid::createUuid().toString(QUuid::WithoutBraces);
+    if (!QDir().mkpath(exportRoot))
+        return QString();
+
     const std::string meshName = (baseName + "_mesh").toStdString();
     const QString nodeName = baseName + "_node";
 
@@ -751,6 +760,7 @@ static QString exportGeneratedTriangleMesh(const QString& baseName)
     if (!node) {
         if (auto old = Ogre::MeshManager::getSingleton().getByName(meshName))
             Ogre::MeshManager::getSingleton().remove(old);
+        QDir(exportRoot).removeRecursively();
         return QString();
     }
 
@@ -759,12 +769,13 @@ static QString exportGeneratedTriangleMesh(const QString& baseName)
         manager->destroySceneNode(node);
         if (auto old = Ogre::MeshManager::getSingleton().getByName(meshName))
             Ogre::MeshManager::getSingleton().remove(old);
+        QDir(exportRoot).removeRecursively();
         return QString();
     }
 
-    const QString outFile = QDir::tempPath() + "/" + baseName + ".mesh";
+    const QString outFile = QDir(exportRoot).filePath(baseName + ".mesh");
     QFile::remove(outFile);
-    QFile::remove(QDir::tempPath() + "/" + baseName + ".material");
+    QFile::remove(QDir(exportRoot).filePath(baseName + ".material"));
 
     const int exportRc = MeshImporterExporter::exporter(node, outFile, "Ogre Mesh (*.mesh)");
 
@@ -773,9 +784,20 @@ static QString exportGeneratedTriangleMesh(const QString& baseName)
     if (auto old = Ogre::MeshManager::getSingleton().getByName(meshName))
         Ogre::MeshManager::getSingleton().remove(old);
 
-    if (exportRc != 0)
+    if (exportRc != 0) {
+        QDir(exportRoot).removeRecursively();
         return QString();
+    }
     return outFile;
+}
+
+/// Remove a mesh exported via exportGeneratedTriangleMesh (unique per-call temp directory).
+static void removeCliExportTree(const QString& meshFilePath)
+{
+    if (meshFilePath.isEmpty())
+        return;
+    QFileInfo fi(meshFilePath);
+    QDir(fi.absolutePath()).removeRecursively();
 }
 
 static QByteArray firstAnimationNameForFile(const QString& filePath)
@@ -1811,8 +1833,7 @@ TEST_F(CLIPipelineCmdValidateTest, CmdValidate_SucceedsForGeneratedMeshTextAndJs
     TestArgv jsonArgs({"qtmesh", "validate", sourceBa.constData(), "--json"});
     EXPECT_EQ(CLIPipeline::cmdValidate(jsonArgs.argc(), jsonArgs.argv()), 0);
 
-    QFile::remove(sourceFile);
-    QFile::remove(QDir::tempPath() + "/cli_validate_generated.material");
+    removeCliExportTree(sourceFile);
 }
 
 // ==========================================================================
@@ -1950,8 +1971,7 @@ TEST_F(CLIPipelineCmdLodTest, CmdLod_InfoAndRemoveFromGeneratedMesh)
     EXPECT_EQ(CLIPipeline::cmdLod(removeArgs.argc(), removeArgs.argv()), 0);
     EXPECT_TRUE(QFile::exists(removedOut));
 
-    QFile::remove(sourceFile);
-    QFile::remove(QDir::tempPath() + "/cli_lod_generated.material");
+    removeCliExportTree(sourceFile);
     QFile::remove(removedOut);
     QFile::remove(QDir::tempPath() + "/cli_lod_removed.material");
 }
@@ -2042,16 +2062,16 @@ TEST_F(CLIPipelineCmdLodTest, CmdLod_AutoModeOnTinyMeshReturnsNoGeneratedLevels)
     ASSERT_TRUE(QFile::exists(sourceFile));
     QByteArray sourceBa = sourceFile.toUtf8();
 
-    const QString unexpectedLod1 = QDir::tempPath() + "/cli_lod_auto_tiny_source_lod1.mesh";
+    const QString exportDir = QFileInfo(sourceFile).absolutePath();
+    const QString unexpectedLod1 = QDir(exportDir).filePath("cli_lod_auto_tiny_source_lod1.mesh");
     QFile::remove(unexpectedLod1);
 
     TestArgv args({"qtmesh", "lod", sourceBa.constData(), "--auto"});
     EXPECT_EQ(CLIPipeline::cmdLod(args.argc(), args.argv()), 1);
 
     QFile::remove(unexpectedLod1);
-    QFile::remove(QDir::tempPath() + "/cli_lod_auto_tiny_source_lod1.material");
-    QFile::remove(sourceFile);
-    QFile::remove(QDir::tempPath() + "/cli_lod_auto_tiny_source.material");
+    QFile::remove(QDir(exportDir).filePath("cli_lod_auto_tiny_source_lod1.material"));
+    removeCliExportTree(sourceFile);
 }
 
 // ==========================================================================
@@ -2204,8 +2224,7 @@ TEST_F(CLIPipelineCmdTest, CmdPose_NoSkeletonMeshReturnsError)
     EXPECT_EQ(CLIPipeline::cmdPose(args.argc(), args.argv()), 1);
 
     removeObjAndMtl(outputFile);
-    QFile::remove(sourceFile);
-    QFile::remove(QDir::tempPath() + "/cli_pose_noskeleton_source.material");
+    removeCliExportTree(sourceFile);
 }
 
 // ==========================================================================

--- a/src/CLIPipeline_test.cpp
+++ b/src/CLIPipeline_test.cpp
@@ -105,7 +105,11 @@ public:
     void setOffscreenThreadsafe()
     {
         qputenv("QT_QPA_PLATFORM", QByteArray("offscreen"));
-        GTEST_FLAG_SET(death_test_style, "threadsafe");
+        // "fast" re-execs the test binary in a clean process (no duplicate
+        // QApplication). "threadsafe" forks while UnitTests already has a
+        // QApplication in main(), and CLIPipeline::run() would construct a
+        // second one → abort / exit 1 instead of _exit(2).
+        GTEST_FLAG_SET(death_test_style, "fast");
     }
 
     ~ScopedDeathTestEnvironment()

--- a/src/CLIPipeline_test.cpp
+++ b/src/CLIPipeline_test.cpp
@@ -240,8 +240,8 @@ TEST_F(CLIPipelineFormatTest, FormatMeshInfoJson_NoSkeleton)
 class CLIPipelineOgreTest : public ::testing::Test {
 protected:
     void SetUp() override {
-        if (!tryInitOgre() || !canLoadMeshFiles())
-            GTEST_SKIP() << "Ogre not available";
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+        ASSERT_TRUE(canLoadMeshFiles());
         createStandardOgreMaterials();
     }
 };
@@ -681,8 +681,8 @@ private:
 class CLIPipelineInitTest : public ::testing::Test {
 protected:
     void SetUp() override {
-        if (!tryInitOgre() || !canLoadMeshFiles())
-            GTEST_SKIP() << "Ogre not available";
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+        ASSERT_TRUE(canLoadMeshFiles());
         createStandardOgreMaterials();
     }
 };
@@ -725,8 +725,8 @@ protected:
     }
 
     void SetUp() override {
-        if (!tryInitOgre() || !canLoadMeshFiles())
-            GTEST_SKIP() << "Ogre not available";
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+        ASSERT_TRUE(canLoadMeshFiles());
         createStandardOgreMaterials();
     }
     void TearDown() override {
@@ -859,7 +859,7 @@ TEST(CLIPipelineCmdInfoError, NonexistentFileWithJsonAndCliFlag)
 TEST_F(CLIPipelineCmdTest, CmdInfo_TextOutput)
 {
     QString file = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(file)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(file)) << "Test data not found: " << file.toStdString();
     QByteArray fileBa = file.toUtf8();
 
     TestArgv args({"qtmesh", "info", fileBa.constData()});
@@ -869,7 +869,7 @@ TEST_F(CLIPipelineCmdTest, CmdInfo_TextOutput)
 TEST_F(CLIPipelineCmdTest, CmdInfo_JsonOutput)
 {
     QString file = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(file)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(file)) << "Test data not found: " << file.toStdString();
     QByteArray fileBa = file.toUtf8();
 
     TestArgv args({"qtmesh", "info", fileBa.constData(), "--json"});
@@ -879,7 +879,7 @@ TEST_F(CLIPipelineCmdTest, CmdInfo_JsonOutput)
 TEST_F(CLIPipelineCmdTest, CmdInfo_SkipsCliFlag)
 {
     QString file = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(file)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(file)) << "Test data not found: " << file.toStdString();
     QByteArray fileBa = file.toUtf8();
 
     TestArgv args({"qtmesh", "--cli", "info", fileBa.constData()});
@@ -934,7 +934,7 @@ TEST(CLIPipelineCmdConvertError, NonexistentFileWithFormatAndLongOutputFlag)
 TEST_F(CLIPipelineCmdTest, CmdConvert_ValidFile)
 {
     QString file = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(file)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(file)) << "Test data not found: " << file.toStdString();
     QByteArray fileBa = file.toUtf8();
 
     QString outFile = QDir::tempPath() + "/cli_test_convert_inproc.mesh";
@@ -951,7 +951,7 @@ TEST_F(CLIPipelineCmdTest, CmdConvert_ValidFile)
 TEST_F(CLIPipelineCmdTest, CmdConvert_OutputLongForm)
 {
     QString file = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(file)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(file)) << "Test data not found: " << file.toStdString();
     QByteArray fileBa = file.toUtf8();
 
     QString outFile = QDir::tempPath() + "/cli_test_convert_long.mesh";
@@ -968,7 +968,7 @@ TEST_F(CLIPipelineCmdTest, CmdConvert_OutputLongForm)
 TEST_F(CLIPipelineCmdTest, CmdConvert_FormatFlag)
 {
     QString file = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(file)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(file)) << "Test data not found: " << file.toStdString();
     QByteArray fileBa = file.toUtf8();
 
     QString outFile = QDir::tempPath() + "/cli_test_convert_fmt.mesh";
@@ -1025,7 +1025,7 @@ TEST(CLIPipelineCmdFixError, ExistingInvalidFileWithAllFlagReturnsError)
 TEST_F(CLIPipelineCmdTest, CmdFix_Basic)
 {
     QString file = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(file)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(file)) << "Test data not found: " << file.toStdString();
     QByteArray fileBa = file.toUtf8();
 
     QString outFile = QDir::tempPath() + "/cli_test_fix_basic.mesh";
@@ -1042,7 +1042,7 @@ TEST_F(CLIPipelineCmdTest, CmdFix_Basic)
 TEST_F(CLIPipelineCmdTest, CmdFix_AllFlag)
 {
     QString file = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(file)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(file)) << "Test data not found: " << file.toStdString();
     QByteArray fileBa = file.toUtf8();
 
     QString outFile = QDir::tempPath() + "/cli_test_fix_all.mesh";
@@ -1059,7 +1059,7 @@ TEST_F(CLIPipelineCmdTest, CmdFix_AllFlag)
 TEST_F(CLIPipelineCmdTest, CmdFix_RemoveDegenerates)
 {
     QString file = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(file)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(file)) << "Test data not found: " << file.toStdString();
     QByteArray fileBa = file.toUtf8();
 
     QString outFile = QDir::tempPath() + "/cli_test_fix_degen.mesh";
@@ -1077,7 +1077,7 @@ TEST_F(CLIPipelineCmdTest, CmdFix_RemoveDegenerates)
 TEST_F(CLIPipelineCmdTest, CmdFix_MergeMaterials)
 {
     QString file = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(file)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(file)) << "Test data not found: " << file.toStdString();
     QByteArray fileBa = file.toUtf8();
 
     QString outFile = QDir::tempPath() + "/cli_test_fix_merge.mesh";
@@ -1095,7 +1095,7 @@ TEST_F(CLIPipelineCmdTest, CmdFix_MergeMaterials)
 TEST_F(CLIPipelineCmdTest, CmdFix_BothFlags)
 {
     QString file = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(file)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(file)) << "Test data not found: " << file.toStdString();
     QByteArray fileBa = file.toUtf8();
 
     QString outFile = QDir::tempPath() + "/cli_test_fix_both.mesh";
@@ -1113,7 +1113,7 @@ TEST_F(CLIPipelineCmdTest, CmdFix_BothFlags)
 TEST_F(CLIPipelineCmdTest, CmdFix_OutputLongForm)
 {
     QString file = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(file)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(file)) << "Test data not found: " << file.toStdString();
     QByteArray fileBa = file.toUtf8();
 
     QString outFile = QDir::tempPath() + "/cli_test_fix_long.mesh";
@@ -1181,7 +1181,7 @@ TEST(CLIPipelineCmdAnimError, MergeModeWithoutOutputUsesDefaultOutputPath)
 TEST_F(CLIPipelineCmdTest, CmdAnimList_Text)
 {
     QString file = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(file)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(file)) << "Test data not found: " << file.toStdString();
     QByteArray fileBa = file.toUtf8();
 
     TestArgv args({"qtmesh", "anim", fileBa.constData(), "--list"});
@@ -1191,7 +1191,7 @@ TEST_F(CLIPipelineCmdTest, CmdAnimList_Text)
 TEST_F(CLIPipelineCmdTest, CmdAnimList_Json)
 {
     QString file = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(file)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(file)) << "Test data not found: " << file.toStdString();
     QByteArray fileBa = file.toUtf8();
 
     TestArgv args({"qtmesh", "anim", fileBa.constData(), "--list", "--json"});
@@ -1219,7 +1219,7 @@ TEST_F(CLIPipelineCmdTest, CmdAnimList_NoSkeletonFile)
 TEST_F(CLIPipelineCmdTest, CmdAnimList_WithCliFlag)
 {
     QString file = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(file)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(file)) << "Test data not found: " << file.toStdString();
     QByteArray fileBa = file.toUtf8();
 
     TestArgv args({"qtmesh", "--cli", "anim", fileBa.constData(), "--list"});
@@ -1272,11 +1272,11 @@ TEST_F(CLIPipelineCmdTest, CmdAnimList_NoAnimationsGeneratedMeshReturnsError)
 TEST_F(CLIPipelineCmdTest, CmdAnimResample_Valid)
 {
     QString file = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(file)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(file)) << "Test data not found: " << file.toStdString();
     QByteArray fileBa = file.toUtf8();
 
     const QByteArray animName = firstAnimationNameForFile(file);
-    if (animName.isEmpty()) GTEST_SKIP() << "Could not discover animation name";
+    ASSERT_FALSE(animName.isEmpty()) << "Could not discover animation name";
 
     const QString outFile = QDir::tempPath() + "/cli_test_resample.mesh";
     QByteArray outBa = outFile.toUtf8();
@@ -1297,7 +1297,7 @@ TEST_F(CLIPipelineCmdTest, CmdAnimResample_Valid)
 TEST_F(CLIPipelineCmdTest, CmdAnimResample_NoMatchingAnimationReturnsError)
 {
     QString file = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(file)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(file)) << "Test data not found: " << file.toStdString();
     QByteArray fileBa = file.toUtf8();
 
     const QString outFile = QDir::tempPath() + "/cli_test_resample_nomatch.mesh";
@@ -1318,11 +1318,11 @@ TEST_F(CLIPipelineCmdTest, CmdAnimResample_NoMatchingAnimationReturnsError)
 TEST_F(CLIPipelineCmdTest, CmdAnimDecimate_Valid)
 {
     QString file = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(file)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(file)) << "Test data not found: " << file.toStdString();
     QByteArray fileBa = file.toUtf8();
 
     const QByteArray animName = firstAnimationNameForFile(file);
-    if (animName.isEmpty()) GTEST_SKIP() << "Could not discover animation name";
+    ASSERT_FALSE(animName.isEmpty()) << "Could not discover animation name";
 
     const QString outFile = QDir::tempPath() + "/cli_test_decimate.mesh";
     QByteArray outBa = outFile.toUtf8();
@@ -1343,7 +1343,7 @@ TEST_F(CLIPipelineCmdTest, CmdAnimDecimate_Valid)
 TEST_F(CLIPipelineCmdTest, CmdAnimDecimate_NoMatchingAnimationReturnsError)
 {
     QString file = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(file)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(file)) << "Test data not found: " << file.toStdString();
     QByteArray fileBa = file.toUtf8();
 
     const QString outFile = QDir::tempPath() + "/cli_test_decimate_nomatch.mesh";
@@ -1366,7 +1366,7 @@ TEST_F(CLIPipelineCmdTest, CmdAnimDecimate_NoMatchingAnimationReturnsError)
 TEST_F(CLIPipelineCmdTest, CmdAnimRename_NonexistentAnim)
 {
     QString file = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(file)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(file)) << "Test data not found: " << file.toStdString();
     QByteArray fileBa = file.toUtf8();
 
     TestArgv args({"qtmesh", "anim", fileBa.constData(),
@@ -1377,7 +1377,7 @@ TEST_F(CLIPipelineCmdTest, CmdAnimRename_NonexistentAnim)
 TEST_F(CLIPipelineCmdTest, CmdAnimRename_Valid)
 {
     QString file = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(file)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(file)) << "Test data not found: " << file.toStdString();
     QByteArray fileBa = file.toUtf8();
 
     QString outFile = QDir::tempPath() + "/cli_test_rename_inproc.mesh";
@@ -1387,12 +1387,12 @@ TEST_F(CLIPipelineCmdTest, CmdAnimRename_Valid)
     // Load file first to discover animation name
     MeshImporterExporter::importer({file});
     auto& entities = Manager::getSingleton()->getEntities();
-    if (entities.isEmpty() || !entities.first()->hasSkeleton())
-        GTEST_SKIP() << "Could not load animated file";
+    ASSERT_FALSE(entities.isEmpty()) << "Could not load animated file";
+    ASSERT_TRUE(entities.first()->hasSkeleton());
 
     auto skel = entities.first()->getMesh()->getSkeleton();
-    if (!skel || skel->getNumAnimations() == 0)
-        GTEST_SKIP() << "No animations in file";
+    ASSERT_TRUE(static_cast<bool>(skel));
+    ASSERT_GT(skel->getNumAnimations(), 0u);
 
     QByteArray animName = QString::fromStdString(skel->getAnimation(0)->getName()).toUtf8();
 
@@ -1415,7 +1415,7 @@ TEST_F(CLIPipelineCmdTest, CmdAnimRename_Valid)
 TEST_F(CLIPipelineCmdTest, CmdAnimRename_SameNameNoop)
 {
     QString file = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(file)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(file)) << "Test data not found: " << file.toStdString();
     QByteArray fileBa = file.toUtf8();
 
     QString outFile = QDir::tempPath() + "/cli_test_rename_noop.mesh";
@@ -1425,11 +1425,11 @@ TEST_F(CLIPipelineCmdTest, CmdAnimRename_SameNameNoop)
     // Discover animation name
     MeshImporterExporter::importer({file});
     auto& entities = Manager::getSingleton()->getEntities();
-    if (entities.isEmpty() || !entities.first()->hasSkeleton())
-        GTEST_SKIP() << "Could not load animated file";
+    ASSERT_FALSE(entities.isEmpty()) << "Could not load animated file";
+    ASSERT_TRUE(entities.first()->hasSkeleton());
     auto skel = entities.first()->getMesh()->getSkeleton();
-    if (!skel || skel->getNumAnimations() == 0)
-        GTEST_SKIP() << "No animations in file";
+    ASSERT_TRUE(static_cast<bool>(skel));
+    ASSERT_GT(skel->getNumAnimations(), 0u);
     QByteArray animName = QString::fromStdString(skel->getAnimation(0)->getName()).toUtf8();
 
     auto nodes = Manager::getSingleton()->getSceneNodes();
@@ -1507,8 +1507,8 @@ TEST_F(CLIPipelineCmdTest, CmdAnimMerge_Valid)
 {
     QString baseFile = testDataDir() + "/Twist Dance.fbx";
     QString animFile = testDataDir() + "/Hip Hop Dancing.fbx";
-    if (!QFile::exists(baseFile) || !QFile::exists(animFile))
-        GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(baseFile)) << "Test data not found: " << baseFile.toStdString();
+    ASSERT_TRUE(QFile::exists(animFile)) << "Test data not found: " << animFile.toStdString();
     QByteArray baseBa = baseFile.toUtf8();
     QByteArray animBa = animFile.toUtf8();
 
@@ -1533,8 +1533,8 @@ TEST_F(CLIPipelineCmdTest, CmdAnimMerge_MultipleFiles)
     QString baseFile = testDataDir() + "/Twist Dance.fbx";
     QString animFile1 = testDataDir() + "/Twist Dance.fbx";
     QString animFile2 = testDataDir() + "/Hip Hop Dancing.fbx";
-    if (!QFile::exists(baseFile) || !QFile::exists(animFile2))
-        GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(baseFile)) << "Test data not found: " << baseFile.toStdString();
+    ASSERT_TRUE(QFile::exists(animFile2)) << "Test data not found: " << animFile2.toStdString();
     QByteArray baseBa = baseFile.toUtf8();
     QByteArray anim1Ba = animFile1.toUtf8();
     QByteArray anim2Ba = animFile2.toUtf8();
@@ -1555,7 +1555,7 @@ TEST_F(CLIPipelineCmdTest, CmdAnimMerge_MultipleFiles)
 TEST_F(CLIPipelineCmdTest, CmdAnimMerge_NonexistentAnimFile)
 {
     QString baseFile = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(baseFile)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(baseFile)) << "Test data not found: " << baseFile.toStdString();
     QByteArray baseBa = baseFile.toUtf8();
 
     TestArgv args({"qtmesh", "anim", baseBa.constData(),
@@ -1760,8 +1760,8 @@ protected:
     void SetUp() override {
         MeshValidator::kill();
         MeshLodController::kill();
-        if (!tryInitOgre() || !canLoadMeshFiles())
-            GTEST_SKIP() << "Ogre not available";
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+        ASSERT_TRUE(canLoadMeshFiles());
         createStandardOgreMaterials();
         if (Manager::getSingletonPtr())
             SelectionSet::getSingleton()->clear();
@@ -1895,8 +1895,8 @@ protected:
     void SetUp() override {
         MeshLodController::kill();
         MeshValidator::kill();
-        if (!tryInitOgre() || !canLoadMeshFiles())
-            GTEST_SKIP() << "Ogre not available";
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+        ASSERT_TRUE(canLoadMeshFiles());
         createStandardOgreMaterials();
         if (Manager::getSingletonPtr())
             SelectionSet::getSingleton()->clear();
@@ -1979,7 +1979,7 @@ TEST_F(CLIPipelineCmdLodTest, CmdLod_InfoAndRemoveFromGeneratedMesh)
 TEST_F(CLIPipelineCmdLodTest, CmdLod_CountModeGeneratesAndExportsLods)
 {
     const QString fixtureMesh = testDataDir() + "/robot.mesh";
-    if (!QFile::exists(fixtureMesh)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(fixtureMesh)) << "Test data not found: " << fixtureMesh.toStdString();
 
     QTemporaryDir sourceDir;
     ASSERT_TRUE(sourceDir.isValid());
@@ -2021,7 +2021,7 @@ TEST_F(CLIPipelineCmdLodTest, CmdLod_CountModeGeneratesAndExportsLods)
 TEST_F(CLIPipelineCmdLodTest, CmdLod_CountModeWithoutOutputUsesInputStem)
 {
     const QString fixtureMesh = testDataDir() + "/robot.mesh";
-    if (!QFile::exists(fixtureMesh)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(fixtureMesh)) << "Test data not found: " << fixtureMesh.toStdString();
 
     QTemporaryDir sourceDir;
     ASSERT_TRUE(sourceDir.isValid());
@@ -2115,9 +2115,9 @@ TEST(CLIPipelineCmdPoseError, NonexistentFile)
 TEST_F(CLIPipelineCmdTest, CmdPose_SingleTimeExportFromAnimatedMesh)
 {
     const QString sourceFile = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(sourceFile)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(sourceFile)) << "Test data not found: " << sourceFile.toStdString();
     const QByteArray animName = firstAnimationNameForFile(sourceFile);
-    if (animName.isEmpty()) GTEST_SKIP() << "Could not discover animation name";
+    ASSERT_FALSE(animName.isEmpty()) << "Could not discover animation name";
     QByteArray sourceBa = sourceFile.toUtf8();
 
     const QString outputFile = QDir::tempPath() + "/cli_pose_single.obj";
@@ -2137,9 +2137,9 @@ TEST_F(CLIPipelineCmdTest, CmdPose_SingleTimeExportFromAnimatedMesh)
 TEST_F(CLIPipelineCmdTest, CmdPose_CountExportWithPrintfPattern)
 {
     const QString sourceFile = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(sourceFile)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(sourceFile)) << "Test data not found: " << sourceFile.toStdString();
     const QByteArray animName = firstAnimationNameForFile(sourceFile);
-    if (animName.isEmpty()) GTEST_SKIP() << "Could not discover animation name";
+    ASSERT_FALSE(animName.isEmpty()) << "Could not discover animation name";
     QByteArray sourceBa = sourceFile.toUtf8();
 
     const QString pattern = QDir::tempPath() + "/cli_pose_pattern_%02d.obj";
@@ -2165,9 +2165,9 @@ TEST_F(CLIPipelineCmdTest, CmdPose_CountExportWithPrintfPattern)
 TEST_F(CLIPipelineCmdTest, CmdPose_CountExportWithoutPatternAddsFrameSuffix)
 {
     const QString sourceFile = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(sourceFile)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(sourceFile)) << "Test data not found: " << sourceFile.toStdString();
     const QByteArray animName = firstAnimationNameForFile(sourceFile);
-    if (animName.isEmpty()) GTEST_SKIP() << "Could not discover animation name";
+    ASSERT_FALSE(animName.isEmpty()) << "Could not discover animation name";
     QByteArray sourceBa = sourceFile.toUtf8();
 
     const QString outputFile = QDir::tempPath() + "/cli_pose_suffix.obj";
@@ -2190,7 +2190,7 @@ TEST_F(CLIPipelineCmdTest, CmdPose_CountExportWithoutPatternAddsFrameSuffix)
 TEST_F(CLIPipelineCmdTest, CmdPose_AnimationNotFoundOnValidAnimatedSource)
 {
     const QString sourceFile = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(sourceFile)) GTEST_SKIP() << "Test data not found";
+    ASSERT_TRUE(QFile::exists(sourceFile)) << "Test data not found: " << sourceFile.toStdString();
     QByteArray sourceBa = sourceFile.toUtf8();
 
     const QString outputFile = QDir::tempPath() + "/cli_pose_missing_anim.obj";

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -462,7 +462,8 @@ if(BUILD_TESTS)
     ${QML_RESOURCE_SRCS}
     ${CMAKE_CURRENT_SOURCE_DIR}/test_main.cpp
     )
-    target_compile_definitions(UnitTests PRIVATE BATCH_EXPORTER_TEST_SEAM)
+    target_compile_definitions(UnitTests PRIVATE BATCH_EXPORTER_TEST_SEAM
+        "QTMESH_UT_SOURCE_ROOT=\"${CMAKE_SOURCE_DIR}\"")
 
     # Link against Google Test libraries (no gtest_main - we provide our own main)
     target_link_libraries(UnitTests

--- a/src/EditModeController_test.cpp
+++ b/src/EditModeController_test.cpp
@@ -18,7 +18,6 @@ The MIT License
 #include "HalfEdgeMesh.h"
 #include <Ogre.h>
 #include <QSignalSpy>
-#include <QThread>
 #include <QDir>
 #include <QFile>
 #include <QTextStream>
@@ -1060,12 +1059,8 @@ protected:
     std::string m_nodeName;
 
     void SetUp() override {
-        // EditModeController connects to SelectionSet in its ctor; Manager::kill()
-        // destroys SelectionSet — recycle the controller first so the next
-        // instance wires to the fresh SelectionSet after tryInitOgre().
-        EditModeController::kill();
-        Manager::kill();
-        QThread::msleep(50);
+        // One Ogre Root for the whole suite: tearing Manager down every test
+        // and re-initing GL was crashing the second bevel on Linux CI (SIGSEGV).
         ASSERT_TRUE(tryInitOgre()) << "Ogre not available (Xvfb/GL required in CI)";
         ASSERT_TRUE(canLoadMeshFiles());
         createStandardOgreMaterials();
@@ -1086,6 +1081,7 @@ protected:
     void TearDown() override {
         auto* ctrl = EditModeController::instance();
         if (ctrl->isEditModeActive()) ctrl->exitEditMode(false);
+        SelectionSet::getSingleton()->clear();
         if (m_node) {
             Manager::getSingleton()->destroySceneNode(m_node);
             m_node = nullptr;
@@ -1096,6 +1092,9 @@ protected:
                 mm.remove(m_meshName);
             m_meshName.clear();
         }
+        // Fresh controller next test: BevelGizmo stays in unique_ptr; recycling
+        // avoids a stale gizmo tied to a removed entity while keeping one Root.
+        EditModeController::kill();
     }
 };
 

--- a/src/EditModeController_test.cpp
+++ b/src/EditModeController_test.cpp
@@ -18,6 +18,7 @@ The MIT License
 #include "HalfEdgeMesh.h"
 #include <Ogre.h>
 #include <QSignalSpy>
+#include <QThread>
 #include <QDir>
 #include <QFile>
 #include <QTextStream>
@@ -1059,6 +1060,8 @@ protected:
     std::string m_nodeName;
 
     void SetUp() override {
+        Manager::kill();
+        QThread::msleep(50);
         ASSERT_TRUE(tryInitOgre()) << "Ogre not available (Xvfb/GL required in CI)";
         ASSERT_TRUE(canLoadMeshFiles());
         createStandardOgreMaterials();

--- a/src/EditModeController_test.cpp
+++ b/src/EditModeController_test.cpp
@@ -292,14 +292,8 @@ protected:
     static int s_counter;
 
     void SetUp() override {
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Ogre not available";
-            return;
-        }
-        if (!canLoadMeshFiles()) {
-            GTEST_SKIP() << "Cannot create hardware buffers";
-            return;
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre not available (Xvfb/GL required in CI)";
+        ASSERT_TRUE(canLoadMeshFiles()) << "Cannot create hardware buffers (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
 
         // Create a triangle mesh entity and select it (required for enterEditMode)
@@ -1065,8 +1059,8 @@ protected:
     std::string m_nodeName;
 
     void SetUp() override {
-        if (!tryInitOgre()) { GTEST_SKIP() << "Ogre not available"; return; }
-        if (!canLoadMeshFiles()) { GTEST_SKIP() << "Cannot create HW buffers"; return; }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre not available (Xvfb/GL required in CI)";
+        ASSERT_TRUE(canLoadMeshFiles());
         createStandardOgreMaterials();
 
         // Unique names per test so reruns don't collide with Ogre's

--- a/src/EditModeController_test.cpp
+++ b/src/EditModeController_test.cpp
@@ -1060,6 +1060,10 @@ protected:
     std::string m_nodeName;
 
     void SetUp() override {
+        // EditModeController connects to SelectionSet in its ctor; Manager::kill()
+        // destroys SelectionSet — recycle the controller first so the next
+        // instance wires to the fresh SelectionSet after tryInitOgre().
+        EditModeController::kill();
         Manager::kill();
         QThread::msleep(50);
         ASSERT_TRUE(tryInitOgre()) << "Ogre not available (Xvfb/GL required in CI)";

--- a/src/EditableMesh_test.cpp
+++ b/src/EditableMesh_test.cpp
@@ -86,6 +86,28 @@ namespace {
     }
 }
 
+TEST(EditableMeshStandalone, VertexColorBrushFalloffHigherExponentWeakerAtEdge)
+{
+    EditableMesh meshLo;
+    EditableMesh meshHi;
+    EditableSubMesh subLo;
+    EditableSubMesh subHi;
+    subLo.vertices.push_back(makeV(0, 0, 0));
+    subLo.vertices.push_back(makeV(0.9f, 0, 0));
+    subHi.vertices = subLo.vertices;
+    meshLo.subMeshes().push_back(std::move(subLo));
+    meshHi.subMeshes().push_back(std::move(subHi));
+
+    const Ogre::ColourValue red(1, 0, 0, 1);
+    const Ogre::Vector3 center(0, 0, 0);
+    ASSERT_TRUE(EditModeController::applyVertexColorBrush(meshLo, center, 1.0f, red, 1.0f, 0.0f));
+    ASSERT_TRUE(EditModeController::applyVertexColorBrush(meshHi, center, 1.0f, red, 1.0f, 1.0f));
+
+    const float gLo = meshLo.subMeshes()[0].vertices[1].color.g;
+    const float gHi = meshHi.subMeshes()[0].vertices[1].color.g;
+    EXPECT_GT(gHi, gLo);
+}
+
 TEST(EditableMeshStandalone, WeldByPositionMergesCoincidentVerts) {
     EditableMesh em;
     EditableSubMesh sub;
@@ -460,6 +482,12 @@ protected:
             return;
         }
         createStandardOgreMaterials();
+
+        // Make tests deterministic even if the user has persisted settings.
+        auto* ctrl = EditModeController::instance();
+        ctrl->setSoftSelectionEnabled(false);
+        ctrl->setSoftSelectionRadius(2.0);
+        ctrl->setSoftSelectionFalloff(0);
     }
 };
 

--- a/src/EditableMesh_test.cpp
+++ b/src/EditableMesh_test.cpp
@@ -25,14 +25,8 @@ The MIT License
 class EditableMeshTest : public ::testing::Test {
 protected:
     void SetUp() override {
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Ogre not available";
-            return;
-        }
-        if (!canLoadMeshFiles()) {
-            GTEST_SKIP() << "Cannot create hardware buffers";
-            return;
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre not available (Xvfb/GL required in CI)";
+        ASSERT_TRUE(canLoadMeshFiles()) << "Cannot create hardware buffers (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
     }
 };
@@ -473,14 +467,8 @@ TEST_F(EditableMeshTest, UVManipulation) {
 class EditModeControllerTest : public ::testing::Test {
 protected:
     void SetUp() override {
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Ogre not available";
-            return;
-        }
-        if (!canLoadMeshFiles()) {
-            GTEST_SKIP() << "Cannot create hardware buffers";
-            return;
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre not available (Xvfb/GL required in CI)";
+        ASSERT_TRUE(canLoadMeshFiles()) << "Cannot create hardware buffers (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
 
         // Make tests deterministic even if the user has persisted settings.

--- a/src/EditorViewport_test.cpp
+++ b/src/EditorViewport_test.cpp
@@ -5,6 +5,7 @@
 #include <QThread>
 #include <QStyleFactory>
 #include <exception>
+#include <OgreException.h>
 #include "EditorViewport.h"
 #include "mainwindow.h"
 #include "Manager.h"
@@ -32,6 +33,13 @@ protected:
             QThread::msleep(75);
             try {
                 mainWindow = new MainWindow();
+            } catch (const Ogre::Exception& e) {
+                GTEST_LOG_(WARNING) << "MainWindow init attempt " << attempt
+                                    << " failed: " << e.getFullDescription();
+                mainWindow = nullptr;
+                Manager::kill();
+                app->processEvents();
+                QThread::msleep(200 * attempt);
             } catch (const std::exception& e) {
                 GTEST_LOG_(WARNING) << "MainWindow init attempt " << attempt
                                     << " failed: " << e.what();
@@ -52,14 +60,18 @@ protected:
     }
 
     static void TearDownTestSuite() {
-        delete mainWindow;
-        mainWindow = nullptr;
-        if (app) {
-            app->processEvents();
+        // NOTE: We intentionally do NOT delete the MainWindow nor kill Manager here.
+        //
+        // The overall test suite has multiple fixtures that create/destroy Ogre-backed
+        // singletons in different orders. Deleting MainWindow during this suite teardown
+        // can crash inside Ogre-backed destructors (e.g. gizmos) if another fixture already
+        // tore down parts of Ogre. Leaking the window at process shutdown is acceptable for
+        // unit tests; gtest will exit immediately afterwards.
+        if (mainWindow) {
+            mainWindow->close();
         }
-        Manager::kill();
-        QThread::msleep(100);
-        app = nullptr;
+        if (app) app->processEvents();
+        mainWindow = nullptr;
     }
 
     void SetUp() override {
@@ -106,6 +118,10 @@ TEST_F(EditorViewportTest, WidgetAboutToCloseSignalEmitted) {
     QSignalSpy spy(viewport, &EditorViewport::widgetAboutToClose);
     ASSERT_TRUE(spy.isValid());
     viewport->close();
+    // Let Qt deliver close events / deferred deletes before we destroy the viewport.
+    if (app) {
+        app->processEvents();
+    }
     EXPECT_EQ(spy.count(), 1);
     delete viewport;
 }

--- a/src/FBX/FBXExporter_test.cpp
+++ b/src/FBX/FBXExporter_test.cpp
@@ -463,12 +463,8 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
-        if (!canLoadMeshFiles()) {
-            GTEST_SKIP() << "Skipping: no GL context / hardware buffers available";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+        ASSERT_TRUE(canLoadMeshFiles()) << "GL/hardware buffers required (Xvfb in CI)";
         createStandardOgreMaterials();
 
         // Provide a real texture file so FBXExporter can embed Video.Content.

--- a/src/GizmoAxisHelpers_test.cpp
+++ b/src/GizmoAxisHelpers_test.cpp
@@ -48,9 +48,7 @@ TEST(GizmoAxisHelpersTest, ForEachAxisIndexedVisitsAllAxesWithIndices)
 
 TEST(GizmoAxisHelpersTest, AxisFromObjectIdentifiesMatchingAxis)
 {
-    if (!tryInitOgre()) {
-        GTEST_SKIP() << "Skipping: Ogre initialization failed";
-    }
+    ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
 
     Manager* manager = Manager::getSingletonPtr();
     ASSERT_NE(manager, nullptr);

--- a/src/HalfEdgeMesh_test.cpp
+++ b/src/HalfEdgeMesh_test.cpp
@@ -860,14 +860,8 @@ TEST(HalfEdgeMeshStandalone, MaterialNamesPreserved) {
 class HalfEdgeMeshOgreTest : public ::testing::Test {
 protected:
     void SetUp() override {
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Ogre not available";
-            return;
-        }
-        if (!canLoadMeshFiles()) {
-            GTEST_SKIP() << "Cannot create hardware buffers";
-            return;
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre not available (Xvfb/GL required in CI)";
+        ASSERT_TRUE(canLoadMeshFiles()) << "Cannot create hardware buffers (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
     }
 };
@@ -3740,7 +3734,7 @@ TEST(HalfEdgeMeshStandalone, SplitEdgePreservesSubmeshCount) {
 
     const auto beforeSubCount = he.subMeshCount();
     const int edge = findEdge(he, 0, 1);
-    if (edge < 0) GTEST_SKIP() << "v0-v1 edge not present in mesh";
+    ASSERT_GE(edge, 0) << "v0-v1 edge not present in mesh";
 
     const int vMid = he.splitEdge(edge, 0.5f);
     ASSERT_GE(vMid, 0);

--- a/src/MCPServer_test.cpp
+++ b/src/MCPServer_test.cpp
@@ -207,9 +207,7 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
 
         server = std::make_unique<MCPServer>();
@@ -412,7 +410,7 @@ TEST_F(MCPServerTest, ListMaterials)
 
 TEST_F(MCPServerTest, CreatePrimitive)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject args;
     args["type"] = "sphere";
     args["name"] = "TestSphere";
@@ -423,7 +421,7 @@ TEST_F(MCPServerTest, CreatePrimitive)
 
 TEST_F(MCPServerTest, CreatePrimitiveTypes)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QStringList types = {"box", "cylinder", "cone"};
     for (const QString &type : types) {
         QJsonObject args;
@@ -447,7 +445,7 @@ TEST_F(MCPServerTest, CreatePrimitiveInvalidType)
 
 TEST_F(MCPServerTest, GetSceneInfo)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject primArgs;
     primArgs["type"] = "cube";
     primArgs["name"] = "SceneInfoCube";
@@ -464,7 +462,7 @@ TEST_F(MCPServerTest, GetSceneInfo)
 
 TEST_F(MCPServerTest, GetMeshInfo)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject primArgs;
     primArgs["type"] = "sphere";
     primArgs["name"] = "MeshInfoSphere";
@@ -481,7 +479,7 @@ TEST_F(MCPServerTest, GetMeshInfo)
 
 TEST_F(MCPServerTest, TransformMesh)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject primArgs;
     primArgs["type"] = "cube";
     primArgs["name"] = "TransformCube";
@@ -509,7 +507,7 @@ TEST_F(MCPServerTest, TransformMeshNotFound)
 
 TEST_F(MCPServerTest, ApplyMaterial)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     // Create a material
     QJsonObject matArgs;
     matArgs["name"] = "ApplyTestMat";
@@ -577,7 +575,7 @@ TEST_F(MCPServerTest, SetTextureMaterialNotFound)
 
 TEST_F(MCPServerTest, Animate)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject primArgs;
     primArgs["type"] = "sphere";
     primArgs["name"] = "AnimSphere";
@@ -593,7 +591,7 @@ TEST_F(MCPServerTest, Animate)
 
 TEST_F(MCPServerTest, AnimateStop)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject primArgs;
     primArgs["type"] = "sphere";
     primArgs["name"] = "AnimStopSphere";
@@ -859,7 +857,7 @@ TEST_F(MCPServerTest, ModifyMaterialEmptyName)
 
 TEST_F(MCPServerTest, TransformMeshRotation)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject primArgs;
     primArgs["type"] = "cube";
     primArgs["name"] = "RotateCube";
@@ -875,7 +873,7 @@ TEST_F(MCPServerTest, TransformMeshRotation)
 
 TEST_F(MCPServerTest, TransformMeshScale)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject primArgs;
     primArgs["type"] = "cube";
     primArgs["name"] = "ScaleCube";
@@ -891,7 +889,7 @@ TEST_F(MCPServerTest, TransformMeshScale)
 
 TEST_F(MCPServerTest, TransformMeshAllThreeTransforms)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject primArgs;
     primArgs["type"] = "sphere";
     primArgs["name"] = "FullTransformSphere";
@@ -927,7 +925,7 @@ TEST_F(MCPServerTest, TransformMeshNoNameNoSelection)
 
 TEST_F(MCPServerTest, GetSceneInfoMultipleObjects)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     // Create several primitives
     QJsonObject args1;
     args1["type"] = "sphere";
@@ -1086,7 +1084,7 @@ TEST_F(MCPServerTest, CreatePrimitiveEmptyType)
 
 TEST_F(MCPServerTest, CreatePrimitivePlane)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject args;
     args["type"] = "plane";
     args["name"] = "TestPlane";
@@ -1097,7 +1095,7 @@ TEST_F(MCPServerTest, CreatePrimitivePlane)
 
 TEST_F(MCPServerTest, CreatePrimitiveTorus)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject args;
     args["type"] = "torus";
     args["name"] = "TestTorus";
@@ -1108,7 +1106,7 @@ TEST_F(MCPServerTest, CreatePrimitiveTorus)
 
 TEST_F(MCPServerTest, CreatePrimitiveTube)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject args;
     args["type"] = "tube";
     args["name"] = "TestTube";
@@ -1119,7 +1117,7 @@ TEST_F(MCPServerTest, CreatePrimitiveTube)
 
 TEST_F(MCPServerTest, CreatePrimitiveCapsule)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject args;
     args["type"] = "capsule";
     args["name"] = "TestCapsule";
@@ -1130,7 +1128,7 @@ TEST_F(MCPServerTest, CreatePrimitiveCapsule)
 
 TEST_F(MCPServerTest, CreatePrimitiveIcoSphere)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject args;
     args["type"] = "icosphere";
     args["name"] = "TestIcoSphere";
@@ -1141,7 +1139,7 @@ TEST_F(MCPServerTest, CreatePrimitiveIcoSphere)
 
 TEST_F(MCPServerTest, CreatePrimitiveSpring)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject args;
     args["type"] = "spring";
     args["name"] = "TestSpring";
@@ -1152,7 +1150,7 @@ TEST_F(MCPServerTest, CreatePrimitiveSpring)
 
 TEST_F(MCPServerTest, CreatePrimitiveAutoGeneratedName)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     // When no name is provided, create_primitive auto-generates one
     QJsonObject args;
     args["type"] = "sphere";
@@ -1168,7 +1166,7 @@ TEST_F(MCPServerTest, CreatePrimitiveAutoGeneratedName)
 
 TEST_F(MCPServerTest, AnimateWithPitchAndRoll)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject primArgs;
     primArgs["type"] = "cube";
     primArgs["name"] = "PitchRollCube";
@@ -1188,7 +1186,7 @@ TEST_F(MCPServerTest, AnimateWithPitchAndRoll)
 
 TEST_F(MCPServerTest, AnimateZeroSpeedsDefaultsToYaw45)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject primArgs;
     primArgs["type"] = "sphere";
     primArgs["name"] = "DefaultAnimSphere";
@@ -1209,7 +1207,7 @@ TEST_F(MCPServerTest, AnimateZeroSpeedsDefaultsToYaw45)
 
 TEST_F(MCPServerTest, AnimateNoSpeedsDefaultsToYaw45)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject primArgs;
     primArgs["type"] = "sphere";
     primArgs["name"] = "NoSpeedAnimSphere";
@@ -1236,7 +1234,7 @@ TEST_F(MCPServerTest, AnimateEmptyName)
 
 TEST_F(MCPServerTest, AnimateTimerIsRunningAfterStart)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject primArgs;
     primArgs["type"] = "cube";
     primArgs["name"] = "TimerTestCube";
@@ -1350,7 +1348,7 @@ TEST_F(MCPServerTest, CreateMaterialWithAllColors)
 
 TEST_F(MCPServerTest, GetMeshInfoMultipleEntities)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject args1;
     args1["type"] = "sphere";
     args1["name"] = "MeshInfoSphere1";
@@ -1410,7 +1408,7 @@ TEST_F(MCPServerTest, ListSkeletalAnimationsEmptyScene)
 
 TEST_F(MCPServerTest, ListSkeletalAnimationsNoSkeletonEntities)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     // Primitives have no skeleton
     QJsonObject primArgs;
     primArgs["type"] = "sphere";
@@ -1465,7 +1463,7 @@ TEST_F(MCPServerTest, GetAnimationInfoEntityNotFound)
 
 TEST_F(MCPServerTest, GetAnimationInfoNoSkeleton)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject primArgs;
     primArgs["type"] = "cube";
     primArgs["name"] = "AnimInfoCube";
@@ -1536,7 +1534,7 @@ TEST_F(MCPServerTest, SetAnimationLengthEntityNotFound)
 
 TEST_F(MCPServerTest, SetAnimationLengthNoSkeleton)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject primArgs;
     primArgs["type"] = "sphere";
     primArgs["name"] = "AnimLenSphere";
@@ -1585,7 +1583,7 @@ TEST_F(MCPServerTest, SetAnimationTimeEntityNotFound)
 
 TEST_F(MCPServerTest, SetAnimationTimeMissingTimeAndNavigate)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     // Create a primitive — it won't have the animation, but we test the param validation path
     QJsonObject primArgs;
     primArgs["type"] = "cube";
@@ -1676,7 +1674,7 @@ TEST_F(MCPServerTest, AddKeyframeEntityNotFound)
 
 TEST_F(MCPServerTest, AddKeyframeNoSkeleton)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject primArgs;
     primArgs["type"] = "cube";
     primArgs["name"] = "AddKfCube";
@@ -1741,7 +1739,7 @@ TEST_F(MCPServerTest, RemoveKeyframeEntityNotFound)
 
 TEST_F(MCPServerTest, RemoveKeyframeNoSkeleton)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject primArgs;
     primArgs["type"] = "sphere";
     primArgs["name"] = "RemoveKfSphere";
@@ -1790,7 +1788,7 @@ TEST_F(MCPServerTest, PlayAnimationEntityNotFound)
 
 TEST_F(MCPServerTest, PlayAnimationNoAnimation)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject primArgs;
     primArgs["type"] = "cube";
     primArgs["name"] = "PlayAnimCube";
@@ -1836,7 +1834,7 @@ TEST_F(MCPServerTest, ToggleSkeletonDebugEntityNotFound)
 
 TEST_F(MCPServerTest, ToggleSkeletonDebugNoSkeleton)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject primArgs;
     primArgs["type"] = "sphere";
     primArgs["name"] = "SkelDebugSphere";
@@ -1852,7 +1850,7 @@ TEST_F(MCPServerTest, ToggleSkeletonDebugNoSkeleton)
 
 TEST_F(MCPServerTest, ToggleSkeletonDebugNoMainWindow)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     // Server has no MainWindow set — should fail for entities with skeleton
     // But primitives have no skeleton, so test the no-skeleton path
     QJsonObject primArgs;
@@ -1900,7 +1898,7 @@ TEST_F(MCPServerTest, ToggleBoneWeightsEntityNotFound)
 
 TEST_F(MCPServerTest, ToggleBoneWeightsNoSkeleton)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject primArgs;
     primArgs["type"] = "cube";
     primArgs["name"] = "BoneWeightCube";
@@ -1928,7 +1926,7 @@ TEST_F(MCPServerTest, MergeAnimationsNoEntities)
 
 TEST_F(MCPServerTest, MergeAnimationsNoSkeletonEntities)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     // Create primitives (no skeleton) — should still fail
     QJsonObject args1;
     args1["type"] = "sphere";
@@ -1962,7 +1960,7 @@ TEST_F(MCPServerTest, MergeAnimationsInvalidBaseEntity)
 
 TEST_F(MCPServerTest, ExportMeshWithSelection)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     // Create a primitive and select it
     QJsonObject primArgs;
@@ -2407,7 +2405,7 @@ TEST_F(MCPServerHttpTest, CorsHeadersOnAllResponses)
 
 TEST_F(MCPServerTest, CreatePrimitiveWithCustomParams)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject args;
     args["type"] = "sphere";
     args["name"] = "CustomParamSphere";
@@ -2420,7 +2418,7 @@ TEST_F(MCPServerTest, CreatePrimitiveWithCustomParams)
 
 TEST_F(MCPServerTest, CreatePrimitiveCylinderWithParams)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject args;
     args["type"] = "cylinder";
     args["name"] = "CustomCylinder";
@@ -2517,7 +2515,7 @@ TEST_F(MCPServerTest, ModifyMaterialAllColors)
 
 TEST_F(MCPServerTest, CreatePrimitiveRoundedBoxWithParams)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject args;
     args["type"] = "roundedbox";
     args["name"] = "CustomRBox";
@@ -2535,7 +2533,7 @@ TEST_F(MCPServerTest, CreatePrimitiveRoundedBoxWithParams)
 
 TEST_F(MCPServerTest, AnimateWithOnlyPitch)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject primArgs;
     primArgs["type"] = "cube";
     primArgs["name"] = "PitchOnlyCube";
@@ -2557,7 +2555,7 @@ TEST_F(MCPServerTest, AnimateWithOnlyPitch)
 
 TEST_F(MCPServerTest, AnimateWithOnlyRoll)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     QJsonObject primArgs;
     primArgs["type"] = "sphere";
     primArgs["name"] = "RollOnlySphere";
@@ -2579,7 +2577,7 @@ TEST_F(MCPServerTest, AnimateWithOnlyRoll)
 
 TEST_F(MCPServerTest, GetMeshInfoWithInMemoryEntity)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     auto mesh = createInMemoryTriangleMesh("MCPMeshInfoTriangle");
     auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
@@ -2595,7 +2593,7 @@ TEST_F(MCPServerTest, GetMeshInfoWithInMemoryEntity)
 
 TEST_F(MCPServerTest, TransformMeshPositionWithInMemoryEntity)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     auto mesh = createInMemoryTriangleMesh("MCPTransformTriangle");
     auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
@@ -2618,7 +2616,7 @@ TEST_F(MCPServerTest, TransformMeshPositionWithInMemoryEntity)
 
 TEST_F(MCPServerTest, TransformMeshRotationWithInMemoryEntity)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     auto mesh = createInMemoryTriangleMesh("MCPRotateTriangle");
     auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
@@ -2636,7 +2634,7 @@ TEST_F(MCPServerTest, TransformMeshRotationWithInMemoryEntity)
 
 TEST_F(MCPServerTest, TransformMeshScaleWithInMemoryEntity)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     auto mesh = createInMemoryTriangleMesh("MCPScaleTriangle");
     auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
@@ -2658,7 +2656,7 @@ TEST_F(MCPServerTest, TransformMeshScaleWithInMemoryEntity)
 
 TEST_F(MCPServerTest, ExportMeshWithInMemoryEntity)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     auto mesh = createInMemoryTriangleMesh("MCPExportTriangle");
     auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
@@ -2682,7 +2680,7 @@ TEST_F(MCPServerTest, ExportMeshWithInMemoryEntity)
 
 TEST_F(MCPServerTest, SetMaterialOnInMemoryEntity)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     // Create material
     QJsonObject matArgs;
@@ -2707,7 +2705,7 @@ TEST_F(MCPServerTest, SetMaterialOnInMemoryEntity)
 
 TEST_F(MCPServerTest, GetSceneInfoWithInMemoryEntities)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     auto mesh1 = createInMemoryTriangleMesh("MCPSceneInfo1");
     auto mesh2 = createInMemoryTriangleMesh("MCPSceneInfo2");
@@ -2731,7 +2729,7 @@ TEST_F(MCPServerTest, GetSceneInfoWithInMemoryEntities)
 
 TEST_F(MCPServerTest, ListSkeletalAnimationsWithSkeletonEntity)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("MCPSkelAnimEntity");
     ASSERT_NE(entity, nullptr);
@@ -2744,7 +2742,7 @@ TEST_F(MCPServerTest, ListSkeletalAnimationsWithSkeletonEntity)
 
 TEST_F(MCPServerTest, GetAnimationInfoWithSkeletonEntity)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("MCPAnimInfoEntity");
     ASSERT_NE(entity, nullptr);
@@ -2761,7 +2759,7 @@ TEST_F(MCPServerTest, GetAnimationInfoWithSkeletonEntity)
 
 TEST_F(MCPServerTest, SetAnimationLengthWithSkeletonEntity)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("MCPSetAnimLenEntity");
     ASSERT_NE(entity, nullptr);
@@ -2777,7 +2775,7 @@ TEST_F(MCPServerTest, SetAnimationLengthWithSkeletonEntity)
 
 TEST_F(MCPServerTest, SetAnimationTimeWithSkeletonEntity)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("MCPSetAnimTimeEntity");
     ASSERT_NE(entity, nullptr);
@@ -2792,7 +2790,7 @@ TEST_F(MCPServerTest, SetAnimationTimeWithSkeletonEntity)
 
 TEST_F(MCPServerTest, AddKeyframeWithSkeletonEntity)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("MCPAddKfEntity");
     ASSERT_NE(entity, nullptr);
@@ -2808,7 +2806,7 @@ TEST_F(MCPServerTest, AddKeyframeWithSkeletonEntity)
 
 TEST_F(MCPServerTest, RemoveKeyframeWithSkeletonEntity)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("MCPRemoveKfEntity");
     ASSERT_NE(entity, nullptr);
@@ -2825,7 +2823,7 @@ TEST_F(MCPServerTest, RemoveKeyframeWithSkeletonEntity)
 
 TEST_F(MCPServerTest, PlayAnimationWithSkeletonEntity)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("MCPPlayAnimEntity");
     ASSERT_NE(entity, nullptr);
@@ -3008,7 +3006,7 @@ TEST_F(MCPServerTest, GetMaterialWithEmptyNameReturnsError)
 
 TEST_F(MCPServerTest, MergeAnimations_WithAnimatedEntity)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     // Create two animated entities (merge_animations needs at least 2 skeleton entities)
     Ogre::Entity* entity1 = createAnimatedTestEntity("MCPMergeAnim1");
@@ -3101,7 +3099,7 @@ TEST_F(MCPServerTest, ToggleMeshInfo_SuccessPath)
 
 TEST_F(MCPServerTest, PlayAnimation_StartAndStop)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("MCPPlayStopAnimEntity");
     ASSERT_NE(entity, nullptr);
@@ -3144,7 +3142,7 @@ TEST_F(MCPServerTest, SetOgreInitFailed_AffectsToolCalls)
 
 TEST_F(MCPServerTest, GetMeshInfo_WithSkeletonEntity)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     auto mesh = createInMemorySkeletonMesh("MCPMeshInfoSkelMesh");
     auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
@@ -3164,7 +3162,7 @@ TEST_F(MCPServerTest, GetMeshInfo_WithSkeletonEntity)
 
 TEST_F(MCPServerTest, ExportMesh_ToTempFile)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     auto mesh = createInMemoryTriangleMesh("MCPExportTempMesh");
     auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
@@ -3200,7 +3198,7 @@ TEST_F(MCPServerTest, ExportMesh_ToTempFile)
 
 TEST_F(MCPServerTest, AnimSuccPath_ListSkeletalAnimations)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimSuccListSkel");
     ASSERT_NE(entity, nullptr);
@@ -3216,7 +3214,7 @@ TEST_F(MCPServerTest, AnimSuccPath_ListSkeletalAnimations)
 
 TEST_F(MCPServerTest, AnimSuccPath_GetAnimationInfo)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimSuccGetInfo");
     ASSERT_NE(entity, nullptr);
@@ -3239,7 +3237,7 @@ TEST_F(MCPServerTest, AnimSuccPath_GetAnimationInfo)
 
 TEST_F(MCPServerTest, AnimSuccPath_SetAnimationLength)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimSuccSetLen");
     ASSERT_NE(entity, nullptr);
@@ -3265,7 +3263,7 @@ TEST_F(MCPServerTest, AnimSuccPath_SetAnimationLength)
 
 TEST_F(MCPServerTest, AnimSuccPath_SetAnimationTime)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimSuccSetTime");
     ASSERT_NE(entity, nullptr);
@@ -3284,7 +3282,7 @@ TEST_F(MCPServerTest, AnimSuccPath_SetAnimationTime)
 
 TEST_F(MCPServerTest, AnimSuccPath_SetAnimationTimeWithNavigateNext)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimSuccNavNext");
     ASSERT_NE(entity, nullptr);
@@ -3310,7 +3308,7 @@ TEST_F(MCPServerTest, AnimSuccPath_SetAnimationTimeWithNavigateNext)
 
 TEST_F(MCPServerTest, AnimSuccPath_SetAnimationTimeWithNavigatePrev)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimSuccNavPrev");
     ASSERT_NE(entity, nullptr);
@@ -3337,7 +3335,7 @@ TEST_F(MCPServerTest, AnimSuccPath_SetAnimationTimeWithNavigatePrev)
 
 TEST_F(MCPServerTest, AnimSuccPath_SetAnimationTimeWithNavigateFirst)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimSuccNavFirst");
     ASSERT_NE(entity, nullptr);
@@ -3364,7 +3362,7 @@ TEST_F(MCPServerTest, AnimSuccPath_SetAnimationTimeWithNavigateFirst)
 
 TEST_F(MCPServerTest, AnimSuccPath_SetAnimationTimeWithNavigateLast)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimSuccNavLast");
     ASSERT_NE(entity, nullptr);
@@ -3384,7 +3382,7 @@ TEST_F(MCPServerTest, AnimSuccPath_SetAnimationTimeWithNavigateLast)
 
 TEST_F(MCPServerTest, AnimSuccPath_SetAnimationTimeNavigateInvalidDirection)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimSuccNavInvalid");
     ASSERT_NE(entity, nullptr);
@@ -3401,7 +3399,7 @@ TEST_F(MCPServerTest, AnimSuccPath_SetAnimationTimeNavigateInvalidDirection)
 
 TEST_F(MCPServerTest, AnimSuccPath_SetAnimationTimeNavigateMissingTrack)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimSuccNavNoTrack");
     ASSERT_NE(entity, nullptr);
@@ -3418,7 +3416,7 @@ TEST_F(MCPServerTest, AnimSuccPath_SetAnimationTimeNavigateMissingTrack)
 
 TEST_F(MCPServerTest, AnimSuccPath_AddKeyframe)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimSuccAddKf");
     ASSERT_NE(entity, nullptr);
@@ -3446,7 +3444,7 @@ TEST_F(MCPServerTest, AnimSuccPath_AddKeyframe)
 
 TEST_F(MCPServerTest, AnimSuccPath_AddKeyframeWithExplicitTransforms)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimSuccAddKfTransform");
     ASSERT_NE(entity, nullptr);
@@ -3472,7 +3470,7 @@ TEST_F(MCPServerTest, AnimSuccPath_AddKeyframeWithExplicitTransforms)
 
 TEST_F(MCPServerTest, AnimSuccPath_RemoveKeyframe)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimSuccRemoveKf");
     ASSERT_NE(entity, nullptr);
@@ -3501,7 +3499,7 @@ TEST_F(MCPServerTest, AnimSuccPath_RemoveKeyframe)
 
 TEST_F(MCPServerTest, AnimSuccPath_RemoveKeyframeNotFound)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimSuccRemoveKfNF");
     ASSERT_NE(entity, nullptr);
@@ -3519,7 +3517,7 @@ TEST_F(MCPServerTest, AnimSuccPath_RemoveKeyframeNotFound)
 
 TEST_F(MCPServerTest, AnimSuccPath_PlayAnimation)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimSuccPlay");
     ASSERT_NE(entity, nullptr);
@@ -3542,7 +3540,7 @@ TEST_F(MCPServerTest, AnimSuccPath_PlayAnimation)
 
 TEST_F(MCPServerTest, AnimSuccPath_PlayAnimationStop)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimSuccPlayStop");
     ASSERT_NE(entity, nullptr);
@@ -3573,7 +3571,7 @@ TEST_F(MCPServerTest, AnimSuccPath_PlayAnimationStop)
 
 TEST_F(MCPServerTest, AnimSuccPath_PlayAnimationNoLoop)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimSuccPlayNoLoop");
     ASSERT_NE(entity, nullptr);
@@ -3596,7 +3594,7 @@ TEST_F(MCPServerTest, AnimSuccPath_PlayAnimationNoLoop)
 
 TEST_F(MCPServerTest, AnimSuccPath_MergeAnimations)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity1 = createAnimatedTestEntity("AnimSuccMerge1");
     ASSERT_NE(entity1, nullptr);
@@ -3614,7 +3612,7 @@ TEST_F(MCPServerTest, AnimSuccPath_MergeAnimations)
 
 TEST_F(MCPServerTest, AnimSuccPath_SetAnimationTimeWithLoopDisabled)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimSuccTimeLoop");
     ASSERT_NE(entity, nullptr);
@@ -3634,7 +3632,7 @@ TEST_F(MCPServerTest, AnimSuccPath_SetAnimationTimeWithLoopDisabled)
 
 TEST_F(MCPServerTest, AnimSuccPath_SetAnimationTimeDisabled)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimSuccTimeDisabled");
     ASSERT_NE(entity, nullptr);
@@ -3656,7 +3654,7 @@ TEST_F(MCPServerTest, AnimSuccPath_SetAnimationTimeDisabled)
 
 TEST_F(MCPServerTest, AnimSuccPath_AddKeyframeTrackNotFound)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimSuccAddKfNoTrack");
     ASSERT_NE(entity, nullptr);
@@ -3673,7 +3671,7 @@ TEST_F(MCPServerTest, AnimSuccPath_AddKeyframeTrackNotFound)
 
 TEST_F(MCPServerTest, AnimSuccPath_RemoveKeyframeTrackNotFound)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimSuccRemKfNoTrack");
     ASSERT_NE(entity, nullptr);
@@ -3690,7 +3688,7 @@ TEST_F(MCPServerTest, AnimSuccPath_RemoveKeyframeTrackNotFound)
 
 TEST_F(MCPServerTest, AnimSuccPath_GetAnimationInfoAnimNotFound)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimSuccInfoAnimNF");
     ASSERT_NE(entity, nullptr);
@@ -3705,7 +3703,7 @@ TEST_F(MCPServerTest, AnimSuccPath_GetAnimationInfoAnimNotFound)
 
 TEST_F(MCPServerTest, AnimSuccPath_SetAnimationLengthAnimNotFound)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimSuccLenAnimNF");
     ASSERT_NE(entity, nullptr);
@@ -3721,7 +3719,7 @@ TEST_F(MCPServerTest, AnimSuccPath_SetAnimationLengthAnimNotFound)
 
 TEST_F(MCPServerTest, AnimSuccPath_PlayAnimationAnimNotFound)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimSuccPlayAnimNF");
     ASSERT_NE(entity, nullptr);
@@ -3736,7 +3734,7 @@ TEST_F(MCPServerTest, AnimSuccPath_PlayAnimationAnimNotFound)
 
 TEST_F(MCPServerTest, AnimSuccPath_AddKeyframeAnimNotFound)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimSuccAddKfAnimNF");
     ASSERT_NE(entity, nullptr);
@@ -3753,7 +3751,7 @@ TEST_F(MCPServerTest, AnimSuccPath_AddKeyframeAnimNotFound)
 
 TEST_F(MCPServerTest, AnimSuccPath_NavigateNextAtEnd)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimSuccNavNextEnd");
     ASSERT_NE(entity, nullptr);
@@ -3781,7 +3779,7 @@ TEST_F(MCPServerTest, AnimSuccPath_NavigateNextAtEnd)
 
 TEST_F(MCPServerTest, AnimSuccPath_NavigatePrevAtStart)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimSuccNavPrevStart");
     ASSERT_NE(entity, nullptr);
@@ -3808,7 +3806,7 @@ TEST_F(MCPServerTest, AnimSuccPath_NavigatePrevAtStart)
 
 TEST_F(MCPServerTest, SaveScene_EmptyPath_ReturnsError)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     QJsonObject args;
     args["file_path"] = "";
@@ -3819,7 +3817,7 @@ TEST_F(MCPServerTest, SaveScene_EmptyPath_ReturnsError)
 
 TEST_F(MCPServerTest, OpenScene_MissingFile_ReturnsError)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     QJsonObject args;
     args["file_path"] = "/tmp/nonexistent_scene_file_12345.scene.glb";
@@ -3830,7 +3828,7 @@ TEST_F(MCPServerTest, OpenScene_MissingFile_ReturnsError)
 
 TEST_F(MCPServerTest, SaveScene_ValidScene_Succeeds)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     auto mesh1 = createInMemoryTriangleMesh("SaveSceneMesh1");
     auto mesh2 = createInMemoryTriangleMesh("SaveSceneMesh2");
@@ -3855,7 +3853,7 @@ TEST_F(MCPServerTest, SaveScene_ValidScene_Succeeds)
 
 TEST_F(MCPServerTest, OpenScene_ValidFile_LoadsEntities)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     // Create entities and save the scene
     auto mesh1 = createInMemoryTriangleMesh("OpenSceneMesh1");
@@ -5041,7 +5039,7 @@ TEST_F(MCPServerTest, TakeScreenshot_MainWindowWithoutOgreWidgetReturnsError)
 
 TEST_F(MCPServerTest, SetAnimationLength_ClampsCurrentStateTime)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimClampLenEntity");
     ASSERT_NE(entity, nullptr);
@@ -5060,7 +5058,7 @@ TEST_F(MCPServerTest, SetAnimationLength_ClampsCurrentStateTime)
 
 TEST_F(MCPServerTest, SetAnimationTime_NavigateMissingTrackOnSkeletonEntity)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimNavMissingTrackEntity");
     ASSERT_NE(entity, nullptr);
@@ -5077,7 +5075,7 @@ TEST_F(MCPServerTest, SetAnimationTime_NavigateMissingTrackOnSkeletonEntity)
 
 TEST_F(MCPServerTest, SetAnimationTime_MissingTimeAndNavigateWithValidAnimation)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("AnimMissingTimeEntity");
     ASSERT_NE(entity, nullptr);
@@ -5092,7 +5090,7 @@ TEST_F(MCPServerTest, SetAnimationTime_MissingTimeAndNavigateWithValidAnimation)
 
 TEST_F(MCPServerTest, RemoveKeyframe_AnimationNotFoundOnSkeletonEntity)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("RemoveMissingAnimEntity");
     ASSERT_NE(entity, nullptr);
@@ -5109,7 +5107,7 @@ TEST_F(MCPServerTest, RemoveKeyframe_AnimationNotFoundOnSkeletonEntity)
 
 TEST_F(MCPServerTest, ToggleSkeletonDebug_SkeletonEntityWithoutMainWindowReturnsMainWindowError)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("SkelNoMainWindowEntity");
     ASSERT_NE(entity, nullptr);
@@ -5124,7 +5122,7 @@ TEST_F(MCPServerTest, ToggleSkeletonDebug_SkeletonEntityWithoutMainWindowReturns
 
 TEST_F(MCPServerTest, ToggleSkeletonDebug_SkeletonEntityWithoutAnimationWidgetReturnsError)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("SkelNoAnimWidgetEntity");
     ASSERT_NE(entity, nullptr);
@@ -5193,7 +5191,7 @@ TEST_F(MCPServerTest, ToggleMeshInfo_MainWindowWithoutOverlayReturnsError)
 
 TEST_F(MCPServerTest, MergeAnimations_InvalidBaseEntityWhenSkeletonEntitiesExist)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     ASSERT_NE(createAnimatedTestEntity("MergeInvalidBaseA"), nullptr);
     ASSERT_NE(createAnimatedTestEntity("MergeInvalidBaseB"), nullptr);
@@ -5207,7 +5205,7 @@ TEST_F(MCPServerTest, MergeAnimations_InvalidBaseEntityWhenSkeletonEntitiesExist
 
 TEST_F(MCPServerTest, MergeAnimations_WithoutBaseEntityUsesFallbackSelection)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     ASSERT_NE(createAnimatedTestEntity("MergeFallbackA"), nullptr);
     ASSERT_NE(createAnimatedTestEntity("MergeFallbackB"), nullptr);
@@ -5308,7 +5306,7 @@ TEST_F(MCPServerTest, SearchFiles_MaxDepthStopsRecursion)
 
 TEST_F(MCPServerTest, DuplicateEntity_Valid)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     QJsonObject primArgs;
     primArgs["type"] = "cube";
@@ -5359,7 +5357,7 @@ TEST_F(MCPServerTest, TransformSubmesh_MissingEntity)
 
 TEST_F(MCPServerTest, TransformSubmesh_InvalidIndex)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAndSelectTriangleEntity("SubMeshIdxTest");
     ASSERT_NE(entity, nullptr);
@@ -5386,7 +5384,7 @@ TEST_F(MCPServerTest, TransformSubmesh_EntityNotFound)
 
 TEST_F(MCPServerTest, TransformSubmesh_NoTransformSpecified)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAndSelectTriangleEntity("SubMeshNoTrans");
     ASSERT_NE(entity, nullptr);
@@ -5402,7 +5400,7 @@ TEST_F(MCPServerTest, TransformSubmesh_NoTransformSpecified)
 
 TEST_F(MCPServerTest, TransformSubmesh_TranslateValid)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAndSelectTriangleEntity("SubMeshTranslate");
     ASSERT_NE(entity, nullptr);
@@ -5543,7 +5541,7 @@ TEST_F(MCPServerTest, ExportPose_NoEntityInScene)
 
 TEST_F(MCPServerTest, ExportPose_EntityWithoutSkeleton)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     // Create a primitive (no skeleton)
     QJsonObject primArgs;
@@ -5562,7 +5560,7 @@ TEST_F(MCPServerTest, ExportPose_EntityWithoutSkeleton)
 
 TEST_F(MCPServerTest, ExportPose_AnimatedEntitySuccess)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("ExportPoseAnimEntity");
     ASSERT_NE(entity, nullptr);
@@ -5588,7 +5586,7 @@ TEST_F(MCPServerTest, ExportPose_AnimatedEntitySuccess)
 
 TEST_F(MCPServerTest, GroupNodes_Valid)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     auto* mgr = Manager::getSingletonPtr();
     ASSERT_NE(mgr, nullptr);
@@ -5620,7 +5618,7 @@ TEST_F(MCPServerTest, GroupNodes_Valid)
 
 TEST_F(MCPServerTest, GroupNodes_TooFewNodes)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     auto* mgr = Manager::getSingletonPtr();
     ASSERT_NE(mgr, nullptr);
@@ -5657,7 +5655,7 @@ TEST_F(MCPServerTest, GroupNodes_NonexistentNode)
 
 TEST_F(MCPServerTest, UngroupNode_Valid)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     auto* mgr = Manager::getSingletonPtr();
     ASSERT_NE(mgr, nullptr);
@@ -5689,7 +5687,7 @@ TEST_F(MCPServerTest, UngroupNode_Valid)
 
 TEST_F(MCPServerTest, UngroupNode_NotAGroup)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     auto* mgr = Manager::getSingletonPtr();
     ASSERT_NE(mgr, nullptr);
@@ -5714,7 +5712,7 @@ TEST_F(MCPServerTest, UngroupNode_NotAGroup)
 
 TEST_F(MCPServerTest, ReparentNode_Valid)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     auto* mgr = Manager::getSingletonPtr();
     ASSERT_NE(mgr, nullptr);
@@ -5734,7 +5732,7 @@ TEST_F(MCPServerTest, ReparentNode_Valid)
 
 TEST_F(MCPServerTest, ReparentNode_CyclePrevented)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     auto* mgr = Manager::getSingletonPtr();
     ASSERT_NE(mgr, nullptr);
@@ -5813,7 +5811,7 @@ TEST_F(MCPServerTest, ResampleAnimation_MissingArgs)
 
 TEST_F(MCPServerTest, ResampleAnimation_Valid)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("ResampleAnimEntity");
     ASSERT_NE(entity, nullptr);

--- a/src/Manager_test.cpp
+++ b/src/Manager_test.cpp
@@ -40,9 +40,7 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
     }
 
@@ -290,7 +288,7 @@ TEST_F(ManagerHeadlessTest, IsValidFileExtention)
 
 TEST_F(ManagerHeadlessTest, CreateEmptyScene)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     auto* mgr = Manager::getSingletonPtr();
     ASSERT_NE(mgr, nullptr);
 
@@ -320,7 +318,7 @@ TEST_F(ManagerHeadlessTest, GetEntities)
 
 TEST_F(ManagerHeadlessTest, CreateEntity)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     auto* mgr = Manager::getSingletonPtr();
     ASSERT_NE(mgr, nullptr);
 
@@ -367,7 +365,7 @@ TEST_F(ManagerHeadlessTest, GetSceneNode_NonExistentNode)
 
 TEST_F(ManagerHeadlessTest, DestroyAllAttachedMovableObjects)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     auto* mgr = Manager::getSingletonPtr();
     ASSERT_NE(mgr, nullptr);
     Ogre::SceneNode* cubeNode = PrimitiveObject::createCube("CubeForDestroy");
@@ -433,7 +431,7 @@ TEST_F(ManagerHeadlessTest, SceneNodeDestroyed_Signal_ByPointer)
 
 TEST_F(ManagerHeadlessTest, EntityCreated_Signal)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     auto* mgr = Manager::getSingletonPtr();
     ASSERT_NE(mgr, nullptr);
     QSignalSpy spy(mgr, &Manager::entityCreated);
@@ -490,7 +488,7 @@ TEST_F(ManagerHeadlessTest, DestroySceneNodeForbiddenName)
 
 TEST_F(ManagerHeadlessTest, DestroySceneNodePrimitive)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     auto* mgr = Manager::getSingletonPtr();
     ASSERT_NE(mgr, nullptr);
 
@@ -587,7 +585,7 @@ TEST_F(ManagerHeadlessTest, DestroySceneNodeByNameWithSignal)
 
 TEST_F(ManagerHeadlessTest, HasAnimationNameNoSkeleton)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     auto* mgr = Manager::getSingletonPtr();
     ASSERT_NE(mgr, nullptr);
 
@@ -613,7 +611,7 @@ TEST_F(ManagerHeadlessTest, HasAnimationNameNoSkeleton)
 
 TEST_F(ManagerHeadlessTest, CreateInMemoryEntity)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     auto* mgr = Manager::getSingletonPtr();
     ASSERT_NE(mgr, nullptr);
 
@@ -629,7 +627,7 @@ TEST_F(ManagerHeadlessTest, CreateInMemoryEntity)
 
 TEST_F(ManagerHeadlessTest, CreateInMemorySkeletonEntity)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     auto* mgr = Manager::getSingletonPtr();
     ASSERT_NE(mgr, nullptr);
 
@@ -645,7 +643,7 @@ TEST_F(ManagerHeadlessTest, CreateInMemorySkeletonEntity)
 
 TEST_F(ManagerHeadlessTest, CreateAnimatedEntity)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     auto* mgr = Manager::getSingletonPtr();
     ASSERT_NE(mgr, nullptr);
 
@@ -661,7 +659,7 @@ TEST_F(ManagerHeadlessTest, CreateAnimatedEntity)
 
 TEST_F(ManagerHeadlessTest, HasAnimationNameWithSkeleton)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     auto* mgr = Manager::getSingletonPtr();
     ASSERT_NE(mgr, nullptr);
 
@@ -674,7 +672,7 @@ TEST_F(ManagerHeadlessTest, HasAnimationNameWithSkeleton)
 
 TEST_F(ManagerHeadlessTest, DestroyInMemoryEntity)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     auto* mgr = Manager::getSingletonPtr();
     ASSERT_NE(mgr, nullptr);
 
@@ -715,7 +713,7 @@ TEST_F(ManagerHeadlessTest, SceneNodeParenting)
 // Test clearScene-like behavior: destroy all user nodes and verify cleanup
 TEST_F(ManagerHeadlessTest, DestroyAllUserNodes_ClearsScene)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     auto* mgr = Manager::getSingletonPtr();
     ASSERT_NE(mgr, nullptr);
 
@@ -849,7 +847,7 @@ TEST_F(ManagerHeadlessTest, DuplicateSceneNode_NullSourceReturnsNull)
 
 TEST_F(ManagerHeadlessTest, DuplicateSceneNode_ClonesAnimatedEntityWithIndependentSkeleton)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     auto* mgr = Manager::getSingletonPtr();
     ASSERT_NE(mgr, nullptr);
 
@@ -915,7 +913,7 @@ TEST_F(ManagerHeadlessTest, DuplicateSceneNode_ClonesAnimatedEntityWithIndepende
 // Test hasAnimationName with createAnimatedTestEntity - multiple animation name checks
 TEST_F(ManagerHeadlessTest, HasAnimationName_MultipleChecks)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     auto* mgr = Manager::getSingletonPtr();
     ASSERT_NE(mgr, nullptr);
 
@@ -980,7 +978,7 @@ TEST_F(ManagerHeadlessTest, SceneNodeParentChain_MultipleDepth)
 // Test createEntity via Manager::createEntity helper (not manual attach)
 TEST_F(ManagerHeadlessTest, CreateEntityViaManagerHelper)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     auto* mgr = Manager::getSingletonPtr();
     ASSERT_NE(mgr, nullptr);
 

--- a/src/MaterialComboDelegate_test.cpp
+++ b/src/MaterialComboDelegate_test.cpp
@@ -22,9 +22,7 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
     }
 

--- a/src/MaterialEditorQML_test.cpp
+++ b/src/MaterialEditorQML_test.cpp
@@ -1953,7 +1953,7 @@ TEST_F(MaterialEditorQMLTest, GenerateMaterialFromPrompt_EmptyPromptEmitsError) 
 
 TEST_F(MaterialEditorQMLTest, GenerateMaterialFromPrompt_NoModelLoadedEmitsError) {
 #ifdef ENABLE_LOCAL_LLM
-    LLMManager::getSingleton().unloadModel();
+    LLMManager::instance()->unloadModel();
     for (int i = 0; i < 100 && editor->llmModelLoaded(); ++i) {
         QThread::msleep(20);
         if (app) app->processEvents();

--- a/src/MaterialEditorQML_test.cpp
+++ b/src/MaterialEditorQML_test.cpp
@@ -11,6 +11,9 @@
 #include "Manager.h"
 #include <OgreException.h>
 #include "TestHelpers.h"
+#ifdef ENABLE_LOCAL_LLM
+#include "LLMManager.h"
+#endif
 
 // Ensure a QApplication exists for the process lifetime.
 // gtest_main does not create one, so we lazily create it here.
@@ -62,9 +65,7 @@ protected:
         app = ensureQApplication();
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
 
         editor = std::make_unique<MaterialEditorQML>();
@@ -1951,9 +1952,15 @@ TEST_F(MaterialEditorQMLTest, GenerateMaterialFromPrompt_EmptyPromptEmitsError) 
 }
 
 TEST_F(MaterialEditorQMLTest, GenerateMaterialFromPrompt_NoModelLoadedEmitsError) {
-    if (editor->llmModelLoaded()) {
-        GTEST_SKIP() << "LLM model is already loaded in this environment";
+#ifdef ENABLE_LOCAL_LLM
+    LLMManager::getSingleton().unloadModel();
+    for (int i = 0; i < 100 && editor->llmModelLoaded(); ++i) {
+        QThread::msleep(20);
+        if (app) app->processEvents();
     }
+#endif
+    ASSERT_FALSE(editor->llmModelLoaded())
+        << "LLM model must be unloaded to test the no-model error path";
 
     QSignalSpy errorSpy(editor.get(), &MaterialEditorQML::aiGenerationError);
 

--- a/src/MaterialEditorQML_test.cpp
+++ b/src/MaterialEditorQML_test.cpp
@@ -1953,6 +1953,7 @@ TEST_F(MaterialEditorQMLTest, GenerateMaterialFromPrompt_EmptyPromptEmitsError) 
 
 TEST_F(MaterialEditorQMLTest, GenerateMaterialFromPrompt_NoModelLoadedEmitsError) {
 #ifdef ENABLE_LOCAL_LLM
+    LLMManager::instance()->setAutoLoadModel(false);
     LLMManager::instance()->unloadModel();
     for (int i = 0; i < 100 && editor->llmModelLoaded(); ++i) {
         QThread::msleep(20);

--- a/src/MaterialPresetLibrary_test.cpp
+++ b/src/MaterialPresetLibrary_test.cpp
@@ -94,9 +94,7 @@ TEST_F(MaterialPresetLibraryTests, ApplyPresetWithoutSelection) {
     Manager::kill();
     QThread::msleep(50);
 
-    if (!tryInitOgre()) {
-        GTEST_SKIP() << "Skipping: Ogre initialization failed";
-    }
+    ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
     createStandardOgreMaterials();
 
     auto* inst = MaterialPresetLibrary::instance();
@@ -110,12 +108,8 @@ TEST_F(MaterialPresetLibraryTests, ApplyPresetEmitsSignalWithEntity) {
     Manager::kill();
     QThread::msleep(50);
 
-    if (!tryInitOgre()) {
-        GTEST_SKIP() << "Skipping: Ogre initialization failed";
-    }
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     createStandardOgreMaterials();
 
     auto mesh = createInMemoryTriangleMesh("PresetTestMesh");
@@ -144,12 +138,8 @@ TEST_F(MaterialPresetLibraryTests, ApplyAllPresets) {
     Manager::kill();
     QThread::msleep(50);
 
-    if (!tryInitOgre()) {
-        GTEST_SKIP() << "Skipping: Ogre initialization failed";
-    }
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     createStandardOgreMaterials();
 
     auto mesh = createInMemoryTriangleMesh("PresetAllMesh");
@@ -181,12 +171,8 @@ TEST_F(MaterialPresetLibraryTests, PlasticPresetConfiguresExpectedMaterialProper
     Manager::kill();
     QThread::msleep(50);
 
-    if (!tryInitOgre()) {
-        GTEST_SKIP() << "Skipping: Ogre initialization failed";
-    }
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     createStandardOgreMaterials();
 
     Ogre::Entity* entity = createSelectedEntity("PlasticNode", "PlasticEntity", "PlasticMesh");
@@ -209,12 +195,8 @@ TEST_F(MaterialPresetLibraryTests, MetalPresetConfiguresExpectedMaterialProperti
     Manager::kill();
     QThread::msleep(50);
 
-    if (!tryInitOgre()) {
-        GTEST_SKIP() << "Skipping: Ogre initialization failed";
-    }
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     createStandardOgreMaterials();
 
     Ogre::Entity* entity = createSelectedEntity("MetalNode", "MetalEntity", "MetalMesh");
@@ -237,12 +219,8 @@ TEST_F(MaterialPresetLibraryTests, WoodPresetConfiguresExpectedMaterialPropertie
     Manager::kill();
     QThread::msleep(50);
 
-    if (!tryInitOgre()) {
-        GTEST_SKIP() << "Skipping: Ogre initialization failed";
-    }
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     createStandardOgreMaterials();
 
     Ogre::Entity* entity = createSelectedEntity("WoodNode", "WoodEntity", "WoodMesh");
@@ -265,12 +243,8 @@ TEST_F(MaterialPresetLibraryTests, GlassPresetConfiguresTransparentMaterialPrope
     Manager::kill();
     QThread::msleep(50);
 
-    if (!tryInitOgre()) {
-        GTEST_SKIP() << "Skipping: Ogre initialization failed";
-    }
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     createStandardOgreMaterials();
 
     Ogre::Entity* entity = createSelectedEntity("GlassNode", "GlassEntity", "GlassMesh");
@@ -292,12 +266,8 @@ TEST_F(MaterialPresetLibraryTests, UnlitAndWireframePresetsDisableLighting) {
     Manager::kill();
     QThread::msleep(50);
 
-    if (!tryInitOgre()) {
-        GTEST_SKIP() << "Skipping: Ogre initialization failed";
-    }
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     createStandardOgreMaterials();
 
     Ogre::Entity* entity = createSelectedEntity("SpecialNode", "SpecialEntity", "SpecialMesh");

--- a/src/MaterialPresetLibrary_test.cpp
+++ b/src/MaterialPresetLibrary_test.cpp
@@ -91,15 +91,12 @@ TEST_F(MaterialPresetLibraryTests, PresetNamesContainsExpected) {
 }
 
 TEST_F(MaterialPresetLibraryTests, ApplyPresetWithoutSelection) {
+    // No Ogre needed: applyPreset returns early when MaterialManager is absent
+    // and the selection resolves to no entities.
     Manager::kill();
     QThread::msleep(50);
 
-    ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
-    createStandardOgreMaterials();
-
     auto* inst = MaterialPresetLibrary::instance();
-
-    // With no selection, applyPreset should return early without crashing
     SelectionSet::getSingleton()->clear();
     EXPECT_NO_THROW(inst->applyPreset("Plastic (Red)"));
 }

--- a/src/MaterialPreviewRenderer_test.cpp
+++ b/src/MaterialPreviewRenderer_test.cpp
@@ -113,41 +113,28 @@ TEST_F(MaterialPreviewRendererTests, FirstMaterialNameFromNonexistentFile) {
 }
 
 TEST_F(MaterialPreviewRendererTests, RenderPreviewWithOgreBaseWhite) {
-    if (!tryInitOgre()) {
-        GTEST_SKIP() << "Ogre not available";
-    }
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Cannot create meshes (no GL context)";
-    }
+    ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     createStandardOgreMaterials();
 
     auto* renderer = MaterialPreviewRenderer::instance();
     QImage img = renderer->renderPreview("BaseWhite");
-    // The preview should succeed when Ogre is fully initialized
-    if (!img.isNull()) {
-        EXPECT_EQ(img.width(), 64);
-        EXPECT_EQ(img.height(), 64);
-        EXPECT_EQ(img.format(), QImage::Format_RGBA8888);
-    }
-    // If null, the RTT may not be supported in this test environment (acceptable)
+    ASSERT_FALSE(img.isNull()) << "material preview RTT failed (headless GL required)";
+    EXPECT_EQ(img.width(), 64);
+    EXPECT_EQ(img.height(), 64);
+    EXPECT_EQ(img.format(), QImage::Format_RGBA8888);
 }
 
 TEST_F(MaterialPreviewRendererTests, DataUriCachesResults) {
-    if (!tryInitOgre()) {
-        GTEST_SKIP() << "Ogre not available";
-    }
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Cannot create meshes (no GL context)";
-    }
+    ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     createStandardOgreMaterials();
 
     auto* renderer = MaterialPreviewRenderer::instance();
     QString uri1 = renderer->renderPreviewAsDataUri("BaseWhite");
-    if (uri1.isEmpty()) {
-        GTEST_SKIP() << "RTT preview not available in this environment";
-    }
+    ASSERT_FALSE(uri1.isEmpty()) << "material preview RTT failed (headless GL required)";
 
     QString uri2 = renderer->renderPreviewAsDataUri("BaseWhite");
     EXPECT_EQ(uri1, uri2); // Should be cached
@@ -158,22 +145,15 @@ TEST_F(MaterialPreviewRendererTests, DataUriCachesResults) {
 }
 
 TEST_F(MaterialPreviewRendererTests, ClearCacheInvalidatesPreviousResults) {
-    if (!tryInitOgre()) {
-        GTEST_SKIP() << "Ogre not available";
-    }
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Cannot create meshes (no GL context)";
-    }
+    ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     createStandardOgreMaterials();
 
     auto* renderer = MaterialPreviewRenderer::instance();
 
-    // Generate a preview to populate the cache
     QString uri1 = renderer->renderPreviewAsDataUri("BaseWhite");
-    if (uri1.isEmpty()) {
-        GTEST_SKIP() << "RTT preview not available in this environment";
-    }
+    ASSERT_FALSE(uri1.isEmpty()) << "material preview RTT failed (headless GL required)";
 
     // Verify cache is populated (second call returns same result)
     QString uri2 = renderer->renderPreviewAsDataUri("BaseWhite");

--- a/src/MeshImporterExporter.cpp
+++ b/src/MeshImporterExporter.cpp
@@ -1031,9 +1031,6 @@ static void ensureResourceGroup(const QString &path)
         } catch (const Ogre::Exception& e) {
             Ogre::LogManager::getSingleton().logMessage(
                 "Note: removeResourceLocation: " + e.getFullDescription());
-        } catch (const std::exception& e) {
-            Ogre::LogManager::getSingleton().logMessage(
-                "Note: removeResourceLocation: " + Ogre::String(e.what()));
         }
     }
 
@@ -1045,9 +1042,6 @@ static void ensureResourceGroup(const QString &path)
     } catch (const Ogre::Exception& e) {
         Ogre::LogManager::getSingleton().logMessage(
             "Warning during resource group init: " + e.getFullDescription());
-    } catch (const std::exception& e) {
-        Ogre::LogManager::getSingleton().logMessage(
-            "Warning during resource group init: " + Ogre::String(e.what()));
     }
 }
 

--- a/src/MeshImporterExporter.cpp
+++ b/src/MeshImporterExporter.cpp
@@ -1015,17 +1015,34 @@ void MeshImporterExporter::applyNormalMapsToEntity(const Ogre::Entity* en)
 
 static void ensureResourceGroup(const QString &path)
 {
-    auto group = path.toStdString();
+    const QString absPath = QFileInfo(path).absoluteFilePath();
+    auto group = absPath.toStdString();
     auto &rgm = Ogre::ResourceGroupManager::getSingleton();
-    if (!rgm.resourceLocationExists(group, group))
+    const bool haveLocation = rgm.resourceLocationExists(group, group);
+
+    // If the directory was already registered earlier in this process (common in tests and CLI),
+    // Ogre's FileSystem archive may have been initialised before new files were written there.
+    // Re-registering the same location forces Ogre to re-scan the directory so freshly exported
+    // `.mesh` / `.material` sidecars are discoverable by name.
+    if (haveLocation && rgm.isResourceGroupInitialised(group))
     {
-        rgm.addResourceLocation(group, "FileSystem", group);
         try {
-            rgm.initialiseResourceGroup(group);
-        } catch (Ogre::Exception &e) {
-            Ogre::LogManager::getSingleton().logMessage(
-                "Warning during resource group init: " + e.getFullDescription());
+            rgm.removeResourceLocation(group, group);
+        } catch (...) {
+            // Ignore — location may be in use or already removed.
         }
+    }
+
+    // Ensure the location exists, then (re)initialise to refresh the file listing.
+    try {
+        if (!rgm.resourceLocationExists(group, group))
+            rgm.addResourceLocation(group, "FileSystem", group);
+        rgm.initialiseResourceGroup(group);
+    } catch (Ogre::Exception &e) {
+        Ogre::LogManager::getSingleton().logMessage(
+            "Warning during resource group init: " + e.getFullDescription());
+    } catch (...) {
+        // Ignore exceptions during shutdown / missing plugins
     }
 }
 
@@ -1150,9 +1167,8 @@ void MeshImporterExporter::importer(const QStringList &_uriList, unsigned int ad
         {
             if(!fileName.size()) continue;
 
-            QFileInfo file;
-            file.setFile(fileName);
-            ensureResourceGroup(file.path());
+            const QFileInfo file(QFileInfo(fileName).absoluteFilePath());
+            ensureResourceGroup(file.absolutePath());
 
             Ogre::SceneNode *sn;
             const Ogre::Entity *en;
@@ -1160,9 +1176,13 @@ void MeshImporterExporter::importer(const QStringList &_uriList, unsigned int ad
             if(!file.suffix().compare("mesh",Qt::CaseInsensitive))
             {
                 tryLoadSidecarMaterialScript(file);
+                const Ogre::String meshResName = file.fileName().toStdString();
+                const Ogre::String meshGroup = file.absolutePath().toStdString();
+                // Drop any cached mesh so a replaced file on disk is re-read (tests/CLI reuse paths).
+                if (auto existing = Ogre::MeshManager::getSingleton().getByName(meshResName, meshGroup))
+                    Ogre::MeshManager::getSingleton().remove(existing);
                 Ogre::MeshPtr mesh = Ogre::MeshManager::getSingleton().load(
-                    file.fileName().toStdString().data(),
-                    file.path().toStdString().data());
+                    meshResName, meshGroup);
                 if (!mesh)
                     continue;
 

--- a/src/MeshImporterExporter.cpp
+++ b/src/MeshImporterExporter.cpp
@@ -1018,18 +1018,22 @@ static void ensureResourceGroup(const QString &path)
     const QString absPath = QFileInfo(path).absoluteFilePath();
     auto group = absPath.toStdString();
     auto &rgm = Ogre::ResourceGroupManager::getSingleton();
-    const bool haveLocation = rgm.resourceLocationExists(group, group);
 
     // If the directory was already registered earlier in this process (common in tests and CLI),
     // Ogre's FileSystem archive may have been initialised before new files were written there.
     // Re-registering the same location forces Ogre to re-scan the directory so freshly exported
     // `.mesh` / `.material` sidecars are discoverable by name.
-    if (haveLocation && rgm.isResourceGroupInitialised(group))
+    if (const bool haveLocation = rgm.resourceLocationExists(group, group);
+        haveLocation && rgm.isResourceGroupInitialised(group))
     {
         try {
             rgm.removeResourceLocation(group, group);
-        } catch (...) {
-            // Ignore — location may be in use or already removed.
+        } catch (const Ogre::Exception& e) {
+            Ogre::LogManager::getSingleton().logMessage(
+                "Note: removeResourceLocation: " + e.getFullDescription());
+        } catch (const std::exception& e) {
+            Ogre::LogManager::getSingleton().logMessage(
+                "Note: removeResourceLocation: " + Ogre::String(e.what()));
         }
     }
 
@@ -1038,11 +1042,12 @@ static void ensureResourceGroup(const QString &path)
         if (!rgm.resourceLocationExists(group, group))
             rgm.addResourceLocation(group, "FileSystem", group);
         rgm.initialiseResourceGroup(group);
-    } catch (Ogre::Exception &e) {
+    } catch (const Ogre::Exception& e) {
         Ogre::LogManager::getSingleton().logMessage(
             "Warning during resource group init: " + e.getFullDescription());
-    } catch (...) {
-        // Ignore exceptions during shutdown / missing plugins
+    } catch (const std::exception& e) {
+        Ogre::LogManager::getSingleton().logMessage(
+            "Warning during resource group init: " + Ogre::String(e.what()));
     }
 }
 

--- a/src/MeshImporterExporter_test.cpp
+++ b/src/MeshImporterExporter_test.cpp
@@ -59,9 +59,7 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
     }
 
@@ -330,9 +328,7 @@ TEST_F(MeshImporterExporterTest, Importer_MissingMeshFile_IsIgnored) {
 }
 
 TEST_F(MeshImporterExporterTest, Importer_MeshLoadsSidecarMaterialScript) {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: no GL context / hardware buffers available";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "GL/hardware buffers required (Xvfb in CI)";
     // Create a mesh with a custom material, export both .mesh and .material,
     // then reimport and ensure the material isn't falling back to BaseWhite.
     auto* manager = Manager::getSingleton();
@@ -501,9 +497,7 @@ TEST_F(MeshImporterExporterTest, SceneImporter_NodeOnlyExportBehavesAsValidEmpty
 
 TEST_F(MeshImporterExporterTest, SceneExporter_InMemoryMeshEntity_WritesSceneFile)
 {
-    if (!canLoadMeshFiles())
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     ASSERT_TRUE(tempDir.isValid());
     const QString scenePath = tempDir.filePath("mesh_entity.scene.glb");
     Ogre::SceneNode* node = createSceneNodeWithEntity("ExportNode", "ExportSceneMesh");
@@ -527,9 +521,7 @@ TEST_F(MeshImporterExporterTest, SceneExporter_InMemoryMeshEntity_WritesSceneFil
 
 TEST_F(MeshImporterExporterTest, SceneExporter_MixedEmptyAndEntityNodesOnlyCountsEntitiesInProgress)
 {
-    if (!canLoadMeshFiles())
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     ASSERT_TRUE(tempDir.isValid());
     const QString scenePath = tempDir.filePath("mixed_nodes.scene.gltf");
 
@@ -650,12 +642,8 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
-        if (!canLoadMeshFiles()) {
-            GTEST_SKIP() << "Skipping: Cannot load mesh files (no GL context)";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+        ASSERT_TRUE(canLoadMeshFiles()) << "Cannot load mesh files (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
     }
 

--- a/src/MeshInfoOverlay_test.cpp
+++ b/src/MeshInfoOverlay_test.cpp
@@ -62,9 +62,7 @@ protected:
         QThread::msleep(50);
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
 
         window = new QMainWindow();
@@ -133,9 +131,7 @@ protected:
         QThread::msleep(50);
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
     }
 
@@ -151,9 +147,7 @@ protected:
 
 TEST_F(MeshInfoOverlayIntegrationTest, FormatStatsSingleEntity)
 {
-    if (!canLoadMeshFiles())
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
     auto meshPtr = createInMemoryTriangleMesh("MeshInfoSingleMesh");
     ASSERT_TRUE(meshPtr);
 
@@ -191,9 +185,7 @@ TEST_F(MeshInfoOverlayIntegrationTest, FormatStatsSingleEntity)
 
 TEST_F(MeshInfoOverlayIntegrationTest, FormatStatsMultipleEntitiesScene)
 {
-    if (!canLoadMeshFiles())
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
     std::vector<Ogre::Entity*> entities;
     std::vector<Ogre::SceneNode*> nodes;
 
@@ -242,12 +234,9 @@ TEST_F(MeshInfoOverlayIntegrationTest, FormatStatsMultipleEntitiesScene)
 
 TEST_F(MeshInfoOverlayIntegrationTest, FormatStatsWithSkeleton)
 {
-    if (!canLoadMeshFiles())
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
     Ogre::Entity* entity = createAnimatedTestEntity("MeshInfoAnimEntity");
-    if (!entity)
-        GTEST_SKIP() << "Skipping: could not create animated test entity";
+    ASSERT_NE(entity, nullptr);
 
     ASSERT_TRUE(entity->hasSkeleton());
 
@@ -269,8 +258,7 @@ TEST_F(MeshInfoOverlayIntegrationTest, FormatStatsWithSkeleton)
 
 TEST_F(MeshInfoOverlayIntegrationTest, FormatStatsMixedNullAndValid)
 {
-    if (!canLoadMeshFiles())
-        GTEST_SKIP() << "mesh loading not supported";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     auto meshPtr = createInMemoryTriangleMesh("MeshInfoMixedMesh");
     ASSERT_TRUE(meshPtr);

--- a/src/MeshLodController_test.cpp
+++ b/src/MeshLodController_test.cpp
@@ -23,9 +23,7 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Ogre initialization failed — skipping";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
     }
 
@@ -153,21 +151,21 @@ TEST_F(MeshLodControllerTest, ExportLodsEmitsErrorWithNoSelection) {
 // ===========================================================================
 
 TEST_F(MeshLodControllerTest, HasSelectionTrueWithEntitySelected) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
     ASSERT_NE(createAndSelectMesh("HasSel"), nullptr);
 
     EXPECT_TRUE(MeshLodController::instance()->hasSelection());
 }
 
 TEST_F(MeshLodControllerTest, CurrentLodLevelsZeroBeforeGeneration) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
     ASSERT_NE(createAndSelectMesh("LodLevelZero"), nullptr);
 
     EXPECT_EQ(MeshLodController::instance()->currentLodLevels(), 0);
 }
 
 TEST_F(MeshLodControllerTest, LodLevelInfoReturnsBaseEntryWithEntity) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
     ASSERT_NE(createAndSelectMesh("LodInfoBase"), nullptr);
 
     auto info = MeshLodController::instance()->lodLevelInfo();
@@ -180,7 +178,7 @@ TEST_F(MeshLodControllerTest, LodLevelInfoReturnsBaseEntryWithEntity) {
 }
 
 TEST_F(MeshLodControllerTest, ExportLodsEmitsErrorWhenNoLodsGenerated) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
     ASSERT_NE(createAndSelectMesh("ExportNoLods"), nullptr);
 
     auto* ctrl = MeshLodController::instance();
@@ -195,7 +193,7 @@ TEST_F(MeshLodControllerTest, ExportLodsEmitsErrorWhenNoLodsGenerated) {
 }
 
 TEST_F(MeshLodControllerTest, SelectionChangePropagatesLodChangedSignal) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     auto* ctrl = MeshLodController::instance();
     QSignalSpy selSpy(ctrl, &MeshLodController::selectionChanged);
@@ -214,7 +212,7 @@ TEST_F(MeshLodControllerTest, SelectionChangePropagatesLodChangedSignal) {
 // ===========================================================================
 
 TEST_F(MeshLodControllerTest, GenerateLodsEmitsGenerationSucceeded) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
     ASSERT_NE(createAndSelectMesh("GenSucceed"), nullptr);
 
     auto* ctrl = MeshLodController::instance();
@@ -232,7 +230,7 @@ TEST_F(MeshLodControllerTest, GenerateLodsEmitsGenerationSucceeded) {
 }
 
 TEST_F(MeshLodControllerTest, GenerateLodsUpdatesCurrentLodLevels) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
     ASSERT_NE(createAndSelectMesh("GenLevels"), nullptr);
 
     auto* ctrl = MeshLodController::instance();
@@ -243,7 +241,7 @@ TEST_F(MeshLodControllerTest, GenerateLodsUpdatesCurrentLodLevels) {
 }
 
 TEST_F(MeshLodControllerTest, GenerateLodsCountClampedToMin1) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
     ASSERT_NE(createAndSelectMesh("ClampMin"), nullptr);
 
     auto* ctrl = MeshLodController::instance();
@@ -258,7 +256,7 @@ TEST_F(MeshLodControllerTest, GenerateLodsCountClampedToMin1) {
 }
 
 TEST_F(MeshLodControllerTest, GenerateLodsCountClampedToMax4) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
     ASSERT_NE(createAndSelectMesh("ClampMax"), nullptr);
 
     auto* ctrl = MeshLodController::instance();
@@ -273,7 +271,7 @@ TEST_F(MeshLodControllerTest, GenerateLodsCountClampedToMax4) {
 }
 
 TEST_F(MeshLodControllerTest, GenerateLodsReductionFallbackWhenListShort) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
     ASSERT_NE(createAndSelectMesh("FallbackReduction"), nullptr);
 
     auto* ctrl = MeshLodController::instance();
@@ -289,7 +287,7 @@ TEST_F(MeshLodControllerTest, GenerateLodsReductionFallbackWhenListShort) {
 }
 
 TEST_F(MeshLodControllerTest, LodLevelInfoAfterGeneration) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
     ASSERT_NE(createAndSelectMesh("InfoAfterGen"), nullptr);
 
     auto* ctrl = MeshLodController::instance();
@@ -309,7 +307,7 @@ TEST_F(MeshLodControllerTest, LodLevelInfoAfterGeneration) {
 }
 
 TEST_F(MeshLodControllerTest, GenerateAutoLodsEmitsGenerationSucceeded) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
     ASSERT_NE(createAndSelectMesh("AutoSucceed"), nullptr);
 
     auto* ctrl = MeshLodController::instance();
@@ -328,7 +326,7 @@ TEST_F(MeshLodControllerTest, GenerateAutoLodsEmitsGenerationSucceeded) {
 // ===========================================================================
 
 TEST_F(MeshLodControllerTest, RemoveLodsClearsLodLevels) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
     ASSERT_NE(createAndSelectMesh("Remove"), nullptr);
 
     auto* ctrl = MeshLodController::instance();
@@ -345,7 +343,7 @@ TEST_F(MeshLodControllerTest, RemoveLodsClearsLodLevels) {
 }
 
 TEST_F(MeshLodControllerTest, RemoveLodsLodLevelInfoReturnsSingleBaseAfterRemoval) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
     ASSERT_NE(createAndSelectMesh("RemoveInfo"), nullptr);
 
     auto* ctrl = MeshLodController::instance();
@@ -365,7 +363,7 @@ TEST_F(MeshLodControllerTest, RemoveLodsLodLevelInfoReturnsSingleBaseAfterRemova
 // ===========================================================================
 
 TEST_F(MeshLodControllerTest, PreviewLodWithEntityDoesNotCrash) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
     ASSERT_NE(createAndSelectMesh("Preview"), nullptr);
 
     EXPECT_NO_FATAL_FAILURE(MeshLodController::instance()->previewLod(-1));
@@ -373,7 +371,7 @@ TEST_F(MeshLodControllerTest, PreviewLodWithEntityDoesNotCrash) {
 }
 
 TEST_F(MeshLodControllerTest, PreviewLodAfterGenerationDoesNotCrash) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
     ASSERT_NE(createAndSelectMesh("PreviewAfterGen"), nullptr);
 
     auto* ctrl = MeshLodController::instance();
@@ -389,7 +387,7 @@ TEST_F(MeshLodControllerTest, PreviewLodAfterGenerationDoesNotCrash) {
 // ===========================================================================
 
 TEST_F(MeshLodControllerTest, ExportLodsEmitsExportLodsRequestedAfterGeneration) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
     ASSERT_NE(createAndSelectMesh("ExportReq"), nullptr);
 
     auto* ctrl = MeshLodController::instance();
@@ -407,7 +405,7 @@ TEST_F(MeshLodControllerTest, ExportLodsEmitsExportLodsRequestedAfterGeneration)
 }
 
 TEST_F(MeshLodControllerTest, DoExportLodsNoopWithNoLods) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
     ASSERT_NE(createAndSelectMesh("DoExportNoLods"), nullptr);
 
     QTemporaryDir tmpDir;
@@ -426,7 +424,7 @@ TEST_F(MeshLodControllerTest, DoExportLodsNoopWithNoLods) {
 }
 
 TEST_F(MeshLodControllerTest, DoExportLodsEmitsExportSucceeded) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
     ASSERT_NE(createAndSelectMesh("DoExport"), nullptr);
 
     auto* ctrl = MeshLodController::instance();
@@ -463,7 +461,7 @@ TEST_F(MeshLodControllerTest, DoExportLodsNoopWithNoSelection) {
 }
 
 TEST_F(MeshLodControllerTest, DoExportLodsErrorWhenEntityHasNoSceneNode) {
-    if (!canLoadMeshFiles()) GTEST_SKIP() << "No GL context";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     // Can't easily detach a scene node without crashing Ogre,
     // so just verify doExportLods is guarded against null SelectionSet.

--- a/src/MeshTransform_test.cpp
+++ b/src/MeshTransform_test.cpp
@@ -98,11 +98,9 @@ protected:
         QThread::msleep(50);
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
-        if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+        ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     }
     void TearDown() override {
         if (app) app->processEvents();
@@ -875,10 +873,7 @@ TEST_F(MeshTransformTest, RotateMeshAlsoRotatesNormals)
     Ogre::Mesh* mesh = entity->getMesh().get();
 
     std::vector<Ogre::Vector3> originalNormals = getVertexNormals(mesh);
-    if (originalNormals.empty()) {
-        Manager::getSingleton()->destroySceneNode("RotateNormCube");
-        GTEST_SKIP() << "Skipping: mesh has no normals";
-    }
+    ASSERT_FALSE(originalNormals.empty()) << "mesh has no normals";
 
     // Rotate 90 degrees around UNIT_Y (via _rotate.x)
     Ogre::Quaternion expectedQuat(Ogre::Degree(90.0f), Ogre::Vector3::UNIT_Y);
@@ -912,10 +907,7 @@ TEST_F(MeshTransformTest, RotateMeshNormalsPreserveLength)
     Ogre::Mesh* mesh = entity->getMesh().get();
 
     std::vector<Ogre::Vector3> originalNormals = getVertexNormals(mesh);
-    if (originalNormals.empty()) {
-        Manager::getSingleton()->destroySceneNode("RotateNormSphere");
-        GTEST_SKIP() << "Skipping: mesh has no normals";
-    }
+    ASSERT_FALSE(originalNormals.empty()) << "mesh has no normals";
 
     // Rotate 45 degrees
     MeshTransform::rotateMesh(entity, Ogre::Vector3(0.0f, 45.0f, 0.0f));
@@ -1013,10 +1005,7 @@ TEST_F(MeshTransformTest, RotateMeshQuaternionAlsoRotatesNormals)
 
     Ogre::Mesh* mesh = entity->getMesh().get();
     auto originalNormals = getVertexNormals(mesh);
-    if (originalNormals.empty()) {
-        Manager::getSingleton()->destroySceneNode("RotateQuatNormCube");
-        GTEST_SKIP() << "Skipping: mesh has no normals";
-    }
+    ASSERT_FALSE(originalNormals.empty()) << "mesh has no normals";
 
     Ogre::Quaternion quat(Ogre::Degree(90.0f), Ogre::Vector3::UNIT_Y);
     MeshTransform::rotateMesh(entity, quat);

--- a/src/MeshValidator_test.cpp
+++ b/src/MeshValidator_test.cpp
@@ -152,9 +152,7 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
 
         validator = MeshValidator::instance();
@@ -203,9 +201,7 @@ TEST_F(MeshValidatorTest, HasSelectionReflectsSelectionSet)
 {
     EXPECT_FALSE(validator->hasSelection());
 
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: mesh creation requires GL context";
-    }
+    ASSERT_TRUE(canLoadMeshFiles());
 
     auto mesh = createValidUvMesh("MeshValidatorHasSelectionMesh");
     auto* entity = createEntityFromMesh("MeshValidatorHasSelectionNode", mesh);
@@ -238,9 +234,7 @@ TEST_F(MeshValidatorTest, DoValidateWithoutSelectionKeepsStateUnvalidated)
 
 TEST_F(MeshValidatorTest, DoValidateValidMeshReturnsOkIssue)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: mesh creation requires GL context";
-    }
+    ASSERT_TRUE(canLoadMeshFiles());
 
     auto mesh = createValidUvMesh("MeshValidatorValidMesh");
     auto* entity = createEntityFromMesh("MeshValidatorValidNode", mesh);
@@ -265,9 +259,7 @@ TEST_F(MeshValidatorTest, DoValidateValidMeshReturnsOkIssue)
 
 TEST_F(MeshValidatorTest, DoValidateDetectsDegeneratesAndUvProblems)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: mesh creation requires GL context";
-    }
+    ASSERT_TRUE(canLoadMeshFiles());
 
     auto mesh = createDegenerateUvMesh("MeshValidatorBadMesh");
     auto* entity = createEntityFromMesh("MeshValidatorBadNode", mesh);
@@ -297,9 +289,7 @@ TEST_F(MeshValidatorTest, DoValidateDetectsDegeneratesAndUvProblems)
 
 TEST_F(MeshValidatorTest, ValidateDefersAndFrameStartedRunsValidation)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: mesh creation requires GL context";
-    }
+    ASSERT_TRUE(canLoadMeshFiles());
 
     auto mesh = createValidUvMesh("MeshValidatorFrameMesh");
     auto* entity = createEntityFromMesh("MeshValidatorFrameNode", mesh);
@@ -326,9 +316,7 @@ TEST_F(MeshValidatorTest, ValidateDefersAndFrameStartedRunsValidation)
 
 TEST_F(MeshValidatorTest, SelectionChangeClearsIssuesAndCancelsPendingValidation)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: mesh creation requires GL context";
-    }
+    ASSERT_TRUE(canLoadMeshFiles());
 
     auto mesh = createValidUvMesh("MeshValidatorSelectionClearMesh");
     auto* entity = createEntityFromMesh("MeshValidatorSelectionClearNode", mesh);

--- a/src/NodeGrouping_test.cpp
+++ b/src/NodeGrouping_test.cpp
@@ -15,9 +15,7 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
     }
 
@@ -31,8 +29,7 @@ protected:
 
 TEST_F(NodeGroupingTest, GroupNodes_Basic)
 {
-    if (!canLoadMeshFiles())
-        GTEST_SKIP() << "No GL context for mesh operations";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     auto* mgr = Manager::getSingleton();
 
@@ -74,8 +71,7 @@ TEST_F(NodeGroupingTest, GroupNodes_Basic)
 
 TEST_F(NodeGroupingTest, UngroupNode)
 {
-    if (!canLoadMeshFiles())
-        GTEST_SKIP() << "No GL context for mesh operations";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     auto* mgr = Manager::getSingleton();
 
@@ -125,8 +121,7 @@ TEST_F(NodeGroupingTest, IsGroupNode)
 
 TEST_F(NodeGroupingTest, GroupTransformPropagation)
 {
-    if (!canLoadMeshFiles())
-        GTEST_SKIP() << "No GL context for mesh operations";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     auto* mgr = Manager::getSingleton();
 
@@ -156,8 +151,7 @@ TEST_F(NodeGroupingTest, GroupTransformPropagation)
 
 TEST_F(NodeGroupingTest, NestedGroups)
 {
-    if (!canLoadMeshFiles())
-        GTEST_SKIP() << "No GL context for mesh operations";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     auto* mgr = Manager::getSingleton();
 
@@ -199,8 +193,7 @@ TEST_F(NodeGroupingTest, NestedGroups)
 
 TEST_F(NodeGroupingTest, GetSceneNodesIncludesGroupChildren)
 {
-    if (!canLoadMeshFiles())
-        GTEST_SKIP() << "No GL context for mesh operations";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     auto* mgr = Manager::getSingleton();
 
@@ -231,8 +224,7 @@ TEST_F(NodeGroupingTest, GetSceneNodesIncludesGroupChildren)
 
 TEST_F(NodeGroupingTest, GetEntitiesIncludesGroupedEntities)
 {
-    if (!canLoadMeshFiles())
-        GTEST_SKIP() << "No GL context for mesh operations";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     auto* mgr = Manager::getSingleton();
 
@@ -260,8 +252,7 @@ TEST_F(NodeGroupingTest, GetEntitiesIncludesGroupedEntities)
 
 TEST_F(NodeGroupingTest, HasSceneNodeFindsNestedNodes)
 {
-    if (!canLoadMeshFiles())
-        GTEST_SKIP() << "No GL context for mesh operations";
+    ASSERT_TRUE(canLoadMeshFiles());
 
     auto* mgr = Manager::getSingleton();
 

--- a/src/NormalVisualizer_test.cpp
+++ b/src/NormalVisualizer_test.cpp
@@ -21,9 +21,7 @@ protected:
         QThread::msleep(50);
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
 
         // Remove leftover material so createMaterial() runs fresh
@@ -113,9 +111,7 @@ TEST_F(NormalVisualizerIntegrationTest, DoubleSetVisibleTrueNoError)
 
 TEST_F(NormalVisualizerIntegrationTest, DestructorCleansUpWhileVisible)
 {
-    if (!canLoadMeshFiles())
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
     auto meshPtr = createInMemoryTriangleMesh("NormVizDestructorMesh");
     ASSERT_TRUE(meshPtr);
 
@@ -141,9 +137,7 @@ TEST_F(NormalVisualizerIntegrationTest, DestructorCleansUpWhileVisible)
 
 TEST_F(NormalVisualizerIntegrationTest, BuildsOverlayForInMemoryMesh)
 {
-    if (!canLoadMeshFiles())
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
     auto meshPtr = createInMemoryTriangleMesh("NormalVisualizerTestMesh");
     ASSERT_TRUE(meshPtr);
 
@@ -170,12 +164,9 @@ TEST_F(NormalVisualizerIntegrationTest, BuildsOverlayForInMemoryMesh)
 
 TEST_F(NormalVisualizerIntegrationTest, OverlayCreatedForSkeletalEntity)
 {
-    if (!canLoadMeshFiles())
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
     Ogre::Entity* entity = createAnimatedTestEntity("NormVizAnimEntity");
-    if (!entity)
-        GTEST_SKIP() << "Skipping: could not create animated test entity";
+    ASSERT_NE(entity, nullptr);
 
     ASSERT_TRUE(entity->hasSkeleton());
 
@@ -198,9 +189,7 @@ TEST_F(NormalVisualizerIntegrationTest, OverlayCreatedForSkeletalEntity)
 // should automatically get a normal overlay via the signal connection.
 TEST_F(NormalVisualizerIntegrationTest, OnEntityCreatedWhileVisible)
 {
-    if (!canLoadMeshFiles())
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
     NormalVisualizer visualizer(Manager::getSingleton()->getSceneMgr());
     visualizer.setVisible(true);
 
@@ -233,9 +222,7 @@ TEST_F(NormalVisualizerIntegrationTest, OnEntityCreatedWhileVisible)
 // onEntityCreated signal when visibility is off: overlay should NOT be built.
 TEST_F(NormalVisualizerIntegrationTest, OnEntityCreatedWhileNotVisible)
 {
-    if (!canLoadMeshFiles())
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
     NormalVisualizer visualizer(Manager::getSingleton()->getSceneMgr());
     // Visibility is off by default
     ASSERT_FALSE(visualizer.isVisible());
@@ -262,9 +249,7 @@ TEST_F(NormalVisualizerIntegrationTest, OnEntityCreatedWhileNotVisible)
 // onSceneNodeDestroyed signal with visibility on: overlay should be cleaned up.
 TEST_F(NormalVisualizerIntegrationTest, OnSceneNodeDestroyedCleansUpOverlay)
 {
-    if (!canLoadMeshFiles())
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
     auto meshPtr = createInMemoryTriangleMesh("NormVizDestroySignalMesh");
     ASSERT_TRUE(meshPtr);
 
@@ -299,9 +284,7 @@ TEST_F(NormalVisualizerIntegrationTest, OnSceneNodeDestroyedCleansUpOverlay)
 // Verify overlay works with shared vertex data (createInMemoryTriangleMesh uses shared).
 TEST_F(NormalVisualizerIntegrationTest, OverlayWithSharedVertexData)
 {
-    if (!canLoadMeshFiles())
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
     // createInMemoryTriangleMesh creates a mesh with sharedVertexData and
     // sub->useSharedVertices = true, which exercises the shared vertex path.
     auto meshPtr = createInMemoryTriangleMesh("NormVizSharedMesh");
@@ -330,9 +313,7 @@ TEST_F(NormalVisualizerIntegrationTest, OverlayWithSharedVertexData)
 // Multiple entities: show normals for 3+ entities simultaneously.
 TEST_F(NormalVisualizerIntegrationTest, MultipleEntitiesSimultaneously)
 {
-    if (!canLoadMeshFiles())
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
     const int NUM_ENTITIES = 4;
     std::vector<Ogre::Entity*> entities;
     std::vector<Ogre::SceneNode*> nodes;
@@ -380,12 +361,9 @@ TEST_F(NormalVisualizerIntegrationTest, MultipleEntitiesSimultaneously)
 // Exercise updateAnimatedOverlays via the timer path for skeletal entities.
 TEST_F(NormalVisualizerIntegrationTest, UpdateAnimatedOverlaysViaTimer)
 {
-    if (!canLoadMeshFiles())
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
     Ogre::Entity* entity = createAnimatedTestEntity("NormVizAnimTimer");
-    if (!entity)
-        GTEST_SKIP() << "Skipping: could not create animated test entity";
+    ASSERT_NE(entity, nullptr);
 
     ASSERT_TRUE(entity->hasSkeleton());
 
@@ -430,9 +408,7 @@ TEST_F(NormalVisualizerIntegrationTest, UpdateAnimatedOverlaysViaTimer)
 // Multiple show/hide/show cycles to exercise repeated toggling with entities.
 TEST_F(NormalVisualizerIntegrationTest, MultipleShowHideShowCycles)
 {
-    if (!canLoadMeshFiles())
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
     auto meshPtr = createInMemoryTriangleMesh("NormVizCycleMesh");
     ASSERT_TRUE(meshPtr);
 
@@ -465,9 +441,7 @@ TEST_F(NormalVisualizerIntegrationTest, MultipleShowHideShowCycles)
 // Add entity while visible, then remove it -- exercises full lifecycle.
 TEST_F(NormalVisualizerIntegrationTest, AddEntityWhileVisibleThenRemove)
 {
-    if (!canLoadMeshFiles())
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
     NormalVisualizer visualizer(Manager::getSingleton()->getSceneMgr());
     visualizer.setVisible(true);
 
@@ -503,12 +477,9 @@ TEST_F(NormalVisualizerIntegrationTest, AddEntityWhileVisibleThenRemove)
 // Animated entity overlay update with animation state changes
 TEST_F(NormalVisualizerIntegrationTest, AnimatedOverlayWithStateChanges)
 {
-    if (!canLoadMeshFiles())
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
     Ogre::Entity* entity = createAnimatedTestEntity("NormVizAnimState");
-    if (!entity)
-        GTEST_SKIP() << "Skipping: could not create animated test entity";
+    ASSERT_NE(entity, nullptr);
 
     ASSERT_TRUE(entity->hasSkeleton());
 
@@ -556,9 +527,7 @@ TEST_F(NormalVisualizerIntegrationTest, AnimatedOverlayWithStateChanges)
 // Toggle normals while adding/removing entities via signals.
 TEST_F(NormalVisualizerIntegrationTest, ToggleWhileAddingRemovingEntities)
 {
-    if (!canLoadMeshFiles())
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
     NormalVisualizer visualizer(Manager::getSingleton()->getSceneMgr());
 
     // Start with normals ON

--- a/src/ObjectItemModel_test.cpp
+++ b/src/ObjectItemModel_test.cpp
@@ -20,9 +20,7 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
     }
 
@@ -64,7 +62,7 @@ TEST_F(ObjectItemModelTest, ConstructorCreatesRootSceneItem)
 // Test: reloadSceneNode builds tree from scene graph
 TEST_F(ObjectItemModelTest, ReloadSceneNodeBuildsTreeFromSceneGraph)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     // Create a primitive to add a node to the scene
     PrimitiveObject::createCube("TestCube");
 
@@ -98,7 +96,7 @@ TEST_F(ObjectItemModelTest, ReloadSceneNodeBuildsTreeFromSceneGraph)
 // Test: reloadSceneNode rebuilds the tree (clears and repopulates)
 TEST_F(ObjectItemModelTest, ReloadSceneNodeRebuildsTree)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     ObjectItemModel model;
 
     QModelIndex rootIndex = model.getRootIndex();
@@ -123,7 +121,7 @@ TEST_F(ObjectItemModelTest, ReloadSceneNodeRebuildsTree)
 // Test: newObjectNode adds nodes to the model
 TEST_F(ObjectItemModelTest, NewObjectNodeAddsNodesToModel)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     ObjectItemModel model;
 
     QModelIndex rootIndex = model.getRootIndex();
@@ -159,7 +157,7 @@ TEST_F(ObjectItemModelTest, NewObjectNodeAddsNodesToModel)
 // Test: objectNodeRemoved removes nodes from the model
 TEST_F(ObjectItemModelTest, ObjectNodeRemovedRemovesNodes)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     // Create a primitive first
     PrimitiveObject::createCube("RemoveTestCube");
 
@@ -234,7 +232,7 @@ TEST_F(ObjectItemModelTest, SetHeaderTextWithEmptyString)
 // Test: Model stores node data in user roles
 TEST_F(ObjectItemModelTest, ModelStoresNodeDataInUserRoles)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     PrimitiveObject::createCube("DataTestCube");
 
     ObjectItemModel model;
@@ -265,7 +263,7 @@ TEST_F(ObjectItemModelTest, ModelStoresNodeDataInUserRoles)
 // Test: Entities are added as children of their scene node
 TEST_F(ObjectItemModelTest, EntitiesAreChildrenOfSceneNode)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     PrimitiveObject::createCube("EntityTestCube");
 
     ObjectItemModel model;
@@ -308,7 +306,7 @@ TEST_F(ObjectItemModelTest, EntitiesAreChildrenOfSceneNode)
 // Test: Multiple nodes can be tracked in the model
 TEST_F(ObjectItemModelTest, MultipleNodesTracked)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     PrimitiveObject::createCube("MultiCube1");
     PrimitiveObject::createSphere("MultiSphere1");
 

--- a/src/OgreWidget_test.cpp
+++ b/src/OgreWidget_test.cpp
@@ -65,6 +65,8 @@ protected:
                 QThread::msleep(200 * attempt);
             }
         }
+        ASSERT_NE(mainWindow, nullptr)
+            << "MainWindow failed to initialize (Xvfb/GL required for integration tests)";
     }
 
     static void TearDownTestSuite()
@@ -82,11 +84,14 @@ protected:
 
     void SetUp() override
     {
-        if (!mainWindow) {
-            GTEST_SKIP() << "Failed to initialize MainWindow for OgreWidgetTest";
+        ASSERT_NE(mainWindow, nullptr);
+        try {
+            viewport = new EditorViewport(mainWindow, 7);
+        } catch (const std::exception& e) {
+            FAIL() << "EditorViewport creation failed: " << e.what();
+        } catch (...) {
+            FAIL() << "EditorViewport creation failed with unknown exception";
         }
-
-        viewport = new EditorViewport(mainWindow, 7);
         ASSERT_NE(viewport, nullptr);
 
         widget = viewport->getOgreWidget();

--- a/src/PrimitiveObject_test.cpp
+++ b/src/PrimitiveObject_test.cpp
@@ -245,11 +245,9 @@ protected:
         QThread::msleep(50);
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
-        if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+        ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     }
     void TearDown() override {
         if (app) app->processEvents();

--- a/src/PrimitivesWidget_test.cpp
+++ b/src/PrimitivesWidget_test.cpp
@@ -29,11 +29,9 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
-        if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+        ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     }
 
     void TearDown() override

--- a/src/PropertiesPanelController_test.cpp
+++ b/src/PropertiesPanelController_test.cpp
@@ -35,9 +35,7 @@ protected:
         Manager::kill();
         app->processEvents();
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
 
         createStandardOgreMaterials();
         controller = PropertiesPanelController::instance();
@@ -197,9 +195,7 @@ TEST_F(PropertiesPanelControllerTests, TransformSettersUpdateSelectedNodeAndEmit
 
 TEST_F(PropertiesPanelControllerTests, PrimitiveMetadataForCubeMatchesExpectedFields)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::SceneNode* cubeNode = PrimitiveObject::createCube("PanelCube");
     ASSERT_NE(cubeNode, nullptr);
@@ -231,9 +227,7 @@ TEST_F(PropertiesPanelControllerTests, PrimitiveMetadataForCubeMatchesExpectedFi
 
 TEST_F(PropertiesPanelControllerTests, PrimitiveMetadataForTorusUsesRadiusLabels)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::SceneNode* torusNode = PrimitiveObject::createTorus("PanelTorus");
     ASSERT_NE(torusNode, nullptr);
@@ -257,9 +251,7 @@ TEST_F(PropertiesPanelControllerTests, PrimitiveMetadataForTorusUsesRadiusLabels
 
 TEST_F(PropertiesPanelControllerTests, PrimitiveSettersMutateSelectedPrimitiveAndEmitSignal)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::SceneNode* cubeNode = PrimitiveObject::createCube("PanelPrimitiveMutation");
     ASSERT_NE(cubeNode, nullptr);
@@ -290,9 +282,7 @@ TEST_F(PropertiesPanelControllerTests, PrimitiveSettersMutateSelectedPrimitiveAn
 
 TEST_F(PropertiesPanelControllerTests, PrimitiveMetadataCoversAdditionalPrimitiveTypes)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     struct PrimitiveCase {
         Ogre::SceneNode* (*create)(const QString&);
@@ -416,9 +406,7 @@ TEST_F(PropertiesPanelControllerTests, AnimationQueriesAreSafeWithoutAnimatedSel
 
 TEST_F(PropertiesPanelControllerTests, AnimationDataAndControlsWorkForAnimatedEntity)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("PanelAnimData");
     ASSERT_NE(entity, nullptr);
@@ -481,9 +469,7 @@ TEST_F(PropertiesPanelControllerTests, AnimationDataAndControlsWorkForAnimatedEn
 
 TEST_F(PropertiesPanelControllerTests, SkeletonAndWeightTogglesEmitForMatchingEntity)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("PanelAnimToggleEntity");
     ASSERT_NE(entity, nullptr);
@@ -511,9 +497,7 @@ TEST_F(PropertiesPanelControllerTests, SkeletonAndWeightTogglesEmitForMatchingEn
 
 TEST_F(PropertiesPanelControllerTests, RenameAnimationRenamesStateAndStopsPlayback)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createAnimatedTestEntity("PanelRenameAnim");
     ASSERT_NE(entity, nullptr);
@@ -547,9 +531,7 @@ TEST_F(PropertiesPanelControllerTests, RenameAnimationRenamesStateAndStopsPlayba
 
 TEST_F(PropertiesPanelControllerTests, ExportCurrentPoseRequiresAnimatedSelectionAndWritesFile)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     auto* mgr = Manager::getSingleton();
     ASSERT_NE(mgr, nullptr);
@@ -581,9 +563,7 @@ TEST_F(PropertiesPanelControllerTests, ExportCurrentPoseRequiresAnimatedSelectio
 
 TEST_F(PropertiesPanelControllerTests, SetSettingCoversViewportSentryAndThemeBranches)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     auto* mgr = Manager::getSingleton();
     ASSERT_NE(mgr, nullptr);

--- a/src/RTShaderHelper_test.cpp
+++ b/src/RTShaderHelper_test.cpp
@@ -22,19 +22,23 @@ protected:
         rtssDir = appDir + "/media/RTShaderLib";
         mainDir = appDir + "/media/Main";
 
-        // On macOS dev builds the install puts media at bin/media/ while
-        // the test binary is directly in bin/, so appDir/media works.
-        // If neither candidate exists, skip (e.g. pre-install build).
         if (!QDir(rtssDir).exists()) {
-            // Try sibling path (Linux .deb layout)
             QString alt = appDir + "/../media/RTShaderLib";
             if (QDir(alt).exists()) {
                 rtssDir = QDir(alt).canonicalPath();
                 mainDir = QDir(appDir + "/../media/Main").canonicalPath();
-            } else {
-                GTEST_SKIP() << "RTSS media not installed (run cmake --install)";
             }
         }
+        if (!QDir(rtssDir).exists()) {
+            const QString srcRoot = QString::fromUtf8(QTMESH_UT_SOURCE_ROOT);
+            if (!srcRoot.isEmpty()) {
+                rtssDir = QDir(srcRoot).filePath(QStringLiteral("media/RTShaderLib"));
+                mainDir = QDir(srcRoot).filePath(QStringLiteral("media/Main"));
+            }
+        }
+        ASSERT_TRUE(QDir(rtssDir).exists())
+            << "RTShaderLib not found next to UnitTests or under source tree";
+        ASSERT_TRUE(QDir(mainDir).exists()) << mainDir.toStdString();
     }
 };
 

--- a/src/RotationGizmo_test.cpp
+++ b/src/RotationGizmo_test.cpp
@@ -38,11 +38,9 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createOGREMaterials();
-        if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+        ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
         Manager* manager = Manager::getSingleton();
         ASSERT_NE(manager, nullptr);

--- a/src/ScaleGizmo_test.cpp
+++ b/src/ScaleGizmo_test.cpp
@@ -35,11 +35,9 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createOGREMaterials();
-        if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+        ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
         Manager* manager = Manager::getSingleton();
         ASSERT_NE(manager, nullptr);

--- a/src/ScanEngine_test.cpp
+++ b/src/ScanEngine_test.cpp
@@ -1446,9 +1446,8 @@ TEST(ScanEngineTest, InspectAsset_ObjParsesGeometryAndTextureReferences)
 TEST(ScanEngineTest, InspectAsset_AnimatedFixtureCollectsAnimationMetadata)
 {
     const QString filePath = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(filePath)) {
-        GTEST_SKIP() << "Animated fixture missing: " << filePath.toStdString();
-    }
+    ASSERT_TRUE(QFile::exists(filePath))
+        << "Animated fixture missing: " << filePath.toStdString();
 
     const AssetInfo info = ScanEngine::inspectAsset(filePath, QFileInfo(filePath).absolutePath());
     ASSERT_FALSE(info.loadError);
@@ -1505,9 +1504,8 @@ TEST(ScanEngineTest, AssimpReadPolicy_IncompleteFlagWithAnimIsNotLoadFailure)
 TEST(ScanEngineTest, EvaluateRules_RedundantKeyframesOffWhenThresholdZero)
 {
     const QString filePath = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(filePath)) {
-        GTEST_SKIP() << "Animated fixture missing: " << filePath.toStdString();
-    }
+    ASSERT_TRUE(QFile::exists(filePath))
+        << "Animated fixture missing: " << filePath.toStdString();
 
     const AssetInfo info = ScanEngine::inspectAsset(filePath, QFileInfo(filePath).absolutePath());
     ScanConfig config;
@@ -1522,9 +1520,8 @@ TEST(ScanEngineTest, EvaluateRules_RedundantKeyframesFiresOnMixamoFixture)
     // Mixamo clips bake one key per frame per bone, so a low threshold should
     // light up the rule and the message must include the projected savings.
     const QString filePath = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(filePath)) {
-        GTEST_SKIP() << "Animated fixture missing: " << filePath.toStdString();
-    }
+    ASSERT_TRUE(QFile::exists(filePath))
+        << "Animated fixture missing: " << filePath.toStdString();
 
     const AssetInfo info = ScanEngine::inspectAsset(filePath, QFileInfo(filePath).absolutePath());
     ScanConfig config;
@@ -1551,9 +1548,8 @@ TEST(ScanEngineTest, EvaluateRules_RedundantKeyframesRespectsHighThreshold)
     // Setting the threshold above 100% should disable the warning even when
     // the file has redundant keys.
     const QString filePath = testDataDir() + "/Twist Dance.fbx";
-    if (!QFile::exists(filePath)) {
-        GTEST_SKIP() << "Animated fixture missing: " << filePath.toStdString();
-    }
+    ASSERT_TRUE(QFile::exists(filePath))
+        << "Animated fixture missing: " << filePath.toStdString();
 
     const AssetInfo info = ScanEngine::inspectAsset(filePath, QFileInfo(filePath).absolutePath());
     ScanConfig config;

--- a/src/SceneTreeModel_test.cpp
+++ b/src/SceneTreeModel_test.cpp
@@ -25,9 +25,7 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
 
         createStandardOgreMaterials();
         model = new SceneTreeModel();
@@ -141,9 +139,7 @@ TEST_F(SceneTreeModelTests, RootIndexIsInvalid) {
 }
 
 TEST_F(SceneTreeModelTests, RebuildWithEntity) {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     createStandardOgreMaterials();
 
     auto mesh = createInMemoryTriangleMesh("TreeModelTestMesh");
@@ -253,9 +249,7 @@ TEST(SceneTreeItemTests, ChildParentRowAndTypeLabelsWork)
 
 TEST_F(SceneTreeModelTests, RebuildCreatesNodeEntityAndSubEntityHierarchy)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     const auto data = createEntityHierarchy("HierarchyNode", "HierarchyEntity", "HierarchyMesh");
     ASSERT_NE(data.node, nullptr);
@@ -303,9 +297,7 @@ TEST_F(SceneTreeModelTests, RebuildCreatesNodeEntityAndSubEntityHierarchy)
 
 TEST_F(SceneTreeModelTests, SelectItemSupportsNodeEntityAndSubEntitySelection)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     const auto data = createEntityHierarchy("SelectHierarchyNode", "SelectHierarchyEntity", "SelectHierarchyMesh");
     ASSERT_NE(data.node, nullptr);
@@ -348,9 +340,7 @@ TEST_F(SceneTreeModelTests, SelectItemSupportsNodeEntityAndSubEntitySelection)
 
 TEST_F(SceneTreeModelTests, SetMaterialUpdatesEntityAndSubEntityAndEmitsDataChanged)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     const auto data = createEntityHierarchy("MaterialNode", "MaterialEntity", "MaterialMesh");
     ASSERT_NE(data.node, nullptr);

--- a/src/SelectionBoxObject_test.cpp
+++ b/src/SelectionBoxObject_test.cpp
@@ -18,9 +18,7 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
 
         createStandardOgreMaterials();
     }

--- a/src/SelectionSet_test.cpp
+++ b/src/SelectionSet_test.cpp
@@ -42,9 +42,7 @@ protected:
         Manager::kill();
         SelectionSet::kill();
         QThread::msleep(50);
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
     }
     void TearDown() override {
         SelectionSet::kill();
@@ -196,7 +194,7 @@ TEST_F(SelectionSetTests, GetCount)
     EXPECT_EQ(selectionSet->getEntitiesCount(), 0);
     EXPECT_EQ(selectionSet->getSubEntitiesCount(), 0);
 
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     // Add an entity to verify count sums across types
     createStandardOgreMaterials();
@@ -234,7 +232,7 @@ TEST_F(SelectionSetTests, HasNodes)
 
 TEST_F(SelectionSetTests, EntitySelection)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     SelectionSet* selectionSet = SelectionSet::getSingleton();
     selectionSet->clear();
     createStandardOgreMaterials();
@@ -278,7 +276,7 @@ TEST_F(SelectionSetTests, EntitySelection)
 
 TEST_F(SelectionSetTests, EntityScaleRotationFactors)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     SelectionSet* selectionSet = SelectionSet::getSingleton();
     selectionSet->clear();
     createStandardOgreMaterials();
@@ -349,7 +347,7 @@ TEST_F(SelectionSetTests, GetSelectionScaleEmpty)
 
 TEST_F(SelectionSetTests, SubEntitySelection)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     SelectionSet* selectionSet = SelectionSet::getSingleton();
     selectionSet->clear();
     createStandardOgreMaterials();
@@ -396,7 +394,7 @@ TEST_F(SelectionSetTests, SubEntitySelection)
 
 TEST_F(SelectionSetTests, IndexedAccessors)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     SelectionSet* selectionSet = SelectionSet::getSingleton();
     selectionSet->clear();
     createStandardOgreMaterials();
@@ -429,7 +427,7 @@ TEST_F(SelectionSetTests, IndexedAccessors)
 
 TEST_F(SelectionSetTests, SelectionListGetters)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     SelectionSet* selectionSet = SelectionSet::getSingleton();
     selectionSet->clear();
     createStandardOgreMaterials();
@@ -476,7 +474,7 @@ TEST_F(SelectionSetTests, GetSelectionOrientationWithNode)
 
 TEST_F(SelectionSetTests, GetSelectionOrientationWithEntity)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     SelectionSet* selectionSet = SelectionSet::getSingleton();
     selectionSet->clear();
     createStandardOgreMaterials();
@@ -518,7 +516,7 @@ TEST_F(SelectionSetTests, GetSelectionScaleWithNode)
 
 TEST_F(SelectionSetTests, GetSelectionScaleWithEntity)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     SelectionSet* selectionSet = SelectionSet::getSingleton();
     selectionSet->clear();
     createStandardOgreMaterials();
@@ -542,7 +540,7 @@ TEST_F(SelectionSetTests, GetSelectionScaleWithEntity)
 
 TEST_F(SelectionSetTests, GetSelectionCenterWithEntity)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     SelectionSet* selectionSet = SelectionSet::getSingleton();
     selectionSet->clear();
     createStandardOgreMaterials();
@@ -564,7 +562,7 @@ TEST_F(SelectionSetTests, GetSelectionCenterWithEntity)
 
 TEST_F(SelectionSetTests, GetSelectionNodesCenterWithEntity)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     SelectionSet* selectionSet = SelectionSet::getSingleton();
     selectionSet->clear();
     createStandardOgreMaterials();
@@ -623,7 +621,7 @@ TEST_F(SelectionSetTests, RemoveNonExistent)
 
 TEST_F(SelectionSetTests, GetResolvedEntitiesReturnsDirectEntitySelection)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     SelectionSet* selectionSet = SelectionSet::getSingleton();
     selectionSet->clear();
 
@@ -644,7 +642,7 @@ TEST_F(SelectionSetTests, GetResolvedEntitiesReturnsDirectEntitySelection)
 
 TEST_F(SelectionSetTests, GetResolvedEntitiesResolvesSelectedNodesWithEntities)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     SelectionSet* selectionSet = SelectionSet::getSingleton();
     selectionSet->clear();
 
@@ -665,7 +663,7 @@ TEST_F(SelectionSetTests, GetResolvedEntitiesResolvesSelectedNodesWithEntities)
 
 TEST_F(SelectionSetTests, GetResolvedEntitiesSkipsNodesWithoutAttachedEntities)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     SelectionSet* selectionSet = SelectionSet::getSingleton();
     selectionSet->clear();
 
@@ -714,7 +712,7 @@ TEST_F(SelectionSetTests, GetSelectionScaleAveragesMultipleNodes)
 
 TEST_F(SelectionSetTests, GetSelectionScaleAveragesMultipleEntitiesUsingStoredFactors)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     SelectionSet* selectionSet = SelectionSet::getSingleton();
     selectionSet->clear();
 
@@ -743,7 +741,7 @@ TEST_F(SelectionSetTests, GetSelectionScaleAveragesMultipleEntitiesUsingStoredFa
 
 TEST_F(SelectionSetTests, GetSelectionOrientationAveragesMultipleEntitiesUsingStoredRotations)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     SelectionSet* selectionSet = SelectionSet::getSingleton();
     selectionSet->clear();
 
@@ -772,7 +770,7 @@ TEST_F(SelectionSetTests, GetSelectionOrientationAveragesMultipleEntitiesUsingSt
 
 TEST_F(SelectionSetTests, GetSelectionCenterWithSubEntityUsesParentBoundingBox)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     SelectionSet* selectionSet = SelectionSet::getSingleton();
     selectionSet->clear();
 
@@ -802,7 +800,7 @@ TEST_F(SelectionSetTests, GetSelectionCenterWithSubEntityUsesParentBoundingBox)
 
 TEST_F(SelectionSetTests, RemoveNonExistentEntityAndSubEntityReturnFalse)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     SelectionSet* selectionSet = SelectionSet::getSingleton();
     selectionSet->clear();
 

--- a/src/SkeletonDebug_test.cpp
+++ b/src/SkeletonDebug_test.cpp
@@ -19,19 +19,13 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
 
-        if (!canLoadMeshFiles()) {
-            GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-        }
+        ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
 
         Ogre::Entity* entity = createAnimatedTestEntity("SkeletonDebugTestEntity");
-        if (!entity) {
-            GTEST_SKIP() << "Skipping SkeletonDebug tests: failed to create animated test entity";
-        }
+        ASSERT_NE(entity, nullptr);
 
         Ogre::SceneManager* sceneManager = Manager::getSingleton()->getSceneMgr();
         skeletonDebug = std::make_unique<SkeletonDebug>(entity, sceneManager);

--- a/src/SkeletonTransform_test.cpp
+++ b/src/SkeletonTransform_test.cpp
@@ -25,7 +25,9 @@ protected:
 
         ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
 
-        QStringList validUri{"./media/models/robot.mesh"};
+        const QString robotPath = testRobotMeshPath();
+        ASSERT_FALSE(robotPath.isEmpty()) << "robot.mesh not found under media/models";
+        QStringList validUri{robotPath};
         ASSERT_NO_THROW(MeshImporterExporter::importer(validUri));
 
         ASSERT_FALSE(Manager::getSingleton()->getEntities().isEmpty());

--- a/src/SkeletonTransform_test.cpp
+++ b/src/SkeletonTransform_test.cpp
@@ -20,33 +20,18 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
 
-        if (!canLoadMeshFiles()) {
-            GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-        }
+        ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
 
-        // Import robot.mesh which has a skeleton with animations
         QStringList validUri{"./media/models/robot.mesh"};
-        try {
-            MeshImporterExporter::importer(validUri);
-        } catch (const Ogre::Exception& e) {
-            GTEST_SKIP() << "Skipping: failed to import robot.mesh ("
-                         << e.getFullDescription() << ")";
-        }
+        ASSERT_NO_THROW(MeshImporterExporter::importer(validUri));
 
-        entity = Manager::getSingleton()->getEntities().isEmpty()
-                     ? nullptr
-                     : Manager::getSingleton()->getEntities().last();
-        if (!entity) {
-            GTEST_SKIP() << "Skipping: no entity available after import";
-        }
-        if (!entity->hasSkeleton()) {
-            GTEST_SKIP() << "Skipping: imported entity has no skeleton";
-        }
+        ASSERT_FALSE(Manager::getSingleton()->getEntities().isEmpty());
+        entity = Manager::getSingleton()->getEntities().last();
+        ASSERT_NE(entity, nullptr);
+        ASSERT_TRUE(entity->hasSkeleton());
     }
 
     void TearDown() override {
@@ -99,9 +84,7 @@ TEST_F(SkeletonTransformTest, RenameAnimationValidRenameReturnsTrue)
     ASSERT_NE(sk, nullptr);
 
     // Find a real animation name from the skeleton
-    if (sk->getNumAnimations() == 0) {
-        GTEST_SKIP() << "Skipping: skeleton has no animations";
-    }
+    ASSERT_GT(sk->getNumAnimations(), 0u);
     Ogre::Animation* firstAnim = sk->getAnimation(0);
     QString oldName = QString::fromStdString(firstAnim->getName());
     Ogre::Real expectedLength = firstAnim->getLength();
@@ -131,9 +114,7 @@ TEST_F(SkeletonTransformTest, RenameAnimationPreservesKeyframes)
     ASSERT_NE(sk, nullptr);
 
     // Find an animation with tracks and keyframes
-    if (sk->getNumAnimations() == 0) {
-        GTEST_SKIP() << "Skipping: skeleton has no animations";
-    }
+    ASSERT_GT(sk->getNumAnimations(), 0u);
     Ogre::Animation* firstAnim = sk->getAnimation(0);
     QString oldName = QString::fromStdString(firstAnim->getName());
 
@@ -163,9 +144,7 @@ TEST_F(SkeletonTransformTest, RenameAnimationPreservesKeyframes)
         break;
     }
 
-    if (!foundTrack) {
-        GTEST_SKIP() << "Skipping: no animation tracks found with keyframes";
-    }
+    ASSERT_TRUE(foundTrack) << "no animation tracks found with keyframes";
 
     QString newName = "KeyframePreserved_TestUnique";
     bool result = SkeletonTransform::renameAnimation(entity, oldName, newName);
@@ -192,9 +171,7 @@ TEST_F(SkeletonTransformTest, RenameAnimationAlreadyRenamedReturnsFalse)
     Ogre::Skeleton* sk = entity->getSkeleton();
     ASSERT_NE(sk, nullptr);
 
-    if (sk->getNumAnimations() == 0) {
-        GTEST_SKIP() << "Skipping: skeleton has no animations";
-    }
+    ASSERT_GT(sk->getNumAnimations(), 0u);
     Ogre::Animation* firstAnim = sk->getAnimation(0);
     QString oldName = QString::fromStdString(firstAnim->getName());
     QString newName = "AlreadyRenamed_TestUnique";
@@ -217,9 +194,7 @@ TEST_F(SkeletonTransformTest, ScaleSkeletonUniformScale)
     ASSERT_NE(sk, nullptr);
 
     auto bones = sk->getBones();
-    if (bones.empty()) {
-        GTEST_SKIP() << "Skipping: skeleton has no bones";
-    }
+    ASSERT_FALSE(bones.empty()) << "skeleton has no bones";
 
     // Record the initial root bone positions
     std::vector<Ogre::Vector3> initialPositions;
@@ -252,9 +227,7 @@ TEST_F(SkeletonTransformTest, ScaleSkeletonDoubleScale)
     ASSERT_NE(sk, nullptr);
 
     auto bones = sk->getBones();
-    if (bones.empty()) {
-        GTEST_SKIP() << "Skipping: skeleton has no bones";
-    }
+    ASSERT_FALSE(bones.empty()) << "skeleton has no bones";
 
     // Record root bone positions before scaling
     std::vector<Ogre::Vector3> initialPositions;
@@ -291,9 +264,7 @@ TEST_F(SkeletonTransformTest, TranslateSkeletonZeroVector)
     ASSERT_NE(sk, nullptr);
 
     auto bones = sk->getBones();
-    if (bones.empty()) {
-        GTEST_SKIP() << "Skipping: skeleton has no bones";
-    }
+    ASSERT_FALSE(bones.empty()) << "skeleton has no bones";
 
     // Record root bone positions
     std::vector<Ogre::Vector3> initialPositions;
@@ -325,9 +296,7 @@ TEST_F(SkeletonTransformTest, TranslateSkeletonAppliesOffset)
     ASSERT_NE(sk, nullptr);
 
     auto bones = sk->getBones();
-    if (bones.empty()) {
-        GTEST_SKIP() << "Skipping: skeleton has no bones";
-    }
+    ASSERT_FALSE(bones.empty()) << "skeleton has no bones";
 
     // Record root bone positions
     std::vector<Ogre::Vector3> initialPositions;
@@ -364,9 +333,7 @@ TEST_F(SkeletonTransformTest, RotateSkeletonZeroRotation)
     ASSERT_NE(sk, nullptr);
 
     auto bones = sk->getBones();
-    if (bones.empty()) {
-        GTEST_SKIP() << "Skipping: skeleton has no bones";
-    }
+    ASSERT_FALSE(bones.empty()) << "skeleton has no bones";
 
     // Record root bone orientations
     std::vector<Ogre::Quaternion> initialOrientations;
@@ -400,9 +367,7 @@ TEST_F(SkeletonTransformTest, RotateSkeletonXAxis)
     ASSERT_NE(sk, nullptr);
 
     auto bones = sk->getBones();
-    if (bones.empty()) {
-        GTEST_SKIP() << "Skipping: skeleton has no bones";
-    }
+    ASSERT_FALSE(bones.empty()) << "skeleton has no bones";
 
     // Record root bone orientations before rotation
     std::vector<Ogre::Quaternion> initialOrientations;
@@ -437,9 +402,7 @@ TEST_F(SkeletonTransformTest, RotateSkeletonYAxis)
     ASSERT_NE(sk, nullptr);
 
     auto bones = sk->getBones();
-    if (bones.empty()) {
-        GTEST_SKIP() << "Skipping: skeleton has no bones";
-    }
+    ASSERT_FALSE(bones.empty()) << "skeleton has no bones";
 
     std::vector<Ogre::Quaternion> initialOrientations;
     for (const auto& bone : bones) {
@@ -472,9 +435,7 @@ TEST_F(SkeletonTransformTest, RotateSkeletonZAxis)
     ASSERT_NE(sk, nullptr);
 
     auto bones = sk->getBones();
-    if (bones.empty()) {
-        GTEST_SKIP() << "Skipping: skeleton has no bones";
-    }
+    ASSERT_FALSE(bones.empty()) << "skeleton has no bones";
 
     std::vector<Ogre::Quaternion> initialOrientations;
     for (const auto& bone : bones) {
@@ -511,9 +472,7 @@ TEST_F(SkeletonTransformTest, RotateSkeletonRotatesBonePositionsAroundMeshCenter
     ASSERT_NE(sk, nullptr);
 
     auto bones = sk->getBones();
-    if (bones.empty()) {
-        GTEST_SKIP() << "Skipping: skeleton has no bones";
-    }
+    ASSERT_FALSE(bones.empty()) << "skeleton has no bones";
 
     Ogre::Vector3 meshCenter = entity->getMesh()->getBounds().getCenter();
 
@@ -553,9 +512,7 @@ TEST_F(SkeletonTransformTest, RotateSkeletonYAxisRotatesBonePositions)
     ASSERT_NE(sk, nullptr);
 
     auto bones = sk->getBones();
-    if (bones.empty()) {
-        GTEST_SKIP() << "Skipping: skeleton has no bones";
-    }
+    ASSERT_FALSE(bones.empty()) << "skeleton has no bones";
 
     Ogre::Vector3 meshCenter = entity->getMesh()->getBounds().getCenter();
 
@@ -598,9 +555,7 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
     }
 
@@ -613,7 +568,7 @@ protected:
 
 TEST_F(SkeletonTransformNoSkeletonTest, ScaleSkeletonNoSkeletonDoesNotCrash)
 {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
     // Create a simple mesh without a skeleton
     auto* mgr = Manager::getSingletonPtr();
     ASSERT_NE(mgr, nullptr);
@@ -681,14 +636,10 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
 
-        if (!canLoadMeshFiles()) {
-            GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-        }
+        ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
         // Use unique names per test to avoid resource conflicts
         static int counter = 0;
@@ -698,9 +649,7 @@ protected:
         nodeName = QString("ProgSkNode_%1").arg(counter);
 
         entity = createEntityWithSkeleton();
-        if (!entity) {
-            GTEST_SKIP() << "Skipping: failed to create programmatic skeleton entity";
-        }
+        ASSERT_NE(entity, nullptr) << "failed to create programmatic skeleton entity";
     }
 
     void TearDown() override {
@@ -931,9 +880,7 @@ TEST_F(SkeletonTransformProgrammaticTest, RotatePreservesAnimationData)
     auto* sk = entity->getSkeleton();
     ASSERT_NE(sk, nullptr);
 
-    if (sk->getNumAnimations() == 0) {
-        GTEST_SKIP() << "Skipping: no animations on skeleton";
-    }
+    ASSERT_GT(sk->getNumAnimations(), 0u);
 
     auto* anim = sk->getAnimation(static_cast<unsigned short>(0));
     Ogre::Real originalLength = anim->getLength();
@@ -1031,8 +978,7 @@ TEST_F(SkeletonTransformProgrammaticTest, ScalePreservesAnimationData)
     auto* sk = entity->getSkeleton();
     ASSERT_NE(sk, nullptr);
 
-    if (sk->getNumAnimations() == 0)
-        GTEST_SKIP() << "Skipping: no animations on skeleton";
+    ASSERT_GT(sk->getNumAnimations(), 0u);
 
     auto* anim = sk->getAnimation(static_cast<unsigned short>(0));
     Ogre::Real originalLength = anim->getLength();

--- a/src/SpaceCamera_test.cpp
+++ b/src/SpaceCamera_test.cpp
@@ -40,9 +40,7 @@ protected:
         auto* app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
     }
 
@@ -716,6 +714,8 @@ protected:
                 QThread::msleep(200 * attempt);
             }
         }
+        ASSERT_NE(mainWindow, nullptr)
+            << "MainWindow failed to initialize (Xvfb/GL required for integration tests)";
     }
 
     static void TearDownTestSuite()
@@ -733,16 +733,13 @@ protected:
 
     void SetUp() override
     {
-        if (!mainWindow) {
-            GTEST_SKIP() << "Failed to initialize MainWindow for SpaceCameraWidgetIntegrationTest";
-        }
-
+        ASSERT_NE(mainWindow, nullptr);
         try {
             viewport = new EditorViewport(mainWindow, 31);
         } catch (const std::exception& e) {
-            GTEST_SKIP() << "EditorViewport creation failed: " << e.what();
+            FAIL() << "EditorViewport creation failed: " << e.what();
         } catch (...) {
-            GTEST_SKIP() << "EditorViewport creation failed with unknown exception";
+            FAIL() << "EditorViewport creation failed with unknown exception";
         }
         ASSERT_NE(viewport, nullptr);
 

--- a/src/SubEntityHighlight_test.cpp
+++ b/src/SubEntityHighlight_test.cpp
@@ -22,9 +22,7 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
 
         createStandardOgreMaterials();
         SelectionSet::getSingleton()->clear();

--- a/src/TestHelpers.h
+++ b/src/TestHelpers.h
@@ -10,6 +10,8 @@
 #include <QGuiApplication>
 #include <QWidget>
 #include <QFile>
+#include <QFileInfo>
+#include <QDir>
 #include "Manager.h"
 
 /**
@@ -82,6 +84,34 @@ static inline void createStandardOgreMaterials()
         guiMat->getTechnique(0)->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
         guiMat->getTechnique(0)->setDepthCheckEnabled(false);
     }
+}
+
+/**
+ * Absolute path to media/models/robot.mesh for tests (binary is typically
+ * under <build>/bin; two levels up reaches the repo root). Falls back to
+ * QTMESH_UT_SOURCE_ROOT when defined (UnitTests target), then ./media/...
+ */
+static inline QString testRobotMeshPath()
+{
+    const QString binDir = QCoreApplication::applicationDirPath();
+    QDir dir(binDir);
+    if (dir.cdUp() && dir.cdUp()) {
+        const QString p = dir.absoluteFilePath(QStringLiteral("media/models/robot.mesh"));
+        if (QFile::exists(p))
+            return p;
+    }
+#ifdef QTMESH_UT_SOURCE_ROOT
+    {
+        const QString p = QDir(QString::fromUtf8(QTMESH_UT_SOURCE_ROOT))
+                              .filePath(QStringLiteral("media/models/robot.mesh"));
+        if (QFile::exists(p))
+            return p;
+    }
+#endif
+    const QString legacy = QStringLiteral("./media/models/robot.mesh");
+    if (QFile::exists(legacy))
+        return QFileInfo(legacy).absoluteFilePath();
+    return {};
 }
 
 /**

--- a/src/TestHelpers.h
+++ b/src/TestHelpers.h
@@ -6,6 +6,7 @@
 #include <OgreRoot.h>
 #include <OgreException.h>
 #include <OgreStringConverter.h>
+#include <QCoreApplication>
 #include <QGuiApplication>
 #include <QWidget>
 #include <QFile>
@@ -115,6 +116,9 @@ static inline bool createTestRenderWindow()
         hiddenWidget->resize(1, 1);
         hiddenWidget->show();
     }
+    // Native window / valid WId for externalWindowHandle (needed on headless X11 / Xvfb).
+    if (QCoreApplication::instance())
+        QCoreApplication::processEvents();
     try {
         Ogre::NameValuePairList params;
         params["externalWindowHandle"] = Ogre::StringConverter::toString(
@@ -142,21 +146,17 @@ static inline bool createTestRenderWindow()
  * the crash is a SIGSEGV (not a C++ exception) and cannot be caught
  * here. On Linux CI with Xvfb, GL context creation succeeds.
  *
- * Returns true if Ogre initialized successfully, false otherwise.
- * Test fixtures should call this and GTEST_SKIP() on false.
+ * Returns true only if a render window exists or was created (GL context for HW buffers).
+ * Test fixtures should use ASSERT_TRUE(tryInitOgre()) in CI — never skip silently.
  */
 static inline bool tryInitOgre()
 {
-    // Already initialized — ensure render window exists
-    if (Manager::getSingletonPtr()) {
-        createTestRenderWindow();
-        return true;
-    }
+    if (Manager::getSingletonPtr())
+        return createTestRenderWindow();
 
     try {
         Manager::getSingleton();
-        createTestRenderWindow();
-        return true;
+        return createTestRenderWindow();
     } catch (const Ogre::Exception&) {
         return false;
     } catch (...) {
@@ -171,8 +171,7 @@ static inline bool tryInitOgre()
  * A GL context is available when either a RenderWindow has been created
  * (via createTestRenderWindow() or OgreWidget) or Ogre auto-created one.
  *
- * Tests that create entities or meshes should call this and GTEST_SKIP()
- * if false.
+ * Use ASSERT_TRUE(canLoadMeshFiles()) in tests — failures must fail the job, not skip.
  */
 static inline bool canLoadMeshFiles()
 {
@@ -194,7 +193,8 @@ static inline bool canLoadMeshFiles()
 #if defined(__clang__) || defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
-    return false;
+    // Ogre is up but no window yet — create TestHidden (Linux CI / Xvfb path).
+    return Manager::getSingletonPtr() && createTestRenderWindow();
 }
 
 /**

--- a/src/TestHelpers.h
+++ b/src/TestHelpers.h
@@ -100,9 +100,9 @@ static inline bool createTestRenderWindow()
     if (!root || !root->getRenderSystem())
         return false;
 
-    // Already have a render window
+    // Already have a render window (tests use TestHidden; CLIPipeline::initOgreHeadless uses CLIHidden)
     try {
-        if (root->getRenderTarget("TestHidden"))
+        if (root->getRenderTarget("TestHidden") || root->getRenderTarget("CLIHidden"))
             return true;
     } catch (...) {
         // getRenderTarget throws if not found in some Ogre versions
@@ -179,9 +179,9 @@ static inline bool canLoadMeshFiles()
     auto* root = Ogre::Root::getSingletonPtr();
     if (!root || !root->getRenderSystem())
         return false;
-    // Check for our test render window
+    // Check for our test / CLI headless render window
     try {
-        if (root->getRenderTarget("TestHidden"))
+        if (root->getRenderTarget("TestHidden") || root->getRenderTarget("CLIHidden"))
             return true;
     } catch (...) {}
     // Check for auto-created window (legacy path)

--- a/src/TransformOperator_test.cpp
+++ b/src/TransformOperator_test.cpp
@@ -77,9 +77,7 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
 
         createStandardOgreMaterials();
         op = TransformOperator::getSingleton();
@@ -227,9 +225,7 @@ TEST_F(TransformOperatorTests, PivotPointForNodeSelectionSupportsCenterBottomAnd
 
 TEST_F(TransformOperatorTests, PivotPointForEntitySelectionSupportsCenterBottomAndOrigin)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entityA = createSelectedEntity("PivotEntityNodeA", "PivotEntityA", "PivotEntityMeshA");
     Ogre::Entity* entityB = createSelectedEntity("PivotEntityNodeB", "PivotEntityB", "PivotEntityMeshB");
@@ -264,9 +260,7 @@ TEST_F(TransformOperatorTests, PivotPointForEntitySelectionSupportsCenterBottomA
 
 TEST_F(TransformOperatorTests, PivotPointForSubEntitySelectionSupportsCenterBottomAndOrigin)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
     Ogre::Entity* entity = createSelectedEntity("PivotSubNode", "PivotSubEntity", "PivotSubMesh");
     ASSERT_NE(entity, nullptr);
@@ -420,9 +414,7 @@ TEST_F(TransformOperatorTests, UpdateGizmoUsesRootOrientationForMultipleLocalNod
 TEST_F(TransformOperatorTests, UpdateGizmoPositionForEntitySelectionUsesTrackedScaleAndOrientation)
 {
     Ogre::Entity* entity = createSelectedEntity("TrackedEntityNode", "TrackedEntity", "TrackedEntityMesh");
-    if (!entity) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_NE(entity, nullptr);
 
     SelectionSet::getSingleton()->setEntityScaleFactor(entity, Ogre::Vector3(1.4f, 1.5f, 1.6f));
     SelectionSet::getSingleton()->setEntityRotation(entity, Ogre::Vector3(10.0f, 20.0f, 30.0f));
@@ -522,9 +514,7 @@ TEST_F(TransformOperatorTests, OnSelectionChangedRestoresNodeInitialState)
 TEST_F(TransformOperatorTests, OnSelectionChangedNormalizesSelectedEntityParentNode)
 {
     Ogre::Entity* entity = createSelectedEntity("EntityStateNode", "EntityStateEntity", "EntityStateMesh");
-    if (!entity) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_NE(entity, nullptr);
 
     Ogre::SceneNode* parentNode = entity->getParentSceneNode();
     // onSelectionChanged() treats an Entity selection differently: it normalizes the parent SceneNode
@@ -541,9 +531,7 @@ TEST_F(TransformOperatorTests, OnSelectionChangedNormalizesSelectedEntityParentN
 TEST_F(TransformOperatorTests, OnSelectionChangedNormalizesSelectedSubEntityParentNode)
 {
     Ogre::Entity* entity = createSelectedEntity("SubEntityStateNode", "SubEntityStateEntity", "SubEntityStateMesh");
-    if (!entity) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_NE(entity, nullptr);
 
     Ogre::SubEntity* subEntity = entity->getSubEntity(0);
     ASSERT_NE(subEntity, nullptr);
@@ -564,9 +552,7 @@ TEST_F(TransformOperatorTests, OnSelectionChangedNormalizesSelectedSubEntityPare
 TEST_F(TransformOperatorTests, EntityRotationVectorSetterTracksAbsoluteRotation)
 {
     Ogre::Entity* entity = createSelectedEntity("EntityRotateNode", "EntityRotateEntity", "EntityRotateMesh");
-    if (!entity) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_NE(entity, nullptr);
 
     op->rotateSelected(Ogre::Vector3(10.0f, 20.0f, 30.0f));
     EXPECT_EQ(SelectionSet::getSingleton()->getEntityRotation(entity), Ogre::Vector3(10.0f, 20.0f, 30.0f));
@@ -578,9 +564,7 @@ TEST_F(TransformOperatorTests, EntityRotationVectorSetterTracksAbsoluteRotation)
 TEST_F(TransformOperatorTests, EntityScaleSetterTracksScaleFactor)
 {
     Ogre::Entity* entity = createSelectedEntity("EntityScaleNode", "EntityScaleEntity", "EntityScaleMesh");
-    if (!entity) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_NE(entity, nullptr);
 
     op->setSelectedScale(Ogre::Vector3(1.2f, 1.3f, 1.4f));
 
@@ -590,9 +574,7 @@ TEST_F(TransformOperatorTests, EntityScaleSetterTracksScaleFactor)
 TEST_F(TransformOperatorTests, EntityScaleSetterReplacesPreviousTrackedScale)
 {
     Ogre::Entity* entity = createSelectedEntity("EntityScaleNode2", "EntityScaleEntity2", "EntityScaleMesh2");
-    if (!entity) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_NE(entity, nullptr);
 
     op->setSelectedScale(Ogre::Vector3(1.2f, 1.3f, 1.4f));
     op->setSelectedScale(Ogre::Vector3(2.0f, 2.5f, 3.0f));
@@ -603,9 +585,7 @@ TEST_F(TransformOperatorTests, EntityScaleSetterReplacesPreviousTrackedScale)
 TEST_F(TransformOperatorTests, EntityQuaternionRotationAccumulatesTrackedEulerDelta)
 {
     Ogre::Entity* entity = createSelectedEntity("EntityQuatNode", "EntityQuatEntity", "EntityQuatMesh");
-    if (!entity) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_NE(entity, nullptr);
 
     SelectionSet::getSingleton()->setEntityRotation(entity, Ogre::Vector3(0.0f, 10.0f, 0.0f));
     op->rotateSelected(Ogre::Quaternion(Ogre::Degree(20), Ogre::Vector3::UNIT_Y));

--- a/src/TranslationGizmo_test.cpp
+++ b/src/TranslationGizmo_test.cpp
@@ -38,11 +38,9 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createOGREMaterials();
-        if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: entity creation not supported without render window"; }
+        ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
 
         Manager* manager = Manager::getSingleton();
         ASSERT_NE(manager, nullptr);

--- a/src/ViewportGrid_test.cpp
+++ b/src/ViewportGrid_test.cpp
@@ -18,9 +18,7 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
 
         ensureMaterialManagerInitialised();
 

--- a/src/commands/TransformCommands_test.cpp
+++ b/src/commands/TransformCommands_test.cpp
@@ -19,9 +19,7 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
     }
 
     void TearDown() override {
@@ -438,7 +436,7 @@ TEST_F(TransformCommandsTests, DeleteCommand_FirstRedoIsNoop) {
 }
 
 TEST_F(TransformCommandsTests, DeleteCommand_UndoRestoresVisibility) {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: needs entity"; }
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Manager* mgr = Manager::getSingleton();
     Ogre::SceneNode* node = mgr->addSceneNode("DelCmdNode2");
@@ -489,7 +487,7 @@ TEST_F(TransformCommandsTests, DeleteCommand_SecondRedoHidesNode) {
 }
 
 TEST_F(TransformCommandsTests, DeleteCommand_SecondRedoHidesAttachedEntity) {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: needs entity"; }
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Manager* mgr = Manager::getSingleton();
     Ogre::SceneNode* node = mgr->addSceneNode("DelCmdNodeEntity");
@@ -603,7 +601,7 @@ TEST_F(TransformCommandsTests, DuplicateCommand_FirstRedoIsNoop) {
 }
 
 TEST_F(TransformCommandsTests, DuplicateCommand_UndoDestroysClones) {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: needs entity"; }
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Manager* mgr = Manager::getSingleton();
     Ogre::SceneNode* srcNode = mgr->addSceneNode("DupCmdHideSrc");
@@ -638,7 +636,7 @@ TEST_F(TransformCommandsTests, DuplicateCommand_UndoDestroysClones) {
 }
 
 TEST_F(TransformCommandsTests, DuplicateCommand_RedoRecreatesClones) {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: needs entity"; }
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Manager* mgr = Manager::getSingleton();
     Ogre::SceneNode* srcNode = mgr->addSceneNode("DupCmdShowSrc");
@@ -1176,7 +1174,7 @@ TEST_F(TransformCommandsTests, ReparentCommand_RedoToRootWhenNewParentNameEmpty)
 // ---- SubMeshTransformCommand ----
 
 TEST_F(TransformCommandsTests, SubMeshTransformCommand_TranslateUndoRedo) {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: needs GL context"; }
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Manager* mgr = Manager::getSingleton();
     auto mesh = createInMemoryTriangleMesh("SubMeshCmdTranslate");
@@ -1242,7 +1240,7 @@ TEST_F(TransformCommandsTests, SubMeshTransformCommand_NullSubEntity) {
 }
 
 TEST_F(TransformCommandsTests, SubMeshTransformCommand_NonZeroSubMeshIndexTargetsCorrectSubMesh) {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: needs GL context"; }
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Manager* mgr = Manager::getSingleton();
     auto mesh = createInMemoryTwoSubMeshMesh("SubMeshCmdTwoSubMeshIndex");
@@ -1296,7 +1294,7 @@ TEST_F(TransformCommandsTests, SubMeshTransformCommand_NonZeroSubMeshIndexTarget
 }
 
 TEST_F(TransformCommandsTests, SubMeshTransform_GetCenter) {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: needs GL context"; }
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Manager* mgr = Manager::getSingleton();
     auto mesh = createInMemoryTriangleMesh("SubMeshCenterTest");
@@ -1313,7 +1311,7 @@ TEST_F(TransformCommandsTests, SubMeshTransform_GetCenter) {
 }
 
 TEST_F(TransformCommandsTests, SubMeshTransform_ReadWritePositions) {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: needs GL context"; }
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Manager* mgr = Manager::getSingleton();
     auto mesh = createInMemoryTriangleMesh("SubMeshRWTest");
@@ -1339,7 +1337,7 @@ TEST_F(TransformCommandsTests, SubMeshTransform_ReadWritePositions) {
 // ---- SubMeshTransform: scaleSubMesh ----
 
 TEST_F(TransformCommandsTests, SubMeshTransform_ScaleSubMesh) {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: needs GL context"; }
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Manager* mgr = Manager::getSingleton();
     auto mesh = createInMemoryTriangleMesh("SubMeshScaleTest");
@@ -1373,7 +1371,7 @@ TEST_F(TransformCommandsTests, SubMeshTransform_ScaleSubMesh) {
 // ---- SubMeshTransform: rotateSubMesh ----
 
 TEST_F(TransformCommandsTests, SubMeshTransform_RotateSubMesh) {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: needs GL context"; }
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Manager* mgr = Manager::getSingleton();
     auto mesh = createInMemoryTriangleMesh("SubMeshRotateTest");
@@ -1408,7 +1406,7 @@ TEST_F(TransformCommandsTests, SubMeshTransform_RotateSubMesh) {
 // ---- SubMeshTransform: rotateSubMesh preserves centroid ----
 
 TEST_F(TransformCommandsTests, SubMeshTransform_RotatePreservesCentroid) {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: needs GL context"; }
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Manager* mgr = Manager::getSingleton();
     auto mesh = createInMemoryTriangleMesh("SubMeshRotCenterTest");
@@ -1432,7 +1430,7 @@ TEST_F(TransformCommandsTests, SubMeshTransform_RotatePreservesCentroid) {
 // ---- SubMeshTransform: scaleSubMesh preserves centroid ----
 
 TEST_F(TransformCommandsTests, SubMeshTransform_ScalePreservesCentroid) {
-    if (!canLoadMeshFiles()) { GTEST_SKIP() << "Skipping: needs GL context"; }
+    ASSERT_TRUE(canLoadMeshFiles());
 
     Manager* mgr = Manager::getSingleton();
     auto mesh = createInMemoryTriangleMesh("SubMeshScaleCenterTest");

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -269,20 +269,25 @@ MainWindow::~MainWindow()
     // The Manager will clean up all OGRE resources (scene manager, root, etc.)
     // Only destroy Manager if it still exists and belongs to this MainWindow
     // (In tests, Manager may be destroyed separately in TearDown)
-    // These singletons are safe to destroy unconditionally.
-    EditModeController::kill();
-    SubEntityHighlight::kill();
-    AnimationControlController::kill();
-    MeshLodController::kill();
-    MeshValidator::kill();
-    MaterialPresetLibrary::kill();
-    MaterialPreviewRenderer::kill();
-    AIChatManager::kill();
-    // Only destroy Manager if it still exists and belongs to this MainWindow
-    // (In tests, Manager may be destroyed separately in TearDown)
+    // In tests, other suites may have already destroyed Manager (and therefore
+    // Ogre resources). In that case, destroying Ogre-backed singletons can
+    // crash due to dangling SceneManager pointers — skip teardown and let the
+    // process exit cleanly.
     Manager* manager = Manager::getSingletonPtr();
-    if(manager && manager->getMainWindow() == this)
-        Manager::kill();
+    if (manager) {
+        EditModeController::kill();
+        SubEntityHighlight::kill();
+        AnimationControlController::kill();
+        MeshLodController::kill();
+        MeshValidator::kill();
+        MaterialPresetLibrary::kill();
+        MaterialPreviewRenderer::kill();
+        AIChatManager::kill();
+
+        // Only destroy Manager if it still exists and belongs to this MainWindow
+        if (manager->getMainWindow() == this)
+            Manager::kill();
+    }
 }
 
 void MainWindow::initToolBar()

--- a/src/mainwindow_test.cpp
+++ b/src/mainwindow_test.cpp
@@ -60,17 +60,15 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
         createStandardOgreMaterials();
 
         try {
             window = new MainWindow();
         } catch (const std::exception& e) {
-            GTEST_SKIP() << "Skipping: MainWindow construction failed in this environment: " << e.what();
+            FAIL() << "MainWindow construction failed: " << e.what();
         } catch (...) {
-            GTEST_SKIP() << "Skipping: MainWindow construction failed in this environment";
+            FAIL() << "MainWindow construction failed with unknown exception";
         }
 
         ASSERT_NE(window, nullptr);
@@ -529,9 +527,9 @@ TEST_F(MainWindowTest, ConstructorAutostartsMCPServerWhenEnabledInSettings)
     try {
         window = new MainWindow();
     } catch (const std::exception& e) {
-        GTEST_SKIP() << "Skipping: MainWindow reconstruction failed in this environment: " << e.what();
+        FAIL() << "MainWindow reconstruction failed: " << e.what();
     } catch (...) {
-        GTEST_SKIP() << "Skipping: MainWindow reconstruction failed in this environment";
+        FAIL() << "MainWindow reconstruction failed with unknown exception";
     }
 
     ASSERT_NE(window, nullptr);
@@ -551,9 +549,7 @@ TEST_F(MainWindowTest, UpdateMergeAnimationsButtonDisablesActionWhenSelectionHas
 
 TEST_F(MainWindowTest, UpdateMergeAnimationsButtonDisablesActionForSingleSkeletonEntity) {
     Ogre::Entity* entity = createAnimatedEntity("SingleSkeletonEntity");
-    if (!entity) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_NE(entity, nullptr);
 
     SelectionSet::getSingleton()->clear();
     SelectionSet::getSingleton()->append(entity);
@@ -566,9 +562,8 @@ TEST_F(MainWindowTest, UpdateMergeAnimationsButtonDisablesActionForSingleSkeleto
 TEST_F(MainWindowTest, UpdateMergeAnimationsButtonEnablesActionForCompatibleSkeletonEntities) {
     Ogre::Entity* entityA = createAnimatedEntity("MergeSkeletonEntityA");
     Ogre::Entity* entityB = createAnimatedEntity("MergeSkeletonEntityB");
-    if (!entityA || !entityB) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_NE(entityA, nullptr);
+    ASSERT_NE(entityB, nullptr);
 
     SelectionSet::getSingleton()->clear();
     SelectionSet::getSingleton()->append(entityA);
@@ -582,9 +577,8 @@ TEST_F(MainWindowTest, UpdateMergeAnimationsButtonEnablesActionForCompatibleSkel
 TEST_F(MainWindowTest, UpdateMergeAnimationsButtonResolvesEntitiesFromSelectedNodes) {
     Ogre::Entity* entityA = createAnimatedEntity("MergeNodeEntityA");
     Ogre::Entity* entityB = createAnimatedEntity("MergeNodeEntityB");
-    if (!entityA || !entityB) {
-        GTEST_SKIP() << "Skipping: entity creation not supported without render window";
-    }
+    ASSERT_NE(entityA, nullptr);
+    ASSERT_NE(entityB, nullptr);
 
     SelectionSet::getSingleton()->clear();
     SelectionSet::getSingleton()->append(entityA->getParentSceneNode());
@@ -682,9 +676,7 @@ TEST_F(MainWindowTest, UngroupSelectedIgnoresNonGroupNode) {
 }
 TEST_F(MainWindowTest, EditModeKeyboardShortcutsCoverModeAndTopologyPaths)
 {
-    if (!canLoadMeshFiles()) {
-        GTEST_SKIP() << "Skipping: mesh loading not supported in headless mode";
-    }
+    ASSERT_TRUE(canLoadMeshFiles()) << "mesh loading requires GL (Xvfb in CI)";
 
     const std::string meshName = "mainwindow_shortcuts_mesh";
     auto mesh = createInMemoryTriangleMesh(meshName);
@@ -775,9 +767,7 @@ TEST_F(MainWindowTest, TriggeringDynamicHelpAndPreferencesActionsCreatesDialogs)
 
 TEST_F(MainWindowTest, AiChatToolbarButtonAndMenuActionRevealDock)
 {
-    if (!window->m_chatDock) {
-        GTEST_SKIP() << "Skipping: chat dock not available in this build";
-    }
+    ASSERT_NE(window->m_chatDock, nullptr);
 
     window->show();
     app->processEvents();
@@ -805,9 +795,7 @@ TEST_F(MainWindowTest, AiChatToolbarButtonAndMenuActionRevealDock)
 
 TEST_F(MainWindowTest, AssetBrowserMenuActionTracksDockVisibility)
 {
-    if (!window->m_assetBrowserDock) {
-        GTEST_SKIP() << "Skipping: asset browser dock not available in this build";
-    }
+    ASSERT_NE(window->m_assetBrowserDock, nullptr);
 
     window->show();
     app->processEvents();
@@ -896,9 +884,7 @@ TEST_F(MainWindowTest, FrameEndedStatusMessageCoversSelectionKindsAndTransformSp
 TEST_F(MainWindowTest, FrameRenderingQueuedAdvancesEnabledAnimationWhenPlaying)
 {
     Ogre::Entity* entity = createAnimatedEntity("mainwindow_frame_anim_entity");
-    if (!entity) {
-        GTEST_SKIP() << "Skipping: animated entity creation not supported in this environment";
-    }
+    ASSERT_NE(entity, nullptr);
 
     Ogre::AnimationStateSet* states = entity->getAllAnimationStates();
     ASSERT_NE(states, nullptr);
@@ -965,9 +951,9 @@ TEST_F(MainWindowTest, ConstructorAppliesCustomPaletteFromSettings)
     try {
         window = new MainWindow();
     } catch (const std::exception& e) {
-        GTEST_SKIP() << "Skipping: MainWindow reconstruction failed in this environment: " << e.what();
+        FAIL() << "MainWindow reconstruction failed: " << e.what();
     } catch (...) {
-        GTEST_SKIP() << "Skipping: MainWindow reconstruction failed in this environment";
+        FAIL() << "MainWindow reconstruction failed with unknown exception";
     }
     ASSERT_NE(window, nullptr);
 

--- a/src/material_test.cpp
+++ b/src/material_test.cpp
@@ -23,9 +23,7 @@ protected:
         app = qobject_cast<QApplication*>(QCoreApplication::instance());
         ASSERT_NE(app, nullptr);
 
-        if (!tryInitOgre()) {
-            GTEST_SKIP() << "Skipping: Ogre initialization failed";
-        }
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
 
         // Ensure materials are initialized
         ensureMaterialManagerInitialised();

--- a/src/test_main.cpp
+++ b/src/test_main.cpp
@@ -12,6 +12,7 @@
 #include <cstdlib>
 #include <OgreLogManager.h>
 #include "Manager.h"
+#include "TestHelpers.h"
 
 #ifndef Q_OS_WIN
 #include <unistd.h>
@@ -76,6 +77,15 @@ int main(int argc, char **argv)
 #endif
 
     testing::InitGoogleTest(&argc, argv);
+
+    // All GPU-backed tests require a headless GL context (Xvfb on Linux CI).
+    // Fail fast instead of silently skipping hundreds of tests.
+    if (!tryInitOgre()) {
+        fprintf(stderr,
+                "UnitTests FATAL: tryInitOgre() failed — need working DISPLAY / Xvfb for GL.\n");
+        return 1;
+    }
+
     int result = RUN_ALL_TESTS();
     g_testsCompleted = true;
 

--- a/src/test_main.cpp
+++ b/src/test_main.cpp
@@ -8,6 +8,8 @@
  */
 #include <gtest/gtest.h>
 #include <QApplication>
+#include <QCoreApplication>
+#include <QThread>
 #include <csignal>
 #include <cstdlib>
 #include <OgreLogManager.h>
@@ -78,13 +80,18 @@ int main(int argc, char **argv)
 
     testing::InitGoogleTest(&argc, argv);
 
-    // All GPU-backed tests require a headless GL context (Xvfb on Linux CI).
-    // Fail fast instead of silently skipping hundreds of tests.
+    // Prove headless GL works on this runner, then tear down: many suites
+    // (Assimp processors, etc.) construct their own Ogre::Root and cannot
+    // coexist with a live Manager singleton from a prior init.
     if (!tryInitOgre()) {
         fprintf(stderr,
                 "UnitTests FATAL: tryInitOgre() failed — need working DISPLAY / Xvfb for GL.\n");
         return 1;
     }
+    Manager::kill();
+    if (QCoreApplication::instance())
+        QCoreApplication::processEvents();
+    QThread::msleep(50);
 
     int result = RUN_ALL_TESTS();
     g_testsCompleted = true;


### PR DESCRIPTION
## Summary
Improves reliability of the unit test suite and CLI-related mesh loading paths.

## Changes
- **TestHelpers**: `canLoadMeshFiles` / `createTestRenderWindow` recognize `CLIHidden` (from `CLIPipeline::initOgreHeadless`) as well as `TestHidden`, avoiding false "no GL" state after CLI tests.
- **MeshImporterExporter**: Normalize resource group paths with absolute `QFileInfo`; remove a cached mesh in the same (name, group) before `MeshManager::load` so updated files on disk are not masked.
- **CLIPipeline tests**: Export generated `.mesh` files under unique `/tmp/qtmesh_cli_exp_<uuid>/` directories; fix LOD auto-mode test to look for outputs next to the source; centralize cleanup with `removeCliExportTree`.
- **EditableMesh_test**: Regression test for vertex color brush falloff (exponent curve).
- **AnimationMerger_test**: Skip when hardware buffers / GL are unavailable.
- **EditorViewport_test**: Safer teardown and event processing before widget delete.
- **MainWindow**: Skip Ogre singleton `kill()` when `Manager` is already gone (test ordering).

## Verification
- [ ] CI green (Linux tests + Sonar)
- Local: `xvfb-run -a ./bin/UnitTests --gtest_shuffle`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mesh import reliability and resource reloading.
  * Safer shutdown to avoid crashes when shared graphics subsystems are already torn down.

* **Tests**
  * Strengthened test preconditions so missing graphics/runtime support fail explicitly instead of skipping.
  * Improved test isolation and cleanup for exported artifacts and temporary directories.
  * Added/expanded tests for vertex-color painting, deterministic selection setup, preview rendering, and better exception handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->