### PR TITLE
feat(curve-editor): live drag preview + trackpad pan + scroll/zoom controls

### DIFF
--- a/qml/AnimationCurveEditor.qml
+++ b/qml/AnimationCurveEditor.qml
@@ -2,11 +2,7 @@ import QtQuick
 import QtQuick.Controls
 import AnimationControl 1.0
 
-// Curve editor — visualizes per-channel animation curves with Bezier handles.
-// Reads keyframe times + values from AnimationControlController and tangent
-// state from CurveEditModel. Read-only display in this slice (D3a); handle
-// dragging + resample-into-track lands in D3b. The dope sheet remains the
-// primary editing surface for keyframe selection and time shifts.
+// Curve editor — per-channel animation curves with Bezier handles.
 Rectangle {
     id: root
     color: AnimationControlController.panelColor
@@ -19,13 +15,7 @@ Rectangle {
 
     property int leftStripWidth: 130
 
-    // Pulled from AnimationControlController on signal. Each row is the same
-    // shape as the dope sheet's allBoneRows() returns: { bone, keyTimes,
-    // channels: { tx, ty, ..., sz: bool } }.
     property var rows: AnimationControlController.allBoneRows()
-
-    // Selected bone — only that bone's animated channels are drawn. Reuses
-    // AnimationControlController.selectedBone for cross-panel sync.
     readonly property string selectedBone: AnimationControlController.selectedBone
 
     readonly property var channelOrder: [
@@ -61,6 +51,45 @@ Rectangle {
         return activeChannelsFor(selectedBoneRow())
     }
 
+    // anchorPx is the pixel that should stay fixed while zooming.
+    function zoomHorizontal(factor, anchorPx) {
+        var newPx = Math.max(20, Math.min(2000, root.pxPerSec * factor))
+        if (newPx === root.pxPerSec) return
+        var tCursor = root.viewStart + anchorPx / root.pxPerSec
+        root.pxPerSec = newPx
+        root.viewStart = Math.max(0, tCursor - anchorPx / newPx)
+        clampViewStart()
+        curveCanvas.requestPaint()
+    }
+
+    function zoomVertical(factor, anchorPy) {
+        var newScale = Math.max(8, Math.min(800, root.yScale * factor))
+        if (newScale === root.yScale) return
+        var midY = (curveCanvas.height - 16) / 2
+        var vCursor = root.yCenter - (anchorPy - midY) / root.yScale
+        root.yScale = newScale
+        root.yCenter = vCursor + (anchorPy - midY) / newScale
+        curveCanvas.requestPaint()
+    }
+
+    function fitToView() {
+        var maxT = AnimationControlController.animationLength
+        if (maxT <= 0 || curveCanvas.width <= 0) return
+        var pad = 0.05
+        root.pxPerSec = Math.max(20, curveCanvas.width / (maxT * (1.0 + pad)))
+        root.viewStart = 0
+        curveCanvas.requestPaint()
+    }
+
+    function clampViewStart() {
+        var maxT = AnimationControlController.animationLength
+        if (maxT <= 0) { root.viewStart = 0; return }
+        var visibleSecs = curveCanvas.width / root.pxPerSec
+        var maxStart = Math.max(0, maxT - visibleSecs * 0.5)
+        if (root.viewStart > maxStart) root.viewStart = maxStart
+        if (root.viewStart < 0) root.viewStart = 0
+    }
+
     Connections {
         target: AnimationControlController
         function onBoneRowsChanged()      {
@@ -85,7 +114,6 @@ Rectangle {
         function onModelChanged() { curveCanvas.requestPaint() }
     }
 
-    // ── Empty-state placeholder ──────────────────────────────────────────────
     Text {
         anchors.centerIn: parent
         visible: !AnimationControlController.hasAnimation || !root.selectedBone
@@ -96,7 +124,6 @@ Rectangle {
         font.pixelSize: 12
     }
 
-    // ── Header ───────────────────────────────────────────────────────────────
     Rectangle {
         id: header
         width: parent.width; height: 24
@@ -112,11 +139,67 @@ Rectangle {
             color: AnimationControlController.textColor
         }
 
-        // Channel legend
         Row {
             anchors.right: parent.right; anchors.rightMargin: 8
             anchors.verticalCenter: parent.verticalCenter
             spacing: 10
+
+            Row {
+                spacing: 2
+                anchors.verticalCenter: parent.verticalCenter
+                Text {
+                    text: "H:"
+                    color: AnimationControlController.textColor
+                    font.pixelSize: 10
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+                Button {
+                    text: "−"; width: 22; height: 18
+                    font.pixelSize: 12
+                    onClicked: root.zoomHorizontal(1.0 / 1.25, curveCanvas.width / 2)
+                    ToolTip.visible: hovered
+                    ToolTip.text: "Zoom out time axis (wheel)"
+                }
+                Button {
+                    text: "+"; width: 22; height: 18
+                    font.pixelSize: 12
+                    onClicked: root.zoomHorizontal(1.25, curveCanvas.width / 2)
+                    ToolTip.visible: hovered
+                    ToolTip.text: "Zoom in time axis (wheel)"
+                }
+                Button {
+                    text: "⤢"; width: 22; height: 18
+                    font.pixelSize: 11
+                    onClicked: root.fitToView()
+                    ToolTip.visible: hovered
+                    ToolTip.text: "Fit animation to view"
+                }
+            }
+            Row {
+                spacing: 2
+                anchors.verticalCenter: parent.verticalCenter
+                Text {
+                    text: "V:"
+                    color: AnimationControlController.textColor
+                    font.pixelSize: 10
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+                Button {
+                    text: "−"; width: 22; height: 18
+                    font.pixelSize: 12
+                    onClicked: root.zoomVertical(1.0 / 1.25, curveCanvas.height / 2)
+                    ToolTip.visible: hovered
+                    ToolTip.text: "Zoom out value axis (Shift+wheel)"
+                }
+                Button {
+                    text: "+"; width: 22; height: 18
+                    font.pixelSize: 12
+                    onClicked: root.zoomVertical(1.25, curveCanvas.height / 2)
+                    ToolTip.visible: hovered
+                    ToolTip.text: "Zoom in value axis (Shift+wheel)"
+                }
+            }
+
             Repeater {
                 model: root.activeChannelsForSelected()
                 Row {
@@ -137,17 +220,15 @@ Rectangle {
         }
     }
 
-    // ── Curve canvas ─────────────────────────────────────────────────────────
     Canvas {
         id: curveCanvas
         anchors.left: parent.left
         anchors.top: header.visible ? header.bottom : parent.top
         anchors.right: parent.right
         anchors.bottom: parent.bottom
+        anchors.bottomMargin: 14   // matches hScrollBar.height
         visible: header.visible
 
-        // Cache per-channel values keyed by channel id. Refreshed whenever
-        // the controller emits boneRowsChanged.
         property var channelValues: ({})
 
         function refreshChannelValues(boneRow) {
@@ -171,9 +252,6 @@ Rectangle {
             )
         }
 
-        // Populate the cache up-front so the first paint shows real curves
-        // even when the view is opened after a selection is already active
-        // (no fresh boneRowsChanged signal will fire to seed it otherwise).
         Component.onCompleted: refreshChannelValues(root.selectedBoneRow())
 
         onPaint: {
@@ -183,7 +261,6 @@ Rectangle {
             var maxT = AnimationControlController.animationLength
             if (maxT <= 0) return
 
-            // Time-axis ruler at the bottom
             ctx.strokeStyle = AnimationControlController.borderColor
             ctx.fillStyle   = AnimationControlController.textColor
             ctx.font        = "10px sans-serif"; ctx.lineWidth = 1
@@ -194,7 +271,6 @@ Rectangle {
                 ctx.fillText(t.toFixed(2) + "s", x + 2, height - 14)
             }
 
-            // Horizontal value-axis grid lines (every 0.5 in value units)
             var midY = (height - 16) / 2
             ctx.strokeStyle = AnimationControlController.borderColor
             ctx.globalAlpha = 0.25
@@ -206,9 +282,6 @@ Rectangle {
             }
             ctx.globalAlpha = 1.0
 
-            // Per-channel curve. evaluate() reads real per-channel values
-            // pulled from the controller and cached in channelValues, so the
-            // curve reflects the underlying TransformKeyFrame data.
             var chans = root.activeChannelsForSelected()
             for (var c = 0; c < chans.length; c++) {
                 var ch = chans[c]
@@ -227,8 +300,6 @@ Rectangle {
                 }
                 ctx.stroke()
 
-                // Keyframe squares + tangent handle stubs (drawn only for
-                // visual reference in D3a — non-interactive).
                 ctx.fillStyle = ch.color
                 for (var k = 0; k < row.keyTimes.length; k++) {
                     var kt = row.keyTimes[k]
@@ -246,7 +317,6 @@ Rectangle {
                         var outT = tdata[1]
                         ctx.strokeStyle = ch.color; ctx.lineWidth = 1
                         ctx.globalAlpha = 0.6
-                        // Draw a short handle in each direction
                         var handlePx = 30
                         ctx.beginPath()
                         ctx.moveTo(kx - handlePx, ky + inT * handlePx * 0.5)
@@ -260,7 +330,6 @@ Rectangle {
         }
     }
 
-    // ── Interp-mode picker (right-click on keyframe square) ────────────────
     Menu {
         id: modeMenu
         property string boneName: ""
@@ -280,9 +349,6 @@ Rectangle {
         MenuItem { text: "Auto";     onTriggered: modeMenu.applyMode(CurveEditModel.ModeAuto) }
     }
 
-    // Look up a keyframe near (px, py) and return { bone, channel, time, x, y }
-    // or null if the click missed everything. Used by the right-click handler
-    // to decide whether to open the mode picker.
     function pickKeyframeAt(px, py) {
         var row = selectedBoneRow()
         if (!row) return null
@@ -297,63 +363,324 @@ Rectangle {
                 var ky = midY - (kv - yCenter) * yScale
                 if (Math.abs(px - kx) < 8 && Math.abs(py - ky) < 8) {
                     return { bone: row.bone, channel: ch.id,
-                             time: kt, x: kx, y: ky }
+                             time: kt, value: kv, x: kx, y: ky }
                 }
             }
         }
         return null
     }
 
-    // Wheel = zoom horizontally (Ctrl/Cmd) or vertically (Shift), pan with
-    // middle-drag. Right-click on a keyframe square opens the interp-mode
-    // picker. Matches the dope sheet's input vocabulary as closely as
-    // possible to keep mental load low when switching panels.
+    function pickTangentHandleAt(px, py) {
+        var row = selectedBoneRow()
+        if (!row) return null
+        var midY = (curveCanvas.height - 16) / 2
+        var chans = activeChannelsFor(row)
+        var handlePx = 30
+        for (var c = 0; c < chans.length; c++) {
+            var ch = chans[c]
+            for (var k = 0; k < row.keyTimes.length; k++) {
+                var kt = row.keyTimes[k]
+                var kv = curveCanvas.valueAtTimeForChannel(row, ch.id, kt)
+                var kx = (kt - viewStart) * pxPerSec
+                var ky = midY - (kv - yCenter) * yScale
+                var tdata = CurveEditModel.tangentsAt(
+                    AnimationControlController.selectedEntityName,
+                    AnimationControlController.selectedAnimation,
+                    row.bone, ch.id, kt)
+                if (!tdata || tdata.length < 2) continue
+                var inT  = tdata[0]
+                var outT = tdata[1]
+                var inHx  = kx - handlePx, inHy  = ky + inT * handlePx * 0.5
+                var outHx = kx + handlePx, outHy = ky - outT * handlePx * 0.5
+                if (Math.abs(px - inHx) < 6 && Math.abs(py - inHy) < 6) {
+                    return { bone: row.bone, channel: ch.id, time: kt,
+                             side: "in", inT: inT, outT: outT, kx: kx, ky: ky }
+                }
+                if (Math.abs(px - outHx) < 6 && Math.abs(py - outHy) < 6) {
+                    return { bone: row.bone, channel: ch.id, time: kt,
+                             side: "out", inT: inT, outT: outT, kx: kx, ky: ky }
+                }
+            }
+        }
+        return null
+    }
+
     MouseArea {
         id: panArea
         anchors.fill: parent
-        acceptedButtons: Qt.MiddleButton | Qt.RightButton
+        acceptedButtons: Qt.LeftButton | Qt.MiddleButton | Qt.RightButton
         property real panStartX: 0
         property real panStartView: 0
+
+        // dragMode: "" / "keyframe" / "tangent"
+        property string dragMode: ""
+        property string dragBone: ""
+        property string dragChannel: ""
+        property real   dragKeyTime: 0
+        property real   dragOriginalKeyTime: 0
+        property real   dragOriginalValue: 0
+        property real   dragLastValue: 0
+        property real   dragPressX: 0
+        property real   dragPressY: 0
+        property string dragTangentSide: ""
+        property real   dragTangentKx: 0
+        property real   dragTangentKy: 0
+        property real   dragInT: 0
+        property real   dragOutT: 0
+
         onPressed: function(mouse) {
             if (mouse.button === Qt.MiddleButton) {
                 panStartX = mouse.x; panStartView = root.viewStart
                 mouse.accepted = true
             } else if (mouse.button === Qt.RightButton) {
-                var hit = root.pickKeyframeAt(
+                var rhit = root.pickKeyframeAt(
                     mouse.x - curveCanvas.x, mouse.y - curveCanvas.y)
-                if (hit) {
-                    modeMenu.boneName  = hit.bone
-                    modeMenu.channelId = hit.channel
-                    modeMenu.keyTime   = hit.time
+                if (rhit) {
+                    modeMenu.boneName  = rhit.bone
+                    modeMenu.channelId = rhit.channel
+                    modeMenu.keyTime   = rhit.time
                     modeMenu.popup()
                     mouse.accepted = true
                 } else {
                     mouse.accepted = false
                 }
+            } else if (mouse.button === Qt.LeftButton) {
+                // Try tangent handle (smaller target) first, then keyframe square.
+                var canvasX = mouse.x - curveCanvas.x
+                var canvasY = mouse.y - curveCanvas.y
+                var thit = root.pickTangentHandleAt(canvasX, canvasY)
+                if (thit) {
+                    panArea.dragMode = "tangent"
+                    panArea.dragBone = thit.bone
+                    panArea.dragChannel = thit.channel
+                    panArea.dragKeyTime = thit.time
+                    panArea.dragTangentSide = thit.side
+                    panArea.dragTangentKx = thit.kx
+                    panArea.dragTangentKy = thit.ky
+                    panArea.dragInT = thit.inT
+                    panArea.dragOutT = thit.outT
+                    mouse.accepted = true
+                    return
+                }
+                var khit = root.pickKeyframeAt(canvasX, canvasY)
+                if (khit) {
+                    panArea.dragMode = "keyframe"
+                    panArea.dragBone = khit.bone
+                    panArea.dragChannel = khit.channel
+                    panArea.dragKeyTime = khit.time
+                    panArea.dragOriginalKeyTime = khit.time
+                    panArea.dragOriginalValue = khit.value
+                    panArea.dragPressX = canvasX
+                    panArea.dragPressY = canvasY
+                    mouse.accepted = true
+                    return
+                }
+                mouse.accepted = false
             } else mouse.accepted = false
         }
         onPositionChanged: function(mouse) {
-            // mouse.button on a move event is the event trigger, not the
-            // held buttons — check the bitmask in mouse.buttons instead.
-            // Otherwise middle-drag pan never fires after the initial press.
-            if (!pressed || !(mouse.buttons & Qt.MiddleButton)) return
-            var dx = mouse.x - panStartX
-            root.viewStart = panStartView - dx / root.pxPerSec
-            if (root.viewStart < 0) root.viewStart = 0
-            curveCanvas.requestPaint()
+            if (!pressed) return
+
+            if (mouse.buttons & Qt.MiddleButton) {
+                var dx = mouse.x - panStartX
+                root.viewStart = panStartView - dx / root.pxPerSec
+                if (root.viewStart < 0) root.viewStart = 0
+                curveCanvas.requestPaint()
+                return
+            }
+
+            if (!(mouse.buttons & Qt.LeftButton) || panArea.dragMode === "") return
+            var canvasX = mouse.x - curveCanvas.x
+            var canvasY = mouse.y - curveCanvas.y
+
+            if (panArea.dragMode === "keyframe") {
+                // Shift locks to the dominant axis since press.
+                var midY = (curveCanvas.height - 16) / 2
+                var newValue = root.yCenter - (canvasY - midY) / root.yScale
+                var newTime  = root.viewStart + canvasX / root.pxPerSec
+                if (newTime < 0) newTime = 0
+
+                var dxAxis = Math.abs(canvasX - panArea.dragPressX)
+                var dyAxis = Math.abs(canvasY - panArea.dragPressY)
+                var shift = (mouse.modifiers & Qt.ShiftModifier) !== 0
+                var lockX = shift && dyAxis > dxAxis
+                var lockY = shift && dxAxis > dyAxis
+
+                // Preview API skips the undo stack — pushing a command
+                // per move fires MainWindow's indexChanged handler,
+                // which calls Skeleton::reset(true) and snaps the bone
+                // to T-pose between events. Commit on release.
+                panArea.dragLastValue = newValue
+                if (!lockX) {
+                    AnimationControlController.setKeyframeValuePreview(
+                        panArea.dragBone, panArea.dragChannel,
+                        panArea.dragKeyTime, newValue)
+                }
+                if (!lockY) {
+                    var ok = AnimationControlController.moveKeyframePreview(
+                        panArea.dragBone, panArea.dragKeyTime, newTime)
+                    if (ok) panArea.dragKeyTime = newTime
+                }
+                // boneRowsChanged is suppressed by the preview API; refresh inline.
+                root.rows = AnimationControlController.allBoneRows()
+                curveCanvas.refreshChannelValues(root.selectedBoneRow())
+                curveCanvas.requestPaint()
+            } else if (panArea.dragMode === "tangent") {
+                // Mirrors the encoding in onPaint.
+                var handlePx = 30
+                if (panArea.dragTangentSide === "in") {
+                    var newInT = (canvasY - panArea.dragTangentKy) / (handlePx * 0.5)
+                    panArea.dragInT = newInT
+                    CurveEditModel.setTangents(
+                        AnimationControlController.selectedEntityName,
+                        AnimationControlController.selectedAnimation,
+                        panArea.dragBone, panArea.dragChannel,
+                        panArea.dragKeyTime, newInT, panArea.dragOutT)
+                } else {
+                    var newOutT = -(canvasY - panArea.dragTangentKy) / (handlePx * 0.5)
+                    panArea.dragOutT = newOutT
+                    CurveEditModel.setTangents(
+                        AnimationControlController.selectedEntityName,
+                        AnimationControlController.selectedAnimation,
+                        panArea.dragBone, panArea.dragChannel,
+                        panArea.dragKeyTime, panArea.dragInT, newOutT)
+                }
+                curveCanvas.requestPaint()
+            }
+        }
+        onReleased: function(mouse) {
+            if (panArea.dragMode === "keyframe") {
+                var valueChanged = panArea.dragLastValue !== panArea.dragOriginalValue
+                var timeChanged  = panArea.dragKeyTime    !== panArea.dragOriginalKeyTime
+
+                // Restore originals before pushing the real commands so
+                // their redo() captures the correct old-state snapshot.
+                if (timeChanged) {
+                    AnimationControlController.moveKeyframePreview(
+                        panArea.dragBone,
+                        panArea.dragKeyTime, panArea.dragOriginalKeyTime)
+                    AnimationControlController.moveKeyframe(
+                        panArea.dragBone,
+                        panArea.dragOriginalKeyTime, panArea.dragKeyTime)
+                }
+                if (valueChanged) {
+                    AnimationControlController.setKeyframeValuePreview(
+                        panArea.dragBone, panArea.dragChannel,
+                        panArea.dragKeyTime, panArea.dragOriginalValue)
+                    AnimationControlController.setKeyframeValue(
+                        panArea.dragBone, panArea.dragChannel,
+                        panArea.dragKeyTime, panArea.dragLastValue)
+                }
+            }
+            panArea.dragMode = ""
+        }
+
+        // Pointer handlers must be children of the MouseArea — at root
+        // level the MouseArea blocks them.
+
+        // Plain wheel / two-finger scroll = pan; horizontal swipe pans
+        // time, vertical pans value. pixelDelta is preferred when set
+        // so trackpad pan tracks finger motion 1:1.
+        WheelHandler {
+            acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
+            acceptedModifiers: Qt.NoModifier
+            onWheel: function(event) {
+                var pxX = event.pixelDelta.x !== 0 ? event.pixelDelta.x
+                                                   : event.angleDelta.x / 8
+                var pxY = event.pixelDelta.y !== 0 ? event.pixelDelta.y
+                                                   : event.angleDelta.y / 8
+
+                if (Math.abs(pxX) > Math.abs(pxY)) {
+                    root.viewStart -= pxX / root.pxPerSec
+                    root.clampViewStart()
+                } else {
+                    root.yCenter += pxY / root.yScale
+                }
+                curveCanvas.requestPaint()
+            }
+        }
+        WheelHandler {
+            acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
+            acceptedModifiers: Qt.ControlModifier | Qt.MetaModifier
+            onWheel: function(event) {
+                var dy = event.pixelDelta.y !== 0 ? event.pixelDelta.y
+                                                  : event.angleDelta.y
+                var factor = dy > 0 ? 1.15 : (1.0 / 1.15)
+                root.zoomHorizontal(factor, event.point.position.x)
+            }
+        }
+        WheelHandler {
+            acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
+            acceptedModifiers: Qt.ShiftModifier
+            onWheel: function(event) {
+                var dy = event.pixelDelta.y !== 0 ? event.pixelDelta.y
+                                                  : event.angleDelta.y
+                var factor = dy > 0 ? 1.15 : (1.0 / 1.15)
+                root.zoomVertical(factor, event.point.position.y)
+            }
         }
     }
-    WheelHandler {
-        target: null
-        acceptedModifiers: Qt.ControlModifier | Qt.MetaModifier
-        onWheel: function(event) {
-            var factor = event.angleDelta.y > 0 ? 1.15 : (1.0 / 1.15)
-            var newPx = Math.max(20, Math.min(2000, root.pxPerSec * factor))
-            if (newPx === root.pxPerSec) return
-            var tCursor = root.viewStart + event.point.position.x / root.pxPerSec
-            root.pxPerSec = newPx
-            root.viewStart = tCursor - event.point.position.x / newPx
-            if (root.viewStart < 0) root.viewStart = 0
+
+    // Drives root.viewStart while the user drags the thumb. Visible
+    // only when the timeline overflows the canvas width.
+    ScrollBar {
+        id: hScrollBar
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        height: 14
+        active: true
+        orientation: Qt.Horizontal
+        policy: ScrollBar.AlwaysOn
+        visible: header.visible
+                 && AnimationControlController.animationLength > 0
+                 && (AnimationControlController.animationLength * root.pxPerSec)
+                    > curveCanvas.width
+
+        readonly property real scrollableSecs: {
+            var maxT = AnimationControlController.animationLength
+            if (maxT <= 0 || curveCanvas.width <= 0) return 0
+            var visibleSecs = curveCanvas.width / root.pxPerSec
+            return Math.max(0, maxT - visibleSecs)
+        }
+
+        // Both directions of the position↔viewStart sync are imperative;
+        // the `syncing` guard prevents a bounce.
+        size: {
+            var maxT = AnimationControlController.animationLength
+            if (maxT <= 0 || curveCanvas.width <= 0) return 1
+            var visibleSecs = curveCanvas.width / root.pxPerSec
+            return Math.min(1, visibleSecs / maxT)
+        }
+
+        property bool syncing: false
+        function syncFromViewStart() {
+            var maxT = AnimationControlController.animationLength
+            if (maxT <= 0) return
+            syncing = true
+            position = Math.max(0, Math.min(1 - size, root.viewStart / maxT))
+            syncing = false
+        }
+
+        Component.onCompleted: syncFromViewStart()
+        Connections {
+            target: root
+            function onViewStartChanged() {
+                if (hScrollBar.pressed) return
+                hScrollBar.syncFromViewStart()
+            }
+        }
+
+        Connections {
+            target: AnimationControlController
+            function onAnimationLengthChanged() { hScrollBar.syncFromViewStart() }
+        }
+
+        onPositionChanged: {
+            if (syncing) return
+            var maxT = AnimationControlController.animationLength
+            if (maxT <= 0) return
+            root.viewStart = position * maxT
             curveCanvas.requestPaint()
         }
     }

--- a/qml/AnimationCurveEditor.qml
+++ b/qml/AnimationCurveEditor.qml
@@ -84,8 +84,10 @@ Rectangle {
     function clampViewStart() {
         var maxT = AnimationControlController.animationLength
         if (maxT <= 0) { root.viewStart = 0; return }
+        // Match ScrollBar's scrollable range so panning can't drift past
+        // the thumb's end position.
         var visibleSecs = curveCanvas.width / root.pxPerSec
-        var maxStart = Math.max(0, maxT - visibleSecs * 0.5)
+        var maxStart = Math.max(0, maxT - visibleSecs)
         if (root.viewStart > maxStart) root.viewStart = maxStart
         if (root.viewStart < 0) root.viewStart = 0
     }
@@ -470,6 +472,11 @@ Rectangle {
                     panArea.dragKeyTime = khit.time
                     panArea.dragOriginalKeyTime = khit.time
                     panArea.dragOriginalValue = khit.value
+                    // Seed lastValue too — onReleased compares it to
+                    // originalValue to decide whether to commit. Without
+                    // this, a click without drag (or a Shift-X-locked
+                    // drag) would commit a stale `0` back to the curve.
+                    panArea.dragLastValue = khit.value
                     panArea.dragPressX = canvasX
                     panArea.dragPressY = canvasY
                     mouse.accepted = true
@@ -484,7 +491,7 @@ Rectangle {
             if (mouse.buttons & Qt.MiddleButton) {
                 var dx = mouse.x - panStartX
                 root.viewStart = panStartView - dx / root.pxPerSec
-                if (root.viewStart < 0) root.viewStart = 0
+                root.clampViewStart()
                 curveCanvas.requestPaint()
                 return
             }
@@ -503,20 +510,23 @@ Rectangle {
                 var dxAxis = Math.abs(canvasX - panArea.dragPressX)
                 var dyAxis = Math.abs(canvasY - panArea.dragPressY)
                 var shift = (mouse.modifiers & Qt.ShiftModifier) !== 0
-                var lockX = shift && dyAxis > dxAxis
-                var lockY = shift && dxAxis > dyAxis
+                // Shift constrains to the dominant axis. writeValue/writeTime
+                // are gated so axis-locked drags don't smear into the orthogonal
+                // channel.
+                var writeValue = !shift || dyAxis >= dxAxis
+                var writeTime  = !shift || dxAxis >  dyAxis
 
                 // Preview API skips the undo stack — pushing a command
                 // per move fires MainWindow's indexChanged handler,
                 // which calls Skeleton::reset(true) and snaps the bone
                 // to T-pose between events. Commit on release.
-                panArea.dragLastValue = newValue
-                if (!lockX) {
+                if (writeValue) {
+                    panArea.dragLastValue = newValue
                     AnimationControlController.setKeyframeValuePreview(
                         panArea.dragBone, panArea.dragChannel,
                         panArea.dragKeyTime, newValue)
                 }
-                if (!lockY) {
+                if (writeTime) {
                     var ok = AnimationControlController.moveKeyframePreview(
                         panArea.dragBone, panArea.dragKeyTime, newTime)
                     if (ok) panArea.dragKeyTime = newTime

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -941,6 +941,55 @@ bool AnimationControlController::moveKeyframe(const QString& boneName,
     return true;
 }
 
+bool AnimationControlController::moveKeyframePreview(const QString& boneName,
+                                                      double oldTime, double newTime)
+{
+    if (boneName.isEmpty()) return false;
+    if (!m_selectedSkeleton || m_selectedAnimation.empty()) return false;
+    if (!m_selectedSkeleton->hasAnimation(m_selectedAnimation)) return false;
+    if (qFuzzyCompare(oldTime + 1.0, newTime + 1.0)) return false;
+
+    Ogre::Animation* anim = m_selectedSkeleton->getAnimation(m_selectedAnimation);
+    const std::string boneStd = boneName.toStdString();
+    if (!m_selectedSkeleton->hasBone(boneStd)) return false;
+    Ogre::Bone* bone = m_selectedSkeleton->getBone(boneStd);
+    if (!bone || !anim->hasNodeTrack(bone->getHandle())) return false;
+    Ogre::NodeAnimationTrack* track = anim->getNodeTrack(bone->getHandle());
+
+    constexpr float kEpsilon = 0.001f;
+    int sourceIdx = -1;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        if (std::fabs(track->getKeyFrame(i)->getTime() - static_cast<float>(oldTime)) <= kEpsilon) {
+            sourceIdx = static_cast<int>(i);
+            break;
+        }
+    }
+    if (sourceIdx < 0) return false;
+
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        if (static_cast<int>(i) == sourceIdx) continue;
+        if (std::fabs(track->getKeyFrame(i)->getTime() - static_cast<float>(newTime)) <= kEpsilon) {
+            return false;
+        }
+    }
+
+    auto* oldKf = static_cast<Ogre::TransformKeyFrame*>(track->getKeyFrame(sourceIdx));
+    const Ogre::Vector3    t = oldKf->getTranslate();
+    const Ogre::Quaternion r = oldKf->getRotation();
+    const Ogre::Vector3    s = oldKf->getScale();
+    track->removeKeyFrame(static_cast<unsigned short>(sourceIdx));
+    auto* newKf = track->createNodeKeyFrame(static_cast<float>(newTime));
+    newKf->setTranslate(t);
+    newKf->setRotation(r);
+    newKf->setScale(s);
+    track->_keyFrameDataChanged();
+
+    // Skip refreshSliderTicks + boneRowsChanged: the release-time
+    // MoveKeyframeCommand re-emits both.
+    notifyOgreUpdate();
+    return true;
+}
+
 // ── Bulk keyframe ops (slice D1) ──────────────────────────────────────────────
 
 namespace {
@@ -1268,6 +1317,23 @@ bool isKnownChannel(const QString& ch) {
     return kKnown.contains(ch.toLower());
 }
 
+// Symmetric writer to readChannel — writes the requested scalar onto
+// the keyframe's TRS without touching the other 9 components.
+void writeChannel(Ogre::TransformKeyFrame* kf, const QString& ch, double v) {
+    const QString c = ch.toLower();
+    const float fv = static_cast<float>(v);
+    if (c == "tx") { auto t = kf->getTranslate(); t.x = fv; kf->setTranslate(t); return; }
+    if (c == "ty") { auto t = kf->getTranslate(); t.y = fv; kf->setTranslate(t); return; }
+    if (c == "tz") { auto t = kf->getTranslate(); t.z = fv; kf->setTranslate(t); return; }
+    if (c == "rw") { auto r = kf->getRotation();  r.w = fv; kf->setRotation(r);  return; }
+    if (c == "rx") { auto r = kf->getRotation();  r.x = fv; kf->setRotation(r);  return; }
+    if (c == "ry") { auto r = kf->getRotation();  r.y = fv; kf->setRotation(r);  return; }
+    if (c == "rz") { auto r = kf->getRotation();  r.z = fv; kf->setRotation(r);  return; }
+    if (c == "sx") { auto s = kf->getScale();     s.x = fv; kf->setScale(s);     return; }
+    if (c == "sy") { auto s = kf->getScale();     s.y = fv; kf->setScale(s);     return; }
+    if (c == "sz") { auto s = kf->getScale();     s.z = fv; kf->setScale(s);     return; }
+}
+
 } // namespace
 
 QVariantList AnimationControlController::channelValuesAt(
@@ -1326,5 +1392,30 @@ bool AnimationControlController::setKeyframeValue(const QString& boneName,
     UndoManager::getSingleton()->push(cmd);
     refreshSliderTicks();
     emit boneRowsChanged();
+    return true;
+}
+
+bool AnimationControlController::setKeyframeValuePreview(const QString& boneName,
+                                                          const QString& channel,
+                                                          double time, double value)
+{
+    if (boneName.isEmpty() || !isKnownChannel(channel)) return false;
+    if (!m_selectedSkeleton || m_selectedAnimation.empty()) return false;
+    if (!m_selectedSkeleton->hasAnimation(m_selectedAnimation)) return false;
+    if (!m_selectedSkeleton->hasBone(boneName.toStdString())) return false;
+    Ogre::Animation* anim = m_selectedSkeleton->getAnimation(m_selectedAnimation);
+    Ogre::Bone* bone = m_selectedSkeleton->getBone(boneName.toStdString());
+    if (!anim->hasNodeTrack(bone->getHandle())) return false;
+    auto* track = anim->getNodeTrack(bone->getHandle());
+    Ogre::TransformKeyFrame* target = nullptr;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        auto* kf = static_cast<Ogre::TransformKeyFrame*>(track->getKeyFrame(i));
+        if (std::fabs(kf->getTime() - static_cast<float>(time)) <= 0.001f) {
+            target = kf; break;
+        }
+    }
+    if (!target) return false;
+    writeChannel(target, channel, value);
+    notifyOgreUpdate();
     return true;
 }

--- a/src/AnimationControlController.h
+++ b/src/AnimationControlController.h
@@ -205,6 +205,13 @@ public:
     Q_INVOKABLE bool moveKeyframe(const QString& boneName,
                                   double oldTime, double newTime);
 
+    /// Retime a keyframe in place without pushing an undo command. The
+    /// caller commits one MoveKeyframeCommand on drag release; without
+    /// the preview path each move event triggers Skeleton::reset(true)
+    /// via MainWindow's indexChanged handler, blinking to T-pose.
+    Q_INVOKABLE bool moveKeyframePreview(const QString& boneName,
+                                         double oldTime, double newTime);
+
     // ── Bulk keyframe ops (slice D1) ──────────────────────────────────────────
     /// Move every selected keyframe by the same `dt` in seconds. Selection
     /// is a list of QVariantMaps with "bone" + "time" keys. Atomic: a
@@ -240,6 +247,13 @@ public:
     Q_INVOKABLE bool setKeyframeValue(const QString& boneName,
                                        const QString& channel,
                                        double time, double value);
+
+    /// Write a channel value in place without pushing an undo command.
+    /// Caller commits one SetKeyframeValueCommand on drag release. See
+    /// moveKeyframePreview for the rationale.
+    Q_INVOKABLE bool setKeyframeValuePreview(const QString& boneName,
+                                              const QString& channel,
+                                              double time, double value);
 
 public slots:
     void updateAnimationTree();

--- a/src/AnimationControlController_test.cpp
+++ b/src/AnimationControlController_test.cpp
@@ -977,6 +977,179 @@ TEST_F(AnimationControlControllerTest, MoveKeyframeRejectsCollision) {
     EXPECT_TRUE(stillThere);
 }
 
+// ── Preview API (curve editor live-drag) ──────────────────────────────────────
+
+TEST_F(AnimationControlControllerTest, MoveKeyframePreviewRetimesWithoutUndoPush) {
+    // The curve editor calls this on every mouseMove during a keyframe
+    // drag — it must NOT push onto the undo stack (otherwise MainWindow's
+    // indexChanged handler resets the skeleton and the bone blinks to
+    // T-pose between events).
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("CurveEditor_MovePreview");
+    ASSERT_NE(entity, nullptr);
+
+    auto* ctrl = AnimationControlController::instance();
+    ctrl->updateAnimationTree();
+    ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+    QString bone = ctrl->boneNames().first();
+
+    const int undoBefore = UndoManager::getSingleton()->stack()->count();
+
+    EXPECT_TRUE(ctrl->moveKeyframePreview(bone, 0.5, 0.7));
+
+    EXPECT_EQ(UndoManager::getSingleton()->stack()->count(), undoBefore)
+        << "moveKeyframePreview must not push undo commands";
+
+    auto* track = entity->getSkeleton()->getAnimation("TestAnim")
+                         ->_getNodeTrackList().begin()->second;
+    bool foundMoved = false, foundOriginal = false;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        const float t = track->getKeyFrame(i)->getTime();
+        if (std::fabs(t - 0.5f) < 0.001f) foundOriginal = true;
+        if (std::fabs(t - 0.7f) < 0.001f) foundMoved = true;
+    }
+    EXPECT_FALSE(foundOriginal);
+    EXPECT_TRUE(foundMoved);
+}
+
+TEST_F(AnimationControlControllerTest, MoveKeyframePreviewPreservesTRS) {
+    // The retime must preserve the keyframe's translate/rotate/scale.
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("CurveEditor_MovePreservesTRS");
+    ASSERT_NE(entity, nullptr);
+
+    auto* ctrl = AnimationControlController::instance();
+    ctrl->updateAnimationTree();
+    ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+    QString bone = ctrl->boneNames().first();
+
+    auto* track = entity->getSkeleton()->getAnimation("TestAnim")
+                         ->_getNodeTrackList().begin()->second;
+    Ogre::TransformKeyFrame* before = nullptr;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        auto* kf = static_cast<Ogre::TransformKeyFrame*>(track->getKeyFrame(i));
+        if (std::fabs(kf->getTime() - 0.5f) < 0.001f) { before = kf; break; }
+    }
+    ASSERT_NE(before, nullptr);
+    const Ogre::Vector3 t = before->getTranslate();
+    const Ogre::Quaternion r = before->getRotation();
+    const Ogre::Vector3 s = before->getScale();
+
+    EXPECT_TRUE(ctrl->moveKeyframePreview(bone, 0.5, 0.65));
+
+    Ogre::TransformKeyFrame* after = nullptr;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        auto* kf = static_cast<Ogre::TransformKeyFrame*>(track->getKeyFrame(i));
+        if (std::fabs(kf->getTime() - 0.65f) < 0.001f) { after = kf; break; }
+    }
+    ASSERT_NE(after, nullptr);
+    EXPECT_NEAR(after->getTranslate().x, t.x, 1e-4);
+    EXPECT_NEAR(after->getTranslate().y, t.y, 1e-4);
+    EXPECT_NEAR(after->getTranslate().z, t.z, 1e-4);
+    EXPECT_NEAR(after->getRotation().w, r.w, 1e-4);
+    EXPECT_NEAR(after->getScale().x,    s.x, 1e-4);
+}
+
+TEST_F(AnimationControlControllerTest, MoveKeyframePreviewRejectsCollision) {
+    // Same collision rules as moveKeyframe so the preview can't silently
+    // overwrite an adjacent keyframe mid-drag.
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("CurveEditor_MovePreviewCollision");
+    ASSERT_NE(entity, nullptr);
+
+    auto* ctrl = AnimationControlController::instance();
+    ctrl->updateAnimationTree();
+    ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+    QString bone = ctrl->boneNames().first();
+
+    EXPECT_FALSE(ctrl->moveKeyframePreview(bone, 0.5, 1.0));
+
+    auto* track = entity->getSkeleton()->getAnimation("TestAnim")
+                         ->_getNodeTrackList().begin()->second;
+    bool stillThere = false;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        if (std::fabs(track->getKeyFrame(i)->getTime() - 0.5f) < 0.001f) {
+            stillThere = true; break;
+        }
+    }
+    EXPECT_TRUE(stillThere);
+}
+
+TEST_F(AnimationControlControllerTest, MoveKeyframePreviewRejectsMissingTime) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("CurveEditor_MovePreviewMissing");
+    ASSERT_NE(entity, nullptr);
+
+    auto* ctrl = AnimationControlController::instance();
+    ctrl->updateAnimationTree();
+    ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+    QString bone = ctrl->boneNames().first();
+
+    EXPECT_FALSE(ctrl->moveKeyframePreview(bone, 0.42, 0.6));
+}
+
+TEST_F(AnimationControlControllerTest, MoveKeyframePreviewNoOpOnIdenticalTime) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("CurveEditor_MovePreviewSame");
+    ASSERT_NE(entity, nullptr);
+
+    auto* ctrl = AnimationControlController::instance();
+    ctrl->updateAnimationTree();
+    ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+    QString bone = ctrl->boneNames().first();
+
+    EXPECT_FALSE(ctrl->moveKeyframePreview(bone, 0.5, 0.5));
+}
+
+TEST_F(AnimationControlControllerPlaybackTest, MoveKeyframePreviewNoOpWithoutSelection) {
+    auto* ctrl = AnimationControlController::instance();
+    EXPECT_FALSE(ctrl->moveKeyframePreview("Bone", 0.5, 0.6));
+}
+
+TEST_F(AnimationControlControllerTest, SetKeyframeValuePreviewWritesWithoutUndoPush) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("CurveEditor_ValuePreview");
+    ASSERT_NE(entity, nullptr);
+
+    auto* ctrl = AnimationControlController::instance();
+    ctrl->updateAnimationTree();
+    ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+    QString bone = ctrl->boneNames().first();
+
+    const int undoBefore = UndoManager::getSingleton()->stack()->count();
+    EXPECT_TRUE(ctrl->setKeyframeValuePreview(bone, "tx", 0.5, 9.25));
+    EXPECT_EQ(UndoManager::getSingleton()->stack()->count(), undoBefore);
+
+    auto* track = entity->getSkeleton()->getAnimation("TestAnim")
+                         ->_getNodeTrackList().begin()->second;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        auto* kf = static_cast<Ogre::TransformKeyFrame*>(track->getKeyFrame(i));
+        if (std::fabs(kf->getTime() - 0.5f) < 0.001f) {
+            EXPECT_NEAR(kf->getTranslate().x, 9.25f, 1e-4);
+            return;
+        }
+    }
+    FAIL() << "Keyframe at t=0.5 not found";
+}
+
+TEST_F(AnimationControlControllerTest, SetKeyframeValuePreviewRejectsUnknownChannel) {
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("CurveEditor_ValuePreviewUnknown");
+    ASSERT_NE(entity, nullptr);
+
+    auto* ctrl = AnimationControlController::instance();
+    ctrl->updateAnimationTree();
+    ctrl->selectAnimation(QString::fromStdString(entity->getName()), "TestAnim");
+    QString bone = ctrl->boneNames().first();
+
+    EXPECT_FALSE(ctrl->setKeyframeValuePreview(bone, "qq", 0.5, 1.0));
+}
+
+TEST_F(AnimationControlControllerPlaybackTest, SetKeyframeValuePreviewNoOpWithoutSelection) {
+    auto* ctrl = AnimationControlController::instance();
+    EXPECT_FALSE(ctrl->setKeyframeValuePreview("Bone", "tx", 0.5, 1.0));
+}
+
 // ── Bulk keyframe ops (slice D1) ──────────────────────────────────────────────
 
 TEST_F(AnimationControlControllerPlaybackTest, MoveKeyframesEmptySelectionReturnsFalse) {


### PR DESCRIPTION
## Summary

Addresses the two follow-up issues from D3 (#380, #382) and the user-reported "T-pose blink while dragging keyframes":

- **Live drag preview** — adds `moveKeyframePreview` / `setKeyframeValuePreview` non-undoable setters used during keyframe drag. Single Ctrl+Z still reverts the whole gesture because the real `MoveKeyframeCommand` + `SetKeyframeValueCommand` are pushed once on release.
- **Trackpad pan** — two-finger swipe pans (horizontal = time, vertical = value) via `WheelHandler` with `pixelDelta` for high-resolution input.
- **Scroll + zoom** — horizontal `ScrollBar.AlwaysOn` for long animations, +/− zoom buttons for both axes, fit-to-view button, Cmd/Ctrl+wheel for horizontal zoom, Shift+wheel for vertical zoom.

## Why the preview API

Before: every keyframe drag move pushed a `SetKeyframeValueCommand` AND `MoveKeyframeCommand` onto the undo stack — once per pixel of cursor motion. `MainWindow`'s `QUndoStack::indexChanged` handler calls `skel->reset(true)` after every push, so the bone visibly snapped to T-pose between events.

After: drag previews retime/rewrite in place and skip the undo stack. On release, the QML handler restores the originals first, then pushes the real commands — `redo()` captures the correct old-state snapshot, so Ctrl+Z reverts the whole gesture as a single edit.

## Trackpad gesture summary

- Plain two-finger scroll → pan (time + value)
- Cmd/Ctrl + wheel → horizontal zoom
- Shift + wheel → vertical zoom
- +/− toolbar buttons → zoom either axis
- ⤢ → fit animation length to canvas

Pinch-to-zoom isn't wired up: Qt 6 routes macOS native magnify gestures (`NSEventTypeMagnify`) through paths that `PinchHandler` doesn't observe when a covering `MouseArea` owns the pointer. Cmd+wheel and the +/− buttons cover the use case consistently across platforms.

## Test plan

- [x] Drag a keyframe square in the curve editor → no T-pose blink, square + curve track cursor
- [x] Two-finger trackpad swipe → pans cleanly
- [x] Cmd+wheel / Shift+wheel → zoom horizontally / vertically
- [x] +/− toolbar buttons → zoom around canvas center
- [x] ⤢ → animation fits to view width
- [x] Long animation → scrollbar appears, drag thumb scrolls, position stays in sync with wheel pan
- [x] Single Ctrl+Z reverts the whole drag gesture (value + time)
- [x] Unit tests: `MoveKeyframePreview*` and `SetKeyframeValuePreview*` cover undo-stack behavior, TRS preservation, collision/missing-time rejection, no-op cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added horizontal and vertical zoom controls to the animation curve editor with +/-, and fit-to-view buttons.
  * Enabled drag-and-drop keyframe editing with optional axis-locking.
  * Added tangent handle manipulation with live curve updates.
  * Enhanced mouse wheel controls for panning and zooming.
  * Introduced live preview mode for keyframe edits without affecting undo history.

* **Tests**
  * Added comprehensive tests for keyframe preview operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->