### PR TITLE
Add viewport title-bar display controls

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@ SkeletonDebug.cpp
 SkeletonTransform.cpp
 MeshImporterExporter.cpp
 EditorViewport.cpp
+ViewportTitleBar.cpp
 RotationGizmo.cpp
 TranslationGizmo.cpp
 ScaleGizmo.cpp
@@ -111,6 +112,7 @@ SkeletonDebug.h
 SkeletonTransform.h
 MeshImporterExporter.h
 EditorViewport.h
+ViewportTitleBar.h
 RotationGizmo.h
 TranslationGizmo.h
 ScaleGizmo.h

--- a/src/EditorViewport.cpp
+++ b/src/EditorViewport.cpp
@@ -32,6 +32,7 @@ THE SOFTWARE.
 
 #include "EditorViewport.h"
 #include "OgreWidget.h"
+#include "ViewportTitleBar.h"
 #include "mainwindow.h"
 
 #include <Ogre.h>
@@ -53,6 +54,22 @@ EditorViewport::EditorViewport(MainWindow* parent, int index)
     m_pOgreWidget = new OgreWidget(this);
 
     setWidget(m_pOgreWidget);
+
+    // Replace Qt's default dock title bar with a compact strip that hosts
+    // the per-viewport display toggles (Show Grid / Show Normals /
+    // Show Mesh Info / Show View Cube). This used to be a free-floating
+    // QQuickWidget overlay
+    // sitting on top of the OgreWidget, but it had to be a top-level Qt::Tool
+    // window to compose correctly over Ogre's WA_PaintOnScreen surface, which
+    // collided with the View Cube and gave us nothing to anchor to in
+    // multi-viewport layouts. Embedding the controls in the title bar is
+    // both simpler and per-viewport by construction.
+    QAction* gridAction     = m_pMainWindow ? m_pMainWindow->actionShowGrid()     : nullptr;
+    QAction* normalsAction  = m_pMainWindow ? m_pMainWindow->actionShowNormals()  : nullptr;
+    QAction* meshInfoAction = m_pMainWindow ? m_pMainWindow->actionShowMeshInfo() : nullptr;
+    QAction* viewCubeAction = m_pMainWindow ? m_pMainWindow->actionShowViewCube() : nullptr;
+    m_titleBar = new ViewportTitleBar(this, gridAction, normalsAction, meshInfoAction, viewCubeAction, this);
+    setTitleBarWidget(m_titleBar);
 }
 
 EditorViewport::~EditorViewport()
