### PR TITLE
test: add unit tests to raise Sonar coverage

### DIFF
--- a/src/BevelGizmo_test.cpp
+++ b/src/BevelGizmo_test.cpp
@@ -3,6 +3,7 @@
 #include <OgreCamera.h>
 #include <OgreManualObject.h>
 #include <OgreRay.h>
+#include <OgreSceneNode.h>
 #include <QApplication>
 #include <QCoreApplication>
 #include <QThread>
@@ -57,8 +58,13 @@ TEST_F(BevelGizmoTest, AxisVisibilityScaleAndPick)
     EXPECT_NEAR(gizmo.origin().x, 1.0f, 1e-5f);
 
     auto* cam = sm->createCamera("BevelGizmoUT_Cam");
-    cam->setPosition(0, 0, 10);
-    cam->lookAt(Ogre::Vector3(0, 0, 0));
+    cam->setNearClipDistance(0.1f);
+    cam->setFarClipDistance(1000.0f);
+    cam->setAspectRatio(1.0f);
+    Ogre::SceneNode* camNode = sm->getRootSceneNode()->createChildSceneNode("BevelGizmoUT_CamNode");
+    camNode->attachObject(cam);
+    camNode->setPosition(0.0f, 0.0f, 10.0f);
+    camNode->lookAt(Ogre::Vector3::ZERO, Ogre::Node::TS_WORLD);
     gizmo.updateScreenSpaceScale(cam);
     gizmo.updateScreenSpaceScale(nullptr);
 

--- a/src/BevelGizmo_test.cpp
+++ b/src/BevelGizmo_test.cpp
@@ -1,0 +1,80 @@
+#include <gtest/gtest.h>
+#include <cmath>
+#include <OgreCamera.h>
+#include <OgreManualObject.h>
+#include <OgreRay.h>
+#include <QApplication>
+#include <QCoreApplication>
+#include <QThread>
+
+#include "BevelGizmo.h"
+#include "Manager.h"
+#include "TestHelpers.h"
+
+TEST(BevelGizmoStandalone, NullSceneManagerIsSafe)
+{
+    BevelGizmo gizmo(nullptr, "NullBevel");
+    EXPECT_FALSE(gizmo.isVisible());
+    EXPECT_FALSE(gizmo.isHandle(nullptr));
+    Ogre::Ray ray(Ogre::Vector3::ZERO, Ogre::Vector3::UNIT_X);
+    EXPECT_FLOAT_EQ(gizmo.distanceAlongAxis(ray), 0.0f);
+    gizmo.setAxis(Ogre::Vector3(1, 2, 3), Ogre::Vector3::ZERO);
+    EXPECT_TRUE(gizmo.axis().positionEquals(Ogre::Vector3::UNIT_Y, 1e-5f));
+}
+
+class BevelGizmoTest : public ::testing::Test {
+protected:
+    void SetUp() override
+    {
+        Manager::kill();
+        QThread::msleep(50);
+        ASSERT_NE(qobject_cast<QApplication*>(QCoreApplication::instance()), nullptr);
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+        createStandardOgreMaterials();
+    }
+};
+
+TEST_F(BevelGizmoTest, AxisVisibilityScaleAndPick)
+{
+    auto* sm = Manager::getSingleton()->getSceneMgr();
+    ASSERT_NE(sm, nullptr);
+
+    BevelGizmo gizmo(sm, "BevelGizmoUT");
+
+    gizmo.setAxis(Ogre::Vector3(1, 0, 0), Ogre::Vector3(0, 0, 1));
+    EXPECT_TRUE(gizmo.origin().positionEquals(Ogre::Vector3(1, 0, 0), 1e-5f));
+    EXPECT_TRUE(gizmo.axis().positionEquals(Ogre::Vector3::UNIT_Z, 1e-5f));
+
+    gizmo.setVisible(true);
+    EXPECT_TRUE(gizmo.isVisible());
+
+    Ogre::ManualObject* handle = sm->getManualObject("BevelGizmoUT_Handle_Geom");
+    ASSERT_NE(handle, nullptr);
+    EXPECT_TRUE(gizmo.isHandle(handle));
+
+    gizmo.setHandleOffset(0.2f);
+    gizmo.setScale(0.0f);
+    EXPECT_NEAR(gizmo.origin().x, 1.0f, 1e-5f);
+
+    auto* cam = sm->createCamera("BevelGizmoUT_Cam");
+    cam->setPosition(0, 0, 10);
+    cam->lookAt(Ogre::Vector3(0, 0, 0));
+    gizmo.updateScreenSpaceScale(cam);
+    gizmo.updateScreenSpaceScale(nullptr);
+
+    gizmo.setVisible(false);
+    EXPECT_FALSE(gizmo.isVisible());
+}
+
+TEST_F(BevelGizmoTest, DistanceAlongAxisParallelRayReturnsZero)
+{
+    auto* sm = Manager::getSingleton()->getSceneMgr();
+    BevelGizmo gizmo(sm, "BevelGizmoUTParallel");
+    gizmo.setAxis(Ogre::Vector3::ZERO, Ogre::Vector3::UNIT_Y);
+    Ogre::Ray ray(Ogre::Vector3(5, 0, 0), Ogre::Vector3::UNIT_Y);
+    EXPECT_NEAR(gizmo.distanceAlongAxis(ray), 0.0f, 1e-5f);
+
+    Ogre::Ray skew(Ogre::Vector3::ZERO, Ogre::Vector3::UNIT_X);
+    float t = gizmo.distanceAlongAxis(skew);
+    EXPECT_TRUE(std::isfinite(t));
+}

