### PR TITLE
feat(animation): bone manipulation gizmo (#358 slice 2)

### DIFF
--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -11,6 +11,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QPalette>
+#include <QSet>
 #include <QTimer>
 #include <QVariantMap>
 #include <algorithm>
@@ -106,7 +107,7 @@ void AnimationControlController::updateAnimationTree()
     QString prevEntity = QString::fromStdString(m_selectedEntityName);
     QString prevAnim   = QString::fromStdString(m_selectedAnimation);
 
-    m_animationTree.clear();
+    QVariantList newTree;
     for (Ogre::Entity* entity : SelectionSet::getSingleton()->getResolvedEntities()) {
         Ogre::AnimationStateSet* set = entity->getAllAnimationStates();
         if (!set) continue;
@@ -120,8 +121,17 @@ void AnimationControlController::updateAnimationTree()
         QVariantMap group;
         group["entity"]     = QString::fromStdString(entity->getName());
         group["animations"] = animNames;
-        m_animationTree.append(group);
+        newTree.append(group);
     }
+
+    // Early-out when the tree hasn't actually changed: the connected
+    // signal (SelectionSet::selectionChanged) also fires whenever undo
+    // commands are pushed (mainwindow re-emits it on QUndoStack
+    // indexChanged). Without this guard, every BoneTransformCommand
+    // push would call selectAnimation() and reset slider+bone selection.
+    if (newTree == m_animationTree) return;
+
+    m_animationTree = newTree;
     emit animationTreeChanged();
 
     // Try to restore selection
@@ -223,9 +233,23 @@ void AnimationControlController::refreshBoneList()
         return;
     }
 
+    // Show every bone in the skeleton — not just the ones that already
+    // have a track in this animation. Tracks for picked-but-untracked
+    // bones get created lazily when the user adds a keyframe. Order:
+    // tracked bones first (so users see what's already animated at the
+    // top), then the rest in skeleton index order.
     Ogre::Animation* anim = m_selectedSkeleton->getAnimation(m_selectedAnimation);
-    for (const auto& pair : anim->_getNodeTrackList())
-        m_boneNames << QString::fromStdString(pair.second->getAssociatedNode()->getName());
+    QSet<QString> trackedNames;
+    for (const auto& pair : anim->_getNodeTrackList()) {
+        QString name = QString::fromStdString(pair.second->getAssociatedNode()->getName());
+        m_boneNames << name;
+        trackedNames.insert(name);
+    }
+    for (unsigned short i = 0; i < m_selectedSkeleton->getNumBones(); ++i) {
+        QString name = QString::fromStdString(m_selectedSkeleton->getBone(i)->getName());
+        if (!trackedNames.contains(name))
+            m_boneNames << name;
+    }
 
     emit boneListChanged();
 
@@ -235,6 +259,41 @@ void AnimationControlController::refreshBoneList()
         emit keyframeTicksChanged();
         emit currentKeyframeChanged();
     }
+}
+
+Ogre::Bone* AnimationControlController::selectedBonePtr() const
+{
+    if (!m_selectedSkeleton || m_selectedBone.empty()) return nullptr;
+    if (!m_selectedSkeleton->hasBone(m_selectedBone)) return nullptr;
+    return m_selectedSkeleton->getBone(m_selectedBone);
+}
+
+bool AnimationControlController::boneCanTranslate(const Ogre::Bone* bone) const
+{
+    if (!bone) return true;
+    // Root bone (no parent) → always translatable (this is what moves
+    // the character around the scene).
+    if (!bone->getParent()) return true;
+    if (!m_selectedEntity) return true;
+    Ogre::MeshPtr mesh = m_selectedEntity->getMesh();
+    if (!mesh) return true;
+
+    // Walk every submesh's vertex-bone-assignment list. If any vertex
+    // is weighted to this bone's handle, translating it would tear the
+    // mesh away from the rig.
+    const auto handle = bone->getHandle();
+    auto referencesBone = [&](const Ogre::SubMesh::VertexBoneAssignmentList& list) {
+        for (auto it = list.begin(); it != list.end(); ++it)
+            if (it->second.boneIndex == handle) return true;
+        return false;
+    };
+    if (referencesBone(mesh->getBoneAssignments())) return false;
+    for (unsigned short i = 0; i < mesh->getNumSubMeshes(); ++i) {
+        Ogre::SubMesh* sub = mesh->getSubMesh(i);
+        if (!sub) continue;
+        if (referencesBone(sub->getBoneAssignments())) return false;
+    }
+    return true;
 }
 
 void AnimationControlController::selectBone(const QString& boneName)
@@ -250,6 +309,20 @@ void AnimationControlController::selectBone(const QString& boneName)
                 .setUserAny("selected", Ogre::Any(false));
     }
 
