### PR TITLE
feat(animation): keyframe undo + bone rotation/scale gizmos

### DIFF
--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -6,6 +6,7 @@
 #include "commands/MoveKeyframeCommand.h"
 #include "commands/BulkKeyframeCommands.h"
 #include "commands/SetKeyframeValueCommand.h"
+#include "commands/AddKeyframeCommand.h"
 #include <QApplication>
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -603,6 +604,11 @@ void AnimationControlController::addKeyframe()
     if (!m_selectedSkeleton->hasBone(m_selectedBone)) return;
     if (!m_selectedSkeleton->hasAnimation(m_selectedAnimation)) return;
 
+    // Determine the operation mode for undo: track-create vs.
+    // keyframe-create vs. keyframe-update.
+    const bool trackExisted = (m_selectedTrack != nullptr);
+    AddKeyframeCommand::Mode mode = AddKeyframeCommand::Mode::TrackCreated;
+
     // Lazily create an animation track for this bone if it doesn't have
     // one yet (non-rigged bones, or bones the imported animation didn't
     // touch). Without this, the user's edit would be a runtime-only
@@ -625,29 +631,58 @@ void AnimationControlController::addKeyframe()
     // this controller treats same-time collisions as invalid, and auto-key
     // would otherwise stack duplicates on every drag-end at the same scrub
     // time. Match the same epsilon used by deleteKeyframe (1 ms).
-    Ogre::TransformKeyFrame* newKf = nullptr;
+    Ogre::TransformKeyFrame* existingKf = nullptr;
     constexpr float kKeyframeEpsilon = 0.001f;
     for (unsigned short i = 0; i < m_selectedTrack->getNumKeyFrames(); ++i) {
         auto* existing = static_cast<Ogre::TransformKeyFrame*>(m_selectedTrack->getKeyFrame(i));
         if (std::fabs(existing->getTime() - time) <= kKeyframeEpsilon) {
-            newKf = existing;
+            existingKf = existing;
             break;
         }
     }
-    if (!newKf)
-        newKf = m_selectedTrack->createNodeKeyFrame(time);
 
-    // Capture the bone's current LOCAL TRS (relative to its initial bind pose),
-    // which is the format TransformKeyFrame stores. Previously this used
-    // getInterpolatedKeyFrame, which samples the existing animation curve at
-    // `time` and produces an identity-ish keyframe whenever the curve is flat
-    // there — the user-visible "blank registry" bug. With this change, hitting
-    // +KF after dragging the scene node (or, with #358's bone gizmo, the bone
-    // directly) captures the actual pose under the cursor at that scrub time.
+    // Capture before-TRS so undo restores the keyframe's pre-edit state.
+    // Defaults are identity for the create paths (the keyframe didn't
+    // exist; undo will remove it instead of restoring values).
+    Ogre::Vector3    beforeT = Ogre::Vector3::ZERO;
+    Ogre::Quaternion beforeR = Ogre::Quaternion::IDENTITY;
+    Ogre::Vector3    beforeS = Ogre::Vector3::UNIT_SCALE;
+    if (existingKf) {
+        beforeT = existingKf->getTranslate();
+        beforeR = existingKf->getRotation();
+        beforeS = existingKf->getScale();
+        mode = AddKeyframeCommand::Mode::KeyframeUpdated;
+    } else if (trackExisted) {
+        mode = AddKeyframeCommand::Mode::KeyframeCreated;
+    }
+    // else: trackExisted == false → Mode::TrackCreated (already set above).
+
+    // Compute the after-TRS from the bone's current local pose
+    // (relative to its initial bind pose, the format
+    // TransformKeyFrame stores). Previously this used
+    // getInterpolatedKeyFrame, which samples the existing animation
+    // curve at `time` and produces an identity-ish keyframe whenever
+    // the curve is flat there — the user-visible "blank registry"
+    // bug. With this change, hitting +KF after dragging the scene
+    // node (or, via the bone gizmo, the bone directly) captures the
+    // actual pose under the cursor at that scrub time.
     const Ogre::Bone* bone = m_selectedSkeleton->getBone(m_selectedBone);
-    newKf->setTranslate(bone->getPosition() - bone->getInitialPosition());
-    newKf->setRotation(bone->getInitialOrientation().Inverse() * bone->getOrientation());
-    newKf->setScale(bone->getScale() / bone->getInitialScale());
+    const Ogre::Vector3    afterT = bone->getPosition() - bone->getInitialPosition();
+    const Ogre::Quaternion afterR = bone->getInitialOrientation().Inverse() * bone->getOrientation();
+    const Ogre::Vector3    afterS = bone->getScale() / bone->getInitialScale();
+
+    // QUndoStack::push() executes redo() immediately, which performs the
+    // actual write. Pushing the command both creates the keyframe and
+    // makes it undoable.
+    auto* cmd = new AddKeyframeCommand(  // NOSONAR — QUndoStack owns
+        m_selectedSkeleton,
+        m_selectedAnimation,
+        m_selectedBone,
+        time,
+        mode,
+        beforeT, beforeR, beforeS,
+        afterT,  afterR,  afterS);
+    UndoManager::getSingleton()->push(cmd);
 
     refreshSliderTicks();
     setAnimationFrame(m_sliderValue);

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -546,6 +546,22 @@ void AnimationControlController::refreshSliderTicks()
     emit boneRowsChanged();
 }
 
+void AnimationControlController::onUndoRedoCommandApplied()
+{
+    // Structural undo/redo (track destroy, keyframe add/remove) can
+    // invalidate cached pointers we hold. Drop them, then rebuild the
+    // bone-list and slider ticks against the current skeleton state.
+    // refreshBoneList re-resolves m_selectedTrack against the active
+    // animation; refreshSliderTicks rebuilds the tick array from the
+    // (possibly new) track's current keyframes.
+    m_selectedTrack   = nullptr;
+    m_currentKeyframe = nullptr;
+    m_selectedTick    = -1;
+    refreshBoneList();
+    refreshSliderTicks();
+    setAnimationFrame(m_sliderValue);
+}
+
 // ── Keyframe editing ──────────────────────────────────────────────────────────
 
 bool AnimationControlController::hasPrevKeyframe() const

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -7,6 +7,7 @@
 #include "commands/BulkKeyframeCommands.h"
 #include "commands/SetKeyframeValueCommand.h"
 #include "commands/AddKeyframeCommand.h"
+#include "commands/DeleteKeyframeCommand.h"
 #include <QApplication>
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -549,15 +550,31 @@ void AnimationControlController::refreshSliderTicks()
 void AnimationControlController::onUndoRedoCommandApplied()
 {
     // Structural undo/redo (track destroy, keyframe add/remove) can
-    // invalidate cached pointers we hold. Drop them, then rebuild the
-    // bone-list and slider ticks against the current skeleton state.
-    // refreshBoneList re-resolves m_selectedTrack against the active
-    // animation; refreshSliderTicks rebuilds the tick array from the
-    // (possibly new) track's current keyframes.
+    // invalidate cached pointers we hold. Drop them and re-resolve
+    // against the current skeleton state — but preserve the user's
+    // current bone selection (refreshBoneList would reset to the
+    // first bone, which is jarring).
     m_selectedTrack   = nullptr;
     m_currentKeyframe = nullptr;
     m_selectedTick    = -1;
-    refreshBoneList();
+
+    // Re-resolve m_selectedTrack from the active animation + bone, if
+    // both are still valid (the track may have been destroyed by an
+    // AddKeyframeCommand undo on a lazy-created track).
+    if (m_selectedSkeleton && !m_selectedAnimation.empty()
+        && m_selectedSkeleton->hasAnimation(m_selectedAnimation)
+        && !m_selectedBone.empty()
+        && m_selectedSkeleton->hasBone(m_selectedBone))
+    {
+        Ogre::Animation* anim = m_selectedSkeleton->getAnimation(m_selectedAnimation);
+        for (const auto& pair : anim->_getNodeTrackList()) {
+            if (pair.second->getAssociatedNode()->getName() == m_selectedBone) {
+                m_selectedTrack = pair.second;
+                break;
+            }
+        }
+    }
+
     refreshSliderTicks();
     setAnimationFrame(m_sliderValue);
 }