--- a/src/Euler_test.cpp
+++ b/src/Euler_test.cpp
@@ -1,0 +1,55 @@
+#include <gtest/gtest.h>
+#include <cmath>
+#include "Euler.h"
+
+using namespace Ogre;
+
+TEST(EulerTest, IdentityForwardRightUp)
+{
+    Euler e;
+    EXPECT_TRUE(e.forward().positionEquals(Vector3::NEGATIVE_UNIT_Z, 1e-4f));
+    EXPECT_TRUE(e.right().positionEquals(Vector3::UNIT_X, 1e-4f));
+    EXPECT_TRUE(e.up().positionEquals(Vector3::UNIT_Y, 1e-4f));
+}
+
+TEST(EulerTest, ToQuaternionMatchesYawPitchRollOrder)
+{
+    Euler e(Radian(0.5f), Radian(0.25f), Radian(0.1f));
+    Quaternion q = e.toQuaternion();
+    Quaternion expected = Quaternion(e.yaw(), Vector3::UNIT_Y)
+        * Quaternion(e.pitch(), Vector3::UNIT_X)
+        * Quaternion(e.roll(), Vector3::UNIT_Z);
+    EXPECT_NEAR(std::abs(q.dotProduct(expected)), 1.0f, 1e-4f);
+}
+
+TEST(EulerTest, QuaternionRoundTrip)
+{
+    Euler e(Degree(33).valueRadians(), Degree(-12).valueRadians(), Degree(77).valueRadians());
+    Quaternion q = e.toQuaternion();
+    Euler e2(q);
+    EXPECT_NEAR(std::abs(q.dotProduct(e2.toQuaternion())), 1.0f, 1e-3f);
+}
+
+TEST(EulerTest, DirectionSetsYawPitch)
+{
+    Euler e;
+    e.direction(Vector3(0, 0, -1));
+    EXPECT_GT(e.forward().dotProduct(Vector3::NEGATIVE_UNIT_Z), 0.99f);
+}
+
+TEST(EulerTest, RelativeYawPitchRoll)
+{
+    Euler e;
+    e.yaw(Radian(0.1f)).pitch(Radian(0.2f)).roll(Radian(0.3f));
+    EXPECT_NEAR(e.yaw().valueRadians(), 0.1f, 1e-5f);
+    EXPECT_NEAR(e.pitch().valueRadians(), 0.2f, 1e-5f);
+    EXPECT_NEAR(e.roll().valueRadians(), 0.3f, 1e-5f);
+}
+
+TEST(EulerTest, NormaliseWrapsLargeYaw)
+{
+    Euler e;
+    e.setYaw(Radian(5.0f));
+    e.normalise(true, false, false);
+    EXPECT_LT(std::abs(e.yaw().valueRadians()), Math::PI + 0.01f);
+}

