### PR TITLE
feat(animation): multi-bone dope sheet (Phase 5 slice C)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 2.34.0 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 2.35.0 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/qml/AnimationDopeSheet.qml
+++ b/qml/AnimationDopeSheet.qml
@@ -1,0 +1,240 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import AnimationControl 1.0
+
+// Multi-bone dope sheet — one row per animated bone with diamond markers
+// at each keyframe time. Drag a marker horizontally to move the keyframe
+// (calls AnimationControlController.moveKeyframe). Wheel to zoom around the
+// cursor; middle-drag to pan.
+Rectangle {
+    id: root
+    color: AnimationControlController.panelColor
+
+    // Pixels-per-second view scale and horizontal scroll offset (in seconds).
+    property real pxPerSec: 200
+    property real viewStart: 0.0
+
+    property int leftStripWidth: 130
+    property int rowHeight: 22
+
+    // Cached row data refreshed from the controller.
+    property var rows: AnimationControlController.allBoneRows()
+
+    Connections {
+        target: AnimationControlController
+        function onBoneRowsChanged()       { root.rows = AnimationControlController.allBoneRows() }
+        function onSelectionChanged()      { root.rows = AnimationControlController.allBoneRows() }
+        function onKeyframeTicksChanged()  { root.rows = AnimationControlController.allBoneRows() }
+    }
+
+    // ── Empty-state placeholder ──────────────────────────────────────────────
+    Text {
+        anchors.centerIn: parent
+        visible: root.rows.length === 0
+        text: AnimationControlController.hasAnimation
+              ? "No animated bones in this clip."
+              : "Select a rigged mesh and an animation to view its keyframes."
+        color: AnimationControlController.disabledTextColor
+        font.pixelSize: 12
+    }
+
+    // ── Header strip with timeline ruler + zoom hint ─────────────────────────
+    Rectangle {
+        id: header
+        width: parent.width; height: 24
+        color: AnimationControlController.headerColor
+        border.color: AnimationControlController.borderColor
+        visible: root.rows.length > 0
+
+        Text {
+            anchors.left: parent.left; anchors.leftMargin: 6
+            anchors.verticalCenter: parent.verticalCenter
+            text: "Bone"
+            font.bold: true; font.pixelSize: 11
+            color: AnimationControlController.textColor
+        }
+
+        // Time ruler — major ticks every 0.5s
+        Canvas {
+            id: rulerCanvas
+            anchors.left: parent.left; anchors.leftMargin: root.leftStripWidth
+            anchors.top: parent.top; anchors.bottom: parent.bottom
+            anchors.right: parent.right
+            onPaint: {
+                var ctx = getContext("2d"); ctx.clearRect(0, 0, width, height)
+                ctx.strokeStyle = AnimationControlController.borderColor
+                ctx.fillStyle = AnimationControlController.textColor
+                ctx.font = "10px sans-serif"; ctx.lineWidth = 1
+                var t0 = root.viewStart, t1 = root.viewStart + width / root.pxPerSec
+                var step = root.pxPerSec >= 100 ? 0.25 : (root.pxPerSec >= 40 ? 1.0 : 5.0)
+                for (var t = Math.ceil(t0 / step) * step; t < t1; t += step) {
+                    var x = (t - root.viewStart) * root.pxPerSec
+                    ctx.beginPath(); ctx.moveTo(x, height - 6); ctx.lineTo(x, height); ctx.stroke()
+                    ctx.fillText(t.toFixed(2) + "s", x + 2, height - 8)
+                }
+            }
+            Connections {
+                target: root
+                function onPxPerSecChanged() { rulerCanvas.requestPaint() }
+                function onViewStartChanged() { rulerCanvas.requestPaint() }
+            }
+            Connections {
+                target: AnimationControlController
+                function onThemeChanged() { rulerCanvas.requestPaint() }
+            }
+        }
+    }
+
+    // ── Bone rows ────────────────────────────────────────────────────────────
+    ListView {
+        id: rowsView
+        anchors.left: parent.left; anchors.right: parent.right
+        anchors.top: header.visible ? header.bottom : parent.top
+        anchors.bottom: parent.bottom
+        clip: true
+        model: root.rows
+        spacing: 1
+        visible: root.rows.length > 0
+
+        delegate: Rectangle {
+            width: rowsView.width; height: root.rowHeight
+            color: (modelData.bone === AnimationControlController.selectedBone)
+                   ? Qt.lighter(AnimationControlController.panelColor, 1.15)
+                   : AnimationControlController.panelColor
+
+            // Bone name (clickable — selects the bone)
+            Rectangle {
+                width: root.leftStripWidth; height: parent.height
+                color: "transparent"
+                border.color: AnimationControlController.borderColor; border.width: 1
+                Text {
+                    anchors.left: parent.left; anchors.leftMargin: 6
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: modelData.bone
+                    color: AnimationControlController.textColor
+                    elide: Text.ElideRight; font.pixelSize: 11
+                    width: parent.width - 12
+                }
+                MouseArea {
+                    anchors.fill: parent
+                    onClicked: AnimationControlController.selectBone(modelData.bone)
+                }
+            }
+
+            // Track strip with diamond markers
+            Item {
+                id: trackStrip
+                anchors.left: parent.left; anchors.leftMargin: root.leftStripWidth
+                anchors.top: parent.top; anchors.bottom: parent.bottom
+                anchors.right: parent.right
+                clip: true
+
+                // Underline
+                Rectangle {
+                    anchors.left: parent.left; anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    height: 1
+                    color: AnimationControlController.borderColor
+                    opacity: 0.4
+                }
+
+                // Diamonds
+                Repeater {
+                    model: modelData.keyTimes
+                    Rectangle {
+                        property real keyTime: modelData
+                        // Convert keyTime → x relative to the strip
+                        x: (keyTime - root.viewStart) * root.pxPerSec - width / 2
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: 10; height: 10
+                        rotation: 45
+                        color: dragArea.dragging
+                               ? "#ff8855"
+                               : (Math.abs(keyTime * 1000 - AnimationControlController.selectedTick) < 1
+                                  ? "#ff4444" : "#ffcc00")
+                        border.color: AnimationControlController.borderColor
+
+                        MouseArea {
+                            id: dragArea
+                            anchors.fill: parent
+                            anchors.margins: -3 // larger hit area
+                            cursorShape: Qt.SizeHorCursor
+                            preventStealing: true
+                            property bool dragging: false
+                            property real pressX: 0
+                            property real originalTime: 0
+                            // Snapshot at press; drag updates the time live and lets
+                            // moveKeyframe push exactly one undo command per drag.
+                            onPressed: function(mouse) {
+                                dragging = true
+                                pressX = mouse.x
+                                originalTime = parent.keyTime
+                            }
+                            onPositionChanged: function(mouse) {
+                                if (!dragging) return
+                                var dx = mouse.x - pressX
+                                var dt = dx / root.pxPerSec
+                                var target = originalTime + dt
+                                if (target < 0) target = 0
+                                var len = AnimationControlController.animationLength
+                                if (target > len) target = len
+                                if (Math.abs(target - parent.keyTime) > 0.001) {
+                                    if (AnimationControlController.moveKeyframe(
+                                            modelData.bone, parent.keyTime, target)) {
+                                        // The model rebuilds via boneRowsChanged; the
+                                        // new keyTime arrives in the next binding pass.
+                                    }
+                                }
+                            }
+                            onReleased: dragging = false
+                            onClicked: function(mouse) {
+                                AnimationControlController.selectBone(modelData.bone)
+                                AnimationControlController.sliderValue =
+                                        Math.round(parent.keyTime * 1000)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ── Wheel zoom + middle-drag pan over the timeline area ──────────────────
+    MouseArea {
+        anchors.left: parent.left; anchors.leftMargin: root.leftStripWidth
+        anchors.top: header.visible ? header.bottom : parent.top
+        anchors.right: parent.right; anchors.bottom: parent.bottom
+        acceptedButtons: Qt.MiddleButton
+        propagateComposedEvents: true
+        property real panStartX: 0
+        property real panStartView: 0
+        onPressed: function(mouse) {
+            if (mouse.button === Qt.MiddleButton) {
+                panStartX = mouse.x
+                panStartView = root.viewStart
+                mouse.accepted = true
+            } else { mouse.accepted = false }
+        }
+        onPositionChanged: function(mouse) {
+            if (!pressed) return
+            var dx = mouse.x - panStartX
+            root.viewStart = panStartView - dx / root.pxPerSec
+            if (root.viewStart < 0) root.viewStart = 0
+        }
+
+        WheelHandler {
+            // Zoom around the cursor: keep the time under the cursor stationary.
+            onWheel: function(event) {
+                var factor = event.angleDelta.y > 0 ? 1.15 : (1.0 / 1.15)
+                var newPxPerSec = root.pxPerSec * factor
+                newPxPerSec = Math.max(20, Math.min(2000, newPxPerSec))
+                if (newPxPerSec === root.pxPerSec) return
+                var tCursor = root.viewStart + event.point.position.x / root.pxPerSec
+                root.pxPerSec = newPxPerSec
+                root.viewStart = tCursor - event.point.position.x / newPxPerSec
+                if (root.viewStart < 0) root.viewStart = 0
+            }
+        }
+    }
+}

--- a/qml/AnimationDopeSheet.qml
+++ b/qml/AnimationDopeSheet.qml
@@ -98,8 +98,15 @@ Rectangle {
         visible: root.rows.length > 0
 
         delegate: Rectangle {
+            id: rowDelegate
+            // Capture row data once at the delegate scope. The inner Repeater
+            // shadows `modelData` with the keyTime number, so we can't reach
+            // back to the row map from inside it.
+            property string boneName: modelData.bone
+            property var keyTimes: modelData.keyTimes
+
             width: rowsView.width; height: root.rowHeight
-            color: (modelData.bone === AnimationControlController.selectedBone)
+            color: (boneName === AnimationControlController.selectedBone)
                    ? Qt.lighter(AnimationControlController.panelColor, 1.15)
                    : AnimationControlController.panelColor
 
@@ -111,14 +118,14 @@ Rectangle {
                 Text {
                     anchors.left: parent.left; anchors.leftMargin: 6
                     anchors.verticalCenter: parent.verticalCenter
-                    text: modelData.bone
+                    text: rowDelegate.boneName
                     color: AnimationControlController.textColor
                     elide: Text.ElideRight; font.pixelSize: 11
                     width: parent.width - 12
                 }
                 MouseArea {
                     anchors.fill: parent
-                    onClicked: AnimationControlController.selectBone(modelData.bone)
+                    onClicked: AnimationControlController.selectBone(rowDelegate.boneName)
                 }
             }
 
@@ -141,11 +148,16 @@ Rectangle {
 
                 // Diamonds
                 Repeater {
-                    model: modelData.keyTimes
+                    model: rowDelegate.keyTimes
                     Rectangle {
+                        // The bound keyTime; while dragging we render at
+                        // `dragPreviewTime` instead of pushing a command per
+                        // pixel. The single MoveKeyframeCommand is pushed on
+                        // release, giving exactly one undoable step per gesture.
                         property real keyTime: modelData
-                        // Convert keyTime → x relative to the strip
-                        x: (keyTime - root.viewStart) * root.pxPerSec - width / 2
+                        property real dragPreviewTime: keyTime
+                        property real displayTime: dragArea.dragging ? dragPreviewTime : keyTime
+                        x: (displayTime - root.viewStart) * root.pxPerSec - width / 2
                         anchors.verticalCenter: parent.verticalCenter
                         width: 10; height: 10
                         rotation: 45
@@ -164,12 +176,19 @@ Rectangle {
                             property bool dragging: false
                             property real pressX: 0
                             property real originalTime: 0
-                            // Snapshot at press; drag updates the time live and lets
-                            // moveKeyframe push exactly one undo command per drag.
+                            // Single press snapshot; release commits one move.
                             onPressed: function(mouse) {
                                 dragging = true
                                 pressX = mouse.x
                                 originalTime = parent.keyTime
+                                parent.dragPreviewTime = parent.keyTime
+                                // Selecting the diamond's bone + jumping the
+                                // playhead is the natural "click" outcome —
+                                // do it on press so it works even if the user
+                                // drags slightly afterwards.
+                                AnimationControlController.selectBone(rowDelegate.boneName)
+                                AnimationControlController.sliderValue =
+                                        Math.round(parent.keyTime * 1000)
                             }
                             onPositionChanged: function(mouse) {
                                 if (!dragging) return
@@ -179,19 +198,16 @@ Rectangle {
                                 if (target < 0) target = 0
                                 var len = AnimationControlController.animationLength
                                 if (target > len) target = len
-                                if (Math.abs(target - parent.keyTime) > 0.001) {
-                                    if (AnimationControlController.moveKeyframe(
-                                            modelData.bone, parent.keyTime, target)) {
-                                        // The model rebuilds via boneRowsChanged; the
-                                        // new keyTime arrives in the next binding pass.
-                                    }
-                                }
+                                parent.dragPreviewTime = target
                             }
-                            onReleased: dragging = false
-                            onClicked: function(mouse) {
-                                AnimationControlController.selectBone(modelData.bone)
-                                AnimationControlController.sliderValue =
-                                        Math.round(parent.keyTime * 1000)
+                            onReleased: function(mouse) {
+                                if (!dragging) return
+                                dragging = false
+                                var target = parent.dragPreviewTime
+                                if (Math.abs(target - originalTime) > 0.001) {
+                                    AnimationControlController.moveKeyframe(
+                                        rowDelegate.boneName, originalTime, target)
+                                }
                             }
                         }
                     }

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -621,9 +621,37 @@ bool AnimationControlController::moveKeyframe(const QString& boneName,
     if (!m_selectedSkeleton->hasAnimation(m_selectedAnimation)) return false;
     if (qFuzzyCompare(oldTime + 1.0, newTime + 1.0)) return false;
 
+    // Validate up-front so we never push a no-op onto the undo stack.
+    // The command's internal validation is the source of truth, but
+    // duplicating the find-source-keyframe + collision-check here lets
+    // us return false without polluting the undo history.
+    Ogre::Animation* anim = m_selectedSkeleton->getAnimation(m_selectedAnimation);
+    const std::string boneStd = boneName.toStdString();
+    if (!m_selectedSkeleton->hasBone(boneStd)) return false;
+    Ogre::Bone* bone = m_selectedSkeleton->getBone(boneStd);
+    if (!bone || !anim->hasNodeTrack(bone->getHandle())) return false;
+    Ogre::NodeAnimationTrack* track = anim->getNodeTrack(bone->getHandle());
+
+    constexpr float kEpsilon = 0.001f;
+    int sourceIdx = -1;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        if (std::fabs(track->getKeyFrame(i)->getTime() - static_cast<float>(oldTime)) <= kEpsilon) {
+            sourceIdx = static_cast<int>(i);
+            break;
+        }
+    }
+    if (sourceIdx < 0) return false; // no keyframe at oldTime
+
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        if (static_cast<int>(i) == sourceIdx) continue;
+        if (std::fabs(track->getKeyFrame(i)->getTime() - static_cast<float>(newTime)) <= kEpsilon) {
+            return false; // collision with another existing keyframe
+        }
+    }
+
     auto* cmd = new MoveKeyframeCommand(m_selectedSkeleton,
                                         m_selectedAnimation,
-                                        boneName.toStdString(),
+                                        boneStd,
                                         static_cast<float>(oldTime),
                                         static_cast<float>(newTime));
     UndoManager::getSingleton()->push(cmd);

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -1,9 +1,12 @@
 #include "AnimationControlController.h"
 #include "SelectionSet.h"
 #include "Manager.h"
+#include "UndoManager.h"
+#include "commands/MoveKeyframeCommand.h"
 #include <QApplication>
 #include <QPalette>
 #include <QTimer>
+#include <QVariantMap>
 #include <cmath>
 
 #include <Ogre.h>
@@ -426,6 +429,9 @@ void AnimationControlController::refreshSliderTicks()
     }
 
     emit keyframeTicksChanged();
+    // Dope-sheet view re-queries rows on the same signals as track-level
+    // changes (add/delete/move/select).
+    emit boneRowsChanged();
 }
 
 // ── Keyframe editing ──────────────────────────────────────────────────────────
@@ -579,3 +585,51 @@ KF_SET_ROT(W, w)
 KF_SET_ROT(X, x)
 KF_SET_ROT(Y, y)
 KF_SET_ROT(Z, z)
+
+// ── Dope sheet API (slice C) ──────────────────────────────────────────────────
+
+QVariantList AnimationControlController::allBoneRows() const
+{
+    QVariantList rows;
+    if (!m_selectedSkeleton || m_selectedAnimation.empty()) return rows;
+    if (!m_selectedSkeleton->hasAnimation(m_selectedAnimation)) return rows;
+
+    Ogre::Animation* anim = m_selectedSkeleton->getAnimation(m_selectedAnimation);
+    for (const auto& [handle, track] : anim->_getNodeTrackList()) {
+        Ogre::Node* node = track->getAssociatedNode();
+        if (!node) continue;
+
+        QVariantList keyTimes;
+        keyTimes.reserve(static_cast<int>(track->getNumKeyFrames()));
+        for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+            keyTimes.append(static_cast<double>(track->getKeyFrame(i)->getTime()));
+        }
+
+        QVariantMap row;
+        row[QStringLiteral("bone")] = QString::fromStdString(node->getName());
+        row[QStringLiteral("keyTimes")] = keyTimes;
+        rows.append(row);
+    }
+    return rows;
+}
+
+bool AnimationControlController::moveKeyframe(const QString& boneName,
+                                              double oldTime, double newTime)
+{
+    if (boneName.isEmpty()) return false;
+    if (!m_selectedSkeleton || m_selectedAnimation.empty()) return false;
+    if (!m_selectedSkeleton->hasAnimation(m_selectedAnimation)) return false;
+    if (qFuzzyCompare(oldTime + 1.0, newTime + 1.0)) return false;
+
+    auto* cmd = new MoveKeyframeCommand(m_selectedSkeleton,
+                                        m_selectedAnimation,
+                                        boneName.toStdString(),
+                                        static_cast<float>(oldTime),
+                                        static_cast<float>(newTime));
+    UndoManager::getSingleton()->push(cmd);
+    // The command's redo() ran inside push(); refresh the slider ticks for
+    // the currently-edited bone and signal QML views to re-read rows.
+    refreshSliderTicks();
+    emit boneRowsChanged();
+    return true;
+}

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -649,7 +649,9 @@ bool AnimationControlController::moveKeyframe(const QString& boneName,
         }
     }
 
-    auto* cmd = new MoveKeyframeCommand(m_selectedSkeleton,
+    // QUndoStack::push() takes ownership of the command — this raw new is
+    // the standard QUndoCommand idiom (mirrors TransformCommands callers).
+    auto* cmd = new MoveKeyframeCommand(m_selectedSkeleton, // NOSONAR — QUndoStack owns
                                         m_selectedAnimation,
                                         boneStd,
                                         static_cast<float>(oldTime),

--- a/src/AnimationControlController.h
+++ b/src/AnimationControlController.h
@@ -160,6 +160,21 @@ public:
     Q_INVOKABLE void setKfRotY(double v);
     Q_INVOKABLE void setKfRotZ(double v);
 
+    // ── Dope sheet API (slice C) ─────────────────────────────────────────────
+    /// One row per animated bone on the currently selected animation.
+    /// Each row is a QVariantMap: { "bone": QString, "keyTimes": QVariantList<double seconds> }.
+    /// Returns an empty list when no animation is selected.
+    Q_INVOKABLE QVariantList allBoneRows() const;
+
+    /// Move a keyframe on `boneName`'s track from `oldTime` to `newTime`
+    /// (both seconds). Match tolerance is 1 ms — same as the existing
+    /// keyframe-tick comparison. Refuses the move if `newTime` collides
+    /// with another existing keyframe on the same track. Pushes a
+    /// MoveKeyframeCommand so the operation is undoable. Returns true
+    /// when the move was applied.
+    Q_INVOKABLE bool moveKeyframe(const QString& boneName,
+                                  double oldTime, double newTime);
+
 public slots:
     void updateAnimationTree();
 
@@ -174,6 +189,9 @@ signals:
     void currentKeyframeChanged();
     void playbackSpeedChanged();
     void loopRegionChanged();
+    /// Emitted when the dope-sheet view should refresh — track edits, clip
+    /// selection, or keyframe add/delete/move.
+    void boneRowsChanged();
 
 private:
     AnimationControlController();

--- a/src/AnimationControlController_test.cpp
+++ b/src/AnimationControlController_test.cpp
@@ -622,3 +622,88 @@ TEST_F(AnimationControlControllerTest, PollTimerDoesNotCrashWithAnimation) {
     QTest::qWait(100);
     SUCCEED();
 }
+
+// ── Dope sheet API (slice C) ──────────────────────────────────────────────────
+
+TEST_F(AnimationControlControllerPlaybackTest, AllBoneRowsEmptyWithoutSelection) {
+    auto* ctrl = AnimationControlController::instance();
+    EXPECT_TRUE(ctrl->allBoneRows().isEmpty());
+}
+
+TEST_F(AnimationControlControllerPlaybackTest, MoveKeyframeNoOpWithoutSelection) {
+    auto* ctrl = AnimationControlController::instance();
+    EXPECT_FALSE(ctrl->moveKeyframe("Bone", 0.5, 0.6));
+}
+
+TEST_F(AnimationControlControllerTest, AllBoneRowsReflectsTracks) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("DopeSheet_RowsTest");
+    ASSERT_NE(entity, nullptr);
+
+    auto* ctrl = AnimationControlController::instance();
+    ctrl->updateAnimationTree();
+    ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+
+    QVariantList rows = ctrl->allBoneRows();
+    ASSERT_FALSE(rows.isEmpty());
+    auto firstRow = rows.first().toMap();
+    EXPECT_TRUE(firstRow.contains("bone"));
+    EXPECT_TRUE(firstRow.contains("keyTimes"));
+    // TestAnim has 3 keyframes on the Child track (handle 1)
+    auto times = firstRow["keyTimes"].toList();
+    EXPECT_EQ(times.size(), 3);
+}
+
+TEST_F(AnimationControlControllerTest, MoveKeyframeShiftsTime) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("DopeSheet_MoveTest");
+    ASSERT_NE(entity, nullptr);
+
+    auto* ctrl = AnimationControlController::instance();
+    ctrl->updateAnimationTree();
+    ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+    ASSERT_FALSE(ctrl->boneNames().isEmpty());
+    QString bone = ctrl->boneNames().first();
+
+    auto* track = entity->getSkeleton()->getAnimation("TestAnim")
+                         ->_getNodeTrackList().begin()->second;
+    const int beforeCount = track->getNumKeyFrames();
+
+    EXPECT_TRUE(ctrl->moveKeyframe(bone, 0.5, 0.7));
+
+    // Same number of keyframes, none at 0.5, one at 0.7.
+    EXPECT_EQ(track->getNumKeyFrames(), beforeCount);
+    bool foundOriginal = false, foundMoved = false;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        const float t = track->getKeyFrame(i)->getTime();
+        if (std::fabs(t - 0.5f) < 0.001f) foundOriginal = true;
+        if (std::fabs(t - 0.7f) < 0.001f) foundMoved = true;
+    }
+    EXPECT_FALSE(foundOriginal);
+    EXPECT_TRUE(foundMoved);
+}
+
+TEST_F(AnimationControlControllerTest, MoveKeyframeRejectsCollision) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("DopeSheet_CollisionTest");
+    ASSERT_NE(entity, nullptr);
+
+    auto* ctrl = AnimationControlController::instance();
+    ctrl->updateAnimationTree();
+    ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+    QString bone = ctrl->boneNames().first();
+
+    // TestAnim has keyframes at 0.0, 0.5, 1.0. Moving 0.5 onto 1.0 must fail.
+    EXPECT_FALSE(ctrl->moveKeyframe(bone, 0.5, 1.0));
+
+    // The 0.5 keyframe is still there.
+    auto* track = entity->getSkeleton()->getAnimation("TestAnim")
+                         ->_getNodeTrackList().begin()->second;
+    bool stillThere = false;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        if (std::fabs(track->getKeyFrame(i)->getTime() - 0.5f) < 0.001f) {
+            stillThere = true; break;
+        }
+    }
+    EXPECT_TRUE(stillThere);
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,6 +54,7 @@ UndoManager.cpp
 SubMeshTransform.cpp
 SubEntityHighlight.cpp
 commands/TransformCommands.cpp
+commands/MoveKeyframeCommand.cpp
 PropertiesPanelController.cpp
 SceneTreeModel.cpp
 ThemeManager.cpp

--- a/src/commands/MoveKeyframeCommand.cpp
+++ b/src/commands/MoveKeyframeCommand.cpp
@@ -1,0 +1,97 @@
+#include "MoveKeyframeCommand.h"
+
+#include <Ogre.h>
+#include <OgreSkeleton.h>
+#include <OgreAnimation.h>
+#include <OgreAnimationTrack.h>
+#include <OgreKeyFrame.h>
+
+#include <QObject>
+#include <cmath>
+#include <utility>
+
+namespace {
+constexpr float kEpsilon = 0.001f; // 1 ms — same tolerance as keyframe ticks
+
+Ogre::NodeAnimationTrack* resolveTrack(Ogre::Skeleton* skel,
+                                       const std::string& animName,
+                                       const std::string& boneName)
+{
+    if (!skel || animName.empty() || boneName.empty()) return nullptr;
+    if (!skel->hasAnimation(animName)) return nullptr;
+    if (!skel->hasBone(boneName)) return nullptr;
+    Ogre::Animation* anim = skel->getAnimation(animName);
+    Ogre::Bone* bone = skel->getBone(boneName);
+    if (!anim || !bone) return nullptr;
+    if (!anim->hasNodeTrack(bone->getHandle())) return nullptr;
+    return anim->getNodeTrack(bone->getHandle());
+}
+
+} // namespace
+
+MoveKeyframeCommand::MoveKeyframeCommand(Ogre::Skeleton* skeleton,
+                                         std::string animationName,
+                                         std::string boneName,
+                                         float oldTime,
+                                         float newTime,
+                                         QUndoCommand* parent)
+    : QUndoCommand(parent)
+    , mSkeleton(skeleton)
+    , mAnimationName(std::move(animationName))
+    , mBoneName(std::move(boneName))
+    , mOldTime(oldTime)
+    , mNewTime(newTime)
+{
+    setText(QObject::tr("Move keyframe"));
+}
+
+bool MoveKeyframeCommand::moveKeyframeTo(float searchTime, float targetTime)
+{
+    auto* track = resolveTrack(mSkeleton, mAnimationName, mBoneName);
+    if (!track) return false;
+
+    // Find the keyframe at searchTime (± epsilon).
+    int foundIdx = -1;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        Ogre::KeyFrame* kf = track->getKeyFrame(i);
+        if (std::fabs(kf->getTime() - searchTime) <= kEpsilon) {
+            foundIdx = static_cast<int>(i);
+            break;
+        }
+    }
+    if (foundIdx < 0) return false;
+
+    // Reject if newTime collides with another existing keyframe.
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        if (static_cast<int>(i) == foundIdx) continue;
+        if (std::fabs(track->getKeyFrame(i)->getTime() - targetTime) <= kEpsilon) {
+            return false;
+        }
+    }
+
+    // Ogre's KeyFrame has no setTime() — remove + recreate at the new time
+    // and copy the T/R/S values across. Track auto-sorts on createNodeKeyFrame.
+    auto* oldKf = static_cast<Ogre::TransformKeyFrame*>(track->getKeyFrame(foundIdx));
+    const Ogre::Vector3    t = oldKf->getTranslate();
+    const Ogre::Quaternion r = oldKf->getRotation();
+    const Ogre::Vector3    s = oldKf->getScale();
+
+    track->removeKeyFrame(static_cast<unsigned short>(foundIdx));
+    auto* newKf = track->createNodeKeyFrame(targetTime);
+    newKf->setTranslate(t);
+    newKf->setRotation(r);
+    newKf->setScale(s);
+
+    track->_keyFrameDataChanged();
+    return true;
+}
+
+void MoveKeyframeCommand::redo()
+{
+    moveKeyframeTo(mOldTime, mNewTime);
+}
+
+void MoveKeyframeCommand::undo()
+{
+    moveKeyframeTo(mNewTime, mOldTime);
+}

--- a/src/commands/MoveKeyframeCommand.h
+++ b/src/commands/MoveKeyframeCommand.h
@@ -1,0 +1,48 @@
+#ifndef MOVE_KEYFRAME_COMMAND_H
+#define MOVE_KEYFRAME_COMMAND_H
+
+#include <QUndoCommand>
+#include <string>
+
+namespace Ogre {
+    class Skeleton;
+    class NodeAnimationTrack;
+}
+
+/**
+ * Moves a single keyframe on a bone-specific animation track from `oldTime`
+ * to `newTime`. Recoverable via undo, which restores the keyframe to its
+ * original time. The track's keyframe count is unchanged either way — the
+ * keyframe's identity is its index after re-sorting.
+ *
+ * The command stores the skeleton + animation + bone names rather than raw
+ * pointers so it survives skeleton/track rebuilds (some Ogre operations
+ * reallocate tracks when keyframes are inserted/removed elsewhere).
+ */
+class MoveKeyframeCommand : public QUndoCommand
+{
+public:
+    MoveKeyframeCommand(Ogre::Skeleton* skeleton,
+                        std::string animationName,
+                        std::string boneName,
+                        float oldTime,
+                        float newTime,
+                        QUndoCommand* parent = nullptr);
+
+    void undo() override;
+    void redo() override;
+
+private:
+    /// Locate the keyframe currently at `searchTime` (± epsilon) on this
+    /// command's track. Returns nullptr if no match. Helper used by both
+    /// undo and redo to re-resolve the keyframe after a previous move.
+    bool moveKeyframeTo(float searchTime, float targetTime);
+
+    Ogre::Skeleton* mSkeleton;
+    std::string     mAnimationName;
+    std::string     mBoneName;
+    float           mOldTime;
+    float           mNewTime;
+};
+
+#endif // MOVE_KEYFRAME_COMMAND_H

--- a/src/commands/MoveKeyframeCommand.h
+++ b/src/commands/MoveKeyframeCommand.h
@@ -34,8 +34,10 @@ public:
 
 private:
     /// Locate the keyframe currently at `searchTime` (± epsilon) on this
-    /// command's track. Returns nullptr if no match. Helper used by both
-    /// undo and redo to re-resolve the keyframe after a previous move.
+    /// command's track and shift it to `targetTime`. Used by both undo and
+    /// redo to re-resolve the keyframe after a previous move. Returns true
+    /// when the move was applied; false if the source keyframe wasn't
+    /// found or the target time would collide with another keyframe.
     bool moveKeyframeTo(float searchTime, float targetTime);
 
     Ogre::Skeleton* mSkeleton;

--- a/src/commands/MoveKeyframeCommand_test.cpp
+++ b/src/commands/MoveKeyframeCommand_test.cpp
@@ -1,0 +1,123 @@
+#include <gtest/gtest.h>
+#include <QApplication>
+#include <QCoreApplication>
+#include <QThread>
+#include <QUndoStack>
+
+#include "MoveKeyframeCommand.h"
+#include "../Manager.h"
+#include "../TestHelpers.h"
+
+#include <OgreSkeletonInstance.h>
+#include <OgreAnimation.h>
+#include <OgreAnimationTrack.h>
+#include <OgreKeyFrame.h>
+
+#include <cmath>
+
+class MoveKeyframeCommandTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        Manager::kill();
+        QThread::msleep(20);
+        app = qobject_cast<QApplication*>(QCoreApplication::instance());
+        ASSERT_NE(app, nullptr);
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+        createStandardOgreMaterials();
+    }
+    void TearDown() override {
+        if (app) app->processEvents();
+    }
+    QApplication* app = nullptr;
+
+    static float keyTimeAt(Ogre::NodeAnimationTrack* track, unsigned short i) {
+        return track->getKeyFrame(i)->getTime();
+    }
+};
+
+TEST_F(MoveKeyframeCommandTest, RedoMovesUndoRestores) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = createAnimatedTestEntity("MKF_RedoUndoTest");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+
+    // TestAnim has keyframes at 0.0, 0.5, 1.0 on the Child bone.
+    QUndoStack stack;
+    stack.push(new MoveKeyframeCommand(skel, "TestAnim", "Child", 0.5f, 0.7f));
+
+    auto* track = skel->getAnimation("TestAnim")->_getNodeTrackList().begin()->second;
+    bool found07 = false;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        if (std::fabs(keyTimeAt(track, i) - 0.7f) < 0.001f) { found07 = true; break; }
+    }
+    EXPECT_TRUE(found07);
+
+    stack.undo();
+    bool found05 = false; found07 = false;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        const float t = keyTimeAt(track, i);
+        if (std::fabs(t - 0.5f) < 0.001f) found05 = true;
+        if (std::fabs(t - 0.7f) < 0.001f) found07 = true;
+    }
+    EXPECT_TRUE(found05);
+    EXPECT_FALSE(found07);
+
+    stack.redo();
+    found07 = false;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        if (std::fabs(keyTimeAt(track, i) - 0.7f) < 0.001f) { found07 = true; break; }
+    }
+    EXPECT_TRUE(found07);
+}
+
+TEST_F(MoveKeyframeCommandTest, PreservesTRSValuesAcrossMove) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = createAnimatedTestEntity("MKF_PreservesTRSTest");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+    auto* track = skel->getAnimation("TestAnim")->_getNodeTrackList().begin()->second;
+
+    // Capture the keyframe at 0.5 before the move.
+    Ogre::Vector3 origT, origS;
+    Ogre::Quaternion origR;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        auto* kf = static_cast<Ogre::TransformKeyFrame*>(track->getKeyFrame(i));
+        if (std::fabs(kf->getTime() - 0.5f) < 0.001f) {
+            origT = kf->getTranslate();
+            origR = kf->getRotation();
+            origS = kf->getScale();
+            break;
+        }
+    }
+
+    QUndoStack stack;
+    stack.push(new MoveKeyframeCommand(skel, "TestAnim", "Child", 0.5f, 0.7f));
+
+    // Find the moved keyframe and verify TRS is preserved.
+    bool found = false;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        auto* kf = static_cast<Ogre::TransformKeyFrame*>(track->getKeyFrame(i));
+        if (std::fabs(kf->getTime() - 0.7f) < 0.001f) {
+            EXPECT_EQ(kf->getTranslate(), origT);
+            EXPECT_EQ(kf->getRotation(), origR);
+            EXPECT_EQ(kf->getScale(), origS);
+            found = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(found);
+}
+
+TEST_F(MoveKeyframeCommandTest, NoOpWhenSearchTimeMissing) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = createAnimatedTestEntity("MKF_MissingTest");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+    auto* track = skel->getAnimation("TestAnim")->_getNodeTrackList().begin()->second;
+    const int before = track->getNumKeyFrames();
+
+    QUndoStack stack;
+    // No keyframe at 0.42 — command runs but moves nothing.
+    stack.push(new MoveKeyframeCommand(skel, "TestAnim", "Child", 0.42f, 0.6f));
+    EXPECT_EQ(track->getNumKeyFrames(), before);
+}

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -511,14 +511,17 @@ void MainWindow::initToolBar()
         });
     }
 
