### PR TITLE
feat(animation): curve editor per-channel data + interp-mode picker (Phase 5 slice D3b)

### DIFF
--- a/qml/AnimationCurveEditor.qml
+++ b/qml/AnimationCurveEditor.qml
@@ -171,6 +171,11 @@ Rectangle {
             )
         }
 
+        // Populate the cache up-front so the first paint shows real curves
+        // even when the view is opened after a selection is already active
+        // (no fresh boneRowsChanged signal will fire to seed it otherwise).
+        Component.onCompleted: refreshChannelValues(root.selectedBoneRow())
+
         onPaint: {
             var ctx = getContext("2d"); ctx.clearRect(0, 0, width, height)
             var row = root.selectedBoneRow()
@@ -328,7 +333,10 @@ Rectangle {
             } else mouse.accepted = false
         }
         onPositionChanged: function(mouse) {
-            if (!pressed || mouse.button !== Qt.MiddleButton) return
+            // mouse.button on a move event is the event trigger, not the
+            // held buttons — check the bitmask in mouse.buttons instead.
+            // Otherwise middle-drag pan never fires after the initial press.
+            if (!pressed || !(mouse.buttons & Qt.MiddleButton)) return
             var dx = mouse.x - panStartX
             root.viewStart = panStartView - dx / root.pxPerSec
             if (root.viewStart < 0) root.viewStart = 0

--- a/qml/AnimationCurveEditor.qml
+++ b/qml/AnimationCurveEditor.qml
@@ -48,8 +48,7 @@ Rectangle {
         return null
     }
 
-    function activeChannelsForSelected() {
-        var row = selectedBoneRow()
+    function activeChannelsFor(row) {
         if (!row || !row.channels) return []
         var result = []
         for (var i = 0; i < channelOrder.length; i++) {
@@ -58,12 +57,27 @@ Rectangle {
         return result
     }
 
+    function activeChannelsForSelected() {
+        return activeChannelsFor(selectedBoneRow())
+    }
+
     Connections {
         target: AnimationControlController
-        function onBoneRowsChanged()      { root.rows = AnimationControlController.allBoneRows(); curveCanvas.requestPaint() }
-        function onSelectionChanged()     { root.rows = AnimationControlController.allBoneRows(); curveCanvas.requestPaint() }
+        function onBoneRowsChanged()      {
+            root.rows = AnimationControlController.allBoneRows()
+            curveCanvas.refreshChannelValues(root.selectedBoneRow())
+            curveCanvas.requestPaint()
+        }
+        function onSelectionChanged()     {
+            root.rows = AnimationControlController.allBoneRows()
+            curveCanvas.refreshChannelValues(root.selectedBoneRow())
+            curveCanvas.requestPaint()
+        }
         function onKeyframeTicksChanged() { curveCanvas.requestPaint() }
-        function onBoneListChanged()      { curveCanvas.requestPaint() }
+        function onBoneListChanged()      {
+            curveCanvas.refreshChannelValues(root.selectedBoneRow())
+            curveCanvas.requestPaint()
+        }
     }
 
     Connections {
@@ -132,19 +146,28 @@ Rectangle {
         anchors.bottom: parent.bottom
         visible: header.visible
 
+        // Cache per-channel values keyed by channel id. Refreshed whenever
+        // the controller emits boneRowsChanged.
+        property var channelValues: ({})
+
+        function refreshChannelValues(boneRow) {
+            var cache = {}
+            var chans = root.activeChannelsFor(boneRow)
+            for (var i = 0; i < chans.length; i++) {
+                cache[chans[i].id] = AnimationControlController.channelValuesAt(
+                    boneRow.bone, chans[i].id)
+            }
+            curveCanvas.channelValues = cache
+        }
+
         function valueAtTimeForChannel(boneRow, channelId, time) {
-            // Read the channel's values directly from the keyframes via the
-            // controller. We don't have a dedicated API yet; fall back to
-            // CurveEditModel.evaluate, passing in the values we sample from
-            // the dope-sheet row's keyframe metadata. For D3a we approximate
-            // by using a single sentinel sample series — D3b will plumb the
-            // per-channel values through.
+            var values = channelValues[channelId] || []
             return CurveEditModel.evaluate(
                 AnimationControlController.selectedEntityName,
                 AnimationControlController.selectedAnimation,
                 boneRow.bone, channelId, time,
                 boneRow.keyTimes,
-                boneRow.keyTimes // placeholder; D3b reads real channel values
+                values
             )
         }
 
@@ -178,11 +201,9 @@ Rectangle {
             }
             ctx.globalAlpha = 1.0
 
-            // Per-channel curve. For D3a we plot the keyframe values directly
-            // from row.keyTimes paired with the channel's values — but we
-            // don't yet have per-channel value arrays from the controller, so
-            // we sample the model's evaluate() across the visible range as a
-            // demonstration. D3b plumbs the real per-channel data through.
+            // Per-channel curve. evaluate() reads real per-channel values
+            // pulled from the controller and cached in channelValues, so the
+            // curve reflects the underlying TransformKeyFrame data.
             var chans = root.activeChannelsForSelected()
             for (var c = 0; c < chans.length; c++) {
                 var ch = chans[c]
@@ -234,23 +255,80 @@ Rectangle {
         }
     }
 
+    // ── Interp-mode picker (right-click on keyframe square) ────────────────
+    Menu {
+        id: modeMenu
+        property string boneName: ""
+        property string channelId: ""
+        property real keyTime: 0
+
+        function applyMode(mode) {
+            CurveEditModel.setMode(
+                AnimationControlController.selectedEntityName,
+                AnimationControlController.selectedAnimation,
+                boneName, channelId, keyTime, mode)
+        }
+
+        MenuItem { text: "Bezier";   onTriggered: modeMenu.applyMode(CurveEditModel.ModeBezier) }
+        MenuItem { text: "Linear";   onTriggered: modeMenu.applyMode(CurveEditModel.ModeLinear) }
+        MenuItem { text: "Stepped";  onTriggered: modeMenu.applyMode(CurveEditModel.ModeStepped) }
+        MenuItem { text: "Auto";     onTriggered: modeMenu.applyMode(CurveEditModel.ModeAuto) }
+    }
+
+    // Look up a keyframe near (px, py) and return { bone, channel, time, x, y }
+    // or null if the click missed everything. Used by the right-click handler
+    // to decide whether to open the mode picker.
+    function pickKeyframeAt(px, py) {
+        var row = selectedBoneRow()
+        if (!row) return null
+        var midY = (curveCanvas.height - 16) / 2
+        var chans = activeChannelsFor(row)
+        for (var c = 0; c < chans.length; c++) {
+            var ch = chans[c]
+            for (var k = 0; k < row.keyTimes.length; k++) {
+                var kt = row.keyTimes[k]
+                var kv = curveCanvas.valueAtTimeForChannel(row, ch.id, kt)
+                var kx = (kt - viewStart) * pxPerSec
+                var ky = midY - (kv - yCenter) * yScale
+                if (Math.abs(px - kx) < 8 && Math.abs(py - ky) < 8) {
+                    return { bone: row.bone, channel: ch.id,
+                             time: kt, x: kx, y: ky }
+                }
+            }
+        }
+        return null
+    }
+
     // Wheel = zoom horizontally (Ctrl/Cmd) or vertically (Shift), pan with
-    // middle-drag. Matches the dope sheet's input vocabulary as closely as
+    // middle-drag. Right-click on a keyframe square opens the interp-mode
+    // picker. Matches the dope sheet's input vocabulary as closely as
     // possible to keep mental load low when switching panels.
     MouseArea {
         id: panArea
         anchors.fill: parent
-        acceptedButtons: Qt.MiddleButton
+        acceptedButtons: Qt.MiddleButton | Qt.RightButton
         property real panStartX: 0
         property real panStartView: 0
         onPressed: function(mouse) {
             if (mouse.button === Qt.MiddleButton) {
                 panStartX = mouse.x; panStartView = root.viewStart
                 mouse.accepted = true
+            } else if (mouse.button === Qt.RightButton) {
+                var hit = root.pickKeyframeAt(
+                    mouse.x - curveCanvas.x, mouse.y - curveCanvas.y)
+                if (hit) {
+                    modeMenu.boneName  = hit.bone
+                    modeMenu.channelId = hit.channel
+                    modeMenu.keyTime   = hit.time
+                    modeMenu.popup()
+                    mouse.accepted = true
+                } else {
+                    mouse.accepted = false
+                }
             } else mouse.accepted = false
         }
         onPositionChanged: function(mouse) {
-            if (!pressed) return
+            if (!pressed || mouse.button !== Qt.MiddleButton) return
             var dx = mouse.x - panStartX
             root.viewStart = panStartView - dx / root.pxPerSec
             if (root.viewStart < 0) root.viewStart = 0

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -5,6 +5,7 @@
 #include "UndoManager.h"
 #include "commands/MoveKeyframeCommand.h"
 #include "commands/BulkKeyframeCommands.h"
+#include "commands/SetKeyframeValueCommand.h"
 #include <QApplication>
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -1017,4 +1018,79 @@ int AnimationControlController::pasteKeyframesAt(const QString& json,
     refreshSliderTicks();
     emit boneRowsChanged();
     return n;
+}
+
+// ── Curve editor API (slice D3b) ──────────────────────────────────────────────
+
+namespace {
+
+// Resolve channel id → scalar reader on a TransformKeyFrame. Mirrors
+// SetKeyframeValueCommand's accessor without pulling that header in.
+double readChannel(const Ogre::TransformKeyFrame* kf, const QString& ch) {
+    const QString c = ch.toLower();
+    if (c == "tx") return kf->getTranslate().x;
+    if (c == "ty") return kf->getTranslate().y;
+    if (c == "tz") return kf->getTranslate().z;
+    if (c == "rw") return kf->getRotation().w;
+    if (c == "rx") return kf->getRotation().x;
+    if (c == "ry") return kf->getRotation().y;
+    if (c == "rz") return kf->getRotation().z;
+    if (c == "sx") return kf->getScale().x;
+    if (c == "sy") return kf->getScale().y;
+    if (c == "sz") return kf->getScale().z;
+    return 0.0;
+}
+
+bool isKnownChannel(const QString& ch) {
+    static const QStringList kKnown = {
+        QStringLiteral("tx"), QStringLiteral("ty"), QStringLiteral("tz"),
+        QStringLiteral("rw"), QStringLiteral("rx"),
+        QStringLiteral("ry"), QStringLiteral("rz"),
+        QStringLiteral("sx"), QStringLiteral("sy"), QStringLiteral("sz"),
+    };
+    return kKnown.contains(ch.toLower());
+}
+
+} // namespace
+
+QVariantList AnimationControlController::channelValuesAt(
+        const QString& boneName, const QString& channel) const
+{
+    QVariantList out;
+    if (boneName.isEmpty() || !isKnownChannel(channel)) return out;
+    if (!m_selectedSkeleton || m_selectedAnimation.empty()) return out;
+    if (!m_selectedSkeleton->hasAnimation(m_selectedAnimation)) return out;
+    if (!m_selectedSkeleton->hasBone(boneName.toStdString())) return out;
+
+    Ogre::Animation* anim = m_selectedSkeleton->getAnimation(m_selectedAnimation);
+    Ogre::Bone* bone = m_selectedSkeleton->getBone(boneName.toStdString());
+    if (!anim->hasNodeTrack(bone->getHandle())) return out;
+    auto* track = anim->getNodeTrack(bone->getHandle());
+
+    out.reserve(static_cast<int>(track->getNumKeyFrames()));
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        const auto* kf = static_cast<const Ogre::TransformKeyFrame*>(track->getKeyFrame(i));
+        out.append(readChannel(kf, channel));
+    }
+    return out;
+}
+
+bool AnimationControlController::setKeyframeValue(const QString& boneName,
+                                                   const QString& channel,
+                                                   double time, double value)
+{
+    if (boneName.isEmpty() || !isKnownChannel(channel)) return false;
+    if (!m_selectedSkeleton || m_selectedAnimation.empty()) return false;
+    if (!m_selectedSkeleton->hasAnimation(m_selectedAnimation)) return false;
+
+    auto* cmd = new SetKeyframeValueCommand(m_selectedSkeleton, // NOSONAR — QUndoStack owns
+                                             m_selectedAnimation,
+                                             boneName.toStdString(),
+                                             channel.toLower().toStdString(),
+                                             static_cast<float>(time),
+                                             value);
+    UndoManager::getSingleton()->push(cmd);
+    refreshSliderTicks();
+    emit boneRowsChanged();
+    return true;
 }

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -1082,6 +1082,23 @@ bool AnimationControlController::setKeyframeValue(const QString& boneName,
     if (boneName.isEmpty() || !isKnownChannel(channel)) return false;
     if (!m_selectedSkeleton || m_selectedAnimation.empty()) return false;
     if (!m_selectedSkeleton->hasAnimation(m_selectedAnimation)) return false;
+    if (!m_selectedSkeleton->hasBone(boneName.toStdString())) return false;
+
+    // Pre-check that there's actually a keyframe at `time` — otherwise the
+    // command would push a no-op onto the undo stack. Mirrors the same
+    // tolerance the command itself uses (1 ms).
+    Ogre::Animation* anim = m_selectedSkeleton->getAnimation(m_selectedAnimation);
+    Ogre::Bone* bone = m_selectedSkeleton->getBone(boneName.toStdString());
+    if (!anim->hasNodeTrack(bone->getHandle())) return false;
+    auto* track = anim->getNodeTrack(bone->getHandle());
+    bool found = false;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        if (std::fabs(track->getKeyFrame(i)->getTime() - static_cast<float>(time))
+                <= 0.001f) {
+            found = true; break;
+        }
+    }
+    if (!found) return false;
 
     auto* cmd = new SetKeyframeValueCommand(m_selectedSkeleton, // NOSONAR — QUndoStack owns
                                              m_selectedAnimation,

--- a/src/AnimationControlController.h
+++ b/src/AnimationControlController.h
@@ -195,6 +195,22 @@ public:
     /// track. Returns the count actually pasted.
     Q_INVOKABLE int pasteKeyframesAt(const QString& json, double atTime);
 
+    // ── Curve editor API (slice D3b) ──────────────────────────────────────────
+    /// Returns the scalar value of one channel at every keyframe of `bone`'s
+    /// track on the currently-selected animation, in keyframe-time order.
+    /// `channel` ∈ {tx, ty, tz, rw, rx, ry, rz, sx, sy, sz}.
+    /// Empty when no animation/bone selected or the channel id is unknown.
+    Q_INVOKABLE QVariantList channelValuesAt(const QString& boneName,
+                                              const QString& channel) const;
+
+    /// Write a single channel value into the keyframe at `time` on `bone`'s
+    /// track, leaving the other 9 channels untouched. Pushes a
+    /// SetKeyframeValueCommand so Ctrl+Z restores the original value.
+    /// Returns true when the keyframe was found and updated.
+    Q_INVOKABLE bool setKeyframeValue(const QString& boneName,
+                                       const QString& channel,
+                                       double time, double value);
+
 public slots:
     void updateAnimationTree();
 

--- a/src/AnimationControlController_test.cpp
+++ b/src/AnimationControlController_test.cpp
@@ -756,6 +756,72 @@ TEST_F(AnimationControlControllerTest, AllBoneRowsAllChannelsFalseForIdentityOnl
     }
 }
 
+// ── Curve editor APIs (slice D3b) ──────────────────────────────────────────────
+
+TEST_F(AnimationControlControllerPlaybackTest, ChannelValuesEmptyWhenNoSelection) {
+    auto* ctrl = AnimationControlController::instance();
+    EXPECT_TRUE(ctrl->channelValuesAt("Bone", "tx").isEmpty());
+}
+
+TEST_F(AnimationControlControllerPlaybackTest, ChannelValuesUnknownChannelReturnsEmpty) {
+    auto* ctrl = AnimationControlController::instance();
+    EXPECT_TRUE(ctrl->channelValuesAt("Bone", "unknown").isEmpty());
+}
+
+TEST_F(AnimationControlControllerPlaybackTest, SetKeyframeValueRejectsUnknownChannel) {
+    auto* ctrl = AnimationControlController::instance();
+    EXPECT_FALSE(ctrl->setKeyframeValue("Bone", "qq", 0.5, 1.0));
+}
+
+TEST_F(AnimationControlControllerTest, ChannelValuesReadsTrack) {
+    // TestAnim's middle keyframe has translate.x = 0.5 (rest are 0). The
+    // channelValuesAt API must return [0, 0.5, 0] for "tx" in time order.
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("CurveEditor_ChannelValuesTest");
+    ASSERT_NE(entity, nullptr);
+
+    auto* ctrl = AnimationControlController::instance();
+    ctrl->updateAnimationTree();
+    ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+    QString bone = ctrl->boneNames().first();
+
+    QVariantList tx = ctrl->channelValuesAt(bone, "tx");
+    ASSERT_EQ(tx.size(), 3);
+    EXPECT_NEAR(tx[0].toDouble(), 0.0, 1e-4);
+    EXPECT_NEAR(tx[1].toDouble(), 0.5, 1e-4);
+    EXPECT_NEAR(tx[2].toDouble(), 0.0, 1e-4);
+}
+
+TEST_F(AnimationControlControllerTest, SetKeyframeValueWritesOneChannelOnly) {
+    // Setting tx must leave ty/tz/r*/s* on the same keyframe alone.
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("CurveEditor_SetValueTest");
+    ASSERT_NE(entity, nullptr);
+
+    auto* ctrl = AnimationControlController::instance();
+    ctrl->updateAnimationTree();
+    ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+    QString bone = ctrl->boneNames().first();
+
+    EXPECT_TRUE(ctrl->setKeyframeValue(bone, "tx", 0.5, 7.5));
+
+    auto* track = entity->getSkeleton()->getAnimation("TestAnim")
+                         ->_getNodeTrackList().begin()->second;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        auto* kf = static_cast<Ogre::TransformKeyFrame*>(track->getKeyFrame(i));
+        if (std::fabs(kf->getTime() - 0.5f) < 0.001f) {
+            EXPECT_NEAR(kf->getTranslate().x, 7.5f, 1e-4);
+            // The original middle keyframe had ty/tz = 0 — must still be 0.
+            EXPECT_NEAR(kf->getTranslate().y, 0.0f, 1e-4);
+            EXPECT_NEAR(kf->getTranslate().z, 0.0f, 1e-4);
+            // Rotation around Y (30°) — verify it survived the tx write.
+            EXPECT_NEAR(kf->getRotation().y, 0.2588f, 1e-3);
+            return;
+        }
+    }
+    FAIL() << "Keyframe at t=0.5 not found";
+}
+
 TEST_F(AnimationControlControllerTest, MoveKeyframeShiftsTime) {
     ASSERT_TRUE(canLoadMeshFiles());
     Ogre::Entity* entity = setupAnimatedEntity("DopeSheet_MoveTest");

--- a/src/AnimationControlController_test.cpp
+++ b/src/AnimationControlController_test.cpp
@@ -773,6 +773,13 @@ TEST_F(AnimationControlControllerPlaybackTest, SetKeyframeValueRejectsUnknownCha
     EXPECT_FALSE(ctrl->setKeyframeValue("Bone", "qq", 0.5, 1.0));
 }
 
+TEST_F(AnimationControlControllerPlaybackTest, SetKeyframeValueRejectsWithoutSelection) {
+    auto* ctrl = AnimationControlController::instance();
+    // No animation selected → should return false, not silently push a
+    // no-op command onto the undo stack.
+    EXPECT_FALSE(ctrl->setKeyframeValue("Bone", "tx", 0.5, 1.0));
+}
+
 TEST_F(AnimationControlControllerTest, ChannelValuesReadsTrack) {
     // TestAnim's middle keyframe has translate.x = 0.5 (rest are 0). The
     // channelValuesAt API must return [0, 0.5, 0] for "tx" in time order.
@@ -790,6 +797,19 @@ TEST_F(AnimationControlControllerTest, ChannelValuesReadsTrack) {
     EXPECT_NEAR(tx[0].toDouble(), 0.0, 1e-4);
     EXPECT_NEAR(tx[1].toDouble(), 0.5, 1e-4);
     EXPECT_NEAR(tx[2].toDouble(), 0.0, 1e-4);
+}
+
+TEST_F(AnimationControlControllerTest, SetKeyframeValueRejectsMissingTime) {
+    // No keyframe at 0.42 — the controller must return false instead of
+    // pushing a no-op SetKeyframeValueCommand onto the undo stack.
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("CurveEditor_MissingTimeTest");
+    ASSERT_NE(entity, nullptr);
+    auto* ctrl = AnimationControlController::instance();
+    ctrl->updateAnimationTree();
+    ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+    QString bone = ctrl->boneNames().first();
+    EXPECT_FALSE(ctrl->setKeyframeValue(bone, "tx", 0.42, 5.0));
 }
 
 TEST_F(AnimationControlControllerTest, SetKeyframeValueWritesOneChannelOnly) {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,7 @@ SubEntityHighlight.cpp
 commands/TransformCommands.cpp
 commands/MoveKeyframeCommand.cpp
 commands/BulkKeyframeCommands.cpp
+commands/SetKeyframeValueCommand.cpp
 PropertiesPanelController.cpp
 SceneTreeModel.cpp
 ThemeManager.cpp

--- a/src/commands/SetKeyframeValueCommand.cpp
+++ b/src/commands/SetKeyframeValueCommand.cpp
@@ -1,0 +1,99 @@
+#include "SetKeyframeValueCommand.h"
+
+#include <Ogre.h>
+#include <OgreSkeleton.h>
+#include <OgreAnimation.h>
+#include <OgreAnimationTrack.h>
+#include <OgreKeyFrame.h>
+
+#include <QObject>
+#include <cmath>
+#include <utility>
+
+namespace {
+constexpr float kEpsilon = 0.001f;
+
+Ogre::TransformKeyFrame* findKeyframe(Ogre::Skeleton* skel,
+                                       const std::string& animName,
+                                       const std::string& boneName,
+                                       float time)
+{
+    if (!skel || animName.empty() || boneName.empty()) return nullptr;
+    if (!skel->hasAnimation(animName) || !skel->hasBone(boneName)) return nullptr;
+    Ogre::Animation* anim = skel->getAnimation(animName);
+    Ogre::Bone* bone = skel->getBone(boneName);
+    if (!anim->hasNodeTrack(bone->getHandle())) return nullptr;
+    auto* track = anim->getNodeTrack(bone->getHandle());
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        auto* kf = static_cast<Ogre::TransformKeyFrame*>(track->getKeyFrame(i));
+        if (std::fabs(kf->getTime() - time) <= kEpsilon) return kf;
+    }
+    return nullptr;
+}
+
+// Read or write one of the 10 scalar channels on a TransformKeyFrame.
+// Returns true on a known channel id.
+bool getChannel(const Ogre::TransformKeyFrame* kf, const std::string& ch, double& out) {
+    if (ch == "tx") { out = kf->getTranslate().x; return true; }
+    if (ch == "ty") { out = kf->getTranslate().y; return true; }
+    if (ch == "tz") { out = kf->getTranslate().z; return true; }
+    if (ch == "rw") { out = kf->getRotation().w;  return true; }
+    if (ch == "rx") { out = kf->getRotation().x;  return true; }
+    if (ch == "ry") { out = kf->getRotation().y;  return true; }
+    if (ch == "rz") { out = kf->getRotation().z;  return true; }
+    if (ch == "sx") { out = kf->getScale().x;     return true; }
+    if (ch == "sy") { out = kf->getScale().y;     return true; }
+    if (ch == "sz") { out = kf->getScale().z;     return true; }
+    return false;
+}
+
+bool setChannel(Ogre::TransformKeyFrame* kf, const std::string& ch, double v) {
+    if (ch == "tx") { auto t = kf->getTranslate(); t.x = static_cast<float>(v); kf->setTranslate(t); return true; }
+    if (ch == "ty") { auto t = kf->getTranslate(); t.y = static_cast<float>(v); kf->setTranslate(t); return true; }
+    if (ch == "tz") { auto t = kf->getTranslate(); t.z = static_cast<float>(v); kf->setTranslate(t); return true; }
+    if (ch == "rw") { auto r = kf->getRotation();  r.w = static_cast<float>(v); kf->setRotation(r); return true; }
+    if (ch == "rx") { auto r = kf->getRotation();  r.x = static_cast<float>(v); kf->setRotation(r); return true; }
+    if (ch == "ry") { auto r = kf->getRotation();  r.y = static_cast<float>(v); kf->setRotation(r); return true; }
+    if (ch == "rz") { auto r = kf->getRotation();  r.z = static_cast<float>(v); kf->setRotation(r); return true; }
+    if (ch == "sx") { auto s = kf->getScale();     s.x = static_cast<float>(v); kf->setScale(s); return true; }
+    if (ch == "sy") { auto s = kf->getScale();     s.y = static_cast<float>(v); kf->setScale(s); return true; }
+    if (ch == "sz") { auto s = kf->getScale();     s.z = static_cast<float>(v); kf->setScale(s); return true; }
+    return false;
+}
+
+} // namespace
+
+SetKeyframeValueCommand::SetKeyframeValueCommand(Ogre::Skeleton* skeleton,
+                                                  std::string animationName,
+                                                  std::string boneName,
+                                                  std::string channel,
+                                                  float time,
+                                                  double newValue,
+                                                  QUndoCommand* parent)
+    : QUndoCommand(parent)
+    , mSkeleton(skeleton)
+    , mAnimationName(std::move(animationName))
+    , mBoneName(std::move(boneName))
+    , mChannel(std::move(channel))
+    , mTime(time)
+    , mNewValue(newValue)
+{
+    setText(QObject::tr("Set keyframe value"));
+}
+
+bool SetKeyframeValueCommand::apply(double value)
+{
+    auto* kf = findKeyframe(mSkeleton, mAnimationName, mBoneName, mTime);
+    if (!kf) return false;
+    if (!mCaptured) {
+        // First-time apply: snapshot the original so undo can restore it.
+        // QUndoStack::push() always calls redo() exactly once before any
+        // undo, so this branch is the right place to capture.
+        getChannel(kf, mChannel, mOldValue);
+        mCaptured = true;
+    }
+    return setChannel(kf, mChannel, value);
+}
+
+void SetKeyframeValueCommand::redo() { apply(mNewValue); }
+void SetKeyframeValueCommand::undo() { apply(mOldValue); }

--- a/src/commands/SetKeyframeValueCommand.h
+++ b/src/commands/SetKeyframeValueCommand.h
@@ -1,0 +1,48 @@
+#ifndef SET_KEYFRAME_VALUE_COMMAND_H
+#define SET_KEYFRAME_VALUE_COMMAND_H
+
+#include <QUndoCommand>
+#include <string>
+
+namespace Ogre {
+    class Skeleton;
+}
+
+/**
+ * Sets a single TRS channel (tx/ty/tz/rw/rx/ry/rz/sx/sy/sz) on a specific
+ * keyframe of a bone's track, leaving the other nine channels untouched.
+ * Used by the curve editor when the user drags a keyframe square in the
+ * Y axis (channel value) without retiming.
+ *
+ * Stores the previous value so undo restores it exactly. Stores the
+ * channel name as a string so the command survives any track rebuilds
+ * that happen between push and undo.
+ */
+class SetKeyframeValueCommand : public QUndoCommand
+{
+public:
+    SetKeyframeValueCommand(Ogre::Skeleton* skeleton,
+                            std::string animationName,
+                            std::string boneName,
+                            std::string channel,
+                            float time,
+                            double newValue,
+                            QUndoCommand* parent = nullptr);
+
+    void undo() override;
+    void redo() override;
+
+private:
+    bool apply(double value);
+
+    Ogre::Skeleton* mSkeleton;
+    std::string     mAnimationName;
+    std::string     mBoneName;
+    std::string     mChannel;
+    float           mTime;
+    double          mOldValue = 0.0;
+    double          mNewValue;
+    bool            mCaptured = false;
+};
+
+#endif // SET_KEYFRAME_VALUE_COMMAND_H

--- a/src/commands/SetKeyframeValueCommand_test.cpp
+++ b/src/commands/SetKeyframeValueCommand_test.cpp
@@ -1,0 +1,87 @@
+#include <gtest/gtest.h>
+#include <QApplication>
+#include <QCoreApplication>
+#include <QThread>
+#include <QUndoStack>
+
+#include "SetKeyframeValueCommand.h"
+#include "../Manager.h"
+#include "../TestHelpers.h"
+
+#include <OgreSkeletonInstance.h>
+#include <OgreAnimation.h>
+#include <OgreAnimationTrack.h>
+#include <OgreKeyFrame.h>
+
+#include <cmath>
+
+class SetKeyframeValueCommandTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        Manager::kill();
+        QThread::msleep(20);
+        app = qobject_cast<QApplication*>(QCoreApplication::instance());
+        ASSERT_NE(app, nullptr);
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+        createStandardOgreMaterials();
+    }
+    void TearDown() override { if (app) app->processEvents(); }
+    QApplication* app = nullptr;
+
+    static Ogre::TransformKeyFrame* keyAt(Ogre::Entity* entity, float time) {
+        auto* track = entity->getSkeleton()->getAnimation("TestAnim")
+                             ->_getNodeTrackList().begin()->second;
+        for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+            auto* kf = static_cast<Ogre::TransformKeyFrame*>(track->getKeyFrame(i));
+            if (std::fabs(kf->getTime() - time) < 0.001f) return kf;
+        }
+        return nullptr;
+    }
+};
+
+TEST_F(SetKeyframeValueCommandTest, RedoUndoRoundTrip) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = createAnimatedTestEntity("SKV_RedoUndoTest");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+
+    QUndoStack stack;
+    stack.push(new SetKeyframeValueCommand(skel, "TestAnim", "Child", "tx", 0.5f, 9.0));
+
+    auto* kf = keyAt(entity, 0.5f);
+    ASSERT_NE(kf, nullptr);
+    EXPECT_NEAR(kf->getTranslate().x, 9.0f, 1e-4);
+
+    stack.undo();
+    EXPECT_NEAR(kf->getTranslate().x, 0.5f, 1e-4); // original
+
+    stack.redo();
+    EXPECT_NEAR(kf->getTranslate().x, 9.0f, 1e-4);
+}
+
+TEST_F(SetKeyframeValueCommandTest, NoOpWhenChannelUnknown) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = createAnimatedTestEntity("SKV_UnknownChannelTest");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+
+    QUndoStack stack;
+    stack.push(new SetKeyframeValueCommand(skel, "TestAnim", "Child", "qq", 0.5f, 9.0));
+    // Original 0.5 keyframe should be untouched.
+    auto* kf = keyAt(entity, 0.5f);
+    EXPECT_NEAR(kf->getTranslate().x, 0.5f, 1e-4);
+}
+
+TEST_F(SetKeyframeValueCommandTest, NoOpWhenTimeNotFound) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = createAnimatedTestEntity("SKV_MissingTimeTest");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+
+    QUndoStack stack;
+    stack.push(new SetKeyframeValueCommand(skel, "TestAnim", "Child", "tx", 0.42f, 9.0));
+    // No keyframe at 0.42 → the original 0.0/0.5/1.0 keyframes stay intact.
+    EXPECT_NEAR(keyAt(entity, 0.0f)->getTranslate().x, 0.0f, 1e-4);
+    EXPECT_NEAR(keyAt(entity, 0.5f)->getTranslate().x, 0.5f, 1e-4);
+    EXPECT_NEAR(keyAt(entity, 1.0f)->getTranslate().x, 0.0f, 1e-4);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,6 +66,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/TransformCommands.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/MoveKeyframeCommand.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/BulkKeyframeCommands.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/SetKeyframeValueCommand.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/PropertiesPanelController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/SceneTreeModel.cpp
 


### PR DESCRIPTION
## Summary
Builds on D3a (#379). Curve editor is now visually live (real per-channel values) and per-keyframe interpolation mode is user-editable via a right-click picker.

## What's in this PR
- **`channelValuesAt(bone, channel)`** — controller reads the scalar value of one TRS channel at every keyframe of the bone's track. Curve editor uses it to plot real curves.
- **`setKeyframeValue(bone, channel, time, value)`** — writes one channel back without disturbing the other 9. Undoable via the new `SetKeyframeValueCommand`.
- **Right-click → interp-mode picker** in the curve editor. Bezier / Linear / Stepped / Auto per keyframe. Hit-tests against the visible keyframe square positions.
- **Per-channel value cache** in QML (refreshed on selection/track changes) so the canvas paints the actual underlying data.

## Tests
- 3 pure-data controller cases (empty selection / unknown channel / setKeyframeValue rejects unknown channel).
- 2 Ogre-fixture controller cases (channelValuesAt reads correct data; setKeyframeValue writes one channel without disturbing others).
- 3 `SetKeyframeValueCommandTest` cases (redo→undo round-trip, unknown-channel no-op, missing-time no-op).

## Out of scope (deferred to follow-up)
- Free-form tangent handle drag (substantial QML refactor — overlaying MouseAreas at arbitrary canvas positions).
- Resample-into-TransformKeyFrame on tangent change (only matters once handle drag lands).
- Sidecar JSON persistence.

I'll open a follow-up issue tracking these so the curve editor work is fully captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)