@@ -708,15 +725,23 @@ void AnimationControlController::deleteKeyframe()
 {
     if (!m_selectedTrack || !m_currentKeyframe) return;
 
-    float t = m_currentKeyframe->getTime();
-    for (unsigned short i = 0; i < m_selectedTrack->getNumKeyFrames(); ++i) {
-        if (std::fabs(m_selectedTrack->getKeyFrame(i)->getTime() - t) < 0.001f) {
-            m_selectedTrack->removeKeyFrame(i);
-            break;
-        }
-    }
+    // Capture the keyframe's TRS so the undo path can restore it.
+    const float            t = m_currentKeyframe->getTime();
+    const Ogre::Vector3    keyT = m_currentKeyframe->getTranslate();
+    const Ogre::Quaternion keyR = m_currentKeyframe->getRotation();
+    const Ogre::Vector3    keyS = m_currentKeyframe->getScale();
+
+    // Push the command — its redo() removes the keyframe. Drop our
+    // cached pointer first since the command will invalidate it.
     m_currentKeyframe = nullptr;
     m_selectedTick    = -1;
+    auto* cmd = new DeleteKeyframeCommand(  // NOSONAR — QUndoStack owns
+        m_selectedSkeleton,
+        m_selectedAnimation,
+        m_selectedBone,
+        t, keyT, keyR, keyS);
+    UndoManager::getSingleton()->push(cmd);
+
     refreshSliderTicks();
     setAnimationFrame(m_sliderValue);
 }

--- a/src/AnimationControlController.h
+++ b/src/AnimationControlController.h
@@ -131,6 +131,13 @@ public:
     void   setLoopRegionActive(bool on);
     void   setAutoKey(bool on);
 
+    /// Invalidate cached track / keyframe pointers and rebuild the bone
+    /// list + slider ticks. Call after structural changes (track destroy,
+    /// keyframe add/remove) — e.g., from the QUndoStack indexChanged
+    /// handler — so subsequent slider scrubs don't read dangling
+    /// pointers from the previous state.
+    void onUndoRedoCommandApplied();
+
     // Compute the time after applying speed scaling and (optional) loop wrap.
     // Used by MainWindow::frameRenderingQueued. `currentTime` and `dt` are
     // in seconds; returns the new time position to assign back to the state.

--- a/src/AnimationControlController_test.cpp
+++ b/src/AnimationControlController_test.cpp
@@ -1221,3 +1221,41 @@ TEST_F(AnimationControlControllerTest, BoneCanTranslateUnriggedNonRootAllowed) {
     ASSERT_TRUE(attach->getParent());
     EXPECT_TRUE(ctrl->boneCanTranslate(attach));
 }
+
+// ── onUndoRedoCommandApplied ──────────────────────────────────────────────────
+//
+// Called from MainWindow's QUndoStack::indexChanged handler after a
+// keyframe-affecting command runs. Must invalidate stale track/keyframe
+// pointers (an AddKeyframeCommand undo can destroy a lazy-created track)
+// and preserve the user's current bone selection (rebuilding via
+// refreshBoneList would reset it to the first bone — jarring UX).
+
+TEST_F(AnimationControlControllerTest, OnUndoRedoCommandAppliedPreservesBoneSelection) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("ACC_UndoPreservesBone");
+    ASSERT_NE(entity, nullptr);
+
+    auto* ctrl = AnimationControlController::instance();
+    ctrl->updateAnimationTree();
+    ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+    ASSERT_FALSE(ctrl->boneNames().isEmpty());
+
+    // Pick a non-default bone (the second in the list, if any). With
+    // only one bone, this still validates "preserves selection".
+    const QString picked = ctrl->boneNames().size() > 1
+        ? ctrl->boneNames().at(1)
+        : ctrl->boneNames().first();
+    ctrl->selectBone(picked);
+    ASSERT_EQ(ctrl->selectedBone(), picked);
+
+    ctrl->onUndoRedoCommandApplied();
+    EXPECT_EQ(ctrl->selectedBone(), picked)
+        << "onUndoRedoCommandApplied reset bone selection (regression)";
+}
+
+TEST_F(AnimationControlControllerTest, OnUndoRedoCommandAppliedSurvivesMissingBone) {
+    // Defensive: if m_selectedBone is empty (no bone picked yet),
+    // the helper must not crash.
+    auto* ctrl = AnimationControlController::instance();
+    EXPECT_NO_THROW(ctrl->onUndoRedoCommandApplied());
+}

--- a/src/AnimationControlController_test.cpp
+++ b/src/AnimationControlController_test.cpp
@@ -8,6 +8,8 @@
 #include "Manager.h"
 #include "SelectionSet.h"
 #include "TestHelpers.h"
+#include "UndoManager.h"
+#include <QUndoStack>
 #include <OgreSkeletonInstance.h>
 #include <OgreAnimation.h>
 #include <OgreAnimationState.h>