--- a/src/Euler_test.cpp
+++ b/src/Euler_test.cpp
@@ -19,7 +19,7 @@ TEST(EulerTest, ToQuaternionMatchesYawPitchRollOrder)
     Quaternion expected = Quaternion(e.yaw(), Vector3::UNIT_Y)
         * Quaternion(e.pitch(), Vector3::UNIT_X)
         * Quaternion(e.roll(), Vector3::UNIT_Z);
-    EXPECT_NEAR(std::abs(q.dotProduct(expected)), 1.0f, 1e-4f);
+    EXPECT_NEAR(std::abs(q.Dot(expected)), 1.0f, 1e-4f);
 }
 
 TEST(EulerTest, QuaternionRoundTrip)
@@ -27,7 +27,7 @@ TEST(EulerTest, QuaternionRoundTrip)
     Euler e(Degree(33).valueRadians(), Degree(-12).valueRadians(), Degree(77).valueRadians());
     Quaternion q = e.toQuaternion();
     Euler e2(q);
-    EXPECT_NEAR(std::abs(q.dotProduct(e2.toQuaternion())), 1.0f, 1e-3f);
+    EXPECT_NEAR(std::abs(q.Dot(e2.toQuaternion())), 1.0f, 1e-3f);
 }
 
 TEST(EulerTest, DirectionSetsYawPitch)

--- a/src/ScanEngine_test.cpp
+++ b/src/ScanEngine_test.cpp
@@ -10,6 +10,7 @@
 #include <QFile>
 #include <QJsonDocument>
 #include <QTemporaryDir>
+#include <QTemporaryFile>
 
 namespace {
 QString writeMinimalObj(const QString& dirPath, const QString& fileName)
@@ -1677,4 +1678,74 @@ TEST(ScanEngineTest, ApplyFixes_RedundantKeyframesPctDryRun)
     ScanEngine::applyFixes(config, QStringLiteral("/"), asset, findings);
     EXPECT_FALSE(findings[0].fixed);
     EXPECT_TRUE(findings[0].message.contains(QStringLiteral("dry-run")));
+}
+
+// ---------------------------------------------------------------------------
+// ScanConfig::loadFromFile (YAML/JSON + missing/invalid)
+// ---------------------------------------------------------------------------
+
+TEST(ScanConfigLoadTest, LoadFromFile_MissingPathReturnsDefaults)
+{
+    ScanConfig c = ScanConfig::loadFromFile(QStringLiteral("/nonexistent/path/qtmesh_nope.yml"));
+    ScanConfig d = ScanConfig::defaults();
+    EXPECT_EQ(c.version, d.version);
+    EXPECT_EQ(c.roots, d.roots);
+}
+
+TEST(ScanConfigLoadTest, LoadFromFile_ValidYaml)
+{
+    QTemporaryFile file(QStringLiteral("%1/scan_ut_XXXXXX.yml").arg(QDir::tempPath()));
+    file.setAutoRemove(true);
+    ASSERT_TRUE(file.open());
+    const char* yaml =
+        "version: 2\n"
+        "scan:\n"
+        "  roots:\n"
+        "    - ./assets\n"
+        "rules:\n"
+        "  max_file_size_mb: 100.5\n"
+        "  require_skeleton: true\n";
+    file.write(yaml);
+    file.flush();
+
+    ScanConfig c = ScanConfig::loadFromFile(file.fileName());
+    EXPECT_EQ(c.version, 2);
+    ASSERT_EQ(c.roots.size(), 1);
+    EXPECT_EQ(c.roots[0], QStringLiteral("./assets"));
+    EXPECT_DOUBLE_EQ(c.maxFileSizeMb, 100.5);
+    EXPECT_TRUE(c.requireSkeleton);
+}
+
+TEST(ScanConfigLoadTest, LoadFromFile_ValidJson)
+{
+    QTemporaryFile file(QStringLiteral("%1/scan_ut_XXXXXX.json").arg(QDir::tempPath()));
+    file.setAutoRemove(true);
+    ASSERT_TRUE(file.open());
+    const char* json = R"json({
+  "version": 3,
+  "scan": { "roots": ["a", "b"] },
+  "report": { "format": "json", "fail_on": "warning" }
+})json";
+    file.write(json);
+    file.flush();
+
+    ScanConfig c = ScanConfig::loadFromFile(file.fileName());
+    EXPECT_EQ(c.version, 3);
+    ASSERT_EQ(c.roots.size(), 2);
+    EXPECT_EQ(c.roots[0], QStringLiteral("a"));
+    EXPECT_EQ(c.reportFormat, QStringLiteral("json"));
+    EXPECT_EQ(c.failOn, QStringLiteral("warning"));
+}
+
+TEST(ScanConfigLoadTest, LoadFromFile_InvalidJsonFallsBackToDefaults)
+{
+    QTemporaryFile file(QStringLiteral("%1/scan_ut_XXXXXX.json").arg(QDir::tempPath()));
+    file.setAutoRemove(true);
+    ASSERT_TRUE(file.open());
+    file.write("{ not valid json");
+    file.flush();
+
+    ScanConfig c = ScanConfig::loadFromFile(file.fileName());
+    ScanConfig d = ScanConfig::defaults();
+    EXPECT_EQ(c.version, d.version);
 }

