### PR TITLE
Modernize editor mode surfaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 2.35.0 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 2.36.0 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/qml/BottomContextPanel.qml
+++ b/qml/BottomContextPanel.qml
@@ -13,6 +13,11 @@ Rectangle {
     property bool expanded: true
     property int contentMode: EditorModeController.currentMode
 
+    // Set from C++ (mainwindow.cpp) so the Material Editor button can trigger
+    // the QAction directly. Declared explicitly so the QML compiler resolves
+    // the identifier locally instead of relying on an ambient context value.
+    property var materialEditorAction: null
+
     ColumnLayout {
         anchors.fill: parent
         spacing: 0

--- a/qml/BottomContextPanel.qml
+++ b/qml/BottomContextPanel.qml
@@ -1,0 +1,170 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import EditorMode 1.0
+import PropertiesPanel 1.0
+import AnimationControl 1.0
+
+Rectangle {
+    id: root
+    color: PropertiesPanelController.panelColor
+    border.color: PropertiesPanelController.borderColor
+
+    property bool expanded: true
+    property int contentMode: EditorModeController.currentMode
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 0
+
+        Rectangle {
+            Layout.fillWidth: true
+            height: 28
+            color: PropertiesPanelController.headerColor
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.leftMargin: 8
+                anchors.rightMargin: 8
+                spacing: 8
+
+                Text {
+                    Layout.fillWidth: true
+                    text: EditorModeController.modeName + " Context"
+                    color: PropertiesPanelController.textColor
+                    font.pixelSize: 12
+                    font.bold: true
+                    elide: Text.ElideRight
+                }
+
+                Button {
+                    implicitWidth: 28
+                    implicitHeight: 22
+                    text: root.expanded ? "-" : "+"
+                    onClicked: root.expanded = !root.expanded
+                }
+            }
+        }
+
+        Loader {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            visible: root.expanded
+            sourceComponent: {
+                if (root.contentMode === EditorModeController.EditMode) return editSummary
+                if (root.contentMode === EditorModeController.AnimationMode) return animationSummary
+                if (root.contentMode === EditorModeController.MaterialMode) return materialSummary
+                if (root.contentMode === EditorModeController.ValidationMode) return validationSummary
+                return objectSummary
+            }
+        }
+    }
+
+    Component {
+        id: objectSummary
+        RowLayout {
+            anchors.fill: parent
+            anchors.margins: 10
+            spacing: 18
+
+            SummaryText { label: "Selection"; value: PropertiesPanelController.hasSelection ? PropertiesPanelController.selectionName : "None" }
+            SummaryText { label: "Scene Nodes"; value: PropertiesPanelController.sceneTreeModel ? PropertiesPanelController.sceneTreeModel.rowCount() : 0 }
+            SummaryText { label: "Primitive"; value: PropertiesPanelController.hasPrimitive ? PropertiesPanelController.primitiveType : "No" }
+            Item { Layout.fillWidth: true }
+        }
+    }
+
+    Component {
+        id: editSummary
+        RowLayout {
+            anchors.fill: parent
+            anchors.margins: 10
+            spacing: 18
+
+            SummaryText { label: "Vertices"; value: EditModeController.vertexCount }
+            SummaryText { label: "Triangles"; value: EditModeController.triangleCount }
+            SummaryText { label: "Selected V/E/F"; value: EditModeController.selectedVertexCount + " / " + EditModeController.selectedEdgeCount + " / " + EditModeController.selectedFaceCount }
+            SummaryText { label: "Warnings"; value: EditModeController.hasValidationWarnings ? EditModeController.degenerateTriangleCount : "None" }
+            Item { Layout.fillWidth: true }
+        }
+    }
+
+    Component {
+        id: animationSummary
+        RowLayout {
+            anchors.fill: parent
+            anchors.margins: 10
+            spacing: 14
+
+            SummaryText { label: "Animated"; value: PropertiesPanelController.hasAnimations ? "Available" : "None" }
+            SummaryText { label: "Timeline"; value: AnimationControlController.hasAnimation ? AnimationControlController.selectedAnimation : "No clip" }
+            Button {
+                text: PropertiesPanelController.playing ? "Pause" : "Play"
+                enabled: PropertiesPanelController.hasAnimations
+                onClicked: PropertiesPanelController.playing = !PropertiesPanelController.playing
+            }
+            Item { Layout.fillWidth: true }
+        }
+    }
+
+    Component {
+        id: materialSummary
+        RowLayout {
+            anchors.fill: parent
+            anchors.margins: 10
+            spacing: 14
+
+            SummaryText { label: "Selection"; value: PropertiesPanelController.hasSelection ? PropertiesPanelController.selectionName : "None" }
+            Button {
+                text: "Material Editor"
+                onClicked: if (materialEditorAction) materialEditorAction.trigger()
+            }
+            SummaryText { label: "Presets"; value: PropertiesPanelController.hasSelection ? "Available" : "Select an object" }
+            Item { Layout.fillWidth: true }
+        }
+    }
+
+    Component {
+        id: validationSummary
+        RowLayout {
+            anchors.fill: parent
+            anchors.margins: 10
+            spacing: 14
+
+            SummaryText { label: "Selection"; value: MeshValidator.hasSelection ? PropertiesPanelController.selectionName : "None" }
+            SummaryText { label: "Findings"; value: MeshValidator.validated ? MeshValidator.issues.length : "Not run" }
+            Button {
+                text: MeshValidator.validating ? "Validating" : "Validate"
+                enabled: MeshValidator.hasSelection && !MeshValidator.validating
+                onClicked: MeshValidator.validate()
+            }
+            Button {
+                text: "Fix All"
+                enabled: MeshValidator.hasFixableIssues
+                onClicked: MeshValidator.fixAll()
+            }
+            Item { Layout.fillWidth: true }
+        }
+    }
+
+    component SummaryText: ColumnLayout {
+        required property string label
+        required property var value
+        spacing: 2
+
+        Text {
+            text: label
+            color: PropertiesPanelController.textColor
+            opacity: 0.62
+            font.pixelSize: 10
+        }
+        Text {
+            text: String(value)
+            color: PropertiesPanelController.textColor
+            font.pixelSize: 12
+            font.bold: true
+            elide: Text.ElideRight
+            Layout.maximumWidth: 220
+        }
+    }
+}

--- a/qml/ModeBar.qml
+++ b/qml/ModeBar.qml
@@ -1,0 +1,92 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import EditorMode 1.0
+import PropertiesPanel 1.0
+
+Rectangle {
+    id: root
+    color: PropertiesPanelController.headerColor
+    implicitHeight: 38
+
+    property var modes: [
+        { label: "Object", mode: EditorModeController.ObjectMode, tip: "Object mode" },
+        { label: "Edit", mode: EditorModeController.EditMode, tip: "Edit mesh components" },
+        { label: "Animation", mode: EditorModeController.AnimationMode, tip: "Animation tools" },
+        { label: "Material", mode: EditorModeController.MaterialMode, tip: "Material tools" },
+        { label: "Validation", mode: EditorModeController.ValidationMode, tip: "Mesh validation" }
+    ]
+
+    RowLayout {
+        anchors.fill: parent
+        anchors.leftMargin: 10
+        anchors.rightMargin: 10
+        spacing: 10
+
+        Row {
+            Layout.alignment: Qt.AlignVCenter
+            spacing: 2
+
+            Repeater {
+                model: root.modes
+
+                Rectangle {
+                    width: Math.max(64, modeText.implicitWidth + 20)
+                    height: 26
+                    radius: 4
+                    border.width: 1
+                    border.color: EditorModeController.currentMode === modelData.mode
+                        ? PropertiesPanelController.highlightColor
+                        : PropertiesPanelController.borderColor
+                    color: EditorModeController.currentMode === modelData.mode
+                        ? PropertiesPanelController.highlightColor
+                        : modeMouse.containsMouse
+                          ? Qt.lighter(PropertiesPanelController.panelColor, 1.2)
+                          : PropertiesPanelController.panelColor
+
+                    Text {
+                        id: modeText
+                        anchors.centerIn: parent
+                        text: modelData.label
+                        color: PropertiesPanelController.textColor
+                        font.pixelSize: 11
+                        font.bold: EditorModeController.currentMode === modelData.mode
+                    }
+
+                    MouseArea {
+                        id: modeMouse
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: EditorModeController.requestMode(modelData.mode)
+                    }
+
+                    ToolTip.text: modelData.tip
+                    ToolTip.visible: modeMouse.containsMouse
+                }
+            }
+        }
+
+        Text {
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignVCenter
+            text: EditorModeController.statusText
+            color: PropertiesPanelController.textColor
+            elide: Text.ElideRight
+            font.pixelSize: 11
+            opacity: 0.82
+        }
+
+        Button {
+            Layout.alignment: Qt.AlignVCenter
+            text: EditModeController.editModeActive ? "Exit Edit" : "Edit"
+            enabled: EditModeController.editModeActive || EditorModeController.editModeAvailable
+            implicitHeight: 26
+            implicitWidth: 76
+            font.pixelSize: 11
+            onClicked: EditorModeController.toggleObjectEditMode()
+            ToolTip.text: "Toggle Edit mode (Tab)"
+            ToolTip.visible: hovered
+        }
+    }
+}