@@ -1258,4 +1260,111 @@ TEST_F(AnimationControlControllerTest, OnUndoRedoCommandAppliedSurvivesMissingBo
     // the helper must not crash.
     auto* ctrl = AnimationControlController::instance();
     EXPECT_NO_THROW(ctrl->onUndoRedoCommandApplied());
+}
+
+// ── addKeyframe + undo/redo (integration) ────────────────────────────────────
+//
+// Exercises the +KF / auto-key wiring through AnimationControlController::
+// addKeyframe() and the QUndoStack rather than the AddKeyframeCommand
+// helper directly. The TrackCreated path in particular is fragile because
+// the controller pre-creates the track before pushing the command, so a
+// pure unit test misses what production code actually runs.
+
+TEST_F(AnimationControlControllerTest, AddKeyframeIsUndoableViaQUndoStack) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("ACC_AddKfUndo");
+    ASSERT_NE(entity, nullptr);
+
+    auto* ctrl = AnimationControlController::instance();
+    ctrl->updateAnimationTree();
+    ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+    ctrl->selectBone(ctrl->boneNames().first());
+
+    auto* track = entity->getSkeleton()->getAnimation("TestAnim")
+                         ->_getNodeTrackList().begin()->second;
+    const auto countBefore = track->getNumKeyFrames();
+
+    // Add a kf at a slider position that doesn't already have one
+    // (TestAnim has keys at 0.0, 0.5, 1.0 — pick 0.25).
+    ctrl->setSliderValue(250);
+    ctrl->addKeyframe();
+    app->processEvents();
+    EXPECT_EQ(track->getNumKeyFrames(), countBefore + 1);
+
+    UndoManager::getSingleton()->stack()->undo();
+    app->processEvents();
+    EXPECT_EQ(track->getNumKeyFrames(), countBefore);
+
+    UndoManager::getSingleton()->stack()->redo();
+    app->processEvents();
+    EXPECT_EQ(track->getNumKeyFrames(), countBefore + 1);
+}
+
+TEST_F(AnimationControlControllerTest, AddKeyframeOnUntrackedBoneIsUndoable) {
+    // The TrackCreated path: lazy-create a track for a bone that
+    // doesn't have one in the active animation, then undo. The
+    // whole track should be destroyed, and the controller's cached
+    // m_selectedTrack pointer must be invalidated so subsequent
+    // slider scrubs don't crash.
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("ACC_AddKfTrackCreated");
+    ASSERT_NE(entity, nullptr);
+
+    auto* skel = entity->getSkeleton();
+    Ogre::Bone* extra = skel->createBone("ExtraBone", 2);
+    extra->setPosition(Ogre::Vector3(0, 0, 1));
+    skel->getBone("Root")->addChild(extra);
+    auto* anim = skel->getAnimation("TestAnim");
+    ASSERT_FALSE(anim->hasNodeTrack(extra->getHandle()));
+
+    auto* ctrl = AnimationControlController::instance();
+    ctrl->updateAnimationTree();
+    ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+    ctrl->selectBone("ExtraBone");
+    ctrl->setSliderValue(250);
+
+    ctrl->addKeyframe();
+    app->processEvents();
+    EXPECT_TRUE(anim->hasNodeTrack(extra->getHandle()));
+
+    UndoManager::getSingleton()->stack()->undo();
+    app->processEvents();
+    EXPECT_FALSE(anim->hasNodeTrack(extra->getHandle()));
+
+    // Slider scrub after undo must not crash on a stale m_selectedTrack
+    // (regression for the user-reported "crash after undo" bug).
+    EXPECT_NO_THROW(ctrl->setSliderValue(500));
+}
+
+TEST_F(AnimationControlControllerTest, DeleteKeyframeIsUndoableViaQUndoStack) {
+    // Verify -KF integration with the QUndoStack: deleting a keyframe,
+    // undoing restores it; redoing removes it again.
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("ACC_DelKfUndo");
+    ASSERT_NE(entity, nullptr);
+
+    auto* ctrl = AnimationControlController::instance();
+    ctrl->updateAnimationTree();
+    ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+    ctrl->selectBone(ctrl->boneNames().first());
+
+    auto* track = entity->getSkeleton()->getAnimation("TestAnim")
+                         ->_getNodeTrackList().begin()->second;
+    const auto countBefore = track->getNumKeyFrames();
+
+    // Land on the keyframe at 0.5s, then delete it.
+    ctrl->setSliderValue(500);
+    app->processEvents();
+    ASSERT_TRUE(ctrl->onKeyframe());
+    ctrl->deleteKeyframe();
+    app->processEvents();
+    EXPECT_EQ(track->getNumKeyFrames(), countBefore - 1);
+
+    UndoManager::getSingleton()->stack()->undo();
+    app->processEvents();
+    EXPECT_EQ(track->getNumKeyFrames(), countBefore);
+
+    UndoManager::getSingleton()->stack()->redo();
+    app->processEvents();
+    EXPECT_EQ(track->getNumKeyFrames(), countBefore - 1);
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,6 +60,7 @@ commands/BulkKeyframeCommands.cpp
 commands/SetKeyframeValueCommand.cpp
 commands/BoneTransformCommand.cpp
 commands/AddKeyframeCommand.cpp
+commands/DeleteKeyframeCommand.cpp
 BoneDragRelease.cpp
 PropertiesPanelController.cpp
 SceneTreeModel.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,6 +59,7 @@ commands/MoveKeyframeCommand.cpp
 commands/BulkKeyframeCommands.cpp
 commands/SetKeyframeValueCommand.cpp
 commands/BoneTransformCommand.cpp
+commands/AddKeyframeCommand.cpp
 BoneDragRelease.cpp
 PropertiesPanelController.cpp
 SceneTreeModel.cpp

--- a/src/TransformOperator.cpp
+++ b/src/TransformOperator.cpp
@@ -1080,21 +1080,24 @@ void TransformOperator::mousePressEvent(QMouseEvent *e)
             m_pSelectionBox->setVisible(true);
 
         }