-    // Dope Sheet dock — multi-bone keyframe view (Phase 5 slice C)
+    // Dope Sheet dock — multi-bone keyframe view (Phase 5 slice C).
+    // Qt takes parent ownership of QQuickWidget + QDockWidget — the same
+    // pattern the rest of mainwindow.cpp uses. Sonar's S5025 wants smart
+    // pointers, but raw `new` is idiomatic for Qt parent-owned widgets.
     {
-        auto* dopeSheetWidget = new QQuickWidget();
+        auto* dopeSheetWidget = new QQuickWidget(); // NOSONAR — Qt parent ownership
         dopeSheetWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
         dopeSheetWidget->setMinimumHeight(160);
         dopeSheetWidget->setFocusPolicy(Qt::StrongFocus);
         dopeSheetWidget->setSource(QUrl("qrc:/AnimationControl/AnimationDopeSheet.qml"));
-        m_dopeSheetDock = new QDockWidget(tr("Dope Sheet"), this);
+        m_dopeSheetDock = new QDockWidget(tr("Dope Sheet"), this); // NOSONAR — Qt parent ownership
         m_dopeSheetDock->setWidget(dopeSheetWidget);
         m_dopeSheetDock->setObjectName("DopeSheetDock");
         addDockWidget(Qt::BottomDockWidgetArea, m_dopeSheetDock);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -511,6 +511,24 @@ void MainWindow::initToolBar()
         });
     }
 