@@ -72,21 +89,6 @@ MainWindow*   EditorViewport::getMainWindow() const
 
 void EditorViewport::paintEvent(QPaintEvent *e)
 {
-    // Safety check: don't access OgreWidget if it's being destroyed
-    if (m_pOgreWidget)
-    {
-        if (m_pOgreWidget->hasFocus())
-        {
-            setPalette(QPalette(QColor(0, 255, 127)));
-            setAutoFillBackground(true);
-        }
-        else
-        {
-            setPalette(QGuiApplication::palette());
-            setAutoFillBackground(true);
-        }
-    }
-
     QDockWidget::paintEvent(e);
     //m_pOgreWidget->update();
     e->accept();

--- a/src/EditorViewport.h
+++ b/src/EditorViewport.h
@@ -33,6 +33,7 @@ THE SOFTWARE.
 
 class OgreWidget;
 class MainWindow;
+class ViewportTitleBar;
 
 class EditorViewport : public QDockWidget
 {
@@ -45,6 +46,11 @@ public:
     int           getIndex()      const;
     OgreWidget*   getOgreWidget() const;
     MainWindow*   getMainWindow() const;
+
+    /// Custom title bar built in the constructor — exposed for tests so they
+    /// can verify the embedded G/N/I toolbuttons are wired to the right
+    /// QActions without poking at private layout state.
+    ViewportTitleBar* titleBarWidgetCustom() const { return m_titleBar; }
 
 signals:
     void widgetAboutToClose(EditorViewport* const& widget);
@@ -60,6 +66,7 @@ private:
     int                 mIndex;
     OgreWidget*         m_pOgreWidget;
     MainWindow*         m_pMainWindow;
+    ViewportTitleBar*   m_titleBar = nullptr;
 
 };
 

--- a/src/EditorViewport_test.cpp
+++ b/src/EditorViewport_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <QApplication>
 #include <QCoreApplication>
+#include <QPaintEvent>
 #include <QSignalSpy>
 #include <QThread>
 #include <QStyleFactory>
@@ -89,6 +90,14 @@ protected:
 QApplication* EditorViewportTest::app = nullptr;
 MainWindow* EditorViewportTest::mainWindow = nullptr;
 
+namespace {
+class PaintableEditorViewport : public EditorViewport {
+public:
+    using EditorViewport::EditorViewport;
+    using EditorViewport::paintEvent;
+};
+}
+
 TEST_F(EditorViewportTest, ConstructionWithIndex) {
     EditorViewport viewport(mainWindow, 5);
     EXPECT_EQ(viewport.getIndex(), 5);
@@ -111,6 +120,19 @@ TEST_F(EditorViewportTest, GetOgreWidgetReturnsValid) {
     EditorViewport viewport(mainWindow, 0);
     OgreWidget* ogreWidget = viewport.getOgreWidget();
     EXPECT_NE(ogreWidget, nullptr);
+}
+
+TEST_F(EditorViewportTest, PaintEventDoesNotOverridePaletteForFocusedViewport) {
+    PaintableEditorViewport viewport(mainWindow, 0);
+    QPalette markerPalette = viewport.palette();
+    markerPalette.setColor(QPalette::Window, QColor(12, 34, 56));
+    viewport.setPalette(markerPalette);
+
+    QPaintEvent paintEvent(viewport.rect());
+    viewport.paintEvent(&paintEvent);
+
+    EXPECT_EQ(viewport.palette().color(QPalette::Window), QColor(12, 34, 56));
+    EXPECT_NE(viewport.palette().color(QPalette::Window), QColor(0, 255, 127));
 }
 
 TEST_F(EditorViewportTest, WidgetAboutToCloseSignalEmitted) {

--- a/src/PropertiesPanelController.cpp
+++ b/src/PropertiesPanelController.cpp
@@ -428,10 +428,10 @@ QVariantList PropertiesPanelController::shortcutData() const
     data << entry("File", "Ctrl + ,",       "Open preferences");
 
     // View
-    data << entry("View", "Show Grid",       "Toggle grid display (Options menu)");
-    data << entry("View", "Show Normals",    "Toggle vertex normals (Options menu)");
-    data << entry("View", "Show Mesh Info",  "Toggle mesh info overlay (Options menu)");
-    data << entry("View", "Show View Cube",  "Toggle 3D view cube (Options menu)");
+    data << entry("View", "Show Grid",       "Toggle grid display (View menu)");
+    data << entry("View", "Show Normals",    "Toggle vertex normals (View menu)");
+    data << entry("View", "Show Mesh Info",  "Toggle mesh info overlay (View menu)");
+    data << entry("View", "Show View Cube",  "Toggle 3D view cube (View menu)");
 
     // Help
     data << entry("Help", "Ctrl + /", "Open keyboard shortcut reference");

--- a/src/ViewportTitleBar.cpp
+++ b/src/ViewportTitleBar.cpp
@@ -1,0 +1,258 @@
+/*
+-----------------------------------------------------------------------------------
+A QtMeshEditor file
+
+Copyright (c) Fernando Tonon (https://github.com/fernandotonon)
+
+The MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-----------------------------------------------------------------------------------
+*/
+
+#include "ViewportTitleBar.h"
+
+#include <QAction>
+#include <QApplication>
+#include <QDockWidget>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QMouseEvent>
+#include <QStyle>
+#include <QToolButton>
+
+namespace {
+constexpr int kBarHeight        = 20;
+constexpr int kButtonWidth      = 22;
+constexpr int kButtonHeight     = 18;
+constexpr int kIconButtonWidth  = 20;
+constexpr int kHorizontalMargin = 4;
+constexpr int kButtonSpacing    = 2;
+constexpr int kLabelFontDelta   = -1; ///< px shrink off default font for compactness
+
+const char* kTitleButtonStyle = R"(
+    QToolButton {
+        border: 1px solid #666666;
+        border-radius: 2px;
+        background: #3b3b3b;
+        color: #d8d8d8;
+        padding: 0;
+    }
+    QToolButton:hover {
+        border-color: #8a8a8a;
+        background: #4a4a4a;
+    }
+    QToolButton:checked {
+        border-color: #8a8a8a;
+        background: #4a4a4a;
+        color: #f2f2f2;
+    }
+    QToolButton:pressed {
+        background: #2f2f2f;
+    }
+    QToolButton:disabled {
+        color: #7a7a7a;
+    }
+)";
+
+const char* kTitleBarStyle = R"(
+    QWidget#viewportTitleBar {
+        background: #2d2d2d;
+    }
+    QLabel#viewportTitleLabel {
+        color: #d8d8d8;
+        background: transparent;
+    }
+)";
+}
+
+ViewportTitleBar::ViewportTitleBar(QDockWidget* dock,
+                                   QAction* gridAction,
+                                   QAction* normalsAction,
+                                   QAction* meshInfoAction,
+                                   QAction* viewCubeAction,
+                                   QWidget* parent)
+    : QWidget(parent ? parent : dock)
+    , m_dock(dock)
+{
+    setObjectName(QStringLiteral("viewportTitleBar"));
+    setAutoFillBackground(true);
+    setFixedHeight(kBarHeight);
+    setStyleSheet(QString::fromLatin1(kTitleBarStyle));
+
+    auto* layout = new QHBoxLayout(this);
+    layout->setContentsMargins(kHorizontalMargin, 0, 2, 0);
+    layout->setSpacing(kButtonSpacing);
+
+    m_titleLabel = new QLabel(this);
+    m_titleLabel->setObjectName(QStringLiteral("viewportTitleLabel"));
+    if (m_dock)
+        m_titleLabel->setText(m_dock->windowTitle());
+    QFont labelFont = font();
+    if (labelFont.pixelSize() > 0)
+        labelFont.setPixelSize(qMax(8, labelFont.pixelSize() + kLabelFontDelta));
+    else
+        labelFont.setPointSize(qMax(7, labelFont.pointSize() - 1));
+    m_titleLabel->setFont(labelFont);
+    m_titleLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    layout->addWidget(m_titleLabel, /*stretch*/ 1);
+
+    if (m_dock) {
+        connect(m_dock, &QDockWidget::windowTitleChanged,
+                m_titleLabel, &QLabel::setText);
+    }
+
+    m_gridButton     = makeActionButton(gridAction,     QStringLiteral("G"));
+    m_normalsButton  = makeActionButton(normalsAction,  QStringLiteral("N"));
+    m_meshInfoButton = makeActionButton(meshInfoAction, QStringLiteral("I"));
+    m_viewCubeButton = makeActionButton(viewCubeAction, QStringLiteral("C"));
+    if (m_gridButton)     layout->addWidget(m_gridButton);
+    if (m_normalsButton)  layout->addWidget(m_normalsButton);
+    if (m_meshInfoButton) layout->addWidget(m_meshInfoButton);
+    if (m_viewCubeButton) layout->addWidget(m_viewCubeButton);
+
+    if (m_dock) {
+        // Re-implement the float/close buttons that `setTitleBarWidget`
+        // removed. Use QStyle pixmaps so the icons follow the platform/theme.
+        m_floatButton = new QToolButton(this);
+        m_floatButton->setObjectName(QStringLiteral("viewportFloatButton"));
+        m_floatButton->setAutoRaise(true);
+        m_floatButton->setFixedSize(kIconButtonWidth, kButtonHeight);
+        m_floatButton->setFocusPolicy(Qt::NoFocus);
+        m_floatButton->setStyleSheet(QString::fromLatin1(kTitleButtonStyle));
+        m_floatButton->setIcon(style()->standardIcon(QStyle::SP_TitleBarNormalButton));
+        m_floatButton->setToolTip(tr("Float / dock viewport"));
+        connect(m_floatButton, &QToolButton::clicked, m_dock, [this]() {
+            if (m_dock)
+                m_dock->setFloating(!m_dock->isFloating());
+        });
+        layout->addWidget(m_floatButton);
+
+        m_closeButton = new QToolButton(this);
+        m_closeButton->setObjectName(QStringLiteral("viewportCloseButton"));
+        m_closeButton->setAutoRaise(true);
+        m_closeButton->setFixedSize(kIconButtonWidth, kButtonHeight);
+        m_closeButton->setFocusPolicy(Qt::NoFocus);
+        m_closeButton->setStyleSheet(QString::fromLatin1(kTitleButtonStyle));
+        m_closeButton->setIcon(style()->standardIcon(QStyle::SP_TitleBarCloseButton));
+        m_closeButton->setToolTip(tr("Close viewport"));
+        connect(m_closeButton, &QToolButton::clicked, m_dock, &QDockWidget::close);
+        layout->addWidget(m_closeButton);
+    }
+}
+
+QToolButton* ViewportTitleBar::makeActionButton(QAction* action,
+                                                const QString& letterLabel)
+{
+    if (!action)
+        return nullptr;
+
+    auto* button = new QToolButton(this);
+    button->setObjectName(QStringLiteral("viewport") + letterLabel + QStringLiteral("Button"));
+    button->setAutoRaise(true);
+    button->setCheckable(true);
+    button->setFocusPolicy(Qt::NoFocus);
+    button->setFixedSize(kButtonWidth, kButtonHeight);
+    button->setText(letterLabel);
+    button->setToolButtonStyle(Qt::ToolButtonTextOnly);
+    button->setStyleSheet(QString::fromLatin1(kTitleButtonStyle));
+    button->setToolTip(action->toolTip().isEmpty() ? action->text() : action->toolTip());
+
+    // Mirror the QAction state — we deliberately do NOT use `setDefaultAction`
+    // because that would also adopt the action's full text/icon and override
+    // our compact letter glyph. Instead, sync state both directions manually.
+    button->setChecked(action->isChecked());
+    button->setEnabled(action->isEnabled());
+
+    connect(action, &QAction::changed, button, [button, action]() {
+        const QSignalBlocker blocker(button);
+        button->setChecked(action->isChecked());
+        button->setEnabled(action->isEnabled());
+    });
+    connect(action, &QAction::toggled, button, [button](bool on) {
+        const QSignalBlocker blocker(button);
+        button->setChecked(on);
+    });
+    connect(button, &QToolButton::clicked, action, [action]() {
+        action->trigger();
+    });
+
+    return button;
+}
+
+void ViewportTitleBar::mousePressEvent(QMouseEvent* event)
+{
+    // Treat presses on the title label (or the empty strip) as the drag
+    // handle — anywhere a child toolbutton answers `childAt` is excluded so
+    // clicks on G/N/I/C/float/close fall through to the buttons.
+    QWidget* hit = childAt(event->pos());
+    const bool onDragArea = (hit == nullptr || hit == m_titleLabel);
+    m_pressedOnDragArea = (event->button() == Qt::LeftButton) && onDragArea && m_dock;
+
+    if (m_pressedOnDragArea) {
+        m_dragStartGlobal = event->globalPosition().toPoint();
+        // Track offset between cursor and dock top-left so detaching feels
+        // continuous rather than snapping the floating window to the cursor.
+        m_dragOffset = event->globalPosition().toPoint() - m_dock->mapToGlobal(QPoint(0, 0));
+    }
+
+    QWidget::mousePressEvent(event);
+}
+
+void ViewportTitleBar::mouseMoveEvent(QMouseEvent* event)
+{
+    if (m_pressedOnDragArea && m_dock && (event->buttons() & Qt::LeftButton)) {
+        const QPoint delta = event->globalPosition().toPoint() - m_dragStartGlobal;
+        const int distance = qMax(qAbs(delta.x()), qAbs(delta.y()));
+
+        if (!m_dock->isFloating() && distance > QApplication::startDragDistance()) {
+            // Detach into a floating window. We resize-then-float (instead
+            // of relying on `setFloating(true)`'s default placement) so the
+            // window appears under the cursor where the drag started.
+            m_dock->setFloating(true);
+        }
+
+        if (m_dock->isFloating()) {
+            m_dock->move(event->globalPosition().toPoint() - m_dragOffset);
+        }
+    }
+
+    QWidget::mouseMoveEvent(event);
+}
+
+void ViewportTitleBar::mouseReleaseEvent(QMouseEvent* event)
+{
+    m_pressedOnDragArea = false;
+    QWidget::mouseReleaseEvent(event);
+}
+
+void ViewportTitleBar::mouseDoubleClickEvent(QMouseEvent* event)
+{
+    QWidget* hit = childAt(event->pos());
+    if (event->button() == Qt::LeftButton && m_dock
+        && (hit == nullptr || hit == m_titleLabel))
+    {
+        // Double-click on title toggles floating, matching Qt's default
+        // QDockWidget title-bar behaviour.
+        m_dock->setFloating(!m_dock->isFloating());
+        event->accept();
+        return;
+    }
+    QWidget::mouseDoubleClickEvent(event);
+}