-        else if (mTransformState == TS_TRANSLATE
+        else if ((mTransformState == TS_TRANSLATE
+                  || mTransformState == TS_ROTATE
+                  || mTransformState == TS_SCALE)
                  && AnimationControlController::instance()->selectedBonePtr()
                  && e->button() == Qt::LeftButton)
         {
-            // Bone-gizmo translation: drive the bone's local position
-            // instead of any scene-node selection. Capture before-state
-            // for undo; the actual delta is applied in mouseMoveEvent
-            // via the bone-aware translate path.
+            // Bone-gizmo press (translate/rotate/scale): drive the
+            // bone's local TRS instead of any scene-node selection.
+            // Capture before-state for undo; the actual delta is
+            // applied in mouseMoveEvent via the bone-aware path.
             Ogre::Bone* bone = AnimationControlController::instance()->selectedBonePtr();
-            // Block translation on rigged non-root bones — moving them
-            // tears the bone away from its parent in the hierarchy and
-            // produces broken poses (children flail to compensate).
-            // Root bone (locomotion) and unrigged attachment points
-            // (sword/shield/hat sockets) remain freely translatable.
-            if (!AnimationControlController::instance()->boneCanTranslate(bone))
+            // Translation is restricted on rigged non-root bones —
+            // moving them tears the bone from its parent. Rotation
+            // and scale are always allowed (rotation is the primary
+            // posing tool; scale is uncommon but valid for stretchy
+            // rigs).
+            if (mTransformState == TS_TRANSLATE
+                && !AnimationControlController::instance()->boneCanTranslate(bone))
             {
                 SentryReporter::addBreadcrumb("ui.transform",
                     "Bone translate blocked: rigged non-root bone");
@@ -1106,17 +1109,20 @@ void TransformOperator::mousePressEvent(QMouseEvent *e)
             mBoneStartScale       = bone->getScale();
             mBoneStartDerivedPos  = bone->_getDerivedPosition();
             mBoneDragGizmoOrigin  = m_pTransformNode->getPosition();
-            // Lock the axis at PRESS time, not on first move. If the
-            // user clicked on an arrow, that's the axis they want — even
-            // if their cursor drifts onto a neighboring arrow during the
-            // drag motion. Without this, a stale axis from the previous
-            // drag could persist or the survey might hit the wrong axis
-            // mid-motion.
+            // Lock the axis at PRESS time. The relevant gizmo varies
+            // by mode: translate uses arrow handles, rotate uses
+            // circle handles, scale uses cube handles.
             Ogre::MovableObject* pressGizmoAxis = performRaySelection(e->pos(), true);
-            if (pressGizmoAxis)
-                mTransformVector = m_pTranslationGizmo->highlightAxis(pressGizmoAxis);
-            else
+            if (pressGizmoAxis) {
+                if (mTransformState == TS_TRANSLATE)
+                    mTransformVector = m_pTranslationGizmo->highlightAxis(pressGizmoAxis);
+                else if (mTransformState == TS_ROTATE)
+                    mTransformVector = m_pRotationGizmo->highlightCircle(pressGizmoAxis);
+                else
+                    mTransformVector = m_pScaleGizmo->highlightAxis(pressGizmoAxis);
+            } else {
                 mTransformVector = Ogre::Vector3::ZERO;
+            }
             // Without this the skeleton's animation system overwrites
             // the bone's local TRS every frame from interpolated keys,
             // so our drag never visibly sticks. Manual-control mode
@@ -1154,13 +1160,22 @@ void TransformOperator::mousePressEvent(QMouseEvent *e)
             mBoneDragWasPlaying = PropertiesPanelController::instance()->isPlaying();
             if (mBoneDragWasPlaying)
                 PropertiesPanelController::instance()->setPlaying(false);
-            SentryReporter::addBreadcrumb("ui.transform", "Translate bone");
+            const char* breadcrumb =
+                mTransformState == TS_TRANSLATE ? "Translate bone" :
+                mTransformState == TS_ROTATE    ? "Rotate bone"    :
+                                                  "Scale bone";
+            SentryReporter::addBreadcrumb("ui.transform", breadcrumb);
 
             Ogre::Ray mouseRay = rayFromScreenPoint(e->pos());
             auto result = mouseRay.intersects(
                 Ogre::Plane(mouseRay.getDirection(), m_pTransformNode->getPosition()));
             if (result.first)
                 mStartPoint = mouseRay.getPoint(result.second);
+            // Scale uses a pixel-delta model rather than world-space
+            // rays; capture the press-time pixel so the move handler
+            // can compute deltas.
+            if (mTransformState == TS_SCALE)
+                mScaleDragStartPixel = e->pos();
         }
         else if((!SelectionSet::getSingleton()->isEmpty()) && (e->button() == Qt::LeftButton))
         {
@@ -1467,6 +1482,80 @@ void TransformOperator::mouseMoveEvent(QMouseEvent *e)
         updateGizmoPosition();
         return;
     }
+    else if (mTransformState == TS_ROTATE && mBoneDragActive
+             && AnimationControlController::instance()->selectedBonePtr())
+    {
+        // Bone-gizmo rotation: drive the bone's local orientation. The
+        // RotationGizmo's circles are anchored to the bone-world frame
+        // (via the gizmo node), so dragging a circle rotates the bone
+        // around the corresponding axis. Math mirrors the scene-node
+        // rotate handler — start/end vectors from gizmo center, get
+        // the rotation between them, mask to the highlighted circle.
+        if (mTransformVector.isZeroLength()) return;
+        Ogre::Ray mouseRay = rayFromScreenPoint(e->pos());
+        auto result = mouseRay.intersects(
+            Ogre::Plane(mouseRay.getDirection(), mBoneDragGizmoOrigin));
+        if (!result.first) return;
+
+        Ogre::Vector3 point = mouseRay.getPoint(result.second);
+        Ogre::Vector3 vectorStart = mStartPoint - mBoneDragGizmoOrigin;
+        Ogre::Vector3 vectorEnd   = point - mBoneDragGizmoOrigin;
+        Ogre::Quaternion gizmoOri = m_pTransformNode->getOrientation();
+        Ogre::Vector3 localStart  = gizmoOri.Inverse() * vectorStart;
+        Ogre::Vector3 localEnd    = gizmoOri.Inverse() * vectorEnd;
+        Ogre::Quaternion localRot = localStart.getRotationTo(localEnd);
+        localRot.x *= mTransformVector.x;
+        localRot.y *= mTransformVector.y;
+        localRot.z *= mTransformVector.z;
+        localRot.normalise();
+        // Convert to world rotation, then accumulate onto the press-time
+        // bone orientation. Re-anchor mStartPoint each event so the
+        // delta is incremental (matches the scene-node behavior).
+        Ogre::Quaternion worldRot = gizmoOri * localRot * gizmoOri.Inverse();
+        Ogre::Bone* bone = AnimationControlController::instance()->selectedBonePtr();
+        Ogre::Entity* ent = AnimationControlController::instance()->selectedEntity();
+        if (!ent || !ent->getParentSceneNode()) return;
+
+        // Map world rotation into bone-local space by composing with
+        // the entity world + parent-bone derived orientations.
+        Ogre::Quaternion entWorldOri = ent->getParentSceneNode()->_getDerivedOrientation();
+        Ogre::Quaternion parentDerOri = Ogre::Quaternion::IDENTITY;
+        if (bone->getParent())
+            parentDerOri = static_cast<Ogre::Bone*>(bone->getParent())->_getDerivedOrientation();
+        Ogre::Quaternion worldToParent = (entWorldOri * parentDerOri).Inverse();
+        Ogre::Quaternion localFrameRot = worldToParent * worldRot * (entWorldOri * parentDerOri);
+
+        bone->rotate(localFrameRot, Ogre::Node::TS_LOCAL);
+        bone->needUpdate(true);
+        mStartPoint = point;
+        updateGizmoPosition();
+        return;
+    }
+    else if (mTransformState == TS_SCALE && mBoneDragActive
+             && AnimationControlController::instance()->selectedBonePtr())
+    {
+        // Bone-gizmo scale: pixel-delta drag against the press-time
+        // pixel position, scale uniformly (or per-axis when an axis
+        // is locked) on the bone's local scale. Less common than
+        // rotation but completes the W/E/R triad.
+        if (mTransformVector.isZeroLength()) return;
+        const QPoint pixelDelta = e->pos() - mScaleDragStartPixel;
+        const float pixels = static_cast<float>(pixelDelta.x() - pixelDelta.y());
+        constexpr float kPixelsPerDouble = 100.0f;
+        float ratio = std::pow(2.0f, pixels / kPixelsPerDouble);
+        if (ratio < 0.01f) ratio = 0.01f;
+        if (ratio > 100.0f) ratio = 100.0f;
+
+        Ogre::Vector3 scaleFactor = (mTransformVector == Ogre::Vector3::ZERO)
+            ? Ogre::Vector3(ratio, ratio, ratio)
+            : Ogre::Vector3::UNIT_SCALE + (mTransformVector * (ratio - 1.0f));
+
+        Ogre::Bone* bone = AnimationControlController::instance()->selectedBonePtr();
+        bone->setScale(mBoneStartScale * scaleFactor);
+        bone->needUpdate(true);
+        updateGizmoPosition();
+        return;
+    }
     else if(mTransformState == TS_TRANSLATE && (!SelectionSet::getSingleton()->isEmpty()))
     {
         //Translate the selected object
@@ -1770,10 +1859,12 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
                 hasActiveAnim, autoKeyOn,
                 AnimationControlController::instance()->selectedEntity());
             if (outcome == BoneDragRelease::Result::Commit) {
-                UndoManager::getSingleton()->push(
-                    new BoneTransformCommand(skel, bone->getName(),
-                        mBoneStartPos, mBoneStartOrient, mBoneStartScale,
-                        afterPos,      afterOrient,      afterScale));
+                // autoKeyOnTransform → addKeyframe → AddKeyframeCommand
+                // captures the durable artifact (the keyframe). The
+                // bone's live local TRS is fully determined by the
+                // curve at slider time after Skeleton::reset, so we
+                // don't need a separate BoneTransformCommand here —
+                // undoing the keyframe is enough.
                 AnimationControlController::instance()->autoKeyOnTransform();
             } else if (outcome == BoneDragRelease::Result::CommitBind) {
                 // bindMode=true so undo also reverts the bone's initial

--- a/src/commands/AddKeyframeCommand.cpp
+++ b/src/commands/AddKeyframeCommand.cpp
@@ -1,0 +1,116 @@
+#include "AddKeyframeCommand.h"
+
+#include <OgreSkeleton.h>
+#include <OgreBone.h>
+#include <OgreAnimation.h>
+#include <OgreAnimationTrack.h>
+#include <OgreKeyFrame.h>
+
+#include <cmath>
+
+namespace { constexpr float kKeyframeEpsilon = 0.001f; }
+
+AddKeyframeCommand::AddKeyframeCommand(Ogre::Skeleton* skeleton,
+                                       std::string animationName,
+                                       std::string boneName,
+                                       float time,
+                                       Mode mode,
+                                       const Ogre::Vector3& beforeTranslate,
+                                       const Ogre::Quaternion& beforeRotation,
+                                       const Ogre::Vector3& beforeScale,
+                                       const Ogre::Vector3& afterTranslate,
+                                       const Ogre::Quaternion& afterRotation,
+                                       const Ogre::Vector3& afterScale,
+                                       QUndoCommand* parent)
+    : QUndoCommand(parent)
+    , mSkeleton(skeleton)
+    , mAnimationName(std::move(animationName))
+    , mBoneName(std::move(boneName))
+    , mTime(time)
+    , mMode(mode)
+    , mBeforeTranslate(beforeTranslate)
+    , mBeforeRotation(beforeRotation)
+    , mBeforeScale(beforeScale)
+    , mAfterTranslate(afterTranslate)
+    , mAfterRotation(afterRotation)
+    , mAfterScale(afterScale)
+{
+    setText(QStringLiteral("Add keyframe"));
+}
+
+Ogre::NodeAnimationTrack* AddKeyframeCommand::findTrack() const
+{
+    if (!mSkeleton || !mSkeleton->hasAnimation(mAnimationName)) return nullptr;
+    Ogre::Animation* anim = mSkeleton->getAnimation(mAnimationName);
+    if (!mSkeleton->hasBone(mBoneName)) return nullptr;
+    Ogre::Bone* bone = mSkeleton->getBone(mBoneName);
+    for (const auto& pair : anim->_getNodeTrackList()) {
+        if (pair.second->getAssociatedNode()->getName() == bone->getName())
+            return pair.second;
+    }
+    return nullptr;
+}
+
+Ogre::TransformKeyFrame* AddKeyframeCommand::findKeyframe(Ogre::NodeAnimationTrack* track) const
+{
+    if (!track) return nullptr;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        auto* kf = static_cast<Ogre::TransformKeyFrame*>(track->getKeyFrame(i));
+        if (std::fabs(kf->getTime() - mTime) <= kKeyframeEpsilon) return kf;
+    }
+    return nullptr;
+}
+
+void AddKeyframeCommand::redo()
+{
+    if (!mSkeleton || !mSkeleton->hasAnimation(mAnimationName)) return;
+    Ogre::Animation* anim = mSkeleton->getAnimation(mAnimationName);
+    if (!mSkeleton->hasBone(mBoneName)) return;
+    Ogre::Bone* bone = mSkeleton->getBone(mBoneName);
+
+    Ogre::NodeAnimationTrack* track = findTrack();
+    if (!track && mMode == Mode::TrackCreated)
+        track = anim->createNodeTrack(bone->getHandle(), bone);
+    if (!track) return;
+
+    Ogre::TransformKeyFrame* kf = findKeyframe(track);
+    if (!kf) kf = track->createNodeKeyFrame(mTime);
+    kf->setTranslate(mAfterTranslate);
+    kf->setRotation(mAfterRotation);
+    kf->setScale(mAfterScale);
+}
+
+void AddKeyframeCommand::undo()
+{
+    Ogre::NodeAnimationTrack* track = findTrack();
+    if (!track) return;
+
+    if (mMode == Mode::TrackCreated) {
+        // Lazy-created track: destroy it entirely so the bone returns
+        // to its "no track" state (curve doesn't drive it during
+        // playback, bone holds its bind/manual pose).
+        Ogre::Animation* anim = mSkeleton->getAnimation(mAnimationName);
+        Ogre::Bone* bone = mSkeleton->getBone(mBoneName);
+        anim->destroyNodeTrack(bone->getHandle());
+        return;
+    }
+
+    Ogre::TransformKeyFrame* kf = findKeyframe(track);
+    if (!kf) return;
+
+    if (mMode == Mode::KeyframeCreated) {
+        // Find the keyframe's index and remove it.
+        for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+            auto* candidate = static_cast<Ogre::TransformKeyFrame*>(track->getKeyFrame(i));
+            if (std::fabs(candidate->getTime() - mTime) <= kKeyframeEpsilon) {
+                track->removeKeyFrame(i);
+                return;
+            }
+        }
+    } else {
+        // KeyframeUpdated: restore the pre-edit TRS in place.
+        kf->setTranslate(mBeforeTranslate);
+        kf->setRotation(mBeforeRotation);
+        kf->setScale(mBeforeScale);
+    }
+}

--- a/src/commands/AddKeyframeCommand.h
+++ b/src/commands/AddKeyframeCommand.h
@@ -1,0 +1,72 @@
+#ifndef ADD_KEYFRAME_COMMAND_H
+#define ADD_KEYFRAME_COMMAND_H
+
+#include <QUndoCommand>
+#include <OgreVector3.h>
+#include <OgreQuaternion.h>
+#include <string>
+
+namespace Ogre {
+    class Skeleton;
+    class NodeAnimationTrack;
+    class TransformKeyFrame;
+}
+
+/**
+ * Records an addKeyframe() operation so it can be undone. Captures all
+ * three modes the caller can produce:
+ *
+ *   1. Track did not exist pre-edit, keyframe was created → on undo,
+ *      destroy the track entirely (the bone returns to "no track" state
+ *      so non-rigged bones keep their bind pose under animation playback).
+ *   2. Track existed, keyframe at this time did not → on undo, remove
+ *      the keyframe.
+ *   3. Track existed, keyframe at this time existed → on undo, restore
+ *      the keyframe's pre-edit TRS.
+ *
+ * Stores skeleton/animation/bone names (not pointers) so it survives
+ * skeleton rebuilds. The mTime field is the keyframe's time in seconds.
+ */
+class AddKeyframeCommand : public QUndoCommand
+{
+public:
+    enum class Mode {
+        TrackCreated,        ///< Lazy-created track + first keyframe
+        KeyframeCreated,     ///< Existing track, new keyframe added
+        KeyframeUpdated,     ///< Existing track, existing keyframe updated in-place
+    };
+
+    AddKeyframeCommand(Ogre::Skeleton* skeleton,
+                       std::string animationName,
+                       std::string boneName,
+                       float time,
+                       Mode mode,
+                       const Ogre::Vector3& beforeTranslate,
+                       const Ogre::Quaternion& beforeRotation,
+                       const Ogre::Vector3& beforeScale,
+                       const Ogre::Vector3& afterTranslate,
+                       const Ogre::Quaternion& afterRotation,
+                       const Ogre::Vector3& afterScale,
+                       QUndoCommand* parent = nullptr);
+
+    void undo() override;
+    void redo() override;
+
+private:
+    Ogre::NodeAnimationTrack* findTrack() const;
+    Ogre::TransformKeyFrame*  findKeyframe(Ogre::NodeAnimationTrack* track) const;
+
+    Ogre::Skeleton*  mSkeleton;
+    std::string      mAnimationName;
+    std::string      mBoneName;
+    float            mTime;        ///< keyframe time in seconds
+    Mode             mMode;
+    Ogre::Vector3    mBeforeTranslate;
+    Ogre::Quaternion mBeforeRotation;
+    Ogre::Vector3    mBeforeScale;
+    Ogre::Vector3    mAfterTranslate;
+    Ogre::Quaternion mAfterRotation;
+    Ogre::Vector3    mAfterScale;
+};
+
+#endif // ADD_KEYFRAME_COMMAND_H

--- a/src/commands/AddKeyframeCommand_test.cpp
+++ b/src/commands/AddKeyframeCommand_test.cpp
@@ -1,0 +1,164 @@
+#include <gtest/gtest.h>
+#include <QApplication>
+#include <QCoreApplication>
+#include <QThread>
+
+#include "commands/AddKeyframeCommand.h"
+#include "Manager.h"
+#include "TestHelpers.h"
+
+#include <OgreSkeletonInstance.h>
+#include <OgreBone.h>
+#include <OgreEntity.h>
+#include <OgreAnimation.h>
+#include <OgreAnimationTrack.h>
+#include <OgreKeyFrame.h>
+
+#include <cmath>
+
+class AddKeyframeCommandTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        Manager::kill();
+        QThread::msleep(20);
+        app = qobject_cast<QApplication*>(QCoreApplication::instance());
+        ASSERT_NE(app, nullptr);
+        ASSERT_TRUE(tryInitOgre());
+        createStandardOgreMaterials();
+        ASSERT_TRUE(canLoadMeshFiles());
+    }
+    void TearDown() override {
+        Manager::kill();
+        if (app) app->processEvents();
+        QThread::msleep(20);
+    }
+    QApplication* app = nullptr;
+};
+
+namespace {
+Ogre::NodeAnimationTrack* findTrack(Ogre::SkeletonInstance* skel,
+                                    const std::string& animName,
+                                    const std::string& boneName) {
+    if (!skel || !skel->hasAnimation(animName)) return nullptr;
+    auto* anim = skel->getAnimation(animName);
+    for (const auto& p : anim->_getNodeTrackList()) {
+        if (p.second->getAssociatedNode()->getName() == boneName)
+            return p.second;
+    }
+    return nullptr;
+}
+Ogre::TransformKeyFrame* findKeyframe(Ogre::NodeAnimationTrack* track, float time) {
+    if (!track) return nullptr;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        auto* kf = static_cast<Ogre::TransformKeyFrame*>(track->getKeyFrame(i));
+        if (std::fabs(kf->getTime() - time) <= 0.001f) return kf;
+    }
+    return nullptr;
+}
+}
+
+TEST_F(AddKeyframeCommandTest, KeyframeUpdatedRoundTrips) {
+    // The "Child" bone has a track with keyframes at 0.0, 0.5, 1.0
+    // (see TestHelpers.h). Updating the kf at 0.5 must be undoable.
+    Ogre::Entity* entity = createAnimatedTestEntity("AKC_Updated");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+    auto* track = findTrack(skel, "TestAnim", "Child");
+    ASSERT_NE(track, nullptr);
+    auto* kf = findKeyframe(track, 0.5f);
+    ASSERT_NE(kf, nullptr);
+    const Ogre::Vector3 origT = kf->getTranslate();
+
+    AddKeyframeCommand cmd(
+        skel, "TestAnim", "Child", 0.5f,
+        AddKeyframeCommand::Mode::KeyframeUpdated,
+        origT, kf->getRotation(), kf->getScale(),
+        Ogre::Vector3(99, 0, 0), kf->getRotation(), kf->getScale());
+    cmd.redo();
+    auto* kfAfter = findKeyframe(track, 0.5f);
+    ASSERT_NE(kfAfter, nullptr);
+    EXPECT_EQ(kfAfter->getTranslate(), Ogre::Vector3(99, 0, 0));
+
+    cmd.undo();
+    auto* kfRestored = findKeyframe(track, 0.5f);
+    ASSERT_NE(kfRestored, nullptr);
+    EXPECT_EQ(kfRestored->getTranslate(), origT);
+}
+
+TEST_F(AddKeyframeCommandTest, KeyframeCreatedUndoRemovesKeyframe) {
+    // Create a new keyframe at 0.25 (time with no existing kf), then
+    // undo it. The keyframe must be removed; existing kfs untouched.
+    Ogre::Entity* entity = createAnimatedTestEntity("AKC_Created");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+    auto* track = findTrack(skel, "TestAnim", "Child");
+    ASSERT_NE(track, nullptr);
+    const auto countBefore = track->getNumKeyFrames();
+
+    AddKeyframeCommand cmd(
+        skel, "TestAnim", "Child", 0.25f,
+        AddKeyframeCommand::Mode::KeyframeCreated,
+        Ogre::Vector3::ZERO, Ogre::Quaternion::IDENTITY, Ogre::Vector3::UNIT_SCALE,
+        Ogre::Vector3(2, 0, 0), Ogre::Quaternion::IDENTITY, Ogre::Vector3::UNIT_SCALE);
+    cmd.redo();
+    EXPECT_EQ(track->getNumKeyFrames(), countBefore + 1);
+    EXPECT_NE(findKeyframe(track, 0.25f), nullptr);
+
+    cmd.undo();
+    EXPECT_EQ(track->getNumKeyFrames(), countBefore);
+    EXPECT_EQ(findKeyframe(track, 0.25f), nullptr);
+}
+
+TEST_F(AddKeyframeCommandTest, TrackCreatedUndoDestroysTrack) {
+    // Lazy-creating a track (e.g., for a non-rigged bone the user
+    // wants to animate) and undoing must destroy the track entirely.
+    Ogre::Entity* entity = createAnimatedTestEntity("AKC_TrackCreated");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+    // Add a bone with no track in TestAnim — simulating a non-rigged
+    // bone the user just edited via the gizmo.
+    Ogre::Bone* extra = skel->createBone("Extra", 2);
+    extra->setPosition(Ogre::Vector3(0, 0, 1));
+    skel->getBone("Root")->addChild(extra);
+
+    ASSERT_EQ(findTrack(skel, "TestAnim", "Extra"), nullptr);
+
+    AddKeyframeCommand cmd(
+        skel, "TestAnim", "Extra", 0.0f,
+        AddKeyframeCommand::Mode::TrackCreated,
+        Ogre::Vector3::ZERO, Ogre::Quaternion::IDENTITY, Ogre::Vector3::UNIT_SCALE,
+        Ogre::Vector3(0.5f, 0, 0), Ogre::Quaternion::IDENTITY, Ogre::Vector3::UNIT_SCALE);
+    cmd.redo();
+    EXPECT_NE(findTrack(skel, "TestAnim", "Extra"), nullptr);
+
+    cmd.undo();
+    EXPECT_EQ(findTrack(skel, "TestAnim", "Extra"), nullptr)
+        << "Undo did not destroy the lazy-created track";
+}
+
+TEST_F(AddKeyframeCommandTest, RedoAfterUndoRestoresKeyframe) {
+    // Round-trip through undo and redo to confirm symmetry.
+    Ogre::Entity* entity = createAnimatedTestEntity("AKC_Redo");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+    auto* track = findTrack(skel, "TestAnim", "Child");
+    ASSERT_NE(track, nullptr);
+    const auto countBefore = track->getNumKeyFrames();
+
+    AddKeyframeCommand cmd(
+        skel, "TestAnim", "Child", 0.75f,
+        AddKeyframeCommand::Mode::KeyframeCreated,
+        Ogre::Vector3::ZERO, Ogre::Quaternion::IDENTITY, Ogre::Vector3::UNIT_SCALE,
+        Ogre::Vector3(3, 0, 0), Ogre::Quaternion::IDENTITY, Ogre::Vector3::UNIT_SCALE);
+    cmd.redo();
+    EXPECT_EQ(track->getNumKeyFrames(), countBefore + 1);
+
+    cmd.undo();
+    EXPECT_EQ(track->getNumKeyFrames(), countBefore);
+
+    cmd.redo();
+    EXPECT_EQ(track->getNumKeyFrames(), countBefore + 1);
+    auto* kf = findKeyframe(track, 0.75f);
+    ASSERT_NE(kf, nullptr);
+    EXPECT_EQ(kf->getTranslate(), Ogre::Vector3(3, 0, 0));
+}