--- a/qml/PreferencesDialog.qml
+++ b/qml/PreferencesDialog.qml
@@ -458,9 +458,9 @@ Rectangle {
                                     clip: true
                                     selectByMouse: true
                                     validator: DoubleValidator { bottom: 0.001; top: 1000; decimals: 3 }
-                                    text: readSetting("Viewport/nearClip", "0.1")
+                                    text: readSetting("Viewport/nearClip", "0.01")
 
-                                    onEditingFinished: writeSetting("Viewport/nearClip", parseFloat(text) || 0.1)
+                                    onEditingFinished: writeSetting("Viewport/nearClip", parseFloat(text) || 0.01)
                                 }
                             }
                         }

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -21,6 +21,7 @@ Rectangle {
     function targetAccent(kind) {
         switch (kind) {
         case "node": return "#6ca0dc"
+        case "editMesh": return "#55b65a"
         case "mesh": return "#55b65a"
         case "submesh": return "#c9b64f"
         case "mixed":

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -33,10 +33,12 @@ Rectangle {
     Connections {
         target: EditorModeController
         function onModeChanged() {
-            if (root.showModeToolsForMode(EditorModeController.currentMode))
-                root.currentTab = 2
-            else
-                root.currentTab = 0
+            // Don't yank the user away from Scene (1) or History (3) when
+            // they're explicitly browsing those tabs. Only retarget the
+            // Inspector/Mode-Tools pair, which are the mode-aware ones.
+            if (root.currentTab === 1 || root.currentTab === 3)
+                return
+            root.currentTab = root.showModeToolsForMode(EditorModeController.currentMode) ? 2 : 0
         }
     }
 
@@ -258,7 +260,9 @@ Rectangle {
             // ---- Animations ----
             CollapsibleSection {
                 title: "Animations"
-                sectionVisible: root.currentTab === 2 && PropertiesPanelController.hasAnimations
+                sectionVisible: root.currentTab === 2
+                    && EditorModeController.currentMode === EditorModeController.AnimationMode
+                    && PropertiesPanelController.hasAnimations
 
                 Component.onCompleted: content = animationComponent
             }
@@ -266,7 +270,9 @@ Rectangle {
             // ---- Animation Control (keyframe editor) ----
             CollapsibleSection {
                 title: "Animation Control"
-                sectionVisible: root.currentTab === 2 && AnimationControlController.hasAnimation
+                sectionVisible: root.currentTab === 2
+                    && EditorModeController.currentMode === EditorModeController.AnimationMode
+                    && AnimationControlController.hasAnimation
                 expanded: false
 
                 Component.onCompleted: content = animControlComponent
@@ -284,7 +290,9 @@ Rectangle {
             // ---- Material Presets ----
             CollapsibleSection {
                 title: "Material Presets"
-                sectionVisible: root.currentTab === 2 && PropertiesPanelController.hasSelection
+                sectionVisible: root.currentTab === 2
+                    && EditorModeController.currentMode === EditorModeController.MaterialMode
+                    && PropertiesPanelController.hasSelection
                 expanded: false
 
                 Component.onCompleted: content = materialPresetsComponent
@@ -293,7 +301,9 @@ Rectangle {
             // ---- Mesh Validation ----
             CollapsibleSection {
                 title: "Mesh Validation"
-                sectionVisible: root.currentTab === 2 && MeshValidator.hasSelection
+                sectionVisible: root.currentTab === 2
+                    && EditorModeController.currentMode === EditorModeController.ValidationMode
+                    && MeshValidator.hasSelection
                 expanded: false
 
                 Component.onCompleted: content = validationComponent

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -18,6 +18,17 @@ Rectangle {
             || mode === EditorModeController.ValidationMode
     }
 
+    function targetAccent(kind) {
+        switch (kind) {
+        case "node": return "#6ca0dc"
+        case "mesh": return "#55b65a"
+        case "submesh": return "#c9b64f"
+        case "mixed":
+        case "mixedGeometry": return "#d18f3f"
+        default: return PropertiesPanelController.borderColor
+        }
+    }
+
     Connections {
         target: EditorModeController
         function onModeChanged() {
@@ -130,6 +141,76 @@ Rectangle {
                 }
             }
 
+            // ---- Selection Target Indicator ----
+            Rectangle {
+                width: parent.width
+                height: visible ? 58 : 0
+                visible: PropertiesPanelController.hasSelection
+                color: Qt.darker(PropertiesPanelController.panelColor, 1.08)
+                border.color: root.targetAccent(PropertiesPanelController.transformTargetKind)
+                border.width: 1
+
+                RowLayout {
+                    anchors.fill: parent
+                    anchors.margins: 8
+                    spacing: 8
+
+                    Rectangle {
+                        width: 4
+                        Layout.fillHeight: true
+                        radius: 2
+                        color: root.targetAccent(PropertiesPanelController.transformTargetKind)
+                    }
+
+                    ColumnLayout {
+                        spacing: 2
+                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignVCenter
+
+                        RowLayout {
+                            spacing: 6
+                            Layout.fillWidth: true
+
+                            Text {
+                                text: PropertiesPanelController.transformTargetLabel
+                                color: PropertiesPanelController.textColor
+                                font.pixelSize: 12
+                                font.bold: true
+                                elide: Text.ElideRight
+                                Layout.fillWidth: true
+                            }
+
+                            Rectangle {
+                                radius: 3
+                                color: root.targetAccent(PropertiesPanelController.transformTargetKind)
+                                implicitWidth: impactLabel.implicitWidth + 10
+                                implicitHeight: 18
+
+                                Text {
+                                    id: impactLabel
+                                    anchors.centerIn: parent
+                                    text: PropertiesPanelController.transformAffectsMesh ? "EXPORTS" : "PLACEMENT"
+                                    color: "white"
+                                    font.pixelSize: 9
+                                    font.bold: true
+                                }
+                            }
+                        }
+
+                        Text {
+                            text: PropertiesPanelController.transformTargetDetail
+                            color: PropertiesPanelController.textColor
+                            opacity: 0.78
+                            font.pixelSize: 10
+                            wrapMode: Text.WordWrap
+                            maximumLineCount: 2
+                            elide: Text.ElideRight
+                            Layout.fillWidth: true
+                        }
+                    }
+                }
+            }
+
             // ---- Edit Mode Tools ----
             CollapsibleSection {
                 title: "Edit Mode Tools"
@@ -150,7 +231,7 @@ Rectangle {
 
             // ---- Transform ----
             CollapsibleSection {
-                title: "Transform"
+                title: PropertiesPanelController.transformTargetLabel
                 sectionVisible: root.currentTab === 0 && PropertiesPanelController.hasSelection
 
                 Component.onCompleted: content = transformComponent

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -3,10 +3,30 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import PropertiesPanel 1.0
 import AnimationControl 1.0
+import EditorMode 1.0
 
 Rectangle {
     id: root
     color: PropertiesPanelController.panelColor
+
+    property int currentTab: 0
+
+    function showModeToolsForMode(mode) {
+        return mode === EditorModeController.EditMode
+            || mode === EditorModeController.AnimationMode
+            || mode === EditorModeController.MaterialMode
+            || mode === EditorModeController.ValidationMode
+    }
+
+    Connections {
+        target: EditorModeController
+        function onModeChanged() {
+            if (root.showModeToolsForMode(EditorModeController.currentMode))
+                root.currentTab = 2
+            else
+                root.currentTab = 0
+        }
+    }
 
     ScrollView {
         anchors.fill: parent
@@ -15,6 +35,53 @@ Rectangle {
         Column {
             width: root.width
             spacing: 0
+
+            // ---- Top-level Inspector Tabs ----
+            Rectangle {
+                width: parent.width
+                height: 38
+                color: PropertiesPanelController.headerColor
+
+                Row {
+                    anchors.fill: parent
+                    anchors.margins: 5
+                    spacing: 3
+
+                    Repeater {
+                        model: [ "Inspector", "Scene", "Mode Tools", "History" ]
+
+                        Rectangle {
+                            width: Math.max(66, (parent.width - 9) / 4)
+                            height: 28
+                            radius: 4
+                            color: root.currentTab === index
+                                ? PropertiesPanelController.highlightColor
+                                : tabMouse.containsMouse
+                                  ? Qt.lighter(PropertiesPanelController.panelColor, 1.2)
+                                  : PropertiesPanelController.panelColor
+                            border.color: PropertiesPanelController.borderColor
+                            border.width: 1
+
+                            Text {
+                                anchors.centerIn: parent
+                                text: modelData
+                                color: PropertiesPanelController.textColor
+                                font.pixelSize: 10
+                                font.bold: root.currentTab === index
+                                elide: Text.ElideRight
+                            }
+
+                            MouseArea {
+                                id: tabMouse
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: root.currentTab = index
+                            }
+                        }
+                    }
+                }
+            }
 
             // ---- Edit Mode Indicator ----
             Rectangle {
@@ -58,7 +125,7 @@ Rectangle {
                         font.pixelSize: 10
                         ToolTip.text: "Toggle Edit Mode (Tab)"
                         ToolTip.visible: hovered
-                        onClicked: EditModeController.toggleEditMode()
+                        onClicked: EditorModeController.toggleObjectEditMode()
                     }
                 }
             }
@@ -66,7 +133,7 @@ Rectangle {
             // ---- Edit Mode Tools ----
             CollapsibleSection {
                 title: "Edit Mode Tools"
-                sectionVisible: EditModeController.editModeActive
+                sectionVisible: root.currentTab === 2 && EditModeController.editModeActive
                 expanded: true
 
                 Component.onCompleted: content = editModeToolsComponent
@@ -75,6 +142,7 @@ Rectangle {
             // ---- Scene Outliner ----
             CollapsibleSection {
                 title: "Scene"
+                sectionVisible: root.currentTab === 1
                 expanded: true
 
                 Component.onCompleted: content = sceneOutlinerComponent
@@ -83,7 +151,7 @@ Rectangle {
             // ---- Transform ----
             CollapsibleSection {
                 title: "Transform"
-                sectionVisible: PropertiesPanelController.hasSelection
+                sectionVisible: root.currentTab === 0 && PropertiesPanelController.hasSelection
 
                 Component.onCompleted: content = transformComponent
             }
@@ -91,6 +159,7 @@ Rectangle {
             // ---- Snap Settings ----
             CollapsibleSection {
                 title: "Snap Settings"
+                sectionVisible: root.currentTab === 0
                 expanded: false
 
                 Component.onCompleted: content = snapSettingsComponent
@@ -99,7 +168,7 @@ Rectangle {
             // ---- Primitive Parameters ----
             CollapsibleSection {
                 title: "Primitive: " + PropertiesPanelController.primitiveType
-                sectionVisible: PropertiesPanelController.hasPrimitive
+                sectionVisible: root.currentTab === 0 && PropertiesPanelController.hasPrimitive
 
                 Component.onCompleted: content = primitiveComponent
             }
@@ -107,7 +176,7 @@ Rectangle {
             // ---- Animations ----
             CollapsibleSection {
                 title: "Animations"
-                sectionVisible: PropertiesPanelController.hasAnimations
+                sectionVisible: root.currentTab === 2 && PropertiesPanelController.hasAnimations
 
                 Component.onCompleted: content = animationComponent
             }
@@ -115,7 +184,7 @@ Rectangle {
             // ---- Animation Control (keyframe editor) ----
             CollapsibleSection {
                 title: "Animation Control"
-                sectionVisible: AnimationControlController.hasAnimation
+                sectionVisible: root.currentTab === 2 && AnimationControlController.hasAnimation
                 expanded: false
 
                 Component.onCompleted: content = animControlComponent
@@ -124,7 +193,7 @@ Rectangle {
             // ---- LOD Generation ----
             CollapsibleSection {
                 title: "LOD Generation"
-                sectionVisible: MeshLodController.hasSelection
+                sectionVisible: root.currentTab === 2 && MeshLodController.hasSelection
                 expanded: false
 
                 Component.onCompleted: content = lodComponent
@@ -133,7 +202,7 @@ Rectangle {
             // ---- Material Presets ----
             CollapsibleSection {
                 title: "Material Presets"
-                sectionVisible: PropertiesPanelController.hasSelection
+                sectionVisible: root.currentTab === 2 && PropertiesPanelController.hasSelection
                 expanded: false
 
                 Component.onCompleted: content = materialPresetsComponent
@@ -142,7 +211,7 @@ Rectangle {
             // ---- Mesh Validation ----
             CollapsibleSection {
                 title: "Mesh Validation"
-                sectionVisible: MeshValidator.hasSelection
+                sectionVisible: root.currentTab === 2 && MeshValidator.hasSelection
                 expanded: false
 
                 Component.onCompleted: content = validationComponent
@@ -151,6 +220,7 @@ Rectangle {
             // ---- Undo History ----
             CollapsibleSection {
                 title: "Undo History"
+                sectionVisible: root.currentTab === 3
                 expanded: false
 
                 Component.onCompleted: content = undoHistoryComponent

--- a/qml/SceneTreeNode.qml
+++ b/qml/SceneTreeNode.qml
@@ -26,6 +26,38 @@ Column {
             selected = treeModel.isSelected(nodeIndex.row, treeModel.parent(nodeIndex))
     }
 
+    function typeLabel() {
+        return treeModel ? (treeModel.data(nodeIndex, 259) || "") : ""
+    }
+
+    function impactBadgeText() {
+        switch (typeLabel()) {
+        case "Node":
+        case "Group":
+            return "PLACEMENT"
+        case "Mesh":
+            return "MESH DATA"
+        case "Submesh":
+            return "SUBMESH"
+        default:
+            return ""
+        }
+    }
+
+    function impactBadgeColor() {
+        switch (typeLabel()) {
+        case "Node":
+        case "Group":
+            return "#6ca0dc"
+        case "Mesh":
+            return "#55b65a"
+        case "Submesh":
+            return "#c9b64f"
+        default:
+            return PropertiesPanelController.borderColor
+        }
+    }
+
     Connections {
         target: treeModel
         function onSelectionUpdated() { treeNode.refreshSelected() }
@@ -58,6 +90,7 @@ Column {
         }
 
         Row {
+            id: treeRowContent
             anchors.verticalCenter: parent.verticalCenter
             anchors.left: parent.left
             anchors.leftMargin: 4 + indentLevel * 16
@@ -124,7 +157,32 @@ Column {
                 color: treeNode.selected ? "white" : PropertiesPanelController.textColor
                 font.pixelSize: 11
                 elide: Text.ElideRight
+                width: Math.max(40, treeNode.width - treeRowContent.anchors.leftMargin
+                                - 14 - 10 - 4
+                                - (treeNode.impactBadgeText() !== "" ? badgeText.implicitWidth + 12 : 0)
+                                - (matSelector.visible ? matSelector.width + 4 : 0)
+                                - 8)
                 anchors.verticalCenter: parent.verticalCenter
+            }
+
+            Rectangle {
+                visible: treeNode.impactBadgeText() !== ""
+                width: visible ? badgeText.implicitWidth + 8 : 0
+                height: 16
+                radius: 3
+                color: treeNode.selected ? Qt.rgba(1, 1, 1, 0.18) : Qt.rgba(0, 0, 0, 0)
+                border.color: treeNode.selected ? "white" : treeNode.impactBadgeColor()
+                border.width: 1
+                anchors.verticalCenter: parent.verticalCenter
+
+                Text {
+                    id: badgeText
+                    anchors.centerIn: parent
+                    text: treeNode.impactBadgeText()
+                    color: treeNode.selected ? "white" : treeNode.impactBadgeColor()
+                    font.pixelSize: 8
+                    font.bold: true
+                }
             }
 
             // Material selector (typeahead combo for submeshes)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,6 +84,7 @@ AssetBrowserController.cpp
 MaterialPreviewRenderer.cpp
 EditableMesh.cpp
 EditModeController.cpp
+EditorModeController.cpp
 HalfEdgeMesh.cpp
 )
 
@@ -163,6 +164,7 @@ AssetBrowserController.h
 MaterialPreviewRenderer.h
 EditableMesh.h
 EditModeController.h
+EditorModeController.h
 HalfEdgeMesh.h
 )
 

--- a/src/EditorModeController.cpp
+++ b/src/EditorModeController.cpp
@@ -22,7 +22,10 @@ EditorModeController::EditorModeController(QObject* parent)
             this, &EditorModeController::refreshEditAvailability);
 
     m_currentMode = edit->isEditModeActive() ? EditMode : ObjectMode;
-    setStatusText(QStringLiteral("Object mode"));
+    if (m_currentMode == EditMode)
+        setStatusText(edit->modeLabel());
+    else
+        setStatusText(QStringLiteral("Object mode"));
 }
 
 EditorModeController* EditorModeController::instance()
@@ -92,12 +95,12 @@ void EditorModeController::syncFromEditMode()
 {
     auto* edit = editController();
     if (edit->isEditModeActive()) {
+        // setModeInternal already refreshes the status text via
+        // edit->modeLabel() when entering EditMode, so don't double-set it.
         setModeInternal(EditMode, false);
-        setStatusText(edit->modeLabel());
-    } else {
-        if (m_currentMode == EditMode)
-            setModeInternal(ObjectMode, false);
-        setStatusText(QStringLiteral("Object mode"));
+    } else if (m_currentMode == EditMode) {
+        // setModeInternal sets status text to "Object mode" here too.
+        setModeInternal(ObjectMode, false);
     }
     emit editModeAvailabilityChanged();
 }

--- a/src/EditorModeController.cpp
+++ b/src/EditorModeController.cpp
@@ -1,0 +1,156 @@
+#include "EditorModeController.h"
+
+#include "EditModeController.h"
+#include "SentryReporter.h"
+
+#include <QJSEngine>
+
+EditorModeController* EditorModeController::m_pSingleton = nullptr;
+
+EditorModeController::EditorModeController(QObject* parent)
+    : QObject(parent)
+{
+    auto* edit = editController();
+    connect(edit, &EditModeController::editModeChanged,
+            this, &EditorModeController::syncFromEditMode);
+    connect(edit, &EditModeController::selectionModeChanged,
+            this, [this]() {
+        if (m_currentMode == EditMode)
+            setStatusText(editController()->modeLabel());
+    });
+    connect(edit, &EditModeController::selectionStateChanged,
+            this, &EditorModeController::refreshEditAvailability);
+
+    m_currentMode = edit->isEditModeActive() ? EditMode : ObjectMode;
+    setStatusText(QStringLiteral("Object mode"));
+}
+
+EditorModeController* EditorModeController::instance()
+{
+    if (!m_pSingleton)
+        m_pSingleton = new EditorModeController();
+    return m_pSingleton;
+}
+
+EditorModeController* EditorModeController::qmlInstance(QQmlEngine* engine, QJSEngine* scriptEngine)
+{
+    Q_UNUSED(engine);
+    Q_UNUSED(scriptEngine);
+    auto* inst = instance();
+    QQmlEngine::setObjectOwnership(inst, QQmlEngine::CppOwnership);
+    return inst;
+}
+
+void EditorModeController::kill()
+{
+    delete m_pSingleton;
+    m_pSingleton = nullptr;
+}
+
+void EditorModeController::setCurrentMode(int mode)
+{
+    requestMode(mode);
+}
+
+void EditorModeController::requestMode(int mode)
+{
+    if (mode < ObjectMode || mode > ValidationMode)
+        return;
+
+    setModeInternal(static_cast<Mode>(mode), true);
+}
+
+void EditorModeController::toggleObjectEditMode()
+{
+    setModeInternal(editController()->isEditModeActive() ? ObjectMode : EditMode, true);
+}
+
+QString EditorModeController::modeName() const
+{
+    return modeNameFor(static_cast<int>(m_currentMode));
+}
+
+QString EditorModeController::modeNameFor(int mode) const
+{
+    switch (static_cast<Mode>(mode)) {
+    case ObjectMode: return QStringLiteral("Object");
+    case EditMode: return QStringLiteral("Edit");
+    case AnimationMode: return QStringLiteral("Animation");
+    case MaterialMode: return QStringLiteral("Material");
+    case ValidationMode: return QStringLiteral("Validation");
+    }
+    return QStringLiteral("Object");
+}
+
+bool EditorModeController::editModeAvailable() const
+{
+    auto* edit = editController();
+    return edit->isEditModeActive() || edit->canEnterEditMode();
+}
+
+void EditorModeController::syncFromEditMode()
+{
+    auto* edit = editController();
+    if (edit->isEditModeActive()) {
+        setModeInternal(EditMode, false);
+        setStatusText(edit->modeLabel());
+    } else {
+        if (m_currentMode == EditMode)
+            setModeInternal(ObjectMode, false);
+        setStatusText(QStringLiteral("Object mode"));
+    }
+    emit editModeAvailabilityChanged();
+}
+
+void EditorModeController::refreshEditAvailability()
+{
+    emit editModeAvailabilityChanged();
+}
+
+void EditorModeController::setModeInternal(Mode mode, bool driveEditController)
+{
+    auto* edit = editController();
+
+    if (driveEditController) {
+        if (mode == EditMode) {
+            if (!edit->isEditModeActive() && !edit->enterEditMode()) {
+                setStatusText(QStringLiteral("Select one mesh to enter Edit mode"));
+                emit editModeAvailabilityChanged();
+                return;
+            }
+        } else if (edit->isEditModeActive()) {
+            edit->exitEditMode(true);
+        }
+    }
+
+    if (m_currentMode == mode) {
+        if (mode == EditMode)
+            setStatusText(edit->modeLabel());
+        return;
+    }
+
+    m_currentMode = mode;
+    SentryReporter::addBreadcrumb(
+        "ui.mode",
+        QStringLiteral("Editor mode: %1").arg(modeName()));
+    emit modeChanged();
+
+    if (mode == EditMode)
+        setStatusText(edit->modeLabel());
+    else
+        setStatusText(QStringLiteral("%1 mode").arg(modeName()));
+}
+
+void EditorModeController::setStatusText(const QString& text)
+{
+    if (m_statusText == text)
+        return;
+
+    m_statusText = text;
+    emit statusTextChanged();
+}
+
+EditModeController* EditorModeController::editController() const
+{
+    return EditModeController::instance();
+}

--- a/src/EditorModeController.h
+++ b/src/EditorModeController.h
@@ -1,0 +1,66 @@
+#ifndef EDITORMODECONTROLLER_H
+#define EDITORMODECONTROLLER_H
+
+#include <QObject>
+#include <QQmlEngine>
+#include <QString>
+
+class EditModeController;
+
+class EditorModeController : public QObject
+{
+    Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
+
+    Q_PROPERTY(int currentMode READ currentMode WRITE setCurrentMode NOTIFY modeChanged)
+    Q_PROPERTY(QString modeName READ modeName NOTIFY modeChanged)
+    Q_PROPERTY(QString statusText READ statusText NOTIFY statusTextChanged)
+    Q_PROPERTY(bool editModeAvailable READ editModeAvailable NOTIFY editModeAvailabilityChanged)
+
+public:
+    enum Mode {
+        ObjectMode = 0,
+        EditMode = 1,
+        AnimationMode = 2,
+        MaterialMode = 3,
+        ValidationMode = 4
+    };
+    Q_ENUM(Mode)
+
+    static EditorModeController* instance();
+    static EditorModeController* qmlInstance(QQmlEngine* engine, QJSEngine* scriptEngine);
+    static void kill();
+
+    int currentMode() const { return static_cast<int>(m_currentMode); }
+    void setCurrentMode(int mode);
+
+    QString modeName() const;
+    QString statusText() const { return m_statusText; }
+    bool editModeAvailable() const;
+
+    Q_INVOKABLE void requestMode(int mode);
+    Q_INVOKABLE void toggleObjectEditMode();
+    Q_INVOKABLE QString modeNameFor(int mode) const;
+
+signals:
+    void modeChanged();
+    void statusTextChanged();
+    void editModeAvailabilityChanged();
+
+private slots:
+    void syncFromEditMode();
+    void refreshEditAvailability();
+
+private:
+    explicit EditorModeController(QObject* parent = nullptr);
+    void setModeInternal(Mode mode, bool driveEditController);
+    void setStatusText(const QString& text);
+    EditModeController* editController() const;
+
+    static EditorModeController* m_pSingleton;
+    Mode m_currentMode = ObjectMode;
+    QString m_statusText;
+};
+
+#endif // EDITORMODECONTROLLER_H

--- a/src/EditorModeController_test.cpp
+++ b/src/EditorModeController_test.cpp
@@ -1,0 +1,51 @@
+#include <gtest/gtest.h>
+
+#include "EditorModeController.h"
+#include "EditModeController.h"
+
+class EditorModeControllerTest : public ::testing::Test
+{
+protected:
+    void TearDown() override
+    {
+        EditorModeController::kill();
+        EditModeController::kill();
+    }
+};
+
+TEST_F(EditorModeControllerTest, ModeNamesCoverPublicModes)
+{
+    auto* ctrl = EditorModeController::instance();
+
+    EXPECT_EQ(ctrl->modeNameFor(EditorModeController::ObjectMode), QStringLiteral("Object"));
+    EXPECT_EQ(ctrl->modeNameFor(EditorModeController::EditMode), QStringLiteral("Edit"));
+    EXPECT_EQ(ctrl->modeNameFor(EditorModeController::AnimationMode), QStringLiteral("Animation"));
+    EXPECT_EQ(ctrl->modeNameFor(EditorModeController::MaterialMode), QStringLiteral("Material"));
+    EXPECT_EQ(ctrl->modeNameFor(EditorModeController::ValidationMode), QStringLiteral("Validation"));
+}
+
+TEST_F(EditorModeControllerTest, NonEditModesUpdateModeAndStatus)
+{
+    auto* ctrl = EditorModeController::instance();
+
+    ctrl->requestMode(EditorModeController::AnimationMode);
+    EXPECT_EQ(ctrl->currentMode(), EditorModeController::AnimationMode);
+    EXPECT_EQ(ctrl->modeName(), QStringLiteral("Animation"));
+    EXPECT_EQ(ctrl->statusText(), QStringLiteral("Animation mode"));
+
+    ctrl->requestMode(EditorModeController::MaterialMode);
+    EXPECT_EQ(ctrl->currentMode(), EditorModeController::MaterialMode);
+    EXPECT_EQ(ctrl->statusText(), QStringLiteral("Material mode"));
+}
+
+TEST_F(EditorModeControllerTest, InvalidModeIsIgnored)
+{
+    auto* ctrl = EditorModeController::instance();
+    ctrl->requestMode(EditorModeController::ValidationMode);
+
+    ctrl->requestMode(-1);
+    EXPECT_EQ(ctrl->currentMode(), EditorModeController::ValidationMode);
+
+    ctrl->requestMode(99);
+    EXPECT_EQ(ctrl->currentMode(), EditorModeController::ValidationMode);
+}

--- a/src/EditorModeController_test.cpp
+++ b/src/EditorModeController_test.cpp
@@ -49,3 +49,32 @@ TEST_F(EditorModeControllerTest, InvalidModeIsIgnored)
     ctrl->requestMode(99);
     EXPECT_EQ(ctrl->currentMode(), EditorModeController::ValidationMode);
 }
+
+TEST_F(EditorModeControllerTest, ObjectModeRequestUpdatesStatusText)
+{
+    auto* ctrl = EditorModeController::instance();
+
+    // Hop away first so the request actually transitions back to ObjectMode.
+    ctrl->requestMode(EditorModeController::AnimationMode);
+    ASSERT_EQ(ctrl->currentMode(), EditorModeController::AnimationMode);
+
+    ctrl->requestMode(EditorModeController::ObjectMode);
+    EXPECT_EQ(ctrl->currentMode(), EditorModeController::ObjectMode);
+    EXPECT_EQ(ctrl->modeName(), QStringLiteral("Object"));
+    EXPECT_EQ(ctrl->statusText(), QStringLiteral("Object mode"));
+}
+
+TEST_F(EditorModeControllerTest, EditModeRequestWithoutMeshFallsBackToHint)
+{
+    auto* ctrl = EditorModeController::instance();
+    auto* edit = EditModeController::instance();
+    ASSERT_FALSE(edit->isEditModeActive());
+    ASSERT_FALSE(edit->canEnterEditMode());
+
+    // No selection → enterEditMode() refuses, so EditorModeController stays
+    // in ObjectMode and surfaces a hint via statusText().
+    ctrl->requestMode(EditorModeController::EditMode);
+    EXPECT_EQ(ctrl->currentMode(), EditorModeController::ObjectMode);
+    EXPECT_EQ(ctrl->statusText(), QStringLiteral("Select one mesh to enter Edit mode"));
+    EXPECT_FALSE(edit->isEditModeActive());
+}

--- a/src/OgreWidget.cpp
+++ b/src/OgreWidget.cpp
@@ -77,13 +77,19 @@ void applyViewportCameraFromSettings(SpaceCamera* cam)
     if (!cam || !cam->getCamera())
         return;
     QSettings settings;
-    Ogre::Real speed = settings.value(ViewportSettingsKeys::cameraSpeed(), 1.0).toReal();
+    Ogre::Real speed = settings.value(
+        ViewportSettingsKeys::cameraSpeed(),
+        ViewportSettingsKeys::defaultCameraSpeed()).toReal();
     if (speed > 0)
         cam->setCameraSpeed(speed);
     cam->getCamera()->setNearClipDistance(
-        settings.value(ViewportSettingsKeys::nearClip(), 0.1).toDouble());
+        settings.value(
+            ViewportSettingsKeys::nearClip(),
+            ViewportSettingsKeys::defaultNearClip()).toDouble());
     cam->getCamera()->setFarClipDistance(
-        settings.value(ViewportSettingsKeys::farClip(), 10000.0).toDouble());
+        settings.value(
+            ViewportSettingsKeys::farClip(),
+            ViewportSettingsKeys::defaultFarClip()).toDouble());
 }
 }
 
@@ -241,9 +247,9 @@ void OgreWidget::initOgreWindow(void)
 #endif
 
     QSettings settings;
-    // Default FSAA=0 on Linux: MSAA support varies by driver/setup and can cause
-    // a black viewport in some installed environments. Users can opt-in via settings.
-    const int requestedFsaa = settings.value(ViewportSettingsKeys::fsaaSamples(), 0).toInt();
+    const int requestedFsaa = settings.value(
+        ViewportSettingsKeys::fsaaSamples(),
+        ViewportSettingsKeys::defaultFsaaSamples()).toInt();
     if (requestedFsaa > 0)
         params["FSAA"] = Ogre::StringConverter::toString(requestedFsaa);
 

--- a/src/OgreWidget.cpp
+++ b/src/OgreWidget.cpp
@@ -46,6 +46,7 @@ THE SOFTWARE.
 #include "QtInputManager.h"
 #include "EditModeController.h"
 #include "TransformOperator.h"
+#include "SentryReporter.h"
 
 namespace {
 
@@ -77,19 +78,31 @@ void applyViewportCameraFromSettings(SpaceCamera* cam)
     if (!cam || !cam->getCamera())
         return;
     QSettings settings;
-    Ogre::Real speed = settings.value(
+    const Ogre::Real speed = settings.value(
         ViewportSettingsKeys::cameraSpeed(),
         ViewportSettingsKeys::defaultCameraSpeed()).toReal();
-    if (speed > 0)
+    if (speed > 0) {
         cam->setCameraSpeed(speed);
-    cam->getCamera()->setNearClipDistance(
-        settings.value(
-            ViewportSettingsKeys::nearClip(),
-            ViewportSettingsKeys::defaultNearClip()).toDouble());
-    cam->getCamera()->setFarClipDistance(
-        settings.value(
-            ViewportSettingsKeys::farClip(),
-            ViewportSettingsKeys::defaultFarClip()).toDouble());
+        SentryReporter::addBreadcrumb(
+            QStringLiteral("viewport.settings"),
+            QStringLiteral("Apply camera speed: %1").arg(speed));
+    }
+
+    const double nearClip = settings.value(
+        ViewportSettingsKeys::nearClip(),
+        ViewportSettingsKeys::defaultNearClip()).toDouble();
+    cam->getCamera()->setNearClipDistance(nearClip);
+    SentryReporter::addBreadcrumb(
+        QStringLiteral("viewport.settings"),
+        QStringLiteral("Apply near clip: %1").arg(nearClip));
+
+    const double farClip = settings.value(
+        ViewportSettingsKeys::farClip(),
+        ViewportSettingsKeys::defaultFarClip()).toDouble();
+    cam->getCamera()->setFarClipDistance(farClip);
+    SentryReporter::addBreadcrumb(
+        QStringLiteral("viewport.settings"),
+        QStringLiteral("Apply far clip: %1").arg(farClip));
 }
 }
 
@@ -250,8 +263,12 @@ void OgreWidget::initOgreWindow(void)
     const int requestedFsaa = settings.value(
         ViewportSettingsKeys::fsaaSamples(),
         ViewportSettingsKeys::defaultFsaaSamples()).toInt();
-    if (requestedFsaa > 0)
+    if (requestedFsaa > 0) {
         params["FSAA"] = Ogre::StringConverter::toString(requestedFsaa);
+        SentryReporter::addBreadcrumb(
+            QStringLiteral("viewport.settings"),
+            QStringLiteral("Apply FSAA samples: %1").arg(requestedFsaa));
+    }
 
     QString name = "Viewport " + QString::number(getIndex());
     while (mOgreRoot->getRenderTarget(name.toStdString())) {

--- a/src/OgreWidget_test.cpp
+++ b/src/OgreWidget_test.cpp
@@ -253,13 +253,25 @@ TEST_F(OgreWidgetTest, RebuildRenderWindowPreservesBackgroundAndKeepsCamera)
     EXPECT_NEAR(widget->getSpaceCamera()->getCamera()->getFarClipDistance(), 5000.0, 1e-3);
 }
 
-TEST_F(OgreWidgetTest, FsaaDefaultsToZeroWhenUnset)
+TEST_F(OgreWidgetTest, ViewportDefaultsApplyWhenUnset)
 {
     QSettings settings;
     settings.remove(ViewportSettingsKeys::fsaaSamples());
+    settings.remove(ViewportSettingsKeys::nearClip());
+    settings.remove(ViewportSettingsKeys::farClip());
+    settings.remove(ViewportSettingsKeys::cameraSpeed());
 
     EXPECT_NO_THROW(widget->rebuildRenderWindow());
     app->processEvents();
 
-    EXPECT_EQ(widget->fsaaSamples(), 0u);
+    EXPECT_EQ(widget->fsaaSamples(),
+              static_cast<unsigned int>(ViewportSettingsKeys::defaultFsaaSamples()));
+    ASSERT_NE(widget->getSpaceCamera(), nullptr);
+    ASSERT_NE(widget->getSpaceCamera()->getCamera(), nullptr);
+    EXPECT_NEAR(widget->getSpaceCamera()->getCameraSpeed(),
+                ViewportSettingsKeys::defaultCameraSpeed(), 1e-5);
+    EXPECT_NEAR(widget->getSpaceCamera()->getCamera()->getNearClipDistance(),
+                ViewportSettingsKeys::defaultNearClip(), 1e-5);
+    EXPECT_NEAR(widget->getSpaceCamera()->getCamera()->getFarClipDistance(),
+                ViewportSettingsKeys::defaultFarClip(), 1e-3);
 }

--- a/src/PropertiesPanelController.cpp
+++ b/src/PropertiesPanelController.cpp
@@ -9,6 +9,7 @@
 #include "AnimationControlController.h"
 #include "AnimationMerger.h"
 #include "CurveEditModel.h"
+#include "EditModeController.h"
 #include "SentryReporter.h"
 #include "MeshImporterExporter.h"
 #include "UndoManager.h"
@@ -55,6 +56,8 @@ PropertiesPanelController::PropertiesPanelController() : QObject(nullptr)
 {
     connect(SelectionSet::getSingleton(), &SelectionSet::selectionChanged,
             this, &PropertiesPanelController::onSelectionChanged);
+    connect(EditModeController::instance(), &EditModeController::editModeChanged,
+            this, [this]() { emit selectionChanged(); });
 
     // When the blender bakes a new clip, the entity's animation list grew —
     // tell the Inspector to re-query so the new clip shows up immediately.
@@ -244,6 +247,9 @@ QString PropertiesPanelController::selectionName() const
 
 QString PropertiesPanelController::transformTargetKind() const
 {
+    if (EditModeController::instance()->isEditModeActive())
+        return QStringLiteral("editMesh");
+
     auto* sel = SelectionSet::getSingleton();
     const bool hasNodes = sel->hasNodes();
     const bool hasEntities = sel->hasEntities();
@@ -267,6 +273,8 @@ QString PropertiesPanelController::transformTargetLabel() const
     const QString kind = transformTargetKind();
     if (kind == QStringLiteral("node"))
         return QStringLiteral("Node Transform");
+    if (kind == QStringLiteral("editMesh"))
+        return QStringLiteral("Mesh Geometry");
     if (kind == QStringLiteral("mesh"))
         return QStringLiteral("Mesh Geometry");
     if (kind == QStringLiteral("submesh"))
@@ -283,6 +291,8 @@ QString PropertiesPanelController::transformTargetDetail() const
     const QString kind = transformTargetKind();
     if (kind == QStringLiteral("node"))
         return QStringLiteral("Object placement only; mesh vertices stay unchanged.");
+    if (kind == QStringLiteral("editMesh"))
+        return QStringLiteral("Edit Mode transforms mesh vertices; exports include these edits.");
     if (kind == QStringLiteral("mesh"))
         return QStringLiteral("Transforms mesh vertex data; exports include these edits.");
     if (kind == QStringLiteral("submesh"))
@@ -298,6 +308,7 @@ bool PropertiesPanelController::transformAffectsMesh() const
 {
     const QString kind = transformTargetKind();
     return kind == QStringLiteral("mesh")
+        || kind == QStringLiteral("editMesh")
         || kind == QStringLiteral("submesh")
         || kind == QStringLiteral("mixedGeometry");
 }

--- a/src/PropertiesPanelController.cpp
+++ b/src/PropertiesPanelController.cpp
@@ -57,7 +57,7 @@ PropertiesPanelController::PropertiesPanelController() : QObject(nullptr)
     connect(SelectionSet::getSingleton(), &SelectionSet::selectionChanged,
             this, &PropertiesPanelController::onSelectionChanged);
     connect(EditModeController::instance(), &EditModeController::editModeChanged,
-            this, [this]() { emit selectionChanged(); });
+            this, [this]() { emit transformTargetMetadataChanged(); });
 
     // When the blender bakes a new clip, the entity's animation list grew —
     // tell the Inspector to re-query so the new clip shows up immediately.
@@ -245,10 +245,24 @@ QString PropertiesPanelController::selectionName() const
     return QString();
 }
 
-QString PropertiesPanelController::transformTargetKind() const
+namespace {
+// Internal enum for transform target classification — drives all four
+// transformTarget* accessors so they share one selection probe and the
+// label/detail/affects-mesh strings can't drift away from kind names.
+enum class TransformTarget {
+    None,
+    Node,
+    EditMesh,
+    Mesh,
+    Submesh,
+    MixedGeometry,
+    Mixed,
+};
+
+TransformTarget resolveTransformTarget()
 {
     if (EditModeController::instance()->isEditModeActive())
-        return QStringLiteral("editMesh");
+        return TransformTarget::EditMesh;
 
     auto* sel = SelectionSet::getSingleton();
     const bool hasNodes = sel->hasNodes();
@@ -256,61 +270,87 @@ QString PropertiesPanelController::transformTargetKind() const
     const bool hasSubEntities = sel->hasSubEntities();
 
     if (!hasNodes && !hasEntities && !hasSubEntities)
-        return QStringLiteral("none");
+        return TransformTarget::None;
     if (hasNodes && (hasEntities || hasSubEntities))
-        return QStringLiteral("mixed");
+        return TransformTarget::Mixed;
     if (hasNodes)
-        return QStringLiteral("node");
+        return TransformTarget::Node;
     if (hasEntities && hasSubEntities)
-        return QStringLiteral("mixedGeometry");
+        return TransformTarget::MixedGeometry;
     if (hasEntities)
-        return QStringLiteral("mesh");
-    return QStringLiteral("submesh");
+        return TransformTarget::Mesh;
+    return TransformTarget::Submesh;
+}
+
+QString transformTargetKindString(TransformTarget kind)
+{
+    switch (kind) {
+    case TransformTarget::None:          return QStringLiteral("none");
+    case TransformTarget::Node:          return QStringLiteral("node");
+    case TransformTarget::EditMesh:      return QStringLiteral("editMesh");
+    case TransformTarget::Mesh:          return QStringLiteral("mesh");
+    case TransformTarget::Submesh:       return QStringLiteral("submesh");
+    case TransformTarget::MixedGeometry: return QStringLiteral("mixedGeometry");
+    case TransformTarget::Mixed:         return QStringLiteral("mixed");
+    }
+    return QStringLiteral("none");
+}
+} // namespace
+
+QString PropertiesPanelController::transformTargetKind() const
+{
+    return transformTargetKindString(resolveTransformTarget());
 }
 
 QString PropertiesPanelController::transformTargetLabel() const
 {
-    const QString kind = transformTargetKind();
-    if (kind == QStringLiteral("node"))
-        return QStringLiteral("Node Transform");
-    if (kind == QStringLiteral("editMesh"))
-        return QStringLiteral("Mesh Geometry");
-    if (kind == QStringLiteral("mesh"))
-        return QStringLiteral("Mesh Geometry");
-    if (kind == QStringLiteral("submesh"))
-        return QStringLiteral("Submesh Geometry");
-    if (kind == QStringLiteral("mixedGeometry"))
-        return QStringLiteral("Mixed Geometry");
-    if (kind == QStringLiteral("mixed"))
-        return QStringLiteral("Mixed Targets");
+    switch (resolveTransformTarget()) {
+    case TransformTarget::Node:          return QStringLiteral("Node Transform");
+    case TransformTarget::EditMesh:      return QStringLiteral("Mesh Geometry");
+    case TransformTarget::Mesh:          return QStringLiteral("Mesh Geometry");
+    case TransformTarget::Submesh:       return QStringLiteral("Submesh Geometry");
+    case TransformTarget::MixedGeometry: return QStringLiteral("Mixed Geometry");
+    case TransformTarget::Mixed:         return QStringLiteral("Mixed Targets");
+    case TransformTarget::None:          break;
+    }
     return QStringLiteral("No Selection");
 }
 
 QString PropertiesPanelController::transformTargetDetail() const
 {
-    const QString kind = transformTargetKind();
-    if (kind == QStringLiteral("node"))
+    switch (resolveTransformTarget()) {
+    case TransformTarget::Node:
         return QStringLiteral("Object placement only; mesh vertices stay unchanged.");
-    if (kind == QStringLiteral("editMesh"))
+    case TransformTarget::EditMesh:
         return QStringLiteral("Edit Mode transforms mesh vertices; exports include these edits.");
-    if (kind == QStringLiteral("mesh"))
+    case TransformTarget::Mesh:
         return QStringLiteral("Transforms mesh vertex data; exports include these edits.");
-    if (kind == QStringLiteral("submesh"))
+    case TransformTarget::Submesh:
         return QStringLiteral("Transforms selected submesh vertex data.");
-    if (kind == QStringLiteral("mixedGeometry"))
+    case TransformTarget::MixedGeometry:
         return QStringLiteral("Geometry selection is mixed; use one mesh target type for precise edits.");
-    if (kind == QStringLiteral("mixed"))
+    case TransformTarget::Mixed:
         return QStringLiteral("Node transform path is active; select only Mesh/Submesh to edit geometry.");
+    case TransformTarget::None:
+        break;
+    }
     return QStringLiteral("Select a node for placement or a mesh for geometry edits.");
 }
 
 bool PropertiesPanelController::transformAffectsMesh() const
 {
-    const QString kind = transformTargetKind();
-    return kind == QStringLiteral("mesh")
-        || kind == QStringLiteral("editMesh")
-        || kind == QStringLiteral("submesh")
-        || kind == QStringLiteral("mixedGeometry");
+    switch (resolveTransformTarget()) {
+    case TransformTarget::Mesh:
+    case TransformTarget::EditMesh:
+    case TransformTarget::Submesh:
+    case TransformTarget::MixedGeometry:
+        return true;
+    case TransformTarget::None:
+    case TransformTarget::Node:
+    case TransformTarget::Mixed:
+        return false;
+    }
+    return false;
 }
 
 QStringList PropertiesPanelController::sceneNodeNames() const
@@ -972,6 +1012,7 @@ void PropertiesPanelController::onSelectionChanged()
 {
     onTransformChanged();
     emit selectionChanged();
+    emit transformTargetMetadataChanged();
     emit primitiveChanged();
 }
 

--- a/src/PropertiesPanelController.cpp
+++ b/src/PropertiesPanelController.cpp
@@ -242,6 +242,66 @@ QString PropertiesPanelController::selectionName() const
     return QString();
 }
 
+QString PropertiesPanelController::transformTargetKind() const
+{
+    auto* sel = SelectionSet::getSingleton();
+    const bool hasNodes = sel->hasNodes();
+    const bool hasEntities = sel->hasEntities();
+    const bool hasSubEntities = sel->hasSubEntities();
+
+    if (!hasNodes && !hasEntities && !hasSubEntities)
+        return QStringLiteral("none");
+    if (hasNodes && (hasEntities || hasSubEntities))
+        return QStringLiteral("mixed");
+    if (hasNodes)
+        return QStringLiteral("node");
+    if (hasEntities && hasSubEntities)
+        return QStringLiteral("mixedGeometry");
+    if (hasEntities)
+        return QStringLiteral("mesh");
+    return QStringLiteral("submesh");
+}
+
+QString PropertiesPanelController::transformTargetLabel() const
+{
+    const QString kind = transformTargetKind();
+    if (kind == QStringLiteral("node"))
+        return QStringLiteral("Node Transform");
+    if (kind == QStringLiteral("mesh"))
+        return QStringLiteral("Mesh Geometry");
+    if (kind == QStringLiteral("submesh"))
+        return QStringLiteral("Submesh Geometry");
+    if (kind == QStringLiteral("mixedGeometry"))
+        return QStringLiteral("Mixed Geometry");
+    if (kind == QStringLiteral("mixed"))
+        return QStringLiteral("Mixed Targets");
+    return QStringLiteral("No Selection");
+}
+
+QString PropertiesPanelController::transformTargetDetail() const
+{
+    const QString kind = transformTargetKind();
+    if (kind == QStringLiteral("node"))
+        return QStringLiteral("Object placement only; mesh vertices stay unchanged.");
+    if (kind == QStringLiteral("mesh"))
+        return QStringLiteral("Transforms mesh vertex data; exports include these edits.");
+    if (kind == QStringLiteral("submesh"))
+        return QStringLiteral("Transforms selected submesh vertex data.");
+    if (kind == QStringLiteral("mixedGeometry"))
+        return QStringLiteral("Geometry selection is mixed; use one mesh target type for precise edits.");
+    if (kind == QStringLiteral("mixed"))
+        return QStringLiteral("Node transform path is active; select only Mesh/Submesh to edit geometry.");
+    return QStringLiteral("Select a node for placement or a mesh for geometry edits.");
+}
+
+bool PropertiesPanelController::transformAffectsMesh() const
+{
+    const QString kind = transformTargetKind();
+    return kind == QStringLiteral("mesh")
+        || kind == QStringLiteral("submesh")
+        || kind == QStringLiteral("mixedGeometry");
+}
+
 QStringList PropertiesPanelController::sceneNodeNames() const
 {
     QStringList names;

--- a/src/PropertiesPanelController.h
+++ b/src/PropertiesPanelController.h
@@ -39,6 +39,10 @@ class PropertiesPanelController : public QObject
     Q_PROPERTY(bool hasSelection READ hasSelection NOTIFY selectionChanged)
     Q_PROPERTY(bool hasEntitySelection READ hasEntitySelection NOTIFY selectionChanged)
     Q_PROPERTY(QString selectionName READ selectionName NOTIFY selectionChanged)
+    Q_PROPERTY(QString transformTargetKind READ transformTargetKind NOTIFY selectionChanged)
+    Q_PROPERTY(QString transformTargetLabel READ transformTargetLabel NOTIFY selectionChanged)
+    Q_PROPERTY(QString transformTargetDetail READ transformTargetDetail NOTIFY selectionChanged)
+    Q_PROPERTY(bool transformAffectsMesh READ transformAffectsMesh NOTIFY selectionChanged)
     Q_PROPERTY(QStringList sceneNodeNames READ sceneNodeNames NOTIFY sceneChanged)
     Q_PROPERTY(SceneTreeModel* sceneTreeModel READ sceneTreeModel CONSTANT)
 
@@ -139,6 +143,10 @@ public:
     bool hasSelection() const;
     bool hasEntitySelection() const;
     QString selectionName() const;
+    QString transformTargetKind() const;
+    QString transformTargetLabel() const;
+    QString transformTargetDetail() const;
+    bool transformAffectsMesh() const;
     QStringList sceneNodeNames() const;
 
     SceneTreeModel* sceneTreeModel() const;

--- a/src/PropertiesPanelController.h
+++ b/src/PropertiesPanelController.h
@@ -39,10 +39,10 @@ class PropertiesPanelController : public QObject
     Q_PROPERTY(bool hasSelection READ hasSelection NOTIFY selectionChanged)
     Q_PROPERTY(bool hasEntitySelection READ hasEntitySelection NOTIFY selectionChanged)
     Q_PROPERTY(QString selectionName READ selectionName NOTIFY selectionChanged)
-    Q_PROPERTY(QString transformTargetKind READ transformTargetKind NOTIFY selectionChanged)
-    Q_PROPERTY(QString transformTargetLabel READ transformTargetLabel NOTIFY selectionChanged)
-    Q_PROPERTY(QString transformTargetDetail READ transformTargetDetail NOTIFY selectionChanged)
-    Q_PROPERTY(bool transformAffectsMesh READ transformAffectsMesh NOTIFY selectionChanged)
+    Q_PROPERTY(QString transformTargetKind READ transformTargetKind NOTIFY transformTargetMetadataChanged)
+    Q_PROPERTY(QString transformTargetLabel READ transformTargetLabel NOTIFY transformTargetMetadataChanged)
+    Q_PROPERTY(QString transformTargetDetail READ transformTargetDetail NOTIFY transformTargetMetadataChanged)
+    Q_PROPERTY(bool transformAffectsMesh READ transformAffectsMesh NOTIFY transformTargetMetadataChanged)
     Q_PROPERTY(QStringList sceneNodeNames READ sceneNodeNames NOTIFY sceneChanged)
     Q_PROPERTY(SceneTreeModel* sceneTreeModel READ sceneTreeModel CONSTANT)
 
@@ -252,6 +252,10 @@ public slots:
 signals:
     void transformChanged();
     void selectionChanged();
+    /// Emitted when the transform-target metadata (`transformTargetKind`,
+    /// `transformTargetLabel`, `transformTargetDetail`, `transformAffectsMesh`)
+    /// may have changed. Fires on selection deltas and on Edit Mode toggles.
+    void transformTargetMetadataChanged();
     void sceneChanged();
     void themeChanged();
     void primitiveChanged();

--- a/src/PropertiesPanelController_test.cpp
+++ b/src/PropertiesPanelController_test.cpp
@@ -11,6 +11,7 @@
 #include <QUndoCommand>
 
 #include "AnimationWidget.h"
+#include "EditModeController.h"
 #include "Manager.h"
 #include "PrimitiveObject.h"
 #include "PropertiesPanelController.h"
@@ -32,6 +33,7 @@ protected:
         originalPalette = app->palette();
 
         PropertiesPanelController::kill();
+        EditModeController::kill();
         Manager::kill();
         app->processEvents();
 
@@ -50,6 +52,7 @@ protected:
         }
 
         PropertiesPanelController::kill();
+        EditModeController::kill();
         Manager::kill();
         if (app)
             app->processEvents();
@@ -166,6 +169,15 @@ TEST_F(PropertiesPanelControllerTests, TransformTargetMetadataExplainsSelectionI
     EXPECT_EQ(controller->transformTargetKind(), QString("mesh"));
     EXPECT_EQ(controller->transformTargetLabel(), QString("Mesh Geometry"));
     EXPECT_TRUE(controller->transformAffectsMesh());
+
+    SelectionSet::getSingleton()->selectOne(meshNode);
+    EXPECT_EQ(controller->transformTargetKind(), QString("node"));
+    ASSERT_TRUE(EditModeController::instance()->enterEditMode());
+    EXPECT_EQ(controller->transformTargetKind(), QString("editMesh"));
+    EXPECT_EQ(controller->transformTargetLabel(), QString("Mesh Geometry"));
+    EXPECT_TRUE(controller->transformAffectsMesh());
+    EXPECT_TRUE(controller->transformTargetDetail().contains("Edit Mode transforms mesh vertices"));
+    EditModeController::instance()->exitEditMode(false);
 
     SelectionSet::getSingleton()->selectOne(entity->getSubEntity(0));
     EXPECT_EQ(controller->transformTargetKind(), QString("submesh"));

--- a/src/PropertiesPanelController_test.cpp
+++ b/src/PropertiesPanelController_test.cpp
@@ -141,6 +141,46 @@ TEST_F(PropertiesPanelControllerTests, SelectionStateFollowsSelectedSceneNode)
     EXPECT_EQ(SelectionSet::getSingleton()->getSceneNode(0), node);
 }
 
+TEST_F(PropertiesPanelControllerTests, TransformTargetMetadataExplainsSelectionImpact)
+{
+    EXPECT_EQ(controller->transformTargetKind(), QString("none"));
+    EXPECT_EQ(controller->transformTargetLabel(), QString("No Selection"));
+    EXPECT_FALSE(controller->transformAffectsMesh());
+
+    Ogre::SceneNode* node = createSelectedNode("PanelTargetNode");
+    ASSERT_NE(node, nullptr);
+
+    EXPECT_EQ(controller->transformTargetKind(), QString("node"));
+    EXPECT_EQ(controller->transformTargetLabel(), QString("Node Transform"));
+    EXPECT_FALSE(controller->transformAffectsMesh());
+    EXPECT_TRUE(controller->transformTargetDetail().contains("mesh vertices stay unchanged"));
+
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
+    Ogre::SceneNode* meshNode = Manager::getSingleton()->addSceneNode("PanelTargetMeshNode");
+    ASSERT_NE(meshNode, nullptr);
+    Ogre::MeshPtr mesh = createInMemoryTriangleMesh("PanelTargetMesh");
+    Ogre::Entity* entity = Manager::getSingleton()->createEntity(meshNode, mesh);
+    ASSERT_NE(entity, nullptr);
+
+    SelectionSet::getSingleton()->selectOne(entity);
+    EXPECT_EQ(controller->transformTargetKind(), QString("mesh"));
+    EXPECT_EQ(controller->transformTargetLabel(), QString("Mesh Geometry"));
+    EXPECT_TRUE(controller->transformAffectsMesh());
+
+    SelectionSet::getSingleton()->selectOne(entity->getSubEntity(0));
+    EXPECT_EQ(controller->transformTargetKind(), QString("submesh"));
+    EXPECT_EQ(controller->transformTargetLabel(), QString("Submesh Geometry"));
+    EXPECT_TRUE(controller->transformAffectsMesh());
+
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->append(node);
+    SelectionSet::getSingleton()->append(entity);
+    EXPECT_EQ(controller->transformTargetKind(), QString("mixed"));
+    EXPECT_EQ(controller->transformTargetLabel(), QString("Mixed Targets"));
+    EXPECT_FALSE(controller->transformAffectsMesh());
+    EXPECT_TRUE(controller->transformTargetDetail().contains("Node transform path is active"));
+}
+
 TEST_F(PropertiesPanelControllerTests, SceneNodeNamesAndSelectionHelpersHandleMultipleNodes)
 {
     Ogre::SceneNode* first = Manager::getSingleton()->addSceneNode("PanelNodeA");

--- a/src/ViewportSettingsKeys.h
+++ b/src/ViewportSettingsKeys.h
@@ -35,6 +35,26 @@ OTHER DEALINGS IN THE SOFTWARE.
 namespace ViewportSettingsKeys
 {
 
+inline int defaultFsaaSamples()
+{
+    return 4;
+}
+
+inline double defaultNearClip()
+{
+    return 0.01;
+}
+
+inline double defaultFarClip()
+{
+    return 10000.0;
+}
+
+inline double defaultCameraSpeed()
+{
+    return 1.0;
+}
+
 /**
  * @brief QSettings key strings for Viewport/ preferences (single source of truth).
  *

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -67,6 +67,7 @@
 #include "WelcomeScreenController.h"
 #include "AssetBrowserController.h"
 #include "EditModeController.h"
+#include "EditorModeController.h"
 #include <QDockWidget>
 #include <QQuickWidget>
 #include <QQmlContext>
@@ -77,6 +78,27 @@
 #include <QColorDialog>
 #include <QSignalBlocker>
 #include <QGridLayout>
+#include <QToolBar>
+
+namespace {
+
+constexpr int kBottomToolHeight = 180;
+constexpr int kBottomDockMaxHeight = 220;
+
+void registerEditorModeQmlSingletons()
+{
+    static bool registered = false;
+    if (registered)
+        return;
+
+    qmlRegisterSingletonType<EditorModeController>("EditorMode", 1, 0, "EditorModeController",
+        [](QQmlEngine* engine, QJSEngine*) -> QObject* {
+            return EditorModeController::qmlInstance(engine, nullptr);
+        });
+    registered = true;
+}
+
+} // namespace
 
 MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent), ui(new Ui::MainWindow),
@@ -113,6 +135,9 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->menuFile->insertMenu(ui->actionExport_Selected, m_recentFilesMenu);
     ui->menuFile->insertSeparator(ui->actionExport_Selected);
     updateRecentFilesMenu();
+
+    ui->menuOp_es->insertAction(ui->actionChange_Ambient_Light, ui->actionMaterial_Editor);
+    ui->menuOp_es->insertSeparator(ui->actionChange_Ambient_Light);
 
     QSettings settings;
     mCurrentPalette = settings.value("palette","dark").toString();
@@ -170,7 +195,12 @@ MainWindow::MainWindow(QWidget *parent) :
     m_editModeLabel = new QLabel("Object Mode", this);
     m_editModeLabel->setStyleSheet("QLabel { font-weight: bold; padding: 2px 8px; }");
     statusBar()->addPermanentWidget(m_editModeLabel);
+    EditorModeController::instance();
     connect(EditModeController::instance(), &EditModeController::editModeChanged,
+            this, &MainWindow::updateEditModeIndicator);
+    connect(EditorModeController::instance(), &EditorModeController::modeChanged,
+            this, &MainWindow::updateEditModeIndicator);
+    connect(EditorModeController::instance(), &EditorModeController::statusTextChanged,
             this, &MainWindow::updateEditModeIndicator);
     updateEditModeIndicator();
 
@@ -275,6 +305,7 @@ MainWindow::~MainWindow()
     // Ogre resources). In that case, destroying Ogre-backed singletons can
     // crash due to dangling SceneManager pointers — skip teardown and let the
     // process exit cleanly.
+    EditorModeController::kill();
     Manager* manager = Manager::getSingletonPtr();
     if (manager) {
         EditModeController::kill();
@@ -407,6 +438,7 @@ void MainWindow::initToolBar()
         qputenv("QSG_RHI_BACKEND", "software");
         qputenv("QT_QUICK_BACKEND", "software");
         QQuickWindow::setGraphicsApi(QSGRendererInterface::Software);
+        registerEditorModeQmlSingletons();
 
         m_propertiesPanel = new QQuickWidget();
         m_propertiesPanel->setResizeMode(QQuickWidget::SizeRootObjectToView);
@@ -473,6 +505,7 @@ void MainWindow::initToolBar()
             });
 
         m_propertiesPanel->setSource(QUrl("qrc:/PropertiesPanel/PropertiesPanel.qml"));
+        createModeSurfaces();
 
         // Force QQuickWidget repaint when snap settings change — QQuickWidget
         // inside a QDockWidget doesn't repaint on internal QML property changes.
@@ -537,12 +570,14 @@ void MainWindow::initToolBar()
         auto* assetBrowserWidget = new QQuickWidget();
         assetBrowserWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
         assetBrowserWidget->setMinimumWidth(250);
-        assetBrowserWidget->setMinimumHeight(200);
+        assetBrowserWidget->setMinimumHeight(kBottomToolHeight);
+        assetBrowserWidget->setMaximumHeight(kBottomToolHeight);
         assetBrowserWidget->setFocusPolicy(Qt::StrongFocus);
         assetBrowserWidget->setSource(QUrl("qrc:/AssetBrowser/AssetBrowser.qml"));
         m_assetBrowserDock = new QDockWidget(tr("Asset Browser"), this);
         m_assetBrowserDock->setWidget(assetBrowserWidget);
         m_assetBrowserDock->setObjectName("AssetBrowserDock");
+        configureBottomToolDock(m_assetBrowserDock);
         addDockWidget(Qt::BottomDockWidgetArea, m_assetBrowserDock);
         m_assetBrowserDock->hide();
 
@@ -562,7 +597,8 @@ void MainWindow::initToolBar()
     {
         auto* dopeSheetWidget = new QQuickWidget(); // NOSONAR — Qt parent ownership
         dopeSheetWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
-        dopeSheetWidget->setMinimumHeight(160);
+        dopeSheetWidget->setMinimumHeight(kBottomToolHeight);
+        dopeSheetWidget->setMaximumHeight(kBottomToolHeight);
         dopeSheetWidget->setFocusPolicy(Qt::StrongFocus);
         dopeSheetWidget->setSource(QUrl("qrc:/AnimationControl/AnimationDopeSheet.qml"));
 
@@ -599,6 +635,7 @@ void MainWindow::initToolBar()
         m_dopeSheetDock = new QDockWidget(tr("Dope Sheet"), this); // NOSONAR — Qt parent ownership
         m_dopeSheetDock->setWidget(dopeSheetWidget);
         m_dopeSheetDock->setObjectName("DopeSheetDock");
+        configureBottomToolDock(m_dopeSheetDock);
         addDockWidget(Qt::BottomDockWidgetArea, m_dopeSheetDock);
         m_dopeSheetDock->hide();
         connect(m_dopeSheetDock, &QDockWidget::visibilityChanged, this, [](bool vis) {
@@ -626,12 +663,14 @@ void MainWindow::initToolBar()
     {
         auto* curveEditorWidget = new QQuickWidget(); // NOSONAR — Qt parent ownership
         curveEditorWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
-        curveEditorWidget->setMinimumHeight(180);
+        curveEditorWidget->setMinimumHeight(kBottomToolHeight);
+        curveEditorWidget->setMaximumHeight(kBottomToolHeight);
         curveEditorWidget->setFocusPolicy(Qt::StrongFocus);
         curveEditorWidget->setSource(QUrl("qrc:/AnimationControl/AnimationCurveEditor.qml"));
         m_curveEditorDock = new QDockWidget(tr("Curve Editor"), this); // NOSONAR
         m_curveEditorDock->setWidget(curveEditorWidget);
         m_curveEditorDock->setObjectName("CurveEditorDock");
+        configureBottomToolDock(m_curveEditorDock);
         addDockWidget(Qt::BottomDockWidgetArea, m_curveEditorDock);
         // Tab on top of the dope sheet by default — the user toggles whichever
         // they want via the View menu. tabifyDockWidget runs after both docks
@@ -643,6 +682,7 @@ void MainWindow::initToolBar()
                 vis ? "Curve Editor shown" : "Curve Editor hidden");
         });
     }
+    tabifyBottomToolDocks();
 
     // Welcome Screen overlay — shown on first launch or when user hasn't opted out
     {
@@ -731,7 +771,8 @@ void MainWindow::initToolBar()
     addPrimitiveMenu->addAction(pAddSpring);
 
     addPrimitiveButton->setMenu(addPrimitiveMenu);
-    ui->objectsToolbar->addWidget(addPrimitiveButton);
+    QAction* addPrimitiveAction = ui->objectsToolbar->addWidget(addPrimitiveButton);
+    addPrimitiveAction->setObjectName("modeObjectPrimitiveAction");
 
     // AI Chat button — star icon is the common AI shorthand
     auto aiChatButton = new QToolButton(ui->objectsToolbar);
@@ -747,7 +788,8 @@ void MainWindow::initToolBar()
             m_chatDock->raise();
         }
     });
-    ui->objectsToolbar->addWidget(aiChatButton);
+    QAction* aiChatToolbarAction = ui->objectsToolbar->addWidget(aiChatButton);
+    aiChatToolbarAction->setObjectName("modeAnyAiChatAction");
 
     // Topology tools — toolbar shortcuts for Extrude / Bevel. They
     // delegate to the same EditModeController actions the Inspector
@@ -815,6 +857,7 @@ void MainWindow::initToolBar()
     // Hiding the widget directly doesn't affect the toolbar's layout —
     // we have to toggle the action's visibility instead.
     QAction* extrudeAction = ui->objectsToolbar->addWidget(extrudeButton);
+    extrudeAction->setObjectName("modeEditExtrudeAction");
 
     // Bevel: edge OR vertex mode.
     auto bevelButton = new QToolButton(ui->objectsToolbar);
@@ -833,6 +876,7 @@ void MainWindow::initToolBar()
         EditModeController::instance()->bevelSelection();
     });
     QAction* bevelAction = ui->objectsToolbar->addWidget(bevelButton);
+    bevelAction->setObjectName("modeEditBevelAction");
 
     // Knife: opens a multi-point cut session. Available in edit mode
     // regardless of selection component (vertex/edge/face), because
@@ -851,6 +895,7 @@ void MainWindow::initToolBar()
         else                         c->beginKnife();
     });
     QAction* knifeAction = ui->objectsToolbar->addWidget(knifeButton);
+    knifeAction->setObjectName("modeEditKnifeAction");
 
     // Merge: vertex-mode-only collapse of the current selection. Drops a
     // small popup so the user can pick the survivor target (Center / First
@@ -891,6 +936,7 @@ void MainWindow::initToolBar()
         EditModeController::instance()->mergeByDistance(1e-4f);
     });
     QAction* mergeAction = ui->objectsToolbar->addWidget(mergeButton);
+    mergeAction->setObjectName("modeEditMergeAction");
 
     // Delete / Dissolve: works in any selection mode. The dropdown lets
     // the user pick "Delete" (remove element + adjacent geometry) or
@@ -923,6 +969,7 @@ void MainWindow::initToolBar()
         EditModeController::instance()->dissolveSelection();
     });
     QAction* deleteAction = ui->objectsToolbar->addWidget(deleteButton);
+    deleteAction->setObjectName("modeEditDeleteAction");
 
     // Subdivide: dropdown with two modes.
     //  - Standard: 1-to-4 triangle split on the selected faces/edges
@@ -949,6 +996,7 @@ void MainWindow::initToolBar()
         EditModeController::instance()->subdivideCatmullClarkAll();
     });
     QAction* subdivideAction = ui->objectsToolbar->addWidget(subdivideButton);
+    subdivideAction->setObjectName("modeEditSubdivideAction");
 
     // Fill: vertex mode (3-4+ verts → triangle / fan) or edge mode (closed
     // boundary loop → fan-triangulated cap, useful for capping holes).
@@ -962,6 +1010,7 @@ void MainWindow::initToolBar()
         EditModeController::instance()->fillSelection();
     });
     QAction* fillAction = ui->objectsToolbar->addWidget(fillButton);
+    fillAction->setObjectName("modeEditFillAction");
 
     // Loop cut: edge mode only — pick one edge, the op walks the
     // perpendicular ring of quads and bisects each one.
@@ -1170,6 +1219,7 @@ void MainWindow::initToolBar()
     });
 
     QAction* vertexPaintAction = ui->objectsToolbar->addWidget(vertexPaintButton);
+    vertexPaintAction->setObjectName("modeEditVertexPaintAction");
 
     // Context-aware visibility + enabled:
     //  - Hidden entirely when NOT in edit mode.
@@ -1245,6 +1295,9 @@ void MainWindow::initToolBar()
     // the mesh has been promoted.
     connect(editCtrlForTopo, &EditModeController::meshDataChanged,
             this, refreshTopoButtons);
+    connect(EditorModeController::instance(), &EditorModeController::modeChanged,
+            this, &MainWindow::updateToolRailForMode);
+    updateToolRailForMode();
 
     connect(pAddCube,       SIGNAL(triggered()),m_pPrimitivesWidget,SLOT(createCube()));
     connect(pAddSphere,     SIGNAL(triggered()),m_pPrimitivesWidget,SLOT(createSphere()));
@@ -1303,18 +1356,29 @@ void MainWindow::initToolBar()
     for (EditorViewport* vp : mDockWidgetList)
         connect(vp->getOgreWidget(), &OgreWidget::focusOnWidget, m_meshInfoOverlay, &MeshInfoOverlay::setActiveWidget);
 
-    // Asset Browser dock toggle via View menu
-    connect(ui->actionAsset_Browser, &QAction::toggled, this, [this](bool checked) {
-        SentryReporter::addBreadcrumb("ui.action",
-            checked ? "Asset Browser shown" : "Asset Browser hidden");
-        if (m_assetBrowserDock) {
-            m_assetBrowserDock->setVisible(checked);
-        }
-    });
-    // Sync menu checkmark when dock is closed via its title bar
-    if (m_assetBrowserDock) {
-        connect(m_assetBrowserDock, &QDockWidget::visibilityChanged,
-                ui->actionAsset_Browser, &QAction::setChecked);
+    // Asset Browser toggle — use the dock's own action so tabified bottom
+    // docks behave consistently with Dope Sheet / Curve Editor.
+    if (m_assetBrowserDock && ui->menuView) {
+        QAction* assetAct = m_assetBrowserDock->toggleViewAction();
+        assetAct->setText(tr("Asset Browser"));
+        ui->menuView->insertAction(ui->actionAsset_Browser, assetAct);
+        ui->menuView->removeAction(ui->actionAsset_Browser);
+
+        connect(ui->actionAsset_Browser, &QAction::toggled, this, [assetAct](bool checked) {
+            if (assetAct->isChecked() != checked)
+                assetAct->trigger();
+        });
+        connect(assetAct, &QAction::toggled, ui->actionAsset_Browser, &QAction::setChecked);
+        connect(assetAct, &QAction::triggered, this, [this](bool checked) {
+            SentryReporter::addBreadcrumb("ui.action",
+                checked ? "Asset Browser shown" : "Asset Browser hidden");
+            if (!checked || !m_assetBrowserDock)
+                return;
+
+            QTimer::singleShot(0, this, [this]() {
+                showBottomToolDock(m_assetBrowserDock);
+            });
+        });
     }
 
     // Dope Sheet toggle — uses the dock's own toggleViewAction so we don't
@@ -1323,12 +1387,28 @@ void MainWindow::initToolBar()
         QAction* dopeAct = m_dopeSheetDock->toggleViewAction();
         dopeAct->setText(tr("Dope Sheet"));
         ui->menuView->addAction(dopeAct);
+        connect(dopeAct, &QAction::triggered, this, [this](bool checked) {
+            if (!checked || !m_dopeSheetDock)
+                return;
+
+            QTimer::singleShot(0, this, [this]() {
+                showBottomToolDock(m_dopeSheetDock);
+            });
+        });
     }
     // Curve Editor toggle — same pattern, lives next to Dope Sheet.
     if (m_curveEditorDock && ui->menuView) {
         QAction* curveAct = m_curveEditorDock->toggleViewAction();
         curveAct->setText(tr("Curve Editor"));
         ui->menuView->addAction(curveAct);
+        connect(curveAct, &QAction::triggered, this, [this](bool checked) {
+            if (!checked || !m_curveEditorDock)
+                return;
+
+            QTimer::singleShot(0, this, [this]() {
+                showBottomToolDock(m_curveEditorDock);
+            });
+        });
     }
 
     // Connect Browse button to a native file dialog (must be parented to MainWindow on macOS)
@@ -1470,6 +1550,192 @@ const QPalette &MainWindow::darkPalette()
 
 void MainWindow::setPlaying(bool playing)
 {   isPlaying = playing;    }
+
+void MainWindow::createModeSurfaces()
+{
+    if (!m_modeBarShell) {
+        m_modeBarShell = new QToolBar(tr("Modes"), this);
+        m_modeBarShell->setObjectName("modeBarToolbar");
+        m_modeBarShell->setMovable(false);
+        m_modeBarShell->setFloatable(false);
+        m_modeBarShell->setAllowedAreas(Qt::TopToolBarArea);
+
+        m_modeBar = new QQuickWidget(m_modeBarShell);
+        m_modeBar->setResizeMode(QQuickWidget::SizeRootObjectToView);
+        m_modeBar->setMinimumHeight(38);
+        m_modeBar->setMaximumHeight(38);
+        m_modeBar->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+        m_modeBar->setSource(QUrl("qrc:/ModeBar/ModeBar.qml"));
+        m_modeBarShell->addWidget(m_modeBar);
+
+        insertToolBar(ui->toolToolbar, m_modeBarShell);
+    }
+
+    if (!m_bottomContextDock) {
+        auto* contextWidget = new QQuickWidget();
+        contextWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
+        contextWidget->setMinimumHeight(kBottomToolHeight);
+        contextWidget->setMaximumHeight(kBottomToolHeight);
+        contextWidget->rootContext()->setContextProperty("materialEditorAction", ui->actionMaterial_Editor);
+        contextWidget->setSource(QUrl("qrc:/BottomContextPanel/BottomContextPanel.qml"));
+
+        m_bottomContextDock = new QDockWidget(tr("Context"), this);
+        m_bottomContextDock->setObjectName("BottomContextDock");
+        m_bottomContextDock->setAllowedAreas(Qt::BottomDockWidgetArea);
+        m_bottomContextDock->setWidget(contextWidget);
+        configureBottomToolDock(m_bottomContextDock);
+        addDockWidget(Qt::BottomDockWidgetArea, m_bottomContextDock);
+        resizeDocks({m_bottomContextDock}, {kBottomToolHeight}, Qt::Vertical);
+        m_bottomContextDock->hide();
+
+        QAction* contextPanelAction = m_bottomContextDock->toggleViewAction();
+        contextPanelAction->setText(tr("Context Panel"));
+        ui->menuView->addAction(contextPanelAction);
+        connect(contextPanelAction, &QAction::triggered, this, [this](bool checked) {
+            if (!checked || !m_bottomContextDock)
+                return;
+
+            QTimer::singleShot(0, this, [this]() {
+                showBottomToolDock(m_bottomContextDock);
+            });
+        });
+        connect(m_bottomContextDock, &QDockWidget::visibilityChanged, this, [this](bool visible) {
+            if (!visible)
+                return;
+
+            QTimer::singleShot(0, this, [this]() {
+                if (m_bottomContextDock)
+                    m_bottomContextDock->raise();
+            });
+        });
+    }
+
+    if (!ui->toolToolbar->findChild<QToolButton*>(QStringLiteral("viewportOptionsButton"))) {
+        auto* viewportOptionsButton = new QToolButton(ui->toolToolbar);
+        viewportOptionsButton->setObjectName("viewportOptionsButton");
+        viewportOptionsButton->setText(tr("Viewport"));
+        viewportOptionsButton->setToolTip(tr("Viewport display options"));
+        viewportOptionsButton->setPopupMode(QToolButton::InstantPopup);
+
+        auto* viewportOptionsMenu = new QMenu(viewportOptionsButton);
+        viewportOptionsMenu->addAction(ui->actionShow_Grid);
+        viewportOptionsMenu->addAction(ui->actionShow_Normals);
+        viewportOptionsMenu->addAction(ui->actionShow_Mesh_Info);
+        viewportOptionsMenu->addAction(ui->actionShow_View_Cube);
+        viewportOptionsButton->setMenu(viewportOptionsMenu);
+        ui->toolToolbar->addWidget(viewportOptionsButton);
+    }
+
+    QSignalBlocker blocker(ui->actionView_Toolbar);
+    ui->actionView_Toolbar->setChecked(false);
+    ui->viewToolbar->hide();
+}
+
+void MainWindow::configureBottomToolDock(QDockWidget* dock)
+{
+    if (!dock)
+        return;
+
+    dock->setAllowedAreas(Qt::BottomDockWidgetArea);
+
+    QWidget* content = dock->widget();
+    if (content) {
+        content->setMinimumHeight(kBottomToolHeight);
+        content->setMaximumHeight(dock->isFloating() ? QWIDGETSIZE_MAX : kBottomToolHeight);
+    }
+
+    dock->setMaximumHeight(dock->isFloating() ? QWIDGETSIZE_MAX : kBottomDockMaxHeight);
+
+    static const char connectedProperty[] = "_qtme_bottomToolSignalsConnected";
+    if (dock->property(connectedProperty).toBool())
+        return;
+
+    dock->setProperty(connectedProperty, true);
+    connect(dock, &QDockWidget::topLevelChanged, this, [this, dock](bool) {
+        configureBottomToolDock(dock);
+        if (!dock->isFloating()) {
+            QTimer::singleShot(0, this, [this]() {
+                tabifyBottomToolDocks();
+            });
+        }
+    });
+}
+
+void MainWindow::showBottomToolDock(QDockWidget* dock)
+{
+    if (!dock)
+        return;
+
+    if (dock->isFloating())
+        dock->setFloating(false);
+
+    if (dockWidgetArea(dock) != Qt::BottomDockWidgetArea)
+        addDockWidget(Qt::BottomDockWidgetArea, dock);
+
+    configureBottomToolDock(dock);
+    tabifyBottomToolDocks();
+    dock->show();
+    resizeDocks({dock}, {kBottomToolHeight}, Qt::Vertical);
+    dock->raise();
+}
+
+void MainWindow::tabifyBottomToolDocks()
+{
+    const QList<QDockWidget*> docks = {
+        m_dopeSheetDock,
+        m_curveEditorDock,
+        m_assetBrowserDock,
+        m_bottomContextDock
+    };
+
+    QDockWidget* anchor = nullptr;
+    for (QDockWidget* dock : docks) {
+        configureBottomToolDock(dock);
+        if (!anchor && dock && !dock->isFloating() && dockWidgetArea(dock) == Qt::BottomDockWidgetArea)
+            anchor = dock;
+    }
+
+    if (!anchor)
+        return;
+
+    const QList<QDockWidget*> anchorTabs = tabifiedDockWidgets(anchor);
+    for (QDockWidget* dock : docks) {
+        if (!dock || dock == anchor || dock->isFloating() || dockWidgetArea(dock) != Qt::BottomDockWidgetArea)
+            continue;
+
+        if (!anchorTabs.contains(dock) && !tabifiedDockWidgets(dock).contains(anchor))
+            tabifyDockWidget(anchor, dock);
+    }
+}
+
+void MainWindow::updateToolRailForMode()
+{
+    const int mode = EditorModeController::instance()->currentMode();
+    const bool objectMode = mode == EditorModeController::ObjectMode;
+    const bool editMode = mode == EditorModeController::EditMode;
+    const bool animationMode = mode == EditorModeController::AnimationMode;
+    const bool materialMode = mode == EditorModeController::MaterialMode;
+
+    for (QAction* action : ui->objectsToolbar->actions()) {
+        const QString name = action->objectName();
+        if (name.startsWith(QStringLiteral("modeObject"))) {
+            action->setVisible(objectMode);
+        } else if (name.startsWith(QStringLiteral("modeEdit"))) {
+            action->setVisible(editMode && EditModeController::instance()->isEditModeActive());
+        } else if (name.startsWith(QStringLiteral("modeAny"))) {
+            action->setVisible(true);
+        }
+    }
+
+    ui->actionSelect_Object->setVisible(objectMode || editMode);
+    ui->actionTranslate_Object->setVisible(objectMode || editMode);
+    ui->actionRotate_Object->setVisible(objectMode || editMode);
+    ui->actionScale_Object->setVisible(objectMode || editMode);
+    ui->actionToggle_Transform_Space->setVisible(objectMode || editMode);
+    ui->actionRemove_Object->setVisible(objectMode);
+    ui->actionMaterial_Editor->setVisible(objectMode || materialMode);
+    ui->actionMerge_Animations->setVisible(objectMode || animationMode);
+}
 
 // LCOV_EXCL_START — Ogre frame listener requires render loop
 bool MainWindow::frameStarted(const Ogre::FrameEvent &evt)
@@ -1874,7 +2140,7 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
        break;
     case Qt::Key_Tab:
         SentryReporter::addBreadcrumb("ui.shortcut", "Tab — Toggle Edit Mode");
-        EditModeController::instance()->toggleEditMode();
+        EditorModeController::instance()->toggleObjectEditMode();
         event->accept();
        break;
     default:
@@ -2317,7 +2583,9 @@ void MainWindow::on_actionView_Toolbar_toggled(bool arg1)
 {    ui->viewToolbar->setVisible(arg1); }
 
 void MainWindow::on_actionMeshEditor_toggled(bool arg1)
-{    ui->meshEditorWidget->setVisible(arg1);    }
+{
+    ui->meshEditorWidget->setVisible(arg1);
+}
 
 // LCOV_EXCL_START — color dialog
 void MainWindow::chooseBgColor()
@@ -2364,14 +2632,15 @@ void MainWindow::setTransformState(TransformOperator::TransformState newState)
 void MainWindow::updateEditModeIndicator()
 {
     if (!m_editModeLabel) return;
-    auto* ctrl = EditModeController::instance();
-    if (ctrl->isEditModeActive()) {
-        m_editModeLabel->setText("Edit Mode");
+    auto* modeCtrl = EditorModeController::instance();
+    auto* editCtrl = EditModeController::instance();
+    if (editCtrl->isEditModeActive()) {
+        m_editModeLabel->setText(modeCtrl->statusText());
         m_editModeLabel->setStyleSheet(
             "QLabel { font-weight: bold; padding: 2px 8px; "
             "background-color: #3d6b3d; color: white; border-radius: 3px; }");
     } else {
-        m_editModeLabel->setText("Object Mode");
+        m_editModeLabel->setText(modeCtrl->statusText());
         m_editModeLabel->setStyleSheet(
             "QLabel { font-weight: bold; padding: 2px 8px; }");
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -82,8 +82,8 @@
 
 namespace {
 
-constexpr int kBottomToolHeight = 180;
-constexpr int kBottomDockMaxHeight = 220;
+constexpr int kBottomToolHeight = MainWindow::kDefaultDockedHeight;
+constexpr int kBottomDockMaxHeight = MainWindow::kDefaultDockedMaxHeight;
 
 void registerEditorModeQmlSingletons()
 {
@@ -1024,6 +1024,7 @@ void MainWindow::initToolBar()
         EditModeController::instance()->loopCutSelection();
     });
     QAction* loopCutAction = ui->objectsToolbar->addWidget(loopCutButton);
+    loopCutAction->setObjectName("modeEditLoopCutAction");
 
     // Convert to Quads: walks the mesh and merges coplanar adjacent
     // triangle pairs into n-gon quads. Useful when an imported tri
@@ -1038,6 +1039,7 @@ void MainWindow::initToolBar()
         EditModeController::instance()->convertToQuads();
     });
     QAction* convertToQuadsAction = ui->objectsToolbar->addWidget(convertToQuadsButton);
+    convertToQuadsAction->setObjectName("modeEditConvertToQuadsAction");
 
     // Vertex paint: toggle on main click; arrow opens brush settings (color, radius, strength).
     auto makeVertexPaintBrushIcon = []() -> QIcon {
@@ -1576,8 +1578,11 @@ void MainWindow::createModeSurfaces()
         contextWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
         contextWidget->setMinimumHeight(kBottomToolHeight);
         contextWidget->setMaximumHeight(kBottomToolHeight);
-        contextWidget->rootContext()->setContextProperty("materialEditorAction", ui->actionMaterial_Editor);
         contextWidget->setSource(QUrl("qrc:/BottomContextPanel/BottomContextPanel.qml"));
+        if (auto* root = contextWidget->rootObject()) {
+            root->setProperty("materialEditorAction",
+                              QVariant::fromValue(static_cast<QObject*>(ui->actionMaterial_Editor)));
+        }
 
         m_bottomContextDock = new QDockWidget(tr("Context"), this);
         m_bottomContextDock->setObjectName("BottomContextDock");

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -45,6 +45,14 @@ class MainWindow : public QMainWindow, public Ogre::FrameListener
     Q_OBJECT
 
 public:
+    /// Pixel height applied to bottom-docked tool widgets (Asset Browser,
+    /// Dope Sheet, Curve Editor, Context Panel) when docked. Floating
+    /// instances expand freely to QWIDGETSIZE_MAX.
+    static constexpr int kDefaultDockedHeight = 180;
+    /// Slightly larger than kDefaultDockedHeight so the dock title bar fits
+    /// without forcing the inner content to shrink.
+    static constexpr int kDefaultDockedMaxHeight = 220;
+
     explicit MainWindow(QWidget *parent = nullptr);
     virtual ~MainWindow();
     void importMeshs(const QStringList &_uriList);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -18,10 +18,12 @@ class MeshInfoOverlay;
 class ViewCubeController;
 class PropertiesPanelController;
 class EditModeController;
+class EditorModeController;
 class WelcomeScreenController;
 class AssetBrowserController;
 class QQuickWidget;
 class QLabel;
+class QToolBar;
 
 namespace Ui {
 class MainWindow;
@@ -149,6 +151,9 @@ private:
     QDockWidget* m_assetBrowserDock = nullptr;
     QDockWidget* m_dopeSheetDock = nullptr;
     QDockWidget* m_curveEditorDock = nullptr;
+    QDockWidget* m_bottomContextDock = nullptr;
+    QToolBar* m_modeBarShell = nullptr;
+    QQuickWidget* m_modeBar = nullptr;
 
     QMenu* m_recentFilesMenu = nullptr;
     void addToRecentFiles(const QString& filePath);
@@ -168,6 +173,11 @@ private:
     /// `frameEnded()` causes on the status bar's main slot.
     QLabel* m_editHintLabel = nullptr;
     void updateEditModeIndicator();
+    void createModeSurfaces();
+    void configureBottomToolDock(QDockWidget* dock);
+    void showBottomToolDock(QDockWidget* dock);
+    void tabifyBottomToolDocks();
+    void updateToolRailForMode();
 };
 
 #endif // MAINWINDOW_H

--- a/src/mainwindow_test.cpp
+++ b/src/mainwindow_test.cpp
@@ -829,7 +829,8 @@ TEST_F(MainWindowTest, BottomToolDockRedocksAndUsesDefaultDockedHeight)
     EXPECT_FALSE(window->m_assetBrowserDock->isFloating());
     EXPECT_EQ(window->dockWidgetArea(window->m_assetBrowserDock), Qt::BottomDockWidgetArea);
     EXPECT_FALSE(window->m_assetBrowserDock->isHidden());
-    EXPECT_EQ(window->m_assetBrowserDock->widget()->maximumHeight(), 180);
+    EXPECT_EQ(window->m_assetBrowserDock->widget()->maximumHeight(),
+              MainWindow::kDefaultDockedHeight);
 
     window->m_assetBrowserDock->setFloating(true);
     app->processEvents();
@@ -845,7 +846,8 @@ TEST_F(MainWindowTest, BottomToolDockRedocksAndUsesDefaultDockedHeight)
     EXPECT_EQ(window->dockWidgetArea(window->m_assetBrowserDock), Qt::BottomDockWidgetArea);
     EXPECT_FALSE(window->m_assetBrowserDock->isHidden());
     EXPECT_LT(window->m_assetBrowserDock->maximumHeight(), QWIDGETSIZE_MAX);
-    EXPECT_EQ(window->m_assetBrowserDock->widget()->maximumHeight(), 180);
+    EXPECT_EQ(window->m_assetBrowserDock->widget()->maximumHeight(),
+              MainWindow::kDefaultDockedHeight);
 }
 
 TEST_F(MainWindowTest, LoadFileQueuesNonSceneFileAndTracksRecentFiles)

--- a/src/mainwindow_test.cpp
+++ b/src/mainwindow_test.cpp
@@ -815,6 +815,39 @@ TEST_F(MainWindowTest, AssetBrowserMenuActionTracksDockVisibility)
     EXPECT_TRUE(window->m_assetBrowserDock->isHidden());
 }
 
+TEST_F(MainWindowTest, BottomToolDockRedocksAndUsesDefaultDockedHeight)
+{
+    ASSERT_NE(window->m_assetBrowserDock, nullptr);
+    ASSERT_NE(window->m_assetBrowserDock->widget(), nullptr);
+
+    window->show();
+    app->processEvents();
+
+    window->showBottomToolDock(window->m_assetBrowserDock);
+    app->processEvents();
+
+    EXPECT_FALSE(window->m_assetBrowserDock->isFloating());
+    EXPECT_EQ(window->dockWidgetArea(window->m_assetBrowserDock), Qt::BottomDockWidgetArea);
+    EXPECT_FALSE(window->m_assetBrowserDock->isHidden());
+    EXPECT_EQ(window->m_assetBrowserDock->widget()->maximumHeight(), 180);
+
+    window->m_assetBrowserDock->setFloating(true);
+    app->processEvents();
+    EXPECT_TRUE(window->m_assetBrowserDock->isFloating());
+
+    window->m_assetBrowserDock->hide();
+    app->processEvents();
+
+    window->showBottomToolDock(window->m_assetBrowserDock);
+    app->processEvents();
+
+    EXPECT_FALSE(window->m_assetBrowserDock->isFloating());
+    EXPECT_EQ(window->dockWidgetArea(window->m_assetBrowserDock), Qt::BottomDockWidgetArea);
+    EXPECT_FALSE(window->m_assetBrowserDock->isHidden());
+    EXPECT_LT(window->m_assetBrowserDock->maximumHeight(), QWIDGETSIZE_MAX);
+    EXPECT_EQ(window->m_assetBrowserDock->widget()->maximumHeight(), 180);
+}
+
 TEST_F(MainWindowTest, LoadFileQueuesNonSceneFileAndTracksRecentFiles)
 {
     ASSERT_TRUE(tempDir.isValid());

--- a/src/qml_resources.qrc
+++ b/src/qml_resources.qrc
@@ -24,6 +24,12 @@
     <file alias="ProfileGraph.qml">../qml/ProfileGraph.qml</file>
     <file alias="ThemedComboBox.qml">../qml/ThemedComboBox.qml</file>
   </qresource>
+  <qresource prefix="/ModeBar">
+    <file alias="ModeBar.qml">../qml/ModeBar.qml</file>
+  </qresource>
+  <qresource prefix="/BottomContextPanel">
+    <file alias="BottomContextPanel.qml">../qml/BottomContextPanel.qml</file>
+  </qresource>
   <qresource prefix="/AnimationControl">
     <file alias="AnimationControlPanel.qml">../qml/AnimationControlPanel.qml</file>
     <file alias="AnimationDopeSheet.qml">../qml/AnimationDopeSheet.qml</file>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -95,6 +95,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MaterialPreviewRenderer.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/EditableMesh.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/EditModeController.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/EditorModeController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/HalfEdgeMesh.cpp
 
         # PS1 importers are referenced by core code (MaterialEditorQML, MeshImporterExporter).
@@ -175,6 +176,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MaterialPreviewRenderer.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/EditableMesh.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/EditModeController.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/EditorModeController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/HalfEdgeMesh.h
     )
 


### PR DESCRIPTION
## Summary
- Adds the editor mode controller, mode bar, inspector tabs, bottom tool grouping, and bottom context panel UI surfaces.
- Clarifies whether transforms affect node placement or mesh geometry, including edit mode always reporting Mesh Geometry.
- Sets default viewport MSAA to 4x and near clip distance to 0.01, bumps the app version to 2.36.0, and adds focused coverage for the new UI/controller paths.

## Validation
- `cmake -S . -B build_local`
- `cmake --build build_local --target QtMeshEditor -j"$(nproc)"`
- `cmake --build build_local --target UnitTests -j"$(nproc)"`
- `qmllint qml/PropertiesPanel.qml qml/SceneTreeNode.qml qml/PreferencesDialog.qml qml/BottomContextPanel.qml qml/ModeBar.qml`
- `env QT_QPA_PLATFORM=offscreen build_local/bin/UnitTests --gtest_filter=OgreWidgetTest.ViewportDefaultsApplyWhenUnset:PropertiesPanelControllerTests.TransformTargetMetadataExplainsSelectionImpact:MainWindowTest.AssetBrowserMenuActionTracksDockVisibility:MainWindowTest.BottomToolDockRedocksAndUsesDefaultDockedHeight:EditorModeControllerTest.*`
- `build_local/bin/QtMeshEditor --version`

## Notes
- The accidental direct push to `master` was restored with normal revert commits because branch protection rejected force-pushing `master` back.
- A full `UnitTests` run aborted late in `MCPServerTest.CameraTools_WithMainWindowExecuteSuccessPaths` with an OGRE `MatPreviewRTT` cleanup exception; that same test passes when run alone, so this appears to be an existing order-dependent full-suite issue rather than a regression from this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – Version 2.36.0

* **New Features**
  * Added a dedicated mode bar for seamless switching between Object, Edit, Animation, Material, and Validation editor modes.
  * Introduced a bottom context panel displaying mode-specific metrics and action buttons.
  * Redesigned Properties panel with tabbed Inspector layout for improved organization.
  * Added type-based badges in the scene tree for better visual clarity.

* **Improvements**
  * Adjusted default near clip distance setting for improved viewport visibility.
  * Enhanced viewport settings management with configurable rendering parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->