--- a/src/ViewportTitleBar.h
+++ b/src/ViewportTitleBar.h
@@ -1,0 +1,109 @@
+/*
+-----------------------------------------------------------------------------------
+A QtMeshEditor file
+
+Copyright (c) Fernando Tonon (https://github.com/fernandotonon)
+
+The MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-----------------------------------------------------------------------------------
+*/
+
+#ifndef VIEWPORT_TITLE_BAR_H
+#define VIEWPORT_TITLE_BAR_H
+
+#include <QWidget>
+
+class QAction;
+class QDockWidget;
+class QLabel;
+class QToolButton;
+
+/// Custom title-bar widget used by `EditorViewport` (a `QDockWidget`).
+///
+/// Replaces Qt's default dock title bar so the per-viewport display
+/// controls (Show Grid / Show Normals / Show Mesh Info / Show View Cube) live
+/// directly in the title strip instead of as a separate floating widget. This avoids the
+/// long-standing compositing issue with `OgreWidget` (which uses
+/// `WA_PaintOnScreen` and produced black rectangles for any overlapping Qt
+/// child widget) and frees the top-right corner of the viewport for the
+/// View Cube without needing manual collision avoidance.
+///
+/// Because `setTitleBarWidget` removes Qt's built-in float/close buttons, we
+/// re-create them here and wire them to `QDockWidget::setFloating()` /
+/// `QDockWidget::close()` using `QStyle` icons so the look adapts to the
+/// active palette.
+class ViewportTitleBar : public QWidget
+{
+    Q_OBJECT
+
+public:
+    /// Builds a title bar bound to `dock`. Viewport actions may be null (in
+    /// which case no button is created for that slot — useful for tests that
+    /// don't construct a full MainWindow).
+    ViewportTitleBar(QDockWidget* dock,
+                     QAction* gridAction,
+                     QAction* normalsAction,
+                     QAction* meshInfoAction,
+                     QAction* viewCubeAction,
+                     QWidget* parent = nullptr);
+
+    /// Returns the toolbutton bound to the corresponding QAction (or nullptr
+    /// if no action was provided at construction). Exposed for unit tests.
+    QToolButton* gridButton() const { return m_gridButton; }
+    QToolButton* normalsButton() const { return m_normalsButton; }
+    QToolButton* meshInfoButton() const { return m_meshInfoButton; }
+    QToolButton* viewCubeButton() const { return m_viewCubeButton; }
+    QToolButton* floatButton() const { return m_floatButton; }
+    QToolButton* closeButton() const { return m_closeButton; }
+    QLabel* titleLabel() const { return m_titleLabel; }
+
+protected:
+    void mousePressEvent(QMouseEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
+    void mouseReleaseEvent(QMouseEvent* event) override;
+    void mouseDoubleClickEvent(QMouseEvent* event) override;
+
+private:
+    /// Creates a small toolbar-style button bound to `action`. Updates the
+    /// button's label/checked/enabled state from the action and triggers the
+    /// action when clicked. Returns nullptr if `action` is null.
+    QToolButton* makeActionButton(QAction* action, const QString& letterLabel);
+
+    QDockWidget* m_dock;
+    QLabel*      m_titleLabel = nullptr;
+    QToolButton* m_gridButton = nullptr;
+    QToolButton* m_normalsButton = nullptr;
+    QToolButton* m_meshInfoButton = nullptr;
+    QToolButton* m_viewCubeButton = nullptr;
+    QToolButton* m_floatButton = nullptr;
+    QToolButton* m_closeButton = nullptr;
+
+    /// Drag-to-detach state. While the dock is docked, pressing on the
+    /// title strip (not on a button) and dragging past the system drag
+    /// distance promotes the dock to floating and lets the user move it.
+    /// Re-docking by drop is not implemented — use the float button to
+    /// re-dock.
+    bool   m_pressedOnDragArea = false;
+    QPoint m_dragStartGlobal;
+    QPoint m_dragOffset;
+};
+
+#endif // VIEWPORT_TITLE_BAR_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -20,6 +20,7 @@
 #include <QJSEngine>
 #include <QQuickWindow>
 #include <QFileInfo>
+#include <QEvent>
 #include "SentryReporter.h"
 #include <QDialog>
 #include <QProgressDialog>
@@ -1508,10 +1509,10 @@ void MainWindow::initToolBar()
     connect(m_viewCubeController, &ViewCubeController::visibilityChanged, ui->actionShow_View_Cube, &QAction::setChecked);
 
     // Connect viewports created before the ViewCube existed
-    for (EditorViewport* vp : mDockWidgetList)
-        connect(vp->getOgreWidget(), &OgreWidget::focusOnWidget, this, [this](OgreWidget* w) {
-            m_viewCubeController->setActiveWidget(w);
-        });
+    for (EditorViewport* vp : mDockWidgetList) {
+        connect(vp->getOgreWidget(), &OgreWidget::focusOnWidget,
+                m_viewCubeController, &ViewCubeController::setActiveWidget);
+    }
 
     // Activate the first viewport, then set visible
     // (setActiveWidget emits visibilityChanged which checks isVisible(),
@@ -1701,25 +1702,29 @@ void MainWindow::createModeSurfaces()
         });
     }
 
