### PR TITLE
Refine editor mode bar metadata

### DIFF
--- a/qml/ModeBar.qml
+++ b/qml/ModeBar.qml
@@ -9,13 +9,7 @@ Rectangle {
     color: PropertiesPanelController.headerColor
     implicitHeight: 38
 
-    property var modes: [
-        { label: "Object", mode: EditorModeController.ObjectMode, tip: "Object mode" },
-        { label: "Edit", mode: EditorModeController.EditMode, tip: "Edit mesh components" },
-        { label: "Animation", mode: EditorModeController.AnimationMode, tip: "Animation tools" },
-        { label: "Material", mode: EditorModeController.MaterialMode, tip: "Material tools" },
-        { label: "Validation", mode: EditorModeController.ValidationMode, tip: "Mesh validation" }
-    ]
+    property var modes: EditorModeController.availableModes
 
     RowLayout {
         anchors.fill: parent

--- a/qml/ModeBar.qml
+++ b/qml/ModeBar.qml
@@ -54,21 +54,12 @@ Rectangle {
                         cursorShape: Qt.PointingHandCursor
                         onClicked: EditorModeController.requestMode(modelData.mode)
                     }
-
-                    ToolTip.text: modelData.tip
-                    ToolTip.visible: modeMouse.containsMouse
                 }
             }
         }
 
-        Text {
+        Item {
             Layout.fillWidth: true
-            Layout.alignment: Qt.AlignVCenter
-            text: EditorModeController.statusText
-            color: PropertiesPanelController.textColor
-            elide: Text.ElideRight
-            font.pixelSize: 11
-            opacity: 0.82
         }
 
         Button {
@@ -79,8 +70,6 @@ Rectangle {
             implicitWidth: 76
             font.pixelSize: 11
             onClicked: EditorModeController.toggleObjectEditMode()
-            ToolTip.text: "Toggle Edit mode (Tab)"
-            ToolTip.visible: hovered
         }
     }
 }

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -97,53 +97,6 @@ Rectangle {
                 }
             }
 
-            // ---- Edit Mode Indicator ----
-            Rectangle {
-                width: parent.width
-                height: 32
-                color: EditModeController.editModeActive
-                    ? "#3d6b3d" : PropertiesPanelController.headerColor
-                visible: true
-
-                RowLayout {
-                    anchors.fill: parent
-                    anchors.leftMargin: 8
-                    anchors.rightMargin: 8
-                    spacing: 8
-
-                    Text {
-                        text: EditModeController.modeLabel
-                        color: PropertiesPanelController.textColor
-                        font.bold: true
-                        font.pixelSize: 12
-                        Layout.fillWidth: true
-                    }
-
-                    Text {
-                        text: EditModeController.editModeActive
-                            ? "V:" + EditModeController.vertexCount +
-                              " T:" + EditModeController.triangleCount +
-                              " S:" + EditModeController.subMeshCount
-                            : ""
-                        color: PropertiesPanelController.textColor
-                        font.pixelSize: 10
-                        opacity: 0.7
-                        visible: EditModeController.editModeActive
-                    }
-
-                    Button {
-                        text: EditModeController.editModeActive ? "Exit" : "Edit"
-                        enabled: EditModeController.editModeActive || EditModeController.canEnterEditMode
-                        implicitWidth: 48
-                        implicitHeight: 24
-                        font.pixelSize: 10
-                        ToolTip.text: "Toggle Edit Mode (Tab)"
-                        ToolTip.visible: hovered
-                        onClicked: EditorModeController.toggleObjectEditMode()
-                    }
-                }
-            }
-
             // ---- Selection Target Indicator ----
             Rectangle {
                 width: parent.width

--- a/src/EditorModeController.cpp
+++ b/src/EditorModeController.cpp
@@ -4,6 +4,7 @@
 #include "SentryReporter.h"
 
 #include <QJSEngine>
+#include <QVariantMap>
 
 EditorModeController* EditorModeController::m_pSingleton = nullptr;
 
@@ -83,6 +84,40 @@ QString EditorModeController::modeNameFor(int mode) const
     case ValidationMode: return QStringLiteral("Validation");
     }
     return QStringLiteral("Object");
