### PR TITLE
feat(animation): viewport bone-pick (#358 slice 1)

### DIFF
--- a/src/GlobalDefinitions.h
+++ b/src/GlobalDefinitions.h
@@ -34,7 +34,8 @@ THE SOFTWARE.
 #define GUI_MATERIAL_NAME "GUI_Material"
 
 #define GIZMO_QUERY_FLAGS       0x01
-#define SCENE_QUERY_FLAGS       0xFE
+#define BONE_QUERY_FLAGS        0x02
+#define SCENE_QUERY_FLAGS       0xFC
 
 #define GUI_VISIBILITY_FLAGS    0x01
 #define SCENE_VISIBILITY_FLAGS  0xFE

--- a/src/SkeletonDebug.cpp
+++ b/src/SkeletonDebug.cpp
@@ -1,7 +1,30 @@
 #include "SkeletonDebug.h"
+#include "GlobalDefinitions.h"
 
 #include <array>
 #include <cassert>
+
+namespace {
+constexpr const char* kBoneNameTag = "skeletonDebugBoneName";
+
+void tagBoneVisual(Ogre::MovableObject* obj, const Ogre::String& boneName) {
+    if (!obj) return;
+    obj->getUserObjectBindings().setUserAny(kBoneNameTag, Ogre::Any(boneName));
+    obj->setQueryFlags(BONE_QUERY_FLAGS);
+}
+}
+
+Ogre::String SkeletonDebug::boneNameForMovable(const Ogre::MovableObject* obj)
+{
+    if (!obj) return {};
+    const auto& any = obj->getUserObjectBindings().getUserAny(kBoneNameTag);
+    if (!any.has_value()) return {};
+    try {
+        return Ogre::any_cast<Ogre::String>(any);
+    } catch (const std::exception&) {
+        return {};
+    }
+}
 
 SkeletonDebug::SkeletonDebug(Ogre::Entity* entity, Ogre::SceneManager *man, float boneSize, float scaleAxes)
     : mBoneSize(boneSize)
@@ -84,6 +107,10 @@ void SkeletonDebug::createChildBoneRepresentations(const Ogre::Bone* pBone, Ogre
         auto* tp = mEntity->attachObjectToBone(pBone->getName(), (Ogre::MovableObject*)lastEnt);
         mBoneEntities.push_back(lastEnt);
         tp->setScale(length, length, length);
+        // Tag every child bone visual with the parent bone's name —
+        // dragging this segment in the viewport edits the parent bone's
+        // pose (the segment visually represents that bone, not the child).
+        tagBoneVisual(lastEnt, pBone->getName());
     }
 }
 
@@ -112,6 +139,8 @@ std::map<std::string, Ogre::Entity*, std::less<>> SkeletonDebug::createBoneVisua
             float length = pBone->getInitialPosition().length();
             if(length >= 0.00001f)
                 tp->setScale(length, length, length);
+
+            tagBoneVisual(ent, pBone->getName());
         }
         else
         {
@@ -124,6 +153,9 @@ std::map<std::string, Ogre::Entity*, std::less<>> SkeletonDebug::createBoneVisua
         auto* tp = mEntity->attachObjectToBone(pBone->getName(), (Ogre::MovableObject*)ent);
         tp->setScale((mScaleAxes/mEntity->getParentSceneNode()->getScale().x), (mScaleAxes/mEntity->getParentSceneNode()->getScale().y), (mScaleAxes/mEntity->getParentSceneNode()->getScale().z));
         mAxisEntities.push_back(ent);
+        // Tag the axes overlay too — clicking the axis cross is the most
+        // visible target for users when scaling/rotating.
+        tagBoneVisual(ent, pBone->getName());
     }
 
     return mapEntities;

--- a/src/SkeletonDebug.h
+++ b/src/SkeletonDebug.h
@@ -29,6 +29,11 @@ public:
     void update() const;
     short selectedBoneIndex() const { return mLastSelectedBone; }
 
+    // Bone-name tag attached to every visual entity (bone meshes + axes
+    // meshes) so a ray-pick in the viewport can map back to the bone.
+    // Returns empty string when the movable isn't a SkeletonDebug visual.
+    static Ogre::String boneNameForMovable(const Ogre::MovableObject* obj);
+
 signals:
     void boneSelected(unsigned short boneIndex);
 

--- a/src/SkeletonDebug_test.cpp
+++ b/src/SkeletonDebug_test.cpp
@@ -4,6 +4,7 @@
 #include <QThread>
 #include "Manager.h"
 #include "SkeletonDebug.h"
+#include "GlobalDefinitions.h"
 #include <OgreException.h>
 #include "TestHelpers.h"
 
