### PR TITLE
feat(animation): two-way blend preview + bake-to-clip (Phase 5 slice B)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 2.33.0 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 2.34.0 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -1641,8 +1641,7 @@ Rectangle {
             Column {
                 width: parent.width - 16
                 spacing: 4
-                visible: AnimationControlController.hasAnimation
-                         && AnimationBlender.animations.length >= 2
+                visible: AnimationBlender.animations.length >= 2
 
                 Row {
                     spacing: 8

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -1637,6 +1637,132 @@ Rectangle {
                 }
             }
 
+            // ── Blend (two-way live blend + bake) ─────────────────────────────
+            Column {
+                width: parent.width - 16
+                spacing: 4
+                visible: AnimationControlController.hasAnimation
+                         && AnimationBlender.animations.length >= 2
+
+                Row {
+                    spacing: 8
+                    Text {
+                        text: "Blend:"; font.bold: true
+                        color: PropertiesPanelController.textColor; font.pixelSize: 11
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+                    CheckBox {
+                        text: "Active"
+                        checked: AnimationBlender.active
+                        onToggled: AnimationBlender.active = checked
+                        font.pixelSize: 11
+                    }
+                }
+
+                Row {
+                    spacing: 6
+                    width: parent.width
+
+                    ComboBox {
+                        id: animAPicker
+                        width: (parent.width - 12) / 2
+                        height: 24
+                        model: AnimationBlender.animations
+                        property string current: AnimationBlender.animA
+                        currentIndex: model.indexOf(current)
+                        onActivated: AnimationBlender.animA = model[currentIndex]
+                        Connections {
+                            target: AnimationBlender
+                            function onSelectionChanged() {
+                                animAPicker.currentIndex = animAPicker.model.indexOf(AnimationBlender.animA)
+                            }
+                            function onAnimationsChanged() {
+                                animAPicker.currentIndex = animAPicker.model.indexOf(AnimationBlender.animA)
+                            }
+                        }
+                        font.pixelSize: 11
+                    }
+
+                    ComboBox {
+                        id: animBPicker
+                        width: (parent.width - 12) / 2
+                        height: 24
+                        model: AnimationBlender.animations
+                        property string current: AnimationBlender.animB
+                        currentIndex: model.indexOf(current)
+                        onActivated: AnimationBlender.animB = model[currentIndex]
+                        Connections {
+                            target: AnimationBlender
+                            function onSelectionChanged() {
+                                animBPicker.currentIndex = animBPicker.model.indexOf(AnimationBlender.animB)
+                            }
+                            function onAnimationsChanged() {
+                                animBPicker.currentIndex = animBPicker.model.indexOf(AnimationBlender.animB)
+                            }
+                        }
+                        font.pixelSize: 11
+                    }
+                }
+
+                Row {
+                    spacing: 6
+                    width: parent.width
+                    Text {
+                        text: "Weight:"
+                        color: PropertiesPanelController.textColor; font.pixelSize: 11
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+                    Slider {
+                        id: weightSlider
+                        from: 0; to: 1; stepSize: 0.01
+                        width: parent.width - 90
+                        value: AnimationBlender.weight
+                        onMoved: AnimationBlender.weight = value
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+                    Text {
+                        text: AnimationBlender.weight.toFixed(2)
+                        color: PropertiesPanelController.textColor; font.pixelSize: 11
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+                }
+
+                Row {
+                    spacing: 6
+                    width: parent.width
+
+                    ComboBox {
+                        id: modeCombo
+                        width: 100; height: 24
+                        model: ["Mix", "Additive", "Override"]
+                        currentIndex: AnimationBlender.mode
+                        onActivated: AnimationBlender.mode = currentIndex
+                        font.pixelSize: 11
+                    }
+
+                    TextField {
+                        id: bakeNameInput
+                        width: parent.width - 100 - 6 - 70 - 12
+                        height: 24
+                        placeholderText: "BlendedClip"
+                        font.pixelSize: 11
+                    }
+
+                    Button {
+                        text: "Bake"
+                        width: 70; height: 24
+                        font.pixelSize: 11
+                        onClicked: {
+                            var name = bakeNameInput.text.length > 0
+                                       ? bakeNameInput.text
+                                       : "Blended_" + AnimationBlender.animA + "_" + AnimationBlender.animB
+                            var result = AnimationBlender.bake(name, 30)
+                            if (result.length > 0) bakeNameInput.text = ""
+                        }
+                    }
+                }
+            }
+
             // Per-entity groups
             Repeater {
                 model: entityGroups

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -318,7 +318,7 @@ Rectangle {
                 Rectangle {
                     width: 14; height: 14; anchors.verticalCenter: parent.verticalCenter
                     border.color: PropertiesPanelController.borderColor; border.width: 1; radius: 2
-                    color: editToolsCol.softSelOn ? PropertiesPanelController.highlightColor : "transparent"
+                    color: editToolsCol.softSelOn ? PropertiesPanelController.highlightColor : PropertiesPanelController.controlBgColor
                     Behavior on color { ColorAnimation { duration: 50 } }
                     Text { anchors.centerIn: parent; text: editToolsCol.softSelOn ? "\u2713" : ""; color: "white"; font.pixelSize: 10 }
                     MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor
@@ -418,7 +418,7 @@ Rectangle {
                 Rectangle {
                     width: 14; height: 14; anchors.verticalCenter: parent.verticalCenter
                     border.color: PropertiesPanelController.borderColor; border.width: 1; radius: 2
-                    color: editToolsCol.wireframeOn ? PropertiesPanelController.highlightColor : "transparent"
+                    color: editToolsCol.wireframeOn ? PropertiesPanelController.highlightColor : PropertiesPanelController.controlBgColor
                     Behavior on color { ColorAnimation { duration: 50 } }
                     Text { anchors.centerIn: parent; text: editToolsCol.wireframeOn ? "\u2713" : ""; color: "white"; font.pixelSize: 10 }
                     MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor
@@ -436,7 +436,7 @@ Rectangle {
                 Rectangle {
                     width: 14; height: 14; anchors.verticalCenter: parent.verticalCenter
                     border.color: PropertiesPanelController.borderColor; border.width: 1; radius: 2
-                    color: editToolsCol.vertexPreviewOn ? PropertiesPanelController.highlightColor : "transparent"
+                    color: editToolsCol.vertexPreviewOn ? PropertiesPanelController.highlightColor : PropertiesPanelController.controlBgColor
                     Behavior on color { ColorAnimation { duration: 50 } }
                     Text { anchors.centerIn: parent; text: editToolsCol.vertexPreviewOn ? "\u2713" : ""; color: "white"; font.pixelSize: 10 }
                     MouseArea { anchors.fill: parent; cursorShape: Qt.PointingHandCursor
@@ -785,7 +785,7 @@ Rectangle {
                 Rectangle {
                     width: 14; height: 14; anchors.verticalCenter: parent.verticalCenter
                     border.color: PropertiesPanelController.borderColor; border.width: 1; radius: 2
-                    color: snapCol.snapOn ? PropertiesPanelController.highlightColor : "transparent"
+                    color: snapCol.snapOn ? PropertiesPanelController.highlightColor : PropertiesPanelController.controlBgColor
                     Behavior on color { ColorAnimation { duration: 50 } }
                     Text { anchors.centerIn: parent; text: snapCol.snapOn ? "\u2713" : ""; color: "white"; font.pixelSize: 10 }
                     MouseArea {
@@ -1637,126 +1637,191 @@ Rectangle {
                 }
             }
 
-            // ── Blend (two-way live blend + bake) ─────────────────────────────
+            // ── Blend (two-way live blend + bake) — collapsible subgroup ─────
             Column {
+                id: blendGroup
                 width: parent.width - 16
                 spacing: 4
                 visible: AnimationBlender.animations.length >= 2
 
-                Row {
-                    spacing: 8
-                    Text {
-                        text: "Blend:"; font.bold: true
-                        color: PropertiesPanelController.textColor; font.pixelSize: 11
+                property bool blendExpanded: false
+
+                Rectangle {
+                    width: parent.width
+                    height: 22
+                    color: blendHeaderMouse.containsMouse
+                           ? Qt.lighter(PropertiesPanelController.headerColor, 1.1)
+                           : PropertiesPanelController.headerColor
+                    border.color: PropertiesPanelController.borderColor
+                    border.width: 1
+
+                    Row {
                         anchors.verticalCenter: parent.verticalCenter
+                        anchors.left: parent.left; anchors.leftMargin: 6
+                        spacing: 4
+
+                        Text {
+                            text: blendGroup.blendExpanded ? "▼" : "▶"
+                            color: PropertiesPanelController.textColor
+                            font.pixelSize: 9
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                        Text {
+                            text: "Blend"
+                            color: PropertiesPanelController.textColor
+                            font.pixelSize: 11; font.bold: true
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                        Text {
+                            visible: AnimationBlender.active
+                            text: "(active)"
+                            color: PropertiesPanelController.textColor
+                            font.pixelSize: 10; font.italic: true
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
                     }
-                    CheckBox {
-                        text: "Active"
-                        checked: AnimationBlender.active
-                        onToggled: AnimationBlender.active = checked
-                        font.pixelSize: 11
+
+                    MouseArea {
+                        id: blendHeaderMouse
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        onClicked: blendGroup.blendExpanded = !blendGroup.blendExpanded
                     }
                 }
 
-                Row {
-                    spacing: 6
+                Column {
                     width: parent.width
+                    spacing: 4
+                    visible: blendGroup.blendExpanded
 
-                    ComboBox {
-                        id: animAPicker
-                        width: (parent.width - 12) / 2
-                        height: 24
-                        model: AnimationBlender.animations
-                        property string current: AnimationBlender.animA
-                        currentIndex: model.indexOf(current)
-                        onActivated: AnimationBlender.animA = model[currentIndex]
-                        Connections {
-                            target: AnimationBlender
-                            function onSelectionChanged() {
-                                animAPicker.currentIndex = animAPicker.model.indexOf(AnimationBlender.animA)
+                    Row {
+                        spacing: 6
+                        // "Active" toggle styled like the per-anim Enable/Loop boxes
+                        Rectangle {
+                            width: 14; height: 14
+                            anchors.verticalCenter: parent.verticalCenter
+                            border.color: PropertiesPanelController.borderColor; border.width: 1; radius: 2
+                            color: AnimationBlender.active
+                                   ? PropertiesPanelController.highlightColor
+                                   : PropertiesPanelController.controlBgColor
+                            Text {
+                                anchors.centerIn: parent
+                                text: AnimationBlender.active ? "✓" : ""
+                                color: "white"; font.pixelSize: 10
                             }
-                            function onAnimationsChanged() {
-                                animAPicker.currentIndex = animAPicker.model.indexOf(AnimationBlender.animA)
+                            MouseArea {
+                                anchors.fill: parent
+                                onClicked: AnimationBlender.active = !AnimationBlender.active
                             }
                         }
-                        font.pixelSize: 11
-                    }
-
-                    ComboBox {
-                        id: animBPicker
-                        width: (parent.width - 12) / 2
-                        height: 24
-                        model: AnimationBlender.animations
-                        property string current: AnimationBlender.animB
-                        currentIndex: model.indexOf(current)
-                        onActivated: AnimationBlender.animB = model[currentIndex]
-                        Connections {
-                            target: AnimationBlender
-                            function onSelectionChanged() {
-                                animBPicker.currentIndex = animBPicker.model.indexOf(AnimationBlender.animB)
-                            }
-                            function onAnimationsChanged() {
-                                animBPicker.currentIndex = animBPicker.model.indexOf(AnimationBlender.animB)
-                            }
+                        Text {
+                            text: "Active"
+                            color: PropertiesPanelController.textColor
+                            font.pixelSize: 11
+                            anchors.verticalCenter: parent.verticalCenter
                         }
-                        font.pixelSize: 11
-                    }
-                }
-
-                Row {
-                    spacing: 6
-                    width: parent.width
-                    Text {
-                        text: "Weight:"
-                        color: PropertiesPanelController.textColor; font.pixelSize: 11
-                        anchors.verticalCenter: parent.verticalCenter
-                    }
-                    Slider {
-                        id: weightSlider
-                        from: 0; to: 1; stepSize: 0.01
-                        width: parent.width - 90
-                        value: AnimationBlender.weight
-                        onMoved: AnimationBlender.weight = value
-                        anchors.verticalCenter: parent.verticalCenter
-                    }
-                    Text {
-                        text: AnimationBlender.weight.toFixed(2)
-                        color: PropertiesPanelController.textColor; font.pixelSize: 11
-                        anchors.verticalCenter: parent.verticalCenter
-                    }
-                }
-
-                Row {
-                    spacing: 6
-                    width: parent.width
-
-                    ComboBox {
-                        id: modeCombo
-                        width: 100; height: 24
-                        model: ["Mix", "Additive", "Override"]
-                        currentIndex: AnimationBlender.mode
-                        onActivated: AnimationBlender.mode = currentIndex
-                        font.pixelSize: 11
                     }
 
-                    TextField {
-                        id: bakeNameInput
-                        width: parent.width - 100 - 6 - 70 - 12
-                        height: 24
-                        placeholderText: "BlendedClip"
-                        font.pixelSize: 11
+                    Row {
+                        spacing: 6
+                        width: parent.width
+
+                        ComboBox {
+                            id: animAPicker
+                            width: (parent.width - 12) / 2
+                            height: 24
+                            model: AnimationBlender.animations
+                            property string current: AnimationBlender.animA
+                            currentIndex: model.indexOf(current)
+                            onActivated: AnimationBlender.animA = model[currentIndex]
+                            Connections {
+                                target: AnimationBlender
+                                function onSelectionChanged() {
+                                    animAPicker.currentIndex = animAPicker.model.indexOf(AnimationBlender.animA)
+                                }
+                                function onAnimationsChanged() {
+                                    animAPicker.currentIndex = animAPicker.model.indexOf(AnimationBlender.animA)
+                                }
+                            }
+                            font.pixelSize: 11
+                        }
+
+                        ComboBox {
+                            id: animBPicker
+                            width: (parent.width - 12) / 2
+                            height: 24
+                            model: AnimationBlender.animations
+                            property string current: AnimationBlender.animB
+                            currentIndex: model.indexOf(current)
+                            onActivated: AnimationBlender.animB = model[currentIndex]
+                            Connections {
+                                target: AnimationBlender
+                                function onSelectionChanged() {
+                                    animBPicker.currentIndex = animBPicker.model.indexOf(AnimationBlender.animB)
+                                }
+                                function onAnimationsChanged() {
+                                    animBPicker.currentIndex = animBPicker.model.indexOf(AnimationBlender.animB)
+                                }
+                            }
+                            font.pixelSize: 11
+                        }
                     }
 
-                    Button {
-                        text: "Bake"
-                        width: 70; height: 24
-                        font.pixelSize: 11
-                        onClicked: {
-                            var name = bakeNameInput.text.length > 0
-                                       ? bakeNameInput.text
-                                       : "Blended_" + AnimationBlender.animA + "_" + AnimationBlender.animB
-                            var result = AnimationBlender.bake(name, 30)
-                            if (result.length > 0) bakeNameInput.text = ""
+                    Row {
+                        spacing: 6
+                        width: parent.width
+                        Text {
+                            text: "Weight:"
+                            color: PropertiesPanelController.textColor; font.pixelSize: 11
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                        Slider {
+                            id: weightSlider
+                            from: 0; to: 1; stepSize: 0.01
+                            width: parent.width - 90
+                            value: AnimationBlender.weight
+                            onMoved: AnimationBlender.weight = value
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                        Text {
+                            text: AnimationBlender.weight.toFixed(2)
+                            color: PropertiesPanelController.textColor; font.pixelSize: 11
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                    }
+
+                    Row {
+                        spacing: 6
+                        width: parent.width
+
+                        ComboBox {
+                            id: modeCombo
+                            width: 100; height: 24
+                            model: ["Mix", "Additive", "Override"]
+                            currentIndex: AnimationBlender.mode
+                            onActivated: AnimationBlender.mode = currentIndex
+                            font.pixelSize: 11
+                        }
+
+                        TextField {
+                            id: bakeNameInput
+                            width: parent.width - 100 - 6 - 70 - 12
+                            height: 24
+                            placeholderText: "BlendedClip"
+                            font.pixelSize: 11
+                        }
+
+                        Button {
+                            text: "Bake"
+                            width: 70; height: 24
+                            font.pixelSize: 11
+                            onClicked: {
+                                var name = bakeNameInput.text.length > 0
+                                           ? bakeNameInput.text
+                                           : "Blended_" + AnimationBlender.animA + "_" + AnimationBlender.animB
+                                var result = AnimationBlender.bake(name, 30)
+                                if (result.length > 0) bakeNameInput.text = ""
+                            }
                         }
                     }
                 }
@@ -1844,6 +1909,12 @@ Rectangle {
                             Rectangle {
                                 width: parent.width - 8; height: 22; color: "transparent"
 
+                                // True when this entity's per-anim toggles are owned by the blender.
+                                // While the blender is active for this entity, Enable/Loop are
+                                // disabled to avoid fighting blender::apply() each frame.
+                                property bool blenderOwns: AnimationBlender.active
+                                    && AnimationBlender.activeEntityName === grp.entity
+
                                 Row {
                                     anchors.fill: parent; spacing: 6
 
@@ -1851,18 +1922,28 @@ Rectangle {
                                     Rectangle {
                                         width: 14; height: 14; anchors.verticalCenter: parent.verticalCenter
                                         border.color: PropertiesPanelController.borderColor; border.width: 1; radius: 2
-                                        color: modelData.enabled ? PropertiesPanelController.highlightColor : "transparent"
+                                        color: modelData.enabled ? PropertiesPanelController.highlightColor : PropertiesPanelController.controlBgColor
+                                        opacity: blenderOwns ? 0.4 : 1.0
                                         Text { anchors.centerIn: parent; text: modelData.enabled ? "\u2713" : ""; color: "white"; font.pixelSize: 10 }
-                                        MouseArea { anchors.fill: parent; onClicked: PropertiesPanelController.toggleAnimationEnabled(grp.entity, modelData.name, !modelData.enabled) }
+                                        MouseArea {
+                                            anchors.fill: parent
+                                            enabled: !blenderOwns
+                                            onClicked: PropertiesPanelController.toggleAnimationEnabled(grp.entity, modelData.name, !modelData.enabled)
+                                        }
                                     }
 
                                     // Loop checkbox
                                     Rectangle {
                                         width: 14; height: 14; anchors.verticalCenter: parent.verticalCenter
                                         border.color: PropertiesPanelController.borderColor; border.width: 1; radius: 7
-                                        color: modelData.loop ? PropertiesPanelController.highlightColor : "transparent"
+                                        color: modelData.loop ? PropertiesPanelController.highlightColor : PropertiesPanelController.controlBgColor
+                                        opacity: blenderOwns ? 0.4 : 1.0
                                         Text { anchors.centerIn: parent; text: modelData.loop ? "\u21BB" : ""; color: "white"; font.pixelSize: 8 }
-                                        MouseArea { anchors.fill: parent; onClicked: PropertiesPanelController.toggleAnimationLoop(grp.entity, modelData.name, !modelData.loop) }
+                                        MouseArea {
+                                            anchors.fill: parent
+                                            enabled: !blenderOwns
+                                            onClicked: PropertiesPanelController.toggleAnimationLoop(grp.entity, modelData.name, !modelData.loop)
+                                        }
                                     }
 
                                     // Name (double-click to rename)
@@ -1957,7 +2038,7 @@ Rectangle {
                             Rectangle {
                                 width: 14; height: 14; anchors.verticalCenter: parent.verticalCenter
                                 border.color: PropertiesPanelController.borderColor; border.width: 1; radius: 2
-                                color: grp.showSkeleton ? PropertiesPanelController.highlightColor : "transparent"
+                                color: grp.showSkeleton ? PropertiesPanelController.highlightColor : PropertiesPanelController.controlBgColor
                                 Text { anchors.centerIn: parent; text: grp.showSkeleton ? "\u2713" : ""; color: "white"; font.pixelSize: 10 }
                                 MouseArea { anchors.fill: parent; onClicked: PropertiesPanelController.toggleSkeletonDebug(grp.entity, !grp.showSkeleton) }
                             }
@@ -1966,7 +2047,7 @@ Rectangle {
                             Rectangle {
                                 width: 14; height: 14; anchors.verticalCenter: parent.verticalCenter
                                 border.color: PropertiesPanelController.borderColor; border.width: 1; radius: 2
-                                color: grp.showWeights ? PropertiesPanelController.highlightColor : "transparent"
+                                color: grp.showWeights ? PropertiesPanelController.highlightColor : PropertiesPanelController.controlBgColor
                                 Text { anchors.centerIn: parent; text: grp.showWeights ? "\u2713" : ""; color: "white"; font.pixelSize: 10 }
                                 MouseArea { anchors.fill: parent; onClicked: PropertiesPanelController.toggleBoneWeights(grp.entity, !grp.showWeights) }
                             }

--- a/src/AnimationBlender.cpp
+++ b/src/AnimationBlender.cpp
@@ -51,25 +51,54 @@ AnimationBlender::AnimationBlender()
 QString AnimationBlender::animA() const { return QString::fromStdString(m_animA); }
 QString AnimationBlender::animB() const { return QString::fromStdString(m_animB); }
 
+namespace {
+
+// Disable every animation state on `entity`. Pre-condition: caller already
+// captured a PreviewSnapshot so deactivate can restore the original flags.
+void disableAllStates(Ogre::Entity* entity)
+{
+    if (!entity) return;
+    auto* set = entity->getAllAnimationStates();
+    if (!set) return;
+    for (const auto& [name, state] : set->getAnimationStates()) {
+        state->setEnabled(false);
+    }
+}
+
+const char* modeName(int mode)
+{
+    switch (mode) {
+    case AnimationBlender::ModeMix:      return "mix";
+    case AnimationBlender::ModeAdditive: return "additive";
+    case AnimationBlender::ModeOverride: return "override";
+    default:                             return "mix";
+    }
+}
+
+} // namespace
+
 void AnimationBlender::setActive(bool on)
 {
     if (on == m_active) return;
+
+    // Refuse activation unless A/B are both set and distinct. apply() bails
+    // out for the same reasons, but bailing there alone leaves the entity
+    // with all-states-off until the user picks valid clips. Rejecting here
+    // keeps the toggle truthful: "Active" only sticks when it's meaningful.
+    if (on && (m_animA.empty() || m_animB.empty() || m_animA == m_animB)) {
+        return;
+    }
+
     m_active = on;
     if (on) {
         // Snapshot the entity's pre-blend state so deactivation can restore
-        // it, then immediately turn off every animation layer. apply() on
-        // the next frame turns A and B back on with the right weights;
+        // it, then turn off every animation layer immediately. apply() on
+        // the next frame re-enables A and B with the right weights;
         // doing it here prevents a one-frame flash where a stale checked
         // animation continues to play before the blend kicks in.
         Ogre::Entity* entity = resolveActiveEntity();
         captureSnapshot(entity);
-        if (entity) {
-            if (auto* set = entity->getAllAnimationStates()) {
-                for (const auto& [name, state] : set->getAnimationStates()) {
-                    state->setEnabled(false);
-                }
-            }
-        }
+        disableAllStates(entity);
     } else {
         // Toggling off: roll the entity's animation states back to whatever
         // they looked like before the blender started writing to them.
@@ -268,10 +297,10 @@ void advanceState(Ogre::AnimationState* s, const std::string& name,
 
 } // namespace
 
-bool AnimationBlender::apply(Ogre::Entity* entity, double dt)
+bool AnimationBlender::apply(Ogre::Entity* entity, double dt) // NOSONAR — mutates state via entity*; not const
 {
     if (!m_active || !entity) return false;
-    if (m_animA.empty() || m_animB.empty()) return false;
+    if (m_animA.empty() || m_animB.empty() || m_animA == m_animB) return false;
     if (!entity->hasAnimationState(m_animA) || !entity->hasAnimationState(m_animB)) {
         return false;
     }
@@ -421,7 +450,7 @@ QString AnimationBlender::bake(const QString& clipName, int fps)
 {
     if (clipName.isEmpty()) return {};
     if (fps <= 0) fps = 30;
-    if (m_animA.empty() || m_animB.empty()) return {};
+    if (m_animA.empty() || m_animB.empty() || m_animA == m_animB) return {};
 
     const std::string clipStd = clipName.toStdString();
     // Refuse to bake over one of the source clips — sa/sb resolve to those
@@ -482,7 +511,7 @@ QString AnimationBlender::bake(const QString& clipName, int fps)
         "ui.action",
         QString("Bake blended animation '%1' (mode=%2, weight=%3, fps=%4, length=%5s, samples=%6)")
             .arg(clipName)
-            .arg(m_mode == ModeMix ? "mix" : (m_mode == ModeAdditive ? "additive" : "override"))
+            .arg(modeName(m_mode))
             .arg(m_weight, 0, 'f', 2)
             .arg(fps)
             .arg(length, 0, 'f', 3)

--- a/src/AnimationBlender.cpp
+++ b/src/AnimationBlender.cpp
@@ -99,10 +99,18 @@ void AnimationBlender::setActive(bool on)
         Ogre::Entity* entity = resolveActiveEntity();
         captureSnapshot(entity);
         disableAllStates(entity);
+        SentryReporter::addBreadcrumb(
+            "ui.action",
+            QString("Blend preview ON (A=%1, B=%2, mode=%3, weight=%4)")
+                .arg(QString::fromStdString(m_animA))
+                .arg(QString::fromStdString(m_animB))
+                .arg(modeName(m_mode))
+                .arg(m_weight, 0, 'f', 2));
     } else {
         // Toggling off: roll the entity's animation states back to whatever
         // they looked like before the blender started writing to them.
         restoreSnapshot();
+        SentryReporter::addBreadcrumb("ui.action", "Blend preview OFF");
     }
     // Inspector listens to activeChanged and refreshes its animation list,
     // which keeps its per-anim Enable/Loop checkboxes in sync.
@@ -114,6 +122,7 @@ void AnimationBlender::setAnimA(const QString& name)
     const std::string s = name.toStdString();
     if (s == m_animA) return;
     m_animA = s;
+    deactivateIfInvalid();
     emit selectionChanged();
 }
 
@@ -122,7 +131,22 @@ void AnimationBlender::setAnimB(const QString& name)
     const std::string s = name.toStdString();
     if (s == m_animB) return;
     m_animB = s;
+    deactivateIfInvalid();
     emit selectionChanged();
+}
+
+void AnimationBlender::deactivateIfInvalid()
+{
+    // Called whenever animA/animB changes. If preview is currently active and
+    // the new selection is unusable (empty side, or A == B), apply() would
+    // start returning false on the next frame and MainWindow would fall back
+    // to plain addTime(). The entity would still be in its blended enabled/
+    // weight configuration, leaving stale preview playback. Forcing a clean
+    // deactivation here restores the pre-blend snapshot.
+    if (!m_active) return;
+    if (m_animA.empty() || m_animB.empty() || m_animA == m_animB) {
+        setActive(false);
+    }
 }
 
 void AnimationBlender::setWeight(double w)
@@ -367,10 +391,21 @@ void writeBoneKeyframe(Ogre::NodeAnimationTrack* track, float t, const Ogre::Bon
 void positionForSample(Ogre::AnimationState* sa, Ogre::AnimationState* sb,
                        float t, int mode, double weight)
 {
-    const float ta = (sa->getLength() > 0.0f) ? std::fmod(t, sa->getLength()) : 0.0f;
-    const float tb = (sb->getLength() > 0.0f) ? std::fmod(t, sb->getLength()) : 0.0f;
-    sa->setTimePosition(ta);
-    sb->setTimePosition(tb);
+    // Map the bake-clock `t` onto each source clip's own timeline.
+    // t < clipLen → straight pass-through (most common case).
+    // t == clipLen → clamp to clipLen (otherwise fmod returns 0, which
+    //   writes the start pose into the closing keyframe and produces a
+    //   visible pop on equal-length inputs).
+    // t > clipLen → wrap with fmod so a shorter source clip loops within
+    //   a longer bake range.
+    auto mapTime = [](float t, float clipLen) -> float {
+        if (clipLen <= 0.0f) return 0.0f;
+        if (t < clipLen)     return t;
+        if (t > clipLen)     return std::fmod(t, clipLen);
+        return clipLen; // t == clipLen
+    };
+    sa->setTimePosition(mapTime(t, sa->getLength()));
+    sb->setTimePosition(mapTime(t, sb->getLength()));
 
     if (mode == AnimationBlender::ModeOverride) {
         const bool useB = (weight >= 0.5);

--- a/src/AnimationBlender.cpp
+++ b/src/AnimationBlender.cpp
@@ -1,0 +1,286 @@
+#include "AnimationBlender.h"
+#include "AnimationControlController.h"
+#include "SelectionSet.h"
+
+#include <Ogre.h>
+#include <OgreSkeletonInstance.h>
+#include <OgreAnimation.h>
+#include <OgreAnimationState.h>
+#include <OgreKeyFrame.h>
+
+#include <algorithm>
+#include <cmath>
+
+AnimationBlender* AnimationBlender::m_pSingleton = nullptr;
+
+AnimationBlender* AnimationBlender::instance()
+{
+    if (!m_pSingleton) m_pSingleton = new AnimationBlender();
+    return m_pSingleton;
+}
+
+AnimationBlender* AnimationBlender::qmlInstance(QQmlEngine* engine, QJSEngine* scriptEngine)
+{
+    Q_UNUSED(engine); Q_UNUSED(scriptEngine);
+    auto* inst = instance();
+    QQmlEngine::setObjectOwnership(inst, QQmlEngine::CppOwnership);
+    return inst;
+}
+
+void AnimationBlender::kill()
+{
+    delete m_pSingleton;
+    m_pSingleton = nullptr;
+}
+
+AnimationBlender::AnimationBlender()
+    : QObject(nullptr)
+{
+    auto* ctrl = AnimationControlController::instance();
+    connect(ctrl, &AnimationControlController::selectionChanged,
+            this, &AnimationBlender::refreshFromSelection);
+}
+
+QString AnimationBlender::animA() const { return QString::fromStdString(m_animA); }
+QString AnimationBlender::animB() const { return QString::fromStdString(m_animB); }
+
+void AnimationBlender::setActive(bool on)
+{
+    if (on == m_active) return;
+    m_active = on;
+    emit activeChanged();
+}
+
+void AnimationBlender::setAnimA(const QString& name)
+{
+    const std::string s = name.toStdString();
+    if (s == m_animA) return;
+    m_animA = s;
+    emit selectionChanged();
+}
+
+void AnimationBlender::setAnimB(const QString& name)
+{
+    const std::string s = name.toStdString();
+    if (s == m_animB) return;
+    m_animB = s;
+    emit selectionChanged();
+}
+
+void AnimationBlender::setWeight(double w)
+{
+    if (w < 0.0) w = 0.0;
+    if (w > 1.0) w = 1.0;
+    if (qFuzzyCompare(w + 1.0, m_weight + 1.0)) return; // qFuzzyCompare is iffy near zero
+    m_weight = w;
+    emit weightChanged();
+}
+
+void AnimationBlender::setMode(int m)
+{
+    Mode newMode = ModeMix;
+    if (m == ModeMix || m == ModeAdditive || m == ModeOverride) {
+        newMode = static_cast<Mode>(m);
+    }
+    if (newMode == m_mode) return;
+    m_mode = newMode;
+    emit modeChanged();
+}
+
+void AnimationBlender::refreshFromSelection()
+{
+    auto* ctrl = AnimationControlController::instance();
+    const std::string activeEntity = ctrl->selectedEntityName().toStdString();
+
+    // If the active entity changed, reset selection — clip names from the
+    // previous entity may not exist on the new one.
+    if (activeEntity != m_activeEntityName) {
+        m_activeEntityName = activeEntity;
+        if (!m_animA.empty() || !m_animB.empty()) {
+            m_animA.clear();
+            m_animB.clear();
+            emit selectionChanged();
+        }
+    }
+
+    QStringList anims;
+    Ogre::Entity* entity = resolveActiveEntity();
+    if (entity) {
+        if (auto* set = entity->getAllAnimationStates()) {
+            for (const auto& [name, state] : set->getAnimationStates()) {
+                anims << QString::fromStdString(name);
+            }
+        }
+    }
+    if (anims != m_animations) {
+        m_animations = anims;
+        emit animationsChanged();
+    }
+}
+
+Ogre::Entity* AnimationBlender::resolveActiveEntity() const
+{
+    if (m_activeEntityName.empty()) return nullptr;
+    for (Ogre::Entity* ent : SelectionSet::getSingleton()->getResolvedEntities()) {
+        if (ent && ent->getName() == m_activeEntityName) return ent;
+    }
+    return nullptr;
+}
+
+bool AnimationBlender::apply(Ogre::Entity* entity, double dt)
+{
+    if (!m_active || !entity) return false;
+    if (m_animA.empty() || m_animB.empty()) return false;
+    if (!entity->hasAnimationState(m_animA) || !entity->hasAnimationState(m_animB)) {
+        return false;
+    }
+
+    Ogre::AnimationState* a = entity->getAnimationState(m_animA);
+    Ogre::AnimationState* b = entity->getAnimationState(m_animB);
+    if (!a || !b) return false;
+
+    // Set blend mode on the skeleton up-front. We don't restore the previous
+    // mode on toggle-off — projects that need that can read the saved mode
+    // before activating the blender.
+    if (auto* skel = entity->getSkeleton()) {
+        skel->setBlendMode(m_mode == ModeAdditive
+                           ? Ogre::ANIMBLEND_CUMULATIVE
+                           : Ogre::ANIMBLEND_AVERAGE);
+    }
+
+    if (m_mode == ModeOverride) {
+        const bool useB = (m_weight >= 0.5);
+        a->setEnabled(!useB);
+        b->setEnabled(useB);
+        a->setWeight(useB ? 0.0f : 1.0f);
+        b->setWeight(useB ? 1.0f : 0.0f);
+        (useB ? b : a)->addTime(static_cast<float>(dt));
+    } else {
+        a->setEnabled(true);
+        b->setEnabled(true);
+        a->setWeight(static_cast<float>(1.0 - m_weight));
+        b->setWeight(static_cast<float>(m_weight));
+        a->addTime(static_cast<float>(dt));
+        b->addTime(static_cast<float>(dt));
+    }
+    return true;
+}
+
+QString AnimationBlender::bake(const QString& clipName, int fps)
+{
+    if (clipName.isEmpty()) return {};
+    if (fps <= 0) fps = 30;
+    if (m_animA.empty() || m_animB.empty()) return {};
+
+    Ogre::Entity* entity = resolveActiveEntity();
+    if (!entity) return {};
+    Ogre::SkeletonInstance* skel = entity->getSkeleton();
+    if (!skel) return {};
+    if (!entity->hasAnimationState(m_animA) || !entity->hasAnimationState(m_animB)) {
+        return {};
+    }
+
+    Ogre::AnimationState* sa = entity->getAnimationState(m_animA);
+    Ogre::AnimationState* sb = entity->getAnimationState(m_animB);
+
+    // Bake length = max of the two clips, so neither side gets clipped.
+    const float length = std::max(sa->getLength(), sb->getLength());
+    if (length <= 0.0f) return {};
+    const int   sampleCount = std::max(2, static_cast<int>(std::ceil(length * fps)) + 1);
+    const float step        = length / static_cast<float>(sampleCount - 1);
+
+    // Replace any pre-existing clip with the same name.
+    const std::string clipStd = clipName.toStdString();
+    if (skel->hasAnimation(clipStd)) {
+        skel->removeAnimation(clipStd);
+    }
+
+    Ogre::Animation* anim = skel->createAnimation(clipStd, length);
+    anim->setInterpolationMode(Ogre::Animation::IM_LINEAR);
+
+    const unsigned short numBones = skel->getNumBones();
+    // One track per bone, even unanimated bones — keeps bake reproducible
+    // and avoids surprises when a downstream system iterates tracks.
+    for (unsigned short i = 0; i < numBones; ++i) {
+        Ogre::Bone* bone = skel->getBone(i);
+        if (!bone) continue;
+        // Use the bone's handle as track handle (Ogre convention).
+        anim->createNodeTrack(bone->getHandle(), bone);
+    }
+
+    // Save the current state so the live preview isn't disturbed by the bake.
+    const float saTime = sa->getTimePosition();
+    const float sbTime = sb->getTimePosition();
+    const bool  saOn   = sa->getEnabled();
+    const bool  sbOn   = sb->getEnabled();
+    const float saW    = sa->getWeight();
+    const float sbW    = sb->getWeight();
+    const Ogre::SkeletonAnimationBlendMode prevBlend = skel->getBlendMode();
+
+    // Disable everything else so the sampled pose is purely the blend of A+B.
+    if (auto* set = entity->getAllAnimationStates()) {
+        for (const auto& [name, state] : set->getAnimationStates()) {
+            if (name != m_animA && name != m_animB) state->setEnabled(false);
+        }
+    }
+    skel->setBlendMode(m_mode == ModeAdditive
+                       ? Ogre::ANIMBLEND_CUMULATIVE
+                       : Ogre::ANIMBLEND_AVERAGE);
+
+    for (int s = 0; s < sampleCount; ++s) {
+        const float t = (s == sampleCount - 1) ? length : (s * step);
+        // Sample both clips at the same t (looping is naturally handled by
+        // Ogre when t > length of either side; we explicitly modulo to keep
+        // the bake deterministic regardless of state's loop flag).
+        const float ta = (sa->getLength() > 0.0f) ? std::fmod(t, sa->getLength()) : 0.0f;
+        const float tb = (sb->getLength() > 0.0f) ? std::fmod(t, sb->getLength()) : 0.0f;
+        sa->setTimePosition(ta);
+        sb->setTimePosition(tb);
+
+        if (m_mode == ModeOverride) {
+            const bool useB = (m_weight >= 0.5);
+            sa->setEnabled(!useB);
+            sb->setEnabled(useB);
+            sa->setWeight(useB ? 0.0f : 1.0f);
+            sb->setWeight(useB ? 1.0f : 0.0f);
+        } else {
+            sa->setEnabled(true);
+            sb->setEnabled(true);
+            sa->setWeight(static_cast<float>(1.0 - m_weight));
+            sb->setWeight(static_cast<float>(m_weight));
+        }
+
+        // Force the skeleton to evaluate the blended pose at this sample.
+        skel->setAnimationState(*entity->getAllAnimationStates());
+        skel->_updateTransforms();
+
+        // Capture each bone's local TRS (relative to its parent's bind pose),
+        // which is what TransformKeyFrame stores.
+        for (unsigned short i = 0; i < numBones; ++i) {
+            Ogre::Bone*  bone  = skel->getBone(i);
+            if (!bone) continue;
+            auto* track = anim->getNodeTrack(bone->getHandle());
+            if (!track) continue;
+            auto* kf = track->createNodeKeyFrame(t);
+            kf->setTranslate(bone->getPosition() - bone->getInitialPosition());
+            kf->setRotation(bone->getInitialOrientation().Inverse() * bone->getOrientation());
+            kf->setScale(bone->getScale() / bone->getInitialScale());
+        }
+    }
+
+    // Restore previous live state.
+    sa->setTimePosition(saTime);
+    sb->setTimePosition(sbTime);
+    sa->setEnabled(saOn);
+    sb->setEnabled(sbOn);
+    sa->setWeight(saW);
+    sb->setWeight(sbW);
+    skel->setBlendMode(prevBlend);
+
+    // Make sure the new animation is exposed via the entity's state set.
+    entity->refreshAvailableAnimationState();
+
+    refreshFromSelection();
+    emit clipBaked(clipName);
+    return clipName;
+}

--- a/src/AnimationBlender.cpp
+++ b/src/AnimationBlender.cpp
@@ -15,13 +15,14 @@ AnimationBlender* AnimationBlender::m_pSingleton = nullptr;
 
 AnimationBlender* AnimationBlender::instance()
 {
-    if (!m_pSingleton) m_pSingleton = new AnimationBlender();
+    if (!m_pSingleton) m_pSingleton = new AnimationBlender(); // NOSONAR — see kill()
     return m_pSingleton;
 }
 
 AnimationBlender* AnimationBlender::qmlInstance(QQmlEngine* engine, QJSEngine* scriptEngine)
 {
-    Q_UNUSED(engine); Q_UNUSED(scriptEngine);
+    Q_UNUSED(engine)
+    Q_UNUSED(scriptEngine)
     auto* inst = instance();
     QQmlEngine::setObjectOwnership(inst, QQmlEngine::CppOwnership);
     return inst;
@@ -29,14 +30,14 @@ AnimationBlender* AnimationBlender::qmlInstance(QQmlEngine* engine, QJSEngine* s
 
 void AnimationBlender::kill()
 {
-    delete m_pSingleton;
+    delete m_pSingleton; // NOSONAR — manual lifetime mirrors AnimationControlController
     m_pSingleton = nullptr;
 }
 
 AnimationBlender::AnimationBlender()
     : QObject(nullptr)
 {
-    auto* ctrl = AnimationControlController::instance();
+    const auto* ctrl = AnimationControlController::instance();
     connect(ctrl, &AnimationControlController::selectionChanged,
             this, &AnimationBlender::refreshFromSelection);
 }
@@ -48,6 +49,13 @@ void AnimationBlender::setActive(bool on)
 {
     if (on == m_active) return;
     m_active = on;
+    if (!on) {
+        // Toggling off: roll the entity's animation states back to whatever
+        // they looked like before the blender started writing to them.
+        restoreSnapshot();
+    } else {
+        captureSnapshot(resolveActiveEntity());
+    }
     emit activeChanged();
 }
 
@@ -71,7 +79,7 @@ void AnimationBlender::setWeight(double w)
 {
     if (w < 0.0) w = 0.0;
     if (w > 1.0) w = 1.0;
-    if (qFuzzyCompare(w + 1.0, m_weight + 1.0)) return; // qFuzzyCompare is iffy near zero
+    if (qFuzzyCompare(w + 1.0, m_weight + 1.0)) return;
     m_weight = w;
     emit weightChanged();
 }
@@ -89,24 +97,25 @@ void AnimationBlender::setMode(int m)
 
 void AnimationBlender::refreshFromSelection()
 {
-    auto* ctrl = AnimationControlController::instance();
+    const auto* ctrl = AnimationControlController::instance();
     const std::string activeEntity = ctrl->selectedEntityName().toStdString();
 
-    // If the active entity changed, reset selection — clip names from the
-    // previous entity may not exist on the new one.
+    // Active entity changed — anything we'd cached or written to the previous
+    // entity's states needs to be undone before we point at the new one.
     if (activeEntity != m_activeEntityName) {
+        if (m_active) restoreSnapshot();
         m_activeEntityName = activeEntity;
         if (!m_animA.empty() || !m_animB.empty()) {
             m_animA.clear();
             m_animB.clear();
             emit selectionChanged();
         }
+        if (m_active) captureSnapshot(resolveActiveEntity());
     }
 
     QStringList anims;
-    Ogre::Entity* entity = resolveActiveEntity();
-    if (entity) {
-        if (auto* set = entity->getAllAnimationStates()) {
+    if (Ogre::Entity* entity = resolveActiveEntity()) {
+        if (const auto* set = entity->getAllAnimationStates()) {
             for (const auto& [name, state] : set->getAnimationStates()) {
                 anims << QString::fromStdString(name);
             }
@@ -127,6 +136,54 @@ Ogre::Entity* AnimationBlender::resolveActiveEntity() const
     return nullptr;
 }
 
+// ── Snapshot helpers ──────────────────────────────────────────────────────────
+
+void AnimationBlender::captureSnapshot(Ogre::Entity* entity)
+{
+    m_snapshot = {};
+    if (!entity) return;
+    m_snapshot.entityName = entity->getName();
+    if (const auto* set = entity->getAllAnimationStates()) {
+        for (const auto& [name, state] : set->getAnimationStates()) {
+            StateSnapshot s;
+            s.enabled = state->getEnabled();
+            s.weight  = state->getWeight();
+            m_snapshot.states[name] = s;
+        }
+    }
+    if (auto* skel = entity->getSkeleton()) {
+        m_snapshot.blendMode = skel->getBlendMode();
+    }
+    m_snapshot.valid = true;
+}
+
+void AnimationBlender::restoreSnapshot()
+{
+    if (!m_snapshot.valid) return;
+    // Resolve by the snapshot's recorded entity name in case the active
+    // selection has already moved on.
+    Ogre::Entity* entity = nullptr;
+    for (Ogre::Entity* ent : SelectionSet::getSingleton()->getResolvedEntities()) {
+        if (ent && ent->getName() == m_snapshot.entityName) { entity = ent; break; }
+    }
+    if (entity) {
+        if (auto* set = entity->getAllAnimationStates()) {
+            for (const auto& [name, state] : set->getAnimationStates()) {
+                auto it = m_snapshot.states.find(name);
+                if (it == m_snapshot.states.end()) continue;
+                state->setEnabled(it->second.enabled);
+                state->setWeight(it->second.weight);
+            }
+        }
+        if (auto* skel = entity->getSkeleton()) {
+            skel->setBlendMode(m_snapshot.blendMode);
+        }
+    }
+    m_snapshot = {};
+}
+
+// ── Live blend ────────────────────────────────────────────────────────────────
+
 bool AnimationBlender::apply(Ogre::Entity* entity, double dt)
 {
     if (!m_active || !entity) return false;
@@ -139,14 +196,37 @@ bool AnimationBlender::apply(Ogre::Entity* entity, double dt)
     Ogre::AnimationState* b = entity->getAnimationState(m_animB);
     if (!a || !b) return false;
 
-    // Set blend mode on the skeleton up-front. We don't restore the previous
-    // mode on toggle-off — projects that need that can read the saved mode
-    // before activating the blender.
     if (auto* skel = entity->getSkeleton()) {
         skel->setBlendMode(m_mode == ModeAdditive
                            ? Ogre::ANIMBLEND_CUMULATIVE
                            : Ogre::ANIMBLEND_AVERAGE);
     }
+
+    // Disable any non-A/B states so the blended pose is purely A+B. Snapshot
+    // taken in setActive() will reinstate them when the blender is toggled
+    // off, so this is a non-destructive override.
+    if (auto* set = entity->getAllAnimationStates()) {
+        for (const auto& [name, state] : set->getAnimationStates()) {
+            if (name != m_animA && name != m_animB) state->setEnabled(false);
+        }
+    }
+
+    // Use the controller's advance helper so the slice-A loop region still
+    // wraps the *selected* clip (which is what the user is scrubbing).
+    // `dt` here is the raw frame delta from MainWindow; advanceTime() applies
+    // playbackSpeed itself, while the non-active clip uses scaled dt directly.
+    auto* ctrl = AnimationControlController::instance();
+    const std::string activeAnim = ctrl->selectedAnimation().toStdString();
+    const double scaledDt = dt * ctrl->playbackSpeed();
+    auto advance = [&](Ogre::AnimationState* s, const std::string& name) {
+        if (name == activeAnim) {
+            const double now  = static_cast<double>(s->getTimePosition());
+            const double next = ctrl->advanceTime(now, dt);
+            s->setTimePosition(static_cast<float>(next));
+        } else {
+            s->addTime(static_cast<float>(scaledDt));
+        }
+    };
 
     if (m_mode == ModeOverride) {
         const bool useB = (m_weight >= 0.5);
@@ -154,23 +234,99 @@ bool AnimationBlender::apply(Ogre::Entity* entity, double dt)
         b->setEnabled(useB);
         a->setWeight(useB ? 0.0f : 1.0f);
         b->setWeight(useB ? 1.0f : 0.0f);
-        (useB ? b : a)->addTime(static_cast<float>(dt));
+        advance(useB ? b : a, useB ? m_animB : m_animA);
     } else {
         a->setEnabled(true);
         b->setEnabled(true);
         a->setWeight(static_cast<float>(1.0 - m_weight));
         b->setWeight(static_cast<float>(m_weight));
-        a->addTime(static_cast<float>(dt));
-        b->addTime(static_cast<float>(dt));
+        advance(a, m_animA);
+        advance(b, m_animB);
     }
     return true;
 }
+
+// ── Bake ──────────────────────────────────────────────────────────────────────
+
+namespace {
+
+// Per-bake snapshot of one A or B state. Smaller than PreviewSnapshot since
+// bake() also restores the per-state-set's other layers via the entity-level
+// snapshot from setActive().
+struct StateRestore {
+    float time   = 0.0f;
+    bool  on     = false;
+    float weight = 0.0f;
+};
+
+StateRestore captureState(const Ogre::AnimationState* s) {
+    return { s->getTimePosition(), s->getEnabled(), s->getWeight() };
+}
+
+void restoreState(Ogre::AnimationState* s, const StateRestore& r) {
+    s->setTimePosition(r.time);
+    s->setEnabled(r.on);
+    s->setWeight(r.weight);
+}
+
+void writeBoneKeyframe(Ogre::NodeAnimationTrack* track, float t, const Ogre::Bone* bone) {
+    auto* kf = track->createNodeKeyFrame(t);
+    kf->setTranslate(bone->getPosition() - bone->getInitialPosition());
+    kf->setRotation(bone->getInitialOrientation().Inverse() * bone->getOrientation());
+    kf->setScale(bone->getScale() / bone->getInitialScale());
+}
+
+// Set up sa/sb state for a single bake sample at time `t` according to
+// `mode` and `weight`. Wraps t around each state's own clip length so a
+// shorter clip loops within the bake range.
+void positionForSample(Ogre::AnimationState* sa, Ogre::AnimationState* sb,
+                       float t, int mode, double weight)
+{
+    const float ta = (sa->getLength() > 0.0f) ? std::fmod(t, sa->getLength()) : 0.0f;
+    const float tb = (sb->getLength() > 0.0f) ? std::fmod(t, sb->getLength()) : 0.0f;
+    sa->setTimePosition(ta);
+    sb->setTimePosition(tb);
+
+    if (mode == AnimationBlender::ModeOverride) {
+        const bool useB = (weight >= 0.5);
+        sa->setEnabled(!useB);
+        sb->setEnabled(useB);
+        sa->setWeight(useB ? 0.0f : 1.0f);
+        sb->setWeight(useB ? 1.0f : 0.0f);
+    } else {
+        sa->setEnabled(true);
+        sb->setEnabled(true);
+        sa->setWeight(static_cast<float>(1.0 - weight));
+        sb->setWeight(static_cast<float>(weight));
+    }
+}
+
+// Sample every bone's local TRS at the current skeleton state and emit a
+// keyframe at time `t` on each node track owned by `anim`.
+void writeAllBoneKeyframes(Ogre::Animation* anim, Ogre::Skeleton* skel, float t)
+{
+    const unsigned short numBones = skel->getNumBones();
+    for (unsigned short i = 0; i < numBones; ++i) {
+        Ogre::Bone* bone = skel->getBone(i);
+        if (!bone) continue;
+        if (auto* track = anim->getNodeTrack(bone->getHandle())) {
+            writeBoneKeyframe(track, t, bone);
+        }
+    }
+}
+
+} // namespace
 
 QString AnimationBlender::bake(const QString& clipName, int fps)
 {
     if (clipName.isEmpty()) return {};
     if (fps <= 0) fps = 30;
     if (m_animA.empty() || m_animB.empty()) return {};
+
+    const std::string clipStd = clipName.toStdString();
+    // Refuse to bake over one of the source clips — sa/sb resolve to those
+    // states, and removeAnimation() would invalidate them mid-bake.
+    if (clipStd == m_animA || clipStd == m_animB) return {};
 
     Ogre::Entity* entity = resolveActiveEntity();
     if (!entity) return {};
@@ -182,42 +338,35 @@ QString AnimationBlender::bake(const QString& clipName, int fps)
 
     Ogre::AnimationState* sa = entity->getAnimationState(m_animA);
     Ogre::AnimationState* sb = entity->getAnimationState(m_animB);
-
-    // Bake length = max of the two clips, so neither side gets clipped.
     const float length = std::max(sa->getLength(), sb->getLength());
     if (length <= 0.0f) return {};
-    const int   sampleCount = std::max(2, static_cast<int>(std::ceil(length * fps)) + 1);
+    const int   sampleCount = std::max(2,
+        static_cast<int>(std::ceil(length * static_cast<float>(fps))) + 1);
     const float step        = length / static_cast<float>(sampleCount - 1);
 
-    // Replace any pre-existing clip with the same name.
-    const std::string clipStd = clipName.toStdString();
-    if (skel->hasAnimation(clipStd)) {
-        skel->removeAnimation(clipStd);
-    }
-
+    if (skel->hasAnimation(clipStd)) skel->removeAnimation(clipStd);
     Ogre::Animation* anim = skel->createAnimation(clipStd, length);
     anim->setInterpolationMode(Ogre::Animation::IM_LINEAR);
 
+    // Track per bone — keeps the bake reproducible even for unanimated bones.
     const unsigned short numBones = skel->getNumBones();
-    // One track per bone, even unanimated bones — keeps bake reproducible
-    // and avoids surprises when a downstream system iterates tracks.
     for (unsigned short i = 0; i < numBones; ++i) {
-        Ogre::Bone* bone = skel->getBone(i);
-        if (!bone) continue;
-        // Use the bone's handle as track handle (Ogre convention).
-        anim->createNodeTrack(bone->getHandle(), bone);
+        if (Ogre::Bone* bone = skel->getBone(i)) {
+            anim->createNodeTrack(bone->getHandle(), bone);
+        }
     }
 
-    // Save the current state so the live preview isn't disturbed by the bake.
-    const float saTime = sa->getTimePosition();
-    const float sbTime = sb->getTimePosition();
-    const bool  saOn   = sa->getEnabled();
-    const bool  sbOn   = sb->getEnabled();
-    const float saW    = sa->getWeight();
-    const float sbW    = sb->getWeight();
+    // Preserve every state's pre-bake config — A, B, and any third-party
+    // layers the entity had enabled — so the live preview is unaffected.
+    std::unordered_map<std::string, StateRestore> live;
+    if (auto* set = entity->getAllAnimationStates()) {
+        for (const auto& [name, state] : set->getAnimationStates()) {
+            live[name] = captureState(state);
+        }
+    }
     const Ogre::SkeletonAnimationBlendMode prevBlend = skel->getBlendMode();
 
-    // Disable everything else so the sampled pose is purely the blend of A+B.
+    // Disable everything except A and B so each sampled pose is purely A+B.
     if (auto* set = entity->getAllAnimationStates()) {
         for (const auto& [name, state] : set->getAnimationStates()) {
             if (name != m_animA && name != m_animB) state->setEnabled(false);
@@ -228,58 +377,23 @@ QString AnimationBlender::bake(const QString& clipName, int fps)
                        : Ogre::ANIMBLEND_AVERAGE);
 
     for (int s = 0; s < sampleCount; ++s) {
-        const float t = (s == sampleCount - 1) ? length : (s * step);
-        // Sample both clips at the same t (looping is naturally handled by
-        // Ogre when t > length of either side; we explicitly modulo to keep
-        // the bake deterministic regardless of state's loop flag).
-        const float ta = (sa->getLength() > 0.0f) ? std::fmod(t, sa->getLength()) : 0.0f;
-        const float tb = (sb->getLength() > 0.0f) ? std::fmod(t, sb->getLength()) : 0.0f;
-        sa->setTimePosition(ta);
-        sb->setTimePosition(tb);
-
-        if (m_mode == ModeOverride) {
-            const bool useB = (m_weight >= 0.5);
-            sa->setEnabled(!useB);
-            sb->setEnabled(useB);
-            sa->setWeight(useB ? 0.0f : 1.0f);
-            sb->setWeight(useB ? 1.0f : 0.0f);
-        } else {
-            sa->setEnabled(true);
-            sb->setEnabled(true);
-            sa->setWeight(static_cast<float>(1.0 - m_weight));
-            sb->setWeight(static_cast<float>(m_weight));
-        }
-
-        // Force the skeleton to evaluate the blended pose at this sample.
+        const float t = (s == sampleCount - 1) ? length : (static_cast<float>(s) * step);
+        positionForSample(sa, sb, t, m_mode, m_weight);
         skel->setAnimationState(*entity->getAllAnimationStates());
         skel->_updateTransforms();
-
-        // Capture each bone's local TRS (relative to its parent's bind pose),
-        // which is what TransformKeyFrame stores.
-        for (unsigned short i = 0; i < numBones; ++i) {
-            Ogre::Bone*  bone  = skel->getBone(i);
-            if (!bone) continue;
-            auto* track = anim->getNodeTrack(bone->getHandle());
-            if (!track) continue;
-            auto* kf = track->createNodeKeyFrame(t);
-            kf->setTranslate(bone->getPosition() - bone->getInitialPosition());
-            kf->setRotation(bone->getInitialOrientation().Inverse() * bone->getOrientation());
-            kf->setScale(bone->getScale() / bone->getInitialScale());
-        }
+        writeAllBoneKeyframes(anim, skel, t);
     }
 
-    // Restore previous live state.
-    sa->setTimePosition(saTime);
-    sb->setTimePosition(sbTime);
-    sa->setEnabled(saOn);
-    sb->setEnabled(sbOn);
-    sa->setWeight(saW);
-    sb->setWeight(sbW);
+    // Restore live state for every layer we touched.
+    if (auto* set = entity->getAllAnimationStates()) {
+        for (const auto& [name, state] : set->getAnimationStates()) {
+            auto it = live.find(name);
+            if (it != live.end()) restoreState(state, it->second);
+        }
+    }
     skel->setBlendMode(prevBlend);
 
-    // Make sure the new animation is exposed via the entity's state set.
     entity->refreshAvailableAnimationState();
-
     refreshFromSelection();
     emit clipBaked(clipName);
     return clipName;

--- a/src/AnimationBlender.cpp
+++ b/src/AnimationBlender.cpp
@@ -1,6 +1,7 @@
 #include "AnimationBlender.h"
 #include "AnimationControlController.h"
 #include "SelectionSet.h"
+#include "SentryReporter.h"
 
 #include <Ogre.h>
 #include <OgreSkeletonInstance.h>
@@ -37,9 +38,14 @@ void AnimationBlender::kill()
 AnimationBlender::AnimationBlender()
     : QObject(nullptr)
 {
-    const auto* ctrl = AnimationControlController::instance();
+    auto* ctrl = AnimationControlController::instance();
     connect(ctrl, &AnimationControlController::selectionChanged,
             this, &AnimationBlender::refreshFromSelection);
+    // Tell the Animation Control panel about newly baked clips so its
+    // animation tree picks them up without requiring a re-select. Inspector
+    // is wired separately in PropertiesPanelController.
+    connect(this, &AnimationBlender::clipBaked,
+            ctrl, &AnimationControlController::updateAnimationTree);
 }
 
 QString AnimationBlender::animA() const { return QString::fromStdString(m_animA); }
@@ -49,13 +55,28 @@ void AnimationBlender::setActive(bool on)
 {
     if (on == m_active) return;
     m_active = on;
-    if (!on) {
+    if (on) {
+        // Snapshot the entity's pre-blend state so deactivation can restore
+        // it, then immediately turn off every animation layer. apply() on
+        // the next frame turns A and B back on with the right weights;
+        // doing it here prevents a one-frame flash where a stale checked
+        // animation continues to play before the blend kicks in.
+        Ogre::Entity* entity = resolveActiveEntity();
+        captureSnapshot(entity);
+        if (entity) {
+            if (auto* set = entity->getAllAnimationStates()) {
+                for (const auto& [name, state] : set->getAnimationStates()) {
+                    state->setEnabled(false);
+                }
+            }
+        }
+    } else {
         // Toggling off: roll the entity's animation states back to whatever
         // they looked like before the blender started writing to them.
         restoreSnapshot();
-    } else {
-        captureSnapshot(resolveActiveEntity());
     }
+    // Inspector listens to activeChanged and refreshes its animation list,
+    // which keeps its per-anim Enable/Loop checkboxes in sync.
     emit activeChanged();
 }
 
@@ -449,7 +470,23 @@ QString AnimationBlender::bake(const QString& clipName, int fps)
     skel->setBlendMode(prevBlend);
 
     entity->refreshAvailableAnimationState();
+
+    // Deactivate so the per-frame apply() stops re-imposing blender weights
+    // on top of the restored state. Without this, the next render tick would
+    // overwrite the pre-bake configuration we just restored. setActive(false)
+    // also calls restoreSnapshot(), which is a no-op if Active was off.
+    setActive(false);
+
     refreshFromSelection();
+    SentryReporter::addBreadcrumb(
+        "ui.action",
+        QString("Bake blended animation '%1' (mode=%2, weight=%3, fps=%4, length=%5s, samples=%6)")
+            .arg(clipName)
+            .arg(m_mode == ModeMix ? "mix" : (m_mode == ModeAdditive ? "additive" : "override"))
+            .arg(m_weight, 0, 'f', 2)
+            .arg(fps)
+            .arg(length, 0, 'f', 3)
+            .arg(sampleCount));
     emit clipBaked(clipName);
     return clipName;
 }

--- a/src/AnimationBlender.cpp
+++ b/src/AnimationBlender.cpp
@@ -98,11 +98,11 @@ void AnimationBlender::setMode(int m)
 void AnimationBlender::refreshFromSelection()
 {
     const auto* ctrl = AnimationControlController::instance();
-    const std::string activeEntity = ctrl->selectedEntityName().toStdString();
 
     // Active entity changed — anything we'd cached or written to the previous
     // entity's states needs to be undone before we point at the new one.
-    if (activeEntity != m_activeEntityName) {
+    if (const std::string activeEntity = ctrl->selectedEntityName().toStdString();
+        activeEntity != m_activeEntityName) {
         if (m_active) restoreSnapshot();
         m_activeEntityName = activeEntity;
         if (!m_animA.empty() || !m_animB.empty()) {
@@ -114,7 +114,7 @@ void AnimationBlender::refreshFromSelection()
     }
 
     QStringList anims;
-    if (Ogre::Entity* entity = resolveActiveEntity()) {
+    if (const Ogre::Entity* entity = resolveActiveEntity()) {
         if (const auto* set = entity->getAllAnimationStates()) {
             for (const auto& [name, state] : set->getAnimationStates()) {
                 anims << QString::fromStdString(name);
@@ -130,6 +130,8 @@ void AnimationBlender::refreshFromSelection()
 Ogre::Entity* AnimationBlender::resolveActiveEntity() const
 {
     if (m_activeEntityName.empty()) return nullptr;
+    // findEntityByName lives in the anonymous namespace below; forward-declare
+    // here to keep the function above the helper without reordering.
     for (Ogre::Entity* ent : SelectionSet::getSingleton()->getResolvedEntities()) {
         if (ent && ent->getName() == m_activeEntityName) return ent;
     }
@@ -157,32 +159,93 @@ void AnimationBlender::captureSnapshot(Ogre::Entity* entity)
     m_snapshot.valid = true;
 }
 
+namespace {
+
+Ogre::Entity* findEntityByName(const std::string& name) {
+    for (Ogre::Entity* ent : SelectionSet::getSingleton()->getResolvedEntities()) {
+        if (ent && ent->getName() == name) return ent;
+    }
+    return nullptr;
+}
+
+} // namespace
+
 void AnimationBlender::restoreSnapshot()
 {
     if (!m_snapshot.valid) return;
     // Resolve by the snapshot's recorded entity name in case the active
     // selection has already moved on.
-    Ogre::Entity* entity = nullptr;
-    for (Ogre::Entity* ent : SelectionSet::getSingleton()->getResolvedEntities()) {
-        if (ent && ent->getName() == m_snapshot.entityName) { entity = ent; break; }
+    Ogre::Entity* entity = findEntityByName(m_snapshot.entityName);
+    if (!entity) {
+        m_snapshot = {};
+        return;
     }
-    if (entity) {
-        if (auto* set = entity->getAllAnimationStates()) {
-            for (const auto& [name, state] : set->getAnimationStates()) {
-                auto it = m_snapshot.states.find(name);
-                if (it == m_snapshot.states.end()) continue;
-                state->setEnabled(it->second.enabled);
-                state->setWeight(it->second.weight);
-            }
+    if (auto* set = entity->getAllAnimationStates()) {
+        for (const auto& [name, state] : set->getAnimationStates()) {
+            auto it = m_snapshot.states.find(name);
+            if (it == m_snapshot.states.end()) continue;
+            state->setEnabled(it->second.enabled);
+            state->setWeight(it->second.weight);
         }
-        if (auto* skel = entity->getSkeleton()) {
-            skel->setBlendMode(m_snapshot.blendMode);
-        }
+    }
+    if (auto* skel = entity->getSkeleton()) {
+        skel->setBlendMode(m_snapshot.blendMode);
     }
     m_snapshot = {};
 }
 
 // ── Live blend ────────────────────────────────────────────────────────────────
+
+namespace {
+
+// Apply weights + enabled flags for a single sample of the given mode.
+// Used by both live apply() and bake() to keep the math in one place.
+void configureBlend(Ogre::AnimationState* a, Ogre::AnimationState* b,
+                    int mode, double weight)
+{
+    if (mode == AnimationBlender::ModeOverride) {
+        const bool useB = (weight >= 0.5);
+        a->setEnabled(!useB);
+        b->setEnabled(useB);
+        a->setWeight(useB ? 0.0f : 1.0f);
+        b->setWeight(useB ? 1.0f : 0.0f);
+    } else {
+        a->setEnabled(true);
+        b->setEnabled(true);
+        a->setWeight(static_cast<float>(1.0 - weight));
+        b->setWeight(static_cast<float>(weight));
+    }
+}
+
+// Disable any layer that isn't A or B so the entity's pose is exactly A+B.
+// Pre-blend layer enabled-flags are restored by the snapshot pathway.
+void muteOtherLayers(Ogre::Entity* entity,
+                     const std::string& nameA, const std::string& nameB)
+{
+    auto* set = entity->getAllAnimationStates();
+    if (!set) return;
+    for (const auto& [name, state] : set->getAnimationStates()) {
+        if (name != nameA && name != nameB) state->setEnabled(false);
+    }
+}
+
+// Advance a single state, routing through advanceTime() if it's the selected
+// clip (for slice-A loop region) and using speed-scaled addTime() otherwise.
+void advanceState(Ogre::AnimationState* s, const std::string& name,
+                  const std::string& activeAnim,
+                  AnimationControlController* ctrl,
+                  double dt, double scaledDt)
+{
+    if (name == activeAnim) {
+        const auto   now  = static_cast<double>(s->getTimePosition());
+        const double next = ctrl->advanceTime(now, dt);
+        s->setTimePosition(static_cast<float>(next));
+    } else {
+        s->addTime(static_cast<float>(scaledDt));
+    }
+}
+
+} // namespace
 
 bool AnimationBlender::apply(Ogre::Entity* entity, double dt)
 {
@@ -201,47 +264,19 @@ bool AnimationBlender::apply(Ogre::Entity* entity, double dt)
                            ? Ogre::ANIMBLEND_CUMULATIVE
                            : Ogre::ANIMBLEND_AVERAGE);
     }
+    muteOtherLayers(entity, m_animA, m_animB);
+    configureBlend(a, b, m_mode, m_weight);
 
-    // Disable any non-A/B states so the blended pose is purely A+B. Snapshot
-    // taken in setActive() will reinstate them when the blender is toggled
-    // off, so this is a non-destructive override.
-    if (auto* set = entity->getAllAnimationStates()) {
-        for (const auto& [name, state] : set->getAnimationStates()) {
-            if (name != m_animA && name != m_animB) state->setEnabled(false);
-        }
-    }
-
-    // Use the controller's advance helper so the slice-A loop region still
-    // wraps the *selected* clip (which is what the user is scrubbing).
-    // `dt` here is the raw frame delta from MainWindow; advanceTime() applies
-    // playbackSpeed itself, while the non-active clip uses scaled dt directly.
     auto* ctrl = AnimationControlController::instance();
     const std::string activeAnim = ctrl->selectedAnimation().toStdString();
-    const double scaledDt = dt * ctrl->playbackSpeed();
-    auto advance = [&](Ogre::AnimationState* s, const std::string& name) {
-        if (name == activeAnim) {
-            const double now  = static_cast<double>(s->getTimePosition());
-            const double next = ctrl->advanceTime(now, dt);
-            s->setTimePosition(static_cast<float>(next));
-        } else {
-            s->addTime(static_cast<float>(scaledDt));
-        }
-    };
-
+    const double      scaledDt   = dt * ctrl->playbackSpeed();
     if (m_mode == ModeOverride) {
         const bool useB = (m_weight >= 0.5);
-        a->setEnabled(!useB);
-        b->setEnabled(useB);
-        a->setWeight(useB ? 0.0f : 1.0f);
-        b->setWeight(useB ? 1.0f : 0.0f);
-        advance(useB ? b : a, useB ? m_animB : m_animA);
+        advanceState(useB ? b : a, useB ? m_animB : m_animA,
+                     activeAnim, ctrl, dt, scaledDt);
     } else {
-        a->setEnabled(true);
-        b->setEnabled(true);
-        a->setWeight(static_cast<float>(1.0 - m_weight));
-        b->setWeight(static_cast<float>(m_weight));
-        advance(a, m_animA);
-        advance(b, m_animB);
+        advanceState(a, m_animA, activeAnim, ctrl, dt, scaledDt);
+        advanceState(b, m_animB, activeAnim, ctrl, dt, scaledDt);
     }
     return true;
 }
@@ -303,7 +338,7 @@ void positionForSample(Ogre::AnimationState* sa, Ogre::AnimationState* sb,
 
 // Sample every bone's local TRS at the current skeleton state and emit a
 // keyframe at time `t` on each node track owned by `anim`.
-void writeAllBoneKeyframes(Ogre::Animation* anim, Ogre::Skeleton* skel, float t)
+void writeAllBoneKeyframes(Ogre::Animation* anim, const Ogre::Skeleton* skel, float t)
 {
     const unsigned short numBones = skel->getNumBones();
     for (unsigned short i = 0; i < numBones; ++i) {
@@ -311,6 +346,50 @@ void writeAllBoneKeyframes(Ogre::Animation* anim, Ogre::Skeleton* skel, float t)
         if (!bone) continue;
         if (auto* track = anim->getNodeTrack(bone->getHandle())) {
             writeBoneKeyframe(track, t, bone);
+        }
+    }
+}
+
+// Capture every state's enabled/weight/time into a flat map keyed by name.
+std::unordered_map<std::string, StateRestore> captureAllStates(const Ogre::Entity* entity)
+{
+    std::unordered_map<std::string, StateRestore> out;
+    if (const auto* set = entity->getAllAnimationStates()) {
+        for (const auto& [name, state] : set->getAnimationStates()) {
+            out[name] = captureState(state);
+        }
+    }
+    return out;
+}
+
+// Inverse of captureAllStates — re-applies whatever was recorded earlier so
+// the entity's animation states look identical to before bake() ran.
+void restoreAllStates(Ogre::Entity* entity,
+                      const std::unordered_map<std::string, StateRestore>& saved)
+{
+    auto* set = entity->getAllAnimationStates();
+    if (!set) return;
+    for (const auto& [name, state] : set->getAnimationStates()) {
+        auto it = saved.find(name);
+        if (it != saved.end()) restoreState(state, it->second);
+    }
+}
+
+void disableNonAB(Ogre::Entity* entity, const std::string& a, const std::string& b)
+{
+    auto* set = entity->getAllAnimationStates();
+    if (!set) return;
+    for (const auto& [name, state] : set->getAnimationStates()) {
+        if (name != a && name != b) state->setEnabled(false);
+    }
+}
+
+void createBoneTracks(Ogre::Animation* anim, Ogre::Skeleton* skel)
+{
+    const unsigned short numBones = skel->getNumBones();
+    for (unsigned short i = 0; i < numBones; ++i) {
+        if (Ogre::Bone* bone = skel->getBone(i)) {
+            anim->createNodeTrack(bone->getHandle(), bone);
         }
     }
 }
@@ -347,31 +426,13 @@ QString AnimationBlender::bake(const QString& clipName, int fps)
     if (skel->hasAnimation(clipStd)) skel->removeAnimation(clipStd);
     Ogre::Animation* anim = skel->createAnimation(clipStd, length);
     anim->setInterpolationMode(Ogre::Animation::IM_LINEAR);
+    createBoneTracks(anim, skel);
 
-    // Track per bone — keeps the bake reproducible even for unanimated bones.
-    const unsigned short numBones = skel->getNumBones();
-    for (unsigned short i = 0; i < numBones; ++i) {
-        if (Ogre::Bone* bone = skel->getBone(i)) {
-            anim->createNodeTrack(bone->getHandle(), bone);
-        }
-    }
+    // Preserve every state's pre-bake config so the live preview is unaffected.
+    const auto live      = captureAllStates(entity);
+    const auto prevBlend = skel->getBlendMode();
 
-    // Preserve every state's pre-bake config — A, B, and any third-party
-    // layers the entity had enabled — so the live preview is unaffected.
-    std::unordered_map<std::string, StateRestore> live;
-    if (auto* set = entity->getAllAnimationStates()) {
-        for (const auto& [name, state] : set->getAnimationStates()) {
-            live[name] = captureState(state);
-        }
-    }
-    const Ogre::SkeletonAnimationBlendMode prevBlend = skel->getBlendMode();
-
-    // Disable everything except A and B so each sampled pose is purely A+B.
-    if (auto* set = entity->getAllAnimationStates()) {
-        for (const auto& [name, state] : set->getAnimationStates()) {
-            if (name != m_animA && name != m_animB) state->setEnabled(false);
-        }
-    }
+    disableNonAB(entity, m_animA, m_animB);
     skel->setBlendMode(m_mode == ModeAdditive
                        ? Ogre::ANIMBLEND_CUMULATIVE
                        : Ogre::ANIMBLEND_AVERAGE);
@@ -384,13 +445,7 @@ QString AnimationBlender::bake(const QString& clipName, int fps)
         writeAllBoneKeyframes(anim, skel, t);
     }
 
-    // Restore live state for every layer we touched.
-    if (auto* set = entity->getAllAnimationStates()) {
-        for (const auto& [name, state] : set->getAnimationStates()) {
-            auto it = live.find(name);
-            if (it != live.end()) restoreState(state, it->second);
-        }
-    }
+    restoreAllStates(entity, live);
     skel->setBlendMode(prevBlend);
 
     entity->refreshAvailableAnimationState();

--- a/src/AnimationBlender.h
+++ b/src/AnimationBlender.h
@@ -4,7 +4,9 @@
 #include <QObject>
 #include <QStringList>
 #include <QQmlEngine>
+#include <Ogre.h>
 #include <string>
+#include <unordered_map>
 
 namespace Ogre {
     class Entity;
@@ -40,7 +42,11 @@ class AnimationBlender : public QObject
     Q_PROPERTY(QStringList animations READ animations NOTIFY animationsChanged)
 
 public:
-    enum Mode { ModeMix = 0, ModeAdditive = 1, ModeOverride = 2 };
+    enum Mode {
+        ModeMix      = 0,
+        ModeAdditive = 1,
+        ModeOverride = 2
+    };
     Q_ENUM(Mode)
 
     static AnimationBlender* instance();
@@ -93,6 +99,23 @@ private:
 
     Ogre::Entity* resolveActiveEntity() const;
 
+    // Snapshot of every animation state's enabled flag + weight, plus the
+    // skeleton's blend mode, so toggling the blender on/off (or switching
+    // entities) can return live playback to its pre-blend configuration.
+    struct StateSnapshot {
+        bool  enabled = false;
+        float weight  = 0.0f;
+    };
+    struct PreviewSnapshot {
+        std::string entityName;
+        std::unordered_map<std::string, StateSnapshot> states;
+        Ogre::SkeletonAnimationBlendMode blendMode = Ogre::ANIMBLEND_AVERAGE;
+        bool valid = false;
+    };
+
+    void captureSnapshot(Ogre::Entity* entity);
+    void restoreSnapshot();
+
     static AnimationBlender* m_pSingleton;
 
     bool        m_active = false;
@@ -102,6 +125,8 @@ private:
     Mode        m_mode   = ModeMix;
     std::string m_activeEntityName;
     QStringList m_animations;
+
+    PreviewSnapshot m_snapshot;
 };
 
 #endif // ANIMATIONBLENDER_H

--- a/src/AnimationBlender.h
+++ b/src/AnimationBlender.h
@@ -30,7 +30,12 @@ namespace Ogre {
  * skeleton. Existing tracks per bone are extended; existing animations with
  * the same name are removed first.
  */
-class AnimationBlender : public QObject
+// NOSONAR (cpp:S1448) — Q_PROPERTY getters/setters/signals + the QML
+// singleton boilerplate (instance/qmlInstance/kill) push the method count
+// just over Sonar's threshold of 35. Splitting this into smaller classes
+// would fragment the blender's responsibilities (live preview + bake) and
+// double the QML wiring without making the code clearer.
+class AnimationBlender : public QObject // NOSONAR
 {
     Q_OBJECT
 

--- a/src/AnimationBlender.h
+++ b/src/AnimationBlender.h
@@ -40,6 +40,7 @@ class AnimationBlender : public QObject
     Q_PROPERTY(double      weight   READ weight   WRITE setWeight   NOTIFY weightChanged)
     Q_PROPERTY(int         mode     READ mode     WRITE setMode     NOTIFY modeChanged)
     Q_PROPERTY(QStringList animations READ animations NOTIFY animationsChanged)
+    Q_PROPERTY(QString     activeEntityName READ activeEntityName NOTIFY animationsChanged)
 
 public:
     enum Mode {
@@ -53,12 +54,13 @@ public:
     static AnimationBlender* qmlInstance(QQmlEngine* engine, QJSEngine* scriptEngine);
     static void kill();
 
-    bool        active()     const { return m_active; }
-    QString     animA()      const;
-    QString     animB()      const;
-    double      weight()     const { return m_weight; }
-    int         mode()       const { return static_cast<int>(m_mode); }
-    QStringList animations() const { return m_animations; }
+    bool        active()           const { return m_active; }
+    QString     animA()            const;
+    QString     animB()            const;
+    double      weight()           const { return m_weight; }
+    int         mode()             const { return static_cast<int>(m_mode); }
+    QStringList animations()       const { return m_animations; }
+    QString     activeEntityName() const { return QString::fromStdString(m_activeEntityName); }
 
     void setActive(bool on);
     void setAnimA(const QString& name);

--- a/src/AnimationBlender.h
+++ b/src/AnimationBlender.h
@@ -1,0 +1,107 @@
+#ifndef ANIMATIONBLENDER_H
+#define ANIMATIONBLENDER_H
+
+#include <QObject>
+#include <QStringList>
+#include <QQmlEngine>
+#include <string>
+
+namespace Ogre {
+    class Entity;
+    class AnimationState;
+}
+
+/**
+ * Live two-way animation blender for the entity that is currently selected
+ * in the Animation Control panel.
+ *
+ *   Mix       — both states enabled, weights = (1-w, w)
+ *   Additive  — skeleton blend mode set to ANIMBLEND_CUMULATIVE; same weights
+ *   Override  — only state B is enabled when w >= 0.5, else state A
+ *
+ * The blender does not own a frame loop; weights are applied lazily via
+ * apply() (called from MainWindow::frameRenderingQueued) so we can reuse the
+ * existing render-tick path. When inactive, apply() is a no-op.
+ *
+ * Bake samples the live blend at a fixed frame rate over [0, max(lengthA,
+ * lengthB)] seconds and writes a new Ogre::Animation onto the entity's
+ * skeleton. Existing tracks per bone are extended; existing animations with
+ * the same name are removed first.
+ */
+class AnimationBlender : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(bool        active   READ active   WRITE setActive   NOTIFY activeChanged)
+    Q_PROPERTY(QString     animA    READ animA    WRITE setAnimA    NOTIFY selectionChanged)
+    Q_PROPERTY(QString     animB    READ animB    WRITE setAnimB    NOTIFY selectionChanged)
+    Q_PROPERTY(double      weight   READ weight   WRITE setWeight   NOTIFY weightChanged)
+    Q_PROPERTY(int         mode     READ mode     WRITE setMode     NOTIFY modeChanged)
+    Q_PROPERTY(QStringList animations READ animations NOTIFY animationsChanged)
+
+public:
+    enum Mode { ModeMix = 0, ModeAdditive = 1, ModeOverride = 2 };
+    Q_ENUM(Mode)
+
+    static AnimationBlender* instance();
+    static AnimationBlender* qmlInstance(QQmlEngine* engine, QJSEngine* scriptEngine);
+    static void kill();
+
+    bool        active()     const { return m_active; }
+    QString     animA()      const;
+    QString     animB()      const;
+    double      weight()     const { return m_weight; }
+    int         mode()       const { return static_cast<int>(m_mode); }
+    QStringList animations() const { return m_animations; }
+
+    void setActive(bool on);
+    void setAnimA(const QString& name);
+    void setAnimB(const QString& name);
+    void setWeight(double w);
+    void setMode(int m);
+
+    /// Apply the current blend to the active entity's animation states.
+    /// Called from MainWindow's render tick; safe to call when inactive.
+    /// Returns true if the blender consumed the frame (caller should skip
+    /// its own per-state advance for the active entity), false otherwise.
+    bool apply(Ogre::Entity* entity, double dt);
+
+    /// Bake the live blend into a new Ogre::Animation on the entity's
+    /// skeleton. fps controls the sample rate (default 30). Returns the
+    /// new clip name on success or an empty string on failure (errorMsg
+    /// populated). If a clip with `clipName` already exists it is replaced.
+    Q_INVOKABLE QString bake(const QString& clipName, int fps = 30);
+
+public slots:
+    /// Repopulate `animations` from the entity currently selected in
+    /// AnimationControlController, plus reset blend state if the active
+    /// entity changed.
+    void refreshFromSelection();
+
+signals:
+    void activeChanged();
+    void selectionChanged();
+    void weightChanged();
+    void modeChanged();
+    void animationsChanged();
+    /// Emitted after a successful bake. `name` is the new clip name.
+    void clipBaked(const QString& name);
+
+private:
+    AnimationBlender();
+    ~AnimationBlender() override = default;
+
+    Ogre::Entity* resolveActiveEntity() const;
+
+    static AnimationBlender* m_pSingleton;
+
+    bool        m_active = false;
+    std::string m_animA;
+    std::string m_animB;
+    double      m_weight = 0.5;
+    Mode        m_mode   = ModeMix;
+    std::string m_activeEntityName;
+    QStringList m_animations;
+};
+
+#endif // ANIMATIONBLENDER_H

--- a/src/AnimationBlender.h
+++ b/src/AnimationBlender.h
@@ -117,6 +117,11 @@ private:
 
     void captureSnapshot(Ogre::Entity* entity);
     void restoreSnapshot();
+    /// Force-deactivate the blender if the current A/B selection is unusable
+    /// (empty side or A == B). Called by the setters whenever m_animA or
+    /// m_animB changes — without this, the entity keeps playing in its last
+    /// blended configuration when the selection becomes invalid mid-run.
+    void deactivateIfInvalid();
 
     static AnimationBlender* m_pSingleton;
 

--- a/src/AnimationBlender_test.cpp
+++ b/src/AnimationBlender_test.cpp
@@ -64,6 +64,9 @@ TEST_F(AnimationBlenderPropertyTest, ModeClampsToKnownValues) {
 
 TEST_F(AnimationBlenderPropertyTest, ActiveTogglesEmitSignal) {
     auto* b = AnimationBlender::instance();
+    // Precondition: A/B must be set + distinct for activation to be accepted.
+    b->setAnimA("walk");
+    b->setAnimB("run");
     QSignalSpy spy(b, &AnimationBlender::activeChanged);
     b->setActive(true);
     EXPECT_EQ(spy.count(), 1);

--- a/src/AnimationBlender_test.cpp
+++ b/src/AnimationBlender_test.cpp
@@ -135,6 +135,35 @@ TEST_F(AnimationBlenderPropertyTest, BakeOverSourceClipReturnsEmpty) {
     EXPECT_TRUE(b->bake("run", 30).isEmpty());
 }
 
+TEST_F(AnimationBlenderPropertyTest, ActivateRefusedWhenAnimAEmpty) {
+    auto* b = AnimationBlender::instance();
+    b->setAnimB("run"); // A still empty
+    b->setActive(true);
+    EXPECT_FALSE(b->active());
+}
+
+TEST_F(AnimationBlenderPropertyTest, ActivateRefusedWhenAnimBEmpty) {
+    auto* b = AnimationBlender::instance();
+    b->setAnimA("walk"); // B still empty
+    b->setActive(true);
+    EXPECT_FALSE(b->active());
+}
+
+TEST_F(AnimationBlenderPropertyTest, ActivateRefusedWhenAEqualsB) {
+    auto* b = AnimationBlender::instance();
+    b->setAnimA("walk");
+    b->setAnimB("walk"); // same clip both sides
+    b->setActive(true);
+    EXPECT_FALSE(b->active());
+}
+
+TEST_F(AnimationBlenderPropertyTest, BakeRefusedWhenAEqualsB) {
+    auto* b = AnimationBlender::instance();
+    b->setAnimA("walk");
+    b->setAnimB("walk");
+    EXPECT_TRUE(b->bake("X", 30).isEmpty());
+}
+
 // ── Live blend + bake against a real animated entity ──────────────────────────
 //
 // Uses the standard Ogre test fixture pattern. createAnimatedTestEntity() only

--- a/src/AnimationBlender_test.cpp
+++ b/src/AnimationBlender_test.cpp
@@ -167,6 +167,28 @@ TEST_F(AnimationBlenderPropertyTest, BakeRefusedWhenAEqualsB) {
     EXPECT_TRUE(b->bake("X", 30).isEmpty());
 }
 
+TEST_F(AnimationBlenderPropertyTest, ClearingAnimAWhileActiveDeactivates) {
+    auto* b = AnimationBlender::instance();
+    b->setAnimA("walk");
+    b->setAnimB("run");
+    b->setActive(true);
+    ASSERT_TRUE(b->active());
+    // Clearing animA invalidates the blend → blender must self-deactivate.
+    b->setAnimA("");
+    EXPECT_FALSE(b->active());
+}
+
+TEST_F(AnimationBlenderPropertyTest, MakingAEqualBWhileActiveDeactivates) {
+    auto* b = AnimationBlender::instance();
+    b->setAnimA("walk");
+    b->setAnimB("run");
+    b->setActive(true);
+    ASSERT_TRUE(b->active());
+    // Setting B to the same clip as A invalidates the blend.
+    b->setAnimB("walk");
+    EXPECT_FALSE(b->active());
+}
+
 // ── Live blend + bake against a real animated entity ──────────────────────────
 //
 // Uses the standard Ogre test fixture pattern. createAnimatedTestEntity() only

--- a/src/AnimationBlender_test.cpp
+++ b/src/AnimationBlender_test.cpp
@@ -110,6 +110,31 @@ TEST_F(AnimationBlenderPropertyTest, BakeWithNoSelectionReturnsEmpty) {
     EXPECT_TRUE(b->bake("MyClip", 30).isEmpty());
 }
 
+TEST_F(AnimationBlenderPropertyTest, BakeRefusesEmptyAnimAB) {
+    auto* b = AnimationBlender::instance();
+    // animA/animB unset → bake bails out before ever touching the entity.
+    EXPECT_TRUE(b->bake("X", 30).isEmpty());
+    b->setAnimA("walk");
+    EXPECT_TRUE(b->bake("X", 30).isEmpty());
+    b->setAnimA("");
+    b->setAnimB("run");
+    EXPECT_TRUE(b->bake("X", 30).isEmpty());
+}
+
+TEST_F(AnimationBlenderPropertyTest, ActiveEntityNameDefaultsEmpty) {
+    auto* b = AnimationBlender::instance();
+    EXPECT_TRUE(b->activeEntityName().isEmpty());
+}
+
+TEST_F(AnimationBlenderPropertyTest, BakeOverSourceClipReturnsEmpty) {
+    auto* b = AnimationBlender::instance();
+    b->setAnimA("walk");
+    b->setAnimB("run");
+    // Even with no entity resolved, the source-name guard should fire first.
+    EXPECT_TRUE(b->bake("walk", 30).isEmpty());
+    EXPECT_TRUE(b->bake("run", 30).isEmpty());
+}
+
 // ── Live blend + bake against a real animated entity ──────────────────────────
 //
 // Uses the standard Ogre test fixture pattern. createAnimatedTestEntity() only
@@ -290,4 +315,118 @@ TEST_F(AnimationBlenderTest, BakeOverwritesExistingClipWithSameName) {
     auto* track = skel->getAnimation("Reusable")->getNodeTrack(1);
     ASSERT_NE(track, nullptr);
     EXPECT_EQ(track->getNumKeyFrames(), 61u);
+}
+
+// ── New behavior tests (snapshot/restore + bake side effects) ─────────────────
+
+TEST_F(AnimationBlenderTest, BakeRefusesToOverwriteSourceClip) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupBlendEntity("ABT_OverwriteSourceTest");
+    ASSERT_NE(entity, nullptr);
+
+    auto* b = AnimationBlender::instance();
+    b->refreshFromSelection();
+    b->setAnimA("TestAnim");
+    b->setAnimB("TestAnimB");
+    // Both source clip names should be rejected.
+    EXPECT_TRUE(b->bake("TestAnim", 30).isEmpty());
+    EXPECT_TRUE(b->bake("TestAnimB", 30).isEmpty());
+    // Source clips remain intact.
+    EXPECT_TRUE(entity->getSkeleton()->hasAnimation("TestAnim"));
+    EXPECT_TRUE(entity->getSkeleton()->hasAnimation("TestAnimB"));
+}
+
+TEST_F(AnimationBlenderTest, ActivateDisablesEveryAnimationState) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupBlendEntity("ABT_ActivateDisablesTest");
+    ASSERT_NE(entity, nullptr);
+
+    // Pre-condition: both animations enabled before activation.
+    auto* setBefore = entity->getAllAnimationStates();
+    setBefore->getAnimationState("TestAnim")->setEnabled(true);
+    setBefore->getAnimationState("TestAnimB")->setEnabled(true);
+
+    auto* b = AnimationBlender::instance();
+    b->refreshFromSelection();
+    b->setAnimA("TestAnim");
+    b->setAnimB("TestAnimB");
+    b->setActive(true);
+
+    // After activation, every per-anim state should be disabled. apply()
+    // re-enables A and B on the next render tick — but in this test there's
+    // no tick, so we only check the immediate post-activation state.
+    auto* set = entity->getAllAnimationStates();
+    for (const auto& [name, state] : set->getAnimationStates()) {
+        EXPECT_FALSE(state->getEnabled())
+            << "expected " << name << " disabled after blender activate";
+    }
+}
+
+TEST_F(AnimationBlenderTest, DeactivateRestoresPreActivateEnabledFlags) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupBlendEntity("ABT_DeactivateRestoresTest");
+    ASSERT_NE(entity, nullptr);
+
+    // Set a known pre-blend configuration: only TestAnim enabled.
+    auto* set = entity->getAllAnimationStates();
+    set->getAnimationState("TestAnim")->setEnabled(true);
+    set->getAnimationState("TestAnimB")->setEnabled(false);
+
+    auto* b = AnimationBlender::instance();
+    b->refreshFromSelection();
+    b->setAnimA("TestAnim");
+    b->setAnimB("TestAnimB");
+    b->setActive(true);
+    // Verify activation changed things.
+    EXPECT_FALSE(set->getAnimationState("TestAnim")->getEnabled());
+
+    b->setActive(false);
+    // After deactivation, the snapshot should restore the original flags.
+    EXPECT_TRUE(set->getAnimationState("TestAnim")->getEnabled());
+    EXPECT_FALSE(set->getAnimationState("TestAnimB")->getEnabled());
+}
+
+TEST_F(AnimationBlenderTest, BakeDeactivatesBlender) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupBlendEntity("ABT_BakeDeactivatesTest");
+    ASSERT_NE(entity, nullptr);
+
+    auto* b = AnimationBlender::instance();
+    b->refreshFromSelection();
+    b->setAnimA("TestAnim");
+    b->setAnimB("TestAnimB");
+    b->setActive(true);
+    EXPECT_TRUE(b->active());
+
+    ASSERT_FALSE(b->bake("BakedClip", 30).isEmpty());
+
+    // After bake, the blender should have deactivated itself so the live
+    // preview returns to the pre-blend state.
+    EXPECT_FALSE(b->active());
+}
+
+TEST_F(AnimationBlenderTest, ClipBakedSignalEmittedOnSuccess) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupBlendEntity("ABT_ClipBakedSignalTest");
+    ASSERT_NE(entity, nullptr);
+
+    auto* b = AnimationBlender::instance();
+    b->refreshFromSelection();
+    b->setAnimA("TestAnim");
+    b->setAnimB("TestAnimB");
+
+    QSignalSpy spy(b, &AnimationBlender::clipBaked);
+    ASSERT_FALSE(b->bake("SignalClip", 30).isEmpty());
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.takeFirst().at(0).toString(), "SignalClip");
+}
+
+TEST_F(AnimationBlenderTest, ActiveEntityNameTracksControllerSelection) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupBlendEntity("ABT_ActiveEntityNameTest");
+    ASSERT_NE(entity, nullptr);
+
+    auto* b = AnimationBlender::instance();
+    b->refreshFromSelection();
+    EXPECT_EQ(b->activeEntityName().toStdString(), entity->getName());
 }

--- a/src/AnimationBlender_test.cpp
+++ b/src/AnimationBlender_test.cpp
@@ -1,0 +1,293 @@
+#include <gtest/gtest.h>
+#include <QApplication>
+#include <QCoreApplication>
+#include <QSignalSpy>
+#include <QThread>
+
+#include "AnimationBlender.h"
+#include "AnimationControlController.h"
+#include "Manager.h"
+#include "SelectionSet.h"
+#include "TestHelpers.h"
+
+#include <OgreSkeletonInstance.h>
+#include <OgreAnimation.h>
+#include <OgreAnimationState.h>
+#include <OgreKeyFrame.h>
+
+// Pure-data fixture — exercises property setters, signals, and clamping.
+// Doesn't need Ogre to load, so runs on every platform (including macOS
+// where Ogre plugins fail to load for the test binary).
+class AnimationBlenderPropertyTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        AnimationBlender::kill();
+        AnimationControlController::kill();
+        app = qobject_cast<QApplication*>(QCoreApplication::instance());
+        ASSERT_NE(app, nullptr);
+    }
+    void TearDown() override {
+        AnimationBlender::kill();
+        AnimationControlController::kill();
+    }
+    QApplication* app = nullptr;
+};
+
+TEST_F(AnimationBlenderPropertyTest, DefaultsAreSane) {
+    auto* b = AnimationBlender::instance();
+    EXPECT_FALSE(b->active());
+    EXPECT_DOUBLE_EQ(b->weight(), 0.5);
+    EXPECT_EQ(b->mode(), static_cast<int>(AnimationBlender::ModeMix));
+    EXPECT_TRUE(b->animA().isEmpty());
+    EXPECT_TRUE(b->animB().isEmpty());
+}
+
+TEST_F(AnimationBlenderPropertyTest, WeightClamps) {
+    auto* b = AnimationBlender::instance();
+    b->setWeight(-1.0);
+    EXPECT_DOUBLE_EQ(b->weight(), 0.0);
+    b->setWeight(2.5);
+    EXPECT_DOUBLE_EQ(b->weight(), 1.0);
+    b->setWeight(0.42);
+    EXPECT_DOUBLE_EQ(b->weight(), 0.42);
+}
+
+TEST_F(AnimationBlenderPropertyTest, ModeClampsToKnownValues) {
+    auto* b = AnimationBlender::instance();
+    b->setMode(99); // invalid → defaults to Mix
+    EXPECT_EQ(b->mode(), static_cast<int>(AnimationBlender::ModeMix));
+    b->setMode(static_cast<int>(AnimationBlender::ModeAdditive));
+    EXPECT_EQ(b->mode(), static_cast<int>(AnimationBlender::ModeAdditive));
+    b->setMode(static_cast<int>(AnimationBlender::ModeOverride));
+    EXPECT_EQ(b->mode(), static_cast<int>(AnimationBlender::ModeOverride));
+}
+
+TEST_F(AnimationBlenderPropertyTest, ActiveTogglesEmitSignal) {
+    auto* b = AnimationBlender::instance();
+    QSignalSpy spy(b, &AnimationBlender::activeChanged);
+    b->setActive(true);
+    EXPECT_EQ(spy.count(), 1);
+    b->setActive(true); // unchanged → no re-emit
+    EXPECT_EQ(spy.count(), 1);
+    b->setActive(false);
+    EXPECT_EQ(spy.count(), 2);
+}
+
+TEST_F(AnimationBlenderPropertyTest, WeightChangeEmitsSignal) {
+    auto* b = AnimationBlender::instance();
+    QSignalSpy spy(b, &AnimationBlender::weightChanged);
+    b->setWeight(0.25);
+    EXPECT_EQ(spy.count(), 1);
+    b->setWeight(0.25); // same → no re-emit
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(AnimationBlenderPropertyTest, AnimSelectionEmitsSignal) {
+    auto* b = AnimationBlender::instance();
+    QSignalSpy spy(b, &AnimationBlender::selectionChanged);
+    b->setAnimA("walk");
+    EXPECT_EQ(spy.count(), 1);
+    b->setAnimB("run");
+    EXPECT_EQ(spy.count(), 2);
+    b->setAnimA("walk"); // unchanged → no re-emit
+    EXPECT_EQ(spy.count(), 2);
+}
+
+TEST_F(AnimationBlenderPropertyTest, ApplyOnNullEntityIsNoOp) {
+    auto* b = AnimationBlender::instance();
+    b->setActive(true);
+    EXPECT_NO_THROW(b->apply(nullptr, 0.016));
+    EXPECT_FALSE(b->apply(nullptr, 0.016));
+}
+
+TEST_F(AnimationBlenderPropertyTest, BakeWithEmptyClipNameReturnsEmpty) {
+    auto* b = AnimationBlender::instance();
+    EXPECT_TRUE(b->bake("", 30).isEmpty());
+}
+
+TEST_F(AnimationBlenderPropertyTest, BakeWithNoSelectionReturnsEmpty) {
+    auto* b = AnimationBlender::instance();
+    EXPECT_TRUE(b->bake("MyClip", 30).isEmpty());
+}
+
+// ── Live blend + bake against a real animated entity ──────────────────────────
+//
+// Uses the standard Ogre test fixture pattern. createAnimatedTestEntity() only
+// builds one animation ("TestAnim"); the helper below adds a second one so we
+// can exercise the actual blend math.
+
+class AnimationBlenderTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        AnimationBlender::kill();
+        AnimationControlController::kill();
+        Manager::kill();
+        QThread::msleep(20);
+        app = qobject_cast<QApplication*>(QCoreApplication::instance());
+        ASSERT_NE(app, nullptr);
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+        createStandardOgreMaterials();
+    }
+    void TearDown() override {
+        SelectionSet::getSingleton()->clear();
+        if (app) app->processEvents();
+        AnimationBlender::kill();
+        AnimationControlController::kill();
+    }
+
+    // Adds a second animation "TestAnimB" with its own keyframes on the
+    // child bone of the entity returned by createAnimatedTestEntity().
+    static void addSecondAnim(Ogre::Entity* entity) {
+        auto* skel = entity->getSkeleton();
+        // skeleton-instance creation goes through the master skeleton; we add
+        // the animation on the master and then re-init the instance via
+        // refreshAvailableAnimationState below.
+        Ogre::Skeleton* master = skel; // SkeletonInstance shares animations
+        auto* anim = master->createAnimation("TestAnimB", 1.0f);
+        auto* track = anim->createNodeTrack(1);
+        track->setAssociatedNode(skel->getBone(1));
+
+        // KFs designed to differ from TestAnim so weight=0 vs weight=1
+        // produce visibly different poses.
+        auto* kf0 = track->createNodeKeyFrame(0.0f);
+        kf0->setTranslate(Ogre::Vector3(2.0f, 0, 0));
+        kf0->setRotation(Ogre::Quaternion::IDENTITY);
+        kf0->setScale(Ogre::Vector3::UNIT_SCALE);
+        auto* kf1 = track->createNodeKeyFrame(1.0f);
+        kf1->setTranslate(Ogre::Vector3(2.0f, 0, 0));
+        kf1->setRotation(Ogre::Quaternion::IDENTITY);
+        kf1->setScale(Ogre::Vector3::UNIT_SCALE);
+
+        entity->refreshAvailableAnimationState();
+    }
+
+    Ogre::Entity* setupBlendEntity(const std::string& name) {
+        if (!canLoadMeshFiles()) return nullptr;
+        Ogre::Entity* entity = createAnimatedTestEntity(name);
+        if (!entity) return nullptr;
+        addSecondAnim(entity);
+        SelectionSet::getSingleton()->selectOne(entity->getParentSceneNode());
+        if (app) app->processEvents();
+        // Drive the controller so the blender's refreshFromSelection() picks
+        // up the active entity.
+        auto* ctrl = AnimationControlController::instance();
+        ctrl->updateAnimationTree();
+        ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+        return entity;
+    }
+
+    QApplication* app = nullptr;
+};
+
+TEST_F(AnimationBlenderTest, RefreshExposesEntityAnimations) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupBlendEntity("ABT_RefreshTest");
+    ASSERT_NE(entity, nullptr);
+
+    auto* b = AnimationBlender::instance();
+    b->refreshFromSelection();
+    auto names = b->animations();
+    EXPECT_TRUE(names.contains("TestAnim"));
+    EXPECT_TRUE(names.contains("TestAnimB"));
+}
+
+TEST_F(AnimationBlenderTest, BakeProducesNewClipWithExpectedLength) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupBlendEntity("ABT_BakeTest");
+    ASSERT_NE(entity, nullptr);
+
+    auto* b = AnimationBlender::instance();
+    b->refreshFromSelection();
+    b->setAnimA("TestAnim");
+    b->setAnimB("TestAnimB");
+    b->setWeight(0.5);
+    b->setMode(AnimationBlender::ModeMix);
+
+    QString clip = b->bake("BlendedClip", 30);
+    EXPECT_EQ(clip, "BlendedClip");
+
+    auto* skel = entity->getSkeleton();
+    ASSERT_TRUE(skel->hasAnimation("BlendedClip"));
+    auto* baked = skel->getAnimation("BlendedClip");
+    EXPECT_NEAR(baked->getLength(), 1.0f, 1e-3);
+    // 30 fps over 1.0s → 31 samples (including endpoints)
+    auto* track = baked->getNodeTrack(1);
+    ASSERT_NE(track, nullptr);
+    EXPECT_EQ(track->getNumKeyFrames(), 31u);
+}
+
+TEST_F(AnimationBlenderTest, BakeAtZeroWeightMatchesAnimA) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupBlendEntity("ABT_W0Test");
+    ASSERT_NE(entity, nullptr);
+
+    auto* b = AnimationBlender::instance();
+    b->refreshFromSelection();
+    b->setAnimA("TestAnim");
+    b->setAnimB("TestAnimB");
+    b->setWeight(0.0);
+
+    ASSERT_FALSE(b->bake("BlendW0", 30).isEmpty());
+
+    auto* skel = entity->getSkeleton();
+    auto* baked = skel->getAnimation("BlendW0");
+    auto* track = baked->getNodeTrack(1);
+    ASSERT_NE(track, nullptr);
+
+    // TestAnim at t=0.5 sets translate to (0.5, 0, 0). Find the closest
+    // baked keyframe to t=0.5 and confirm.
+    Ogre::TransformKeyFrame* closest = nullptr;
+    float bestDist = 1.0f;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        auto* kf = static_cast<Ogre::TransformKeyFrame*>(track->getKeyFrame(i));
+        const float d = std::fabs(kf->getTime() - 0.5f);
+        if (d < bestDist) { bestDist = d; closest = kf; }
+    }
+    ASSERT_NE(closest, nullptr);
+    // weight=0 ⇒ purely TestAnim (≈0.5 on x at t=0.5)
+    EXPECT_NEAR(closest->getTranslate().x, 0.5f, 0.05f);
+}
+
+TEST_F(AnimationBlenderTest, BakeAtFullWeightMatchesAnimB) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupBlendEntity("ABT_W1Test");
+    ASSERT_NE(entity, nullptr);
+
+    auto* b = AnimationBlender::instance();
+    b->refreshFromSelection();
+    b->setAnimA("TestAnim");
+    b->setAnimB("TestAnimB");
+    b->setWeight(1.0);
+
+    ASSERT_FALSE(b->bake("BlendW1", 30).isEmpty());
+    auto* baked = entity->getSkeleton()->getAnimation("BlendW1");
+    auto* track = baked->getNodeTrack(1);
+    ASSERT_NE(track, nullptr);
+
+    // TestAnimB sets translate to (2, 0, 0) at every t — at weight=1 the
+    // bake should land near 2.0 on x for every sample.
+    auto* mid = static_cast<Ogre::TransformKeyFrame*>(track->getKeyFrame(track->getNumKeyFrames() / 2));
+    EXPECT_NEAR(mid->getTranslate().x, 2.0f, 0.05f);
+}
+
+TEST_F(AnimationBlenderTest, BakeOverwritesExistingClipWithSameName) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupBlendEntity("ABT_OverwriteTest");
+    ASSERT_NE(entity, nullptr);
+
+    auto* b = AnimationBlender::instance();
+    b->refreshFromSelection();
+    b->setAnimA("TestAnim");
+    b->setAnimB("TestAnimB");
+    b->setWeight(0.5);
+
+    ASSERT_FALSE(b->bake("Reusable", 30).isEmpty());
+    ASSERT_FALSE(b->bake("Reusable", 60).isEmpty());
+
+    auto* skel = entity->getSkeleton();
+    EXPECT_TRUE(skel->hasAnimation("Reusable"));
+    // 60 fps version should have ~61 keyframes
+    auto* track = skel->getAnimation("Reusable")->getNodeTrack(1);
+    ASSERT_NE(track, nullptr);
+    EXPECT_EQ(track->getNumKeyFrames(), 61u);
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 set(SRC_FILES
 about.cpp
+AnimationBlender.cpp
 AnimationControlController.cpp
 main.cpp
 Manager.cpp
@@ -74,6 +75,7 @@ HalfEdgeMesh.cpp
 )
 
 set(HEADER_FILES
+AnimationBlender.h
 AnimationControlController.h
 GlobalDefinitions.h
 Euler.h

--- a/src/PropertiesPanelController.cpp
+++ b/src/PropertiesPanelController.cpp
@@ -4,6 +4,7 @@
 #include "TransformOperator.h"
 #include "PrimitiveObject.h"
 #include "AnimationWidget.h"
+#include "AnimationBlender.h"
 #include "SkeletonTransform.h"
 #include "AnimationMerger.h"
 #include "SentryReporter.h"
@@ -52,6 +53,16 @@ PropertiesPanelController::PropertiesPanelController() : QObject(nullptr)
 {
     connect(SelectionSet::getSingleton(), &SelectionSet::selectionChanged,
             this, &PropertiesPanelController::onSelectionChanged);
+
+    // When the blender bakes a new clip, the entity's animation list grew —
+    // tell the Inspector to re-query so the new clip shows up immediately.
+    connect(AnimationBlender::instance(), &AnimationBlender::clipBaked,
+            this, [this]() { emit animationStateChanged(); });
+    // When the blender activates, it disables every per-animation enabled
+    // flag on the active entity; deactivation restores them. Either way the
+    // panel needs to re-read so its checkboxes match.
+    connect(AnimationBlender::instance(), &AnimationBlender::activeChanged,
+            this, [this]() { emit animationStateChanged(); });
 
     auto* transformOp = TransformOperator::getSingleton();
     connect(transformOp, &TransformOperator::selectedPositionChanged, this, [this](const Ogre::Vector3& pos) {
@@ -120,6 +131,15 @@ QColor PropertiesPanelController::borderColor() const
 QColor PropertiesPanelController::inputColor() const
 {
     return QApplication::palette().color(QPalette::Base);
+}
+
+QColor PropertiesPanelController::controlBgColor() const
+{
+    // A lighter shade of the panel background — gives small toggles
+    // (custom checkboxes, small buttons) a visible silhouette in dark mode
+    // without being as dark as Base (which is QColor(35,35,35) and would
+    // disappear next to QPalette::Window).
+    return QApplication::palette().color(QPalette::Button).lighter(115);
 }
 
 QColor PropertiesPanelController::highlightColor() const

--- a/src/PropertiesPanelController.h
+++ b/src/PropertiesPanelController.h
@@ -21,6 +21,7 @@ class PropertiesPanelController : public QObject
     Q_PROPERTY(QColor textColor READ textColor NOTIFY themeChanged)
     Q_PROPERTY(QColor borderColor READ borderColor NOTIFY themeChanged)
     Q_PROPERTY(QColor inputColor READ inputColor NOTIFY themeChanged)
+    Q_PROPERTY(QColor controlBgColor READ controlBgColor NOTIFY themeChanged)
     Q_PROPERTY(QColor highlightColor READ highlightColor NOTIFY themeChanged)
 
     // Transform properties
@@ -90,6 +91,7 @@ public:
     QColor textColor() const;
     QColor borderColor() const;
     QColor inputColor() const;
+    QColor controlBgColor() const;
     QColor highlightColor() const;
 
     // Transform accessors

--- a/src/PropertiesPanelController_test.cpp
+++ b/src/PropertiesPanelController_test.cpp
@@ -109,6 +109,10 @@ TEST_F(PropertiesPanelControllerTests, ThemeColorsTrackApplicationPalette)
     EXPECT_EQ(controller->borderColor(), mid);
     EXPECT_EQ(controller->inputColor(), base);
     EXPECT_EQ(controller->highlightColor(), highlight);
+    // controlBgColor is a lightened Button used as the unchecked-checkbox
+    // background — must differ from the panel itself so toggles stay visible.
+    EXPECT_EQ(controller->controlBgColor(), button.lighter(115));
+    EXPECT_NE(controller->controlBgColor(), controller->panelColor());
 }
 
 TEST_F(PropertiesPanelControllerTests, PaletteChangeEmitsThemeChanged)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -41,6 +41,7 @@
 #include "AnimationWidget.h"
 #include "AnimationMerger.h"
 #include "SelectionSet.h"
+#include "AnimationBlender.h"
 #include "AnimationControlController.h"
 #include "MaterialEditorQML.h"
 #include "LLMSettingsWidget.h"
@@ -277,6 +278,7 @@ MainWindow::~MainWindow()
     if (manager) {
         EditModeController::kill();
         SubEntityHighlight::kill();
+        AnimationBlender::kill();
         AnimationControlController::kill();
         MeshLodController::kill();
         MeshValidator::kill();
@@ -377,6 +379,10 @@ void MainWindow::initToolBar()
         qmlRegisterSingletonType<AnimationControlController>("AnimationControl", 1, 0, "AnimationControlController",
             [](QQmlEngine* engine, QJSEngine*) -> QObject* {
                 return AnimationControlController::qmlInstance(engine, nullptr);
+            });
+        qmlRegisterSingletonType<AnimationBlender>("AnimationControl", 1, 0, "AnimationBlender",
+            [](QQmlEngine* engine, QJSEngine*) -> QObject* {
+                return AnimationBlender::qmlInstance(engine, nullptr);
             });
         qmlRegisterSingletonType<MeshLodController>("PropertiesPanel", 1, 0, "MeshLodController",
             [](QQmlEngine* engine, QJSEngine*) -> QObject* {
@@ -1330,6 +1336,7 @@ bool MainWindow::frameRenderingQueued(const Ogre::FrameEvent &evt)
     if(isPlaying)
     {
         const auto* animCtrl = AnimationControlController::instance();
+        auto* blender = AnimationBlender::instance();
         const std::string activeEntity = animCtrl->selectedEntityName().toStdString();
         const std::string activeAnim   = animCtrl->selectedAnimation().toStdString();
         const auto dt = static_cast<double>(evt.timeSinceLastFrame);
@@ -1344,6 +1351,11 @@ bool MainWindow::frameRenderingQueued(const Ogre::FrameEvent &evt)
 
                 auto* ent = static_cast<Ogre::Entity*>(obj);
                 const bool isActiveEntity = (!activeEntity.empty() && ent->getName() == activeEntity);
+
+                // If the blender is active and owns this entity, it sets all
+                // weights and advances time itself — skip the per-state loop.
+                if (isActiveEntity && blender->apply(ent, scaledDt)) continue;
+
                 Ogre::AnimationStateSet const* set = ent->getAllAnimationStates();
                 if(!set) continue;
                 for(const auto& [key, value] : set->getAnimationStates())

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1328,53 +1328,61 @@ void MainWindow::setPlaying(bool playing)
 bool MainWindow::frameStarted(const Ogre::FrameEvent &evt)
 {    return true;   }
 
+namespace {
+
+// Advance every enabled animation state on `ent`. The selected clip on the
+// active entity goes through advanceTime() (slice-A speed + loop region);
+// everything else uses speed-scaled raw addTime().
+void advanceEntityStates(Ogre::Entity* ent, bool isActiveEntity,
+                         const std::string& activeAnim,
+                         const AnimationControlController* animCtrl,
+                         double dt, double scaledDt)
+{
+    const auto* set = ent->getAllAnimationStates();
+    if (!set) return;
+    for (const auto& [key, value] : set->getAnimationStates()) {
+        if (!value->getEnabled()) continue;
+        if (isActiveEntity && key == activeAnim) {
+            const auto   now  = static_cast<double>(value->getTimePosition());
+            const double next = animCtrl->advanceTime(now, dt);
+            value->setTimePosition(static_cast<float>(next));
+        } else {
+            value->addTime(static_cast<float>(scaledDt));
+        }
+    }
+}
+
+} // namespace
+
 bool MainWindow::frameRenderingQueued(const Ogre::FrameEvent &evt)
 {
     // Advance time for every entity that has enabled animation states.
     // Speed is global (scales dt for all states). The loop region applies only
     // to the entity+animation selected in the Animation Control panel.
-    if(isPlaying)
-    {
-        const auto* animCtrl = AnimationControlController::instance();
-        auto* blender = AnimationBlender::instance();
-        const std::string activeEntity = animCtrl->selectedEntityName().toStdString();
-        const std::string activeAnim   = animCtrl->selectedAnimation().toStdString();
-        const auto dt = static_cast<double>(evt.timeSinceLastFrame);
-        const double scaledDt = dt * animCtrl->playbackSpeed();
-        for(Ogre::SceneNode* node : Manager::getSingleton()->getSceneNodes())
-        {
-            if(!node) continue;
-            for(int i = 0; i < static_cast<int>(node->numAttachedObjects()); ++i)
-            {
-                Ogre::MovableObject* obj = node->getAttachedObject(i);
-                if(!obj || obj->getMovableType() != "Entity") continue;
+    if (!isPlaying) return true;
 
-                auto* ent = static_cast<Ogre::Entity*>(obj);
-                const bool isActiveEntity = (!activeEntity.empty() && ent->getName() == activeEntity);
+    const auto* animCtrl = AnimationControlController::instance();
+    auto*       blender  = AnimationBlender::instance();
+    const std::string activeEntity = animCtrl->selectedEntityName().toStdString();
+    const std::string activeAnim   = animCtrl->selectedAnimation().toStdString();
+    const auto   dt       = static_cast<double>(evt.timeSinceLastFrame);
+    const double scaledDt = dt * animCtrl->playbackSpeed();
 
-                // If the blender is active and owns this entity, it sets all
-                // weights and advances time itself — skip the per-state loop.
-                // Pass raw dt: the blender routes the active clip through
-                // advanceTime() (which applies speed + loop region) and falls
-                // back to scaledDt for the other clip.
-                if (isActiveEntity && blender->apply(ent, dt)) continue;
+    for (Ogre::SceneNode* node : Manager::getSingleton()->getSceneNodes()) {
+        if (!node) continue;
+        for (int i = 0; i < static_cast<int>(node->numAttachedObjects()); ++i) {
+            Ogre::MovableObject* obj = node->getAttachedObject(i);
+            if (!obj || obj->getMovableType() != "Entity") continue;
 
-                Ogre::AnimationStateSet const* set = ent->getAllAnimationStates();
-                if(!set) continue;
-                for(const auto& [key, value] : set->getAnimationStates())
-                {
-                    if(!value->getEnabled()) continue;
-                    if (isActiveEntity && key == activeAnim) {
-                        // Selected animation: speed + loop region wrap.
-                        const auto now  = static_cast<double>(value->getTimePosition());
-                        const double next = animCtrl->advanceTime(now, dt);
-                        value->setTimePosition(static_cast<float>(next));
-                    } else {
-                        // All other animations: speed only, no loop region.
-                        value->addTime(static_cast<float>(scaledDt));
-                    }
-                }
-            }
+            auto* ent = static_cast<Ogre::Entity*>(obj);
+            const bool isActiveEntity =
+                (!activeEntity.empty() && ent->getName() == activeEntity);
+
+            // The blender owns the active entity when active — it writes all
+            // weights and advances time itself. Pass raw dt so its internal
+            // advanceTime() can apply playback speed + loop region.
+            if (isActiveEntity && blender->apply(ent, dt)) continue;
+            advanceEntityStates(ent, isActiveEntity, activeAnim, animCtrl, dt, scaledDt);
         }
     }
     return true;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1354,7 +1354,10 @@ bool MainWindow::frameRenderingQueued(const Ogre::FrameEvent &evt)
 
                 // If the blender is active and owns this entity, it sets all
                 // weights and advances time itself — skip the per-state loop.
-                if (isActiveEntity && blender->apply(ent, scaledDt)) continue;
+                // Pass raw dt: the blender routes the active clip through
+                // advanceTime() (which applies speed + loop region) and falls
+                // back to scaledDt for the other clip.
+                if (isActiveEntity && blender->apply(ent, dt)) continue;
 
                 Ogre::AnimationStateSet const* set = ent->getAllAnimationStates();
                 if(!set) continue;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ if(BUILD_TESTS)
     # Basic source files (excluding main.cpp for tests)
     set(TEST_SRC_FILES 
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/about.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/AnimationBlender.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AnimationControlController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Manager.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/material.cpp
@@ -85,6 +86,7 @@ if(BUILD_TESTS)
     )
 
     set(TEST_HEADER_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/AnimationBlender.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AnimationControlController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/GlobalDefinitions.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Euler.h


### PR DESCRIPTION
## Summary
Closes #360 (slice B of #260).

- **AnimationBlender** singleton (QML: `AnimationControl.AnimationBlender`). Holds two animation names, a 0..1 weight, and a Mix / Additive / Override mode. Tracks whatever entity is selected in the Animation Control panel.
- **Live blend** — `MainWindow::frameRenderingQueued` routes the active entity through `blender->apply()`. Inactive entities still follow the slice-A code path (speed-scaled `addTime` + selected-clip loop wrap).
  - Mix: `setWeight(1-w, w)`, both states enabled, `ANIMBLEND_AVERAGE`.
  - Additive: same weights, skeleton blend mode `ANIMBLEND_CUMULATIVE`.
  - Override: only the dominant state is enabled (B if `w >= 0.5`, else A).
- **Bake to new clip** — samples the blended pose at 30 fps (configurable), forces `Skeleton::_updateTransforms()` per sample, writes one node track per bone with the captured local TRS. Live state is saved + restored so the preview isn't disturbed. Existing clip with the same name is replaced.
- **QML panel** lives inline in the Animations section of the Inspector, only visible when the active entity has ≥ 2 animations.

## Test plan
- [ ] Load a rigged mesh with at least two animations → blend section appears
- [ ] Toggle **Active**, pick A and B, slide the weight → viewport blends both poses
- [ ] Switch mode to **Additive** → second clip layers on top
- [ ] Switch mode to **Override** → snaps between A and B at the 0.5 threshold
- [ ] Click **Bake** → new clip appears in the entity's animation list and plays back identically to the live blend at the same weight
- [ ] Loop region (slice A) still wraps the *selected* clip; speed scaling still affects the whole scene
- [ ] Linux CI: `AnimationBlenderPropertyTest.*` (10 cases) + `AnimationBlenderTest.*` (5 cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Blend" group in Animations: Active toggle, A/B pickers, weight slider (2-decimal), blend mode selector, and Bake with auto-naming and conditional clear
  * Live two-way blending applies during playback and can be baked into a new clip

* **Style**
  * Several UI toggles restyled to use a softer control background; per-animation Enable/Loop now dim and disable when blender controls an entity

* **Tests**
  * Added unit and integration tests for blending and baking

* **Chores**
  * Project version bumped to 2.34.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->