+}
+
+QString EditorModeController::modeTooltipFor(int mode) const
+{
+    switch (static_cast<Mode>(mode)) {
+    case ObjectMode: return QStringLiteral("Object placement and scene organization");
+    case EditMode: return QStringLiteral("Edit mesh components");
+    case AnimationMode: return QStringLiteral("Animation playback and clip tools");
+    case MaterialMode: return QStringLiteral("Material assignment and editing");
+    case ValidationMode: return QStringLiteral("Mesh validation and scan tools");
+    }
+    return QStringLiteral("Object placement and scene organization");
+}
+
+QVariantList EditorModeController::availableModes() const
+{
+    QVariantList modes;
+    const QList<Mode> orderedModes = {
+        ObjectMode,
+        EditMode,
+        AnimationMode,
+        MaterialMode,
+        ValidationMode
+    };
+
+    for (Mode mode : orderedModes) {
+        QVariantMap entry;
+        entry.insert(QStringLiteral("mode"), static_cast<int>(mode));
+        entry.insert(QStringLiteral("label"), modeNameFor(static_cast<int>(mode)));
+        entry.insert(QStringLiteral("tip"), modeTooltipFor(static_cast<int>(mode)));
+        modes.push_back(entry);
+    }
+
+    return modes;
 }
 
 bool EditorModeController::editModeAvailable() const

--- a/src/EditorModeController.cpp
+++ b/src/EditorModeController.cpp
@@ -109,11 +109,15 @@ QVariantList EditorModeController::availableModes() const
         ValidationMode
     };
 
+    // The map intentionally exposes only `mode` and `label`. ModeBar.qml
+    // dropped tooltips in PR #433 to stop them from intercepting clicks on
+    // top-bar buttons, so a `tip` entry would be dead metadata. Tooltip text
+    // is still reachable through `Q_INVOKABLE modeTooltipFor(int)` for
+    // accessibility hooks and any future consumer.
     for (Mode mode : orderedModes) {
         QVariantMap entry;
         entry.insert(QStringLiteral("mode"), static_cast<int>(mode));
         entry.insert(QStringLiteral("label"), modeNameFor(static_cast<int>(mode)));
-        entry.insert(QStringLiteral("tip"), modeTooltipFor(static_cast<int>(mode)));
         modes.push_back(entry);
     }
 

--- a/src/EditorModeController.h
+++ b/src/EditorModeController.h
@@ -18,6 +18,12 @@ class EditorModeController : public QObject
     Q_PROPERTY(QString modeName READ modeName NOTIFY modeChanged)
     Q_PROPERTY(QString statusText READ statusText NOTIFY statusTextChanged)
     Q_PROPERTY(bool editModeAvailable READ editModeAvailable NOTIFY editModeAvailabilityChanged)
+    // `availableModes` is `CONSTANT` because the set of editor modes is fixed
+    // at compile time. If a future plugin/feature flag ever needs to gate a
+    // mode at runtime (e.g. hiding ValidationMode when the scan engine is
+    // disabled), drop CONSTANT, add an `availableModesChanged()` signal, and
+    // emit it whenever the list changes — otherwise QML bindings on this
+    // property will not refresh.
     Q_PROPERTY(QVariantList availableModes READ availableModes CONSTANT)
 
 public:

--- a/src/EditorModeController.h
+++ b/src/EditorModeController.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QQmlEngine>
 #include <QString>
+#include <QVariantList>
 
 class EditModeController;
 
@@ -17,6 +18,7 @@ class EditorModeController : public QObject
     Q_PROPERTY(QString modeName READ modeName NOTIFY modeChanged)
     Q_PROPERTY(QString statusText READ statusText NOTIFY statusTextChanged)
     Q_PROPERTY(bool editModeAvailable READ editModeAvailable NOTIFY editModeAvailabilityChanged)