--- a/src/commands/BoneTransformCommand.cpp
+++ b/src/commands/BoneTransformCommand.cpp
@@ -42,7 +42,11 @@ void BoneTransformCommand::apply(const Ogre::Vector3& p,
     // the new local as the new initial keeps undo/redo round-tripping
     // the bind pose, not just the transient local TRS.
     if (mBindMode) bone->setInitialState();
-    bone->needUpdate();
+    // needUpdate(true) propagates to children, so the whole subtree's
+    // derived transforms are invalidated. Without `true`, child TagPoints
+    // (e.g. SkeletonDebug bone visuals) keep stale derived poses until
+    // the next animation tick.
+    bone->needUpdate(true);
 }
 
 void BoneTransformCommand::undo() { apply(mBeforePos, mBeforeOrient, mBeforeScale); }

--- a/src/commands/DeleteKeyframeCommand.cpp
+++ b/src/commands/DeleteKeyframeCommand.cpp
@@ -1,0 +1,68 @@
+#include "DeleteKeyframeCommand.h"
+
+#include <OgreSkeleton.h>
+#include <OgreBone.h>
+#include <OgreAnimation.h>
+#include <OgreAnimationTrack.h>
+#include <OgreKeyFrame.h>
+
+#include <cmath>
+
+namespace { constexpr float kKeyframeEpsilon = 0.001f; }
+
+DeleteKeyframeCommand::DeleteKeyframeCommand(Ogre::Skeleton* skeleton,
+                                             std::string animationName,
+                                             std::string boneName,
+                                             float time,
+                                             const Ogre::Vector3& translate,
+                                             const Ogre::Quaternion& rotation,
+                                             const Ogre::Vector3& scale,
+                                             QUndoCommand* parent)
+    : QUndoCommand(parent)
+    , mSkeleton(skeleton)
+    , mAnimationName(std::move(animationName))
+    , mBoneName(std::move(boneName))
+    , mTime(time)
+    , mTranslate(translate)
+    , mRotation(rotation)
+    , mScale(scale)
+{
+    setText(QStringLiteral("Delete keyframe"));
+}
+
+Ogre::NodeAnimationTrack* DeleteKeyframeCommand::findTrack() const
+{
+    if (!mSkeleton || !mSkeleton->hasAnimation(mAnimationName)) return nullptr;
+    Ogre::Animation* anim = mSkeleton->getAnimation(mAnimationName);
+    if (!mSkeleton->hasBone(mBoneName)) return nullptr;
+    Ogre::Bone* bone = mSkeleton->getBone(mBoneName);
+    for (const auto& pair : anim->_getNodeTrackList()) {
+        if (pair.second->getAssociatedNode()->getName() == bone->getName())
+            return pair.second;
+    }
+    return nullptr;
+}
+
+void DeleteKeyframeCommand::redo()
+{
+    Ogre::NodeAnimationTrack* track = findTrack();
+    if (!track) return;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        auto* kf = static_cast<Ogre::TransformKeyFrame*>(track->getKeyFrame(i));
+        if (std::fabs(kf->getTime() - mTime) <= kKeyframeEpsilon) {
+            track->removeKeyFrame(i);
+            return;
+        }
+    }
+}
+
+void DeleteKeyframeCommand::undo()
+{
+    Ogre::NodeAnimationTrack* track = findTrack();
+    if (!track) return;
+    // Restore the keyframe with the captured TRS.
+    auto* kf = static_cast<Ogre::TransformKeyFrame*>(track->createNodeKeyFrame(mTime));
+    kf->setTranslate(mTranslate);
+    kf->setRotation(mRotation);
+    kf->setScale(mScale);
+}

