### PR TITLE
fix(animation): resolve skeleton lazily in keyframe undo commands (#389)

### DIFF
--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -708,7 +708,7 @@ void AnimationControlController::addKeyframe()
     // actual write. Pushing the command both creates the keyframe and
     // makes it undoable.
     auto* cmd = new AddKeyframeCommand(  // NOSONAR — QUndoStack owns
-        m_selectedSkeleton,
+        m_selectedEntityName,
         m_selectedAnimation,
         m_selectedBone,
         time,
@@ -736,7 +736,7 @@ void AnimationControlController::deleteKeyframe()
     m_currentKeyframe = nullptr;
     m_selectedTick    = -1;
     auto* cmd = new DeleteKeyframeCommand(  // NOSONAR — QUndoStack owns
-        m_selectedSkeleton,
+        m_selectedEntityName,
         m_selectedAnimation,
         m_selectedBone,
         t, keyT, keyR, keyS);
@@ -928,7 +928,7 @@ bool AnimationControlController::moveKeyframe(const QString& boneName,
 
     // QUndoStack::push() takes ownership of the command — this raw new is
     // the standard QUndoCommand idiom (mirrors TransformCommands callers).
-    auto* cmd = new MoveKeyframeCommand(m_selectedSkeleton, // NOSONAR — QUndoStack owns
+    auto* cmd = new MoveKeyframeCommand(m_selectedEntityName, // NOSONAR — QUndoStack owns
                                         m_selectedAnimation,
                                         boneStd,
                                         static_cast<float>(oldTime),
@@ -1053,7 +1053,7 @@ bool AnimationControlController::moveKeyframes(const QVariantList& selection,
         return false;
     }
 
-    auto* cmd = new MoveKeyframesCommand(m_selectedSkeleton, // NOSONAR — QUndoStack owns
+    auto* cmd = new MoveKeyframesCommand(m_selectedEntityName, // NOSONAR — QUndoStack owns
                                           m_selectedAnimation,
                                           items, dtf);
     UndoManager::getSingleton()->push(cmd);
@@ -1222,7 +1222,7 @@ int AnimationControlController::pasteKeyframesAt(const QString& json,
         return 0;
     }
 
-    auto* cmd = new PasteKeyframesCommand(m_selectedSkeleton, // NOSONAR — QUndoStack owns
+    auto* cmd = new PasteKeyframesCommand(m_selectedEntityName, // NOSONAR — QUndoStack owns
                                            m_selectedAnimation,
                                            entries);
     UndoManager::getSingleton()->push(cmd);
@@ -1317,7 +1317,7 @@ bool AnimationControlController::setKeyframeValue(const QString& boneName,
     }
     if (!found) return false;
 
-    auto* cmd = new SetKeyframeValueCommand(m_selectedSkeleton, // NOSONAR — QUndoStack owns
+    auto* cmd = new SetKeyframeValueCommand(m_selectedEntityName, // NOSONAR — QUndoStack owns
                                              m_selectedAnimation,
                                              boneName.toStdString(),
                                              channel.toLower().toStdString(),

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,6 +61,7 @@ commands/SetKeyframeValueCommand.cpp
 commands/BoneTransformCommand.cpp
 commands/AddKeyframeCommand.cpp
 commands/DeleteKeyframeCommand.cpp
+commands/SkeletonResolver.cpp
 BoneDragRelease.cpp
 PropertiesPanelController.cpp
 SceneTreeModel.cpp

--- a/src/TransformOperator.cpp
+++ b/src/TransformOperator.cpp
@@ -1870,8 +1870,10 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
                 // bindMode=true so undo also reverts the bone's initial
                 // (bind) state — otherwise Skeleton::reset would snap
                 // back to the new bind on the next animation update.
+                const std::string entityName =
+                    AnimationControlController::instance()->selectedEntityName().toStdString();
                 UndoManager::getSingleton()->push(
-                    new BoneTransformCommand(skel, bone->getName(),
+                    new BoneTransformCommand(entityName, bone->getName(),
                         mBoneStartPos, mBoneStartOrient, mBoneStartScale,
                         afterPos,      afterOrient,      afterScale,
                         /*bindMode=*/true));

--- a/src/commands/AddKeyframeCommand.cpp
+++ b/src/commands/AddKeyframeCommand.cpp
@@ -1,6 +1,8 @@
 #include "AddKeyframeCommand.h"
 
-#include <OgreSkeleton.h>
+#include "SkeletonResolver.h"
+
+#include <OgreSkeletonInstance.h>
 #include <OgreBone.h>
 #include <OgreAnimation.h>
 #include <OgreAnimationTrack.h>
@@ -10,7 +12,7 @@
 
 namespace { constexpr float kKeyframeEpsilon = 0.001f; }
 
-AddKeyframeCommand::AddKeyframeCommand(Ogre::Skeleton* skeleton,
+AddKeyframeCommand::AddKeyframeCommand(std::string entityName,
                                        std::string animationName,
                                        std::string boneName,
                                        float time,
@@ -23,7 +25,7 @@ AddKeyframeCommand::AddKeyframeCommand(Ogre::Skeleton* skeleton,
                                        const Ogre::Vector3& afterScale,
                                        QUndoCommand* parent)
     : QUndoCommand(parent)
-    , mSkeleton(skeleton)
+    , mEntityName(std::move(entityName))
     , mAnimationName(std::move(animationName))
     , mBoneName(std::move(boneName))
     , mTime(time)
@@ -40,10 +42,11 @@ AddKeyframeCommand::AddKeyframeCommand(Ogre::Skeleton* skeleton,
 
 Ogre::NodeAnimationTrack* AddKeyframeCommand::findTrack() const
 {
-    if (!mSkeleton || !mSkeleton->hasAnimation(mAnimationName)) return nullptr;
-    Ogre::Animation* anim = mSkeleton->getAnimation(mAnimationName);
-    if (!mSkeleton->hasBone(mBoneName)) return nullptr;
-    Ogre::Bone* bone = mSkeleton->getBone(mBoneName);
+    Ogre::SkeletonInstance* skel = SkeletonResolver::resolve(mEntityName);
+    if (!skel || !skel->hasAnimation(mAnimationName)) return nullptr;
+    if (!skel->hasBone(mBoneName)) return nullptr;
+    Ogre::Animation* anim = skel->getAnimation(mAnimationName);
+    Ogre::Bone* bone = skel->getBone(mBoneName);
     for (const auto& pair : anim->_getNodeTrackList()) {
         if (pair.second->getAssociatedNode()->getName() == bone->getName())
             return pair.second;
@@ -63,10 +66,11 @@ Ogre::TransformKeyFrame* AddKeyframeCommand::findKeyframe(Ogre::NodeAnimationTra
 
 void AddKeyframeCommand::redo()
 {
-    if (!mSkeleton || !mSkeleton->hasAnimation(mAnimationName)) return;
-    Ogre::Animation* anim = mSkeleton->getAnimation(mAnimationName);
-    if (!mSkeleton->hasBone(mBoneName)) return;
-    Ogre::Bone* bone = mSkeleton->getBone(mBoneName);
+    Ogre::SkeletonInstance* skel = SkeletonResolver::resolve(mEntityName);
+    if (!skel || !skel->hasAnimation(mAnimationName)) return;
+    if (!skel->hasBone(mBoneName)) return;
+    Ogre::Animation* anim = skel->getAnimation(mAnimationName);
+    Ogre::Bone* bone = skel->getBone(mBoneName);
 
     Ogre::NodeAnimationTrack* track = findTrack();
     if (!track && mMode == Mode::TrackCreated)
@@ -82,6 +86,8 @@ void AddKeyframeCommand::redo()
 
 void AddKeyframeCommand::undo()
 {
+    Ogre::SkeletonInstance* skel = SkeletonResolver::resolve(mEntityName);
+    if (!skel) return;
     Ogre::NodeAnimationTrack* track = findTrack();
     if (!track) return;
 
@@ -89,8 +95,8 @@ void AddKeyframeCommand::undo()
         // Lazy-created track: destroy it entirely so the bone returns
         // to its "no track" state (curve doesn't drive it during
         // playback, bone holds its bind/manual pose).
-        Ogre::Animation* anim = mSkeleton->getAnimation(mAnimationName);
-        Ogre::Bone* bone = mSkeleton->getBone(mBoneName);
+        Ogre::Animation* anim = skel->getAnimation(mAnimationName);
+        Ogre::Bone* bone = skel->getBone(mBoneName);
         anim->destroyNodeTrack(bone->getHandle());
         return;
     }

--- a/src/commands/AddKeyframeCommand.h
+++ b/src/commands/AddKeyframeCommand.h
@@ -7,7 +7,7 @@
 #include <string>
 
 namespace Ogre {
-    class Skeleton;
+    class SkeletonInstance;
     class NodeAnimationTrack;
     class TransformKeyFrame;
 }
@@ -36,7 +36,11 @@ public:
         KeyframeUpdated,     ///< Existing track, existing keyframe updated in-place
     };
 
-    AddKeyframeCommand(Ogre::Skeleton* skeleton,
+    /// `entityName` is the entity hosting the SkeletonInstance —
+    /// stored instead of a raw pointer so the command resolves the
+    /// skeleton lazily via SkeletonResolver and survives entity
+    /// reload / skeleton rebuild.
+    AddKeyframeCommand(std::string entityName,
                        std::string animationName,
                        std::string boneName,
                        float time,
@@ -56,7 +60,7 @@ private:
     Ogre::NodeAnimationTrack* findTrack() const;
     Ogre::TransformKeyFrame*  findKeyframe(Ogre::NodeAnimationTrack* track) const;
 
-    Ogre::Skeleton*  mSkeleton;
+    std::string      mEntityName;
     std::string      mAnimationName;
     std::string      mBoneName;
     float            mTime;        ///< keyframe time in seconds

--- a/src/commands/AddKeyframeCommand_test.cpp
+++ b/src/commands/AddKeyframeCommand_test.cpp
@@ -70,7 +70,7 @@ TEST_F(AddKeyframeCommandTest, KeyframeUpdatedRoundTrips) {
     const Ogre::Vector3 origT = kf->getTranslate();
 
     AddKeyframeCommand cmd(
-        skel, "TestAnim", "Child", 0.5f,
+        entity->getName(), "TestAnim", "Child", 0.5f,
         AddKeyframeCommand::Mode::KeyframeUpdated,
         origT, kf->getRotation(), kf->getScale(),
         Ogre::Vector3(99, 0, 0), kf->getRotation(), kf->getScale());
@@ -96,7 +96,7 @@ TEST_F(AddKeyframeCommandTest, KeyframeCreatedUndoRemovesKeyframe) {
     const auto countBefore = track->getNumKeyFrames();
 
     AddKeyframeCommand cmd(
-        skel, "TestAnim", "Child", 0.25f,
+        entity->getName(), "TestAnim", "Child", 0.25f,
         AddKeyframeCommand::Mode::KeyframeCreated,
         Ogre::Vector3::ZERO, Ogre::Quaternion::IDENTITY, Ogre::Vector3::UNIT_SCALE,
         Ogre::Vector3(2, 0, 0), Ogre::Quaternion::IDENTITY, Ogre::Vector3::UNIT_SCALE);
@@ -124,7 +124,7 @@ TEST_F(AddKeyframeCommandTest, TrackCreatedUndoDestroysTrack) {
     ASSERT_EQ(findTrack(skel, "TestAnim", "Extra"), nullptr);
 
     AddKeyframeCommand cmd(
-        skel, "TestAnim", "Extra", 0.0f,
+        entity->getName(), "TestAnim", "Extra", 0.0f,
         AddKeyframeCommand::Mode::TrackCreated,
         Ogre::Vector3::ZERO, Ogre::Quaternion::IDENTITY, Ogre::Vector3::UNIT_SCALE,
         Ogre::Vector3(0.5f, 0, 0), Ogre::Quaternion::IDENTITY, Ogre::Vector3::UNIT_SCALE);
@@ -146,7 +146,7 @@ TEST_F(AddKeyframeCommandTest, RedoAfterUndoRestoresKeyframe) {
     const auto countBefore = track->getNumKeyFrames();
 
     AddKeyframeCommand cmd(
-        skel, "TestAnim", "Child", 0.75f,
+        entity->getName(), "TestAnim", "Child", 0.75f,
         AddKeyframeCommand::Mode::KeyframeCreated,
         Ogre::Vector3::ZERO, Ogre::Quaternion::IDENTITY, Ogre::Vector3::UNIT_SCALE,
         Ogre::Vector3(3, 0, 0), Ogre::Quaternion::IDENTITY, Ogre::Vector3::UNIT_SCALE);

--- a/src/commands/BoneTransformCommand.cpp
+++ b/src/commands/BoneTransformCommand.cpp
@@ -1,9 +1,11 @@
 #include "BoneTransformCommand.h"
 
+#include "SkeletonResolver.h"
+
 #include <OgreSkeletonInstance.h>
 #include <OgreBone.h>
 
-BoneTransformCommand::BoneTransformCommand(Ogre::SkeletonInstance* skeleton,
+BoneTransformCommand::BoneTransformCommand(std::string entityName,
                                            std::string boneName,
                                            const Ogre::Vector3& beforePos,
                                            const Ogre::Quaternion& beforeOrient,
@@ -14,7 +16,7 @@ BoneTransformCommand::BoneTransformCommand(Ogre::SkeletonInstance* skeleton,
                                            bool bindMode,
                                            QUndoCommand* parent)
     : QUndoCommand(parent)
-    , mSkeleton(skeleton)
+    , mEntityName(std::move(entityName))
     , mBoneName(std::move(boneName))
     , mBeforePos(beforePos)
     , mBeforeOrient(beforeOrient)
@@ -32,8 +34,9 @@ void BoneTransformCommand::apply(const Ogre::Vector3& p,
                                  const Ogre::Quaternion& o,
                                  const Ogre::Vector3& s)
 {
-    if (!mSkeleton || !mSkeleton->hasBone(mBoneName)) return;
-    Ogre::Bone* bone = mSkeleton->getBone(mBoneName);
+    Ogre::SkeletonInstance* skel = SkeletonResolver::resolve(mEntityName);
+    if (!skel || !skel->hasBone(mBoneName)) return;
+    Ogre::Bone* bone = skel->getBone(mBoneName);
     bone->setPosition(p);
     bone->setOrientation(o);
     bone->setScale(s);

--- a/src/commands/BoneTransformCommand.h
+++ b/src/commands/BoneTransformCommand.h
@@ -28,7 +28,7 @@ namespace Ogre {
 class BoneTransformCommand : public QUndoCommand
 {
 public:
-    BoneTransformCommand(Ogre::SkeletonInstance* skeleton,
+    BoneTransformCommand(std::string entityName,
                          std::string boneName,
                          const Ogre::Vector3& beforePos,
                          const Ogre::Quaternion& beforeOrient,
@@ -46,7 +46,7 @@ private:
     void apply(const Ogre::Vector3& p, const Ogre::Quaternion& o,
                const Ogre::Vector3& s);
 
-    Ogre::SkeletonInstance* mSkeleton;
+    std::string             mEntityName;
     std::string             mBoneName;
     Ogre::Vector3           mBeforePos;
     Ogre::Quaternion        mBeforeOrient;

--- a/src/commands/BulkKeyframeCommands.cpp
+++ b/src/commands/BulkKeyframeCommands.cpp
@@ -1,7 +1,9 @@
 #include "BulkKeyframeCommands.h"
 
+#include "SkeletonResolver.h"
+
 #include <Ogre.h>
-#include <OgreSkeleton.h>
+#include <OgreSkeletonInstance.h>
 #include <OgreAnimation.h>
 #include <OgreAnimationTrack.h>
 #include <OgreKeyFrame.h>
@@ -13,11 +15,13 @@
 namespace {
 constexpr float kEpsilon = 0.001f;
 
-Ogre::NodeAnimationTrack* resolveTrack(Ogre::Skeleton* skel,
+Ogre::NodeAnimationTrack* resolveTrack(const std::string& entityName,
                                        const std::string& animName,
                                        const std::string& boneName)
 {
-    if (!skel || animName.empty() || boneName.empty()) return nullptr;
+    if (animName.empty() || boneName.empty()) return nullptr;
+    Ogre::SkeletonInstance* skel = SkeletonResolver::resolve(entityName);
+    if (!skel) return nullptr;
     if (!skel->hasAnimation(animName)) return nullptr;
     if (!skel->hasBone(boneName)) return nullptr;
     Ogre::Animation* anim = skel->getAnimation(animName);
@@ -59,13 +63,13 @@ bool relocateKeyframe(Ogre::NodeAnimationTrack* track, float fromT, float toT) {
 
 // ── MoveKeyframesCommand ──────────────────────────────────────────────────────
 
-MoveKeyframesCommand::MoveKeyframesCommand(Ogre::Skeleton* skeleton,
+MoveKeyframesCommand::MoveKeyframesCommand(std::string entityName,
                                            std::string animationName,
                                            QVector<Item> items,
                                            float dt,
                                            QUndoCommand* parent)
     : QUndoCommand(parent)
-    , mSkeleton(skeleton)
+    , mEntityName(std::move(entityName))
     , mAnimationName(std::move(animationName))
     , mItems(std::move(items))
     , mDt(dt)
@@ -83,7 +87,7 @@ bool MoveKeyframesCommand::shiftAll(float fromOffset, float toOffset)
     QVector<float> parkSlots;
     parkSlots.reserve(mItems.size());
     for (int i = 0; i < mItems.size(); ++i) {
-        auto* track = resolveTrack(mSkeleton, mAnimationName, mItems[i].boneName);
+        auto* track = resolveTrack(mEntityName, mAnimationName, mItems[i].boneName);
         if (!track) { parkSlots.append(0.0f); continue; }
         const float src = mItems[i].originalTime + fromOffset;
         const float park = -1.0f - static_cast<float>(i); // unique negative slot
@@ -91,7 +95,7 @@ bool MoveKeyframesCommand::shiftAll(float fromOffset, float toOffset)
         parkSlots.append(park);
     }
     for (int i = 0; i < mItems.size(); ++i) {
-        auto* track = resolveTrack(mSkeleton, mAnimationName, mItems[i].boneName);
+        auto* track = resolveTrack(mEntityName, mAnimationName, mItems[i].boneName);
         if (!track) continue;
         const float dst = mItems[i].originalTime + toOffset;
         relocateKeyframe(track, parkSlots[i], dst);
@@ -104,12 +108,12 @@ void MoveKeyframesCommand::undo() { shiftAll(mDt, 0.0f); }
 
 // ── PasteKeyframesCommand ─────────────────────────────────────────────────────
 
-PasteKeyframesCommand::PasteKeyframesCommand(Ogre::Skeleton* skeleton,
+PasteKeyframesCommand::PasteKeyframesCommand(std::string entityName,
                                              std::string animationName,
                                              QVector<Entry> entries,
                                              QUndoCommand* parent)
     : QUndoCommand(parent)
-    , mSkeleton(skeleton)
+    , mEntityName(std::move(entityName))
     , mAnimationName(std::move(animationName))
     , mEntries(std::move(entries))
 {
@@ -123,7 +127,7 @@ void PasteKeyframesCommand::redo()
     for (int i = 0; i < mEntries.size(); ++i) {
         const Entry& e = mEntries[i];
         mApplied[i] = false;
-        auto* track = resolveTrack(mSkeleton, mAnimationName, e.boneName);
+        auto* track = resolveTrack(mEntityName, mAnimationName, e.boneName);
         if (!track) continue;
         if (findKeyframeIndex(track, e.time) >= 0) continue; // collision — skip
         auto* kf = track->createNodeKeyFrame(e.time);
@@ -141,7 +145,7 @@ void PasteKeyframesCommand::undo()
     for (int i = 0; i < mEntries.size(); ++i) {
         if (!mApplied[i]) continue;
         const Entry& e = mEntries[i];
-        auto* track = resolveTrack(mSkeleton, mAnimationName, e.boneName);
+        auto* track = resolveTrack(mEntityName, mAnimationName, e.boneName);
         if (!track) continue;
         const int idx = findKeyframeIndex(track, e.time);
         if (idx < 0) continue;

--- a/src/commands/BulkKeyframeCommands.h
+++ b/src/commands/BulkKeyframeCommands.h
@@ -7,7 +7,7 @@
 #include <string>
 
 namespace Ogre {
-    class Skeleton;
+    class SkeletonInstance;
     class NodeAnimationTrack;
 }
 
@@ -30,7 +30,7 @@ public:
         float       originalTime;
     };
 
-    MoveKeyframesCommand(Ogre::Skeleton* skeleton,
+    MoveKeyframesCommand(std::string entityName,
                          std::string animationName,
                          QVector<Item> items,
                          float dt,
@@ -42,10 +42,10 @@ public:
 private:
     bool shiftAll(float fromOffset, float toOffset);
 
-    Ogre::Skeleton* mSkeleton;
-    std::string     mAnimationName;
-    QVector<Item>   mItems;
-    float           mDt;
+    std::string   mEntityName;
+    std::string   mAnimationName;
+    QVector<Item> mItems;
+    float         mDt;
 };
 
 /**
@@ -69,7 +69,7 @@ public:
         float       sx, sy, sz;
     };
 
-    PasteKeyframesCommand(Ogre::Skeleton* skeleton,
+    PasteKeyframesCommand(std::string entityName,
                           std::string animationName,
                           QVector<Entry> entries,
                           QUndoCommand* parent = nullptr);
@@ -83,13 +83,13 @@ public:
     int pastedCount() const { return mPastedCount; }
 
 private:
-    Ogre::Skeleton* mSkeleton;
-    std::string     mAnimationName;
-    QVector<Entry>  mEntries;
+    std::string    mEntityName;
+    std::string    mAnimationName;
+    QVector<Entry> mEntries;
     /// True for entries that were actually written on the last redo, so
     /// undo only removes the ones we created.
-    QVector<bool>   mApplied;
-    int             mPastedCount = 0;
+    QVector<bool>  mApplied;
+    int            mPastedCount = 0;
 };
 
 #endif // BULK_KEYFRAME_COMMANDS_H

--- a/src/commands/BulkKeyframeCommands_test.cpp
+++ b/src/commands/BulkKeyframeCommands_test.cpp
@@ -60,7 +60,7 @@ TEST_F(BulkKeyframeCommandsTest, MoveKeyframesRedoUndoRoundTrip) {
     items.append({ "Child", 1.0f });
 
     QUndoStack stack;
-    stack.push(new MoveKeyframesCommand(skel, "TestAnim", items, 0.2f));
+    stack.push(new MoveKeyframesCommand(entity->getName(), "TestAnim", items, 0.2f));
 
     // After redo: keyframes at 0.2, 0.7, 1.2.
     EXPECT_EQ(track->getNumKeyFrames(), 3u);
@@ -99,7 +99,7 @@ TEST_F(BulkKeyframeCommandsTest, MoveKeyframesPreservesIntraTrackOrdering) {
     items.append({ "Child", 0.5f });
 
     QUndoStack stack;
-    stack.push(new MoveKeyframesCommand(skel, "TestAnim", items, 0.5f));
+    stack.push(new MoveKeyframesCommand(entity->getName(), "TestAnim", items, 0.5f));
 
     EXPECT_EQ(track->getNumKeyFrames(), 3u); // 0.5, 1.0 (moved), and 1.0 (original)
     EXPECT_TRUE(hasKeyframeAt(track, 0.5f));
@@ -125,7 +125,7 @@ TEST_F(BulkKeyframeCommandsTest, PasteRedoUndoRoundTrip) {
     e2.tx = 0.2f; e2.rw = 1.0f; e2.sx = e2.sy = e2.sz = 1.0f;
     entries.append(e1); entries.append(e2);
 
-    auto* cmd = new PasteKeyframesCommand(skel, "TestAnim", entries);
+    auto* cmd = new PasteKeyframesCommand(entity->getName(), "TestAnim", entries);
     QUndoStack stack;
     stack.push(cmd);
 
@@ -162,7 +162,7 @@ TEST_F(BulkKeyframeCommandsTest, PasteSkipsCollisionsAndUndoOnlyRemovesPasted) {
     novel.rw = 1.0f; novel.sx = novel.sy = novel.sz = 1.0f;
     entries.append(collide); entries.append(novel);
 
-    auto* cmd = new PasteKeyframesCommand(skel, "TestAnim", entries);
+    auto* cmd = new PasteKeyframesCommand(entity->getName(), "TestAnim", entries);
     QUndoStack stack;
     stack.push(cmd);
 

--- a/src/commands/DeleteKeyframeCommand.cpp
+++ b/src/commands/DeleteKeyframeCommand.cpp
@@ -1,6 +1,8 @@
 #include "DeleteKeyframeCommand.h"
 
-#include <OgreSkeleton.h>
+#include "SkeletonResolver.h"
+
+#include <OgreSkeletonInstance.h>
 #include <OgreBone.h>
 #include <OgreAnimation.h>
 #include <OgreAnimationTrack.h>
@@ -10,7 +12,7 @@
 
 namespace { constexpr float kKeyframeEpsilon = 0.001f; }
 
-DeleteKeyframeCommand::DeleteKeyframeCommand(Ogre::Skeleton* skeleton,
+DeleteKeyframeCommand::DeleteKeyframeCommand(std::string entityName,
                                              std::string animationName,
                                              std::string boneName,
                                              float time,
@@ -19,7 +21,7 @@ DeleteKeyframeCommand::DeleteKeyframeCommand(Ogre::Skeleton* skeleton,
                                              const Ogre::Vector3& scale,
                                              QUndoCommand* parent)
     : QUndoCommand(parent)
-    , mSkeleton(skeleton)
+    , mEntityName(std::move(entityName))
     , mAnimationName(std::move(animationName))
     , mBoneName(std::move(boneName))
     , mTime(time)
@@ -32,10 +34,11 @@ DeleteKeyframeCommand::DeleteKeyframeCommand(Ogre::Skeleton* skeleton,
 
 Ogre::NodeAnimationTrack* DeleteKeyframeCommand::findTrack() const
 {
-    if (!mSkeleton || !mSkeleton->hasAnimation(mAnimationName)) return nullptr;
-    Ogre::Animation* anim = mSkeleton->getAnimation(mAnimationName);
-    if (!mSkeleton->hasBone(mBoneName)) return nullptr;
-    Ogre::Bone* bone = mSkeleton->getBone(mBoneName);
+    Ogre::SkeletonInstance* skel = SkeletonResolver::resolve(mEntityName);
+    if (!skel || !skel->hasAnimation(mAnimationName)) return nullptr;
+    if (!skel->hasBone(mBoneName)) return nullptr;
+    Ogre::Animation* anim = skel->getAnimation(mAnimationName);
+    Ogre::Bone* bone = skel->getBone(mBoneName);
     for (const auto& pair : anim->_getNodeTrackList()) {
         if (pair.second->getAssociatedNode()->getName() == bone->getName())
             return pair.second;
@@ -60,7 +63,6 @@ void DeleteKeyframeCommand::undo()
 {
     Ogre::NodeAnimationTrack* track = findTrack();
     if (!track) return;
-    // Restore the keyframe with the captured TRS.
     auto* kf = static_cast<Ogre::TransformKeyFrame*>(track->createNodeKeyFrame(mTime));
     kf->setTranslate(mTranslate);
     kf->setRotation(mRotation);

--- a/src/commands/DeleteKeyframeCommand.h
+++ b/src/commands/DeleteKeyframeCommand.h
@@ -7,7 +7,7 @@
 #include <string>
 
 namespace Ogre {
-    class Skeleton;
+    class SkeletonInstance;
     class NodeAnimationTrack;
     class TransformKeyFrame;
 }
@@ -17,13 +17,14 @@ namespace Ogre {
  * the keyframe at the captured time is removed; on undo the keyframe
  * is recreated with its captured TRS.
  *
- * Stores skeleton/animation/bone names (not pointers) so it survives
- * skeleton rebuilds. The mTime field is the keyframe's time in seconds.
+ * Stores entity / animation / bone names (not pointers) and resolves
+ * the SkeletonInstance lazily via SkeletonResolver, so the command
+ * survives entity reload / skeleton rebuild.
  */
 class DeleteKeyframeCommand : public QUndoCommand
 {
 public:
-    DeleteKeyframeCommand(Ogre::Skeleton* skeleton,
+    DeleteKeyframeCommand(std::string entityName,
                           std::string animationName,
                           std::string boneName,
                           float time,
@@ -38,7 +39,7 @@ public:
 private:
     Ogre::NodeAnimationTrack* findTrack() const;
 
-    Ogre::Skeleton*  mSkeleton;
+    std::string      mEntityName;
     std::string      mAnimationName;
     std::string      mBoneName;
     float            mTime;        ///< keyframe time in seconds

--- a/src/commands/DeleteKeyframeCommand_test.cpp
+++ b/src/commands/DeleteKeyframeCommand_test.cpp
@@ -69,7 +69,7 @@ TEST_F(DeleteKeyframeCommandTest, RedoRemovesKeyframe) {
     ASSERT_NE(kf, nullptr);
     const auto countBefore = track->getNumKeyFrames();
 
-    DeleteKeyframeCommand cmd(skel, "TestAnim", "Child", 0.5f,
+    DeleteKeyframeCommand cmd(entity->getName(), "TestAnim", "Child", 0.5f,
                               kf->getTranslate(), kf->getRotation(), kf->getScale());
     cmd.redo();
     EXPECT_EQ(track->getNumKeyFrames(), countBefore - 1);
@@ -90,7 +90,7 @@ TEST_F(DeleteKeyframeCommandTest, UndoRestoresKeyframeWithCapturedTRS) {
     const Ogre::Quaternion origR = kf->getRotation();
     const Ogre::Vector3    origS = kf->getScale();
 
-    DeleteKeyframeCommand cmd(skel, "TestAnim", "Child", 0.5f, origT, origR, origS);
+    DeleteKeyframeCommand cmd(entity->getName(), "TestAnim", "Child", 0.5f, origT, origR, origS);
     cmd.redo();
     EXPECT_EQ(findKeyframe(track, 0.5f), nullptr);
 
@@ -112,7 +112,7 @@ TEST_F(DeleteKeyframeCommandTest, RedoAfterUndoRemovesAgain) {
     auto* kf = findKeyframe(track, 0.5f);
     ASSERT_NE(kf, nullptr);
 
-    DeleteKeyframeCommand cmd(skel, "TestAnim", "Child", 0.5f,
+    DeleteKeyframeCommand cmd(entity->getName(), "TestAnim", "Child", 0.5f,
                               kf->getTranslate(), kf->getRotation(), kf->getScale());
     cmd.redo();
     cmd.undo();
@@ -133,7 +133,7 @@ TEST_F(DeleteKeyframeCommandTest, RedoIsNoOpWhenKeyframeAlreadyMissing) {
     const auto countBefore = track->getNumKeyFrames();
 
     // Time 0.25 has no keyframe in the test data.
-    DeleteKeyframeCommand cmd(skel, "TestAnim", "Child", 0.25f,
+    DeleteKeyframeCommand cmd(entity->getName(), "TestAnim", "Child", 0.25f,
                               Ogre::Vector3::ZERO, Ogre::Quaternion::IDENTITY,
                               Ogre::Vector3::UNIT_SCALE);
     EXPECT_NO_THROW(cmd.redo());

--- a/src/commands/MoveKeyframeCommand.cpp
+++ b/src/commands/MoveKeyframeCommand.cpp
@@ -1,7 +1,9 @@
 #include "MoveKeyframeCommand.h"
 
+#include "SkeletonResolver.h"
+
 #include <Ogre.h>
-#include <OgreSkeleton.h>
+#include <OgreSkeletonInstance.h>
 #include <OgreAnimation.h>
 #include <OgreAnimationTrack.h>
 #include <OgreKeyFrame.h>
@@ -13,11 +15,13 @@
 namespace {
 constexpr float kEpsilon = 0.001f; // 1 ms — same tolerance as keyframe ticks
 
-Ogre::NodeAnimationTrack* resolveTrack(Ogre::Skeleton* skel,
+Ogre::NodeAnimationTrack* resolveTrack(const std::string& entityName,
                                        const std::string& animName,
                                        const std::string& boneName)
 {
-    if (!skel || animName.empty() || boneName.empty()) return nullptr;
+    if (animName.empty() || boneName.empty()) return nullptr;
+    Ogre::SkeletonInstance* skel = SkeletonResolver::resolve(entityName);
+    if (!skel) return nullptr;
     if (!skel->hasAnimation(animName)) return nullptr;
     if (!skel->hasBone(boneName)) return nullptr;
     Ogre::Animation* anim = skel->getAnimation(animName);
@@ -29,14 +33,14 @@ Ogre::NodeAnimationTrack* resolveTrack(Ogre::Skeleton* skel,
 
 } // namespace
 
-MoveKeyframeCommand::MoveKeyframeCommand(Ogre::Skeleton* skeleton,
+MoveKeyframeCommand::MoveKeyframeCommand(std::string entityName,
                                          std::string animationName,
                                          std::string boneName,
                                          float oldTime,
                                          float newTime,
                                          QUndoCommand* parent)
     : QUndoCommand(parent)
-    , mSkeleton(skeleton)
+    , mEntityName(std::move(entityName))
     , mAnimationName(std::move(animationName))
     , mBoneName(std::move(boneName))
     , mOldTime(oldTime)
@@ -47,7 +51,7 @@ MoveKeyframeCommand::MoveKeyframeCommand(Ogre::Skeleton* skeleton,
 
 bool MoveKeyframeCommand::moveKeyframeTo(float searchTime, float targetTime)
 {
-    auto* track = resolveTrack(mSkeleton, mAnimationName, mBoneName);
+    auto* track = resolveTrack(mEntityName, mAnimationName, mBoneName);
     if (!track) return false;
 
     // Find the keyframe at searchTime (± epsilon).

--- a/src/commands/MoveKeyframeCommand.h
+++ b/src/commands/MoveKeyframeCommand.h
@@ -5,7 +5,7 @@
 #include <string>
 
 namespace Ogre {
-    class Skeleton;
+    class SkeletonInstance;
     class NodeAnimationTrack;
 }
 
@@ -15,14 +15,14 @@ namespace Ogre {
  * original time. The track's keyframe count is unchanged either way — the
  * keyframe's identity is its index after re-sorting.
  *
- * The command stores the skeleton + animation + bone names rather than raw
- * pointers so it survives skeleton/track rebuilds (some Ogre operations
- * reallocate tracks when keyframes are inserted/removed elsewhere).
+ * Stores entity / animation / bone names so it survives entity reload
+ * and skeleton rebuild — the SkeletonInstance is resolved lazily via
+ * SkeletonResolver at apply-time.
  */
 class MoveKeyframeCommand : public QUndoCommand
 {
 public:
-    MoveKeyframeCommand(Ogre::Skeleton* skeleton,
+    MoveKeyframeCommand(std::string entityName,
                         std::string animationName,
                         std::string boneName,
                         float oldTime,
@@ -40,11 +40,11 @@ private:
     /// found or the target time would collide with another keyframe.
     bool moveKeyframeTo(float searchTime, float targetTime);
 
-    Ogre::Skeleton* mSkeleton;
-    std::string     mAnimationName;
-    std::string     mBoneName;
-    float           mOldTime;
-    float           mNewTime;
+    std::string mEntityName;
+    std::string mAnimationName;
+    std::string mBoneName;
+    float       mOldTime;
+    float       mNewTime;
 };
 
 #endif // MOVE_KEYFRAME_COMMAND_H

--- a/src/commands/MoveKeyframeCommand_test.cpp
+++ b/src/commands/MoveKeyframeCommand_test.cpp
@@ -43,7 +43,7 @@ TEST_F(MoveKeyframeCommandTest, RedoMovesUndoRestores) {
 
     // TestAnim has keyframes at 0.0, 0.5, 1.0 on the Child bone.
     QUndoStack stack;
-    stack.push(new MoveKeyframeCommand(skel, "TestAnim", "Child", 0.5f, 0.7f));
+    stack.push(new MoveKeyframeCommand(entity->getName(), "TestAnim", "Child", 0.5f, 0.7f));
 
     auto* track = skel->getAnimation("TestAnim")->_getNodeTrackList().begin()->second;
     bool found07 = false;
@@ -91,7 +91,7 @@ TEST_F(MoveKeyframeCommandTest, PreservesTRSValuesAcrossMove) {
     }
 
     QUndoStack stack;
-    stack.push(new MoveKeyframeCommand(skel, "TestAnim", "Child", 0.5f, 0.7f));
+    stack.push(new MoveKeyframeCommand(entity->getName(), "TestAnim", "Child", 0.5f, 0.7f));
 
     // Find the moved keyframe and verify TRS is preserved.
     bool found = false;
@@ -118,6 +118,6 @@ TEST_F(MoveKeyframeCommandTest, NoOpWhenSearchTimeMissing) {
 
     QUndoStack stack;
     // No keyframe at 0.42 — command runs but moves nothing.
-    stack.push(new MoveKeyframeCommand(skel, "TestAnim", "Child", 0.42f, 0.6f));
+    stack.push(new MoveKeyframeCommand(entity->getName(), "TestAnim", "Child", 0.42f, 0.6f));
     EXPECT_EQ(track->getNumKeyFrames(), before);
 }

--- a/src/commands/SetKeyframeValueCommand.cpp
+++ b/src/commands/SetKeyframeValueCommand.cpp
@@ -1,7 +1,9 @@
 #include "SetKeyframeValueCommand.h"
 
+#include "SkeletonResolver.h"
+
 #include <Ogre.h>
-#include <OgreSkeleton.h>
+#include <OgreSkeletonInstance.h>
 #include <OgreAnimation.h>
 #include <OgreAnimationTrack.h>
 #include <OgreKeyFrame.h>
@@ -13,12 +15,14 @@
 namespace {
 constexpr float kEpsilon = 0.001f;
 
-Ogre::TransformKeyFrame* findKeyframe(Ogre::Skeleton* skel,
+Ogre::TransformKeyFrame* findKeyframe(const std::string& entityName,
                                        const std::string& animName,
                                        const std::string& boneName,
                                        float time)
 {
-    if (!skel || animName.empty() || boneName.empty()) return nullptr;
+    if (animName.empty() || boneName.empty()) return nullptr;
+    Ogre::SkeletonInstance* skel = SkeletonResolver::resolve(entityName);
+    if (!skel) return nullptr;
     if (!skel->hasAnimation(animName) || !skel->hasBone(boneName)) return nullptr;
     Ogre::Animation* anim = skel->getAnimation(animName);
     Ogre::Bone* bone = skel->getBone(boneName);
@@ -63,7 +67,7 @@ bool setChannel(Ogre::TransformKeyFrame* kf, const std::string& ch, double v) {
 
 } // namespace
 
-SetKeyframeValueCommand::SetKeyframeValueCommand(Ogre::Skeleton* skeleton,
+SetKeyframeValueCommand::SetKeyframeValueCommand(std::string entityName,
                                                   std::string animationName,
                                                   std::string boneName,
                                                   std::string channel,
@@ -71,7 +75,7 @@ SetKeyframeValueCommand::SetKeyframeValueCommand(Ogre::Skeleton* skeleton,
                                                   double newValue,
                                                   QUndoCommand* parent)
     : QUndoCommand(parent)
-    , mSkeleton(skeleton)
+    , mEntityName(std::move(entityName))
     , mAnimationName(std::move(animationName))
     , mBoneName(std::move(boneName))
     , mChannel(std::move(channel))
@@ -83,7 +87,7 @@ SetKeyframeValueCommand::SetKeyframeValueCommand(Ogre::Skeleton* skeleton,
 
 bool SetKeyframeValueCommand::apply(double value)
 {
-    auto* kf = findKeyframe(mSkeleton, mAnimationName, mBoneName, mTime);
+    auto* kf = findKeyframe(mEntityName, mAnimationName, mBoneName, mTime);
     if (!kf) return false;
     if (!mCaptured) {
         // First-time apply: snapshot the original so undo can restore it.

--- a/src/commands/SetKeyframeValueCommand.h
+++ b/src/commands/SetKeyframeValueCommand.h
@@ -5,7 +5,7 @@
 #include <string>
 
 namespace Ogre {
-    class Skeleton;
+    class SkeletonInstance;
 }
 
 /**
@@ -21,7 +21,7 @@ namespace Ogre {
 class SetKeyframeValueCommand : public QUndoCommand
 {
 public:
-    SetKeyframeValueCommand(Ogre::Skeleton* skeleton,
+    SetKeyframeValueCommand(std::string entityName,
                             std::string animationName,
                             std::string boneName,
                             std::string channel,
@@ -35,14 +35,14 @@ public:
 private:
     bool apply(double value);
 
-    Ogre::Skeleton* mSkeleton;
-    std::string     mAnimationName;
-    std::string     mBoneName;
-    std::string     mChannel;
-    float           mTime;
-    double          mOldValue = 0.0;
-    double          mNewValue;
-    bool            mCaptured = false;
+    std::string mEntityName;
+    std::string mAnimationName;
+    std::string mBoneName;
+    std::string mChannel;
+    float       mTime;
+    double      mOldValue = 0.0;
+    double      mNewValue;
+    bool        mCaptured = false;
 };
 
 #endif // SET_KEYFRAME_VALUE_COMMAND_H

--- a/src/commands/SetKeyframeValueCommand_test.cpp
+++ b/src/commands/SetKeyframeValueCommand_test.cpp
@@ -46,7 +46,7 @@ TEST_F(SetKeyframeValueCommandTest, RedoUndoRoundTrip) {
     auto* skel = entity->getSkeleton();
 
     QUndoStack stack;
-    stack.push(new SetKeyframeValueCommand(skel, "TestAnim", "Child", "tx", 0.5f, 9.0));
+    stack.push(new SetKeyframeValueCommand(entity->getName(), "TestAnim", "Child", "tx", 0.5f, 9.0));
 
     auto* kf = keyAt(entity, 0.5f);
     ASSERT_NE(kf, nullptr);
@@ -66,7 +66,7 @@ TEST_F(SetKeyframeValueCommandTest, NoOpWhenChannelUnknown) {
     auto* skel = entity->getSkeleton();
 
     QUndoStack stack;
-    stack.push(new SetKeyframeValueCommand(skel, "TestAnim", "Child", "qq", 0.5f, 9.0));
+    stack.push(new SetKeyframeValueCommand(entity->getName(), "TestAnim", "Child", "qq", 0.5f, 9.0));
     // Original 0.5 keyframe should be untouched.
     auto* kf = keyAt(entity, 0.5f);
     EXPECT_NEAR(kf->getTranslate().x, 0.5f, 1e-4);
@@ -79,7 +79,7 @@ TEST_F(SetKeyframeValueCommandTest, NoOpWhenTimeNotFound) {
     auto* skel = entity->getSkeleton();
 
     QUndoStack stack;
-    stack.push(new SetKeyframeValueCommand(skel, "TestAnim", "Child", "tx", 0.42f, 9.0));
+    stack.push(new SetKeyframeValueCommand(entity->getName(), "TestAnim", "Child", "tx", 0.42f, 9.0));
     // No keyframe at 0.42 → the original 0.0/0.5/1.0 keyframes stay intact.
     EXPECT_NEAR(keyAt(entity, 0.0f)->getTranslate().x, 0.0f, 1e-4);
     EXPECT_NEAR(keyAt(entity, 0.5f)->getTranslate().x, 0.5f, 1e-4);

--- a/src/commands/SkeletonResolver.cpp
+++ b/src/commands/SkeletonResolver.cpp
@@ -1,0 +1,39 @@
+#include "SkeletonResolver.h"
+
+#include "Manager.h"
+
+#include <OgreEntity.h>
+#include <OgreSkeletonInstance.h>
+
+namespace SkeletonResolver {
+
+Ogre::SkeletonInstance* resolve(const std::string& entityName)
+{
+    if (entityName.empty()) return nullptr;
+    auto* mgr = Manager::getSingletonPtr();
+    if (!mgr) return nullptr;
+    for (Ogre::Entity* ent : mgr->getEntities()) {
+        if (!ent) continue;
+        if (ent->getMovableType() != "Entity") continue;
+        if (ent->getName() != entityName) continue;
+        if (!ent->hasSkeleton()) return nullptr;
+        return ent->getSkeleton();
+    }
+    return nullptr;
+}
+
+std::string entityNameForSkeleton(Ogre::SkeletonInstance* skel)
+{
+    if (!skel) return {};
+    auto* mgr = Manager::getSingletonPtr();
+    if (!mgr) return {};
+    for (Ogre::Entity* ent : mgr->getEntities()) {
+        if (!ent) continue;
+        if (ent->getMovableType() != "Entity") continue;
+        if (ent->hasSkeleton() && ent->getSkeleton() == skel)
+            return ent->getName();
+    }
+    return {};
+}
+
+} // namespace SkeletonResolver

--- a/src/commands/SkeletonResolver.h
+++ b/src/commands/SkeletonResolver.h
@@ -1,0 +1,37 @@
+#ifndef SKELETON_RESOLVER_H
+#define SKELETON_RESOLVER_H
+
+#include <string>
+
+namespace Ogre {
+    class SkeletonInstance;
+    class Entity;
+}
+
+/**
+ * Resolves a SkeletonInstance from an entity name at apply-time.
+ *
+ * Used by undo commands that need a skeleton handle but cannot safely
+ * hold a raw pointer across the command's lifetime: entities can be
+ * deleted, reloaded, or have their skeletons rebuilt before undo/redo
+ * runs. Storing the entity's name and re-resolving on each apply avoids
+ * dangling-pointer use-after-free.
+ *
+ * Returns nullptr when the entity is gone or has no skeleton — callers
+ * should treat that as "command no-op" rather than a hard error.
+ */
+namespace SkeletonResolver {
+
+/// Resolves the SkeletonInstance for an entity by name. Walks the scene
+/// via Manager::getEntities() to find the entity, then returns its
+/// skeleton. nullptr if entity / skeleton is gone.
+Ogre::SkeletonInstance* resolve(const std::string& entityName);
+
+/// Convenience: get the entity's name from a live skeleton instance,
+/// for callers that capture the command at push time. Returns "" when
+/// no entity in the scene owns this skeleton.
+std::string entityNameForSkeleton(Ogre::SkeletonInstance* skel);
+
+} // namespace SkeletonResolver
+
+#endif // SKELETON_RESOLVER_H

--- a/src/commands/SkeletonResolver_test.cpp
+++ b/src/commands/SkeletonResolver_test.cpp
@@ -1,0 +1,60 @@
+#include <gtest/gtest.h>
+#include <QApplication>
+#include <QCoreApplication>
+#include <QThread>
+
+#include "commands/SkeletonResolver.h"
+#include "Manager.h"
+#include "TestHelpers.h"
+
+#include <OgreSkeletonInstance.h>
+#include <OgreEntity.h>
+
+class SkeletonResolverTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        Manager::kill();
+        QThread::msleep(20);
+        app = qobject_cast<QApplication*>(QCoreApplication::instance());
+        ASSERT_NE(app, nullptr);
+        ASSERT_TRUE(tryInitOgre());
+        createStandardOgreMaterials();
+        ASSERT_TRUE(canLoadMeshFiles());
+    }
+    void TearDown() override {
+        Manager::kill();
+        if (app) app->processEvents();
+        QThread::msleep(20);
+    }
+    QApplication* app = nullptr;
+};
+
+TEST_F(SkeletonResolverTest, ResolveReturnsSkeletonForLiveEntity) {
+    Ogre::Entity* entity = createAnimatedTestEntity("SR_Live");
+    ASSERT_NE(entity, nullptr);
+
+    Ogre::SkeletonInstance* resolved = SkeletonResolver::resolve(entity->getName());
+    EXPECT_EQ(resolved, entity->getSkeleton());
+}
+
+TEST_F(SkeletonResolverTest, ResolveReturnsNullForUnknownEntity) {
+    EXPECT_EQ(SkeletonResolver::resolve("does_not_exist"), nullptr);
+}
+
+TEST_F(SkeletonResolverTest, ResolveReturnsNullForEmptyName) {
+    EXPECT_EQ(SkeletonResolver::resolve(""), nullptr);
+}
+
+TEST_F(SkeletonResolverTest, EntityNameRoundTripsThroughResolver) {
+    Ogre::Entity* entity = createAnimatedTestEntity("SR_RoundTrip");
+    ASSERT_NE(entity, nullptr);
+
+    const std::string name = SkeletonResolver::entityNameForSkeleton(entity->getSkeleton());
+    EXPECT_EQ(name, entity->getName());
+
+    EXPECT_EQ(SkeletonResolver::resolve(name), entity->getSkeleton());
+}
+
+TEST_F(SkeletonResolverTest, EntityNameForNullSkeletonIsEmpty) {
+    EXPECT_TRUE(SkeletonResolver::entityNameForSkeleton(nullptr).empty());
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,6 +70,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/BoneTransformCommand.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/AddKeyframeCommand.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/DeleteKeyframeCommand.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/SkeletonResolver.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/BoneDragRelease.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/PropertiesPanelController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/SceneTreeModel.cpp


### PR DESCRIPTION
## Summary
Closes #389. All five keyframe-related undo commands previously stored a raw \`Ogre::Skeleton*\` (or \`SkeletonInstance*\`). If the entity was reloaded, deleted, or its skeleton rebuilt while the command sat on the undo stack, \`undo()\`/\`redo()\` would dereference freed memory.

### Approach
New \`SkeletonResolver\` utility looks up a \`SkeletonInstance\` by entity name via \`Manager::getEntities()\` at apply-time. Returns nullptr when the entity is gone — commands treat that as no-op.

Six commands now store the entity name and resolve through \`SkeletonResolver\`:
- \`BoneTransformCommand\`
- \`MoveKeyframeCommand\`
- \`SetKeyframeValueCommand\`
- \`MoveKeyframesCommand\` + \`PasteKeyframesCommand\` (in \`BulkKeyframeCommands\`)
- \`AddKeyframeCommand\`
- \`DeleteKeyframeCommand\`

Callers in \`AnimationControlController\` + \`TransformOperator\` updated to pass \`m_selectedEntityName\` / \`selectedEntityName().toStdString()\` instead of raw skeleton pointers.

### Tests
- New \`SkeletonResolver_test.cpp\` covers live-entity lookup, unknown name, empty name, round-trip, null skeleton.
- Existing 5 command-test files updated to pass entity name.

## Test plan
- [x] Local build clean
- [x] All test source files compile
- [ ] CI: build-linux / build-macos / build-windows / unit-tests-linux / sonar

🤖 Generated with [Claude Code](https://claude.com/claude-code)