-    if (!ui->toolToolbar->findChild<QToolButton*>(QStringLiteral("viewportOptionsButton"))) {
-        auto* viewportOptionsButton = new QToolButton(ui->toolToolbar);
-        viewportOptionsButton->setObjectName("viewportOptionsButton");
-        viewportOptionsButton->setText(tr("Viewport"));
-        viewportOptionsButton->setToolTip(tr("Viewport display options"));
-        viewportOptionsButton->setPopupMode(QToolButton::InstantPopup);
-
-        auto* viewportOptionsMenu = new QMenu(viewportOptionsButton);
-        viewportOptionsMenu->addAction(ui->actionShow_Grid);
-        viewportOptionsMenu->addAction(ui->actionShow_Normals);
-        viewportOptionsMenu->addAction(ui->actionShow_Mesh_Info);
-        viewportOptionsMenu->addAction(ui->actionShow_View_Cube);
-        viewportOptionsButton->setMenu(viewportOptionsMenu);
-        ui->toolToolbar->addWidget(viewportOptionsButton);
-    }
-
     QSignalBlocker blocker(ui->actionView_Toolbar);
     ui->actionView_Toolbar->setChecked(false);
     ui->viewToolbar->hide();
+}
+
+QAction* MainWindow::actionShowGrid() const
+{
+    return ui ? ui->actionShow_Grid : nullptr;
+}
+
+QAction* MainWindow::actionShowNormals() const
+{
+    return ui ? ui->actionShow_Normals : nullptr;
+}
+
+QAction* MainWindow::actionShowMeshInfo() const
+{
+    return ui ? ui->actionShow_Mesh_Info : nullptr;
+}
+
+QAction* MainWindow::actionShowViewCube() const
+{
+    return ui ? ui->actionShow_View_Cube : nullptr;
 }
 
 void MainWindow::configureBottomToolDock(QDockWidget* dock)