--- a/src/commands/DeleteKeyframeCommand.h
+++ b/src/commands/DeleteKeyframeCommand.h
@@ -1,0 +1,50 @@
+#ifndef DELETE_KEYFRAME_COMMAND_H
+#define DELETE_KEYFRAME_COMMAND_H
+
+#include <QUndoCommand>
+#include <OgreVector3.h>
+#include <OgreQuaternion.h>
+#include <string>
+
+namespace Ogre {
+    class Skeleton;
+    class NodeAnimationTrack;
+    class TransformKeyFrame;
+}
+
+/**
+ * Records a deleteKeyframe() operation so it can be undone. On redo
+ * the keyframe at the captured time is removed; on undo the keyframe
+ * is recreated with its captured TRS.
+ *
+ * Stores skeleton/animation/bone names (not pointers) so it survives
+ * skeleton rebuilds. The mTime field is the keyframe's time in seconds.
+ */
+class DeleteKeyframeCommand : public QUndoCommand
+{
+public:
+    DeleteKeyframeCommand(Ogre::Skeleton* skeleton,
+                          std::string animationName,
+                          std::string boneName,
+                          float time,
+                          const Ogre::Vector3& translate,
+                          const Ogre::Quaternion& rotation,
+                          const Ogre::Vector3& scale,
+                          QUndoCommand* parent = nullptr);
+
+    void undo() override;
+    void redo() override;
+
+private:
+    Ogre::NodeAnimationTrack* findTrack() const;
+
+    Ogre::Skeleton*  mSkeleton;
+    std::string      mAnimationName;
+    std::string      mBoneName;
+    float            mTime;        ///< keyframe time in seconds
+    Ogre::Vector3    mTranslate;
+    Ogre::Quaternion mRotation;
+    Ogre::Vector3    mScale;
+};
+
+#endif // DELETE_KEYFRAME_COMMAND_H