+    Q_PROPERTY(QVariantList availableModes READ availableModes CONSTANT)
 
 public:
     enum Mode {
@@ -38,10 +40,12 @@ public:
     QString modeName() const;
     QString statusText() const { return m_statusText; }
     bool editModeAvailable() const;
+    QVariantList availableModes() const;
 
     Q_INVOKABLE void requestMode(int mode);
     Q_INVOKABLE void toggleObjectEditMode();
     Q_INVOKABLE QString modeNameFor(int mode) const;
+    Q_INVOKABLE QString modeTooltipFor(int mode) const;
 
 signals:
     void modeChanged();

--- a/src/EditorModeController_test.cpp
+++ b/src/EditorModeController_test.cpp
@@ -30,21 +30,40 @@ TEST_F(EditorModeControllerTest, AvailableModesExposeModeBarMetadata)
     const QVariantList modes = ctrl->availableModes();
 
     ASSERT_EQ(modes.size(), 5);
-    EXPECT_EQ(modes.at(0).toMap().value(QStringLiteral("mode")).toInt(),
-              EditorModeController::ObjectMode);
-    EXPECT_EQ(modes.at(0).toMap().value(QStringLiteral("label")).toString(),
-              QStringLiteral("Object"));
-    EXPECT_EQ(modes.at(0).toMap().value(QStringLiteral("tip")).toString(),
-              ctrl->modeTooltipFor(EditorModeController::ObjectMode));
 
-    EXPECT_EQ(modes.at(1).toMap().value(QStringLiteral("mode")).toInt(),
-              EditorModeController::EditMode);
-    EXPECT_EQ(modes.at(2).toMap().value(QStringLiteral("mode")).toInt(),
-              EditorModeController::AnimationMode);
-    EXPECT_EQ(modes.at(3).toMap().value(QStringLiteral("mode")).toInt(),
-              EditorModeController::MaterialMode);
-    EXPECT_EQ(modes.at(4).toMap().value(QStringLiteral("mode")).toInt(),
-              EditorModeController::ValidationMode);
+    const QList<QPair<EditorModeController::Mode, QString>> expected = {
+        {EditorModeController::ObjectMode,     QStringLiteral("Object")},
+        {EditorModeController::EditMode,       QStringLiteral("Edit")},
+        {EditorModeController::AnimationMode,  QStringLiteral("Animation")},
+        {EditorModeController::MaterialMode,   QStringLiteral("Material")},
+        {EditorModeController::ValidationMode, QStringLiteral("Validation")},
+    };
+
+    for (int i = 0; i < expected.size(); ++i) {
+        const QVariantMap entry = modes.at(i).toMap();
+        EXPECT_EQ(entry.value(QStringLiteral("mode")).toInt(),
+                  static_cast<int>(expected[i].first))
+            << "mode mismatch at index " << i;
+        EXPECT_EQ(entry.value(QStringLiteral("label")).toString(),
+                  expected[i].second)
+            << "label mismatch at index " << i;
+        // The map intentionally exposes only `mode` and `label`. `tip` was
+        // dropped when ModeBar.qml stopped using tooltips.
+        EXPECT_FALSE(entry.contains(QStringLiteral("tip")))
+            << "tip should not be exposed at index " << i;
+    }
+}
+
+TEST_F(EditorModeControllerTest, ModeTooltipsCoverAllModes)
+{
+    auto* ctrl = EditorModeController::instance();
+    // Tooltip strings remain reachable through Q_INVOKABLE for accessibility
+    // hooks even though ModeBar.qml no longer renders them.
+    EXPECT_FALSE(ctrl->modeTooltipFor(EditorModeController::ObjectMode).isEmpty());
+    EXPECT_FALSE(ctrl->modeTooltipFor(EditorModeController::EditMode).isEmpty());
+    EXPECT_FALSE(ctrl->modeTooltipFor(EditorModeController::AnimationMode).isEmpty());
+    EXPECT_FALSE(ctrl->modeTooltipFor(EditorModeController::MaterialMode).isEmpty());
+    EXPECT_FALSE(ctrl->modeTooltipFor(EditorModeController::ValidationMode).isEmpty());
 }
 
 TEST_F(EditorModeControllerTest, NonEditModesUpdateModeAndStatus)

