### PR TITLE
feat(animation): dope sheet per-channel rows (Phase 5 slice D2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 2.36.0 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 2.37.0 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 2.37.0 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 2.34.0 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/qml/AnimationDopeSheet.qml
+++ b/qml/AnimationDopeSheet.qml
@@ -98,6 +98,11 @@ Rectangle {
     // Used by the marquee to commit a rectangle selection. When `additive`
     // is true (Ctrl/Cmd held during marquee), the rect-hit set is unioned
     // with the existing selection instead of replacing it.
+    //
+    // Walks the rows in render order and accumulates Y top-down, factoring
+    // in any per-bone expansion (each expanded bone adds N sub-rows worth
+    // of vertical space). Without this accounting, marquee hit-testing
+    // misses keyframes whenever a bone above is expanded.
     function selectInRect(x1, y1, x2, y2, additive) {
         var lo = Math.min(x1, x2), hi = Math.max(x1, x2)
         var top = Math.min(y1, y2), bot = Math.max(y1, y2)
@@ -111,10 +116,15 @@ Rectangle {
             }
             return false
         }
+        // Cursor walks down in viewport coordinates as we visit each row.
+        var cursorY = (header.visible ? header.height : 0)
         for (var r = 0; r < rows.length; r++) {
-            // Header (24px) + r * (rowHeight + spacing 1)
-            var rowTop = (header.visible ? header.height : 0) + r * (rowHeight + 1)
-            var rowBot = rowTop + rowHeight
+            var activeChans = activeChannelsFor(rows[r])
+            var expanded = isExpanded(rows[r].bone) && activeChans.length > 0
+            var rowH = rowHeight + (expanded ? activeChans.length * rowHeight : 0)
+            var rowTop = cursorY
+            var rowBot = rowTop + rowH
+            cursorY = rowBot + 1 // ListView spacing = 1
             if (rowBot < top || rowTop > bot) continue
             var keyTimes = rows[r].keyTimes
             for (var k = 0; k < keyTimes.length; k++) {
@@ -386,14 +396,24 @@ Rectangle {
                             border.color: AnimationControlController.borderColor
                             border.width: 1
                             opacity: 0.85
+                            // Sub-row diamond click delegates to the parent
+                            // keyframe — same Ctrl/Cmd toggle and selection
+                            // semantics as the parent diamond. Per-channel
+                            // drag/edit lands in slice D3.
                             MouseArea {
                                 anchors.fill: parent
                                 anchors.margins: -2
-                                onClicked: {
+                                onPressed: function(mouse) {
+                                    root.forceActiveFocus()
                                     AnimationControlController.selectBone(rowDelegate.boneName)
                                     AnimationControlController.sliderValue =
                                             Math.round(parent.keyTime * 1000)
-                                    root.setSingleSelection(rowDelegate.boneName, parent.keyTime)
+                                    if (root.isPrimaryModifier(mouse.modifiers)) {
+                                        root.toggleInSelection(rowDelegate.boneName, parent.keyTime)
+                                    } else {
+                                        root.setSingleSelection(rowDelegate.boneName, parent.keyTime)
+                                    }
+                                    mouse.accepted = true
                                 }
                             }
                         }

--- a/qml/AnimationDopeSheet.qml
+++ b/qml/AnimationDopeSheet.qml
@@ -21,6 +21,47 @@ Rectangle {
     // Cached row data refreshed from the controller.
     property var rows: AnimationControlController.allBoneRows()
 
+    // Per-bone expansion state for per-channel rows. Keys are bone names,
+    // values are bool. Reset when a new clip is selected (different bones).
+    property var expandedBones: ({})
+
+    // Per-channel render order + colors. Empty rows are filtered by the
+    // controller's `channels` flags so we never paint a sub-row for a
+    // channel that doesn't deviate from bind pose.
+    readonly property var channelOrder: [
+        { id: "tx", label: "T.X", color: "#c04040" },
+        { id: "ty", label: "T.Y", color: "#40c040" },
+        { id: "tz", label: "T.Z", color: "#4040c0" },
+        { id: "rw", label: "R.W", color: "#a040a0" },
+        { id: "rx", label: "R.X", color: "#c04040" },
+        { id: "ry", label: "R.Y", color: "#40c040" },
+        { id: "rz", label: "R.Z", color: "#4040c0" },
+        { id: "sx", label: "S.X", color: "#c08040" },
+        { id: "sy", label: "S.Y", color: "#80c040" },
+        { id: "sz", label: "S.Z", color: "#4080c0" }
+    ]
+
+    function activeChannelsFor(boneRow) {
+        var result = []
+        if (!boneRow || !boneRow.channels) return result
+        for (var i = 0; i < channelOrder.length; i++) {
+            var c = channelOrder[i]
+            if (boneRow.channels[c.id]) result.push(c)
+        }
+        return result
+    }
+
+    function isExpanded(boneName) {
+        return expandedBones[boneName] === true
+    }
+
+    function toggleExpanded(boneName) {
+        var copy = {}
+        for (var k in expandedBones) copy[k] = expandedBones[k]
+        copy[boneName] = !copy[boneName]
+        expandedBones = copy
+    }
+
     // Selection state. Each entry is { bone: string, time: number }.
     // Stored as a plain array so QML bindings update on assignment.
     property var selection: []
@@ -92,7 +133,11 @@ Rectangle {
         // entirely). Track edits (boneRowsChanged) refresh rows but preserve
         // the user's selection — bulk-drag and bone-click both fire that
         // signal, and dropping selection there breaks bulk drag mid-gesture.
-        function onSelectionChanged()      { root.rows = AnimationControlController.allBoneRows(); root.clearSelection() }
+        function onSelectionChanged() {
+            root.rows = AnimationControlController.allBoneRows()
+            root.clearSelection()
+            root.expandedBones = {}
+        }
         function onBoneRowsChanged()       { root.rows = AnimationControlController.allBoneRows() }
         function onKeyframeTicksChanged()  { root.rows = AnimationControlController.allBoneRows() }
     }
@@ -217,37 +262,151 @@ Rectangle {
             id: rowDelegate
             property string boneName: modelData.bone
             property var keyTimes: modelData.keyTimes
+            property var activeChannels: root.activeChannelsFor(modelData)
+            property bool expanded: root.isExpanded(boneName) && activeChannels.length > 0
 
-            width: rowsView.width; height: root.rowHeight
+            width: rowsView.width
+            height: root.rowHeight + (expanded ? activeChannels.length * root.rowHeight : 0)
 
             // Bone name strip carries the selection-highlight tint. Track
             // strip is transparent so timelineArea behind us catches presses
             // on empty pixels for marquee/pan.
             Rectangle {
-                width: root.leftStripWidth; height: parent.height
+                width: root.leftStripWidth; height: root.rowHeight
                 color: (rowDelegate.boneName === AnimationControlController.selectedBone)
                        ? Qt.lighter(AnimationControlController.panelColor, 1.15)
                        : AnimationControlController.panelColor
                 border.color: AnimationControlController.borderColor; border.width: 1
-                Text {
-                    anchors.left: parent.left; anchors.leftMargin: 6
-                    anchors.verticalCenter: parent.verticalCenter
-                    text: rowDelegate.boneName
-                    color: AnimationControlController.textColor
-                    elide: Text.ElideRight; font.pixelSize: 11
-                    width: parent.width - 12
-                }
-                MouseArea {
+
+                Row {
                     anchors.fill: parent
-                    onClicked: AnimationControlController.selectBone(rowDelegate.boneName)
+                    anchors.leftMargin: 4
+                    spacing: 4
+
+                    // Per-bone expansion chevron. Only shown when the bone
+                    // has at least one active channel (otherwise expanding
+                    // would just show empty rows).
+                    Rectangle {
+                        width: 16; height: parent.height
+                        color: "transparent"
+                        anchors.verticalCenter: parent.verticalCenter
+                        Text {
+                            anchors.centerIn: parent
+                            visible: rowDelegate.activeChannels.length > 0
+                            text: rowDelegate.expanded ? "▼" : "▶"
+                            color: AnimationControlController.textColor
+                            font.pixelSize: 9
+                        }
+                        MouseArea {
+                            anchors.fill: parent
+                            enabled: rowDelegate.activeChannels.length > 0
+                            onClicked: root.toggleExpanded(rowDelegate.boneName)
+                        }
+                    }
+
+                    Text {
+                        anchors.verticalCenter: parent.verticalCenter
+                        text: rowDelegate.boneName
+                        color: AnimationControlController.textColor
+                        elide: Text.ElideRight; font.pixelSize: 11
+                        width: parent.width - 26
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: AnimationControlController.selectBone(rowDelegate.boneName)
+                        }
+                    }
                 }
             }
 
-            // Track strip with diamond markers
+            // Per-channel sub-row strip on the left side, when expanded.
+            Column {
+                visible: rowDelegate.expanded
+                anchors.top: parent.top
+                anchors.topMargin: root.rowHeight
+                anchors.left: parent.left
+                width: root.leftStripWidth
+                Repeater {
+                    model: rowDelegate.activeChannels
+                    Rectangle {
+                        width: root.leftStripWidth; height: root.rowHeight
+                        color: AnimationControlController.panelColor
+                        border.color: AnimationControlController.borderColor; border.width: 1
+                        Row {
+                            anchors.fill: parent
+                            anchors.leftMargin: 24
+                            spacing: 4
+                            Rectangle {
+                                width: 10; height: 10; radius: 2
+                                color: modelData.color
+                                anchors.verticalCenter: parent.verticalCenter
+                            }
+                            Text {
+                                anchors.verticalCenter: parent.verticalCenter
+                                text: modelData.label
+                                color: AnimationControlController.textColor
+                                font.pixelSize: 10
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Per-channel sub-row track strips (right side). Each renders the
+            // same keyframe times as the parent track but in the channel's
+            // signature color. Click on a sub-row diamond delegates to the
+            // parent keyframe (selection / playhead). Per-channel-only edits
+            // arrive in slice D3.
+            Repeater {
+                model: rowDelegate.expanded ? rowDelegate.activeChannels : []
+                Item {
+                    width: rowDelegate.width - root.leftStripWidth
+                    height: root.rowHeight
+                    x: root.leftStripWidth
+                    y: root.rowHeight + index * root.rowHeight
+                    clip: true
+
+                    // Underline, like the parent track strip
+                    Rectangle {
+                        anchors.left: parent.left; anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        height: 1
+                        color: AnimationControlController.borderColor
+                        opacity: 0.3
+                    }
+
+                    Repeater {
+                        model: rowDelegate.keyTimes
+                        Rectangle {
+                            property real keyTime: modelData
+                            x: (keyTime - root.viewStart) * root.pxPerSec - width / 2
+                            anchors.verticalCenter: parent.verticalCenter
+                            width: 8; height: 8
+                            rotation: 45
+                            color: parent.parent.modelData.color
+                            border.color: AnimationControlController.borderColor
+                            border.width: 1
+                            opacity: 0.85
+                            MouseArea {
+                                anchors.fill: parent
+                                anchors.margins: -2
+                                onClicked: {
+                                    AnimationControlController.selectBone(rowDelegate.boneName)
+                                    AnimationControlController.sliderValue =
+                                            Math.round(parent.keyTime * 1000)
+                                    root.setSingleSelection(rowDelegate.boneName, parent.keyTime)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Track strip with diamond markers (parent / aggregate row)
             Item {
                 id: trackStrip
                 anchors.left: parent.left; anchors.leftMargin: root.leftStripWidth
-                anchors.top: parent.top; anchors.bottom: parent.bottom
+                anchors.top: parent.top
+                height: root.rowHeight
                 anchors.right: parent.right
                 clip: true
 

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -607,6 +607,12 @@ constexpr float kChannelEpsilon = 1e-4f;
 // Returns the 9 boolean channel flags for a track in TRS order:
 // {tx, ty, tz, rw, rx, ry, rz, sx, sy, sz}.
 // Only flags whose values deviate from identity are set.
+//
+// Rotation identity covers BOTH (+1, 0, 0, 0) AND (-1, 0, 0, 0) — a
+// quaternion and its negative encode the same rotation. Naive component-
+// wise comparison would flag rw as active for a sign-flipped identity,
+// producing bogus chevrons. We compare against the absolute values
+// instead: |w| ≈ 1, |x| ≈ |y| ≈ |z| ≈ 0 means identity regardless of sign.
 QVariantMap collectActiveChannels(const Ogre::NodeAnimationTrack* track)
 {
     bool tx = false, ty = false, tz = false;
@@ -620,12 +626,11 @@ QVariantMap collectActiveChannels(const Ogre::NodeAnimationTrack* track)
         if (std::fabs(t.x) > kChannelEpsilon) tx = true;
         if (std::fabs(t.y) > kChannelEpsilon) ty = true;
         if (std::fabs(t.z) > kChannelEpsilon) tz = true;
-        // Rotation identity = (1, 0, 0, 0). A deviation in any component means
-        // the bone is rotated relative to bind pose.
-        if (std::fabs(r.w - 1.0f) > kChannelEpsilon) rw = true;
-        if (std::fabs(r.x)        > kChannelEpsilon) rx = true;
-        if (std::fabs(r.y)        > kChannelEpsilon) ry = true;
-        if (std::fabs(r.z)        > kChannelEpsilon) rz = true;
+        // Sign-agnostic rotation identity check — see header comment.
+        if (std::fabs(std::fabs(r.w) - 1.0f) > kChannelEpsilon) rw = true;
+        if (std::fabs(r.x) > kChannelEpsilon) rx = true;
+        if (std::fabs(r.y) > kChannelEpsilon) ry = true;
+        if (std::fabs(r.z) > kChannelEpsilon) rz = true;
         // Scale identity = (1, 1, 1).
         if (std::fabs(s.x - 1.0f) > kChannelEpsilon) sx = true;
         if (std::fabs(s.y - 1.0f) > kChannelEpsilon) sy = true;

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -596,6 +596,51 @@ KF_SET_ROT(Z, z)
 
 // ── Dope sheet API (slice C) ──────────────────────────────────────────────────
 
+namespace {
+
+// A channel is "active" on a track if any keyframe's value differs from the
+// channel's identity (translate.x = 0, rotation = 1+0i+0j+0k, scale = 1) by
+// more than this epsilon. Tighter than kBulkEpsilon since these are values,
+// not times — a 1mm translate is meaningful.
+constexpr float kChannelEpsilon = 1e-4f;
+
+// Returns the 9 boolean channel flags for a track in TRS order:
+// {tx, ty, tz, rw, rx, ry, rz, sx, sy, sz}.
+// Only flags whose values deviate from identity are set.
+QVariantMap collectActiveChannels(const Ogre::NodeAnimationTrack* track)
+{
+    bool tx = false, ty = false, tz = false;
+    bool rw = false, rx = false, ry = false, rz = false;
+    bool sx = false, sy = false, sz = false;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        const auto* kf = static_cast<const Ogre::TransformKeyFrame*>(track->getKeyFrame(i));
+        const Ogre::Vector3    t = kf->getTranslate();
+        const Ogre::Quaternion r = kf->getRotation();
+        const Ogre::Vector3    s = kf->getScale();
+        if (std::fabs(t.x) > kChannelEpsilon) tx = true;
+        if (std::fabs(t.y) > kChannelEpsilon) ty = true;
+        if (std::fabs(t.z) > kChannelEpsilon) tz = true;
+        // Rotation identity = (1, 0, 0, 0). A deviation in any component means
+        // the bone is rotated relative to bind pose.
+        if (std::fabs(r.w - 1.0f) > kChannelEpsilon) rw = true;
+        if (std::fabs(r.x)        > kChannelEpsilon) rx = true;
+        if (std::fabs(r.y)        > kChannelEpsilon) ry = true;
+        if (std::fabs(r.z)        > kChannelEpsilon) rz = true;
+        // Scale identity = (1, 1, 1).
+        if (std::fabs(s.x - 1.0f) > kChannelEpsilon) sx = true;
+        if (std::fabs(s.y - 1.0f) > kChannelEpsilon) sy = true;
+        if (std::fabs(s.z - 1.0f) > kChannelEpsilon) sz = true;
+    }
+    QVariantMap m;
+    m[QStringLiteral("tx")] = tx; m[QStringLiteral("ty")] = ty; m[QStringLiteral("tz")] = tz;
+    m[QStringLiteral("rw")] = rw; m[QStringLiteral("rx")] = rx;
+    m[QStringLiteral("ry")] = ry; m[QStringLiteral("rz")] = rz;
+    m[QStringLiteral("sx")] = sx; m[QStringLiteral("sy")] = sy; m[QStringLiteral("sz")] = sz;
+    return m;
+}
+
+} // namespace
+
 QVariantList AnimationControlController::allBoneRows() const
 {
     QVariantList rows;
@@ -614,8 +659,9 @@ QVariantList AnimationControlController::allBoneRows() const
         }
 
         QVariantMap row;
-        row[QStringLiteral("bone")] = QString::fromStdString(node->getName());
+        row[QStringLiteral("bone")]     = QString::fromStdString(node->getName());
         row[QStringLiteral("keyTimes")] = keyTimes;
+        row[QStringLiteral("channels")] = collectActiveChannels(track);
         rows.append(row);
     }
     return rows;

--- a/src/AnimationControlController_test.cpp
+++ b/src/AnimationControlController_test.cpp
@@ -649,9 +649,41 @@ TEST_F(AnimationControlControllerTest, AllBoneRowsReflectsTracks) {
     auto firstRow = rows.first().toMap();
     EXPECT_TRUE(firstRow.contains("bone"));
     EXPECT_TRUE(firstRow.contains("keyTimes"));
+    EXPECT_TRUE(firstRow.contains("channels"));
     // TestAnim has 3 keyframes on the Child track (handle 1)
     auto times = firstRow["keyTimes"].toList();
     EXPECT_EQ(times.size(), 3);
+}
+
+TEST_F(AnimationControlControllerTest, AllBoneRowsReportsActiveChannels) {
+    // TestAnim's middle keyframe sets translate.x = 0.5 and rotates 30°
+    // around Y. The channel-detection should mark tx, rw, and ry as active
+    // (the rotation around Y leaves rw < 1.0 and ry > 0); ty/tz/rx/rz/s* are
+    // identity throughout and must NOT be marked active.
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("DopeSheet_ChannelsTest");
+    ASSERT_NE(entity, nullptr);
+
+    auto* ctrl = AnimationControlController::instance();
+    ctrl->updateAnimationTree();
+    ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+
+    QVariantList rows = ctrl->allBoneRows();
+    ASSERT_FALSE(rows.isEmpty());
+    auto channels = rows.first().toMap()["channels"].toMap();
+
+    EXPECT_TRUE(channels["tx"].toBool());
+    EXPECT_FALSE(channels["ty"].toBool());
+    EXPECT_FALSE(channels["tz"].toBool());
+
+    EXPECT_TRUE(channels["rw"].toBool());
+    EXPECT_FALSE(channels["rx"].toBool());
+    EXPECT_TRUE(channels["ry"].toBool());
+    EXPECT_FALSE(channels["rz"].toBool());
+
+    EXPECT_FALSE(channels["sx"].toBool());
+    EXPECT_FALSE(channels["sy"].toBool());
+    EXPECT_FALSE(channels["sz"].toBool());
 }
 
 TEST_F(AnimationControlControllerTest, MoveKeyframeShiftsTime) {

--- a/src/AnimationControlController_test.cpp
+++ b/src/AnimationControlController_test.cpp
@@ -693,6 +693,34 @@ TEST_F(AnimationControlControllerTest, AllBoneRowsReportsActiveChannels) {
     EXPECT_FALSE(channels["sz"].toBool());
 }
 
+TEST_F(AnimationControlControllerTest, AllBoneRowsTreatsNegatedQuaternionAsIdentity) {
+    // q and -q encode the same rotation. Set every keyframe's rotation to
+    // (-1, 0, 0, 0) — the negative of identity — and verify no rotation
+    // channel is flagged active. A naive component check would flag rw
+    // because -1 != 1, producing a bogus rotation chevron in the dope sheet.
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("DopeSheet_NegIdentityTest");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+    auto* track = skel->getAnimation("TestAnim")->_getNodeTrackList().begin()->second;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        auto* kf = static_cast<Ogre::TransformKeyFrame*>(track->getKeyFrame(i));
+        kf->setTranslate(Ogre::Vector3::ZERO);
+        kf->setRotation(Ogre::Quaternion(-1.0f, 0.0f, 0.0f, 0.0f));
+        kf->setScale(Ogre::Vector3::UNIT_SCALE);
+    }
+
+    auto* ctrl = AnimationControlController::instance();
+    ctrl->updateAnimationTree();
+    ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+
+    auto channels = ctrl->allBoneRows().first().toMap()["channels"].toMap();
+    EXPECT_FALSE(channels["rw"].toBool());
+    EXPECT_FALSE(channels["rx"].toBool());
+    EXPECT_FALSE(channels["ry"].toBool());
+    EXPECT_FALSE(channels["rz"].toBool());
+}
+
 TEST_F(AnimationControlControllerTest, AllBoneRowsAllChannelsFalseForIdentityOnlyTrack) {
     // Build an animation whose every keyframe is identity (zero translate,
     // identity rotation, unit scale). No channel should be flagged active —

--- a/src/AnimationControlController_test.cpp
+++ b/src/AnimationControlController_test.cpp
@@ -655,6 +655,13 @@ TEST_F(AnimationControlControllerTest, AllBoneRowsReflectsTracks) {
     EXPECT_EQ(times.size(), 3);
 }
 
+TEST_F(AnimationControlControllerPlaybackTest, AllBoneRowsEmptyWhenNoAnimSelected) {
+    // Pure-data guard: with no animation selected, allBoneRows must return
+    // an empty list (not crash, not return stale shape).
+    auto* ctrl = AnimationControlController::instance();
+    EXPECT_TRUE(ctrl->allBoneRows().isEmpty());
+}
+
 TEST_F(AnimationControlControllerTest, AllBoneRowsReportsActiveChannels) {
     // TestAnim's middle keyframe sets translate.x = 0.5 and rotates 30°
     // around Y. The channel-detection should mark tx, rw, and ry as active
@@ -684,6 +691,41 @@ TEST_F(AnimationControlControllerTest, AllBoneRowsReportsActiveChannels) {
     EXPECT_FALSE(channels["sx"].toBool());
     EXPECT_FALSE(channels["sy"].toBool());
     EXPECT_FALSE(channels["sz"].toBool());
+}
+
+TEST_F(AnimationControlControllerTest, AllBoneRowsAllChannelsFalseForIdentityOnlyTrack) {
+    // Build an animation whose every keyframe is identity (zero translate,
+    // identity rotation, unit scale). No channel should be flagged active —
+    // QML uses this to skip painting empty per-channel sub-rows.
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("DopeSheet_IdentityOnlyTest");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+
+    // Replace TestAnim's middle keyframe values with identity so every
+    // sample matches bind pose.
+    auto* track = skel->getAnimation("TestAnim")->_getNodeTrackList().begin()->second;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        auto* kf = static_cast<Ogre::TransformKeyFrame*>(track->getKeyFrame(i));
+        kf->setTranslate(Ogre::Vector3::ZERO);
+        kf->setRotation(Ogre::Quaternion::IDENTITY);
+        kf->setScale(Ogre::Vector3::UNIT_SCALE);
+    }
+
+    auto* ctrl = AnimationControlController::instance();
+    ctrl->updateAnimationTree();
+    ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+
+    QVariantList rows = ctrl->allBoneRows();
+    ASSERT_FALSE(rows.isEmpty());
+    auto channels = rows.first().toMap()["channels"].toMap();
+    for (const QString& key : { "tx", "ty", "tz",
+                                "rw", "rx", "ry", "rz",
+                                "sx", "sy", "sz" }) {
+        EXPECT_FALSE(channels[key].toBool())
+            << "channel " << key.toStdString()
+            << " should be inactive on identity-only track";
+    }
 }
 
 TEST_F(AnimationControlControllerTest, MoveKeyframeShiftsTime) {


### PR DESCRIPTION
## Summary
Closes #376. Second chunk of slice D from #260 — per-channel sub-rows under each bone in the dope sheet.

## What's new
- **Chevron + sub-rows** — every animated bone row gets a ▶/▼ chevron on the left. Click to expand into one sub-row per *active* channel (TX/TY/TZ/RW/RX/RY/RZ/SX/SY/SZ). Channels that never deviate from identity (translate.x=0, rotation=1,0,0,0, scale=1) are skipped — no empty rows.
- **Color-coded** — red/green/blue for X/Y/Z; magenta+RGB for rotation; orange-tinted RGB for scale.
- **Active-channel detection** — controller's `allBoneRows()` adds a `channels` map per row, computed from each track's TransformKeyFrames at construction time.
- **Sub-row diamonds delegate to parent** — clicking a sub-row diamond selects the parent bone + jumps the playhead. Per-channel-only edits land in slice D3 with the curve editor.

## Test plan
- [ ] Open Dope Sheet, expand a bone → only animated channels appear (not 9 empty rows)
- [ ] Sub-row diamonds align horizontally with the parent bone diamonds
- [ ] Click a sub-row diamond → parent bone selected, playhead jumps
- [ ] Multi-select / bulk-drag / copy-paste from slice D1 still work on parent rows
- [ ] Linux CI: 2 new tests verify the `channels` map shape + correctness for TestAnim

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Animation Dope Sheet with expandable per-bone and per-channel UI modes, featuring expansion indicators, channel sub-rows, and individual channel keyframe rendering with click-based selection and playhead integration.

* **Tests**
  * Added comprehensive dope-sheet API test coverage including empty-state validation, channel activity detection, and identity-track verification for all TRS components.

* **Chores**
  * Updated project version to 2.34.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->