--- a/src/commands/TransformCommands_test.cpp
+++ b/src/commands/TransformCommands_test.cpp
@@ -1449,3 +1449,27 @@ TEST_F(TransformCommandsTests, SubMeshTransform_ScalePreservesCentroid) {
     EXPECT_NEAR(centerAfter.y, centerBefore.y, 0.01f);
     EXPECT_NEAR(centerAfter.z, centerBefore.z, 0.01f);
 }
+
+TEST_F(TransformCommandsTests, SubMeshTransform_NullEntityIsNoOp)
+{
+    SubMeshTransform::translateSubMesh(nullptr, 0, Ogre::Vector3::UNIT_X);
+    SubMeshTransform::scaleSubMesh(nullptr, 0, Ogre::Vector3::UNIT_SCALE);
+    SubMeshTransform::rotateSubMesh(nullptr, 0, Ogre::Quaternion::IDENTITY);
+    EXPECT_EQ(SubMeshTransform::getSubMeshCenter(nullptr, 0), Ogre::Vector3::ZERO);
+    EXPECT_TRUE(SubMeshTransform::readPositions(nullptr, 0).empty());
+    SubMeshTransform::writePositions(nullptr, 0, {});
+}
+
+TEST_F(TransformCommandsTests, SubMeshTransform_InvalidSubMeshIndex)
+{
+    ASSERT_TRUE(canLoadMeshFiles());
+
+    Manager* mgr = Manager::getSingleton();
+    auto mesh = createInMemoryTriangleMesh("SubMeshBadIdx");
+    auto* entity = mgr->getSceneMgr()->createEntity(mesh);
+    auto* node = mgr->addSceneNode("SubMeshBadIdxNode");
+    node->attachObject(entity);
+
+    EXPECT_EQ(SubMeshTransform::getSubMeshCenter(entity, 99), Ogre::Vector3::ZERO);
+    EXPECT_TRUE(SubMeshTransform::readPositions(entity, 99).empty());
+}


### PR DESCRIPTION
## Summary

Adds unit tests to raise Sonar coverage for **BevelGizmo**, **Euler**, **ScanConfig::loadFromFile**, and **SubMeshTransform** edge cases. Follow-up commit fixes **Linux CI** compile errors against **Ogre 14** (camera must live on a `SceneNode`; quaternions use `Dot`).

## Technical details

### Features (tests)
- **BevelGizmo**: null `SceneManager` safety; axis, visibility, handle offset, scale, `updateScreenSpaceScale`, `isHandle`, `distanceAlongAxis`.
- **Euler**: identity basis vectors, quaternion composition and round-trip, `direction`, relative yaw/pitch/roll, `normalise`.
- **ScanConfig**: `loadFromFile` for missing path, valid YAML/JSON, invalid JSON fallback.
- **SubMeshTransform**: null-entity no-ops; invalid submesh index.

### Bugfixes
- **BevelGizmo_test**: attach camera to a child `SceneNode`, set clip distances and aspect, `lookAt` on the node (Ogre 14 `Camera` API).
- **Euler_test**: replace `dotProduct` with `Quaternion::Dot`.