@@ -2318,6 +2323,11 @@ void MainWindow::resizeEvent(QResizeEvent *event)
         repositionWelcomeScreen();
 }
 
+bool MainWindow::eventFilter(QObject* watched, QEvent* event)
+{
+    return QMainWindow::eventFilter(watched, event);
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 // LCOV_EXCL_START — opens QFileDialog
 void MainWindow::on_actionImport_triggered()
@@ -2796,9 +2806,8 @@ void MainWindow::createEditorViewport(/*TODO add the type of view (perspective, 
     if (m_meshInfoOverlay)
         connect(pOgreViewport->getOgreWidget(), &OgreWidget::focusOnWidget, m_meshInfoOverlay, &MeshInfoOverlay::setActiveWidget);
     if (m_viewCubeController)
-        connect(pOgreViewport->getOgreWidget(), &OgreWidget::focusOnWidget, this, [this](OgreWidget* w) {
-            m_viewCubeController->setActiveWidget(w);
-        });
+        connect(pOgreViewport->getOgreWidget(), &OgreWidget::focusOnWidget,
+                m_viewCubeController, &ViewCubeController::setActiveWidget);
 
     if(!mDockWidgetList.isEmpty())
     {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -24,6 +24,7 @@ class AssetBrowserController;
 class QQuickWidget;
 class QLabel;
 class QToolBar;
+class OgreWidget;
 
 namespace Ui {
 class MainWindow;
@@ -117,6 +118,17 @@ private slots:
 public slots:
     void setPlaying(bool playing);
 
+public:
+    /// Accessors for the viewport display QActions so per-viewport
+    /// title bars (built by `EditorViewport`) can bind their toolbuttons
+    /// without forcing the whole `Ui::MainWindow` to be public. Each action
+    /// is owned by `ui->menuOptions` (autogen by Qt Designer) and lives for
+    /// the lifetime of MainWindow.
+    QAction* actionShowGrid() const;
+    QAction* actionShowNormals() const;
+    QAction* actionShowMeshInfo() const;
+    QAction* actionShowViewCube() const;
+
 private:
     Ui::MainWindow *ui;
 
@@ -144,6 +156,7 @@ protected:
     void keyReleaseEvent(QKeyEvent *event) override;
     void dragEnterEvent(QDragEnterEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;
+    bool eventFilter(QObject* watched, QEvent* event) override;
 
 private:
     void initToolBar();

--- a/src/mainwindow_test.cpp
+++ b/src/mainwindow_test.cpp
@@ -9,6 +9,7 @@
 #include <QMenuBar>
 #include <QMimeData>
 #include <QMessageBox>
+#include <QQuickItem>
 #include <QQuickWidget>
 #include <QSettings>
 #include <QSignalSpy>
@@ -32,9 +33,11 @@
 #include "TransformOperator.h"
 #include "EditModeController.h"
 #include "EditorModeController.h"
+#include "MeshInfoOverlay.h"
 #include "TestHelpers.h"
 #include "EditorViewport.h"
 #include "ViewportSettingsKeys.h"
+#include "ViewportTitleBar.h"
 #include "OgreWidget.h"
 #include "ui_mainwindow.h"
 
@@ -318,6 +321,74 @@ TEST_F(MainWindowTest, ContextualToolRailButtonsTriggerExistingBottomTools)
     app->processEvents();
     EXPECT_FALSE(window->m_dopeSheetDock->isHidden());
     EXPECT_EQ(window->dockWidgetArea(window->m_dopeSheetDock), Qt::BottomDockWidgetArea);
+}
+
+TEST_F(MainWindowTest, ViewportDisplayActionsLiveInViewMenuNotToolbar)
+{
+    const QList<QAction*> viewMenuActions = window->ui->menuView->actions();
+    EXPECT_TRUE(viewMenuActions.contains(window->ui->actionShow_Grid));
+    EXPECT_TRUE(viewMenuActions.contains(window->ui->actionShow_Normals));
+    EXPECT_TRUE(viewMenuActions.contains(window->ui->actionShow_Mesh_Info));
+    EXPECT_TRUE(viewMenuActions.contains(window->ui->actionShow_View_Cube));
+
+    const QList<QAction*> topOptionsActions = window->ui->menuOp_es->actions();
+    EXPECT_FALSE(topOptionsActions.contains(window->ui->actionShow_Grid));
+    EXPECT_FALSE(topOptionsActions.contains(window->ui->actionShow_Normals));
+    EXPECT_FALSE(topOptionsActions.contains(window->ui->actionShow_Mesh_Info));
+    EXPECT_FALSE(topOptionsActions.contains(window->ui->actionShow_View_Cube));
+
+    const QList<QAction*> viewToolbarActions = window->ui->viewToolbar->actions();
+    EXPECT_FALSE(viewToolbarActions.contains(window->ui->actionShow_Grid));
+    EXPECT_FALSE(viewToolbarActions.contains(window->ui->actionShow_Normals));
+    EXPECT_FALSE(viewToolbarActions.contains(window->ui->actionShow_Mesh_Info));
+    EXPECT_FALSE(viewToolbarActions.contains(window->ui->actionShow_View_Cube));
+}
+
+TEST_F(MainWindowTest, ViewportTitleBarHostsViewportActions)
+{
+    // The viewport display menu is now embedded in each EditorViewport's
+    // custom title bar instead of a free-floating QQuickWidget. Verify the
+    // title bar exists, exposes G/N/I/C toolbuttons, and that triggering one
+    // propagates to the underlying QAction (and therefore the matching
+    // display state in MainWindow).
+    ASSERT_FALSE(window->mDockWidgetList.isEmpty());
+    EditorViewport* viewport = window->mDockWidgetList.first();
+    ASSERT_NE(viewport, nullptr);
+
+    ViewportTitleBar* titleBar = viewport->titleBarWidgetCustom();
+    ASSERT_NE(titleBar, nullptr);
+    EXPECT_EQ(viewport->titleBarWidget(), titleBar);
+
+    ASSERT_NE(titleBar->gridButton(), nullptr);
+    ASSERT_NE(titleBar->normalsButton(), nullptr);
+    ASSERT_NE(titleBar->meshInfoButton(), nullptr);
+    ASSERT_NE(titleBar->viewCubeButton(), nullptr);
+    ASSERT_NE(titleBar->floatButton(), nullptr);
+    ASSERT_NE(titleBar->closeButton(), nullptr);
+
+    EXPECT_EQ(titleBar->viewCubeButton()->text(), QStringLiteral("C"));
+
+    // Buttons should mirror the QAction's checked state immediately.
+    EXPECT_EQ(titleBar->gridButton()->isChecked(),
+              window->ui->actionShow_Grid->isChecked());
+    EXPECT_EQ(titleBar->viewCubeButton()->isChecked(),
+              window->ui->actionShow_View_Cube->isChecked());
+
+    // The viewport action buttons and recreated dock chrome buttons should
+    // share a visible bordered style so they read as one title-bar group.
+    EXPECT_TRUE(titleBar->gridButton()->styleSheet().contains(QStringLiteral("border: 1px")));
+    EXPECT_TRUE(titleBar->viewCubeButton()->styleSheet().contains(QStringLiteral("border: 1px")));
+    EXPECT_TRUE(titleBar->floatButton()->styleSheet().contains(QStringLiteral("border: 1px")));
+    EXPECT_TRUE(titleBar->closeButton()->styleSheet().contains(QStringLiteral("border: 1px")));
+
+    window->ui->actionShow_Mesh_Info->setChecked(false);
+    titleBar->meshInfoButton()->click();
+    app->processEvents();
+
+    EXPECT_TRUE(window->ui->actionShow_Mesh_Info->isChecked());
+    ASSERT_NE(window->m_meshInfoOverlay, nullptr);
+    EXPECT_TRUE(window->m_meshInfoOverlay->isVisible());
+    EXPECT_TRUE(titleBar->meshInfoButton()->isChecked());
 }
 
 // ---- Cycle all transform states via keyboard ----

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/SkeletonTransform.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MeshImporterExporter.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/EditorViewport.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/ViewportTitleBar.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/RotationGizmo.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/TranslationGizmo.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/ScaleGizmo.cpp
@@ -124,6 +125,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/SkeletonTransform.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MeshImporterExporter.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/EditorViewport.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/ViewportTitleBar.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/RotationGizmo.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/TranslationGizmo.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/ScaleGizmo.h

--- a/ui_files/mainwindow.ui
+++ b/ui_files/mainwindow.ui
@@ -61,6 +61,12 @@
      <addaction name="actionTools_Toolbar"/>
      <addaction name="actionView_Toolbar"/>
      <addaction name="actionMeshEditor"/>
+     <addaction name="separator"/>
+     <addaction name="actionShow_Grid"/>
+     <addaction name="actionShow_Normals"/>
+     <addaction name="actionShow_Mesh_Info"/>
+     <addaction name="actionShow_View_Cube"/>
+     <addaction name="separator"/>
      <addaction name="actionAsset_Browser"/>
     </widget>
     <widget class="QMenu" name="menuViewport_Layout">
@@ -80,10 +86,6 @@
      <addaction name="actionDark"/>
      <addaction name="actionCustom"/>
     </widget>
-    <addaction name="actionShow_Grid"/>
-    <addaction name="actionShow_Normals"/>
-    <addaction name="actionShow_Mesh_Info"/>
-    <addaction name="actionShow_View_Cube"/>
     <addaction name="actionChange_Ambient_Light"/>
     <addaction name="actionChange_BG_Color"/>
     <addaction name="menuView"/>
@@ -180,10 +182,6 @@
    <attribute name="toolBarBreak">
     <bool>false</bool>
    </attribute>
-   <addaction name="actionShow_Grid"/>
-   <addaction name="actionShow_Normals"/>
-   <addaction name="actionShow_Mesh_Info"/>
-   <addaction name="actionShow_View_Cube"/>
   </widget>
   <widget class="QDockWidget" name="meshEditorWidget">
    <property name="sizePolicy">


### PR DESCRIPTION
## Summary
- Move grid, normals, mesh info, and view cube display toggles into the View menu instead of the always-visible view toolbar.
- Replace the floating viewport overlay with a compact custom `EditorViewport` title bar that hosts the G/N/I/C display controls next to the dock float and close buttons.
- Bind the title-bar buttons to the existing `QAction`s so menu checkmarks, button state, and existing controllers stay synchronized.
- Add bordered styling for the viewport display buttons and recreated float/close title buttons so the title-bar controls read as one group.

## Validation
- `cmake --build build_local --target UnitTests -j"$(nproc)"`
- `env QT_QPA_PLATFORM=offscreen build_local/bin/UnitTests --gtest_filter=MainWindowTest.Viewport*`
- `cmake --build build_local --target QtMeshEditor -j"$(nproc)"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Viewport display options moved into the View menu.
  * Custom viewport title bars with quick-access buttons for grid, normals, mesh info, and view cube.
  * Drag-to-detach support for floating viewport windows.
  * Welcome screen repositions responsively during window resize.

* **Bug Fixes**
  * Updated keyboard shortcut descriptions to reference the View menu.

* **Tests**
  * Added UI tests verifying viewport action placement, title-bar buttons, and paint-event behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->