### PR TITLE
feat(materials): real PBR shading via SRS_COOK_TORRANCE_LIGHTING (slice F1)

### DIFF
--- a/src/MaterialEditorQML.cpp
+++ b/src/MaterialEditorQML.cpp
@@ -308,6 +308,13 @@ bool MaterialEditorQML::applyMaterial()
         if (m_ogreMaterial) {
             wirePbrSlotsForFFP(m_ogreMaterial.get());
             m_ogreMaterial->compile();
+            // Slice F: if user-edited material text carries the
+            // pbr_workflow tag (e.g. they hand-typed it, or the script
+            // came from MaterialPresetLibrary's PBR templates),
+            // upgrade FFP wiring to Cook-Torrance via Ogre's stock
+            // SRS_COOK_TORRANCE_LIGHTING. Returns false silently for
+            // non-tagged materials → slice E FFP wiring stays.
+            RTShaderHelper::applyPbrIfTagged(m_ogreMaterial);
         }
 
         // Re-apply the edited material to sub-entities that use it.
@@ -1656,6 +1663,14 @@ void MaterialEditorQML::updateMaterialText()
 
         // Recompile the material
         m_ogreMaterial->compile();
+
+        // Slice F: upgrade tagged metallic_roughness materials to the
+        // Cook-Torrance SRS. Runs after compile so the SRS sees the
+        // final pass state (FFP wiring above is harmless — when
+        // applyPbrIfTagged returns true, RTSS replaces the FFP path).
+        // Returns false for non-tagged materials → FFP path stays.
+        const bool pbrApplied = RTShaderHelper::applyPbrIfTagged(m_ogreMaterial);
+        (void)pbrApplied;
 
         // If the material has a normal_map TUS with a texture set, re-wire
         // it through SRS_NORMALMAP. Without this, dropping all shader

--- a/src/MaterialPresetLibrary.cpp
+++ b/src/MaterialPresetLibrary.cpp
@@ -1,5 +1,6 @@
 #include "MaterialPresetLibrary.h"
 #include "Manager.h"
+#include "RTShaderHelper.h"
 #include "SelectionSet.h"
 #include "SentryReporter.h"
 #include "UndoManager.h"
@@ -227,6 +228,15 @@ void MaterialPresetLibrary::applyPreset(const QString& name)
         // re-shuffles), which causes getTechnique(0)->getPass(0) to lose
         // slots. Tests + slice F shaders need the slot count preserved.
         mat->compile(/*autoManageTextureUnits=*/false);
+
+        // Slice F: if the just-built material is tagged with the
+        // metallic_roughness PBR workflow, attach Ogre's stock
+        // SRS_COOK_TORRANCE_LIGHTING SRS so it renders with a real
+        // Cook-Torrance BRDF instead of the slice E FFP approximation.
+        // applyPbrIfTagged returns false (and the material falls back
+        // to FFP) for other workflows or when SRS_COOK_TORRANCE_LIGHTING
+        // isn't built into the running Ogre.
+        RTShaderHelper::applyPbrIfTagged(mat);
     }
 
     // Apply to resolved entities (handles node selection as well as direct entity/sub-entity selection)

--- a/src/MaterialPresetLibrary_test.cpp
+++ b/src/MaterialPresetLibrary_test.cpp
@@ -535,9 +535,26 @@ TEST_F(MaterialPresetLibraryTests, MetallicRoughnessPresetAttachesPbrShaderTechn
             break;
         }
     }
-    EXPECT_TRUE(hasShaderTech)
+    ASSERT_TRUE(hasShaderTech)
         << "Metallic-Roughness preset must produce an RTSS shader technique "
-           "(SRS_COOK_TORRANCE_LIGHTING via applyPbrIfTagged)";
+           "(via applyPbrIfTagged → createShaderBasedTechnique)";
+
+    // Stronger assertion: the RTSS RenderState for this material must
+    // carry the SRS_COOK_TORRANCE_LIGHTING SubRenderState specifically.
+    // Without this, a regression that drops the Cook-Torrance SRS but
+    // leaves a default-Phong RTSS technique attached would still pass
+    // hasShaderTech above (false confidence).
+    auto* shaderGen = Ogre::RTShader::ShaderGenerator::getSingletonPtr();
+    ASSERT_NE(shaderGen, nullptr);
+    auto* renderState = shaderGen->getRenderState(
+        Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME, *mat, 0);
+    ASSERT_NE(renderState, nullptr) << "RTSS render state missing post-apply";
+    auto* cookSRS = renderState->getSubRenderState(
+        Ogre::RTShader::SRS_COOK_TORRANCE_LIGHTING);
+    EXPECT_NE(cookSRS, nullptr)
+        << "Cook-Torrance SubRenderState not attached — slice F1 PBR path "
+           "did not run, or createSubRenderState returned null and the "
+           "function silently fell through.";
 }
 
 // Non-PBR presets must NOT trigger the Cook-Torrance path — they use