--- a/src/EditorModeController_test.cpp
+++ b/src/EditorModeController_test.cpp
@@ -24,6 +24,29 @@ TEST_F(EditorModeControllerTest, ModeNamesCoverPublicModes)
     EXPECT_EQ(ctrl->modeNameFor(EditorModeController::ValidationMode), QStringLiteral("Validation"));
 }
 
+TEST_F(EditorModeControllerTest, AvailableModesExposeModeBarMetadata)
+{
+    auto* ctrl = EditorModeController::instance();
+    const QVariantList modes = ctrl->availableModes();
+
+    ASSERT_EQ(modes.size(), 5);
+    EXPECT_EQ(modes.at(0).toMap().value(QStringLiteral("mode")).toInt(),
+              EditorModeController::ObjectMode);
+    EXPECT_EQ(modes.at(0).toMap().value(QStringLiteral("label")).toString(),
+              QStringLiteral("Object"));
+    EXPECT_EQ(modes.at(0).toMap().value(QStringLiteral("tip")).toString(),
+              ctrl->modeTooltipFor(EditorModeController::ObjectMode));
+
+    EXPECT_EQ(modes.at(1).toMap().value(QStringLiteral("mode")).toInt(),
+              EditorModeController::EditMode);
+    EXPECT_EQ(modes.at(2).toMap().value(QStringLiteral("mode")).toInt(),
+              EditorModeController::AnimationMode);
+    EXPECT_EQ(modes.at(3).toMap().value(QStringLiteral("mode")).toInt(),
+              EditorModeController::MaterialMode);
+    EXPECT_EQ(modes.at(4).toMap().value(QStringLiteral("mode")).toInt(),
+              EditorModeController::ValidationMode);
+}
+
 TEST_F(EditorModeControllerTest, NonEditModesUpdateModeAndStatus)
 {
     auto* ctrl = EditorModeController::instance();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -11,6 +11,7 @@
 #include <QJsonObject>
 #include <QJsonValue>
 #include <QJsonArray>
+#include <QFontMetrics>
 #include <QPainter>
 #include <QPainterPath>
 #include <QPixmap>
@@ -1566,7 +1567,21 @@ void MainWindow::createModeSurfaces()
         m_modeBar->setResizeMode(QQuickWidget::SizeRootObjectToView);
         m_modeBar->setMinimumHeight(38);
         m_modeBar->setMaximumHeight(38);
-        m_modeBar->setMinimumWidth(560);
+        // Pick a minimum width wide enough to fit all five mode buttons plus
+        // the trailing Edit/Exit button without truncating labels. We derive
+        // it from the current font metrics so HiDPI / accessibility-scaled
+        // fonts don't end up clipped, with `kModeBarMinWidthFloor` as a
+        // safety net for unusually narrow fonts.
+        constexpr int kModeBarMinWidthFloor = 560;
+        const QFontMetrics fm(m_modeBar->font());
+        const int labelWidth = fm.horizontalAdvance(
+            QStringLiteral("Object Edit Animation Material Validation Edit"));
+        // Per-button chrome (border + padding + spacing) plus the Edit button
+        // and the layout's left/right margins (~10 px each side).
+        constexpr int kPerButtonChrome = 24;
+        constexpr int kButtons = 6; // 5 modes + Edit toggle
+        const int derivedWidth = labelWidth + kPerButtonChrome * kButtons + 40;
+        m_modeBar->setMinimumWidth(qMax(kModeBarMinWidthFloor, derivedWidth));
         m_modeBar->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
         m_modeBar->setSource(QUrl("qrc:/ModeBar/ModeBar.qml"));
         m_modeBarShell->addWidget(m_modeBar);
@@ -1848,10 +1863,10 @@ bool MainWindow::frameEnded(const Ogre::FrameEvent &evt)
     else
         statusMessage += "No selection";
 
-    // Editor mode status (e.g. "Object mode", "Edit mode (Vertex)")
-    const QString modeStatus = EditorModeController::instance()->statusText();
-    if (!modeStatus.isEmpty())
-        statusMessage += QString(" | %1").arg(modeStatus);
+    // The editor mode (e.g. "Object mode", "Edit mode (Vertex)") is rendered by
+    // the permanent `m_editModeLabel` widget on the right side of the status
+    // bar (see updateEditModeIndicator()). Don't append it here too — that
+    // would duplicate the same string on the rolling left-hand message.
 
     ui->statusBar->showMessage(statusMessage);
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1566,11 +1566,13 @@ void MainWindow::createModeSurfaces()
         m_modeBar->setResizeMode(QQuickWidget::SizeRootObjectToView);
         m_modeBar->setMinimumHeight(38);
         m_modeBar->setMaximumHeight(38);
-        m_modeBar->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+        m_modeBar->setMinimumWidth(560);
+        m_modeBar->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
         m_modeBar->setSource(QUrl("qrc:/ModeBar/ModeBar.qml"));
         m_modeBarShell->addWidget(m_modeBar);
 
         insertToolBar(ui->toolToolbar, m_modeBarShell);
+        insertToolBarBreak(ui->toolToolbar);
     }
 
     if (!m_bottomContextDock) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1848,6 +1848,11 @@ bool MainWindow::frameEnded(const Ogre::FrameEvent &evt)
     else
         statusMessage += "No selection";
 