--- a/src/commands/DeleteKeyframeCommand_test.cpp
+++ b/src/commands/DeleteKeyframeCommand_test.cpp
@@ -1,0 +1,141 @@
+#include <gtest/gtest.h>
+#include <QApplication>
+#include <QCoreApplication>
+#include <QThread>
+
+#include "commands/DeleteKeyframeCommand.h"
+#include "Manager.h"
+#include "TestHelpers.h"
+
+#include <OgreSkeletonInstance.h>
+#include <OgreBone.h>
+#include <OgreEntity.h>
+#include <OgreAnimation.h>
+#include <OgreAnimationTrack.h>
+#include <OgreKeyFrame.h>
+
+#include <cmath>
+
+class DeleteKeyframeCommandTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        Manager::kill();
+        QThread::msleep(20);
+        app = qobject_cast<QApplication*>(QCoreApplication::instance());
+        ASSERT_NE(app, nullptr);
+        ASSERT_TRUE(tryInitOgre());
+        createStandardOgreMaterials();
+        ASSERT_TRUE(canLoadMeshFiles());
+    }
+    void TearDown() override {
+        Manager::kill();
+        if (app) app->processEvents();
+        QThread::msleep(20);
+    }
+    QApplication* app = nullptr;
+};
+
+namespace {
+Ogre::NodeAnimationTrack* findTrack(Ogre::SkeletonInstance* skel,
+                                    const std::string& animName,
+                                    const std::string& boneName) {
+    if (!skel || !skel->hasAnimation(animName)) return nullptr;
+    auto* anim = skel->getAnimation(animName);
+    for (const auto& p : anim->_getNodeTrackList()) {
+        if (p.second->getAssociatedNode()->getName() == boneName)
+            return p.second;
+    }
+    return nullptr;
+}
+Ogre::TransformKeyFrame* findKeyframe(Ogre::NodeAnimationTrack* track, float time) {
+    if (!track) return nullptr;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        auto* kf = static_cast<Ogre::TransformKeyFrame*>(track->getKeyFrame(i));
+        if (std::fabs(kf->getTime() - time) <= 0.001f) return kf;
+    }
+    return nullptr;
+}
+}
+
+TEST_F(DeleteKeyframeCommandTest, RedoRemovesKeyframe) {
+    // The Child bone's track has keyframes at 0.0, 0.5, 1.0 (see
+    // TestHelpers.h). Removing the kf at 0.5 must drop the count by 1.
+    Ogre::Entity* entity = createAnimatedTestEntity("DKC_Remove");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+    auto* track = findTrack(skel, "TestAnim", "Child");
+    ASSERT_NE(track, nullptr);
+    auto* kf = findKeyframe(track, 0.5f);
+    ASSERT_NE(kf, nullptr);
+    const auto countBefore = track->getNumKeyFrames();
+
+    DeleteKeyframeCommand cmd(skel, "TestAnim", "Child", 0.5f,
+                              kf->getTranslate(), kf->getRotation(), kf->getScale());
+    cmd.redo();
+    EXPECT_EQ(track->getNumKeyFrames(), countBefore - 1);
+    EXPECT_EQ(findKeyframe(track, 0.5f), nullptr);
+}
+
+TEST_F(DeleteKeyframeCommandTest, UndoRestoresKeyframeWithCapturedTRS) {
+    // Capture the kf's TRS, delete, undo — the keyframe must reappear
+    // with the same TRS values.
+    Ogre::Entity* entity = createAnimatedTestEntity("DKC_RestoreTRS");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+    auto* track = findTrack(skel, "TestAnim", "Child");
+    ASSERT_NE(track, nullptr);
+    auto* kf = findKeyframe(track, 0.5f);
+    ASSERT_NE(kf, nullptr);
+    const Ogre::Vector3    origT = kf->getTranslate();
+    const Ogre::Quaternion origR = kf->getRotation();
+    const Ogre::Vector3    origS = kf->getScale();
+
+    DeleteKeyframeCommand cmd(skel, "TestAnim", "Child", 0.5f, origT, origR, origS);
+    cmd.redo();
+    EXPECT_EQ(findKeyframe(track, 0.5f), nullptr);
+
+    cmd.undo();
+    auto* restored = findKeyframe(track, 0.5f);
+    ASSERT_NE(restored, nullptr);
+    EXPECT_EQ(restored->getTranslate(), origT);
+    EXPECT_EQ(restored->getRotation(), origR);
+    EXPECT_EQ(restored->getScale(), origS);
+}
+
+TEST_F(DeleteKeyframeCommandTest, RedoAfterUndoRemovesAgain) {
+    // Round-trip: delete, undo (restore), redo (remove again).
+    Ogre::Entity* entity = createAnimatedTestEntity("DKC_Roundtrip");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+    auto* track = findTrack(skel, "TestAnim", "Child");
+    ASSERT_NE(track, nullptr);
+    auto* kf = findKeyframe(track, 0.5f);
+    ASSERT_NE(kf, nullptr);
+
+    DeleteKeyframeCommand cmd(skel, "TestAnim", "Child", 0.5f,
+                              kf->getTranslate(), kf->getRotation(), kf->getScale());
+    cmd.redo();
+    cmd.undo();
+    EXPECT_NE(findKeyframe(track, 0.5f), nullptr);
+
+    cmd.redo();
+    EXPECT_EQ(findKeyframe(track, 0.5f), nullptr);
+}
+
+TEST_F(DeleteKeyframeCommandTest, RedoIsNoOpWhenKeyframeAlreadyMissing) {
+    // Defensive: redo on a kf that doesn't exist (e.g. user deleted
+    // it externally) shouldn't crash, just no-op.
+    Ogre::Entity* entity = createAnimatedTestEntity("DKC_Missing");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+    auto* track = findTrack(skel, "TestAnim", "Child");
+    ASSERT_NE(track, nullptr);
+    const auto countBefore = track->getNumKeyFrames();
+
+    // Time 0.25 has no keyframe in the test data.
+    DeleteKeyframeCommand cmd(skel, "TestAnim", "Child", 0.25f,
+                              Ogre::Vector3::ZERO, Ogre::Quaternion::IDENTITY,
+                              Ogre::Vector3::UNIT_SCALE);
+    EXPECT_NO_THROW(cmd.redo());
+    EXPECT_EQ(track->getNumKeyFrames(), countBefore);
+}

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -360,6 +360,22 @@ void MainWindow::initToolBar()
             auto* sel = SelectionSet::getSingleton();
             if (!sel->isEmpty())
                 emit sel->selectionChanged();