@@ -104,6 +105,46 @@ TEST_F(SkeletonDebugTests, SelectedBoneIndexDefault)
 {
     int index = skeletonDebug->selectedBoneIndex();
     EXPECT_GE(index, -1);
+}
+
+TEST_F(SkeletonDebugTests, BoneNameForMovableReturnsEmptyForNullptr)
+{
+    EXPECT_TRUE(SkeletonDebug::boneNameForMovable(nullptr).empty());
+}
+
+TEST_F(SkeletonDebugTests, BoneNameForMovableReturnsEmptyForUntaggedEntity)
+{
+    Ogre::SceneManager* sm = Manager::getSingleton()->getSceneMgr();
+    Ogre::Entity* plain = sm->createEntity(
+        "BoneNameTest_Plain", Ogre::SceneManager::PT_CUBE);
+    EXPECT_TRUE(SkeletonDebug::boneNameForMovable(plain).empty());
+    sm->destroyEntity(plain);
+}
+
+TEST_F(SkeletonDebugTests, BoneNameForMovableReturnsBoneNameForTaggedVisuals)
+{
+    // After SkeletonDebug constructs visuals, every bone-mesh / axes entity
+    // it creates carries the bone name as a UserAny tag and the
+    // BONE_QUERY_FLAGS query mask. A ray-pick in the viewport relies on
+    // both — the mask filters out scene meshes, the tag maps the hit
+    // movable back to its bone.
+    skeletonDebug->showBones(true);
+    skeletonDebug->showAxes(true);
+
+    Ogre::SceneManager* sm = Manager::getSingleton()->getSceneMgr();
+    int taggedCount = 0;
+    for (auto it = sm->getMovableObjectIterator("Entity").begin();
+         it != sm->getMovableObjectIterator("Entity").end(); ++it)
+    {
+        auto* obj = it->second;
+        Ogre::String tag = SkeletonDebug::boneNameForMovable(obj);
+        if (!tag.empty())
+        {
+            ++taggedCount;
+            EXPECT_EQ(obj->getQueryFlags(), static_cast<Ogre::uint32>(BONE_QUERY_FLAGS));
+        }
+    }
+    EXPECT_GT(taggedCount, 0) << "no SkeletonDebug visuals were tagged";
 }
 
 TEST_F(SkeletonDebugTests, SetAxesScaleZero)

--- a/src/TransformOperator.cpp
+++ b/src/TransformOperator.cpp
@@ -24,6 +24,7 @@
 #include "commands/TransformCommands.h"
 #include "EditModeController.h"
 #include "AnimationControlController.h"
+#include "SkeletonDebug.h"
 #include <Ogre.h>
 
 // TODO  create a virtual class GizmoObject & add Rotation & Translation Gizmo to have only one interface
@@ -989,6 +990,30 @@ void TransformOperator::mousePressEvent(QMouseEvent *e)
 
         if(mTransformState == TS_SELECT)
         {
+            // Bone-pick: when the skeleton overlay is on, a click on a bone
+            // visual selects that bone in the Animation Control panel
+            // instead of starting a box-select. Box-select still kicks in
+            // when the click misses the skeleton.
+            if (m_pRayQuery)
+            {
+                m_pRayQuery->setRay(rayFromScreenPoint(e->pos()));
+                m_pRayQuery->setQueryMask(BONE_QUERY_FLAGS);
+                Ogre::RaySceneQueryResult& res = m_pRayQuery->execute();
+                if (!res.empty() && res.begin()->movable)
+                {
+                    Ogre::String boneName = SkeletonDebug::boneNameForMovable(
+                        res.begin()->movable);
+                    if (!boneName.empty())
+                    {
+                        AnimationControlController::instance()->selectBone(
+                            QString::fromStdString(boneName));
+                        SentryReporter::addBreadcrumb("ui.action",
+                            QString("Bone picked: %1").arg(QString::fromStdString(boneName)));
+                        return;
+                    }
+                }
+            }
+
             mScreenStart = e->pos();
             m_pSelectionBox->clear();
             m_pSelectionBox->setVisible(true);

--- a/src/TransformOperator.cpp
+++ b/src/TransformOperator.cpp
@@ -998,19 +998,20 @@ void TransformOperator::mousePressEvent(QMouseEvent *e)
             {
                 m_pRayQuery->setRay(rayFromScreenPoint(e->pos()));
                 m_pRayQuery->setQueryMask(BONE_QUERY_FLAGS);
+                m_pRayQuery->setSortByDistance(true);
+                // Walk hits front-to-back: skip non-bone movables that
+                // happen to share the mask, accept the first tagged one.
                 Ogre::RaySceneQueryResult& res = m_pRayQuery->execute();
-                if (!res.empty() && res.begin()->movable)
+                for (const auto& hit : res)
                 {
-                    Ogre::String boneName = SkeletonDebug::boneNameForMovable(
-                        res.begin()->movable);
-                    if (!boneName.empty())
-                    {
-                        AnimationControlController::instance()->selectBone(
-                            QString::fromStdString(boneName));
-                        SentryReporter::addBreadcrumb("ui.action",
-                            QString("Bone picked: %1").arg(QString::fromStdString(boneName)));
-                        return;
-                    }
+                    if (!hit.movable) continue;
+                    Ogre::String boneName = SkeletonDebug::boneNameForMovable(hit.movable);
+                    if (boneName.empty()) continue;
+                    AnimationControlController::instance()->selectBone(
+                        QString::fromStdString(boneName));
+                    SentryReporter::addBreadcrumb("ui.action",
+                        QString("Bone picked: %1").arg(QString::fromStdString(boneName)));
+                    return;
                 }
             }
 


### PR DESCRIPTION
## Summary
- Click a bone in the viewport (with skeleton overlay on) → it becomes the panel's selected bone.
- New \`BONE_QUERY_FLAGS\` keeps bone visuals out of the regular scene query.
- \`SkeletonDebug\` tags every bone-mesh / axes entity with the parent bone's name (UserAny) so a ray-pick can map a hit movable back to its bone.
- \`SkeletonDebug::boneNameForMovable()\` is the public helper.
- Tests cover the static helper (nullptr / untagged / tagged) and assert the BONE_QUERY_FLAGS mask is set.

This is slice 1 of #358 — laying the picking groundwork before the next slice anchors a gizmo on the selected bone and writes a \`BoneTransformCommand\`.

## Test plan
- [x] Local build clean (\`cmake --build build_local --target QtMeshEditor\`)
- [x] UnitTests target compiles all touched files cleanly
- [ ] CI: build-linux / build-macos / build-windows / unit-tests-linux / sonar
- [ ] Manual: load animated mesh, toggle skeleton overlay, click a bone visual, panel selection updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)