+    // Editor mode status (e.g. "Object mode", "Edit mode (Vertex)")
+    const QString modeStatus = EditorModeController::instance()->statusText();
+    if (!modeStatus.isEmpty())
+        statusMessage += QString(" | %1").arg(modeStatus);
+
     ui->statusBar->showMessage(statusMessage);
 
     return true;

--- a/src/mainwindow_test.cpp
+++ b/src/mainwindow_test.cpp
@@ -31,6 +31,7 @@
 #include "SentryReporter.h"
 #include "TransformOperator.h"
 #include "EditModeController.h"
+#include "EditorModeController.h"
 #include "TestHelpers.h"
 #include "EditorViewport.h"
 #include "ViewportSettingsKeys.h"
@@ -200,6 +201,32 @@ TEST_F(MainWindowTest, RebuildAllOgreViewportsDoesNotCrash)
     auto* ow = window->mDockWidgetList.first()->getOgreWidget();
     ASSERT_NE(ow, nullptr);
     EXPECT_NO_THROW(ow->fsaaSamples());
+}
+
+TEST_F(MainWindowTest, ModeBarLoadsAndSelectionUpdatesStatusIndicator)
+{
+    ASSERT_NE(window->m_modeBarShell, nullptr);
+    ASSERT_NE(window->m_modeBar, nullptr);
+    ASSERT_NE(window->m_modeBar->rootObject(), nullptr);
+    ASSERT_EQ(window->m_modeBar->status(), QQuickWidget::Ready);
+    EXPECT_GE(window->m_modeBar->minimumWidth(), 560);
+    EXPECT_EQ(window->toolBarArea(window->m_modeBarShell), Qt::TopToolBarArea);
+    EXPECT_FALSE(window->m_modeBarShell->isHidden());
+    ASSERT_NE(window->m_editModeLabel, nullptr);
+
+    auto* modeController = EditorModeController::instance();
+
+    modeController->requestMode(EditorModeController::AnimationMode);
+    app->processEvents();
+    EXPECT_EQ(modeController->currentMode(), EditorModeController::AnimationMode);
+    EXPECT_EQ(modeController->statusText(), QStringLiteral("Animation mode"));
+    EXPECT_EQ(window->m_editModeLabel->text(), QStringLiteral("Animation mode"));
+
+    modeController->requestMode(EditorModeController::MaterialMode);
+    app->processEvents();
+    EXPECT_EQ(modeController->currentMode(), EditorModeController::MaterialMode);
+    EXPECT_EQ(modeController->statusText(), QStringLiteral("Material mode"));
+    EXPECT_EQ(window->m_editModeLabel->text(), QStringLiteral("Material mode"));
 }
 
 // ---- Cycle all transform states via keyboard ----