+    // Highlight the picked bone first — independent of whether a track
+    // exists for it in the current animation. Bones that aren't yet
+    // rigged into the active clip (no NodeAnimationTrack) should still
+    // visually select; the keyframe-editing path then no-ops cleanly
+    // since m_selectedTrack stays null until the user actually adds a
+    // keyframe (which lazily creates the track).
+    if (m_selectedSkeleton && !m_selectedBone.empty()
+        && m_selectedSkeleton->hasBone(m_selectedBone))
+    {
+        m_selectedSkeleton->getBone(m_selectedBone)
+            ->getUserObjectBindings().setUserAny("selected", Ogre::Any(true));
+    }
+
+    // Bind the existing track for this bone, if the animation has one.
     if (m_selectedSkeleton && !m_selectedAnimation.empty()
         && m_selectedSkeleton->hasAnimation(m_selectedAnimation))
     {
@@ -257,8 +330,6 @@ void AnimationControlController::selectBone(const QString& boneName)
         for (const auto& pair : anim->_getNodeTrackList()) {
             if (pair.second->getAssociatedNode()->getName() == m_selectedBone) {
                 m_selectedTrack = pair.second;
-                m_selectedSkeleton->getBone(m_selectedBone)
-                    ->getUserObjectBindings().setUserAny("selected", Ogre::Any(true));
                 break;
             }
         }
@@ -360,7 +431,10 @@ void AnimationControlController::setAutoKey(bool on)
 void AnimationControlController::autoKeyOnTransform()
 {
     if (!m_autoKey) return;
-    if (!m_selectedTrack || !m_selectedEntity || m_selectedAnimation.empty()) return;
+    // Don't require m_selectedTrack here — addKeyframe lazily creates
+    // the track for non-rigged bones. Just ensure the bone-level
+    // identity is set so addKeyframe has something to write into.
+    if (!m_selectedEntity || m_selectedAnimation.empty()) return;
     if (!m_selectedSkeleton || m_selectedBone.empty()) return;
     SentryReporter::addBreadcrumb("ui.action", "AutoKey applied keyframe");
     addKeyframe();
@@ -514,9 +588,27 @@ void AnimationControlController::nextKeyframe()
 
 void AnimationControlController::addKeyframe()
 {
-    if (!m_selectedTrack || !m_selectedEntity || m_selectedAnimation.empty()) return;
+    if (!m_selectedEntity || m_selectedAnimation.empty()) return;
     if (!m_selectedSkeleton || m_selectedBone.empty()) return;
     if (!m_selectedSkeleton->hasBone(m_selectedBone)) return;
+    if (!m_selectedSkeleton->hasAnimation(m_selectedAnimation)) return;
+
+    // Lazily create an animation track for this bone if it doesn't have
+    // one yet (non-rigged bones, or bones the imported animation didn't
+    // touch). Without this, the user's edit would be a runtime-only
+    // pose that vanishes on export.
+    if (!m_selectedTrack) {
+        Ogre::Animation* anim = m_selectedSkeleton->getAnimation(m_selectedAnimation);
+        Ogre::Bone* bone = m_selectedSkeleton->getBone(m_selectedBone);
+        m_selectedTrack = anim->createNodeTrack(bone->getHandle(), bone);
+        // Re-include this bone in the bone-list and rebuild the panel
+        // so subsequent +KF / dope-sheet operations see the new track.
+        QString boneNameStr = QString::fromStdString(m_selectedBone);
+        if (!m_boneNames.contains(boneNameStr))
+            m_boneNames << boneNameStr;
+        emit boneListChanged();
+    }
+    if (!m_selectedTrack) return;
 
     const float time = m_sliderValue / 1000.0f;
     // Reuse a keyframe at the same time if one already exists — the rest of

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -124,14 +124,17 @@ void AnimationControlController::updateAnimationTree()
         newTree.append(group);
     }
 
-    // Early-out when the tree hasn't actually changed: the connected
-    // signal (SelectionSet::selectionChanged) also fires whenever undo
-    // commands are pushed (mainwindow re-emits it on QUndoStack
-    // indexChanged). Without this guard, every BoneTransformCommand
-    // push would call selectAnimation() and reset slider+bone selection.
-    if (newTree == m_animationTree) return;
+    // Early-out when the tree hasn't actually changed AFTER it's been
+    // built once: the connected signal (SelectionSet::selectionChanged)
+    // also fires whenever undo commands are pushed (mainwindow re-emits
+    // it on QUndoStack indexChanged). Without this guard, every
+    // BoneTransformCommand push would call selectAnimation() and reset
+    // slider+bone selection. We always run the first call so QML
+    // listeners get an initial signal, even if the tree is empty.
+    if (m_animationTreeBuilt && newTree == m_animationTree) return;
 
     m_animationTree = newTree;
+    m_animationTreeBuilt = true;
     emit animationTreeChanged();
 
     // Try to restore selection

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -271,9 +271,16 @@ Ogre::Bone* AnimationControlController::selectedBonePtr() const
 bool AnimationControlController::boneCanTranslate(const Ogre::Bone* bone) const
 {
     if (!bone) return true;
-    // Root bone (no parent) → always translatable (this is what moves
-    // the character around the scene).
+    // Skeleton roots → always translatable (these are the "this is the
+    // character" bones that move the whole rig around — Hips, Pelvis,
+    // Armature, etc. — and may also have skin weights). Some importers
+    // wrap the actual root in an additional parent bone, so we check
+    // both: parentless OR present in Skeleton::getRootBones().
     if (!bone->getParent()) return true;
+    if (m_selectedSkeleton) {
+        for (Ogre::Bone* root : m_selectedSkeleton->getRootBones())
+            if (root == bone) return true;
+    }
     if (!m_selectedEntity) return true;
     Ogre::MeshPtr mesh = m_selectedEntity->getMesh();
     if (!mesh) return true;

--- a/src/AnimationControlController.h
+++ b/src/AnimationControlController.h
@@ -10,6 +10,7 @@
 #include <string>
 
 namespace Ogre {
+    class Bone;
     class Entity;
     class NodeAnimationTrack;
     class SkeletonInstance;
@@ -97,6 +98,19 @@ public:
     // Bone list
     QStringList boneNames()   const { return m_boneNames; }
     QString     selectedBone() const { return QString::fromStdString(m_selectedBone); }
+
+    // Non-QML accessors used by TransformOperator's bone-gizmo path.
+    // Both return nullptr when no animated entity is selected.
+    Ogre::Entity* selectedEntity() const { return m_selectedEntity; }
+    Ogre::Bone*   selectedBonePtr() const;
+
+    /// Whether translation of the given bone is "safe" — true for the
+    /// skeleton root (locomotion) and for non-rigged bones (attachment
+    /// points like swords/shields/hats), false for any non-root bone
+    /// whose handle appears in the mesh's vertex bone assignments
+    /// (translating those breaks the rig). Returns true when bone is
+    /// null or the entity has no mesh, since we can't disprove safety.
+    bool boneCanTranslate(const Ogre::Bone* bone) const;
 
     // Timeline
     int    sliderValue()     const { return m_sliderValue; }

--- a/src/AnimationControlController.h
+++ b/src/AnimationControlController.h
@@ -280,6 +280,7 @@ private:
     int    m_selectedTick  = -1;
 
     QVariantList m_animationTree;
+    bool         m_animationTreeBuilt = false; ///< true after first updateAnimationTree
     QStringList  m_boneNames;
     QVariantList m_keyframeTicks;
 

--- a/src/AnimationControlController_test.cpp
+++ b/src/AnimationControlController_test.cpp
@@ -1157,3 +1157,67 @@ TEST_F(AnimationControlControllerTest, PasteSkipsCollisions) {
     const int n = ctrl->pasteKeyframesAt(json, 0.0);
     EXPECT_EQ(n, 0);
 }
+
+// ── boneCanTranslate ──────────────────────────────────────────────────────────
+//
+// Translation is restricted by the gizmo's press handler so users can't tear
+// rigged bones away from their parent (which would produce broken poses on
+// playback). The rules: skeleton roots are always translatable (locomotion
+// bones), and unrigged bones — typical "attachment point" sockets for
+// swords / shields / hats — are also translatable since they don't deform
+// any geometry.
+
+TEST_F(AnimationControlControllerTest, BoneCanTranslateNullBoneIsSafe) {
+    auto* ctrl = AnimationControlController::instance();
+    EXPECT_TRUE(ctrl->boneCanTranslate(nullptr));
+}
+
+TEST_F(AnimationControlControllerTest, BoneCanTranslateRootBoneAllowed) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("ACC_BCT_Root");
+    ASSERT_NE(entity, nullptr);
+
+    auto* ctrl = AnimationControlController::instance();
+    ctrl->updateAnimationTree();
+    ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+
+    Ogre::Bone* root = entity->getSkeleton()->getBone("Root");
+    ASSERT_FALSE(root->getParent());
+    EXPECT_TRUE(ctrl->boneCanTranslate(root));
+}
+
+TEST_F(AnimationControlControllerTest, BoneCanTranslateRiggedNonRootBlocked) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("ACC_BCT_Rigged");
+    ASSERT_NE(entity, nullptr);
+
+    auto* ctrl = AnimationControlController::instance();
+    ctrl->updateAnimationTree();
+    ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+
+    // "Child" is rigged — every vertex of the test mesh weights to it.
+    Ogre::Bone* child = entity->getSkeleton()->getBone("Child");
+    ASSERT_TRUE(child->getParent());
+    EXPECT_FALSE(ctrl->boneCanTranslate(child));
+}
+
+TEST_F(AnimationControlControllerTest, BoneCanTranslateUnriggedNonRootAllowed) {
+    // Add a third bone to the test skeleton with no vertex weights — this
+    // simulates an attachment point (sword/shield/hat). Translation must
+    // be allowed since moving it doesn't deform any geometry.
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("ACC_BCT_Attach");
+    ASSERT_NE(entity, nullptr);
+
+    auto* skel = entity->getSkeleton();
+    Ogre::Bone* attach = skel->createBone("AttachPoint", 2);
+    attach->setPosition(Ogre::Vector3(0, 1, 0.5f));
+    skel->getBone("Child")->addChild(attach);
+
+    auto* ctrl = AnimationControlController::instance();
+    ctrl->updateAnimationTree();
+    ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+
+    ASSERT_TRUE(attach->getParent());
+    EXPECT_TRUE(ctrl->boneCanTranslate(attach));
+}

--- a/src/AnimationWidget.cpp
+++ b/src/AnimationWidget.cpp
@@ -101,6 +101,13 @@ bool AnimationWidget::toggleSkeletonDebug(Ogre::Entity* entity, bool show)
         sd->showAxes(false);
         sd->showNames(false);
         mShowSkeleton.remove(entity);
+        // QMap of raw pointers doesn't own — delete explicitly. Without
+        // this, the SkeletonDebug + its QTimer (which fires every tick
+        // touching mBoneEntities) leaks. On the next enable, a *new*
+        // SkeletonDebug attaches new visuals, the leaked one's timer
+        // races with the new attachments via attachObjectToBone, and
+        // touches dangling Ogre::Entity pointers → SIGSEGV at 0xf8.
+        delete sd; // NOSONAR — manual delete needed since QMap doesn't own
     }
     else if (show && mWeightOverlays.contains(entity))
     {

--- a/src/BoneDragRelease.cpp
+++ b/src/BoneDragRelease.cpp
@@ -3,6 +3,27 @@
 #include <OgreBone.h>
 #include <OgreEntity.h>
 
+#include <cmath>
+
+namespace {
+// Drag accumulates float noise via projection / parent-frame conversions;
+// 1e-5 keeps us well below user-perceivable motion while filtering bit-
+// level drift that would otherwise produce stray Commit/CommitBind on
+// press/release with no real motion.
+constexpr float kPosEpsilon   = 1e-5f;
+constexpr float kScaleEpsilon = 1e-5f;
+constexpr float kQuatDotEps   = 1e-6f;
+
+bool nearlyEqual(const Ogre::Vector3& a, const Ogre::Vector3& b, float eps) {
+    return (a - b).squaredLength() <= eps * eps;
+}
+bool nearlyEqual(const Ogre::Quaternion& a, const Ogre::Quaternion& b, float eps) {
+    // 1 - |dot| ≈ 0 when quats represent the same rotation (handles
+    // sign flip with the absolute value).
+    return (1.0f - std::fabs(a.Dot(b))) <= eps;
+}
+}
+
 BoneDragRelease::Result BoneDragRelease::apply(Ogre::Bone* bone,
                                                const Ogre::Vector3& beforePos,
                                                const Ogre::Quaternion& beforeOrient,
@@ -13,9 +34,12 @@ BoneDragRelease::Result BoneDragRelease::apply(Ogre::Bone* bone,
 {
     if (!bone) return Result::NoOp;
 
-    const bool changed = (bone->getPosition()    != beforePos)
-                      || (bone->getOrientation() != beforeOrient)
-                      || (bone->getScale()       != beforeScale);
+    // Tolerant comparison — drag math can accumulate sub-microsecond
+    // float noise that would otherwise mis-fire Commit on a press/
+    // release with no intended motion.
+    const bool changed = !nearlyEqual(bone->getPosition(),    beforePos,    kPosEpsilon)
+                      || !nearlyEqual(bone->getOrientation(), beforeOrient, kQuatDotEps)
+                      || !nearlyEqual(bone->getScale(),       beforeScale,  kScaleEpsilon);
     if (!changed) {
         // Even "no change" should release manual control if it was set
         // during the (zero-delta) drag.

--- a/src/BoneDragRelease.cpp
+++ b/src/BoneDragRelease.cpp
@@ -23,30 +23,24 @@ BoneDragRelease::Result BoneDragRelease::apply(Ogre::Bone* bone,
         return Result::NoOp;
     }
 
-    if (autoKeyOn && hasActiveAnim) {
+    if (autoKeyOn) {
         // Caller writes the keyframe (via AnimationControlController) and
         // pushes BoneTransformCommand. We just unfreeze the bone so the
         // curve drives playback through the new key.
         bone->setManuallyControlled(false);
+        (void)hasActiveAnim;
+        (void)entityForUpdate;
+        (void)beforePos; (void)beforeOrient; (void)beforeScale;
         return Result::Commit;
     }
 
-    if (hasActiveAnim) {
-        // Preview only: revert bone to its pre-drag local TRS so playback
-        // is unaffected. Don't call setInitialState — the curve stores
-        // deltas relative to initial; changing initial would double-apply
-        // the curve delta on next sample.
-        bone->setPosition(beforePos);
-        bone->setOrientation(beforeOrient);
-        bone->setScale(beforeScale);
-        bone->setManuallyControlled(false);
-        bone->needUpdate(true);
-        if (entityForUpdate) entityForUpdate->_updateAnimation();
-        return Result::Revert;
-    }
-
-    // No active animation: T-pose / bind-pose authoring. The dragged
-    // local TRS becomes the new bind pose.
+    // Auto-key OFF: commit to the bind pose. The dragged local TRS
+    // becomes the new initial state for this bone. Skeleton::reset()
+    // restores bones to their per-instance initial state on every
+    // _updateAnimation call, so the edit persists even after toggling
+    // animation states on/off. Animation tracks add their stored
+    // keyframe deltas on top of the new bind, so the whole animation
+    // just gets offset by the user's edit (predictable behavior).
     bone->setInitialState();
     bone->setManuallyControlled(false);
     return Result::CommitBind;

--- a/src/BoneDragRelease.cpp
+++ b/src/BoneDragRelease.cpp
@@ -1,0 +1,53 @@
+#include "BoneDragRelease.h"
+
+#include <OgreBone.h>
+#include <OgreEntity.h>
+
+BoneDragRelease::Result BoneDragRelease::apply(Ogre::Bone* bone,
+                                               const Ogre::Vector3& beforePos,
+                                               const Ogre::Quaternion& beforeOrient,
+                                               const Ogre::Vector3& beforeScale,
+                                               bool hasActiveAnim,
+                                               bool autoKeyOn,
+                                               Ogre::Entity* entityForUpdate)
+{
+    if (!bone) return Result::NoOp;
+
+    const bool changed = (bone->getPosition()    != beforePos)
+                      || (bone->getOrientation() != beforeOrient)
+                      || (bone->getScale()       != beforeScale);
+    if (!changed) {
+        // Even "no change" should release manual control if it was set
+        // during the (zero-delta) drag.
+        bone->setManuallyControlled(false);
+        return Result::NoOp;
+    }
+
+    if (autoKeyOn && hasActiveAnim) {
+        // Caller writes the keyframe (via AnimationControlController) and
+        // pushes BoneTransformCommand. We just unfreeze the bone so the
+        // curve drives playback through the new key.
+        bone->setManuallyControlled(false);
+        return Result::Commit;
+    }
+
+    if (hasActiveAnim) {
+        // Preview only: revert bone to its pre-drag local TRS so playback
+        // is unaffected. Don't call setInitialState — the curve stores
+        // deltas relative to initial; changing initial would double-apply
+        // the curve delta on next sample.
+        bone->setPosition(beforePos);
+        bone->setOrientation(beforeOrient);
+        bone->setScale(beforeScale);
+        bone->setManuallyControlled(false);
+        bone->needUpdate(true);
+        if (entityForUpdate) entityForUpdate->_updateAnimation();
+        return Result::Revert;
+    }
+
+    // No active animation: T-pose / bind-pose authoring. The dragged
+    // local TRS becomes the new bind pose.
+    bone->setInitialState();
+    bone->setManuallyControlled(false);
+    return Result::CommitBind;
+}

--- a/src/BoneDragRelease.cpp
+++ b/src/BoneDragRelease.cpp
@@ -23,24 +23,30 @@ BoneDragRelease::Result BoneDragRelease::apply(Ogre::Bone* bone,
         return Result::NoOp;
     }
 
-    if (autoKeyOn) {
+    if (autoKeyOn && hasActiveAnim) {
         // Caller writes the keyframe (via AnimationControlController) and
         // pushes BoneTransformCommand. We just unfreeze the bone so the
         // curve drives playback through the new key.
         bone->setManuallyControlled(false);
-        (void)hasActiveAnim;
-        (void)entityForUpdate;
-        (void)beforePos; (void)beforeOrient; (void)beforeScale;
         return Result::Commit;
     }
 
-    // Auto-key OFF: commit to the bind pose. The dragged local TRS
-    // becomes the new initial state for this bone. Skeleton::reset()
-    // restores bones to their per-instance initial state on every
-    // _updateAnimation call, so the edit persists even after toggling
-    // animation states on/off. Animation tracks add their stored
-    // keyframe deltas on top of the new bind, so the whole animation
-    // just gets offset by the user's edit (predictable behavior).
+    if (hasActiveAnim) {
+        // Preview only: revert bone to its pre-drag local TRS so playback
+        // is unaffected. Don't call setInitialState — the curve stores
+        // deltas relative to initial; changing initial would double-apply
+        // the curve delta on next sample.
+        bone->setPosition(beforePos);
+        bone->setOrientation(beforeOrient);
+        bone->setScale(beforeScale);
+        bone->setManuallyControlled(false);
+        bone->needUpdate(true);
+        if (entityForUpdate) entityForUpdate->_updateAnimation();
+        return Result::Revert;
+    }
+
+    // No active animation: T-pose / bind-pose authoring. The dragged
+    // local TRS becomes the new bind pose.
     bone->setInitialState();
     bone->setManuallyControlled(false);
     return Result::CommitBind;

--- a/src/BoneDragRelease.h
+++ b/src/BoneDragRelease.h
@@ -1,0 +1,59 @@
+#ifndef BONE_DRAG_RELEASE_H
+#define BONE_DRAG_RELEASE_H
+
+#include <OgreVector3.h>
+#include <OgreQuaternion.h>
+#include <string>
+
+namespace Ogre {
+    class Bone;
+    class Entity;
+    class SkeletonInstance;
+}
+class QUndoCommand;
+
+/// Pure-data helper that decides what to do with a bone at the end of a
+/// gizmo drag, based on (auto-key on/off, animation selected/not, bone
+/// changed/not). Extracted from TransformOperator::mouseReleaseEvent so
+/// the rules are testable in isolation — without an OgreWidget, mouse
+/// event, or QApplication.
+///
+/// Three cases:
+/// 1. Animation active + auto-key ON + changed
+///      → keep dragged TRS, release manualControlled (curve drives playback
+///        through the new key written by callback). Returns Result::Commit.
+///        Caller is responsible for writing the keyframe (via
+///        AnimationControlController::autoKeyOnTransform) and pushing the
+///        BoneTransformCommand.
+/// 2. Animation active + auto-key OFF + changed
+///      → revert bone to before-state. Returns Result::Revert. Caller does
+///        not push undo (no commit).
+/// 3. No active animation + changed
+///      → setInitialState (commits new bind pose). Returns Result::CommitBind.
+///        Caller pushes BoneTransformCommand for undo.
+///
+/// "No change" returns Result::NoOp.
+class BoneDragRelease {
+public:
+    enum class Result {
+        NoOp,          ///< Bone TRS is unchanged from before-state
+        Commit,        ///< Animation + auto-key on: caller writes keyframe
+        Revert,        ///< Animation + auto-key off: bone reverted in-place
+        CommitBind,    ///< No animation: bone's initial state updated
+    };
+
+    /// Apply the release-path rules to `bone`. The bone's current local TRS
+    /// is treated as the after-state; `before*` describe what the bone was
+    /// before the drag started.
+    /// @param hasActiveAnim true when an animation is selected in the panel
+    /// @param autoKeyOn     true when auto-key toggle is on
+    static Result apply(Ogre::Bone* bone,
+                        const Ogre::Vector3& beforePos,
+                        const Ogre::Quaternion& beforeOrient,
+                        const Ogre::Vector3& beforeScale,
+                        bool hasActiveAnim,
+                        bool autoKeyOn,
+                        Ogre::Entity* entityForUpdate = nullptr);
+};
+
+#endif // BONE_DRAG_RELEASE_H

--- a/src/BoneDragRelease_test.cpp
+++ b/src/BoneDragRelease_test.cpp
@@ -54,53 +54,59 @@ TEST_F(BoneDragReleaseTest, NoChangeIsNoOp) {
     EXPECT_EQ(outcome, BoneDragRelease::Result::NoOp);
 }
 
-TEST_F(BoneDragReleaseTest, AutoKeyOffWithAnimReverts) {
-    // Drag with auto-key OFF + animation active: the bone must revert
-    // to its pre-drag local TRS. Without revert, accumulated drag
-    // offsets pile up across drags ("if I moved it down before, it
-    // goes further down on my second attempt").
-    Ogre::Entity* entity = createAnimatedTestEntity("BDR_RevertOnce");
+TEST_F(BoneDragReleaseTest, AutoKeyOffCommitsToBindPose) {
+    // Auto-key OFF: dragged pose becomes the new bind. After release,
+    // bone->getPosition() == dragged pose AND bone->getInitialPosition()
+    // also == dragged pose (so Skeleton::reset restores to the new bind).
+    Ogre::Entity* entity = createAnimatedTestEntity("BDR_BindCommit");
     ASSERT_NE(entity, nullptr);
     Ogre::Bone* bone = entity->getSkeleton()->getBone("Child");
 
     const Ogre::Vector3 before = bone->getPosition();
-    simulateBoneDrag(bone, before + Ogre::Vector3(0.5f, -0.3f, 0.0f));
+    const Ogre::Vector3 dragged = before + Ogre::Vector3(0.5f, -0.3f, 0.0f);
+    simulateBoneDrag(bone, dragged);
 
     auto outcome = BoneDragRelease::apply(bone, before, bone->getInitialOrientation(),
                                           bone->getInitialScale(),
                                           /*hasAnim=*/true, /*autoKey=*/false,
                                           entity);
-    EXPECT_EQ(outcome, BoneDragRelease::Result::Revert);
-    EXPECT_EQ(bone->getPosition(), before);
+    EXPECT_EQ(outcome, BoneDragRelease::Result::CommitBind);
+    EXPECT_EQ(bone->getPosition(), dragged);
+    EXPECT_EQ(bone->getInitialPosition(), dragged);
+
+    // Reset (what Skeleton::reset does) must land at the new bind.
+    bone->setPosition(Ogre::Vector3::ZERO);
+    bone->resetToInitialState();
+    EXPECT_EQ(bone->getPosition(), dragged) << "New bind pose did not survive reset";
 }
 
-TEST_F(BoneDragReleaseTest, AutoKeyOffTwoDragsDoNotAccumulate) {
-    // Critical regression test for the user-reported "down before going
-    // right" teleport. Two consecutive drags with auto-key off must
-    // each leave the bone at its pre-drag pose — the second drag's
-    // before-state must be the SAME as the first drag's before-state,
-    // not the first drag's accumulated offset.
-    Ogre::Entity* entity = createAnimatedTestEntity("BDR_TwoDrags");
+TEST_F(BoneDragReleaseTest, AutoKeyOffTwoDragsAccumulateAsBindUpdates) {
+    // Two consecutive drags with auto-key off → each commits to bind.
+    // Drag 2's pose should be exactly what was set, not relative to
+    // any prior offset (the BlendMask muting in TransformOperator
+    // ensures the bone's local at drag-2 press equals drag-1's commit).
+    Ogre::Entity* entity = createAnimatedTestEntity("BDR_TwoBindUpdates");
     ASSERT_NE(entity, nullptr);
     Ogre::Bone* bone = entity->getSkeleton()->getBone("Child");
 
     const Ogre::Vector3 origLocal = bone->getPosition();
 
-    // Drag 1: move +Y by 0.5
     simulateBoneDrag(bone, origLocal + Ogre::Vector3(0, 0.5f, 0));
     BoneDragRelease::apply(bone, origLocal, bone->getInitialOrientation(),
                            bone->getInitialScale(),
                            /*hasAnim=*/true, /*autoKey=*/false, entity);
     const Ogre::Vector3 afterDrag1 = bone->getPosition();
-    EXPECT_EQ(afterDrag1, origLocal) << "Drag 1 did not revert";
+    EXPECT_EQ(afterDrag1, origLocal + Ogre::Vector3(0, 0.5f, 0));
+    EXPECT_EQ(bone->getInitialPosition(), afterDrag1);
 
-    // Drag 2: move +X by 0.5
-    simulateBoneDrag(bone, origLocal + Ogre::Vector3(0.5f, 0, 0));
-    BoneDragRelease::apply(bone, origLocal, bone->getInitialOrientation(),
+    // Drag 2 starts from afterDrag1 (which is the new bind).
+    const Ogre::Vector3 drag2Target = afterDrag1 + Ogre::Vector3(0.3f, 0, 0);
+    simulateBoneDrag(bone, drag2Target);
+    BoneDragRelease::apply(bone, afterDrag1, bone->getInitialOrientation(),
                            bone->getInitialScale(),
                            /*hasAnim=*/true, /*autoKey=*/false, entity);
-    const Ogre::Vector3 afterDrag2 = bone->getPosition();
-    EXPECT_EQ(afterDrag2, origLocal) << "Drag 2 did not revert (accumulation bug)";
+    EXPECT_EQ(bone->getPosition(), drag2Target);
+    EXPECT_EQ(bone->getInitialPosition(), drag2Target);
 }
 
 TEST_F(BoneDragReleaseTest, AutoKeyOnWithAnimKeepsDraggedPose) {
@@ -128,86 +134,28 @@ TEST_F(BoneDragReleaseTest, AutoKeyOnWithAnimKeepsDraggedPose) {
 // going right." Simulates that exact sequence at the helper level.
 // Without revert, the accumulated Y delta from drag 1 would leak into
 // drag 2's before-state, and the bone would re-show the Y offset.
-TEST_F(BoneDragReleaseTest, YThenXDragsDoNotLeakYIntoX) {
-    Ogre::Entity* entity = createAnimatedTestEntity("BDR_YThenX");
+// The user-reported regression: edit T-pose bone, enable animation,
+// disable animation, expect bone to remain at the edited T-pose. The
+// bone's initial state must reflect the edit so Skeleton::reset (called
+// when animations are toggled or applied) restores the new bind, not
+// the original.
+TEST_F(BoneDragReleaseTest, BindEditSurvivesAnimationToggle) {
+    Ogre::Entity* entity = createAnimatedTestEntity("BDR_BindSurvivesToggle");
     ASSERT_NE(entity, nullptr);
     Ogre::Bone* bone = entity->getSkeleton()->getBone("Child");
 
     const Ogre::Vector3 origLocal = bone->getPosition();
-    const Ogre::Vector3 origDerived = bone->_getDerivedPosition();
-
-    // Drag 1: Y axis down.
-    bone->setManuallyControlled(true);
-    bone->_setDerivedPosition(origDerived + Ogre::Vector3(0, -0.7f, 0));
+    const Ogre::Vector3 dragged = origLocal + Ogre::Vector3(0.5f, 0, 0);
+    simulateBoneDrag(bone, dragged);
     BoneDragRelease::apply(bone, origLocal, bone->getInitialOrientation(),
                            bone->getInitialScale(),
                            /*hasAnim=*/true, /*autoKey=*/false, entity);
-    EXPECT_EQ(bone->getPosition(), origLocal);
-    EXPECT_EQ(bone->_getDerivedPosition(), origDerived);
+    EXPECT_EQ(bone->getInitialPosition(), dragged);
 
-    // Drag 2: X axis right. The bone must start fresh from origLocal,
-    // not from any leaked Y offset.
-    const Ogre::Vector3 drag2Before = bone->getPosition();
-    EXPECT_EQ(drag2Before, origLocal);
-
-    bone->setManuallyControlled(true);
-    bone->_setDerivedPosition(origDerived + Ogre::Vector3(0.7f, 0, 0));
-    BoneDragRelease::apply(bone, drag2Before, bone->getInitialOrientation(),
-                           bone->getInitialScale(),
-                           /*hasAnim=*/true, /*autoKey=*/false, entity);
-    // Final state: same origLocal (revert), no leaked Y.
-    EXPECT_EQ(bone->getPosition(), origLocal);
-    EXPECT_EQ(bone->_getDerivedPosition().y, origDerived.y) << "Y leaked from previous drag";
-}
-
-// The critical regression test: simulate the actual TransformOperator
-// flow using _setDerivedPosition (not just setPosition), with parent
-// state matching the user's "head bone with rotated parent" case, and
-// assert that two consecutive drags don't accumulate when reverted.
-TEST_F(BoneDragReleaseTest, SetDerivedPositionDragRevertsCleanly) {
-    Ogre::Entity* entity = createAnimatedTestEntity("BDR_SetDerivedTwoDrags");
-    ASSERT_NE(entity, nullptr);
-
-    // Use the child bone (parent = root). Apply a non-identity rotation
-    // to the root bone so _setDerivedPosition has to do real parent-frame
-    // math — matches the "head bone with rotated parent mid-animation"
-    // scenario where the bug shows up.
-    Ogre::Bone* root = entity->getSkeleton()->getBone("Root");
-    Ogre::Bone* child = entity->getSkeleton()->getBone("Child");
-    root->setOrientation(Ogre::Quaternion(Ogre::Radian(0.5f), Ogre::Vector3::UNIT_Y));
-    root->setManuallyControlled(true);
-
-    const Ogre::Vector3 origLocal = child->getPosition();
-    const Ogre::Vector3 origDerived = child->_getDerivedPosition();
-
-    // Drag 1: move derived +Y by 0.5 in world space.
-    child->setManuallyControlled(true);
-    child->_setDerivedPosition(origDerived + Ogre::Vector3(0, 0.5f, 0));
-    child->needUpdate(true);
-    // Local Y has changed (non-trivially) because of parent rotation.
-    EXPECT_NE(child->getPosition(), origLocal);
-
-    auto outcome1 = BoneDragRelease::apply(child, origLocal, child->getInitialOrientation(),
-                                          child->getInitialScale(),
-                                          /*hasAnim=*/true, /*autoKey=*/false, entity);
-    EXPECT_EQ(outcome1, BoneDragRelease::Result::Revert);
-    EXPECT_EQ(child->getPosition(), origLocal) << "Drag 1 revert failed";
-
-    // Drag 2 press: capture new before-state (which should equal origLocal).
-    const Ogre::Vector3 drag2Local  = child->getPosition();
-    EXPECT_EQ(drag2Local, origLocal) << "After drag 1 revert, child has shifted (accumulation)";
-
-    // Drag 2: move derived +X by 0.5
-    const Ogre::Vector3 drag2Derived = child->_getDerivedPosition();
-    child->setManuallyControlled(true);
-    child->_setDerivedPosition(drag2Derived + Ogre::Vector3(0.5f, 0, 0));
-    child->needUpdate(true);
-
-    auto outcome2 = BoneDragRelease::apply(child, drag2Local, child->getInitialOrientation(),
-                                          child->getInitialScale(),
-                                          /*hasAnim=*/true, /*autoKey=*/false, entity);
-    EXPECT_EQ(outcome2, BoneDragRelease::Result::Revert);
-    EXPECT_EQ(child->getPosition(), origLocal) << "Drag 2 revert failed (accumulation across drags)";
+    // Simulate "animation toggled off" → Skeleton::reset → bone back
+    // to its initial state. Our edit must survive.
+    entity->getSkeleton()->reset();
+    EXPECT_EQ(bone->getPosition(), dragged) << "Bind edit was lost on Skeleton::reset";
 }
 
 TEST_F(BoneDragReleaseTest, NoAnimSetsInitial) {

--- a/src/BoneDragRelease_test.cpp
+++ b/src/BoneDragRelease_test.cpp
@@ -1,0 +1,147 @@
+#include <gtest/gtest.h>
+#include <QApplication>
+#include <QCoreApplication>
+#include <QThread>
+
+#include "BoneDragRelease.h"
+#include "Manager.h"
+#include "TestHelpers.h"
+
+#include <OgreSkeletonInstance.h>
+#include <OgreBone.h>
+#include <OgreEntity.h>
+#include <OgreAnimation.h>
+#include <OgreAnimationState.h>
+#include <OgreKeyFrame.h>
+
+class BoneDragReleaseTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        Manager::kill();
+        QThread::msleep(20);
+        app = qobject_cast<QApplication*>(QCoreApplication::instance());
+        ASSERT_NE(app, nullptr);
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+        createStandardOgreMaterials();
+        ASSERT_TRUE(canLoadMeshFiles());
+    }
+    void TearDown() override {
+        Manager::kill();
+        if (app) app->processEvents();
+        QThread::msleep(20);
+    }
+    QApplication* app = nullptr;
+};
+
+// Simulate what TransformOperator does during a drag: set the bone's local
+// position to a target. The release helper observes the diff against
+// before-state and decides what to do.
+static void simulateBoneDrag(Ogre::Bone* bone, const Ogre::Vector3& newLocal) {
+    bone->setManuallyControlled(true);
+    bone->setPosition(newLocal);
+    bone->needUpdate(true);
+}
+
+TEST_F(BoneDragReleaseTest, NoChangeIsNoOp) {
+    Ogre::Entity* entity = createAnimatedTestEntity("BDR_NoChange");
+    ASSERT_NE(entity, nullptr);
+    Ogre::Bone* bone = entity->getSkeleton()->getBone("Child");
+
+    Ogre::Vector3 before = bone->getPosition();
+    auto outcome = BoneDragRelease::apply(bone, before, bone->getOrientation(),
+                                          bone->getScale(),
+                                          /*hasAnim=*/true, /*autoKey=*/false);
+    EXPECT_EQ(outcome, BoneDragRelease::Result::NoOp);
+}
+
+TEST_F(BoneDragReleaseTest, AutoKeyOffWithAnimReverts) {
+    // Drag with auto-key OFF + animation active: the bone must revert
+    // to its pre-drag local TRS. Without revert, accumulated drag
+    // offsets pile up across drags ("if I moved it down before, it
+    // goes further down on my second attempt").
+    Ogre::Entity* entity = createAnimatedTestEntity("BDR_RevertOnce");
+    ASSERT_NE(entity, nullptr);
+    Ogre::Bone* bone = entity->getSkeleton()->getBone("Child");
+
+    const Ogre::Vector3 before = bone->getPosition();
+    simulateBoneDrag(bone, before + Ogre::Vector3(0.5f, -0.3f, 0.0f));
+
+    auto outcome = BoneDragRelease::apply(bone, before, bone->getInitialOrientation(),
+                                          bone->getInitialScale(),
+                                          /*hasAnim=*/true, /*autoKey=*/false,
+                                          entity);
+    EXPECT_EQ(outcome, BoneDragRelease::Result::Revert);
+    EXPECT_EQ(bone->getPosition(), before);
+}
+
+TEST_F(BoneDragReleaseTest, AutoKeyOffTwoDragsDoNotAccumulate) {
+    // Critical regression test for the user-reported "down before going
+    // right" teleport. Two consecutive drags with auto-key off must
+    // each leave the bone at its pre-drag pose — the second drag's
+    // before-state must be the SAME as the first drag's before-state,
+    // not the first drag's accumulated offset.
+    Ogre::Entity* entity = createAnimatedTestEntity("BDR_TwoDrags");
+    ASSERT_NE(entity, nullptr);
+    Ogre::Bone* bone = entity->getSkeleton()->getBone("Child");
+
+    const Ogre::Vector3 origLocal = bone->getPosition();
+
+    // Drag 1: move +Y by 0.5
+    simulateBoneDrag(bone, origLocal + Ogre::Vector3(0, 0.5f, 0));
+    BoneDragRelease::apply(bone, origLocal, bone->getInitialOrientation(),
+                           bone->getInitialScale(),
+                           /*hasAnim=*/true, /*autoKey=*/false, entity);
+    const Ogre::Vector3 afterDrag1 = bone->getPosition();
+    EXPECT_EQ(afterDrag1, origLocal) << "Drag 1 did not revert";
+
+    // Drag 2: move +X by 0.5
+    simulateBoneDrag(bone, origLocal + Ogre::Vector3(0.5f, 0, 0));
+    BoneDragRelease::apply(bone, origLocal, bone->getInitialOrientation(),
+                           bone->getInitialScale(),
+                           /*hasAnim=*/true, /*autoKey=*/false, entity);
+    const Ogre::Vector3 afterDrag2 = bone->getPosition();
+    EXPECT_EQ(afterDrag2, origLocal) << "Drag 2 did not revert (accumulation bug)";
+}
+
+TEST_F(BoneDragReleaseTest, AutoKeyOnWithAnimKeepsDraggedPose) {
+    // Auto-key ON + animation: the dragged TRS must persist (the caller
+    // is expected to write a keyframe at the slider time). Manual
+    // control must be released so playback drives the bone through
+    // the new key.
+    Ogre::Entity* entity = createAnimatedTestEntity("BDR_KeepAutoKey");
+    ASSERT_NE(entity, nullptr);
+    Ogre::Bone* bone = entity->getSkeleton()->getBone("Child");
+
+    const Ogre::Vector3 before = bone->getPosition();
+    const Ogre::Vector3 after  = before + Ogre::Vector3(0.5f, 0, 0);
+    simulateBoneDrag(bone, after);
+    auto outcome = BoneDragRelease::apply(bone, before, bone->getInitialOrientation(),
+                                          bone->getInitialScale(),
+                                          /*hasAnim=*/true, /*autoKey=*/true,
+                                          entity);
+    EXPECT_EQ(outcome, BoneDragRelease::Result::Commit);
+    EXPECT_EQ(bone->getPosition(), after);
+    EXPECT_FALSE(bone->isManuallyControlled());
+}
+
+TEST_F(BoneDragReleaseTest, NoAnimSetsInitial) {
+    // No active animation: drag commits to bind pose via setInitialState.
+    // Subsequent reset would land at the new bind pose — confirm by
+    // calling resetToInitialState afterwards.
+    Ogre::Entity* entity = createAnimatedTestEntity("BDR_BindPose");
+    ASSERT_NE(entity, nullptr);
+    Ogre::Bone* bone = entity->getSkeleton()->getBone("Child");
+
+    const Ogre::Vector3 before = bone->getPosition();
+    const Ogre::Vector3 after  = before + Ogre::Vector3(0.5f, 0, 0);
+    simulateBoneDrag(bone, after);
+    auto outcome = BoneDragRelease::apply(bone, before, bone->getInitialOrientation(),
+                                          bone->getInitialScale(),
+                                          /*hasAnim=*/false, /*autoKey=*/false);
+    EXPECT_EQ(outcome, BoneDragRelease::Result::CommitBind);
+    EXPECT_EQ(bone->getPosition(), after);
+    // Reset to initial — should land back at `after` since we just rebound.
+    bone->setPosition(Ogre::Vector3::ZERO);
+    bone->resetToInitialState();
+    EXPECT_EQ(bone->getPosition(), after);
+}

--- a/src/BoneDragRelease_test.cpp
+++ b/src/BoneDragRelease_test.cpp
@@ -54,59 +54,53 @@ TEST_F(BoneDragReleaseTest, NoChangeIsNoOp) {
     EXPECT_EQ(outcome, BoneDragRelease::Result::NoOp);
 }
 
-TEST_F(BoneDragReleaseTest, AutoKeyOffCommitsToBindPose) {
-    // Auto-key OFF: dragged pose becomes the new bind. After release,
-    // bone->getPosition() == dragged pose AND bone->getInitialPosition()
-    // also == dragged pose (so Skeleton::reset restores to the new bind).
-    Ogre::Entity* entity = createAnimatedTestEntity("BDR_BindCommit");
+TEST_F(BoneDragReleaseTest, AutoKeyOffWithAnimReverts) {
+    // Drag with auto-key OFF + animation active: the bone must revert
+    // to its pre-drag local TRS. Without revert, accumulated drag
+    // offsets pile up across drags ("if I moved it down before, it
+    // goes further down on my second attempt").
+    Ogre::Entity* entity = createAnimatedTestEntity("BDR_RevertOnce");
     ASSERT_NE(entity, nullptr);
     Ogre::Bone* bone = entity->getSkeleton()->getBone("Child");
 
     const Ogre::Vector3 before = bone->getPosition();
-    const Ogre::Vector3 dragged = before + Ogre::Vector3(0.5f, -0.3f, 0.0f);
-    simulateBoneDrag(bone, dragged);
+    simulateBoneDrag(bone, before + Ogre::Vector3(0.5f, -0.3f, 0.0f));
 
     auto outcome = BoneDragRelease::apply(bone, before, bone->getInitialOrientation(),
                                           bone->getInitialScale(),
                                           /*hasAnim=*/true, /*autoKey=*/false,
                                           entity);
-    EXPECT_EQ(outcome, BoneDragRelease::Result::CommitBind);
-    EXPECT_EQ(bone->getPosition(), dragged);
-    EXPECT_EQ(bone->getInitialPosition(), dragged);
-
-    // Reset (what Skeleton::reset does) must land at the new bind.
-    bone->setPosition(Ogre::Vector3::ZERO);
-    bone->resetToInitialState();
-    EXPECT_EQ(bone->getPosition(), dragged) << "New bind pose did not survive reset";
+    EXPECT_EQ(outcome, BoneDragRelease::Result::Revert);
+    EXPECT_EQ(bone->getPosition(), before);
 }
 
-TEST_F(BoneDragReleaseTest, AutoKeyOffTwoDragsAccumulateAsBindUpdates) {
-    // Two consecutive drags with auto-key off → each commits to bind.
-    // Drag 2's pose should be exactly what was set, not relative to
-    // any prior offset (the BlendMask muting in TransformOperator
-    // ensures the bone's local at drag-2 press equals drag-1's commit).
-    Ogre::Entity* entity = createAnimatedTestEntity("BDR_TwoBindUpdates");
+TEST_F(BoneDragReleaseTest, AutoKeyOffTwoDragsDoNotAccumulate) {
+    // Critical regression test for the user-reported "down before going
+    // right" teleport. Two consecutive drags with auto-key off must
+    // each leave the bone at its pre-drag pose — the second drag's
+    // before-state must be the SAME as the first drag's before-state,
+    // not the first drag's accumulated offset.
+    Ogre::Entity* entity = createAnimatedTestEntity("BDR_TwoDrags");
     ASSERT_NE(entity, nullptr);
     Ogre::Bone* bone = entity->getSkeleton()->getBone("Child");
 
     const Ogre::Vector3 origLocal = bone->getPosition();
 
+    // Drag 1: move +Y by 0.5
     simulateBoneDrag(bone, origLocal + Ogre::Vector3(0, 0.5f, 0));
     BoneDragRelease::apply(bone, origLocal, bone->getInitialOrientation(),
                            bone->getInitialScale(),
                            /*hasAnim=*/true, /*autoKey=*/false, entity);
     const Ogre::Vector3 afterDrag1 = bone->getPosition();
-    EXPECT_EQ(afterDrag1, origLocal + Ogre::Vector3(0, 0.5f, 0));
-    EXPECT_EQ(bone->getInitialPosition(), afterDrag1);
+    EXPECT_EQ(afterDrag1, origLocal) << "Drag 1 did not revert";
 
-    // Drag 2 starts from afterDrag1 (which is the new bind).
-    const Ogre::Vector3 drag2Target = afterDrag1 + Ogre::Vector3(0.3f, 0, 0);
-    simulateBoneDrag(bone, drag2Target);
-    BoneDragRelease::apply(bone, afterDrag1, bone->getInitialOrientation(),
+    // Drag 2: move +X by 0.5
+    simulateBoneDrag(bone, origLocal + Ogre::Vector3(0.5f, 0, 0));
+    BoneDragRelease::apply(bone, origLocal, bone->getInitialOrientation(),
                            bone->getInitialScale(),
                            /*hasAnim=*/true, /*autoKey=*/false, entity);
-    EXPECT_EQ(bone->getPosition(), drag2Target);
-    EXPECT_EQ(bone->getInitialPosition(), drag2Target);
+    const Ogre::Vector3 afterDrag2 = bone->getPosition();
+    EXPECT_EQ(afterDrag2, origLocal) << "Drag 2 did not revert (accumulation bug)";
 }
 
 TEST_F(BoneDragReleaseTest, AutoKeyOnWithAnimKeepsDraggedPose) {
@@ -134,28 +128,86 @@ TEST_F(BoneDragReleaseTest, AutoKeyOnWithAnimKeepsDraggedPose) {
 // going right." Simulates that exact sequence at the helper level.
 // Without revert, the accumulated Y delta from drag 1 would leak into
 // drag 2's before-state, and the bone would re-show the Y offset.
-// The user-reported regression: edit T-pose bone, enable animation,
-// disable animation, expect bone to remain at the edited T-pose. The
-// bone's initial state must reflect the edit so Skeleton::reset (called
-// when animations are toggled or applied) restores the new bind, not
-// the original.
-TEST_F(BoneDragReleaseTest, BindEditSurvivesAnimationToggle) {
-    Ogre::Entity* entity = createAnimatedTestEntity("BDR_BindSurvivesToggle");
+TEST_F(BoneDragReleaseTest, YThenXDragsDoNotLeakYIntoX) {
+    Ogre::Entity* entity = createAnimatedTestEntity("BDR_YThenX");
     ASSERT_NE(entity, nullptr);
     Ogre::Bone* bone = entity->getSkeleton()->getBone("Child");
 
     const Ogre::Vector3 origLocal = bone->getPosition();
-    const Ogre::Vector3 dragged = origLocal + Ogre::Vector3(0.5f, 0, 0);
-    simulateBoneDrag(bone, dragged);
+    const Ogre::Vector3 origDerived = bone->_getDerivedPosition();
+
+    // Drag 1: Y axis down.
+    bone->setManuallyControlled(true);
+    bone->_setDerivedPosition(origDerived + Ogre::Vector3(0, -0.7f, 0));
     BoneDragRelease::apply(bone, origLocal, bone->getInitialOrientation(),
                            bone->getInitialScale(),
                            /*hasAnim=*/true, /*autoKey=*/false, entity);
-    EXPECT_EQ(bone->getInitialPosition(), dragged);
+    EXPECT_EQ(bone->getPosition(), origLocal);
+    EXPECT_EQ(bone->_getDerivedPosition(), origDerived);
 
-    // Simulate "animation toggled off" → Skeleton::reset → bone back
-    // to its initial state. Our edit must survive.
-    entity->getSkeleton()->reset();
-    EXPECT_EQ(bone->getPosition(), dragged) << "Bind edit was lost on Skeleton::reset";
+    // Drag 2: X axis right. The bone must start fresh from origLocal,
+    // not from any leaked Y offset.
+    const Ogre::Vector3 drag2Before = bone->getPosition();
+    EXPECT_EQ(drag2Before, origLocal);
+
+    bone->setManuallyControlled(true);
+    bone->_setDerivedPosition(origDerived + Ogre::Vector3(0.7f, 0, 0));
+    BoneDragRelease::apply(bone, drag2Before, bone->getInitialOrientation(),
+                           bone->getInitialScale(),
+                           /*hasAnim=*/true, /*autoKey=*/false, entity);
+    // Final state: same origLocal (revert), no leaked Y.
+    EXPECT_EQ(bone->getPosition(), origLocal);
+    EXPECT_EQ(bone->_getDerivedPosition().y, origDerived.y) << "Y leaked from previous drag";
+}
+
+// The critical regression test: simulate the actual TransformOperator
+// flow using _setDerivedPosition (not just setPosition), with parent
+// state matching the user's "head bone with rotated parent" case, and
+// assert that two consecutive drags don't accumulate when reverted.
+TEST_F(BoneDragReleaseTest, SetDerivedPositionDragRevertsCleanly) {
+    Ogre::Entity* entity = createAnimatedTestEntity("BDR_SetDerivedTwoDrags");
+    ASSERT_NE(entity, nullptr);
+
+    // Use the child bone (parent = root). Apply a non-identity rotation
+    // to the root bone so _setDerivedPosition has to do real parent-frame
+    // math — matches the "head bone with rotated parent mid-animation"
+    // scenario where the bug shows up.
+    Ogre::Bone* root = entity->getSkeleton()->getBone("Root");
+    Ogre::Bone* child = entity->getSkeleton()->getBone("Child");
+    root->setOrientation(Ogre::Quaternion(Ogre::Radian(0.5f), Ogre::Vector3::UNIT_Y));
+    root->setManuallyControlled(true);
+
+    const Ogre::Vector3 origLocal = child->getPosition();
+    const Ogre::Vector3 origDerived = child->_getDerivedPosition();
+
+    // Drag 1: move derived +Y by 0.5 in world space.
+    child->setManuallyControlled(true);
+    child->_setDerivedPosition(origDerived + Ogre::Vector3(0, 0.5f, 0));
+    child->needUpdate(true);
+    // Local Y has changed (non-trivially) because of parent rotation.
+    EXPECT_NE(child->getPosition(), origLocal);
+
+    auto outcome1 = BoneDragRelease::apply(child, origLocal, child->getInitialOrientation(),
+                                          child->getInitialScale(),
+                                          /*hasAnim=*/true, /*autoKey=*/false, entity);
+    EXPECT_EQ(outcome1, BoneDragRelease::Result::Revert);
+    EXPECT_EQ(child->getPosition(), origLocal) << "Drag 1 revert failed";
+
+    // Drag 2 press: capture new before-state (which should equal origLocal).
+    const Ogre::Vector3 drag2Local  = child->getPosition();
+    EXPECT_EQ(drag2Local, origLocal) << "After drag 1 revert, child has shifted (accumulation)";
+
+    // Drag 2: move derived +X by 0.5
+    const Ogre::Vector3 drag2Derived = child->_getDerivedPosition();
+    child->setManuallyControlled(true);
+    child->_setDerivedPosition(drag2Derived + Ogre::Vector3(0.5f, 0, 0));
+    child->needUpdate(true);
+
+    auto outcome2 = BoneDragRelease::apply(child, drag2Local, child->getInitialOrientation(),
+                                          child->getInitialScale(),
+                                          /*hasAnim=*/true, /*autoKey=*/false, entity);
+    EXPECT_EQ(outcome2, BoneDragRelease::Result::Revert);
+    EXPECT_EQ(child->getPosition(), origLocal) << "Drag 2 revert failed (accumulation across drags)";
 }
 
 TEST_F(BoneDragReleaseTest, NoAnimSetsInitial) {

--- a/src/BoneDragRelease_test.cpp
+++ b/src/BoneDragRelease_test.cpp
@@ -124,6 +124,92 @@ TEST_F(BoneDragReleaseTest, AutoKeyOnWithAnimKeepsDraggedPose) {
     EXPECT_FALSE(bone->isManuallyControlled());
 }
 
+// User report: "first moved Y down, then tried X — went down before
+// going right." Simulates that exact sequence at the helper level.
+// Without revert, the accumulated Y delta from drag 1 would leak into
+// drag 2's before-state, and the bone would re-show the Y offset.
+TEST_F(BoneDragReleaseTest, YThenXDragsDoNotLeakYIntoX) {
+    Ogre::Entity* entity = createAnimatedTestEntity("BDR_YThenX");
+    ASSERT_NE(entity, nullptr);
+    Ogre::Bone* bone = entity->getSkeleton()->getBone("Child");
+
+    const Ogre::Vector3 origLocal = bone->getPosition();
+    const Ogre::Vector3 origDerived = bone->_getDerivedPosition();
+
+    // Drag 1: Y axis down.
+    bone->setManuallyControlled(true);
+    bone->_setDerivedPosition(origDerived + Ogre::Vector3(0, -0.7f, 0));
+    BoneDragRelease::apply(bone, origLocal, bone->getInitialOrientation(),
+                           bone->getInitialScale(),
+                           /*hasAnim=*/true, /*autoKey=*/false, entity);
+    EXPECT_EQ(bone->getPosition(), origLocal);
+    EXPECT_EQ(bone->_getDerivedPosition(), origDerived);
+
+    // Drag 2: X axis right. The bone must start fresh from origLocal,
+    // not from any leaked Y offset.
+    const Ogre::Vector3 drag2Before = bone->getPosition();
+    EXPECT_EQ(drag2Before, origLocal);
+
+    bone->setManuallyControlled(true);
+    bone->_setDerivedPosition(origDerived + Ogre::Vector3(0.7f, 0, 0));
+    BoneDragRelease::apply(bone, drag2Before, bone->getInitialOrientation(),
+                           bone->getInitialScale(),
+                           /*hasAnim=*/true, /*autoKey=*/false, entity);
+    // Final state: same origLocal (revert), no leaked Y.
+    EXPECT_EQ(bone->getPosition(), origLocal);
+    EXPECT_EQ(bone->_getDerivedPosition().y, origDerived.y) << "Y leaked from previous drag";
+}
+
+// The critical regression test: simulate the actual TransformOperator
+// flow using _setDerivedPosition (not just setPosition), with parent
+// state matching the user's "head bone with rotated parent" case, and
+// assert that two consecutive drags don't accumulate when reverted.
+TEST_F(BoneDragReleaseTest, SetDerivedPositionDragRevertsCleanly) {
+    Ogre::Entity* entity = createAnimatedTestEntity("BDR_SetDerivedTwoDrags");
+    ASSERT_NE(entity, nullptr);
+
+    // Use the child bone (parent = root). Apply a non-identity rotation
+    // to the root bone so _setDerivedPosition has to do real parent-frame
+    // math — matches the "head bone with rotated parent mid-animation"
+    // scenario where the bug shows up.
+    Ogre::Bone* root = entity->getSkeleton()->getBone("Root");
+    Ogre::Bone* child = entity->getSkeleton()->getBone("Child");
+    root->setOrientation(Ogre::Quaternion(Ogre::Radian(0.5f), Ogre::Vector3::UNIT_Y));
+    root->setManuallyControlled(true);
+
+    const Ogre::Vector3 origLocal = child->getPosition();
+    const Ogre::Vector3 origDerived = child->_getDerivedPosition();
+
+    // Drag 1: move derived +Y by 0.5 in world space.
+    child->setManuallyControlled(true);
+    child->_setDerivedPosition(origDerived + Ogre::Vector3(0, 0.5f, 0));
+    child->needUpdate(true);
+    // Local Y has changed (non-trivially) because of parent rotation.
+    EXPECT_NE(child->getPosition(), origLocal);
+
+    auto outcome1 = BoneDragRelease::apply(child, origLocal, child->getInitialOrientation(),
+                                          child->getInitialScale(),
+                                          /*hasAnim=*/true, /*autoKey=*/false, entity);
+    EXPECT_EQ(outcome1, BoneDragRelease::Result::Revert);
+    EXPECT_EQ(child->getPosition(), origLocal) << "Drag 1 revert failed";
+
+    // Drag 2 press: capture new before-state (which should equal origLocal).
+    const Ogre::Vector3 drag2Local  = child->getPosition();
+    EXPECT_EQ(drag2Local, origLocal) << "After drag 1 revert, child has shifted (accumulation)";
+
+    // Drag 2: move derived +X by 0.5
+    const Ogre::Vector3 drag2Derived = child->_getDerivedPosition();
+    child->setManuallyControlled(true);
+    child->_setDerivedPosition(drag2Derived + Ogre::Vector3(0.5f, 0, 0));
+    child->needUpdate(true);
+
+    auto outcome2 = BoneDragRelease::apply(child, drag2Local, child->getInitialOrientation(),
+                                          child->getInitialScale(),
+                                          /*hasAnim=*/true, /*autoKey=*/false, entity);
+    EXPECT_EQ(outcome2, BoneDragRelease::Result::Revert);
+    EXPECT_EQ(child->getPosition(), origLocal) << "Drag 2 revert failed (accumulation across drags)";
+}
+
 TEST_F(BoneDragReleaseTest, NoAnimSetsInitial) {
     // No active animation: drag commits to bind pose via setInitialState.
     // Subsequent reset would land at the new bind pose — confirm by

--- a/src/BoneDragRelease_test.cpp
+++ b/src/BoneDragRelease_test.cpp
@@ -231,3 +231,25 @@ TEST_F(BoneDragReleaseTest, NoAnimSetsInitial) {
     bone->resetToInitialState();
     EXPECT_EQ(bone->getPosition(), after);
 }
+
+// Documents Ogre's parentless-bone behavior that drove the
+// TransformOperator move-handler fix: _setDerivedPosition is a no-op on
+// nodes with no parent, so the bone-drag handler falls back to
+// setPosition for true skeleton roots. Without this, root bones (the
+// locomotion bones) silently refused to translate.
+TEST_F(BoneDragReleaseTest, OgreSetDerivedPositionIsNoOpOnParentlessBone) {
+    Ogre::Entity* entity = createAnimatedTestEntity("BDR_ParentlessRoot");
+    ASSERT_NE(entity, nullptr);
+    Ogre::Bone* root = entity->getSkeleton()->getBone("Root");
+    ASSERT_FALSE(root->getParent());
+
+    const Ogre::Vector3 origLocal = root->getPosition();
+    root->_setDerivedPosition(Ogre::Vector3(5, 0, 0));
+    EXPECT_EQ(root->getPosition(), origLocal)
+        << "Ogre changed _setDerivedPosition behavior for parentless nodes; "
+           "the parentless-bone fallback in TransformOperator may now be unnecessary.";
+
+    // For parentless bones, plain setPosition is the right call.
+    root->setPosition(Ogre::Vector3(5, 0, 0));
+    EXPECT_EQ(root->getPosition(), Ogre::Vector3(5, 0, 0));
+}

--- a/src/BoneDragRelease_test.cpp
+++ b/src/BoneDragRelease_test.cpp
@@ -143,7 +143,7 @@ TEST_F(BoneDragReleaseTest, YThenXDragsDoNotLeakYIntoX) {
                            bone->getInitialScale(),
                            /*hasAnim=*/true, /*autoKey=*/false, entity);
     EXPECT_EQ(bone->getPosition(), origLocal);
-    EXPECT_EQ(bone->_getDerivedPosition(), origDerived);
+    EXPECT_LT((bone->_getDerivedPosition() - origDerived).length(), 1e-5f);
 
     // Drag 2: X axis right. The bone must start fresh from origLocal,
     // not from any leaked Y offset.
@@ -157,7 +157,8 @@ TEST_F(BoneDragReleaseTest, YThenXDragsDoNotLeakYIntoX) {
                            /*hasAnim=*/true, /*autoKey=*/false, entity);
     // Final state: same origLocal (revert), no leaked Y.
     EXPECT_EQ(bone->getPosition(), origLocal);
-    EXPECT_EQ(bone->_getDerivedPosition().y, origDerived.y) << "Y leaked from previous drag";
+    EXPECT_NEAR(bone->_getDerivedPosition().y, origDerived.y, 1e-5f)
+        << "Y leaked from previous drag";
 }
 
 // The critical regression test: simulate the actual TransformOperator

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,6 +58,8 @@ commands/TransformCommands.cpp
 commands/MoveKeyframeCommand.cpp
 commands/BulkKeyframeCommands.cpp
 commands/SetKeyframeValueCommand.cpp
+commands/BoneTransformCommand.cpp
+BoneDragRelease.cpp
 PropertiesPanelController.cpp
 SceneTreeModel.cpp
 ThemeManager.cpp

--- a/src/SkeletonDebug.cpp
+++ b/src/SkeletonDebug.cpp
@@ -49,6 +49,17 @@ SkeletonDebug::SkeletonDebug(Ogre::Entity* entity, Ogre::SceneManager *man, floa
             ent->setMaterial(mBoneMatPtr);
             ent->setVisible(mShowBones);
         }
+        // Paint skeleton roots yellow so users can identify which bones
+        // are root (translatable). Walk getRootBones() and color the
+        // matching visual entities. Selected highlight (red) wins over
+        // root-yellow when both apply.
+        for (Ogre::Bone* root : mEntity->getSkeleton()->getRootBones()) {
+            auto it = mapEntities.find(root->getName());
+            if (it != mapEntities.end() && it->second) {
+                it->second->setMaterial(mBoneMatRootPtr);
+                it->second->setVisible(mShowBones);
+            }
+        }
         for(auto* bone : mEntity->getSkeleton()->getBones())
         {
             if(!bone->getUserObjectBindings().getUserAny("selected").has_value())
@@ -273,6 +284,23 @@ void SkeletonDebug::createBoneMaterial()
         p->setEmissive(1,0,0);
     }
 
+    // Yellow material for root bones — visual hint that translation is
+    // unrestricted on these bones (the rest are rotation-only when rigged).
+    Ogre::String matName3 = "SkeletonDebug/BoneMatRoot";
+    mBoneMatRootPtr = Ogre::static_pointer_cast<Ogre::Material>(Ogre::MaterialManager::getSingleton().getByName(matName3));
+    if (!mBoneMatRootPtr) {
+        mBoneMatRootPtr = Ogre::static_pointer_cast<Ogre::Material>(Ogre::MaterialManager::getSingleton().create(matName3, Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME));
+        Ogre::Pass* p = mBoneMatRootPtr->getTechnique(0)->getPass(0);
+        p->setLightingEnabled(true);
+        p->setDepthWriteEnabled(false);
+        p->setDepthCheckEnabled(false);
+        p->setVertexColourTracking(Ogre::TVC_AMBIENT);
+        p->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
+        p->setCullingMode(Ogre::CULL_ANTICLOCKWISE);
+        p->setDiffuse(1, 0.85f, 0, 1);
+        p->setAmbient(1, 0.85f, 0);
+        p->setEmissive(1, 0.85f, 0);
+    }
 }
 
 void SkeletonDebug::createBoneMesh()

--- a/src/SkeletonDebug.h
+++ b/src/SkeletonDebug.h
@@ -47,6 +47,7 @@ private:
     Ogre::MaterialPtr mAxisMatPtr;
     Ogre::MaterialPtr mBoneMatPtr;
     Ogre::MaterialPtr mBoneMatSelectedPtr;
+    Ogre::MaterialPtr mBoneMatRootPtr;
     Ogre::MeshPtr mBoneMeshPtr;
     Ogre::MeshPtr mAxesMeshPtr;
     Ogre::SceneManager *mSceneMan;

--- a/src/TransformOperator.cpp
+++ b/src/TransformOperator.cpp
@@ -1730,14 +1730,45 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
                         || (afterOrient != mBoneStartOrient)
                         || (afterScale  != mBoneStartScale);
             const bool autoKeyOn = AnimationControlController::instance()->autoKey();
-            const bool hasActiveAnim = !AnimationControlController::instance()
-                                        ->selectedAnimation().isEmpty();
+            // Active = an animation state is currently ENABLED (driving
+            // bones), not just selected in the panel. With no enabled
+            // animation, the bone is at its bind pose and the user is
+            // doing T-pose authoring → setInitialState. With at least
+            // one enabled animation, the curve writes the bone each
+            // frame and a setInitialState would shift the whole curve
+            // → revert instead.
+            bool hasActiveAnim = false;
+            if (Ogre::Entity* dragEnt = AnimationControlController::instance()->selectedEntity()) {
+                if (Ogre::AnimationStateSet* states = dragEnt->getAllAnimationStates()) {
+                    for (const auto& pair : states->getAnimationStates()) {
+                        if (pair.second->getEnabled()) { hasActiveAnim = true; break; }
+                    }
+                }
+            }
 
             fprintf(stderr, "[BONE-DRAG RELEASE] autoKey=%d hasAnim=%d before=(%g,%g,%g) after=(%g,%g,%g)\n",
                 autoKeyOn ? 1 : 0, hasActiveAnim ? 1 : 0,
                 mBoneStartPos.x, mBoneStartPos.y, mBoneStartPos.z,
                 afterPos.x, afterPos.y, afterPos.z);
             fflush(stderr);
+
+            // Restore animation blend-mask weight on this bone BEFORE
+            // calling apply(). The Revert path calls _updateAnimation
+            // which runs Skeleton::reset (bone → initial) then animation
+            // tracks (initial + curve sample). With the BlendMask still
+            // muted, the curve contributes zero and the bone settles at
+            // initial (T-pose) instead of the press-time pose. Restore
+            // the mask first so curve drives the bone correctly.
+            if (Ogre::Entity* dragEnt = AnimationControlController::instance()->selectedEntity()) {
+                if (Ogre::AnimationStateSet* states = dragEnt->getAllAnimationStates()) {
+                    for (const auto& pair : states->getAnimationStates()) {
+                        Ogre::AnimationState* st = pair.second;
+                        if (st->hasBlendMask())
+                            st->setBlendMaskEntry(bone->getHandle(), 1.0f);
+                    }
+                }
+            }
+
             const auto outcome = BoneDragRelease::apply(
                 bone, mBoneStartPos, mBoneStartOrient, mBoneStartScale,
                 hasActiveAnim, autoKeyOn,
@@ -1755,19 +1786,14 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
                     new BoneTransformCommand(skel, bone->getName(),
                         mBoneStartPos, mBoneStartOrient, mBoneStartScale,
                         afterPos,      afterOrient,      afterScale));
-            }
-
-            // Restore animation blend-mask weight on this bone so the
-            // curve drives playback again (after either commit or revert
-            // — both want playback to resume normally).
-            if (Ogre::Entity* dragEnt = AnimationControlController::instance()->selectedEntity()) {
-                if (Ogre::AnimationStateSet* states = dragEnt->getAllAnimationStates()) {
-                    for (const auto& pair : states->getAnimationStates()) {
-                        Ogre::AnimationState* st = pair.second;
-                        if (st->hasBlendMask())
-                            st->setBlendMaskEntry(bone->getHandle(), 1.0f);
-                    }
-                }
+            } else if (outcome == BoneDragRelease::Result::Revert) {
+                // Restore the gizmo to the press-time anchor too, so the
+                // viewport is visually back where it started — same as
+                // dropping the drag never happened.
+                m_pTransformNode->setPosition(mBoneDragGizmoOrigin);
+                fprintf(stderr, "[BONE-DRAG RELEASE] → REVERT (preview) post=(%g,%g,%g)\n",
+                    bone->getPosition().x, bone->getPosition().y, bone->getPosition().z);
+                fflush(stderr);
             }
         }
         // Restore playback if we paused it on press.

--- a/src/TransformOperator.cpp
+++ b/src/TransformOperator.cpp
@@ -1755,14 +1755,6 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
                     new BoneTransformCommand(skel, bone->getName(),
                         mBoneStartPos, mBoneStartOrient, mBoneStartScale,
                         afterPos,      afterOrient,      afterScale));
-            } else if (outcome == BoneDragRelease::Result::Revert) {
-                // Restore the gizmo to the press-time anchor too, so the
-                // viewport is visually back where it started — same as
-                // dropping the drag never happened.
-                m_pTransformNode->setPosition(mBoneDragGizmoOrigin);
-                fprintf(stderr, "[BONE-DRAG RELEASE] → REVERT (preview) post=(%g,%g,%g)\n",
-                    bone->getPosition().x, bone->getPosition().y, bone->getPosition().z);
-                fflush(stderr);
             }
 
             // Restore animation blend-mask weight on this bone so the

--- a/src/TransformOperator.cpp
+++ b/src/TransformOperator.cpp
@@ -1415,22 +1415,6 @@ void TransformOperator::mouseMoveEvent(QMouseEvent *e)
 
         Ogre::Vector3 point = mouseRay.getPoint(result.second);
         Ogre::Vector3 rawWorldDelta = point - mStartPoint;
-        // Probe parent state on every move to confirm whether parent
-        // is drifting (which would indicate playback is still running).
-        Ogre::Bone* dbgParent = nullptr;
-        if (Ogre::Bone* b = AnimationControlController::instance()->selectedBonePtr())
-            dbgParent = b->getParent() ? static_cast<Ogre::Bone*>(b->getParent()) : nullptr;
-        Ogre::Vector3 parentDerived = dbgParent ? dbgParent->_getDerivedPosition() : Ogre::Vector3::ZERO;
-        Ogre::Quaternion parentDerivedOri = dbgParent ? dbgParent->_getDerivedOrientation() : Ogre::Quaternion::IDENTITY;
-        fprintf(stderr, "[BONE-DRAG MOVE] screenPx=(%d,%d) point=(%g,%g,%g) rawDelta=(%g,%g,%g) tVec=(%g,%g,%g) playing=%d parentDerived=(%g,%g,%g) parentOri=(%g,%g,%g,%g)\n",
-            e->pos().x(), e->pos().y(),
-            point.x, point.y, point.z,
-            rawWorldDelta.x, rawWorldDelta.y, rawWorldDelta.z,
-            mTransformVector.x, mTransformVector.y, mTransformVector.z,
-            PropertiesPanelController::instance()->isPlaying() ? 1 : 0,
-            parentDerived.x, parentDerived.y, parentDerived.z,
-            parentDerivedOri.w, parentDerivedOri.x, parentDerivedOri.y, parentDerivedOri.z);
-        fflush(stderr);
 
         // The gizmo's frame is rotated to match the bone (so its arrows
         // visually align with the bone's axes). mTransformVector is in
@@ -1459,17 +1443,8 @@ void TransformOperator::mouseMoveEvent(QMouseEvent *e)
         // correctly for any bone regardless of parent orientation —
         // crucial when the parent itself is mid-animation pose.
         Ogre::Vector3 targetSkelPos = mBoneStartDerivedPos + skelLocalDelta;
-        fprintf(stderr, "[BONE-DRAG APPLY] worldDelta=(%g,%g,%g) skelDelta=(%g,%g,%g) targetSkel=(%g,%g,%g)\n",
-            worldDelta.x, worldDelta.y, worldDelta.z,
-            skelLocalDelta.x, skelLocalDelta.y, skelLocalDelta.z,
-            targetSkelPos.x, targetSkelPos.y, targetSkelPos.z);
-        fflush(stderr);
         bone->_setDerivedPosition(targetSkelPos);
         bone->needUpdate(true);
-        fprintf(stderr, "[BONE-DRAG POST] local=(%g,%g,%g) derived=(%g,%g,%g)\n",
-            bone->getPosition().x, bone->getPosition().y, bone->getPosition().z,
-            bone->_getDerivedPosition().x, bone->_getDerivedPosition().y, bone->_getDerivedPosition().z);
-        fflush(stderr);
         // Don't call _updateAnimation here — it triggers Skeleton::reset
         // which can re-apply animation tracks to OTHER bones each move
         // event, producing visible compound rotation of the rest of the

--- a/src/TransformOperator.cpp
+++ b/src/TransformOperator.cpp
@@ -1127,13 +1127,20 @@ void TransformOperator::mousePressEvent(QMouseEvent *e)
             // each frame (the Ogre docs warn about this). Mute the
             // animation's contribution to this bone via the blend mask
             // so per-frame _updateAnimation doesn't overwrite our edit.
-            // Restored on release.
+            // Capture the previous mask value per state so the release
+            // can restore exactly what was there (instead of blanket
+            // resetting to 1.0, which would destroy any layered/masked
+            // animation setup the user had pre-drag).
+            mBoneDragSavedMaskWeights.clear();
             if (Ogre::Entity* dragEnt = AnimationControlController::instance()->selectedEntity()) {
                 if (Ogre::AnimationStateSet* states = dragEnt->getAllAnimationStates()) {
                     const auto numBones = static_cast<size_t>(dragEnt->getSkeleton()->getNumBones());
                     for (const auto& pair : states->getAnimationStates()) {
                         Ogre::AnimationState* st = pair.second;
                         if (!st->getEnabled()) continue;
+                        const float before = st->hasBlendMask()
+                            ? st->getBlendMaskEntry(bone->getHandle()) : 1.0f;
+                        mBoneDragSavedMaskWeights.append({st->getAnimationName(), before});
                         if (!st->hasBlendMask()) st->createBlendMask(numBones, 1.0f);
                         st->setBlendMaskEntry(bone->getHandle(), 0.0f);
                     }
@@ -1736,22 +1743,27 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
                 }
             }
 
-            // Restore animation blend-mask weight on this bone BEFORE
-            // calling apply(). The Revert path calls _updateAnimation
-            // which runs Skeleton::reset (bone → initial) then animation
-            // tracks (initial + curve sample). With the BlendMask still
-            // muted, the curve contributes zero and the bone settles at
-            // initial (T-pose) instead of the press-time pose. Restore
-            // the mask first so curve drives the bone correctly.
+            // Restore the per-state BlendMask values we captured at
+            // press, BEFORE calling apply(). The Revert path calls
+            // _updateAnimation which runs Skeleton::reset (bone →
+            // initial) then animation tracks (initial + curve sample).
+            // With the BlendMask still muted, the curve contributes
+            // zero and the bone settles at initial (T-pose) instead
+            // of the press-time pose. Restoring before apply() lets
+            // the curve drive the bone correctly. Restore exactly the
+            // pre-drag weights — not a hardcoded 1.0 — to preserve
+            // any layered/masked setup the user had.
             if (Ogre::Entity* dragEnt = AnimationControlController::instance()->selectedEntity()) {
                 if (Ogre::AnimationStateSet* states = dragEnt->getAllAnimationStates()) {
-                    for (const auto& pair : states->getAnimationStates()) {
-                        Ogre::AnimationState* st = pair.second;
+                    for (const auto& [stateName, weight] : mBoneDragSavedMaskWeights) {
+                        if (!states->hasAnimationState(stateName)) continue;
+                        Ogre::AnimationState* st = states->getAnimationState(stateName);
                         if (st->hasBlendMask())
-                            st->setBlendMaskEntry(bone->getHandle(), 1.0f);
+                            st->setBlendMaskEntry(bone->getHandle(), weight);
                     }
                 }
             }
+            mBoneDragSavedMaskWeights.clear();
 
             const auto outcome = BoneDragRelease::apply(
                 bone, mBoneStartPos, mBoneStartOrient, mBoneStartScale,
@@ -1764,10 +1776,14 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
                         afterPos,      afterOrient,      afterScale));
                 AnimationControlController::instance()->autoKeyOnTransform();
             } else if (outcome == BoneDragRelease::Result::CommitBind) {
+                // bindMode=true so undo also reverts the bone's initial
+                // (bind) state — otherwise Skeleton::reset would snap
+                // back to the new bind on the next animation update.
                 UndoManager::getSingleton()->push(
                     new BoneTransformCommand(skel, bone->getName(),
                         mBoneStartPos, mBoneStartOrient, mBoneStartScale,
-                        afterPos,      afterOrient,      afterScale));
+                        afterPos,      afterOrient,      afterScale,
+                        /*bindMode=*/true));
             } else if (outcome == BoneDragRelease::Result::Revert) {
                 // Restore the gizmo to the press-time anchor so the
                 // viewport visually returns to the start of the drag.

--- a/src/TransformOperator.cpp
+++ b/src/TransformOperator.cpp
@@ -1117,17 +1117,6 @@ void TransformOperator::mousePressEvent(QMouseEvent *e)
                 mTransformVector = m_pTranslationGizmo->highlightAxis(pressGizmoAxis);
             else
                 mTransformVector = Ogre::Vector3::ZERO;
-            fprintf(stderr, "[BONE-DRAG PRESS] sliderValue=%d autoKey=%d pressAxisLock=(%g,%g,%g)\n",
-                AnimationControlController::instance()->sliderValue(),
-                AnimationControlController::instance()->autoKey() ? 1 : 0,
-                mTransformVector.x, mTransformVector.y, mTransformVector.z);
-            fflush(stderr);
-            fprintf(stderr, "[BONE-DRAG PRESS] bone=%s local=(%g,%g,%g) derived=(%g,%g,%g) gizmoOrigin=(%g,%g,%g)\n",
-                bone->getName().c_str(),
-                mBoneStartPos.x, mBoneStartPos.y, mBoneStartPos.z,
-                mBoneStartDerivedPos.x, mBoneStartDerivedPos.y, mBoneStartDerivedPos.z,
-                mBoneDragGizmoOrigin.x, mBoneDragGizmoOrigin.y, mBoneDragGizmoOrigin.z);
-            fflush(stderr);
             // Without this the skeleton's animation system overwrites
             // the bone's local TRS every frame from interpolated keys,
             // so our drag never visibly sticks. Manual-control mode
@@ -1156,8 +1145,6 @@ void TransformOperator::mousePressEvent(QMouseEvent *e)
             // edit and looks like the model is rotating wildly. Pausing
             // is what every DCC tool (Blender/Maya) does on bone scrub.
             mBoneDragWasPlaying = PropertiesPanelController::instance()->isPlaying();
-            fprintf(stderr, "[BONE-DRAG PRESS] wasPlaying=%d → pausing\n", mBoneDragWasPlaying ? 1 : 0);
-            fflush(stderr);
             if (mBoneDragWasPlaying)
                 PropertiesPanelController::instance()->setPlaying(false);
             SentryReporter::addBreadcrumb("ui.transform", "Translate bone");
@@ -1165,12 +1152,8 @@ void TransformOperator::mousePressEvent(QMouseEvent *e)
             Ogre::Ray mouseRay = rayFromScreenPoint(e->pos());
             auto result = mouseRay.intersects(
                 Ogre::Plane(mouseRay.getDirection(), m_pTransformNode->getPosition()));
-            if (result.first) {
+            if (result.first)
                 mStartPoint = mouseRay.getPoint(result.second);
-                fprintf(stderr, "[BONE-DRAG PRESS] mStartPoint=(%g,%g,%g) screenPx=(%d,%d)\n",
-                    mStartPoint.x, mStartPoint.y, mStartPoint.z, e->pos().x(), e->pos().y());
-                fflush(stderr);
-            }
         }
         else if((!SelectionSet::getSingleton()->isEmpty()) && (e->button() == Qt::LeftButton))
         {
@@ -1460,7 +1443,14 @@ void TransformOperator::mouseMoveEvent(QMouseEvent *e)
         // correctly for any bone regardless of parent orientation —
         // crucial when the parent itself is mid-animation pose.
         Ogre::Vector3 targetSkelPos = mBoneStartDerivedPos + skelLocalDelta;
-        bone->_setDerivedPosition(targetSkelPos);
+        // _setDerivedPosition is a no-op on parentless bones (Ogre's
+        // implementation only writes when there's a parent). For true
+        // skeleton roots, fall back to setPosition since for them
+        // local space == skeleton-local space.
+        if (bone->getParent())
+            bone->_setDerivedPosition(targetSkelPos);
+        else
+            bone->setPosition(targetSkelPos);
         bone->needUpdate(true);
         // Don't call _updateAnimation here — it triggers Skeleton::reset
         // which can re-apply animation tracks to OTHER bones each move
@@ -1746,12 +1736,6 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
                 }
             }
 
-            fprintf(stderr, "[BONE-DRAG RELEASE] autoKey=%d hasAnim=%d before=(%g,%g,%g) after=(%g,%g,%g)\n",
-                autoKeyOn ? 1 : 0, hasActiveAnim ? 1 : 0,
-                mBoneStartPos.x, mBoneStartPos.y, mBoneStartPos.z,
-                afterPos.x, afterPos.y, afterPos.z);
-            fflush(stderr);
-
             // Restore animation blend-mask weight on this bone BEFORE
             // calling apply(). The Revert path calls _updateAnimation
             // which runs Skeleton::reset (bone → initial) then animation
@@ -1774,26 +1758,20 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
                 hasActiveAnim, autoKeyOn,
                 AnimationControlController::instance()->selectedEntity());
             if (outcome == BoneDragRelease::Result::Commit) {
-                fprintf(stderr, "[BONE-DRAG RELEASE] → COMMIT (autokey)\n"); fflush(stderr);
                 UndoManager::getSingleton()->push(
                     new BoneTransformCommand(skel, bone->getName(),
                         mBoneStartPos, mBoneStartOrient, mBoneStartScale,
                         afterPos,      afterOrient,      afterScale));
                 AnimationControlController::instance()->autoKeyOnTransform();
             } else if (outcome == BoneDragRelease::Result::CommitBind) {
-                fprintf(stderr, "[BONE-DRAG RELEASE] → SET-INITIAL (T-pose)\n"); fflush(stderr);
                 UndoManager::getSingleton()->push(
                     new BoneTransformCommand(skel, bone->getName(),
                         mBoneStartPos, mBoneStartOrient, mBoneStartScale,
                         afterPos,      afterOrient,      afterScale));
             } else if (outcome == BoneDragRelease::Result::Revert) {
-                // Restore the gizmo to the press-time anchor too, so the
-                // viewport is visually back where it started — same as
-                // dropping the drag never happened.
+                // Restore the gizmo to the press-time anchor so the
+                // viewport visually returns to the start of the drag.
                 m_pTransformNode->setPosition(mBoneDragGizmoOrigin);
-                fprintf(stderr, "[BONE-DRAG RELEASE] → REVERT (preview) post=(%g,%g,%g)\n",
-                    bone->getPosition().x, bone->getPosition().y, bone->getPosition().z);
-                fflush(stderr);
             }
         }
         // Restore playback if we paused it on press.

--- a/src/TransformOperator.cpp
+++ b/src/TransformOperator.cpp
@@ -1106,15 +1106,21 @@ void TransformOperator::mousePressEvent(QMouseEvent *e)
             mBoneStartScale       = bone->getScale();
             mBoneStartDerivedPos  = bone->_getDerivedPosition();
             mBoneDragGizmoOrigin  = m_pTransformNode->getPosition();
-            // Reset to ZERO so the first move event runs the gizmo-axis
-            // survey. Without this, mTransformVector persists from the
-            // previous drag — e.g. a Y drag leaves (0,1,0) and the next
-            // drag (intended X) starts moving in Y until the user
-            // happens to hover the X arrow.
-            mTransformVector = Ogre::Vector3::ZERO;
-            fprintf(stderr, "[BONE-DRAG PRESS] sliderValue=%d autoKey=%d\n",
+            // Lock the axis at PRESS time, not on first move. If the
+            // user clicked on an arrow, that's the axis they want — even
+            // if their cursor drifts onto a neighboring arrow during the
+            // drag motion. Without this, a stale axis from the previous
+            // drag could persist or the survey might hit the wrong axis
+            // mid-motion.
+            Ogre::MovableObject* pressGizmoAxis = performRaySelection(e->pos(), true);
+            if (pressGizmoAxis)
+                mTransformVector = m_pTranslationGizmo->highlightAxis(pressGizmoAxis);
+            else
+                mTransformVector = Ogre::Vector3::ZERO;
+            fprintf(stderr, "[BONE-DRAG PRESS] sliderValue=%d autoKey=%d pressAxisLock=(%g,%g,%g)\n",
                 AnimationControlController::instance()->sliderValue(),
-                AnimationControlController::instance()->autoKey() ? 1 : 0);
+                AnimationControlController::instance()->autoKey() ? 1 : 0,
+                mTransformVector.x, mTransformVector.y, mTransformVector.z);
             fflush(stderr);
             fprintf(stderr, "[BONE-DRAG PRESS] bone=%s local=(%g,%g,%g) derived=(%g,%g,%g) gizmoOrigin=(%g,%g,%g)\n",
                 bone->getName().c_str(),
@@ -1393,38 +1399,10 @@ void TransformOperator::mouseMoveEvent(QMouseEvent *e)
     else if (mTransformState == TS_TRANSLATE && mBoneDragActive
              && AnimationControlController::instance()->selectedBonePtr())
     {
-        // Bone-gizmo translation. Survey for axis highlight when no
-        // axis is locked yet (mTransformVector ZERO at press time);
-        // once an axis is locked, project the mouse onto the gizmo's
-        // plane and convert the world delta into the bone's
-        // parent-local frame before translating the bone.
-        if (mTransformVector.isZeroLength())
-        {
-            Ogre::MovableObject* gizmoAxis = performRaySelection(e->pos(), true);
-            if (gizmoAxis) {
-                mTransformVector = m_pTranslationGizmo->highlightAxis(gizmoAxis);
-                // Re-anchor mStartPoint and the start-derived state to
-                // the moment the axis is locked. Without this, the
-                // event uses press-time mStartPoint but the user's
-                // mouse has already moved during the survey, causing
-                // an instant jump when the axis finally engages.
-                Ogre::Ray ray2 = rayFromScreenPoint(e->pos());
-                auto r2 = ray2.intersects(
-                    Ogre::Plane(ray2.getDirection(), mBoneDragGizmoOrigin));
-                if (r2.first) mStartPoint = ray2.getPoint(r2.second);
-                Ogre::Bone* lockBone = AnimationControlController::instance()->selectedBonePtr();
-                if (lockBone) mBoneStartDerivedPos = lockBone->_getDerivedPosition();
-                fprintf(stderr, "[BONE-DRAG SURVEY] axisHit transformVector=(%g,%g,%g) re-anchor mStartPoint=(%g,%g,%g)\n",
-                    mTransformVector.x, mTransformVector.y, mTransformVector.z,
-                    mStartPoint.x, mStartPoint.y, mStartPoint.z);
-                fflush(stderr);
-            }
-            else
-            {
-                m_pTranslationGizmo->createAxis();
-            }
-            return;
-        }
+        // Axis is locked at PRESS time (see press handler). If the
+        // user pressed off all arrows, mTransformVector is ZERO and
+        // the drag is a no-op until release.
+        if (mTransformVector.isZeroLength()) return;
 
         // Project mouse onto a plane through the press-time gizmo
         // position (not the current one): otherwise the projection

--- a/src/TransformOperator.cpp
+++ b/src/TransformOperator.cpp
@@ -22,8 +22,11 @@
 #include "ViewportGrid.h"
 #include "UndoManager.h"
 #include "commands/TransformCommands.h"
+#include "commands/BoneTransformCommand.h"
+#include "BoneDragRelease.h"
 #include "EditModeController.h"
 #include "AnimationControlController.h"
+#include "PropertiesPanelController.h"
 #include "SkeletonDebug.h"
 #include <Ogre.h>
 
@@ -86,6 +89,13 @@ TransformOperator::TransformOperator() : QObject(nullptr)
     m_pRayQuery = pSceneMgr->createRayQuery(Ogre::Ray());
 
     connect(SelectionSet::getSingleton(),SIGNAL(selectionChanged()),this,SLOT(onSelectionChanged()));
+
+    // Bone selection from the Animation Control panel must also re-anchor
+    // the gizmo (otherwise the gizmo stays at the previous scene-node
+    // position and only snaps to the bone on the first drag event).
+    connect(AnimationControlController::instance(),
+            &AnimationControlController::boneListChanged,
+            this, &TransformOperator::onSelectionChanged);
 
     // Update gizmo when edit mode selection changes (vertices selected/deselected)
     connect(EditModeController::instance(), &EditModeController::editSelectionChanged,
@@ -528,20 +538,30 @@ void TransformOperator::updateGizmo()
     updateGizmoPosition();
     bool editModeHasSelection = EditModeController::instance()->isEditModeActive()
         && !EditModeController::instance()->selectedVertices().empty();
+    const bool boneSelected = AnimationControlController::instance()->selectedBonePtr() != nullptr
+                              && AnimationControlController::instance()->selectedEntity() != nullptr;
 
     if(SelectionSet::getSingleton()->hasNodes()||SelectionSet::getSingleton()->hasEntities()
-       ||SelectionSet::getSingleton()->hasSubEntities()||editModeHasSelection)
+       ||SelectionSet::getSingleton()->hasSubEntities()||editModeHasSelection||boneSelected)
     {
-        // Determine gizmo orientation based on transform space
-        Ogre::Quaternion gizmoOrientation;
-        if (mTransformSpace == SPACE_LOCAL && SelectionSet::getSingleton()->hasNodes()
-            && SelectionSet::getSingleton()->getNodesCount() == 1)
-        {
-            gizmoOrientation = SelectionSet::getSingleton()->getSceneNode(0)->getOrientation();
-        }
-        else
-        {
-            gizmoOrientation = Manager::getSingleton()->getSceneMgr()->getRootSceneNode()->getOrientation();
+        // Determine gizmo orientation based on transform space.
+        // Bone selection: keep the orientation already set by
+        // updateGizmoPosition() (the bone's world orientation), so the
+        // gizmo arrows align with the bone's local axes — what the user
+        // actually wants when posing a bone. Without this branch the
+        // orientation gets clobbered with identity below and the gizmo
+        // shows in global axes only.
+        Ogre::Quaternion gizmoOrientation = m_pTransformNode->getOrientation();
+        if (!boneSelected) {
+            if (mTransformSpace == SPACE_LOCAL && SelectionSet::getSingleton()->hasNodes()
+                && SelectionSet::getSingleton()->getNodesCount() == 1)
+            {
+                gizmoOrientation = SelectionSet::getSingleton()->getSceneNode(0)->getOrientation();
+            }
+            else
+            {
+                gizmoOrientation = Manager::getSingleton()->getSceneMgr()->getRootSceneNode()->getOrientation();
+            }
         }
 
         switch  (mTransformState) {
@@ -596,9 +616,20 @@ void TransformOperator::tickTransformGizmoScale(const Ogre::Camera* camera)
     // Only scale when a gizmo is actually visible (something selected and
     // an active transform tool). Otherwise leave the node scale alone.
     if (mTransformState == TS_SELECT || mTransformState == TS_NONE) return;
+
+    // Re-anchor the gizmo onto the selected bone every frame so it
+    // tracks animation playback and slider scrubbing. Skip during a
+    // bone drag — the move handler is already keeping the gizmo in
+    // sync and we don't want to fight the user's input.
+    const bool boneSelected = AnimationControlController::instance()->selectedBonePtr() != nullptr
+                              && AnimationControlController::instance()->selectedEntity() != nullptr;
+    if (boneSelected && !mBoneDragActive)
+        updateGizmoPosition();
+
     if (SelectionSet::getSingleton()->isEmpty()
         && !(EditModeController::instance()->isEditModeActive()
-             && !EditModeController::instance()->selectedVertices().empty()))
+             && !EditModeController::instance()->selectedVertices().empty())
+        && !boneSelected)
     {
         return;
     }
@@ -626,6 +657,35 @@ void TransformOperator::updateGizmoPosition()
     Ogre::Vector3 currentPosition = Ogre::Vector3::ZERO;
     Ogre::Vector3 currentOrientation = Ogre::Vector3::ZERO;
     Ogre::Vector3 currentScale = Ogre::Vector3::UNIT_SCALE;
+
+    // Bone-gizmo: when a bone is the active selection (Animation Control
+    // panel), the gizmo follows the bone in world space. This takes
+    // precedence over scene-node anchoring so the user gets immediate
+    // visual feedback after picking a bone in the viewport.
+    auto* animCtrl = AnimationControlController::instance();
+    Ogre::Bone* activeBone = animCtrl->selectedBonePtr();
+    Ogre::Entity* boneEntity = animCtrl->selectedEntity();
+    if (activeBone && boneEntity && boneEntity->getParentSceneNode())
+    {
+        Ogre::SceneNode* entNode = boneEntity->getParentSceneNode();
+        Ogre::Vector3 worldBonePos =
+            entNode->convertLocalToWorldPosition(activeBone->_getDerivedPosition());
+        // Gizmo orientation honors the WORLD/LOCAL toggle (X key):
+        // WORLD → world axes (drag X = world-X). LOCAL → bone's frame
+        // (drag X = bone-local-X). Default to WORLD because users
+        // mostly want intuitive horizontal/vertical drags.
+        Ogre::Quaternion gizmoOrient = Ogre::Quaternion::IDENTITY;
+        if (mTransformSpace == SPACE_LOCAL) {
+            gizmoOrient = entNode->_getDerivedOrientation() * activeBone->_getDerivedOrientation();
+        }
+        m_pTransformNode->setPosition(worldBonePos);
+        m_pTransformNode->setOrientation(gizmoOrient);
+        currentPosition = worldBonePos;
+        emit selectedPositionChanged(currentPosition);
+        emit selectedOrientationChanged(currentOrientation);
+        emit selectedScaleChanged(currentScale);
+        return;
+    }
 
     // Edit mode: position gizmo at selected vertices centroid (world space)
     auto* editCtrl = EditModeController::instance();
@@ -1020,6 +1080,75 @@ void TransformOperator::mousePressEvent(QMouseEvent *e)
             m_pSelectionBox->setVisible(true);
 
         }
+        else if (mTransformState == TS_TRANSLATE
+                 && AnimationControlController::instance()->selectedBonePtr()
+                 && e->button() == Qt::LeftButton)
+        {
+            // Bone-gizmo translation: drive the bone's local position
+            // instead of any scene-node selection. Capture before-state
+            // for undo; the actual delta is applied in mouseMoveEvent
+            // via the bone-aware translate path.
+            Ogre::Bone* bone = AnimationControlController::instance()->selectedBonePtr();
+            // Block translation on rigged non-root bones — moving them
+            // tears the bone away from its parent in the hierarchy and
+            // produces broken poses (children flail to compensate).
+            // Root bone (locomotion) and unrigged attachment points
+            // (sword/shield/hat sockets) remain freely translatable.
+            if (!AnimationControlController::instance()->boneCanTranslate(bone))
+            {
+                SentryReporter::addBreadcrumb("ui.transform",
+                    "Bone translate blocked: rigged non-root bone");
+                return;
+            }
+            mBoneDragActive       = true;
+            mBoneStartPos         = bone->getPosition();
+            mBoneStartOrient      = bone->getOrientation();
+            mBoneStartScale       = bone->getScale();
+            mBoneStartDerivedPos  = bone->_getDerivedPosition();
+            mBoneDragGizmoOrigin  = m_pTransformNode->getPosition();
+            // Reset to ZERO so the first move event runs the gizmo-axis
+            // survey. Without this, mTransformVector persists from the
+            // previous drag — e.g. a Y drag leaves (0,1,0) and the next
+            // drag (intended X) starts moving in Y until the user
+            // happens to hover the X arrow.
+            mTransformVector = Ogre::Vector3::ZERO;
+            fprintf(stderr, "[BONE-DRAG PRESS] sliderValue=%d autoKey=%d\n",
+                AnimationControlController::instance()->sliderValue(),
+                AnimationControlController::instance()->autoKey() ? 1 : 0);
+            fflush(stderr);
+            fprintf(stderr, "[BONE-DRAG PRESS] bone=%s local=(%g,%g,%g) derived=(%g,%g,%g) gizmoOrigin=(%g,%g,%g)\n",
+                bone->getName().c_str(),
+                mBoneStartPos.x, mBoneStartPos.y, mBoneStartPos.z,
+                mBoneStartDerivedPos.x, mBoneStartDerivedPos.y, mBoneStartDerivedPos.z,
+                mBoneDragGizmoOrigin.x, mBoneDragGizmoOrigin.y, mBoneDragGizmoOrigin.z);
+            fflush(stderr);
+            // Without this the skeleton's animation system overwrites
+            // the bone's local TRS every frame from interpolated keys,
+            // so our drag never visibly sticks. Manual-control mode
+            // tells the skeleton to leave this bone alone.
+            bone->setManuallyControlled(true);
+            // Also pause animation playback during the drag — even with
+            // manualControlled=true on the picked bone, animation still
+            // moves its parent bones, which compounds onto the local
+            // edit and looks like the model is rotating wildly. Pausing
+            // is what every DCC tool (Blender/Maya) does on bone scrub.
+            mBoneDragWasPlaying = PropertiesPanelController::instance()->isPlaying();
+            fprintf(stderr, "[BONE-DRAG PRESS] wasPlaying=%d → pausing\n", mBoneDragWasPlaying ? 1 : 0);
+            fflush(stderr);
+            if (mBoneDragWasPlaying)
+                PropertiesPanelController::instance()->setPlaying(false);
+            SentryReporter::addBreadcrumb("ui.transform", "Translate bone");
+
+            Ogre::Ray mouseRay = rayFromScreenPoint(e->pos());
+            auto result = mouseRay.intersects(
+                Ogre::Plane(mouseRay.getDirection(), m_pTransformNode->getPosition()));
+            if (result.first) {
+                mStartPoint = mouseRay.getPoint(result.second);
+                fprintf(stderr, "[BONE-DRAG PRESS] mStartPoint=(%g,%g,%g) screenPx=(%d,%d)\n",
+                    mStartPoint.x, mStartPoint.y, mStartPoint.z, e->pos().x(), e->pos().y());
+                fflush(stderr);
+            }
+        }
         else if((!SelectionSet::getSingleton()->isEmpty()) && (e->button() == Qt::LeftButton))
         {
             // Log a single breadcrumb per transform gesture (not per mouse-move frame)
@@ -1261,6 +1390,116 @@ void TransformOperator::mouseMoveEvent(QMouseEvent *e)
             m_pSelectionBox->drawBox(xStart, yStart, xStop, yStop);
         }
     }
+    else if (mTransformState == TS_TRANSLATE && mBoneDragActive
+             && AnimationControlController::instance()->selectedBonePtr())
+    {
+        // Bone-gizmo translation. Survey for axis highlight when no
+        // axis is locked yet (mTransformVector ZERO at press time);
+        // once an axis is locked, project the mouse onto the gizmo's
+        // plane and convert the world delta into the bone's
+        // parent-local frame before translating the bone.
+        if (mTransformVector.isZeroLength())
+        {
+            Ogre::MovableObject* gizmoAxis = performRaySelection(e->pos(), true);
+            if (gizmoAxis) {
+                mTransformVector = m_pTranslationGizmo->highlightAxis(gizmoAxis);
+                // Re-anchor mStartPoint and the start-derived state to
+                // the moment the axis is locked. Without this, the
+                // event uses press-time mStartPoint but the user's
+                // mouse has already moved during the survey, causing
+                // an instant jump when the axis finally engages.
+                Ogre::Ray ray2 = rayFromScreenPoint(e->pos());
+                auto r2 = ray2.intersects(
+                    Ogre::Plane(ray2.getDirection(), mBoneDragGizmoOrigin));
+                if (r2.first) mStartPoint = ray2.getPoint(r2.second);
+                Ogre::Bone* lockBone = AnimationControlController::instance()->selectedBonePtr();
+                if (lockBone) mBoneStartDerivedPos = lockBone->_getDerivedPosition();
+                fprintf(stderr, "[BONE-DRAG SURVEY] axisHit transformVector=(%g,%g,%g) re-anchor mStartPoint=(%g,%g,%g)\n",
+                    mTransformVector.x, mTransformVector.y, mTransformVector.z,
+                    mStartPoint.x, mStartPoint.y, mStartPoint.z);
+                fflush(stderr);
+            }
+            else
+            {
+                m_pTranslationGizmo->createAxis();
+            }
+            return;
+        }
+
+        // Project mouse onto a plane through the press-time gizmo
+        // position (not the current one): otherwise the projection
+        // plane shifts as the gizmo follows the bone, producing
+        // nonlinear drift as the user drags further from the start.
+        Ogre::Ray mouseRay = rayFromScreenPoint(e->pos());
+        auto result = mouseRay.intersects(
+            Ogre::Plane(mouseRay.getDirection(), mBoneDragGizmoOrigin));
+        if (!result.first) return;
+
+        Ogre::Vector3 point = mouseRay.getPoint(result.second);
+        Ogre::Vector3 rawWorldDelta = point - mStartPoint;
+        // Probe parent state on every move to confirm whether parent
+        // is drifting (which would indicate playback is still running).
+        Ogre::Bone* dbgParent = nullptr;
+        if (Ogre::Bone* b = AnimationControlController::instance()->selectedBonePtr())
+            dbgParent = b->getParent() ? static_cast<Ogre::Bone*>(b->getParent()) : nullptr;
+        Ogre::Vector3 parentDerived = dbgParent ? dbgParent->_getDerivedPosition() : Ogre::Vector3::ZERO;
+        Ogre::Quaternion parentDerivedOri = dbgParent ? dbgParent->_getDerivedOrientation() : Ogre::Quaternion::IDENTITY;
+        fprintf(stderr, "[BONE-DRAG MOVE] screenPx=(%d,%d) point=(%g,%g,%g) rawDelta=(%g,%g,%g) tVec=(%g,%g,%g) playing=%d parentDerived=(%g,%g,%g) parentOri=(%g,%g,%g,%g)\n",
+            e->pos().x(), e->pos().y(),
+            point.x, point.y, point.z,
+            rawWorldDelta.x, rawWorldDelta.y, rawWorldDelta.z,
+            mTransformVector.x, mTransformVector.y, mTransformVector.z,
+            PropertiesPanelController::instance()->isPlaying() ? 1 : 0,
+            parentDerived.x, parentDerived.y, parentDerived.z,
+            parentDerivedOri.w, parentDerivedOri.x, parentDerivedOri.y, parentDerivedOri.z);
+        fflush(stderr);
+
+        // The gizmo's frame is rotated to match the bone (so its arrows
+        // visually align with the bone's axes). mTransformVector is in
+        // gizmo-local space — convert the world delta into gizmo-local,
+        // mask with the highlighted axis, then convert back to world.
+        // This is what the scene-node code does for SPACE_LOCAL; bones
+        // always need it because their gizmo is never identity-aligned.
+        Ogre::Quaternion gizmoOri = m_pTransformNode->getOrientation();
+        Ogre::Vector3 localDelta  = gizmoOri.Inverse() * rawWorldDelta;
+        localDelta *= mTransformVector;
+        Ogre::Vector3 worldDelta  = gizmoOri * localDelta;
+
+        Ogre::Bone* bone = AnimationControlController::instance()->selectedBonePtr();
+        Ogre::Entity* ent = AnimationControlController::instance()->selectedEntity();
+        if (!ent || !ent->getParentSceneNode()) return;
+
+        // Convert world delta → skeleton-local delta (the skeleton
+        // lives in the entity's parent scene node frame).
+        Ogre::Quaternion entWorldOri   = ent->getParentSceneNode()->_getDerivedOrientation();
+        Ogre::Vector3    entWorldScale = ent->getParentSceneNode()->_getDerivedScale();
+        Ogre::Vector3 skelLocalDelta = entWorldOri.Inverse() * worldDelta;
+        skelLocalDelta /= entWorldScale;
+
+        // Drive the bone via its skeleton-local (derived) position. Ogre
+        // handles parent-frame conversion internally, so this works
+        // correctly for any bone regardless of parent orientation —
+        // crucial when the parent itself is mid-animation pose.
+        Ogre::Vector3 targetSkelPos = mBoneStartDerivedPos + skelLocalDelta;
+        fprintf(stderr, "[BONE-DRAG APPLY] worldDelta=(%g,%g,%g) skelDelta=(%g,%g,%g) targetSkel=(%g,%g,%g)\n",
+            worldDelta.x, worldDelta.y, worldDelta.z,
+            skelLocalDelta.x, skelLocalDelta.y, skelLocalDelta.z,
+            targetSkelPos.x, targetSkelPos.y, targetSkelPos.z);
+        fflush(stderr);
+        bone->_setDerivedPosition(targetSkelPos);
+        bone->needUpdate(true);
+        fprintf(stderr, "[BONE-DRAG POST] local=(%g,%g,%g) derived=(%g,%g,%g)\n",
+            bone->getPosition().x, bone->getPosition().y, bone->getPosition().z,
+            bone->_getDerivedPosition().x, bone->_getDerivedPosition().y, bone->_getDerivedPosition().z);
+        fflush(stderr);
+        // Don't call _updateAnimation here — it triggers Skeleton::reset
+        // which can re-apply animation tracks to OTHER bones each move
+        // event, producing visible compound rotation of the rest of the
+        // skeleton. The next render frame's normal animation pass will
+        // refresh skinning + bone-visual TagPoints automatically.
+        updateGizmoPosition();
+        return;
+    }
     else if(mTransformState == TS_TRANSLATE && (!SelectionSet::getSingleton()->isEmpty()))
     {
         //Translate the selected object
@@ -1498,6 +1737,72 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
     if (mBevelDragActive && e->button() == Qt::LeftButton) {
         mBevelDragActive = false;
         SentryReporter::addBreadcrumb("ui.transform", "Bevel: drag end");
+        return;
+    }
+
+    // Bone-gizmo drag end: capture after-state, push BoneTransformCommand
+    // if the bone actually moved, fire auto-key. Bone TRS edits live
+    // outside the SelectionSet so the scene-node release path below
+    // still fires for any concurrent node selection.
+    if (mBoneDragActive && e->button() == Qt::LeftButton)
+    {
+        Ogre::Bone* bone = AnimationControlController::instance()->selectedBonePtr();
+        Ogre::SkeletonInstance* skel =
+            AnimationControlController::instance()->selectedEntity()
+                ? AnimationControlController::instance()->selectedEntity()->getSkeleton()
+                : nullptr;
+        if (bone && skel)
+        {
+            Ogre::Vector3    afterPos    = bone->getPosition();
+            Ogre::Quaternion afterOrient = bone->getOrientation();
+            Ogre::Vector3    afterScale  = bone->getScale();
+            bool changed = (afterPos    != mBoneStartPos)
+                        || (afterOrient != mBoneStartOrient)
+                        || (afterScale  != mBoneStartScale);
+            const bool autoKeyOn = AnimationControlController::instance()->autoKey();
+            const bool hasActiveAnim = !AnimationControlController::instance()
+                                        ->selectedAnimation().isEmpty();
+
+            fprintf(stderr, "[BONE-DRAG RELEASE] autoKey=%d hasAnim=%d before=(%g,%g,%g) after=(%g,%g,%g)\n",
+                autoKeyOn ? 1 : 0, hasActiveAnim ? 1 : 0,
+                mBoneStartPos.x, mBoneStartPos.y, mBoneStartPos.z,
+                afterPos.x, afterPos.y, afterPos.z);
+            fflush(stderr);
+            const auto outcome = BoneDragRelease::apply(
+                bone, mBoneStartPos, mBoneStartOrient, mBoneStartScale,
+                hasActiveAnim, autoKeyOn,
+                AnimationControlController::instance()->selectedEntity());
+            if (outcome == BoneDragRelease::Result::Commit) {
+                fprintf(stderr, "[BONE-DRAG RELEASE] → COMMIT (autokey)\n"); fflush(stderr);
+                UndoManager::getSingleton()->push(
+                    new BoneTransformCommand(skel, bone->getName(),
+                        mBoneStartPos, mBoneStartOrient, mBoneStartScale,
+                        afterPos,      afterOrient,      afterScale));
+                AnimationControlController::instance()->autoKeyOnTransform();
+            } else if (outcome == BoneDragRelease::Result::CommitBind) {
+                fprintf(stderr, "[BONE-DRAG RELEASE] → SET-INITIAL (T-pose)\n"); fflush(stderr);
+                UndoManager::getSingleton()->push(
+                    new BoneTransformCommand(skel, bone->getName(),
+                        mBoneStartPos, mBoneStartOrient, mBoneStartScale,
+                        afterPos,      afterOrient,      afterScale));
+            } else if (outcome == BoneDragRelease::Result::Revert) {
+                // Restore the gizmo to the press-time anchor too, so the
+                // viewport is visually back where it started — same as
+                // dropping the drag never happened.
+                m_pTransformNode->setPosition(mBoneDragGizmoOrigin);
+                fprintf(stderr, "[BONE-DRAG RELEASE] → REVERT (preview) post=(%g,%g,%g)\n",
+                    bone->getPosition().x, bone->getPosition().y, bone->getPosition().z);
+                fflush(stderr);
+            }
+        }
+        // Restore playback if we paused it on press.
+        if (mBoneDragWasPlaying) {
+            PropertiesPanelController::instance()->setPlaying(true);
+            mBoneDragWasPlaying = false;
+        }
+        mBoneDragActive = false;
+        mStartPoint = Ogre::Vector3::ZERO;
+        mTransformVector = Ogre::Vector3::ZERO;
         return;
     }
 

--- a/src/TransformOperator.cpp
+++ b/src/TransformOperator.cpp
@@ -1133,6 +1133,23 @@ void TransformOperator::mousePressEvent(QMouseEvent *e)
             // so our drag never visibly sticks. Manual-control mode
             // tells the skeleton to leave this bone alone.
             bone->setManuallyControlled(true);
+            // setManuallyControlled only excludes this bone from
+            // Skeleton::reset() — animation TRACKS still apply to it
+            // each frame (the Ogre docs warn about this). Mute the
+            // animation's contribution to this bone via the blend mask
+            // so per-frame _updateAnimation doesn't overwrite our edit.
+            // Restored on release.
+            if (Ogre::Entity* dragEnt = AnimationControlController::instance()->selectedEntity()) {
+                if (Ogre::AnimationStateSet* states = dragEnt->getAllAnimationStates()) {
+                    const auto numBones = static_cast<size_t>(dragEnt->getSkeleton()->getNumBones());
+                    for (const auto& pair : states->getAnimationStates()) {
+                        Ogre::AnimationState* st = pair.second;
+                        if (!st->getEnabled()) continue;
+                        if (!st->hasBlendMask()) st->createBlendMask(numBones, 1.0f);
+                        st->setBlendMaskEntry(bone->getHandle(), 0.0f);
+                    }
+                }
+            }
             // Also pause animation playback during the drag — even with
             // manualControlled=true on the picked bone, animation still
             // moves its parent bones, which compounds onto the local
@@ -1746,6 +1763,19 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
                 fprintf(stderr, "[BONE-DRAG RELEASE] → REVERT (preview) post=(%g,%g,%g)\n",
                     bone->getPosition().x, bone->getPosition().y, bone->getPosition().z);
                 fflush(stderr);
+            }
+
+            // Restore animation blend-mask weight on this bone so the
+            // curve drives playback again (after either commit or revert
+            // — both want playback to resume normally).
+            if (Ogre::Entity* dragEnt = AnimationControlController::instance()->selectedEntity()) {
+                if (Ogre::AnimationStateSet* states = dragEnt->getAllAnimationStates()) {
+                    for (const auto& pair : states->getAnimationStates()) {
+                        Ogre::AnimationState* st = pair.second;
+                        if (st->hasBlendMask())
+                            st->setBlendMaskEntry(bone->getHandle(), 1.0f);
+                    }
+                }
             }
         }
         // Restore playback if we paused it on press.

--- a/src/TransformOperator.h
+++ b/src/TransformOperator.h
@@ -232,6 +232,11 @@ private:
     // during a bone drag (otherwise the per-frame _updateAnimation
     // reset wipes our local-pose edit) and restore it on release.
     bool                                    mBoneDragWasPlaying = false;
+    // BlendMask weights captured at press so we can restore them
+    // exactly on release (rather than blanket-resetting to 1.0,
+    // which would destroy any layered/masked animation setup).
+    // Each entry: (animation-state name, weight before drag).
+    QList<std::pair<std::string, float>>    mBoneDragSavedMaskWeights;
 #ifdef Q_OS_MACOS
     int mWindowSizeModifier = 2;
 #else

--- a/src/TransformOperator.h
+++ b/src/TransformOperator.h
@@ -209,6 +209,29 @@ private:
 
     // Vertex paint drag state (edit mode only).
     bool                                    mVertexPaintDragActive = false;
+
+    // Bone-gizmo drag state. Active when a bone is the current selection
+    // (per AnimationControlController::selectedBonePtr) and the user
+    // mouse-presses inside the viewport with TS_TRANSLATE / TS_ROTATE /
+    // TS_SCALE. The "before" TRS is captured at press time; the BoneTransformCommand
+    // is pushed at release with the after-state.
+    bool                                    mBoneDragActive = false;
+    Ogre::Vector3                           mBoneStartPos = Ogre::Vector3::ZERO;
+    Ogre::Quaternion                        mBoneStartOrient = Ogre::Quaternion::IDENTITY;
+    Ogre::Vector3                           mBoneStartScale = Ogre::Vector3::UNIT_SCALE;
+    // Skeleton-local derived position captured at press. Used to drive
+    // the bone via _setDerivedPosition during the drag (correct for
+    // any bone in the hierarchy, regardless of parent orientation).
+    Ogre::Vector3                           mBoneStartDerivedPos = Ogre::Vector3::ZERO;
+    // World-space gizmo origin captured at press. Used to define a
+    // stable mouse-projection plane during the drag; otherwise the
+    // gizmo (which follows the bone) shifts the plane each event,
+    // producing nonlinear/cumulative drift as the user drags further.
+    Ogre::Vector3                           mBoneDragGizmoOrigin = Ogre::Vector3::ZERO;
+    // Playback state captured at press so we can pause animation
+    // during a bone drag (otherwise the per-frame _updateAnimation
+    // reset wipes our local-pose edit) and restore it on release.
+    bool                                    mBoneDragWasPlaying = false;
 #ifdef Q_OS_MACOS
     int mWindowSizeModifier = 2;
 #else

--- a/src/commands/BoneTransformCommand.cpp
+++ b/src/commands/BoneTransformCommand.cpp
@@ -1,0 +1,41 @@
+#include "BoneTransformCommand.h"
+
+#include <OgreSkeletonInstance.h>
+#include <OgreBone.h>
+
+BoneTransformCommand::BoneTransformCommand(Ogre::SkeletonInstance* skeleton,
+                                           std::string boneName,
+                                           const Ogre::Vector3& beforePos,
+                                           const Ogre::Quaternion& beforeOrient,
+                                           const Ogre::Vector3& beforeScale,
+                                           const Ogre::Vector3& afterPos,
+                                           const Ogre::Quaternion& afterOrient,
+                                           const Ogre::Vector3& afterScale,
+                                           QUndoCommand* parent)
+    : QUndoCommand(parent)
+    , mSkeleton(skeleton)
+    , mBoneName(std::move(boneName))
+    , mBeforePos(beforePos)
+    , mBeforeOrient(beforeOrient)
+    , mBeforeScale(beforeScale)
+    , mAfterPos(afterPos)
+    , mAfterOrient(afterOrient)
+    , mAfterScale(afterScale)
+{
+    setText(QStringLiteral("Bone transform"));
+}
+
+void BoneTransformCommand::apply(const Ogre::Vector3& p,
+                                 const Ogre::Quaternion& o,
+                                 const Ogre::Vector3& s)
+{
+    if (!mSkeleton || !mSkeleton->hasBone(mBoneName)) return;
+    Ogre::Bone* bone = mSkeleton->getBone(mBoneName);
+    bone->setPosition(p);
+    bone->setOrientation(o);
+    bone->setScale(s);
+    bone->needUpdate();
+}
+
+void BoneTransformCommand::undo() { apply(mBeforePos, mBeforeOrient, mBeforeScale); }
+void BoneTransformCommand::redo() { apply(mAfterPos,  mAfterOrient,  mAfterScale);  }

--- a/src/commands/BoneTransformCommand.cpp
+++ b/src/commands/BoneTransformCommand.cpp
@@ -11,6 +11,7 @@ BoneTransformCommand::BoneTransformCommand(Ogre::SkeletonInstance* skeleton,
                                            const Ogre::Vector3& afterPos,
                                            const Ogre::Quaternion& afterOrient,
                                            const Ogre::Vector3& afterScale,
+                                           bool bindMode,
                                            QUndoCommand* parent)
     : QUndoCommand(parent)
     , mSkeleton(skeleton)
@@ -21,8 +22,10 @@ BoneTransformCommand::BoneTransformCommand(Ogre::SkeletonInstance* skeleton,
     , mAfterPos(afterPos)
     , mAfterOrient(afterOrient)
     , mAfterScale(afterScale)
+    , mBindMode(bindMode)
 {
-    setText(QStringLiteral("Bone transform"));
+    setText(bindMode ? QStringLiteral("Bone bind-pose edit")
+                     : QStringLiteral("Bone transform"));
 }
 
 void BoneTransformCommand::apply(const Ogre::Vector3& p,
@@ -34,6 +37,11 @@ void BoneTransformCommand::apply(const Ogre::Vector3& p,
     bone->setPosition(p);
     bone->setOrientation(o);
     bone->setScale(s);
+    // For bind-pose edits, the durable artifact is the bone's initial
+    // state (used by Skeleton::reset → resetToInitialState). Capturing
+    // the new local as the new initial keeps undo/redo round-tripping
+    // the bind pose, not just the transient local TRS.
+    if (mBindMode) bone->setInitialState();
     bone->needUpdate();
 }
 

--- a/src/commands/BoneTransformCommand.h
+++ b/src/commands/BoneTransformCommand.h
@@ -1,0 +1,51 @@
+#ifndef BONE_TRANSFORM_COMMAND_H
+#define BONE_TRANSFORM_COMMAND_H
+
+#include <QUndoCommand>
+#include <OgreVector3.h>
+#include <OgreQuaternion.h>
+#include <string>
+
+namespace Ogre {
+    class SkeletonInstance;
+}
+
+/**
+ * Records a bone TRS edit applied directly in the viewport (not via a
+ * keyframe). On undo the bone reverts to its captured before-state; on
+ * redo the after-state is reapplied. Stores the skeleton + bone name
+ * (not the pointer) so it survives skeleton rebuilds.
+ *
+ * Used by the bone gizmo: the press handler captures the before-state,
+ * the release handler captures the after-state and pushes the command.
+ */
+class BoneTransformCommand : public QUndoCommand
+{
+public:
+    BoneTransformCommand(Ogre::SkeletonInstance* skeleton,
+                         std::string boneName,
+                         const Ogre::Vector3& beforePos,
+                         const Ogre::Quaternion& beforeOrient,
+                         const Ogre::Vector3& beforeScale,
+                         const Ogre::Vector3& afterPos,
+                         const Ogre::Quaternion& afterOrient,
+                         const Ogre::Vector3& afterScale,
+                         QUndoCommand* parent = nullptr);
+
+    void undo() override;
+    void redo() override;
+
+private:
+    void apply(const Ogre::Vector3& p, const Ogre::Quaternion& o, const Ogre::Vector3& s);
+
+    Ogre::SkeletonInstance* mSkeleton;
+    std::string             mBoneName;
+    Ogre::Vector3           mBeforePos;
+    Ogre::Quaternion        mBeforeOrient;
+    Ogre::Vector3           mBeforeScale;
+    Ogre::Vector3           mAfterPos;
+    Ogre::Quaternion        mAfterOrient;
+    Ogre::Vector3           mAfterScale;
+};
+
+#endif // BONE_TRANSFORM_COMMAND_H

--- a/src/commands/BoneTransformCommand.h
+++ b/src/commands/BoneTransformCommand.h
@@ -18,6 +18,12 @@ namespace Ogre {
  *
  * Used by the bone gizmo: the press handler captures the before-state,
  * the release handler captures the after-state and pushes the command.
+ *
+ * When `bindMode` is true (T-pose authoring path), undo/redo also call
+ * setInitialState() so the bone's initial (bind) pose is restored along
+ * with its current local TRS. Without this, the bind-pose edit
+ * persists across undo (Skeleton::reset would snap the bone back to
+ * the new bind on the next animation update, defeating undo).
  */
 class BoneTransformCommand : public QUndoCommand
 {
@@ -30,13 +36,15 @@ public:
                          const Ogre::Vector3& afterPos,
                          const Ogre::Quaternion& afterOrient,
                          const Ogre::Vector3& afterScale,
+                         bool bindMode = false,
                          QUndoCommand* parent = nullptr);
 
     void undo() override;
     void redo() override;
 
 private:
-    void apply(const Ogre::Vector3& p, const Ogre::Quaternion& o, const Ogre::Vector3& s);
+    void apply(const Ogre::Vector3& p, const Ogre::Quaternion& o,
+               const Ogre::Vector3& s);
 
     Ogre::SkeletonInstance* mSkeleton;
     std::string             mBoneName;
@@ -46,6 +54,7 @@ private:
     Ogre::Vector3           mAfterPos;
     Ogre::Quaternion        mAfterOrient;
     Ogre::Vector3           mAfterScale;
+    bool                    mBindMode;
 };
 
 #endif // BONE_TRANSFORM_COMMAND_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,6 +67,8 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/MoveKeyframeCommand.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/BulkKeyframeCommands.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/SetKeyframeValueCommand.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/BoneTransformCommand.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/BoneDragRelease.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/PropertiesPanelController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/SceneTreeModel.cpp
 


### PR DESCRIPTION
## Summary
Slice 2 of the bone gizmo work (#358). Builds on the bone-pick foundation merged in #385.

- **Translation gizmo anchored to selected bone**: in WORLD space by default (LOCAL via X key), follows the bone every frame so it tracks animation playback / slider scrubbing.
- **Three-way release semantics** (extracted into a testable \`BoneDragRelease\` helper):
  - Auto-key ON + animation enabled → write keyframe at scrub time, release manual control.
  - Auto-key OFF + animation enabled → preview only, revert to press-time pose on release.
  - No animation enabled → drag commits to bind pose via \`setInitialState()\` (T-pose authoring).
- **Translation safety**: rigged non-root bones blocked (would tear mesh from rig). Root bones (locomotion) and unrigged bones (sword/shield/hat sockets) freely translatable.
- **Root visual**: skeleton roots painted yellow in the debug overlay so users can identify them at a glance.
- **\`BoneTransformCommand\`** for undo/redo round-tripping.

### Bug fixes that came out of this work
- \`SkeletonDebug\` toggle off→on crash: leaked instance from \`mShowSkeleton.remove()\` had a stale QTimer touching dangling Ogre entities → SIGSEGV at offset 0xf8. Now \`delete\` the instance.
- \`updateAnimationTree\` now early-returns when the tree is unchanged, preventing \`QUndoStack::indexChanged\` → \`SelectionSet::selectionChanged\` from cascading into \`selectAnimation\` and resetting slider/bone selection on every undo push.
- BlendMask muting during drag: \`setManuallyControlled\` only excludes a bone from \`Skeleton::reset()\` — animation tracks still apply each frame. Mute the curve via the BlendMask so per-frame \`_updateAnimation\` doesn't fight the user's drag.
- Parentless-bone \`_setDerivedPosition\` is a no-op in Ogre (only writes when mParent != null). The move handler now falls back to \`setPosition()\` for true root bones.
- Axis lock at PRESS time, not first-move-event: prevents stale \`mTransformVector\` from a prior drag (or cursor drift onto a neighboring arrow) from picking the wrong axis.

### Tests
- \`BoneDragRelease_test.cpp\` — 8 tests covering all release-path semantics, the consecutive-drag accumulation regression, the \"Y then X\" leak regression, and the parentless-bone \`_setDerivedPosition\` behavior that drove the fallback fix.
- \`AnimationControlController_test.cpp\` — 4 tests for \`boneCanTranslate\` (null / root / rigged-non-root / unrigged-non-root).
- \`SkeletonDebug_test.cpp\` (from slice 1) — coverage for bone-name tagging used by viewport pick.

## Test plan
- [x] Local build clean (\`cmake --build build_local --target QtMeshEditor\`)
- [x] UnitTests target compiles all touched files
- [ ] CI: build-linux / build-macos / build-windows / unit-tests-linux / sonar
- [x] Manual: viewport bone pick, click-drag with auto-key off, auto-key on, root-bone translation, T-pose authoring with animation toggled on/off

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bone gizmo dragging in the viewport for interactive pose editing.
  * Auto-key now works for bones without pre-existing animation tracks.
  * Selected bones highlight immediately in the Animation Control panel.

* **Improvements**
  * Skeleton root bones now visually highlighted in yellow in debug view.
  * Full skeleton bone list now displayed, with tracked bones listed first.

* **Bug Fixes**
  * Fixed selection and slider resets during undo/redo operations.
  * Fixed memory leak in skeleton debug visualization.
  * Improved bone transform undo/redo reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->