@@ -550,6 +567,13 @@ TEST_F(MaterialPresetLibraryTests, NonPbrPresetDoesNotAttachPbrShaderTechnique) 
     ASSERT_TRUE(canLoadMeshFiles());
     createStandardOgreMaterials();
 
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    ASSERT_NE(sceneMgr, nullptr);
+    RTShaderHelper::initialize(sceneMgr);
+    auto rtssShutdown = qScopeGuard([sceneMgr] {
+        RTShaderHelper::shutdown(sceneMgr);
+    });
+
     Ogre::Entity* entity = createSelectedEntity(
         "NonPbr_Node", "NonPbr_Entity", "NonPbr_Mesh");
     ASSERT_NE(entity, nullptr);
@@ -559,14 +583,33 @@ TEST_F(MaterialPresetLibraryTests, NonPbrPresetDoesNotAttachPbrShaderTechnique) 
     auto mat = Ogre::MaterialManager::getSingleton().getByName("Preset/Plastic (Red)");
     ASSERT_TRUE(bool(mat));
 
-    // The Plastic preset's pass has no `pbr_workflow` user-binding, so
-    // applyPbrIfTagged returns early without creating a shader-based
-    // technique. The material may pick up an RTSS technique later via
-    // handleSchemeNotFound (FFP-derived), but applyPreset itself should
-    // not have triggered one.
+    // The Plastic preset's pass has no `pbr_workflow` user-binding, and
+    // its TUS layout doesn't match the 6-slot PBR layout either, so
+    // applyPbrIfTagged must early-return without creating a shader
+    // technique. Verify both signals.
     auto* pass = mat->getTechnique(0)->getPass(0);
     auto tag = pass->getUserObjectBindings().getUserAny(
         MaterialPresetLibrary::kPbrWorkflowKey);
     EXPECT_FALSE(tag.has_value())
         << "Plastic preset must not carry a pbr_workflow tag";
+
+    // Stronger guarantee: no RTSS scheme technique attached *because of*
+    // applyPreset. Future calls (e.g. handleSchemeNotFound on first render)
+    // may add one for FFP shading later — that's fine; the assertion is
+    // simply that applyPreset itself did not trigger a Cook-Torrance
+    // technique. We check the SRS list under the ShaderGenerator scheme.
+    auto* shaderGen = Ogre::RTShader::ShaderGenerator::getSingletonPtr();
+    ASSERT_NE(shaderGen, nullptr);
+    if (shaderGen->hasRenderState(
+            Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME)) {
+        auto* renderState = shaderGen->getRenderState(
+            Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME, *mat, 0);
+        if (renderState) {
+            auto* cookSRS = renderState->getSubRenderState(
+                Ogre::RTShader::SRS_COOK_TORRANCE_LIGHTING);
+            EXPECT_EQ(cookSRS, nullptr)
+                << "Plastic preset unexpectedly produced a Cook-Torrance SRS — "
+                   "applyPbrIfTagged should reject non-PBR materials.";
+        }
+    }
 }

--- a/src/MaterialPresetLibrary_test.cpp
+++ b/src/MaterialPresetLibrary_test.cpp
@@ -3,6 +3,7 @@
 #include "Manager.h"
 #include "SelectionSet.h"
 #include "TestHelpers.h"
+#include <OgreRTShaderSystem.h>
 #include <QApplication>
 #include <QCoreApplication>
 #include <QSignalSpy>