--- a/src/mainwindow_test.cpp
+++ b/src/mainwindow_test.cpp
@@ -78,6 +78,11 @@ protected:
     void TearDown() override {
         delete window;
         window = nullptr;
+        // Tests below switch the editor mode (Animation/Material/etc). Reset
+        // the singleton so subsequent test cases see a fresh ObjectMode
+        // controller — otherwise stale state leaks into m_editModeLabel and
+        // any test that implicitly assumes the default mode.
+        EditorModeController::kill();
         QSettings().clear();
         QCoreApplication::setOrganizationName(previousOrganizationName);
         QCoreApplication::setApplicationName(previousApplicationName);
@@ -203,7 +208,7 @@ TEST_F(MainWindowTest, RebuildAllOgreViewportsDoesNotCrash)
     EXPECT_NO_THROW(ow->fsaaSamples());
 }
 
-TEST_F(MainWindowTest, ModeBarLoadsAndSelectionUpdatesStatusIndicator)
+TEST_F(MainWindowTest, ModeBarLoadsAndModeChangeUpdatesStatusIndicator)
 {
     ASSERT_NE(window->m_modeBarShell, nullptr);
     ASSERT_NE(window->m_modeBar, nullptr);


### PR DESCRIPTION
## Summary
- Moves mode-bar button metadata into `EditorModeController` so QML renders a controller-owned list instead of duplicating mode labels/tooltips.
- Adds mode tooltip metadata as an invokable controller API for QML and tests.
- Adds focused tests for mode-bar metadata and main-window status indicator updates when switching modes.

## UX changes & user-visible removals
- The Properties panel no longer shows the green "Edit Mode" strip. With it goes:
  - the inline **Edit / Exit** button (still reachable via `Tab` and the Mode Bar's Edit toggle),
  - the **V / T / S** counts (vertices / triangles / submeshes) that lit up while in Edit mode.
- Mode tooltips on the Mode Bar were also dropped because they were intercepting clicks on the buttons. Tooltip strings are still reachable through `EditorModeController::modeTooltipFor(int)` for accessibility / future consumers.
- The current editor mode now appears as a permanent label on the right-hand side of the main status bar (driven by `updateEditModeIndicator()`), keeping it always visible without claiming Mode-Bar real estate.

## Validation
- `qmllint qml/ModeBar.qml`
- `cmake --build build_local --target UnitTests -j"$(nproc)"`
- `env QT_QPA_PLATFORM=offscreen build_local/bin/UnitTests --gtest_filter=EditorModeControllerTest.*:MainWindowTest.ModeBarLoadsAndModeChangeUpdatesStatusIndicator`
- `cmake --build build_local --target QtMeshEditor -j"$(nproc)"`

## Tracker
- #391, Slice 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mode selection now exposes descriptive tooltips for each editing mode.

* **Improvements**
  * Mode bar is sourced dynamically and its toolbar sizing/docking updated for improved layout.
  * Editor mode shown via a permanent status label (no longer appended to rolling status messages).

* **Bug Fixes / UI Changes**
  * Removed the Edit/Exit toggle and edit-mode indicator from the properties panel.

* **Tests**
  * Added tests validating available modes and mode-bar initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->