### PR TITLE
feat(animation): dope sheet multi-select + copy/paste/bulk-move (slice D1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 2.35.0 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 2.36.0 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/qml/AnimationDopeSheet.qml
+++ b/qml/AnimationDopeSheet.qml
@@ -3,13 +3,13 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import AnimationControl 1.0
 
-// Multi-bone dope sheet — one row per animated bone with diamond markers
-// at each keyframe time. Drag a marker horizontally to move the keyframe
-// (calls AnimationControlController.moveKeyframe). Wheel to zoom around the
-// cursor; middle-drag to pan.
+// Multi-bone dope sheet with multi-select, bulk move, and copy/paste.
+// One row per animated bone with diamond markers at each keyframe time.
+// Wheel zooms around the cursor; middle-drag pans.
 Rectangle {
     id: root
     color: AnimationControlController.panelColor
+    focus: true
 
     // Pixels-per-second view scale and horizontal scroll offset (in seconds).
     property real pxPerSec: 200
@@ -21,11 +21,100 @@ Rectangle {
     // Cached row data refreshed from the controller.
     property var rows: AnimationControlController.allBoneRows()
 
+    // Selection state. Each entry is { bone: string, time: number }.
+    // Stored as a plain array so QML bindings update on assignment.
+    property var selection: []
+
+    function isSelected(bone, time) {
+        for (var i = 0; i < selection.length; i++) {
+            if (selection[i].bone === bone &&
+                Math.abs(selection[i].time - time) < 0.001) return true
+        }
+        return false
+    }
+
+    function clearSelection() {
+        selection = []
+    }
+
+    function setSingleSelection(bone, time) {
+        selection = [{ bone: bone, time: time }]
+    }
+
+    function toggleInSelection(bone, time) {
+        var copy = selection.slice()
+        for (var i = 0; i < copy.length; i++) {
+            if (copy[i].bone === bone && Math.abs(copy[i].time - time) < 0.001) {
+                copy.splice(i, 1)
+                selection = copy
+                return
+            }
+        }
+        copy.push({ bone: bone, time: time })
+        selection = copy
+    }
+
+    // Used by the marquee to commit a rectangle selection.
+    function selectInRect(x1, y1, x2, y2) {
+        var lo = Math.min(x1, x2), hi = Math.max(x1, x2)
+        var top = Math.min(y1, y2), bot = Math.max(y1, y2)
+        var t1 = (lo - leftStripWidth) / pxPerSec + viewStart
+        var t2 = (hi - leftStripWidth) / pxPerSec + viewStart
+        var newSel = []
+        for (var r = 0; r < rows.length; r++) {
+            // Header (24px) + r * (rowHeight + spacing 1)
+            var rowTop = (header.visible ? header.height : 0) + r * (rowHeight + 1)
+            var rowBot = rowTop + rowHeight
+            if (rowBot < top || rowTop > bot) continue
+            var keyTimes = rows[r].keyTimes
+            for (var k = 0; k < keyTimes.length; k++) {
+                var t = keyTimes[k]
+                if (t >= t1 && t <= t2) newSel.push({ bone: rows[r].bone, time: t })
+            }
+        }
+        selection = newSel
+    }
+
     Connections {
         target: AnimationControlController
-        function onBoneRowsChanged()       { root.rows = AnimationControlController.allBoneRows() }
-        function onSelectionChanged()      { root.rows = AnimationControlController.allBoneRows() }
+        function onBoneRowsChanged()       { root.rows = AnimationControlController.allBoneRows(); root.clearSelection() }
+        function onSelectionChanged()      { root.rows = AnimationControlController.allBoneRows(); root.clearSelection() }
         function onKeyframeTicksChanged()  { root.rows = AnimationControlController.allBoneRows() }
+    }
+
+    // ── Keyboard shortcuts (Esc / Ctrl+C / Ctrl+V) ───────────────────────────
+    Keys.onPressed: function(event) {
+        if (event.key === Qt.Key_Escape) {
+            root.clearSelection()
+            event.accepted = true
+        } else if (event.key === Qt.Key_C && (event.modifiers & Qt.ControlModifier)) {
+            if (root.selection.length > 0) {
+                var json = AnimationControlController.serializeKeyframes(root.selection)
+                if (json.length > 0) {
+                    clipboardHelper.text = json
+                    clipboardHelper.selectAll()
+                    clipboardHelper.copy()
+                }
+            }
+            event.accepted = true
+        } else if (event.key === Qt.Key_V && (event.modifiers & Qt.ControlModifier)) {
+            clipboardHelper.clear()
+            clipboardHelper.paste()
+            var payload = clipboardHelper.text
+            if (payload.length > 0) {
+                var atTime = AnimationControlController.sliderValue / 1000.0
+                AnimationControlController.pasteKeyframesAt(payload, atTime)
+            }
+            event.accepted = true
+        }
+    }
+
+    // Hidden TextEdit acts as a clipboard bridge — Qt 6 QML has no first-class
+    // clipboard accessor, but TextEdit's copy()/paste() use the system clipboard.
+    TextEdit {
+        id: clipboardHelper
+        visible: false
+        width: 0; height: 0
     }
 
     // ── Empty-state placeholder ──────────────────────────────────────────────
@@ -39,7 +128,7 @@ Rectangle {
         font.pixelSize: 12
     }
 
-    // ── Header strip with timeline ruler + zoom hint ─────────────────────────
+    // ── Header strip with timeline ruler ─────────────────────────────────────
     Rectangle {
         id: header
         width: parent.width; height: 24
@@ -50,12 +139,13 @@ Rectangle {
         Text {
             anchors.left: parent.left; anchors.leftMargin: 6
             anchors.verticalCenter: parent.verticalCenter
-            text: "Bone"
+            text: root.selection.length > 0
+                  ? ("Bone (" + root.selection.length + " selected)")
+                  : "Bone"
             font.bold: true; font.pixelSize: 11
             color: AnimationControlController.textColor
         }
 
-        // Time ruler — major ticks every 0.5s
         Canvas {
             id: rulerCanvas
             anchors.left: parent.left; anchors.leftMargin: root.leftStripWidth
@@ -96,12 +186,10 @@ Rectangle {
         model: root.rows
         spacing: 1
         visible: root.rows.length > 0
+        interactive: false // we manage scrolling via wheel/middle-drag
 
         delegate: Rectangle {
             id: rowDelegate
-            // Capture row data once at the delegate scope. The inner Repeater
-            // shadows `modelData` with the keyTime number, so we can't reach
-            // back to the row map from inside it.
             property string boneName: modelData.bone
             property var keyTimes: modelData.keyTimes
 
@@ -137,7 +225,6 @@ Rectangle {
                 anchors.right: parent.right
                 clip: true
 
-                // Underline
                 Rectangle {
                     anchors.left: parent.left; anchors.right: parent.right
                     anchors.verticalCenter: parent.verticalCenter
@@ -146,46 +233,59 @@ Rectangle {
                     opacity: 0.4
                 }
 
-                // Diamonds
                 Repeater {
                     model: rowDelegate.keyTimes
                     Rectangle {
-                        // The bound keyTime; while dragging we render at
-                        // `dragPreviewTime` instead of pushing a command per
-                        // pixel. The single MoveKeyframeCommand is pushed on
-                        // release, giving exactly one undoable step per gesture.
                         property real keyTime: modelData
                         property real dragPreviewTime: keyTime
-                        property real displayTime: dragArea.dragging ? dragPreviewTime : keyTime
+                        // While the gesture is active, dragSelectionDt holds the
+                        // shared delta the whole selection is being shifted by.
+                        property bool isSelected: root.isSelected(rowDelegate.boneName, keyTime)
+                        property real displayTime: dragArea.dragging
+                            ? (dragArea.bulkDragging
+                                ? keyTime + root.dragSelectionDt
+                                : dragPreviewTime)
+                            : keyTime
                         x: (displayTime - root.viewStart) * root.pxPerSec - width / 2
                         anchors.verticalCenter: parent.verticalCenter
-                        width: 10; height: 10
+                        width: isSelected ? 14 : 10
+                        height: width
                         rotation: 45
                         color: dragArea.dragging
                                ? "#ff8855"
-                               : (Math.abs(keyTime * 1000 - AnimationControlController.selectedTick) < 1
-                                  ? "#ff4444" : "#ffcc00")
-                        border.color: AnimationControlController.borderColor
+                               : (isSelected
+                                  ? "#ff4444"
+                                  : (Math.abs(keyTime * 1000 - AnimationControlController.selectedTick) < 1
+                                     ? "#ff4444" : "#ffcc00"))
+                        border.color: isSelected ? "white" : AnimationControlController.borderColor
+                        border.width: isSelected ? 2 : 1
 
                         MouseArea {
                             id: dragArea
                             anchors.fill: parent
-                            anchors.margins: -3 // larger hit area
+                            anchors.margins: -3
                             cursorShape: Qt.SizeHorCursor
                             preventStealing: true
                             property bool dragging: false
+                            property bool bulkDragging: false
                             property real pressX: 0
                             property real originalTime: 0
-                            // Single press snapshot; release commits one move.
                             onPressed: function(mouse) {
-                                dragging = true
-                                pressX = mouse.x
+                                root.forceActiveFocus()
                                 originalTime = parent.keyTime
-                                parent.dragPreviewTime = parent.keyTime
-                                // Selecting the diamond's bone + jumping the
-                                // playhead is the natural "click" outcome —
-                                // do it on press so it works even if the user
-                                // drags slightly afterwards.
+                                pressX = mouse.x
+                                if (mouse.modifiers & Qt.ControlModifier) {
+                                    root.toggleInSelection(rowDelegate.boneName, parent.keyTime)
+                                    AnimationControlController.selectBone(rowDelegate.boneName)
+                                    mouse.accepted = true
+                                    return
+                                }
+                                if (!root.isSelected(rowDelegate.boneName, parent.keyTime)) {
+                                    root.setSingleSelection(rowDelegate.boneName, parent.keyTime)
+                                }
+                                dragging = true
+                                bulkDragging = root.selection.length > 1
+                                root.dragSelectionDt = 0
                                 AnimationControlController.selectBone(rowDelegate.boneName)
                                 AnimationControlController.sliderValue =
                                         Math.round(parent.keyTime * 1000)
@@ -194,19 +294,32 @@ Rectangle {
                                 if (!dragging) return
                                 var dx = mouse.x - pressX
                                 var dt = dx / root.pxPerSec
-                                var target = originalTime + dt
-                                if (target < 0) target = 0
-                                var len = AnimationControlController.animationLength
-                                if (target > len) target = len
-                                parent.dragPreviewTime = target
+                                if (bulkDragging) {
+                                    root.dragSelectionDt = dt
+                                } else {
+                                    var target = originalTime + dt
+                                    if (target < 0) target = 0
+                                    var len = AnimationControlController.animationLength
+                                    if (target > len) target = len
+                                    parent.dragPreviewTime = target
+                                }
                             }
                             onReleased: function(mouse) {
                                 if (!dragging) return
                                 dragging = false
-                                var target = parent.dragPreviewTime
-                                if (Math.abs(target - originalTime) > 0.001) {
-                                    AnimationControlController.moveKeyframe(
-                                        rowDelegate.boneName, originalTime, target)
+                                if (bulkDragging) {
+                                    var dt = root.dragSelectionDt
+                                    root.dragSelectionDt = 0
+                                    bulkDragging = false
+                                    if (Math.abs(dt) > 0.001) {
+                                        AnimationControlController.moveKeyframes(root.selection, dt)
+                                    }
+                                } else {
+                                    var target = parent.dragPreviewTime
+                                    if (Math.abs(target - originalTime) > 0.001) {
+                                        AnimationControlController.moveKeyframe(
+                                            rowDelegate.boneName, originalTime, target)
+                                    }
                                 }
                             }
                         }
@@ -216,31 +329,88 @@ Rectangle {
         }
     }
 
-    // ── Wheel zoom + middle-drag pan over the timeline area ──────────────────
+    // Shared bulk-drag delta — bound by all diamonds in the selection so they
+    // move together. Reset in onReleased.
+    property real dragSelectionDt: 0
+
+    // ── Marquee select + middle-drag pan + wheel zoom over timeline area ────
     MouseArea {
+        id: timelineArea
         anchors.left: parent.left; anchors.leftMargin: root.leftStripWidth
         anchors.top: header.visible ? header.bottom : parent.top
         anchors.right: parent.right; anchors.bottom: parent.bottom
-        acceptedButtons: Qt.MiddleButton
+        acceptedButtons: Qt.MiddleButton | Qt.LeftButton
         propagateComposedEvents: true
         property real panStartX: 0
         property real panStartView: 0
+        property bool marquee: false
+        property real mqStartX: 0
+        property real mqStartY: 0
+        property real mqEndX: 0
+        property real mqEndY: 0
+
         onPressed: function(mouse) {
+            root.forceActiveFocus()
             if (mouse.button === Qt.MiddleButton) {
                 panStartX = mouse.x
                 panStartView = root.viewStart
                 mouse.accepted = true
-            } else { mouse.accepted = false }
+            } else if (mouse.button === Qt.LeftButton) {
+                // Left-click on empty timeline area → start marquee selection.
+                // Click-through on diamonds is handled by their own MouseArea
+                // (preventStealing = true), so this only fires on background.
+                marquee = true
+                mqStartX = mouse.x; mqStartY = mouse.y
+                mqEndX = mouse.x;   mqEndY = mouse.y
+                if (!(mouse.modifiers & Qt.ControlModifier)) root.clearSelection()
+                mouse.accepted = true
+            } else {
+                mouse.accepted = false
+            }
         }
         onPositionChanged: function(mouse) {
             if (!pressed) return
-            var dx = mouse.x - panStartX
-            root.viewStart = panStartView - dx / root.pxPerSec
-            if (root.viewStart < 0) root.viewStart = 0
+            if (marquee) {
+                mqEndX = mouse.x; mqEndY = mouse.y
+                marqueeRect.requestPaint()
+            } else {
+                var dx = mouse.x - panStartX
+                root.viewStart = panStartView - dx / root.pxPerSec
+                if (root.viewStart < 0) root.viewStart = 0
+            }
+        }
+        onReleased: function(mouse) {
+            if (marquee) {
+                marquee = false
+                // Translate marquee from timeline-area coords to root coords.
+                var leftPad = root.leftStripWidth
+                var topPad  = header.visible ? header.height : 0
+                root.selectInRect(mqStartX + leftPad, mqStartY + topPad,
+                                  mqEndX + leftPad,   mqEndY + topPad)
+                marqueeRect.requestPaint()
+            }
+        }
+
+        // Marquee rectangle overlay
+        Canvas {
+            id: marqueeRect
+            anchors.fill: parent
+            visible: timelineArea.marquee
+            onPaint: {
+                var ctx = getContext("2d"); ctx.clearRect(0, 0, width, height)
+                if (!timelineArea.marquee) return
+                var x = Math.min(timelineArea.mqStartX, timelineArea.mqEndX)
+                var y = Math.min(timelineArea.mqStartY, timelineArea.mqEndY)
+                var w = Math.abs(timelineArea.mqEndX - timelineArea.mqStartX)
+                var h = Math.abs(timelineArea.mqEndY - timelineArea.mqStartY)
+                ctx.fillStyle = "rgba(64, 192, 255, 0.18)"
+                ctx.fillRect(x, y, w, h)
+                ctx.strokeStyle = "#40c0ff"; ctx.lineWidth = 1
+                ctx.strokeRect(x + 0.5, y + 0.5, w, h)
+            }
         }
 
         WheelHandler {
-            // Zoom around the cursor: keep the time under the cursor stationary.
             onWheel: function(event) {
                 var factor = event.angleDelta.y > 0 ? 1.15 : (1.0 / 1.15)
                 var newPxPerSec = root.pxPerSec * factor

--- a/qml/AnimationDopeSheet.qml
+++ b/qml/AnimationDopeSheet.qml
@@ -54,13 +54,22 @@ Rectangle {
         selection = copy
     }
 
-    // Used by the marquee to commit a rectangle selection.
-    function selectInRect(x1, y1, x2, y2) {
+    // Used by the marquee to commit a rectangle selection. When `additive`
+    // is true (Ctrl/Cmd held during marquee), the rect-hit set is unioned
+    // with the existing selection instead of replacing it.
+    function selectInRect(x1, y1, x2, y2, additive) {
         var lo = Math.min(x1, x2), hi = Math.max(x1, x2)
         var top = Math.min(y1, y2), bot = Math.max(y1, y2)
         var t1 = (lo - leftStripWidth) / pxPerSec + viewStart
         var t2 = (hi - leftStripWidth) / pxPerSec + viewStart
-        var newSel = []
+        var newSel = additive ? selection.slice() : []
+        function alreadyHas(bone, time) {
+            for (var i = 0; i < newSel.length; i++) {
+                if (newSel[i].bone === bone &&
+                    Math.abs(newSel[i].time - time) < 0.001) return true
+            }
+            return false
+        }
         for (var r = 0; r < rows.length; r++) {
             // Header (24px) + r * (rowHeight + spacing 1)
             var rowTop = (header.visible ? header.height : 0) + r * (rowHeight + 1)
@@ -69,7 +78,9 @@ Rectangle {
             var keyTimes = rows[r].keyTimes
             for (var k = 0; k < keyTimes.length; k++) {
                 var t = keyTimes[k]
-                if (t >= t1 && t <= t2) newSel.push({ bone: rows[r].bone, time: t })
+                if (t >= t1 && t <= t2 && !alreadyHas(rows[r].bone, t)) {
+                    newSel.push({ bone: rows[r].bone, time: t })
+                }
             }
         }
         selection = newSel
@@ -378,6 +389,7 @@ Rectangle {
         property real panStartX: 0
         property real panStartView: 0
         property bool marquee: false
+        property bool marqueeAdditive: false
         property real mqStartX: 0
         property real mqStartY: 0
         property real mqEndX: 0
@@ -393,9 +405,10 @@ Rectangle {
                 // Left-click on empty timeline area → start marquee selection.
                 // Diamonds capture their own presses via preventStealing.
                 marquee = true
+                marqueeAdditive = root.isPrimaryModifier(mouse.modifiers)
                 mqStartX = mouse.x; mqStartY = mouse.y
                 mqEndX = mouse.x;   mqEndY = mouse.y
-                if (!root.isPrimaryModifier(mouse.modifiers)) root.clearSelection()
+                if (!marqueeAdditive) root.clearSelection()
                 mouse.accepted = true
             } else {
                 mouse.accepted = false
@@ -419,7 +432,8 @@ Rectangle {
                 var leftPad = root.leftStripWidth
                 var topPad  = header.visible ? header.height : 0
                 root.selectInRect(mqStartX + leftPad, mqStartY + topPad,
-                                  mqEndX + leftPad,   mqEndY + topPad)
+                                  mqEndX + leftPad,   mqEndY + topPad,
+                                  marqueeAdditive)
                 marqueeRect.requestPaint()
             }
         }

--- a/qml/AnimationDopeSheet.qml
+++ b/qml/AnimationDopeSheet.qml
@@ -77,9 +77,18 @@ Rectangle {
 
     Connections {
         target: AnimationControlController
-        function onBoneRowsChanged()       { root.rows = AnimationControlController.allBoneRows(); root.clearSelection() }
+        // Clip change → rebuild rows AND drop selection (different keyframes
+        // entirely). Track edits (boneRowsChanged) refresh rows but preserve
+        // the user's selection — bulk-drag and bone-click both fire that
+        // signal, and dropping selection there breaks bulk drag mid-gesture.
         function onSelectionChanged()      { root.rows = AnimationControlController.allBoneRows(); root.clearSelection() }
+        function onBoneRowsChanged()       { root.rows = AnimationControlController.allBoneRows() }
         function onKeyframeTicksChanged()  { root.rows = AnimationControlController.allBoneRows() }
+    }
+
+    // Cross-platform "primary" modifier — Ctrl on Win/Linux, Cmd (Meta) on macOS.
+    function isPrimaryModifier(modifiers) {
+        return (modifiers & Qt.ControlModifier) || (modifiers & Qt.MetaModifier)
     }
 
     // ── Keyboard shortcuts (Esc / Ctrl+C / Ctrl+V) ───────────────────────────
@@ -87,7 +96,7 @@ Rectangle {
         if (event.key === Qt.Key_Escape) {
             root.clearSelection()
             event.accepted = true
-        } else if (event.key === Qt.Key_C && (event.modifiers & Qt.ControlModifier)) {
+        } else if (event.key === Qt.Key_C && root.isPrimaryModifier(event.modifiers)) {
             if (root.selection.length > 0) {
                 var json = AnimationControlController.serializeKeyframes(root.selection)
                 if (json.length > 0) {
@@ -97,7 +106,7 @@ Rectangle {
                 }
             }
             event.accepted = true
-        } else if (event.key === Qt.Key_V && (event.modifiers & Qt.ControlModifier)) {
+        } else if (event.key === Qt.Key_V && root.isPrimaryModifier(event.modifiers)) {
             clipboardHelper.clear()
             clipboardHelper.paste()
             var payload = clipboardHelper.text
@@ -186,22 +195,28 @@ Rectangle {
         model: root.rows
         spacing: 1
         visible: root.rows.length > 0
-        interactive: false // we manage scrolling via wheel/middle-drag
+        // Disabled flicking so Flickable doesn't grab presses meant for
+        // diamond MouseAreas / Ctrl+click multi-select. Wheel scrolling is
+        // handled at the root level via a WheelHandler that scrolls
+        // rowsView.contentY directly.
+        interactive: false
+        boundsBehavior: Flickable.StopAtBounds
 
-        delegate: Rectangle {
+        delegate: Item {
             id: rowDelegate
             property string boneName: modelData.bone
             property var keyTimes: modelData.keyTimes
 
             width: rowsView.width; height: root.rowHeight
-            color: (boneName === AnimationControlController.selectedBone)
-                   ? Qt.lighter(AnimationControlController.panelColor, 1.15)
-                   : AnimationControlController.panelColor
 
-            // Bone name (clickable — selects the bone)
+            // Bone name strip carries the selection-highlight tint. Track
+            // strip is transparent so timelineArea behind us catches presses
+            // on empty pixels for marquee/pan.
             Rectangle {
                 width: root.leftStripWidth; height: parent.height
-                color: "transparent"
+                color: (rowDelegate.boneName === AnimationControlController.selectedBone)
+                       ? Qt.lighter(AnimationControlController.panelColor, 1.15)
+                       : AnimationControlController.panelColor
                 border.color: AnimationControlController.borderColor; border.width: 1
                 Text {
                     anchors.left: parent.left; anchors.leftMargin: 6
@@ -241,11 +256,21 @@ Rectangle {
                         // While the gesture is active, dragSelectionDt holds the
                         // shared delta the whole selection is being shifted by.
                         property bool isSelected: root.isSelected(rowDelegate.boneName, keyTime)
-                        property real displayTime: dragArea.dragging
-                            ? (dragArea.bulkDragging
-                                ? keyTime + root.dragSelectionDt
-                                : dragPreviewTime)
-                            : keyTime
+                        // While a bulk drag is in progress, every selected
+                        // diamond renders at keyTime + dragSelectionDt — so the
+                        // visual offset follows the shared delta even though
+                        // only the originating MouseArea has dragArea.dragging.
+                        property real displayTime: {
+                            if (root.bulkDragInProgress && isSelected) {
+                                return keyTime + root.dragSelectionDt
+                            }
+                            if (dragArea.dragging) {
+                                return dragArea.bulkDragging
+                                    ? keyTime + root.dragSelectionDt
+                                    : dragPreviewTime
+                            }
+                            return keyTime
+                        }
                         x: (displayTime - root.viewStart) * root.pxPerSec - width / 2
                         anchors.verticalCenter: parent.verticalCenter
                         width: isSelected ? 14 : 10
@@ -274,10 +299,12 @@ Rectangle {
                                 root.forceActiveFocus()
                                 originalTime = parent.keyTime
                                 pressX = mouse.x
-                                if (mouse.modifiers & Qt.ControlModifier) {
+                                mouse.accepted = true
+                                if (root.isPrimaryModifier(mouse.modifiers)) {
+                                    // Ctrl/Cmd+click: toggle in/out of selection,
+                                    // don't start a drag.
                                     root.toggleInSelection(rowDelegate.boneName, parent.keyTime)
                                     AnimationControlController.selectBone(rowDelegate.boneName)
-                                    mouse.accepted = true
                                     return
                                 }
                                 if (!root.isSelected(rowDelegate.boneName, parent.keyTime)) {
@@ -286,6 +313,7 @@ Rectangle {
                                 dragging = true
                                 bulkDragging = root.selection.length > 1
                                 root.dragSelectionDt = 0
+                                root.bulkDragInProgress = bulkDragging
                                 AnimationControlController.selectBone(rowDelegate.boneName)
                                 AnimationControlController.sliderValue =
                                         Math.round(parent.keyTime * 1000)
@@ -307,6 +335,7 @@ Rectangle {
                             onReleased: function(mouse) {
                                 if (!dragging) return
                                 dragging = false
+                                root.bulkDragInProgress = false
                                 if (bulkDragging) {
                                     var dt = root.dragSelectionDt
                                     root.dragSelectionDt = 0
@@ -329,18 +358,23 @@ Rectangle {
         }
     }
 
-    // Shared bulk-drag delta — bound by all diamonds in the selection so they
-    // move together. Reset in onReleased.
+    // Shared bulk-drag delta — every selected diamond binds against this so
+    // they all animate together while one is being dragged. Reset on release.
     property real dragSelectionDt: 0
+    property bool bulkDragInProgress: false
 
     // ── Marquee select + middle-drag pan + wheel zoom over timeline area ────
+    // z: -1 puts this MouseArea behind the ListView. The row delegate roots
+    // are Items (not Rectangles), so the trackStrip is non-opaque and
+    // presses on empty pixels fall through to here. Diamonds + bone-name
+    // MouseAreas inside each row capture their own presses naturally.
     MouseArea {
         id: timelineArea
+        z: -1
         anchors.left: parent.left; anchors.leftMargin: root.leftStripWidth
         anchors.top: header.visible ? header.bottom : parent.top
         anchors.right: parent.right; anchors.bottom: parent.bottom
         acceptedButtons: Qt.MiddleButton | Qt.LeftButton
-        propagateComposedEvents: true
         property real panStartX: 0
         property real panStartView: 0
         property bool marquee: false
@@ -357,12 +391,11 @@ Rectangle {
                 mouse.accepted = true
             } else if (mouse.button === Qt.LeftButton) {
                 // Left-click on empty timeline area → start marquee selection.
-                // Click-through on diamonds is handled by their own MouseArea
-                // (preventStealing = true), so this only fires on background.
+                // Diamonds capture their own presses via preventStealing.
                 marquee = true
                 mqStartX = mouse.x; mqStartY = mouse.y
                 mqEndX = mouse.x;   mqEndY = mouse.y
-                if (!(mouse.modifiers & Qt.ControlModifier)) root.clearSelection()
+                if (!root.isPrimaryModifier(mouse.modifiers)) root.clearSelection()
                 mouse.accepted = true
             } else {
                 mouse.accepted = false
@@ -391,26 +424,10 @@ Rectangle {
             }
         }
 
-        // Marquee rectangle overlay
-        Canvas {
-            id: marqueeRect
-            anchors.fill: parent
-            visible: timelineArea.marquee
-            onPaint: {
-                var ctx = getContext("2d"); ctx.clearRect(0, 0, width, height)
-                if (!timelineArea.marquee) return
-                var x = Math.min(timelineArea.mqStartX, timelineArea.mqEndX)
-                var y = Math.min(timelineArea.mqStartY, timelineArea.mqEndY)
-                var w = Math.abs(timelineArea.mqEndX - timelineArea.mqStartX)
-                var h = Math.abs(timelineArea.mqEndY - timelineArea.mqStartY)
-                ctx.fillStyle = "rgba(64, 192, 255, 0.18)"
-                ctx.fillRect(x, y, w, h)
-                ctx.strokeStyle = "#40c0ff"; ctx.lineWidth = 1
-                ctx.strokeRect(x + 0.5, y + 0.5, w, h)
-            }
-        }
-
+        // Ctrl/Cmd+wheel zooms around the cursor; plain wheel falls through
+        // to the ListView for vertical scrolling.
         WheelHandler {
+            acceptedModifiers: Qt.ControlModifier | Qt.MetaModifier
             onWheel: function(event) {
                 var factor = event.angleDelta.y > 0 ? 1.15 : (1.0 / 1.15)
                 var newPxPerSec = root.pxPerSec * factor
@@ -421,6 +438,66 @@ Rectangle {
                 root.viewStart = tCursor - event.point.position.x / newPxPerSec
                 if (root.viewStart < 0) root.viewStart = 0
             }
+        }
+    }
+
+    // Marquee rectangle overlay — drawn at root level (z: 100) so it sits on
+    // top of rows + diamonds. timelineArea is at z: -1, so its child Canvas
+    // would be invisible behind the rows.
+    Canvas {
+        id: marqueeRect
+        z: 100
+        x: timelineArea.x
+        y: timelineArea.y
+        width: timelineArea.width
+        height: timelineArea.height
+        visible: timelineArea.marquee
+        onPaint: {
+            var ctx = getContext("2d"); ctx.clearRect(0, 0, width, height)
+            if (!timelineArea.marquee) return
+            var x1 = Math.min(timelineArea.mqStartX, timelineArea.mqEndX)
+            var y1 = Math.min(timelineArea.mqStartY, timelineArea.mqEndY)
+            var w  = Math.abs(timelineArea.mqEndX - timelineArea.mqStartX)
+            var h  = Math.abs(timelineArea.mqEndY - timelineArea.mqStartY)
+            ctx.fillStyle = "rgba(64, 192, 255, 0.18)"
+            ctx.fillRect(x1, y1, w, h)
+            ctx.strokeStyle = "#40c0ff"; ctx.lineWidth = 1
+            ctx.strokeRect(x1 + 0.5, y1 + 0.5, w, h)
+        }
+        Connections {
+            target: timelineArea
+            function onMqStartXChanged() { marqueeRect.requestPaint() }
+            function onMqStartYChanged() { marqueeRect.requestPaint() }
+            function onMqEndXChanged()   { marqueeRect.requestPaint() }
+            function onMqEndYChanged()   { marqueeRect.requestPaint() }
+            function onMarqueeChanged()  { marqueeRect.requestPaint() }
+        }
+    }
+
+    // Plain wheel anywhere in the dope sheet scrolls the bone rows. Lives at
+    // root level so it sees wheel events regardless of which child happens
+    // to be under the cursor (ListView is interactive:false and the inner
+    // diamonds/timelineArea otherwise eat the wheel). Ctrl/Cmd+wheel is
+    // claimed by timelineArea's zoom handler instead.
+    // Public method called by C++ wheel filter on the host QQuickWidget.
+    // QQuickWidget inside QDockWidget can swallow wheel events on macOS;
+    // routing them through here guarantees the rows scroll regardless.
+    function scrollByPixels(dy) {
+        if (dy === 0 || !rowsView.visible) return
+        var maxY = Math.max(0, rowsView.contentHeight - rowsView.height)
+        rowsView.contentY = Math.max(0, Math.min(maxY, rowsView.contentY - dy))
+    }
+
+    WheelHandler {
+        target: null // accept events anywhere on the root, not on a specific item
+        acceptedModifiers: Qt.NoModifier
+        onWheel: function(event) {
+            var dy = (event.pixelDelta && event.pixelDelta.y !== 0)
+                ? event.pixelDelta.y
+                : event.angleDelta.y / 120 * 40
+            if (dy === 0) return
+            root.scrollByPixels(dy)
+            event.accepted = true
         }
     }
 }

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -1,6 +1,7 @@
 #include "AnimationControlController.h"
 #include "SelectionSet.h"
 #include "Manager.h"
+#include "SentryReporter.h"
 #include "UndoManager.h"
 #include "commands/MoveKeyframeCommand.h"
 #include "commands/BulkKeyframeCommands.h"
@@ -753,6 +754,11 @@ bool AnimationControlController::moveKeyframes(const QVariantList& selection,
                                           m_selectedAnimation,
                                           items, dtf);
     UndoManager::getSingleton()->push(cmd);
+    SentryReporter::addBreadcrumb(
+        "ui.action",
+        QString("Dope Sheet: bulk-move %1 keyframe(s) by %2s")
+            .arg(items.size())
+            .arg(dt, 0, 'f', 3));
     refreshSliderTicks();
     emit boneRowsChanged();
     return true;
@@ -856,6 +862,11 @@ int AnimationControlController::pasteKeyframesAt(const QString& json,
                                            entries);
     UndoManager::getSingleton()->push(cmd);
     const int n = cmd->pastedCount();
+    const int skipped = entries.size() - n;
+    SentryReporter::addBreadcrumb(
+        "ui.action",
+        QString("Dope Sheet: paste %1 keyframe(s) at t=%2s (skipped %3 collision(s))")
+            .arg(n).arg(atTime, 0, 'f', 3).arg(skipped));
     refreshSliderTicks();
     emit boneRowsChanged();
     return n;

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <optional>
 
 #include <Ogre.h>
 
@@ -815,7 +816,7 @@ QString AnimationControlController::serializeKeyframes(
     for (const QVariant& v : selection) {
         const QVariantMap m = v.toMap();
         const QString bone = m.value(QStringLiteral("bone")).toString();
-        const float   tabs = static_cast<float>(m.value(QStringLiteral("time")).toDouble());
+        const auto    tabs = static_cast<float>(m.value(QStringLiteral("time")).toDouble());
         if (bone.isEmpty()) continue;
         auto* track = resolveTrackByBone(m_selectedSkeleton, m_selectedAnimation,
                                           bone.toStdString());
@@ -850,6 +851,77 @@ QString AnimationControlController::serializeKeyframes(
     return QString::fromUtf8(QJsonDocument(root).toJson(QJsonDocument::Compact));
 }
 
+namespace {
+
+// All numeric fields that must be present on a clipboard entry. Missing or
+// non-numeric values reject the entry entirely (rather than silently
+// coercing to identity, which would paste corrupted transforms).
+const QStringList& pasteRequiredFields() {
+    static const QStringList kFields = {
+        QStringLiteral("tx"), QStringLiteral("ty"), QStringLiteral("tz"),
+        QStringLiteral("rw"), QStringLiteral("rx"), QStringLiteral("ry"),
+        QStringLiteral("rz"),
+        QStringLiteral("sx"), QStringLiteral("sy"), QStringLiteral("sz"),
+    };
+    return kFields;
+}
+
+bool entryHasAllFields(const QJsonObject& e) {
+    for (const QString& key : pasteRequiredFields()) {
+        if (!e.contains(key) || !e.value(key).isDouble()) return false;
+    }
+    return true;
+}
+
+// Parse one clipboard entry into a PasteKeyframesCommand::Entry. Returns
+// nullopt when the entry is missing required fields or its destination
+// time falls outside [0, length].
+std::optional<PasteKeyframesCommand::Entry>
+parsePasteEntry(const QJsonObject& e, double atTime, float length)
+{
+    const QString bone = e.value(QStringLiteral("bone")).toString();
+    if (bone.isEmpty()) return std::nullopt;
+    if (!entryHasAllFields(e)) return std::nullopt;
+    const auto dst = static_cast<float>(atTime + e.value(QStringLiteral("dt")).toDouble());
+    if (dst < 0.0f || dst > length + kBulkEpsilon) return std::nullopt;
+    PasteKeyframesCommand::Entry pe;
+    pe.boneName = bone.toStdString();
+    pe.time = dst;
+    pe.tx = static_cast<float>(e.value(QStringLiteral("tx")).toDouble());
+    pe.ty = static_cast<float>(e.value(QStringLiteral("ty")).toDouble());
+    pe.tz = static_cast<float>(e.value(QStringLiteral("tz")).toDouble());
+    pe.rw = static_cast<float>(e.value(QStringLiteral("rw")).toDouble());
+    pe.rx = static_cast<float>(e.value(QStringLiteral("rx")).toDouble());
+    pe.ry = static_cast<float>(e.value(QStringLiteral("ry")).toDouble());
+    pe.rz = static_cast<float>(e.value(QStringLiteral("rz")).toDouble());
+    pe.sx = static_cast<float>(e.value(QStringLiteral("sx")).toDouble());
+    pe.sy = static_cast<float>(e.value(QStringLiteral("sy")).toDouble());
+    pe.sz = static_cast<float>(e.value(QStringLiteral("sz")).toDouble());
+    return pe;
+}
+
+// Counts how many entries would actually paste — i.e. don't collide with
+// an existing keyframe on their target track.
+int countNonColliding(Ogre::Skeleton* skel, const std::string& animName,
+                      const QVector<PasteKeyframesCommand::Entry>& entries)
+{
+    int n = 0;
+    for (const auto& e : entries) {
+        auto* track = resolveTrackByBone(skel, animName, e.boneName);
+        if (!track) continue;
+        bool collides = false;
+        for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+            if (std::fabs(track->getKeyFrame(i)->getTime() - e.time) <= kBulkEpsilon) {
+                collides = true; break;
+            }
+        }
+        if (!collides) ++n;
+    }
+    return n;
+}
+
+} // namespace
+
 int AnimationControlController::pasteKeyframesAt(const QString& json,
                                                   double atTime)
 {
@@ -863,66 +935,23 @@ int AnimationControlController::pasteKeyframesAt(const QString& json,
     const QJsonObject root = doc.object();
     if (root.value(QStringLiteral("kind")).toString() !=
         QStringLiteral("qtmesh.dopesheet.keyframes")) return 0;
-    // Reject unknown clipboard versions — keeps stale clipboard payloads
-    // from a different schema out of the undo stack.
     if (root.value(QStringLiteral("version")).toInt() != 1) return 0;
 
     const auto length = static_cast<float>(animationLength());
     QVector<PasteKeyframesCommand::Entry> entries;
     for (const QJsonValue& v : root.value(QStringLiteral("entries")).toArray()) {
-        const QJsonObject e = v.toObject();
-        const QString bone = e.value(QStringLiteral("bone")).toString();
-        const double  dt   = e.value(QStringLiteral("dt")).toDouble();
-        if (bone.isEmpty()) continue;
-        // Require all the numeric fields to be present so we don't silently
-        // paste a partial/corrupted entry as identity TRS.
-        const QStringList required{ QStringLiteral("tx"), QStringLiteral("ty"),
-                                    QStringLiteral("tz"), QStringLiteral("rw"),
-                                    QStringLiteral("rx"), QStringLiteral("ry"),
-                                    QStringLiteral("rz"), QStringLiteral("sx"),
-                                    QStringLiteral("sy"), QStringLiteral("sz") };
-        bool ok = true;
-        for (const QString& key : required) {
-            if (!e.contains(key) || !e.value(key).isDouble()) { ok = false; break; }
+        if (auto pe = parsePasteEntry(v.toObject(), atTime, length)) {
+            entries.append(*pe);
         }
-        if (!ok) continue;
-
-        const auto dst = static_cast<float>(atTime + dt);
-        if (dst < 0.0f || dst > length + kBulkEpsilon) continue; // out of range — skip
-        PasteKeyframesCommand::Entry pe;
-        pe.boneName = bone.toStdString();
-        pe.time = dst;
-        pe.tx = static_cast<float>(e.value(QStringLiteral("tx")).toDouble());
-        pe.ty = static_cast<float>(e.value(QStringLiteral("ty")).toDouble());
-        pe.tz = static_cast<float>(e.value(QStringLiteral("tz")).toDouble());
-        pe.rw = static_cast<float>(e.value(QStringLiteral("rw")).toDouble());
-        pe.rx = static_cast<float>(e.value(QStringLiteral("rx")).toDouble());
-        pe.ry = static_cast<float>(e.value(QStringLiteral("ry")).toDouble());
-        pe.rz = static_cast<float>(e.value(QStringLiteral("rz")).toDouble());
-        pe.sx = static_cast<float>(e.value(QStringLiteral("sx")).toDouble());
-        pe.sy = static_cast<float>(e.value(QStringLiteral("sy")).toDouble());
-        pe.sz = static_cast<float>(e.value(QStringLiteral("sz")).toDouble());
-        entries.append(pe);
     }
     if (entries.isEmpty()) return 0;
 
-    // Pre-check collisions so we don't push a no-op command onto the undo
-    // stack when every entry would skip. The command's own redo() repeats
-    // the check authoritatively — this is purely to avoid polluting undo.
-    int wouldPaste = 0;
-    for (const auto& e : entries) {
-        auto* track = resolveTrackByBone(m_selectedSkeleton, m_selectedAnimation,
-                                          e.boneName);
-        if (!track) continue;
-        bool collides = false;
-        for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
-            if (std::fabs(track->getKeyFrame(i)->getTime() - e.time) <= kBulkEpsilon) {
-                collides = true; break;
-            }
-        }
-        if (!collides) ++wouldPaste;
+    // Skip pushing the command if every entry would collide — keeps the
+    // undo history clean. The command's own redo() does the authoritative
+    // collision check; this is purely a tidiness pre-filter.
+    if (countNonColliding(m_selectedSkeleton, m_selectedAnimation, entries) == 0) {
+        return 0;
     }
-    if (wouldPaste == 0) return 0;
 
     auto* cmd = new PasteKeyframesCommand(m_selectedSkeleton, // NOSONAR — QUndoStack owns
                                            m_selectedAnimation,

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -12,7 +12,9 @@
 #include <QPalette>
 #include <QTimer>
 #include <QVariantMap>
+#include <algorithm>
 #include <cmath>
+#include <limits>
 
 #include <Ogre.h>
 
@@ -709,22 +711,30 @@ QVector<MoveKeyframesCommand::Item> selectionToItems(const QVariantList& sel)
 
 } // namespace
 
-bool AnimationControlController::moveKeyframes(const QVariantList& selection,
-                                                double dt)
+namespace {
+
+// Clamp the batch dt so no item's destination falls outside [0, length].
+// Returns the largest legal magnitude that still has the requested sign.
+float clampBatchDt(const QVector<MoveKeyframesCommand::Item>& items,
+                   float requestedDt, float length)
 {
-    if (selection.isEmpty()) return false;
-    if (!m_selectedSkeleton || m_selectedAnimation.empty()) return false;
-    if (!m_selectedSkeleton->hasAnimation(m_selectedAnimation)) return false;
-    if (qFuzzyCompare(dt + 1.0, 1.0)) return false; // dt == 0 is a no-op
+    if (items.isEmpty()) return 0.0f;
+    float lo = -std::numeric_limits<float>::infinity();
+    float hi =  std::numeric_limits<float>::infinity();
+    for (const auto& it : items) {
+        // Each item's destination must satisfy 0 <= origT + dt <= length.
+        lo = std::max(lo, -it.originalTime);
+        hi = std::min(hi,  length - it.originalTime);
+    }
+    if (lo > hi) return 0.0f; // shouldn't happen for non-empty range
+    return std::clamp(requestedDt, lo, hi);
+}
 
-    QVector<MoveKeyframesCommand::Item> items = selectionToItems(selection);
-    if (items.isEmpty()) return false;
-
-    const float dtf = static_cast<float>(dt);
-    const float length = static_cast<float>(animationLength());
-
-    // Build a quick lookup of which (bone, time) tuples are members of the
-    // selection so the collision check can ignore intra-selection overlap.
+// Returns true if the selection's destinations would collide with any
+// non-selected keyframe on its track.
+bool batchCollides(Ogre::Skeleton* skel, const std::string& animName,
+                   const QVector<MoveKeyframesCommand::Item>& items, float dt)
+{
     auto isMember = [&](const std::string& bone, float time) {
         for (const auto& it : items) {
             if (it.boneName == bone &&
@@ -732,22 +742,45 @@ bool AnimationControlController::moveKeyframes(const QVariantList& selection,
         }
         return false;
     };
-
-    // Validate per-item: clamp window + collision with non-selected keyframes.
     for (const auto& it : items) {
-        const float dst = it.originalTime + dtf;
-        if (dst < 0.0f || dst > length + kBulkEpsilon) return false;
-        auto* track = resolveTrackByBone(m_selectedSkeleton, m_selectedAnimation,
-                                          it.boneName);
-        if (!track) return false;
+        const float dst = it.originalTime + dt;
+        auto* track = resolveTrackByBone(skel, animName, it.boneName);
+        if (!track) return true; // missing track = treat as collision; bail
         for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
             const float t = track->getKeyFrame(i)->getTime();
-            if (std::fabs(t - it.originalTime) <= kBulkEpsilon) continue; // self
+            if (std::fabs(t - it.originalTime) <= kBulkEpsilon) continue;
             if (std::fabs(t - dst) <= kBulkEpsilon &&
                 !isMember(it.boneName, t)) {
-                return false; // collision with a non-member keyframe
+                return true;
             }
         }
+    }
+    return false;
+}
+
+} // namespace
+
+bool AnimationControlController::moveKeyframes(const QVariantList& selection,
+                                                double dt)
+{
+    if (selection.isEmpty()) return false;
+    if (!m_selectedSkeleton || m_selectedAnimation.empty()) return false;
+    if (!m_selectedSkeleton->hasAnimation(m_selectedAnimation)) return false;
+    if (qFuzzyCompare(dt + 1.0, 1.0)) return false;
+
+    QVector<MoveKeyframesCommand::Item> items = selectionToItems(selection);
+    if (items.isEmpty()) return false;
+
+    const auto length = static_cast<float>(animationLength());
+    // Clamp the requested delta so a multi-selection sliding into a clip
+    // boundary lands on the nearest legal time instead of snapping back.
+    const float dtf = clampBatchDt(items, static_cast<float>(dt), length);
+    if (qFuzzyIsNull(dtf)) return false;
+
+    // Refuse if the (now-clamped) shift would collide with any non-selected
+    // keyframe on the same track.
+    if (batchCollides(m_selectedSkeleton, m_selectedAnimation, items, dtf)) {
+        return false;
     }
 
     auto* cmd = new MoveKeyframesCommand(m_selectedSkeleton, // NOSONAR — QUndoStack owns
@@ -757,8 +790,8 @@ bool AnimationControlController::moveKeyframes(const QVariantList& selection,
     SentryReporter::addBreadcrumb(
         "ui.action",
         QString("Dope Sheet: bulk-move %1 keyframe(s) by %2s")
-            .arg(items.size())
-            .arg(dt, 0, 'f', 3));
+            .arg(static_cast<int>(items.size()))
+            .arg(static_cast<double>(dtf), 0, 'f', 3));
     refreshSliderTicks();
     emit boneRowsChanged();
     return true;
@@ -830,15 +863,31 @@ int AnimationControlController::pasteKeyframesAt(const QString& json,
     const QJsonObject root = doc.object();
     if (root.value(QStringLiteral("kind")).toString() !=
         QStringLiteral("qtmesh.dopesheet.keyframes")) return 0;
+    // Reject unknown clipboard versions — keeps stale clipboard payloads
+    // from a different schema out of the undo stack.
+    if (root.value(QStringLiteral("version")).toInt() != 1) return 0;
 
-    const float length = static_cast<float>(animationLength());
+    const auto length = static_cast<float>(animationLength());
     QVector<PasteKeyframesCommand::Entry> entries;
     for (const QJsonValue& v : root.value(QStringLiteral("entries")).toArray()) {
         const QJsonObject e = v.toObject();
         const QString bone = e.value(QStringLiteral("bone")).toString();
         const double  dt   = e.value(QStringLiteral("dt")).toDouble();
         if (bone.isEmpty()) continue;
-        const float dst = static_cast<float>(atTime + dt);
+        // Require all the numeric fields to be present so we don't silently
+        // paste a partial/corrupted entry as identity TRS.
+        const QStringList required{ QStringLiteral("tx"), QStringLiteral("ty"),
+                                    QStringLiteral("tz"), QStringLiteral("rw"),
+                                    QStringLiteral("rx"), QStringLiteral("ry"),
+                                    QStringLiteral("rz"), QStringLiteral("sx"),
+                                    QStringLiteral("sy"), QStringLiteral("sz") };
+        bool ok = true;
+        for (const QString& key : required) {
+            if (!e.contains(key) || !e.value(key).isDouble()) { ok = false; break; }
+        }
+        if (!ok) continue;
+
+        const auto dst = static_cast<float>(atTime + dt);
         if (dst < 0.0f || dst > length + kBulkEpsilon) continue; // out of range — skip
         PasteKeyframesCommand::Entry pe;
         pe.boneName = bone.toStdString();
@@ -846,23 +895,41 @@ int AnimationControlController::pasteKeyframesAt(const QString& json,
         pe.tx = static_cast<float>(e.value(QStringLiteral("tx")).toDouble());
         pe.ty = static_cast<float>(e.value(QStringLiteral("ty")).toDouble());
         pe.tz = static_cast<float>(e.value(QStringLiteral("tz")).toDouble());
-        pe.rw = static_cast<float>(e.value(QStringLiteral("rw")).toDouble(1.0));
+        pe.rw = static_cast<float>(e.value(QStringLiteral("rw")).toDouble());
         pe.rx = static_cast<float>(e.value(QStringLiteral("rx")).toDouble());
         pe.ry = static_cast<float>(e.value(QStringLiteral("ry")).toDouble());
         pe.rz = static_cast<float>(e.value(QStringLiteral("rz")).toDouble());
-        pe.sx = static_cast<float>(e.value(QStringLiteral("sx")).toDouble(1.0));
-        pe.sy = static_cast<float>(e.value(QStringLiteral("sy")).toDouble(1.0));
-        pe.sz = static_cast<float>(e.value(QStringLiteral("sz")).toDouble(1.0));
+        pe.sx = static_cast<float>(e.value(QStringLiteral("sx")).toDouble());
+        pe.sy = static_cast<float>(e.value(QStringLiteral("sy")).toDouble());
+        pe.sz = static_cast<float>(e.value(QStringLiteral("sz")).toDouble());
         entries.append(pe);
     }
     if (entries.isEmpty()) return 0;
+
+    // Pre-check collisions so we don't push a no-op command onto the undo
+    // stack when every entry would skip. The command's own redo() repeats
+    // the check authoritatively — this is purely to avoid polluting undo.
+    int wouldPaste = 0;
+    for (const auto& e : entries) {
+        auto* track = resolveTrackByBone(m_selectedSkeleton, m_selectedAnimation,
+                                          e.boneName);
+        if (!track) continue;
+        bool collides = false;
+        for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+            if (std::fabs(track->getKeyFrame(i)->getTime() - e.time) <= kBulkEpsilon) {
+                collides = true; break;
+            }
+        }
+        if (!collides) ++wouldPaste;
+    }
+    if (wouldPaste == 0) return 0;
 
     auto* cmd = new PasteKeyframesCommand(m_selectedSkeleton, // NOSONAR — QUndoStack owns
                                            m_selectedAnimation,
                                            entries);
     UndoManager::getSingleton()->push(cmd);
     const int n = cmd->pastedCount();
-    const int skipped = entries.size() - n;
+    const int skipped = static_cast<int>(entries.size()) - n;
     SentryReporter::addBreadcrumb(
         "ui.action",
         QString("Dope Sheet: paste %1 keyframe(s) at t=%2s (skipped %3 collision(s))")

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -3,7 +3,11 @@
 #include "Manager.h"
 #include "UndoManager.h"
 #include "commands/MoveKeyframeCommand.h"
+#include "commands/BulkKeyframeCommands.h"
 #include <QApplication>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QPalette>
 #include <QTimer>
 #include <QVariantMap>
@@ -662,4 +666,197 @@ bool AnimationControlController::moveKeyframe(const QString& boneName,
     refreshSliderTicks();
     emit boneRowsChanged();
     return true;
+}
+
+// ── Bulk keyframe ops (slice D1) ──────────────────────────────────────────────
+
+namespace {
+
+constexpr float kBulkEpsilon = 0.001f;
+
+// Resolve an arbitrary bone's track on the controller's current animation.
+// Returns nullptr if any link in the chain is missing.
+Ogre::NodeAnimationTrack* resolveTrackByBone(Ogre::Skeleton* skel,
+                                             const std::string& animName,
+                                             const std::string& boneName)
+{
+    if (!skel || animName.empty() || boneName.empty()) return nullptr;
+    if (!skel->hasAnimation(animName)) return nullptr;
+    if (!skel->hasBone(boneName)) return nullptr;
+    Ogre::Animation* anim = skel->getAnimation(animName);
+    Ogre::Bone* bone = skel->getBone(boneName);
+    if (!anim || !bone) return nullptr;
+    if (!anim->hasNodeTrack(bone->getHandle())) return nullptr;
+    return anim->getNodeTrack(bone->getHandle());
+}
+
+// Convert a QML-side selection list ({bone, time} maps) into the flat
+// command-side list of items, preserving caller-supplied order.
+QVector<MoveKeyframesCommand::Item> selectionToItems(const QVariantList& sel)
+{
+    QVector<MoveKeyframesCommand::Item> out;
+    out.reserve(sel.size());
+    for (const QVariant& v : sel) {
+        const QVariantMap m = v.toMap();
+        const QString bone = m.value(QStringLiteral("bone")).toString();
+        const double  t    = m.value(QStringLiteral("time")).toDouble();
+        if (bone.isEmpty()) continue;
+        out.append({ bone.toStdString(), static_cast<float>(t) });
+    }
+    return out;
+}
+
+} // namespace
+
+bool AnimationControlController::moveKeyframes(const QVariantList& selection,
+                                                double dt)
+{
+    if (selection.isEmpty()) return false;
+    if (!m_selectedSkeleton || m_selectedAnimation.empty()) return false;
+    if (!m_selectedSkeleton->hasAnimation(m_selectedAnimation)) return false;
+    if (qFuzzyCompare(dt + 1.0, 1.0)) return false; // dt == 0 is a no-op
+
+    QVector<MoveKeyframesCommand::Item> items = selectionToItems(selection);
+    if (items.isEmpty()) return false;
+
+    const float dtf = static_cast<float>(dt);
+    const float length = static_cast<float>(animationLength());
+
+    // Build a quick lookup of which (bone, time) tuples are members of the
+    // selection so the collision check can ignore intra-selection overlap.
+    auto isMember = [&](const std::string& bone, float time) {
+        for (const auto& it : items) {
+            if (it.boneName == bone &&
+                std::fabs(it.originalTime - time) <= kBulkEpsilon) return true;
+        }
+        return false;
+    };
+
+    // Validate per-item: clamp window + collision with non-selected keyframes.
+    for (const auto& it : items) {
+        const float dst = it.originalTime + dtf;
+        if (dst < 0.0f || dst > length + kBulkEpsilon) return false;
+        auto* track = resolveTrackByBone(m_selectedSkeleton, m_selectedAnimation,
+                                          it.boneName);
+        if (!track) return false;
+        for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+            const float t = track->getKeyFrame(i)->getTime();
+            if (std::fabs(t - it.originalTime) <= kBulkEpsilon) continue; // self
+            if (std::fabs(t - dst) <= kBulkEpsilon &&
+                !isMember(it.boneName, t)) {
+                return false; // collision with a non-member keyframe
+            }
+        }
+    }
+
+    auto* cmd = new MoveKeyframesCommand(m_selectedSkeleton, // NOSONAR — QUndoStack owns
+                                          m_selectedAnimation,
+                                          items, dtf);
+    UndoManager::getSingleton()->push(cmd);
+    refreshSliderTicks();
+    emit boneRowsChanged();
+    return true;
+}
+
+QString AnimationControlController::serializeKeyframes(
+        const QVariantList& selection) const
+{
+    if (selection.isEmpty()) return {};
+    if (!m_selectedSkeleton || m_selectedAnimation.empty()) return {};
+
+    // Find the earliest selected time so paste stays relative.
+    double t0 = std::numeric_limits<double>::infinity();
+    for (const QVariant& v : selection) {
+        const double t = v.toMap().value(QStringLiteral("time")).toDouble();
+        if (t < t0) t0 = t;
+    }
+    if (!std::isfinite(t0)) return {};
+
+    QJsonArray arr;
+    for (const QVariant& v : selection) {
+        const QVariantMap m = v.toMap();
+        const QString bone = m.value(QStringLiteral("bone")).toString();
+        const float   tabs = static_cast<float>(m.value(QStringLiteral("time")).toDouble());
+        if (bone.isEmpty()) continue;
+        auto* track = resolveTrackByBone(m_selectedSkeleton, m_selectedAnimation,
+                                          bone.toStdString());
+        if (!track) continue;
+        // Find the actual keyframe to capture its TRS values.
+        Ogre::TransformKeyFrame* kf = nullptr;
+        for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+            auto* candidate = static_cast<Ogre::TransformKeyFrame*>(track->getKeyFrame(i));
+            if (std::fabs(candidate->getTime() - tabs) <= kBulkEpsilon) {
+                kf = candidate;
+                break;
+            }
+        }
+        if (!kf) continue;
+
+        const Ogre::Vector3    t = kf->getTranslate();
+        const Ogre::Quaternion r = kf->getRotation();
+        const Ogre::Vector3    s = kf->getScale();
+        QJsonObject e;
+        e[QStringLiteral("bone")] = bone;
+        e[QStringLiteral("dt")]   = static_cast<double>(tabs) - t0;
+        e[QStringLiteral("tx")] = t.x; e[QStringLiteral("ty")] = t.y; e[QStringLiteral("tz")] = t.z;
+        e[QStringLiteral("rw")] = r.w; e[QStringLiteral("rx")] = r.x;
+        e[QStringLiteral("ry")] = r.y; e[QStringLiteral("rz")] = r.z;
+        e[QStringLiteral("sx")] = s.x; e[QStringLiteral("sy")] = s.y; e[QStringLiteral("sz")] = s.z;
+        arr.append(e);
+    }
+    QJsonObject root;
+    root[QStringLiteral("version")] = 1;
+    root[QStringLiteral("kind")]    = QStringLiteral("qtmesh.dopesheet.keyframes");
+    root[QStringLiteral("entries")] = arr;
+    return QString::fromUtf8(QJsonDocument(root).toJson(QJsonDocument::Compact));
+}
+
+int AnimationControlController::pasteKeyframesAt(const QString& json,
+                                                  double atTime)
+{
+    if (json.isEmpty()) return 0;
+    if (!m_selectedSkeleton || m_selectedAnimation.empty()) return 0;
+    if (!m_selectedSkeleton->hasAnimation(m_selectedAnimation)) return 0;
+
+    QJsonParseError err{};
+    const QJsonDocument doc = QJsonDocument::fromJson(json.toUtf8(), &err);
+    if (err.error != QJsonParseError::NoError || !doc.isObject()) return 0;
+    const QJsonObject root = doc.object();
+    if (root.value(QStringLiteral("kind")).toString() !=
+        QStringLiteral("qtmesh.dopesheet.keyframes")) return 0;
+
+    const float length = static_cast<float>(animationLength());
+    QVector<PasteKeyframesCommand::Entry> entries;
+    for (const QJsonValue& v : root.value(QStringLiteral("entries")).toArray()) {
+        const QJsonObject e = v.toObject();
+        const QString bone = e.value(QStringLiteral("bone")).toString();
+        const double  dt   = e.value(QStringLiteral("dt")).toDouble();
+        if (bone.isEmpty()) continue;
+        const float dst = static_cast<float>(atTime + dt);
+        if (dst < 0.0f || dst > length + kBulkEpsilon) continue; // out of range — skip
+        PasteKeyframesCommand::Entry pe;
+        pe.boneName = bone.toStdString();
+        pe.time = dst;
+        pe.tx = static_cast<float>(e.value(QStringLiteral("tx")).toDouble());
+        pe.ty = static_cast<float>(e.value(QStringLiteral("ty")).toDouble());
+        pe.tz = static_cast<float>(e.value(QStringLiteral("tz")).toDouble());
+        pe.rw = static_cast<float>(e.value(QStringLiteral("rw")).toDouble(1.0));
+        pe.rx = static_cast<float>(e.value(QStringLiteral("rx")).toDouble());
+        pe.ry = static_cast<float>(e.value(QStringLiteral("ry")).toDouble());
+        pe.rz = static_cast<float>(e.value(QStringLiteral("rz")).toDouble());
+        pe.sx = static_cast<float>(e.value(QStringLiteral("sx")).toDouble(1.0));
+        pe.sy = static_cast<float>(e.value(QStringLiteral("sy")).toDouble(1.0));
+        pe.sz = static_cast<float>(e.value(QStringLiteral("sz")).toDouble(1.0));
+        entries.append(pe);
+    }
+    if (entries.isEmpty()) return 0;
+
+    auto* cmd = new PasteKeyframesCommand(m_selectedSkeleton, // NOSONAR — QUndoStack owns
+                                           m_selectedAnimation,
+                                           entries);
+    UndoManager::getSingleton()->push(cmd);
+    const int n = cmd->pastedCount();
+    refreshSliderTicks();
+    emit boneRowsChanged();
+    return n;
 }

--- a/src/AnimationControlController.h
+++ b/src/AnimationControlController.h
@@ -175,6 +175,26 @@ public:
     Q_INVOKABLE bool moveKeyframe(const QString& boneName,
                                   double oldTime, double newTime);
 
+    // ── Bulk keyframe ops (slice D1) ──────────────────────────────────────────
+    /// Move every selected keyframe by the same `dt` in seconds. Selection
+    /// is a list of QVariantMaps with "bone" + "time" keys. Atomic: a
+    /// single MoveKeyframesCommand on the undo stack. Returns false if the
+    /// shift would push any member out of [0, length] or collide with a
+    /// non-selected keyframe on the same track — in that case nothing is
+    /// pushed and the entity stays unchanged.
+    Q_INVOKABLE bool moveKeyframes(const QVariantList& selection, double dt);
+
+    /// Serialize a selection to a JSON string suitable for
+    /// QClipboard. The earliest selected time is `t0` so paste is relative.
+    /// Empty selection → empty string.
+    Q_INVOKABLE QString serializeKeyframes(const QVariantList& selection) const;
+
+    /// Paste keyframes serialized by serializeKeyframes() at absolute
+    /// `atTime` (interpreted as the destination "t0"). Skips entries whose
+    /// destination time would collide with an existing keyframe on that
+    /// track. Returns the count actually pasted.
+    Q_INVOKABLE int pasteKeyframesAt(const QString& json, double atTime);
+
 public slots:
     void updateAnimationTree();
 

--- a/src/AnimationControlController_test.cpp
+++ b/src/AnimationControlController_test.cpp
@@ -748,21 +748,32 @@ TEST_F(AnimationControlControllerTest, MoveKeyframesShiftsAllByDt) {
     QVariantMap b; b["bone"] = bone; b["time"] = 0.5;
     sel << a << b;
 
-    EXPECT_TRUE(ctrl->moveKeyframes(sel, 0.1));
-
     auto* track = entity->getSkeleton()->getAnimation("TestAnim")
                          ->_getNodeTrackList().begin()->second;
+    const int beforeCount = track->getNumKeyFrames();
+
+    EXPECT_TRUE(ctrl->moveKeyframes(sel, 0.1));
+
     bool found01 = false, found06 = false;
+    bool foundOriginal00 = false, foundOriginal05 = false;
     for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
         const float t = track->getKeyFrame(i)->getTime();
         if (std::fabs(t - 0.1f) < 0.001f) found01 = true;
         if (std::fabs(t - 0.6f) < 0.001f) found06 = true;
+        if (std::fabs(t - 0.0f) < 0.001f) foundOriginal00 = true;
+        if (std::fabs(t - 0.5f) < 0.001f) foundOriginal05 = true;
     }
     EXPECT_TRUE(found01);
     EXPECT_TRUE(found06);
+    // Originals must be gone — a faulty implementation that inserts new
+    // keyframes at the shifted times without removing the originals would
+    // double the keyframe count and break the round-trip undo.
+    EXPECT_FALSE(foundOriginal00);
+    EXPECT_FALSE(foundOriginal05);
+    EXPECT_EQ(track->getNumKeyFrames(), beforeCount);
 }
 
-TEST_F(AnimationControlControllerTest, MoveKeyframesRejectsClipBoundary) {
+TEST_F(AnimationControlControllerTest, MoveKeyframesClampsAtClipBoundary) {
     ASSERT_TRUE(canLoadMeshFiles());
     Ogre::Entity* entity = setupAnimatedEntity("DopeSheet_BulkBoundsTest");
     ASSERT_NE(entity, nullptr);
@@ -772,12 +783,32 @@ TEST_F(AnimationControlControllerTest, MoveKeyframesRejectsClipBoundary) {
     ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
     QString bone = ctrl->boneNames().first();
 
-    QVariantList sel;
+    // Two keyframes at 0.0 and 0.5 selected; requesting dt = -0.5 would push
+    // the first to -0.5. The controller now clamps the batch delta so the
+    // selection lands on the nearest legal time instead of snapping back.
+    // The largest legal *negative* dt for {0.0, 0.5} is 0 (since the leftmost
+    // member is already at 0); the move becomes a no-op and returns false.
+    QVariantList atZero;
     QVariantMap a; a["bone"] = bone; a["time"] = 0.0;
-    sel << a;
+    atZero << a;
+    EXPECT_FALSE(ctrl->moveKeyframes(atZero, -0.5));
 
-    // dt = -0.5 would push the 0.0 keyframe to -0.5 → out of [0, length].
-    EXPECT_FALSE(ctrl->moveKeyframes(sel, -0.5));
+    // Now try a partial-clamp case: select 0.5 and ask for -0.3. The largest
+    // legal negative dt is -0.5 (since 0.5 - 0.5 = 0), so -0.3 lands fully —
+    // the keyframe ends up at 0.2.
+    QVariantList atHalf;
+    QVariantMap b; b["bone"] = bone; b["time"] = 0.5;
+    atHalf << b;
+    EXPECT_TRUE(ctrl->moveKeyframes(atHalf, -0.3));
+    auto* track = entity->getSkeleton()->getAnimation("TestAnim")
+                         ->_getNodeTrackList().begin()->second;
+    bool found02 = false;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        if (std::fabs(track->getKeyFrame(i)->getTime() - 0.2f) < 0.001f) {
+            found02 = true; break;
+        }
+    }
+    EXPECT_TRUE(found02);
 }
 
 TEST_F(AnimationControlControllerTest, SerializePasteRoundTrip) {

--- a/src/AnimationControlController_test.cpp
+++ b/src/AnimationControlController_test.cpp
@@ -707,3 +707,132 @@ TEST_F(AnimationControlControllerTest, MoveKeyframeRejectsCollision) {
     }
     EXPECT_TRUE(stillThere);
 }
+
+// ── Bulk keyframe ops (slice D1) ──────────────────────────────────────────────
+
+TEST_F(AnimationControlControllerPlaybackTest, MoveKeyframesEmptySelectionReturnsFalse) {
+    auto* ctrl = AnimationControlController::instance();
+    EXPECT_FALSE(ctrl->moveKeyframes(QVariantList{}, 0.1));
+}
+
+TEST_F(AnimationControlControllerPlaybackTest, SerializeKeyframesEmptyReturnsEmpty) {
+    auto* ctrl = AnimationControlController::instance();
+    EXPECT_TRUE(ctrl->serializeKeyframes(QVariantList{}).isEmpty());
+}
+
+TEST_F(AnimationControlControllerPlaybackTest, PasteEmptyReturnsZero) {
+    auto* ctrl = AnimationControlController::instance();
+    EXPECT_EQ(ctrl->pasteKeyframesAt("", 0.0), 0);
+}
+
+TEST_F(AnimationControlControllerPlaybackTest, PasteRejectsMalformedJson) {
+    auto* ctrl = AnimationControlController::instance();
+    EXPECT_EQ(ctrl->pasteKeyframesAt("not-json", 0.0), 0);
+    EXPECT_EQ(ctrl->pasteKeyframesAt("{\"kind\":\"wrong.kind\"}", 0.0), 0);
+}
+
+TEST_F(AnimationControlControllerTest, MoveKeyframesShiftsAllByDt) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("DopeSheet_BulkMoveTest");
+    ASSERT_NE(entity, nullptr);
+
+    auto* ctrl = AnimationControlController::instance();
+    ctrl->updateAnimationTree();
+    ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+    // TestAnim has length 1.0 — extend so 0.0+0.1 / 0.5+0.1 fit.
+    ctrl->setAnimationLength(2.0);
+    QString bone = ctrl->boneNames().first();
+
+    QVariantList sel;
+    QVariantMap a; a["bone"] = bone; a["time"] = 0.0;
+    QVariantMap b; b["bone"] = bone; b["time"] = 0.5;
+    sel << a << b;
+
+    EXPECT_TRUE(ctrl->moveKeyframes(sel, 0.1));
+
+    auto* track = entity->getSkeleton()->getAnimation("TestAnim")
+                         ->_getNodeTrackList().begin()->second;
+    bool found01 = false, found06 = false;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        const float t = track->getKeyFrame(i)->getTime();
+        if (std::fabs(t - 0.1f) < 0.001f) found01 = true;
+        if (std::fabs(t - 0.6f) < 0.001f) found06 = true;
+    }
+    EXPECT_TRUE(found01);
+    EXPECT_TRUE(found06);
+}
+
+TEST_F(AnimationControlControllerTest, MoveKeyframesRejectsClipBoundary) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("DopeSheet_BulkBoundsTest");
+    ASSERT_NE(entity, nullptr);
+
+    auto* ctrl = AnimationControlController::instance();
+    ctrl->updateAnimationTree();
+    ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+    QString bone = ctrl->boneNames().first();
+
+    QVariantList sel;
+    QVariantMap a; a["bone"] = bone; a["time"] = 0.0;
+    sel << a;
+
+    // dt = -0.5 would push the 0.0 keyframe to -0.5 → out of [0, length].
+    EXPECT_FALSE(ctrl->moveKeyframes(sel, -0.5));
+}
+
+TEST_F(AnimationControlControllerTest, SerializePasteRoundTrip) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("DopeSheet_RoundTripTest");
+    ASSERT_NE(entity, nullptr);
+
+    auto* ctrl = AnimationControlController::instance();
+    ctrl->updateAnimationTree();
+    ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+    ctrl->setAnimationLength(2.0);
+    QString bone = ctrl->boneNames().first();
+
+    // Serialize the existing keyframes at 0.0 and 0.5.
+    QVariantList sel;
+    QVariantMap a; a["bone"] = bone; a["time"] = 0.0;
+    QVariantMap b; b["bone"] = bone; b["time"] = 0.5;
+    sel << a << b;
+    QString json = ctrl->serializeKeyframes(sel);
+    EXPECT_FALSE(json.isEmpty());
+
+    // Paste at t=1.2 — copies should land at 1.2 and 1.7.
+    auto* track = entity->getSkeleton()->getAnimation("TestAnim")
+                         ->_getNodeTrackList().begin()->second;
+    const int before = track->getNumKeyFrames();
+    const int pasted = ctrl->pasteKeyframesAt(json, 1.2);
+    EXPECT_EQ(pasted, 2);
+    EXPECT_EQ(track->getNumKeyFrames(), before + 2);
+    bool found12 = false, found17 = false;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        const float t = track->getKeyFrame(i)->getTime();
+        if (std::fabs(t - 1.2f) < 0.001f) found12 = true;
+        if (std::fabs(t - 1.7f) < 0.001f) found17 = true;
+    }
+    EXPECT_TRUE(found12);
+    EXPECT_TRUE(found17);
+}
+
+TEST_F(AnimationControlControllerTest, PasteSkipsCollisions) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("DopeSheet_PasteCollisionTest");
+    ASSERT_NE(entity, nullptr);
+
+    auto* ctrl = AnimationControlController::instance();
+    ctrl->updateAnimationTree();
+    ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+    QString bone = ctrl->boneNames().first();
+
+    // Paste back onto the existing 0.5 → collision; existing 0.0 paste lands at 0.0
+    // → also a collision. Expect 0 pasted.
+    QVariantList sel;
+    QVariantMap a; a["bone"] = bone; a["time"] = 0.0;
+    QVariantMap b; b["bone"] = bone; b["time"] = 0.5;
+    sel << a << b;
+    QString json = ctrl->serializeKeyframes(sel);
+    const int n = ctrl->pasteKeyframesAt(json, 0.0);
+    EXPECT_EQ(n, 0);
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,6 +55,7 @@ SubMeshTransform.cpp
 SubEntityHighlight.cpp
 commands/TransformCommands.cpp
 commands/MoveKeyframeCommand.cpp
+commands/BulkKeyframeCommands.cpp
 PropertiesPanelController.cpp
 SceneTreeModel.cpp
 ThemeManager.cpp

--- a/src/commands/BulkKeyframeCommands.cpp
+++ b/src/commands/BulkKeyframeCommands.cpp
@@ -70,7 +70,7 @@ MoveKeyframesCommand::MoveKeyframesCommand(Ogre::Skeleton* skeleton,
     , mItems(std::move(items))
     , mDt(dt)
 {
-    setText(QObject::tr("Move %n keyframe(s)", "", mItems.size()));
+    setText(QObject::tr("Move %n keyframe(s)", "", static_cast<int>(mItems.size())));
 }
 
 bool MoveKeyframesCommand::shiftAll(float fromOffset, float toOffset)
@@ -114,7 +114,7 @@ PasteKeyframesCommand::PasteKeyframesCommand(Ogre::Skeleton* skeleton,
     , mEntries(std::move(entries))
 {
     mApplied.resize(mEntries.size());
-    setText(QObject::tr("Paste %n keyframe(s)", "", mEntries.size()));
+    setText(QObject::tr("Paste %n keyframe(s)", "", static_cast<int>(mEntries.size())));
 }
 
 void PasteKeyframesCommand::redo()

--- a/src/commands/BulkKeyframeCommands.cpp
+++ b/src/commands/BulkKeyframeCommands.cpp
@@ -1,0 +1,152 @@
+#include "BulkKeyframeCommands.h"
+
+#include <Ogre.h>
+#include <OgreSkeleton.h>
+#include <OgreAnimation.h>
+#include <OgreAnimationTrack.h>
+#include <OgreKeyFrame.h>
+
+#include <QObject>
+#include <cmath>
+#include <utility>
+
+namespace {
+constexpr float kEpsilon = 0.001f;
+
+Ogre::NodeAnimationTrack* resolveTrack(Ogre::Skeleton* skel,
+                                       const std::string& animName,
+                                       const std::string& boneName)
+{
+    if (!skel || animName.empty() || boneName.empty()) return nullptr;
+    if (!skel->hasAnimation(animName)) return nullptr;
+    if (!skel->hasBone(boneName)) return nullptr;
+    Ogre::Animation* anim = skel->getAnimation(animName);
+    Ogre::Bone* bone = skel->getBone(boneName);
+    if (!anim || !bone) return nullptr;
+    if (!anim->hasNodeTrack(bone->getHandle())) return nullptr;
+    return anim->getNodeTrack(bone->getHandle());
+}
+
+int findKeyframeIndex(const Ogre::NodeAnimationTrack* track, float time) {
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        if (std::fabs(track->getKeyFrame(i)->getTime() - time) <= kEpsilon) {
+            return static_cast<int>(i);
+        }
+    }
+    return -1;
+}
+
+// Move a single keyframe via the standard "remove + recreate" recipe (Ogre
+// has no KeyFrame::setTime). Returns true when the keyframe was found and
+// moved. Used by both bulk move and paste-undo.
+bool relocateKeyframe(Ogre::NodeAnimationTrack* track, float fromT, float toT) {
+    const int idx = findKeyframeIndex(track, fromT);
+    if (idx < 0) return false;
+    auto* oldKf = static_cast<Ogre::TransformKeyFrame*>(track->getKeyFrame(idx));
+    const Ogre::Vector3    t = oldKf->getTranslate();
+    const Ogre::Quaternion r = oldKf->getRotation();
+    const Ogre::Vector3    s = oldKf->getScale();
+    track->removeKeyFrame(static_cast<unsigned short>(idx));
+    auto* newKf = track->createNodeKeyFrame(toT);
+    newKf->setTranslate(t);
+    newKf->setRotation(r);
+    newKf->setScale(s);
+    track->_keyFrameDataChanged();
+    return true;
+}
+
+} // namespace
+
+// ── MoveKeyframesCommand ──────────────────────────────────────────────────────
+
+MoveKeyframesCommand::MoveKeyframesCommand(Ogre::Skeleton* skeleton,
+                                           std::string animationName,
+                                           QVector<Item> items,
+                                           float dt,
+                                           QUndoCommand* parent)
+    : QUndoCommand(parent)
+    , mSkeleton(skeleton)
+    , mAnimationName(std::move(animationName))
+    , mItems(std::move(items))
+    , mDt(dt)
+{
+    setText(QObject::tr("Move %n keyframe(s)", "", mItems.size()));
+}
+
+bool MoveKeyframesCommand::shiftAll(float fromOffset, float toOffset)
+{
+    // Apply the shift in two phases per track: first park each member at a
+    // unique negative-time slot to avoid collisions during the rewrite, then
+    // move from the parked slot to the final position. This lets a forward
+    // shift survive cases where keyframe N+1's new time equals keyframe N's
+    // current time on the same track.
+    QVector<float> parkSlots;
+    parkSlots.reserve(mItems.size());
+    for (int i = 0; i < mItems.size(); ++i) {
+        auto* track = resolveTrack(mSkeleton, mAnimationName, mItems[i].boneName);
+        if (!track) { parkSlots.append(0.0f); continue; }
+        const float src = mItems[i].originalTime + fromOffset;
+        const float park = -1.0f - static_cast<float>(i); // unique negative slot
+        relocateKeyframe(track, src, park);
+        parkSlots.append(park);
+    }
+    for (int i = 0; i < mItems.size(); ++i) {
+        auto* track = resolveTrack(mSkeleton, mAnimationName, mItems[i].boneName);
+        if (!track) continue;
+        const float dst = mItems[i].originalTime + toOffset;
+        relocateKeyframe(track, parkSlots[i], dst);
+    }
+    return true;
+}
+
+void MoveKeyframesCommand::redo() { shiftAll(0.0f, mDt); }
+void MoveKeyframesCommand::undo() { shiftAll(mDt, 0.0f); }
+
+// ── PasteKeyframesCommand ─────────────────────────────────────────────────────
+
+PasteKeyframesCommand::PasteKeyframesCommand(Ogre::Skeleton* skeleton,
+                                             std::string animationName,
+                                             QVector<Entry> entries,
+                                             QUndoCommand* parent)
+    : QUndoCommand(parent)
+    , mSkeleton(skeleton)
+    , mAnimationName(std::move(animationName))
+    , mEntries(std::move(entries))
+{
+    mApplied.resize(mEntries.size());
+    setText(QObject::tr("Paste %n keyframe(s)", "", mEntries.size()));
+}
+
+void PasteKeyframesCommand::redo()
+{
+    mPastedCount = 0;
+    for (int i = 0; i < mEntries.size(); ++i) {
+        const Entry& e = mEntries[i];
+        mApplied[i] = false;
+        auto* track = resolveTrack(mSkeleton, mAnimationName, e.boneName);
+        if (!track) continue;
+        if (findKeyframeIndex(track, e.time) >= 0) continue; // collision — skip
+        auto* kf = track->createNodeKeyFrame(e.time);
+        kf->setTranslate(Ogre::Vector3(e.tx, e.ty, e.tz));
+        kf->setRotation(Ogre::Quaternion(e.rw, e.rx, e.ry, e.rz));
+        kf->setScale(Ogre::Vector3(e.sx, e.sy, e.sz));
+        track->_keyFrameDataChanged();
+        mApplied[i] = true;
+        ++mPastedCount;
+    }
+}
+
+void PasteKeyframesCommand::undo()
+{
+    for (int i = 0; i < mEntries.size(); ++i) {
+        if (!mApplied[i]) continue;
+        const Entry& e = mEntries[i];
+        auto* track = resolveTrack(mSkeleton, mAnimationName, e.boneName);
+        if (!track) continue;
+        const int idx = findKeyframeIndex(track, e.time);
+        if (idx < 0) continue;
+        track->removeKeyFrame(static_cast<unsigned short>(idx));
+        track->_keyFrameDataChanged();
+    }
+    mPastedCount = 0;
+}

--- a/src/commands/BulkKeyframeCommands.h
+++ b/src/commands/BulkKeyframeCommands.h
@@ -1,0 +1,95 @@
+#ifndef BULK_KEYFRAME_COMMANDS_H
+#define BULK_KEYFRAME_COMMANDS_H
+
+#include <QUndoCommand>
+#include <QString>
+#include <QVector>
+#include <string>
+
+namespace Ogre {
+    class Skeleton;
+    class NodeAnimationTrack;
+}
+
+/**
+ * Move N keyframes (across one or more bone tracks) by a single shared
+ * delta `dt`. Atomic: undo restores every member; redo re-applies the
+ * shift. Each member is identified by `(boneName, originalTime)` — if
+ * the underlying track loses or rebuilds the keyframe between push and
+ * undo/redo, that member is silently skipped.
+ *
+ * The caller must validate clamping + collision with non-selected
+ * keyframes before constructing the command. The command itself trusts
+ * the input — it does not check bounds.
+ */
+class MoveKeyframesCommand : public QUndoCommand
+{
+public:
+    struct Item {
+        std::string boneName;
+        float       originalTime;
+    };
+
+    MoveKeyframesCommand(Ogre::Skeleton* skeleton,
+                         std::string animationName,
+                         QVector<Item> items,
+                         float dt,
+                         QUndoCommand* parent = nullptr);
+
+    void undo() override;
+    void redo() override;
+
+private:
+    bool shiftAll(float fromOffset, float toOffset);
+
+    Ogre::Skeleton* mSkeleton;
+    std::string     mAnimationName;
+    QVector<Item>   mItems;
+    float           mDt;
+};
+
+/**
+ * Paste a set of keyframes (deserialized from clipboard JSON) onto their
+ * respective bone tracks at the supplied absolute times. Each entry is
+ * `(boneName, time, translate, rotation, scale)`. Skips entries whose
+ * target time already has a keyframe on that track (returns the count
+ * actually pasted via `pastedCount()`).
+ *
+ * Undo removes every successfully pasted keyframe. Redo re-creates them.
+ */
+class PasteKeyframesCommand : public QUndoCommand
+{
+public:
+    struct Entry {
+        std::string boneName;
+        float       time;
+        // TRS values stored flat to avoid pulling Ogre headers into this header.
+        float       tx, ty, tz;
+        float       rw, rx, ry, rz;
+        float       sx, sy, sz;
+    };
+
+    PasteKeyframesCommand(Ogre::Skeleton* skeleton,
+                          std::string animationName,
+                          QVector<Entry> entries,
+                          QUndoCommand* parent = nullptr);
+
+    void undo() override;
+    void redo() override;
+
+    /// Number of entries that were actually pasted on the most recent redo
+    /// (the rest were skipped due to collisions). Caller can read this
+    /// after push() to surface a "skipped N due to collisions" hint.
+    int pastedCount() const { return mPastedCount; }
+
+private:
+    Ogre::Skeleton* mSkeleton;
+    std::string     mAnimationName;
+    QVector<Entry>  mEntries;
+    /// True for entries that were actually written on the last redo, so
+    /// undo only removes the ones we created.
+    QVector<bool>   mApplied;
+    int             mPastedCount = 0;
+};
+
+#endif // BULK_KEYFRAME_COMMANDS_H

--- a/src/commands/BulkKeyframeCommands_test.cpp
+++ b/src/commands/BulkKeyframeCommands_test.cpp
@@ -32,8 +32,12 @@ protected:
     QApplication* app = nullptr;
 
     static bool hasKeyframeAt(Ogre::NodeAnimationTrack* track, float time) {
+        // Match production's <= tolerance (BulkKeyframeCommands.cpp's
+        // findKeyframeIndex uses kEpsilon = 0.001f with `<=`). Using `<`
+        // here would let an exactly-at-epsilon offset slip through the
+        // collision check in production but report false in this test.
         for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
-            if (std::fabs(track->getKeyFrame(i)->getTime() - time) < 0.001f) return true;
+            if (std::fabs(track->getKeyFrame(i)->getTime() - time) <= 0.001f) return true;
         }
         return false;
     }

--- a/src/commands/BulkKeyframeCommands_test.cpp
+++ b/src/commands/BulkKeyframeCommands_test.cpp
@@ -1,0 +1,174 @@
+#include <gtest/gtest.h>
+#include <QApplication>
+#include <QCoreApplication>
+#include <QThread>
+#include <QUndoStack>
+#include <QVector>
+
+#include "BulkKeyframeCommands.h"
+#include "../Manager.h"
+#include "../TestHelpers.h"
+
+#include <OgreSkeletonInstance.h>
+#include <OgreAnimation.h>
+#include <OgreAnimationTrack.h>
+#include <OgreKeyFrame.h>
+
+#include <cmath>
+
+class BulkKeyframeCommandsTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        Manager::kill();
+        QThread::msleep(20);
+        app = qobject_cast<QApplication*>(QCoreApplication::instance());
+        ASSERT_NE(app, nullptr);
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+        createStandardOgreMaterials();
+    }
+    void TearDown() override {
+        if (app) app->processEvents();
+    }
+    QApplication* app = nullptr;
+
+    static bool hasKeyframeAt(Ogre::NodeAnimationTrack* track, float time) {
+        for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+            if (std::fabs(track->getKeyFrame(i)->getTime() - time) < 0.001f) return true;
+        }
+        return false;
+    }
+};
+
+TEST_F(BulkKeyframeCommandsTest, MoveKeyframesRedoUndoRoundTrip) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = createAnimatedTestEntity("BKC_RedoUndoTest");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+    auto* track = skel->getAnimation("TestAnim")->_getNodeTrackList().begin()->second;
+
+    // TestAnim has keyframes at 0.0, 0.5, 1.0 on the Child bone.
+    // Extend length so 0.0+0.2 / 0.5+0.2 / 1.0+0.2 fit within bounds.
+    skel->getAnimation("TestAnim")->setLength(2.0f);
+
+    QVector<MoveKeyframesCommand::Item> items;
+    items.append({ "Child", 0.0f });
+    items.append({ "Child", 0.5f });
+    items.append({ "Child", 1.0f });
+
+    QUndoStack stack;
+    stack.push(new MoveKeyframesCommand(skel, "TestAnim", items, 0.2f));
+
+    // After redo: keyframes at 0.2, 0.7, 1.2.
+    EXPECT_EQ(track->getNumKeyFrames(), 3u);
+    EXPECT_TRUE(hasKeyframeAt(track, 0.2f));
+    EXPECT_TRUE(hasKeyframeAt(track, 0.7f));
+    EXPECT_TRUE(hasKeyframeAt(track, 1.2f));
+    EXPECT_FALSE(hasKeyframeAt(track, 0.0f));
+    EXPECT_FALSE(hasKeyframeAt(track, 0.5f));
+    EXPECT_FALSE(hasKeyframeAt(track, 1.0f));
+
+    stack.undo();
+    EXPECT_TRUE(hasKeyframeAt(track, 0.0f));
+    EXPECT_TRUE(hasKeyframeAt(track, 0.5f));
+    EXPECT_TRUE(hasKeyframeAt(track, 1.0f));
+    EXPECT_FALSE(hasKeyframeAt(track, 0.2f));
+
+    stack.redo();
+    EXPECT_TRUE(hasKeyframeAt(track, 0.7f));
+}
+
+TEST_F(BulkKeyframeCommandsTest, MoveKeyframesPreservesIntraTrackOrdering) {
+    // Forward shift past an adjacent keyframe used to collide if the rewrite
+    // wasn't two-phase. This test guards the park-then-move trick in shiftAll.
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = createAnimatedTestEntity("BKC_OrderingTest");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+    auto* track = skel->getAnimation("TestAnim")->_getNodeTrackList().begin()->second;
+    skel->getAnimation("TestAnim")->setLength(2.0f);
+
+    // Move 0.0 → 0.5 and 0.5 → 1.0 in the same command. The 0.5 keyframe
+    // would already be there when we try to write 0.0 → 0.5 if we naively
+    // rewrote in order.
+    QVector<MoveKeyframesCommand::Item> items;
+    items.append({ "Child", 0.0f });
+    items.append({ "Child", 0.5f });
+
+    QUndoStack stack;
+    stack.push(new MoveKeyframesCommand(skel, "TestAnim", items, 0.5f));
+
+    EXPECT_EQ(track->getNumKeyFrames(), 3u); // 0.5, 1.0 (moved), and 1.0 (original)
+    EXPECT_TRUE(hasKeyframeAt(track, 0.5f));
+    EXPECT_TRUE(hasKeyframeAt(track, 1.0f));
+    EXPECT_FALSE(hasKeyframeAt(track, 0.0f));
+}
+
+TEST_F(BulkKeyframeCommandsTest, PasteRedoUndoRoundTrip) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = createAnimatedTestEntity("BKC_PasteRedoUndoTest");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+    auto* track = skel->getAnimation("TestAnim")->_getNodeTrackList().begin()->second;
+    skel->getAnimation("TestAnim")->setLength(3.0f);
+    const int before = track->getNumKeyFrames();
+
+    QVector<PasteKeyframesCommand::Entry> entries;
+    PasteKeyframesCommand::Entry e1{};
+    e1.boneName = "Child"; e1.time = 1.5f;
+    e1.tx = 0.1f; e1.rw = 1.0f; e1.sx = e1.sy = e1.sz = 1.0f;
+    PasteKeyframesCommand::Entry e2{};
+    e2.boneName = "Child"; e2.time = 2.5f;
+    e2.tx = 0.2f; e2.rw = 1.0f; e2.sx = e2.sy = e2.sz = 1.0f;
+    entries.append(e1); entries.append(e2);
+
+    auto* cmd = new PasteKeyframesCommand(skel, "TestAnim", entries);
+    QUndoStack stack;
+    stack.push(cmd);
+
+    EXPECT_EQ(cmd->pastedCount(), 2);
+    EXPECT_EQ(track->getNumKeyFrames(), before + 2);
+    EXPECT_TRUE(hasKeyframeAt(track, 1.5f));
+    EXPECT_TRUE(hasKeyframeAt(track, 2.5f));
+
+    stack.undo();
+    EXPECT_EQ(track->getNumKeyFrames(), before);
+    EXPECT_FALSE(hasKeyframeAt(track, 1.5f));
+    EXPECT_FALSE(hasKeyframeAt(track, 2.5f));
+
+    stack.redo();
+    EXPECT_TRUE(hasKeyframeAt(track, 1.5f));
+}
+
+TEST_F(BulkKeyframeCommandsTest, PasteSkipsCollisionsAndUndoOnlyRemovesPasted) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = createAnimatedTestEntity("BKC_PasteSkipTest");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+    auto* track = skel->getAnimation("TestAnim")->_getNodeTrackList().begin()->second;
+    const int before = track->getNumKeyFrames();
+
+    // One entry collides with the existing keyframe at 0.5; the other (0.7)
+    // should land. Undo must only remove 0.7 — leaving the existing 0.5 alone.
+    QVector<PasteKeyframesCommand::Entry> entries;
+    PasteKeyframesCommand::Entry collide{};
+    collide.boneName = "Child"; collide.time = 0.5f;
+    collide.rw = 1.0f; collide.sx = collide.sy = collide.sz = 1.0f;
+    PasteKeyframesCommand::Entry novel{};
+    novel.boneName = "Child"; novel.time = 0.7f;
+    novel.rw = 1.0f; novel.sx = novel.sy = novel.sz = 1.0f;
+    entries.append(collide); entries.append(novel);
+
+    auto* cmd = new PasteKeyframesCommand(skel, "TestAnim", entries);
+    QUndoStack stack;
+    stack.push(cmd);
+
+    EXPECT_EQ(cmd->pastedCount(), 1);
+    EXPECT_TRUE(hasKeyframeAt(track, 0.5f));  // existing, untouched
+    EXPECT_TRUE(hasKeyframeAt(track, 0.7f));  // newly pasted
+    EXPECT_EQ(track->getNumKeyFrames(), before + 1);
+
+    stack.undo();
+    EXPECT_TRUE(hasKeyframeAt(track, 0.5f));  // existing, still there
+    EXPECT_FALSE(hasKeyframeAt(track, 0.7f)); // pasted one removed
+    EXPECT_EQ(track->getNumKeyFrames(), before);
+}

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -521,6 +521,37 @@ void MainWindow::initToolBar()
         dopeSheetWidget->setMinimumHeight(160);
         dopeSheetWidget->setFocusPolicy(Qt::StrongFocus);
         dopeSheetWidget->setSource(QUrl("qrc:/AnimationControl/AnimationDopeSheet.qml"));
+
+        // QQuickWidget inside a QDockWidget on macOS can swallow wheel events
+        // before they reach the QML scene's WheelHandler — Qt routes them to
+        // the dock's title bar instead. Install a viewport-level filter that
+        // calls back into the QML root's scrollByPixels() method.
+        class DopeSheetWheelFilter : public QObject {
+        public:
+            explicit DopeSheetWheelFilter(QQuickWidget* host)
+                : QObject(host), m_host(host) {}
+        protected:
+            bool eventFilter(QObject* watched, QEvent* event) override {
+                if (event->type() != QEvent::Wheel) return QObject::eventFilter(watched, event);
+                auto* we = static_cast<QWheelEvent*>(event);
+                // Cmd/Ctrl+wheel falls through to QML's zoom WheelHandler.
+                if (we->modifiers() & (Qt::ControlModifier | Qt::MetaModifier)) {
+                    return QObject::eventFilter(watched, event);
+                }
+                if (!m_host || !m_host->rootObject()) return false;
+                qreal dy = we->pixelDelta().y();
+                if (dy == 0.0) dy = we->angleDelta().y() / 120.0 * 40.0;
+                if (dy == 0.0) return false;
+                QMetaObject::invokeMethod(m_host->rootObject(), "scrollByPixels",
+                                          Q_ARG(QVariant, dy));
+                event->accept();
+                return true;
+            }
+        private:
+            QQuickWidget* m_host;
+        };
+        auto* wheelFilter = new DopeSheetWheelFilter(dopeSheetWidget); // NOSONAR — Qt parent ownership
+        dopeSheetWidget->installEventFilter(wheelFilter);
         m_dopeSheetDock = new QDockWidget(tr("Dope Sheet"), this); // NOSONAR — Qt parent ownership
         m_dopeSheetDock->setWidget(dopeSheetWidget);
         m_dopeSheetDock->setObjectName("DopeSheetDock");
@@ -530,6 +561,21 @@ void MainWindow::initToolBar()
             SentryReporter::addBreadcrumb("ui.action",
                 vis ? "Dope Sheet shown" : "Dope Sheet hidden");
         });
+
+        // Reflect the active animation in the dock title — useful when the
+        // dock is collapsed alongside other docks at the bottom.
+        auto updateDopeSheetTitle = [this]() {
+            if (!m_dopeSheetDock) return;
+            const QString anim =
+                AnimationControlController::instance()->selectedAnimation();
+            m_dopeSheetDock->setWindowTitle(
+                anim.isEmpty() ? tr("Dope Sheet")
+                               : tr("Dope Sheet — %1").arg(anim));
+        };
+        connect(AnimationControlController::instance(),
+                &AnimationControlController::selectionChanged,
+                this, updateDopeSheetTitle);
+        updateDopeSheetTitle();
     }
 
     // Welcome Screen overlay — shown on first launch or when user hasn't opted out

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,6 +64,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/UndoManager.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/TransformCommands.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/MoveKeyframeCommand.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/BulkKeyframeCommands.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/PropertiesPanelController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/SceneTreeModel.cpp
 


### PR DESCRIPTION
## Summary
Closes #374. First chunk of slice D from #260 — the dope sheet (#373) becomes multi-edit-capable. Per-channel rows (D2) and Bezier handles + curve editor (D3) remain as follow-ups.

## What's new
- **Selection** — Ctrl+click toggles, click replaces, Esc clears. Marquee select via left-drag on empty timeline (Ctrl preserves the existing selection). Header shows "(N selected)" while active.
- **Visual** — selected diamonds render larger (14×14) with a thicker white border + solid red fill. No recoloring of unselected ones.
- **Bulk drag** — dragging any selected diamond shifts the whole selection by the same dt visually; release pushes one `MoveKeyframesCommand`. Non-selected drags use the slice-C single-keyframe path.
- **Copy/paste** — Ctrl+C → JSON to clipboard (TextEdit bridge). Ctrl+V → paste at the playhead, times stored relative to the earliest selected time. Collisions are skipped, not failed.

## C++ surface
- `AnimationControlController::moveKeyframes(selection, dt)` — atomic bulk shift, validates clamp + collision against non-selected keyframes before pushing.
- `serializeKeyframes(selection)` — `qtmesh.dopesheet.keyframes` JSON v1 with relative times + TRS.
- `pasteKeyframesAt(json, atTime)` — returns count actually pasted.
- New `commands/BulkKeyframeCommands`:
  - `MoveKeyframesCommand` uses a two-phase rewrite (park each member at a unique negative slot, then move from park to dst) so a forward shift survives intra-track overlap.
  - `PasteKeyframesCommand` tracks which entries were actually applied so undo only removes those.

Version bumped to 2.36.0.

## Test plan
- [ ] Open Dope Sheet, Ctrl+click → diamond toggles selection
- [ ] Drag a rectangle on empty timeline → marquee selects across rows
- [ ] Esc → clears selection
- [ ] Drag any selected diamond → all selected diamonds move together; release commits one undo step
- [ ] Ctrl+C, scrub elsewhere, Ctrl+V → keyframes appear at the new offset; collisions are skipped silently
- [ ] Drag that would push a member past 0 or > length → no-op (no command pushed)
- [ ] Linux CI: 8 new tests (4 pure-data + 4 Ogre-fixture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-keyframe selection with modifier toggles, marquee selection, header count, and bulk drag-and-drop
  * Copy/paste of selected keyframes to/from clipboard with paste-at-time and atomic undo/redo
  * Consolidated timeline interactions: marquee select, middle-button pan, modifier-wheel zoom, and vertical scroll handling

* **Tests**
  * Added unit tests covering bulk move, paste, collision handling, and undo/redo round-trips

* **Chores**
  * Project version bumped to 2.36.0 and build updated to include bulk keyframe support
<!-- end of auto-generated comment: release notes by coderabbit.ai -->