+            // Force the animated entity to recompute skeleton derived
+            // transforms so bone-visual TagPoints + skinning catch up
+            // immediately. Without this, undo/redo of bone TRS edits
+            // updates the data but the SkeletonDebug overlay stays at
+            // its pre-undo pose until the next animation tick.
+            auto* animCtrl = AnimationControlController::instance();
+            if (Ogre::Entity* ent = animCtrl->selectedEntity()) {
+                if (Ogre::SkeletonInstance* skel = ent->getSkeleton()) {
+                    // Manual-bone dirty + immediate transform update —
+                    // pushes derived state through to attached TagPoints
+                    // (SkeletonDebug bone visuals) on this frame.
+                    skel->_notifyManualBonesDirty();
+                    skel->_updateTransforms();
+                }
+                ent->_updateAnimation();
+            }
         });
     });
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -366,6 +366,11 @@ void MainWindow::initToolBar()
             // updates the data but the SkeletonDebug overlay stays at
             // its pre-undo pose until the next animation tick.
             auto* animCtrl = AnimationControlController::instance();
+            // Drop cached track / keyframe pointers BEFORE refreshing
+            // anything: AddKeyframeCommand::undo can destroy a track
+            // entirely, and a stale m_selectedTrack would crash on the
+            // next slider scrub.
+            animCtrl->onUndoRedoCommandApplied();
             if (Ogre::Entity* ent = animCtrl->selectedEntity()) {
                 if (Ogre::SkeletonInstance* skel = ent->getSkeleton()) {
                     // Manual-bone dirty + immediate transform update —

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -373,13 +373,23 @@ void MainWindow::initToolBar()
             animCtrl->onUndoRedoCommandApplied();
             if (Ogre::Entity* ent = animCtrl->selectedEntity()) {
                 if (Ogre::SkeletonInstance* skel = ent->getSkeleton()) {
-                    // Manual-bone dirty + immediate transform update —
-                    // pushes derived state through to attached TagPoints
-                    // (SkeletonDebug bone visuals) on this frame.
+                    // Force a full skeleton refresh so SkeletonDebug
+                    // bone visuals + any TagPoint-attached entities
+                    // pick up the post-undo pose immediately.
+                    //   1. reset(true) — restore ALL bones (including
+                    //      manual ones) to their initial state.
+                    //   2. _updateAnimation — re-applies enabled
+                    //      animation states + computes derived
+                    //      transforms. Higher-level than calling
+                    //      Animation::apply ourselves and handles
+                    //      empty-track and missing-mask edge cases.
+                    //   3. _updateTransforms — extra push to make
+                    //      TagPoint-attached entities catch up.
+                    skel->reset(true);
                     skel->_notifyManualBonesDirty();
+                    ent->_updateAnimation();
                     skel->_updateTransforms();
                 }
-                ent->_updateAnimation();
             }
         });
     });

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,6 +69,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/SetKeyframeValueCommand.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/BoneTransformCommand.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/AddKeyframeCommand.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/DeleteKeyframeCommand.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/BoneDragRelease.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/PropertiesPanelController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/SceneTreeModel.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,6 +68,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/BulkKeyframeCommands.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/SetKeyframeValueCommand.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/BoneTransformCommand.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/AddKeyframeCommand.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/BoneDragRelease.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/PropertiesPanelController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/SceneTreeModel.cpp


### PR DESCRIPTION
## Summary

Resolves #387 and adds the rotation/scale legs of the bone gizmo W/E/R triad.

### Keyframe undo (#387)
- New \`AddKeyframeCommand\` with three modes (\`TrackCreated\`, \`KeyframeCreated\`, \`KeyframeUpdated\`).
- \`AnimationControlController::addKeyframe()\` pushes the command instead of writing the keyframe directly. Both the +KF UI button and the auto-key path through \`TransformOperator\` now produce undoable keyframes.
- Dropped the redundant \`BoneTransformCommand\` push from the \`Commit\` branch in \`TransformOperator\`: with the keyframe undoable, restoring the bone's transient TRS is unnecessary — \`Skeleton::reset\` + curve apply produces the right pose from the keyframe alone.
- 4 tests in \`AddKeyframeCommand_test.cpp\` covering all three modes + a redo-after-undo round-trip.

### Rotation gizmo (E)
- Drives bone local orientation when a bone is selected. Math mirrors the scene-node rotate handler (start/end vectors from gizmo center → rotation between them, masked by the highlighted circle), composed with the parent-bone's derived orientation so it works for any bone regardless of parent pose mid-animation.
- Always allowed (rotation is the primary posing tool — never tears the rig).

### Scale gizmo (R)
- Pixel-delta drag against the press-time pixel position. Same axis-locking pattern as scene-node scale.
- Always allowed (uncommon but valid for stretchy rigs).

Both new modes share the existing bone-drag press/release flow (BlendMask muting, axis lock at press, \`BoneDragRelease\` release semantics) — so revert/commit/CommitBind behave identically across W/E/R.

## Test plan
- [x] Local build clean
- [x] UnitTests target compiles (\`AddKeyframeCommand_test.cpp\`, \`BoneDragRelease_test.cpp\`, \`AnimationControlController_test.cpp\`)
- [ ] CI: build-linux / build-macos / build-windows / unit-tests-linux / sonar
- [x] Manual: bone selected, E mode rotates around clicked circle; R mode scales; Ctrl+Z after auto-key removes the keyframe; Ctrl+Z after +KF on a non-rigged bone destroys the lazy-created track

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full undo/redo for adding, updating, and deleting animation keyframes, with UI resync after undo/redo.
* **Bug Fixes**
  * Prevented stale pointers/state after undo/redo; preserved bone selection and kept sliders/frames consistent.
  * Fixed child transform update propagation to avoid stale visuals.
* **Improvements**
  * Enhanced bone gizmo interactions: rotation and scale gestures, axis selection, and drag behavior.
* **Tests**
  * Added unit/integration tests covering keyframe add/delete undo/redo scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->