@@ -480,4 +481,76 @@ TEST_F(MaterialPresetLibraryTests, PbrSlotColourOpsApproximatePbrSemantics) {
     EXPECT_EQ(roughBlend.operation, Ogre::LBX_MODULATE_X2);
     EXPECT_EQ(roughBlend.source1,   Ogre::LBS_TEXTURE);
     EXPECT_EQ(roughBlend.source2,   Ogre::LBS_CURRENT);
+}
+
+// Slice F1: Metallic-Roughness preset auto-attaches Ogre's stock
+// SRS_COOK_TORRANCE_LIGHTING SubRenderState via
+// RTShaderHelper::applyPbrIfTagged. Without this, the preset would
+// only render via slice E's FFP approximation. We verify it by checking
+// that the material gained a non-default-scheme technique (the RTSS
+// shader-generated one) after applyPreset returns. The exact scheme
+// name comes from ShaderGenerator::DEFAULT_SCHEME_NAME ("ShaderGeneratorDefaultScheme")
+// — different from MaterialManager's default scheme used by FFP.
+TEST_F(MaterialPresetLibraryTests, MetallicRoughnessPresetAttachesPbrShaderTechnique) {
+    Manager::kill();
+    QThread::msleep(50);
+    ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+    ASSERT_TRUE(canLoadMeshFiles());
+    createStandardOgreMaterials();
+
+    Ogre::Entity* entity = createSelectedEntity(
+        "PbrShader_Node", "PbrShader_Entity", "PbrShader_Mesh");
+    ASSERT_NE(entity, nullptr);
+
+    MaterialPresetLibrary::instance()->applyPreset("Metallic-Roughness");
+
+    auto mat = Ogre::MaterialManager::getSingleton().getByName("Preset/Metallic-Roughness");
+    ASSERT_TRUE(bool(mat));
+
+    // applyPbrIfTagged calls createShaderBasedTechnique, which adds a
+    // technique to the material under the RTSS scheme name. Count
+    // techniques whose scheme matches the ShaderGenerator's scheme.
+    bool hasShaderTech = false;
+    const auto& shaderGenScheme =
+        Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME;
+    for (auto* tech : mat->getTechniques()) {
+        if (tech->getSchemeName() == shaderGenScheme) {
+            hasShaderTech = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(hasShaderTech)
+        << "Metallic-Roughness preset must produce an RTSS shader technique "
+           "(SRS_COOK_TORRANCE_LIGHTING via applyPbrIfTagged)";
+}
+
+// Non-PBR presets must NOT trigger the Cook-Torrance path — they use
+// the legacy FFP rendering only. Plastic is the canonical legacy preset
+// (no `pbr_workflow` tag set on its pass).
+TEST_F(MaterialPresetLibraryTests, NonPbrPresetDoesNotAttachPbrShaderTechnique) {
+    Manager::kill();
+    QThread::msleep(50);
+    ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+    ASSERT_TRUE(canLoadMeshFiles());
+    createStandardOgreMaterials();
+
+    Ogre::Entity* entity = createSelectedEntity(
+        "NonPbr_Node", "NonPbr_Entity", "NonPbr_Mesh");
+    ASSERT_NE(entity, nullptr);
+
+    MaterialPresetLibrary::instance()->applyPreset("Plastic (Red)");
+
+    auto mat = Ogre::MaterialManager::getSingleton().getByName("Preset/Plastic (Red)");
+    ASSERT_TRUE(bool(mat));
+
+    // The Plastic preset's pass has no `pbr_workflow` user-binding, so
+    // applyPbrIfTagged returns early without creating a shader-based
+    // technique. The material may pick up an RTSS technique later via
+    // handleSchemeNotFound (FFP-derived), but applyPreset itself should
+    // not have triggered one.
+    auto* pass = mat->getTechnique(0)->getPass(0);
+    auto tag = pass->getUserObjectBindings().getUserAny(
+        MaterialPresetLibrary::kPbrWorkflowKey);
+    EXPECT_FALSE(tag.has_value())
+        << "Plastic preset must not carry a pbr_workflow tag";
 }

--- a/src/MaterialPresetLibrary_test.cpp
+++ b/src/MaterialPresetLibrary_test.cpp
@@ -1,11 +1,13 @@
 #include <gtest/gtest.h>
 #include "MaterialPresetLibrary.h"
 #include "Manager.h"
+#include "RTShaderHelper.h"
 #include "SelectionSet.h"
 #include "TestHelpers.h"
 #include <OgreRTShaderSystem.h>
 #include <QApplication>
 #include <QCoreApplication>
+#include <QScopeGuard>
 #include <QSignalSpy>
 #include <QThread>
 
@@ -486,17 +488,23 @@ TEST_F(MaterialPresetLibraryTests, PbrSlotColourOpsApproximatePbrSemantics) {
 // Slice F1: Metallic-Roughness preset auto-attaches Ogre's stock
 // SRS_COOK_TORRANCE_LIGHTING SubRenderState via
 // RTShaderHelper::applyPbrIfTagged. Without this, the preset would
-// only render via slice E's FFP approximation. We verify it by checking
-// that the material gained a non-default-scheme technique (the RTSS
-// shader-generated one) after applyPreset returns. The exact scheme
-// name comes from ShaderGenerator::DEFAULT_SCHEME_NAME ("ShaderGeneratorDefaultScheme")
-// — different from MaterialManager's default scheme used by FFP.
+// only render via slice E's FFP approximation. We initialize RTSS
+// explicitly in this test (production launches do this in
+// Manager::loadResources, but the test fixture's tryInitOgre() does
+// not run that path).
 TEST_F(MaterialPresetLibraryTests, MetallicRoughnessPresetAttachesPbrShaderTechnique) {
     Manager::kill();
     QThread::msleep(50);
     ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
     ASSERT_TRUE(canLoadMeshFiles());
     createStandardOgreMaterials();
+
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    ASSERT_NE(sceneMgr, nullptr);
+    RTShaderHelper::initialize(sceneMgr);
+    auto rtssShutdown = qScopeGuard([sceneMgr] {
+        RTShaderHelper::shutdown(sceneMgr);
+    });
 
     Ogre::Entity* entity = createSelectedEntity(
         "PbrShader_Node", "PbrShader_Entity", "PbrShader_Mesh");
@@ -506,6 +514,14 @@ TEST_F(MaterialPresetLibraryTests, MetallicRoughnessPresetAttachesPbrShaderTechn
 
     auto mat = Ogre::MaterialManager::getSingleton().getByName("Preset/Metallic-Roughness");
     ASSERT_TRUE(bool(mat));
+
+    // The workflow tag must be set regardless of RTSS state.
+    auto* pass = mat->getTechnique(0)->getPass(0);
+    auto tag = pass->getUserObjectBindings().getUserAny(
+        MaterialPresetLibrary::kPbrWorkflowKey);
+    ASSERT_TRUE(tag.has_value());
+    EXPECT_EQ(Ogre::any_cast<Ogre::String>(tag),
+              Ogre::String(MaterialPresetLibrary::kPbrWorkflowMetallic));
 
     // applyPbrIfTagged calls createShaderBasedTechnique, which adds a
     // technique to the material under the RTSS scheme name. Count

--- a/src/RTShaderHelper.cpp
+++ b/src/RTShaderHelper.cpp
@@ -326,3 +326,130 @@ void RTShaderHelper::applyNormalMap(Ogre::MaterialPtr& mat, const std::string& n
 }
 
 // LCOV_EXCL_STOP
+
+namespace {
+
+/// Look up the slice E `pbr_workflow` user-binding key on a pass and
+/// return the workflow string ("metallic_roughness", "specular_glossiness",
+/// "unlit") or empty if absent. Mirrors the key constant defined in
+/// MaterialPresetLibrary.h without taking a header dependency on it.
+constexpr const char* kPbrWorkflowKey = "pbr_workflow";
+
+Ogre::String readPbrWorkflowTag(const Ogre::Pass* pass)
+{
+    if (!pass) return {};
+    const auto& bindings = pass->getUserObjectBindings();
+    auto any = bindings.getUserAny(kPbrWorkflowKey);
+    if (!any.has_value()) return {};
+    try { return Ogre::any_cast<Ogre::String>(any); }
+    catch (...) { return {}; }
+}
+
+/// Find the texture name on a TUS slot by name. Returns empty if the
+/// slot doesn't exist or has no texture set.
+Ogre::String textureOnSlot(const Ogre::Pass* pass, const Ogre::String& slotName)
+{
+    if (!pass) return {};
+    for (unsigned short i = 0; i < pass->getNumTextureUnitStates(); ++i) {
+        const auto* tus = pass->getTextureUnitState(i);
+        if (tus->getName() == slotName)
+            return tus->getTextureName();
+    }
+    return {};
+}
+
+} // namespace
+
+bool RTShaderHelper::applyPbrIfTagged(Ogre::MaterialPtr& mat)
+{
+    if (!mat || mat->getNumTechniques() == 0) return false;
+    auto* srcPass = mat->getTechnique(0)->getPass(0);
+    const Ogre::String workflow = readPbrWorkflowTag(srcPass);
+
+    // Slice F1 wires only metallic_roughness via Ogre's stock SRS.
+    // Specular-Glossiness and Unlit keep slice E's FFP wiring.
+    if (workflow != "metallic_roughness") return false;
+
+    auto* shaderGen = Ogre::RTShader::ShaderGenerator::getSingletonPtr();
+    if (!shaderGen) return false;
+
+    try {
+        if (!mat->isLoaded())
+            mat->load();
+
+        // Drop any pre-existing RTSS technique so we replace it with
+        // the Cook-Torrance one cleanly. Without this, an FFP-derived
+        // RTSS technique from handleSchemeNotFound persists alongside.
+        Ogre::Technique* srcTech = nullptr;
+        for (auto* t : mat->getTechniques()) {
+            if (t->getSchemeName() == Ogre::MaterialManager::DEFAULT_SCHEME_NAME) {
+                srcTech = t;
+                break;
+            }
+        }
+        if (srcTech) {
+            shaderGen->removeShaderBasedTechnique(
+                srcTech, Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME);
+        }
+
+        bool created = shaderGen->createShaderBasedTechnique(
+            *mat,
+            Ogre::MaterialManager::DEFAULT_SCHEME_NAME,
+            Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME);
+        if (!created) {
+            Ogre::LogManager::getSingleton().logMessage(
+                "RTShaderHelper: PBR technique creation failed for '" + mat->getName() + "'");
+            return false;
+        }
+
+        auto* renderState = shaderGen->getRenderState(
+            Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME, *mat, 0);
+        if (!renderState) return false;
+
+        // Reset to built-in SRSes so we don't accumulate stale state
+        // (e.g., a previous SRS_NORMALMAP with a different texture_index).
+        // We add SRS_COOK_TORRANCE_LIGHTING explicitly; the normal-map
+        // SRS is added separately by applyNormalMap when called.
+        renderState->resetToBuiltinSubRenderStates();
+
+        auto* pbrSRS = shaderGen->createSubRenderState(
+            Ogre::RTShader::SRS_COOK_TORRANCE_LIGHTING);
+        if (!pbrSRS) {
+            Ogre::LogManager::getSingleton().logMessage(
+                "RTShaderHelper: SRS_COOK_TORRANCE_LIGHTING unavailable in this Ogre build");
+            return false;
+        }
+
+        // glTF MR-texture convention: a single RGBA texture with
+        // .r=AO, .g=roughness, .b=metallic. If the user populated the
+        // `metallic` slot (most common), use that as the packed map.
+        // The SRS's `texture` parameter expects the texture *name*.
+        const Ogre::String mrTexName = textureOnSlot(srcPass, "metallic");
+        if (!mrTexName.empty()) {
+            pbrSRS->setParameter("texture", mrTexName);
+        }
+        // No mr texture → SRS uses ACT_SURFACE_SPECULAR_COLOUR.xy as
+        // metal/roughness scalars. We could route the pass shininess
+        // here in a future revision, but the Phong approximation set
+        // by MaterialPresetLibrary already feeds setSpecular/setShininess.
+
+        renderState->addTemplateSubRenderState(pbrSRS);
+
+        shaderGen->invalidateMaterial(
+            Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME, mat->getName());
+        shaderGen->validateMaterial(
+            Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME, *mat);
+
+        Ogre::LogManager::getSingleton().logMessage(
+            "RTShaderHelper: PBR (Cook-Torrance) applied to '" + mat->getName() +
+            (mrTexName.empty() ? "' [no MR texture]" : "' tex='" + mrTexName + "'"));
+        return true;
+    } catch (const Ogre::Exception& e) {
+        Ogre::LogManager::getSingleton().logMessage(
+            "RTShaderHelper: Ogre exception applying PBR: " + e.getDescription());
+    } catch (const std::exception& e) {
+        Ogre::LogManager::getSingleton().logMessage(
+            "RTShaderHelper: Exception applying PBR: " + std::string(e.what()));
+    }
+    return false;
+}

--- a/src/RTShaderHelper.cpp
+++ b/src/RTShaderHelper.cpp
@@ -358,13 +358,49 @@ Ogre::String textureOnSlot(const Ogre::Pass* pass, const Ogre::String& slotName)
     return {};
 }
 
+bool hasNamedTUS(const Ogre::Pass* pass, const Ogre::String& slotName)
+{
+    if (!pass) return false;
+    for (unsigned short i = 0; i < pass->getNumTextureUnitStates(); ++i) {
+        if (pass->getTextureUnitState(i)->getName() == slotName)
+            return true;
+    }
+    return false;
+}
+
+/// MaterialSerializer does NOT serialize Pass::UserObjectBindings, so the
+/// pbr_workflow tag is lost on script round-trip (e.g., user edits the
+/// material text and clicks Apply). Fall back to detecting PBR layout by
+/// the canonical slot names: a pass with all 6 named slots is treated as
+/// metallic-roughness PBR. Slice F2 may add an explicit serialized signal
+/// (script-level extension or material-name convention) — for now this
+/// keeps the text-edit path working.
+bool detectMetallicRoughnessByLayout(const Ogre::Pass* pass)
+{
+    return hasNamedTUS(pass, "albedo")
+        && hasNamedTUS(pass, "normal_map")
+        && hasNamedTUS(pass, "metallic")
+        && hasNamedTUS(pass, "roughness")
+        && hasNamedTUS(pass, "ao")
+        && hasNamedTUS(pass, "emissive");
+}
+
 } // namespace
 
 bool RTShaderHelper::applyPbrIfTagged(Ogre::MaterialPtr& mat)
 {
     if (!mat || mat->getNumTechniques() == 0) return false;
     auto* srcPass = mat->getTechnique(0)->getPass(0);
-    const Ogre::String workflow = readPbrWorkflowTag(srcPass);
+    Ogre::String workflow = readPbrWorkflowTag(srcPass);
+
+    // MaterialSerializer drops UserObjectBindings, so the tag is missing
+    // after parseScript round-trips. Fall back to slot-layout detection
+    // when the tag is absent. Specular-Glossiness and Unlit aren't yet
+    // distinguishable from layout alone, so layout-detection only
+    // promotes to metallic_roughness.
+    if (workflow.empty() && detectMetallicRoughnessByLayout(srcPass)) {
+        workflow = "metallic_roughness";
+    }
 
     // Slice F1 wires only metallic_roughness via Ogre's stock SRS.
     // Specular-Glossiness and Unlit keep slice E's FFP wiring.
@@ -372,6 +408,24 @@ bool RTShaderHelper::applyPbrIfTagged(Ogre::MaterialPtr& mat)
 
     auto* shaderGen = Ogre::RTShader::ShaderGenerator::getSingletonPtr();
     if (!shaderGen) return false;
+
+    // Helper to drop any RTSS technique we may have created so the
+    // material returns to a clean FFP-only state on bail-out paths.
+    // Without this, a partial technique created by
+    // createShaderBasedTechnique persists when getRenderState or
+    // createSubRenderState fail later — handleSchemeNotFound then
+    // validates it as plain Phong, silently overriding the FFP fallback.
+    auto cleanupRtssTech = [&]() {
+        if (!mat) return;
+        for (auto* t : mat->getTechniques()) {
+            if (t->getSchemeName() ==
+                Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME) {
+                shaderGen->removeShaderBasedTechnique(
+                    t, Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME);
+                break;
+            }
+        }
+    };
 
     try {
         if (!mat->isLoaded())
@@ -404,7 +458,10 @@ bool RTShaderHelper::applyPbrIfTagged(Ogre::MaterialPtr& mat)
 
         auto* renderState = shaderGen->getRenderState(
             Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME, *mat, 0);
-        if (!renderState) return false;
+        if (!renderState) {
+            cleanupRtssTech();
+            return false;
+        }
 
         // Reset to built-in SRSes so we don't accumulate stale state
         // (e.g., a previous SRS_NORMALMAP with a different texture_index).
@@ -417,6 +474,7 @@ bool RTShaderHelper::applyPbrIfTagged(Ogre::MaterialPtr& mat)
         if (!pbrSRS) {
             Ogre::LogManager::getSingleton().logMessage(
                 "RTShaderHelper: SRS_COOK_TORRANCE_LIGHTING unavailable in this Ogre build");
+            cleanupRtssTech();
             return false;
         }
 

--- a/src/RTShaderHelper.h
+++ b/src/RTShaderHelper.h
@@ -6,4 +6,27 @@ namespace RTShaderHelper {
     void initialize(Ogre::SceneManager* sceneMgr);
     void shutdown(Ogre::SceneManager* sceneMgr);
     void applyNormalMap(Ogre::MaterialPtr& mat, const std::string& normalMapTexName);
+
+    /// If the material's first pass is tagged with the slice E
+    /// `pbr_workflow` user-binding (set by MaterialPresetLibrary's PBR
+    /// templates), wire Ogre's stock SRS_COOK_TORRANCE_LIGHTING SRS
+    /// for the metal-roughness workflow. Replaces slice E's FFP
+    /// approximations (LBX_ADD_SIGNED metallic, LBX_MODULATE_X2
+    /// roughness, etc.) with a real Cook-Torrance BRDF.
+    ///
+    /// The SRS expects a single packed RGBA texture: .r = AO,
+    /// .g = roughness, .b = metallic (the glTF MR-texture
+    /// convention). If the material has a `metallic` TUS with a
+    /// texture set, that texture is used as the packed map. If only
+    /// separate `roughness` / `ao` TUSs have textures, the SRS uses
+    /// the default ACT_SURFACE_SPECULAR_COLOUR.xy fallback for the
+    /// metal-roughness params.
+    ///
+    /// Returns true if the SRS was applied (workflow=metallic_roughness),
+    /// false otherwise (other workflows, no tag, or PBR runtime support
+    /// missing — caller falls back to slice E's FFP wiring).
+    ///
+    /// Specular-Glossiness and Unlit workflows are not yet supported by
+    /// this helper — those keep their slice E FFP approximations.
+    bool applyPbrIfTagged(Ogre::MaterialPtr& mat);
 }


### PR DESCRIPTION
## Summary

Slice F1 — wire Ogre's stock `SRS_COOK_TORRANCE_LIGHTING` SubRenderState (already in the framework as `OgreShaderCookTorranceLighting`) when the slice E `pbr_workflow` user-binding tag on the Pass is `metallic_roughness`. Replaces slice E's FFP approximations (`LBX_ADD_SIGNED` metallic, `LBX_MODULATE_X2` roughness) with a real Cook-Torrance BRDF: GGX distribution, Schlick Fresnel, Smith geometry. Shader source comes from Ogre's bundled `SGXLib_CookTorrance.glsl` — no custom shader code needed.

## API

```cpp
bool RTShaderHelper::applyPbrIfTagged(Ogre::MaterialPtr&);
```

Checks the pass for the `pbr_workflow` tag (`MaterialPresetLibrary::kPbrWorkflowKey`). When it's `metallic_roughness`, drops any pre-existing RTSS technique and creates a new one driven by `SRS_COOK_TORRANCE_LIGHTING`. Returns `true` on attach, `false` on other workflows / no tag / SRS unavailable.

## Auto-wiring

- `MaterialPresetLibrary::applyPreset` calls it after `mat->compile()`, so the Inspector PBR chips light up with real shading on apply.
- `MaterialEditorQML::applyMaterial` and `updateMaterialText` call it after compile, so user-edited PBR-tagged materials get upgraded too.

## Texture convention (glTF)

Pack metal-roughness into a single RGBA in the `metallic` slot:
- `.r` → AO
- `.g` → roughness
- `.b` → metallic

If empty, the SRS uses `ACT_SURFACE_SPECULAR_COLOUR.xy` as scalar fallbacks (the Phong values from `applyPbrTemplate` already feed this).

## Out of scope (slice F2 territory)

- **Specular-Glossiness** — no equivalent stock SRS in Ogre yet, keeps slice E FFP wiring.
- **Unlit PBR** — `setLightingEnabled(false)` is fine; no shader needed.

## Test plan

- [x] **2 new `MaterialPresetLibraryTests`**:
  - `MetallicRoughnessPresetAttachesPbrShaderTechnique` — M-R preset produces an RTSS scheme technique post-apply.
  - `NonPbrPresetDoesNotAttachPbrShaderTechnique` — Plastic (Red) does not.
- [x] Build clean on macOS arm64 (Qt 6.9.3 + Ogre 14.5.x).
- [x] Smoke-tested on macOS: M-R preset on a sphere primitive logs `RTShaderHelper: PBR (Cook-Torrance) applied to 'Preset/Metallic-Roughness'` and renders.
- [ ] Linux CI runs the new gtest suites under Xvfb.
- [ ] Manual verification: drop a packed glTF metal-roughness texture into the `metallic` slot of an M-R preset and confirm specular response shifts with metalness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for physically-based rendering (PBR) materials with metallic-roughness workflow; tagged materials now automatically apply advanced lighting calculations for enhanced visual fidelity.

* **Tests**
  * Added validation tests for PBR preset application and material tagging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->