+    // Dope Sheet dock — multi-bone keyframe view (Phase 5 slice C)
+    {
+        auto* dopeSheetWidget = new QQuickWidget();
+        dopeSheetWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
+        dopeSheetWidget->setMinimumHeight(160);
+        dopeSheetWidget->setFocusPolicy(Qt::StrongFocus);
+        dopeSheetWidget->setSource(QUrl("qrc:/AnimationControl/AnimationDopeSheet.qml"));
+        m_dopeSheetDock = new QDockWidget(tr("Dope Sheet"), this);
+        m_dopeSheetDock->setWidget(dopeSheetWidget);
+        m_dopeSheetDock->setObjectName("DopeSheetDock");
+        addDockWidget(Qt::BottomDockWidgetArea, m_dopeSheetDock);
+        m_dopeSheetDock->hide();
+        connect(m_dopeSheetDock, &QDockWidget::visibilityChanged, this, [](bool vis) {
+            SentryReporter::addBreadcrumb("ui.action",
+                vis ? "Dope Sheet shown" : "Dope Sheet hidden");
+        });
+    }
+
     // Welcome Screen overlay — shown on first launch or when user hasn't opted out
     {
         m_welcomeController = WelcomeScreenController::instance();
@@ -1182,6 +1200,14 @@ void MainWindow::initToolBar()
     if (m_assetBrowserDock) {
         connect(m_assetBrowserDock, &QDockWidget::visibilityChanged,
                 ui->actionAsset_Browser, &QAction::setChecked);
+    }
+
+    // Dope Sheet toggle — uses the dock's own toggleViewAction so we don't
+    // have to add a new entry to mainwindow.ui.
+    if (m_dopeSheetDock && ui->menuView) {
+        QAction* dopeAct = m_dopeSheetDock->toggleViewAction();
+        dopeAct->setText(tr("Dope Sheet"));
+        ui->menuView->addAction(dopeAct);
     }
 
     // Connect Browse button to a native file dialog (must be parented to MainWindow on macOS)

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -147,6 +147,7 @@ private:
     QQuickWidget* m_propertiesPanel = nullptr;
     QDockWidget* m_chatDock = nullptr;
     QDockWidget* m_assetBrowserDock = nullptr;
+    QDockWidget* m_dopeSheetDock = nullptr;
 
     QMenu* m_recentFilesMenu = nullptr;
     void addToRecentFiles(const QString& filePath);

--- a/src/qml_resources.qrc
+++ b/src/qml_resources.qrc
@@ -26,6 +26,7 @@
   </qresource>
   <qresource prefix="/AnimationControl">
     <file alias="AnimationControlPanel.qml">../qml/AnimationControlPanel.qml</file>
+    <file alias="AnimationDopeSheet.qml">../qml/AnimationDopeSheet.qml</file>
   </qresource>
   <qresource prefix="/AIChatPanel">
     <file alias="AIChatPanel.qml">../qml/AIChatPanel.qml</file>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,6 +63,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/ViewCube/ViewCubeController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/UndoManager.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/TransformCommands.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/MoveKeyframeCommand.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/PropertiesPanelController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/SceneTreeModel.cpp
 


### PR DESCRIPTION
## Summary
Closes #372 (slice C of #260).

Adds a multi-bone dope sheet view at the bottom of the main window: one row per animated bone, diamond markers at every keyframe time, drag-to-move time, undoable. Wheel/middle-drag for zoom and pan.

- **QML** — new `AnimationDopeSheet.qml`. Reuses the existing yellow-diamond / red-selected styling. Click a row's bone name to select it (shared state with the existing single-track panel). Click a diamond to move the playhead there. Drag a diamond to shift its keyframe time.
- **Controller** — `AnimationControlController` gains `allBoneRows()`, `moveKeyframe(bone, oldT, newT)`, and a `boneRowsChanged` signal. The signal is emitted from the existing `refreshSliderTicks()` so any track-affecting op (add / delete / move / select) covers it.
- **Undo/redo** — new `commands/MoveKeyframeCommand`. Ogre's `KeyFrame` has no `setTime()`, so the command captures TRS, removes the source keyframe, creates one at the target time, and restores TRS. Refuses moves that would collide with another keyframe on the same track (1 ms tolerance).
- **Hosting** — new `QDockWidget` at the bottom, toggleable via View menu (uses the dock's built-in `toggleViewAction()` so `mainwindow.ui` is untouched). Sentry breadcrumbs on toggle.

Version bumped to 2.35.0.

## Out of scope (deferred)
- Multi-select rectangle + bulk move/copy/paste — going into slice D alongside the curve editor.
- Per-channel rows (T.X / R.W / etc.) — also slice D.
- Bezier handles — slice D.

## Test plan
- [ ] View → Dope Sheet toggles the bottom dock
- [ ] Loading a rigged mesh + selecting an animation populates one row per animated bone
- [ ] Dragging a diamond shifts its keyframe time; the underlying `Animation` track updates
- [ ] Wheel zooms around the cursor; middle-drag pans
- [ ] Ctrl+Z undoes a keyframe move; Ctrl+Shift+Z redoes
- [ ] Animation Control panel and Dope Sheet stay in sync
- [ ] Linux CI: `AnimationControlController{,Playback}Test` covers row/move/collision; `MoveKeyframeCommandTest` covers undo/redo + TRS preservation + missing-time no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Dope Sheet panel for bone-based keyframe visualization and editing.
  * Interactive keyframe dragging with zoom, pan, and timeline ruler for precise control.
  * Keyframe move operations include collision checks and full undo/redo support.
  * Dope Sheet available as a toggleable dock in the View menu.

* **Chores**
  * Project version bumped to 2.35.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->