### PR TITLE
feat(PS1): Psy-Q PLY quad/ngon round-trip via qtme.faces

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,12 @@ Split View|Skeleton Animation Controls
 | STL | .stl | ✅ | ✅ | — |
 | Ogre Mesh | .mesh / .mesh.xml | ✅ | ✅ | ✅ |
 | PlayStation TMD | .tmd | ✅ | ✅ | — |
+| PlayStation RSD | .rsd | ✅ | ✅ | — |
 | 3DS | .3ds | ✅ | ✅ | — |
-| PLY | .ply | ✅ | ✅ | — |
+| Stanford PLY | .ply | ✅ | ✅ | — |
+| Psy-Q PLY (PlayStation) | .ply | ✅ | ✅ | — |
+
+`.ply` is dispatched by content: **Stanford** (`ply` header) vs **Psy-Q** (`@PLY…` header). See [documentation/playstation-rsd-ply.md](documentation/playstation-rsd-ply.md).
 
 Import supports all formats provided by Assimp (40+).
 

--- a/documentation/playstation-rsd-ply.md
+++ b/documentation/playstation-rsd-ply.md
@@ -1,0 +1,55 @@
+# PlayStation RSD, Psy-Q PLY, and MAT sidecars
+
+QtMeshEditor treats **PlayStation RSD** (`.rsd`) as a small **descriptor** that points at a mesh and optional texture/material sidecars. The mesh is usually a **TMD** (`.tmd`) or a **Sony Psy-Q PLY** (`.ply`). These are **not** Stanford PLY files: Psy-Q PLY uses an `@PLY…` header, separate **vertex** and **normal** tables, and face lines with **independent** vertex and normal indices.
+
+## RSD (`.rsd`)
+
+An RSD file lists paths or basenames for:
+
+- **Model** — typically `.tmd` or Psy-Q `.ply`
+- **Texture / TIM** — PlayStation 4-bit / 8-bit / 16-bit images (`.tim`), applied when loading through the RSD path
+- **Material** — optional `.mat` companion with per-face or material parameters used by classic toolchains
+
+Importing `.rsd` resolves those references, loads the mesh (TMD or Psy-Q PLY), and attaches TIM-driven materials when possible. Exporting to `.rsd` writes the descriptor plus best-effort sidecar filenames (`.tmd` / `.tim` / etc.) next to the output.
+
+## Psy-Q PLY import
+
+1. **Header** — e.g. `@PLY940102` (variant digits allowed).
+2. **Counts** — one line: `nV nN nF` (number of **positions**, **normals**, **faces**). Positions and normals are **separate pools**; `nV` and `nN` need not match.
+3. **Vertices** — `nV` lines of `x y z` (model space; import applies the editor’s Psy-Q PLY world transform).
+4. **Normals** — `nN` lines of `nx ny nz`.
+5. **Faces** — per face:
+   - `0 v0 v1 v2 pad n0 n1 n2 pad` — triangle
+   - `1 v0 v1 v2 v3 n0 n1 n2 n3` — quad (PlayStation-style split into two triangles internally is `(v0,v1,v2)` and `(v1,v2,v3)`)
+
+Corner attributes (position + normal + optional colour) are **welded** on import so Ogre’s indexed triangle list matches shading boundaries.
+
+When the file encodes **quads or higher polygons**, the importer records logical face sizes and stores **n-gon topology** on the mesh (`qtme.faces.*`, same mechanism as FBX n-gons). That preserves artist intent for later export.
+
+## Psy-Q PLY export
+
+Export walks the renderable mesh and writes:
+
+1. **Welded position table** — unique positions after **quantized** welding (fixed-point style bucket in world space).
+2. **Welded normal table** — **independent** pool: same quantization, but normals deduplicate separately from positions. Many corners can share one quantized normal, so **`nN` is often smaller than `nV`**, even when the source file listed more normal lines. That is expected and usually means redundant normals collapsed to one index after quantization.
+3. **Face lines** — triangles (`0 …`) or quads (`1 …`) with **separate** vertex and normal indices per corner.
+
+### Why fewer normals than the original file is OK
+
+Original Psy-Q assets often duplicate the same direction many times with tiny float differences. After import, Ogre may still carry one normal per corner. On export, each corner’s normal is quantized and **welded into the normal pool**. If four corners of a flat quad all map to the same quantized `(nx,ny,nz)`, the file shows **one** normal line and four indices pointing at it — **fewer lines than a verbose original**, but equivalent shading for that polygon.
+
+### `qtme.faces` vs heuristic quad restore
+
+- If **`qtme.faces.0`** (etc.) is present — for example after importing a Psy-Q file with quad lines, or after editing in mesh mode — export uses those **n-gons** directly. Quads stay quads; larger n-gons are fanned to triangles in the file as required by the format.
+- If that metadata is **missing** — e.g. a mesh that only exists as two triangles in the index buffer — export runs a **heuristic**: pairs of adjacent triangles that form a convex quad, share an edge in the PS1 `(v0,v1,v2)+(v1,v2,v3)` pattern, and have **nearly parallel** face normals (dot ≥ 0.94) are merged back into a **single quad line**. That restores many flat quads lost when DCC tools triangulate, without inventing quads across sharp creases.
+
+Together, explicit **n-gon** metadata and the **merge heuristic** are why round-trips through QtMeshEditor often match or **improve** on the original polygon layout: fewer spurious triangle pairs, and normal pools that collapse true duplicates after quantization.
+
+## MAT sidecars
+
+When vertex colours exist on all submeshes, Psy-Q PLY export can optionally emit **per-face colours** (for tooling that builds a `.mat` from face colours). RSD export paths wire this where the pipeline supplies a colour buffer.
+
+## See also
+
+- `PS1PLY.h` / `PS1PLY.cpp` — detection, import, export, merge heuristic
+- `PS1RSD` module — RSD parse/load/save and sidecar resolution

--- a/src/EditableMesh.cpp
+++ b/src/EditableMesh.cpp
@@ -310,8 +310,8 @@ bool readNgonFacesFromMesh(const Ogre::Mesh* mesh,
     try {
         outFaces = Ogre::any_cast<NgonFaceList>(any);
     } catch (const Ogre::Exception&) {
-        // Wrong payload type stored under our key — bail out, exporter
-        // will fall back to the triangle index buffer.
+        return false;
+    } catch (const std::bad_cast&) {
         return false;
     }
     return !outFaces.empty();

--- a/src/PS1/PS1PLY.cpp
+++ b/src/PS1/PS1PLY.cpp
@@ -25,8 +25,10 @@ The MIT License
 #include <QStringConverter>
 #include <QTextStream>
 
+#include <array>
 #include <cmath>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace {
@@ -35,6 +37,39 @@ struct TriSoup {
     std::vector<Ogre::Vector3> pos;
     std::vector<Ogre::Vector3> nrm;
     std::vector<Ogre::RGBA> col; // optional; if present must match pos size
+};
+
+static int32_t quantizeWorld(Ogre::Real v)
+{
+    return static_cast<int32_t>(std::lround(double(v) * 100000.0));
+}
+
+struct WeldKey {
+    int32_t px, py, pz, nx, ny, nz;
+    int32_t crgba;
+
+    bool operator==(const WeldKey& o) const
+    {
+        return px == o.px && py == o.py && pz == o.pz && nx == o.nx && ny == o.ny && nz == o.nz && crgba == o.crgba;
+    }
+};
+
+struct WeldKeyHash {
+    size_t operator()(const WeldKey& k) const noexcept
+    {
+        size_t h = 1469598103934665603ull;
+        auto mix = [&](int32_t x) {
+            h ^= static_cast<size_t>(static_cast<uint32_t>(x)) * 1099511628211ull;
+        };
+        mix(k.px);
+        mix(k.py);
+        mix(k.pz);
+        mix(k.nx);
+        mix(k.ny);
+        mix(k.nz);
+        mix(k.crgba);
+        return h;
+    }
 };
 
 static void applyPlyImportWorldTransform(Ogre::Vector3& p)
@@ -213,6 +248,43 @@ static Ogre::MeshPtr buildMeshFromTriSoup(const std::string& meshName, const Tri
         return {};
     const bool haveColors = (!soup.col.empty() && soup.col.size() == soup.pos.size());
 
+    std::vector<Ogre::Vector3> uniqPos;
+    std::vector<Ogre::Vector3> uniqNrm;
+    std::vector<Ogre::RGBA> uniqCol;
+    std::vector<uint32_t> indices;
+    uniqPos.reserve(soup.pos.size());
+    uniqNrm.reserve(soup.nrm.size());
+    indices.reserve(soup.pos.size());
+    if (haveColors)
+        uniqCol.reserve(soup.pos.size());
+
+    std::unordered_map<WeldKey, uint32_t, WeldKeyHash> cornerWeld;
+    cornerWeld.reserve(soup.pos.size() / 2);
+
+    for (size_t i = 0; i < soup.pos.size(); ++i) {
+        int32_t crgba = 0;
+        if (haveColors)
+            crgba = static_cast<int32_t>(soup.col[i]);
+        const WeldKey key{quantizeWorld(soup.pos[i].x), quantizeWorld(soup.pos[i].y), quantizeWorld(soup.pos[i].z),
+                          quantizeWorld(soup.nrm[i].x), quantizeWorld(soup.nrm[i].y), quantizeWorld(soup.nrm[i].z),
+                          crgba};
+        const auto it = cornerWeld.find(key);
+        if (it == cornerWeld.end()) {
+            const uint32_t ni = static_cast<uint32_t>(uniqPos.size());
+            cornerWeld.emplace(key, ni);
+            uniqPos.push_back(soup.pos[i]);
+            uniqNrm.push_back(soup.nrm[i]);
+            if (haveColors)
+                uniqCol.push_back(soup.col[i]);
+            indices.push_back(ni);
+        } else
+            indices.push_back(it->second);
+    }
+
+    const size_t nVert = uniqPos.size();
+    const size_t nIdx = indices.size();
+    const size_t nTri = nIdx / 3;
+
     if (auto old = Ogre::MeshManager::getSingleton().getByName(meshName))
         Ogre::MeshManager::getSingleton().remove(old);
 
@@ -231,7 +303,6 @@ static Ogre::MeshPtr buildMeshFromTriSoup(const std::string& meshName, const Tri
     sm->setMaterialName(Ogre::MaterialManager::getSingleton().getByName(plyMatName) ? plyMatName : "BaseMaterial");
     sm->useSharedVertices = false;
 
-    const size_t nVert = soup.pos.size();
     sm->vertexData = new Ogre::VertexData();
     sm->vertexData->vertexCount = static_cast<uint32_t>(nVert);
     auto* decl = sm->vertexData->vertexDeclaration;
@@ -253,17 +324,17 @@ static Ogre::MeshPtr buildMeshFromTriSoup(const std::string& meshName, const Tri
         uint8_t* row = dst + i * vsize;
         float* pf = nullptr;
         decl->findElementBySemantic(Ogre::VES_POSITION)->baseVertexPointerToElement(row, &pf);
-        pf[0] = soup.pos[i].x;
-        pf[1] = soup.pos[i].y;
-        pf[2] = soup.pos[i].z;
+        pf[0] = uniqPos[i].x;
+        pf[1] = uniqPos[i].y;
+        pf[2] = uniqPos[i].z;
         decl->findElementBySemantic(Ogre::VES_NORMAL)->baseVertexPointerToElement(row, &pf);
-        pf[0] = soup.nrm[i].x;
-        pf[1] = soup.nrm[i].y;
-        pf[2] = soup.nrm[i].z;
+        pf[0] = uniqNrm[i].x;
+        pf[1] = uniqNrm[i].y;
+        pf[2] = uniqNrm[i].z;
         if (haveColors) {
             Ogre::RGBA* cp = nullptr;
             decl->findElementBySemantic(Ogre::VES_DIFFUSE)->baseVertexPointerToElement(row, (void**)&cp);
-            *cp = soup.col[i];
+            *cp = uniqCol[i];
         }
     }
     vbuf->unlock();
@@ -276,7 +347,6 @@ static Ogre::MeshPtr buildMeshFromTriSoup(const std::string& meshName, const Tri
             if (mat->getNumTechniques() > 0 && mat->getTechnique(0)->getNumPasses() > 0) {
                 Ogre::Pass* p0 = mat->getTechnique(0)->getPass(0);
                 if (p0) {
-                    // Lighting ON by default; vertex colors (if present) modulate diffuse/ambient.
                     p0->setLightingEnabled(true);
                     p0->setAmbient(1.0f, 1.0f, 1.0f);
                     p0->setDiffuse(1.0f, 1.0f, 1.0f, 1.0f);
@@ -288,20 +358,19 @@ static Ogre::MeshPtr buildMeshFromTriSoup(const std::string& meshName, const Tri
     } catch (...) {
     }
 
-    const size_t nTri = nVert / 3;
     const bool use32 = nVert > 65535;
     auto ibuf = Ogre::HardwareBufferManager::getSingleton().createIndexBuffer(
-        use32 ? Ogre::HardwareIndexBuffer::IT_32BIT : Ogre::HardwareIndexBuffer::IT_16BIT, nTri * 3,
+        use32 ? Ogre::HardwareIndexBuffer::IT_32BIT : Ogre::HardwareIndexBuffer::IT_16BIT, nIdx,
         Ogre::HardwareBuffer::HBU_STATIC_WRITE_ONLY);
     if (use32) {
         auto* ip = static_cast<uint32_t*>(ibuf->lock(Ogre::HardwareBuffer::HBL_DISCARD));
-        for (size_t i = 0; i < nVert; ++i)
-            ip[i] = static_cast<uint32_t>(i);
+        for (size_t i = 0; i < nIdx; ++i)
+            ip[i] = indices[i];
         ibuf->unlock();
     } else {
         auto* ip = static_cast<uint16_t*>(ibuf->lock(Ogre::HardwareBuffer::HBL_DISCARD));
-        for (size_t i = 0; i < nVert; ++i)
-            ip[i] = static_cast<uint16_t>(i);
+        for (size_t i = 0; i < nIdx; ++i)
+            ip[i] = static_cast<uint16_t>(indices[i]);
         ibuf->unlock();
     }
     sm->indexData->indexBuffer = ibuf;
@@ -309,7 +378,7 @@ static Ogre::MeshPtr buildMeshFromTriSoup(const std::string& meshName, const Tri
     sm->indexData->indexStart = 0;
 
     Ogre::AxisAlignedBox bounds;
-    for (const auto& v : soup.pos)
+    for (const auto& v : uniqPos)
         bounds.merge(v);
     mesh->_setBounds(bounds);
     mesh->_setBoundingSphereRadius(bounds.getHalfSize().length());
@@ -527,38 +596,136 @@ static Ogre::ColourValue decodePackedColour(const Ogre::VertexElement* colEl, Og
     return cv;
 }
 
-static int32_t quantizeWorld(Ogre::Real v)
+static Ogre::Vector3 triFaceNormalWelded(const Ogre::Vector3& p0, const Ogre::Vector3& p1, const Ogre::Vector3& p2)
 {
-    return static_cast<int32_t>(std::lround(double(v) * 100000.0));
+    Ogre::Vector3 n = (p1 - p0).crossProduct(p2 - p0);
+    const float len = n.normalise();
+    if (len <= 1e-20f)
+        return Ogre::Vector3::ZERO;
+    return n;
 }
 
-struct WeldKey {
-    int32_t px, py, pz, nx, ny, nz;
-    int32_t crgba; // raw packed diffuse, or 0 if mesh has no per-vertex colour
+static bool hasDirectedEdge(uint32_t e0, uint32_t e1, uint32_t x, uint32_t y, uint32_t z)
+{
+    return (x == e0 && y == e1) || (y == e0 && z == e1) || (z == e0 && x == e1);
+}
 
-    bool operator==(const WeldKey& o) const
-    {
-        return px == o.px && py == o.py && pz == o.pz && nx == o.nx && ny == o.ny && nz == o.nz && crgba == o.crgba;
+static bool tryMergeTrisToQuad(const std::array<uint32_t, 3>& A,
+                               const std::array<uint32_t, 3>& B,
+                               const std::vector<Ogre::Vector3>& wp,
+                               float minNormalDot,
+                               std::array<uint32_t, 4>& quad)
+{
+    for (int e = 0; e < 3; ++e) {
+        const uint32_t o = A[static_cast<size_t>(e)];
+        const uint32_t e0 = A[static_cast<size_t>((e + 1) % 3)];
+        const uint32_t e1 = A[static_cast<size_t>((e + 2) % 3)];
+
+        if (!hasDirectedEdge(e0, e1, B[0], B[1], B[2]))
+            continue;
+
+        uint32_t d = 0;
+        bool foundD = false;
+        for (uint32_t t : {B[0], B[1], B[2]}) {
+            if (t != e0 && t != e1) {
+                d = t;
+                foundD = true;
+                break;
+            }
+        }
+        if (!foundD || d == o)
+            continue;
+        if (o == e0 || o == e1)
+            continue;
+
+        std::unordered_set<uint32_t> uniq({o, e0, e1, d});
+        if (uniq.size() != 4)
+            continue;
+
+        const Ogre::Vector3 nA = triFaceNormalWelded(wp[o], wp[e0], wp[e1]);
+        const Ogre::Vector3 nB = triFaceNormalWelded(wp[e0], wp[e1], wp[d]);
+        if (nA.isZeroLength() || nB.isZeroLength())
+            continue;
+        if (nA.dotProduct(nB) < minNormalDot)
+            continue;
+
+        quad = {o, e0, e1, d};
+        return true;
     }
+    return false;
+}
+
+struct PsyqExportFace {
+    bool isQuad = false;
+    uint32_t v[4] = {};
+    QColor color;
+    bool hasColor = false;
 };
 
-struct WeldKeyHash {
-    size_t operator()(const WeldKey& k) const noexcept
-    {
-        size_t h = 1469598103934665603ull;
-        auto mix = [&](int32_t x) {
-            h ^= static_cast<size_t>(static_cast<uint32_t>(x)) * 1099511628211ull;
-        };
-        mix(k.px);
-        mix(k.py);
-        mix(k.pz);
-        mix(k.nx);
-        mix(k.ny);
-        mix(k.nz);
-        mix(k.crgba);
-        return h;
+static void mergeSubmeshTrisToQuads(const std::vector<uint32_t>& I0,
+                                    const std::vector<uint32_t>& I1,
+                                    const std::vector<uint32_t>& I2,
+                                    const std::vector<Ogre::Vector3>& weldPos,
+                                    const QVector<QColor>* triFaceColors,
+                                    std::vector<PsyqExportFace>& outFaces)
+{
+    const size_t n = I0.size();
+    if (I1.size() != n || I2.size() != n || n == 0)
+        return;
+
+    std::vector<char> used(n, 0);
+    const float minDot = 0.98f;
+    const bool haveTriColors = (triFaceColors && triFaceColors->size() == static_cast<int>(n));
+
+    auto triRgb = [&](size_t i) -> QColor {
+        return haveTriColors ? (*triFaceColors)[static_cast<int>(i)] : QColor();
+    };
+
+    for (size_t i = 0; i < n; ++i) {
+        if (used[i])
+            continue;
+
+        bool merged = false;
+        for (size_t j = i + 1; j < n && !merged; ++j) {
+            if (used[j])
+                continue;
+
+            std::array<uint32_t, 4> q{};
+            if (!tryMergeTrisToQuad({I0[i], I1[i], I2[i]}, {I0[j], I1[j], I2[j]}, weldPos, minDot, q))
+                continue;
+
+            PsyqExportFace f;
+            f.isQuad = true;
+            f.v[0] = q[0];
+            f.v[1] = q[1];
+            f.v[2] = q[2];
+            f.v[3] = q[3];
+            if (haveTriColors) {
+                const QColor a = triRgb(i);
+                const QColor b = triRgb(j);
+                f.color = QColor((a.red() + b.red()) / 2, (a.green() + b.green()) / 2, (a.blue() + b.blue()) / 2);
+                f.hasColor = true;
+            }
+            outFaces.push_back(f);
+            used[i] = used[j] = 1;
+            merged = true;
+        }
+
+        if (!merged) {
+            PsyqExportFace f;
+            f.isQuad = false;
+            f.v[0] = I0[i];
+            f.v[1] = I1[i];
+            f.v[2] = I2[i];
+            if (haveTriColors) {
+                f.color = triRgb(i);
+                f.hasColor = true;
+            }
+            outFaces.push_back(f);
+            used[i] = 1;
+        }
     }
-};
+}
 
 } // namespace
 
@@ -678,14 +845,8 @@ bool exportPsyqPlyFromEntity(const Ogre::Entity* entity,
     std::unordered_map<WeldKey, uint32_t, WeldKeyHash> weld;
     weld.reserve(size_t(totalFaces) * 3u);
 
-    std::vector<uint32_t> triI0, triI1, triI2;
-    triI0.reserve(totalFaces);
-    triI1.reserve(totalFaces);
-    triI2.reserve(totalFaces);
-    if (outFaceColors) {
-        outFaceColors->clear();
-        outFaceColors->reserve(static_cast<int>(totalFaces));
-    }
+    std::vector<PsyqExportFace> allExportFaces;
+    allExportFaces.reserve(totalFaces);
 
     auto weldCorner = [&](const Ogre::Vector3& p, const Ogre::Vector3& n, int32_t crgba) -> uint32_t {
         const WeldKey key{quantizeWorld(p.x), quantizeWorld(p.y), quantizeWorld(p.z),
@@ -724,6 +885,15 @@ bool exportPsyqPlyFromEntity(const Ogre::Entity* entity,
         const bool idx32 = (ibuf->getType() == Ogre::HardwareIndexBuffer::IT_32BIT);
         const unsigned ist = sd.id->indexStart;
         const size_t triCount = sd.id->indexCount / 3;
+
+        std::vector<uint32_t> smI0;
+        std::vector<uint32_t> smI1;
+        std::vector<uint32_t> smI2;
+        QVector<QColor> smFaceCols;
+        smI0.reserve(triCount);
+        smI1.reserve(triCount);
+        smI2.reserve(triCount);
+        const bool collectFaceColors = (outFaceColors != nullptr && sd.colEl && colBase);
 
         for (size_t t = 0; t < triCount; ++t) {
             uint32_t i0, i1, i2;
@@ -773,11 +943,11 @@ bool exportPsyqPlyFromEntity(const Ogre::Entity* entity,
             const uint32_t w0 = weldCorner(p0, n0, c0);
             const uint32_t w1 = weldCorner(p1, n1, c1);
             const uint32_t w2 = weldCorner(p2, n2, c2);
-            triI0.push_back(w0);
-            triI1.push_back(w1);
-            triI2.push_back(w2);
+            smI0.push_back(w0);
+            smI1.push_back(w1);
+            smI2.push_back(w2);
 
-            if (outFaceColors && sd.colEl && colBase) {
+            if (collectFaceColors) {
                 const Ogre::ColourValue cv0 = decodePackedColour(sd.colEl, static_cast<Ogre::RGBA>(c0));
                 const Ogre::ColourValue cv1 = decodePackedColour(sd.colEl, static_cast<Ogre::RGBA>(c1));
                 const Ogre::ColourValue cv2 = decodePackedColour(sd.colEl, static_cast<Ogre::RGBA>(c2));
@@ -785,9 +955,17 @@ bool exportPsyqPlyFromEntity(const Ogre::Entity* entity,
                                            (cv0.g + cv1.g + cv2.g) / 3.0f,
                                            (cv0.b + cv1.b + cv2.b) / 3.0f,
                                            1.0f);
-                outFaceColors->push_back(QColor::fromRgbF(ca.r, ca.g, ca.b, 1.0));
+                smFaceCols.push_back(QColor::fromRgbF(ca.r, ca.g, ca.b, 1.0));
             }
         }
+
+        std::vector<PsyqExportFace> subFaces;
+        mergeSubmeshTrisToQuads(smI0, smI1, smI2, weldedPos,
+                                collectFaceColors && smFaceCols.size() == static_cast<int>(smI0.size())
+                                    ? &smFaceCols
+                                    : nullptr,
+                                subFaces);
+        allExportFaces.insert(allExportFaces.end(), subFaces.begin(), subFaces.end());
 
         ibuf->unlock();
         if (sd.colBuf && colBase && sd.colEl->getSource() != sd.posEl->getSource()
@@ -799,8 +977,24 @@ bool exportPsyqPlyFromEntity(const Ogre::Entity* entity,
         sd.posBuf->unlock();
     }
 
+    if (outFaceColors) {
+        outFaceColors->clear();
+        bool allColored = !allExportFaces.empty();
+        for (const PsyqExportFace& ef : allExportFaces) {
+            if (!ef.hasColor) {
+                allColored = false;
+                break;
+            }
+        }
+        if (allColored) {
+            outFaceColors->reserve(static_cast<int>(allExportFaces.size()));
+            for (const PsyqExportFace& ef : allExportFaces)
+                outFaceColors->push_back(ef.color);
+        }
+    }
+
     const uint32_t nV = static_cast<uint32_t>(weldedPos.size());
-    const uint32_t nWrittenFaces = static_cast<uint32_t>(triI0.size());
+    const uint32_t nWrittenFaces = static_cast<uint32_t>(allExportFaces.size());
 
     QFile f(plyPath);
     if (!f.open(QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate)) {
@@ -818,11 +1012,14 @@ bool exportPsyqPlyFromEntity(const Ogre::Entity* entity,
     for (const Ogre::Vector3& n : weldedNrm)
         ts << n.x << " " << n.y << " " << n.z << "\n";
 
-    for (uint32_t fi = 0; fi < nWrittenFaces; ++fi) {
-        const uint32_t v0 = triI0[fi];
-        const uint32_t v1 = triI1[fi];
-        const uint32_t v2 = triI2[fi];
-        ts << "0 " << v0 << " " << v1 << " " << v2 << " 0 " << v0 << " " << v1 << " " << v2 << " 0\n";
+    for (const PsyqExportFace& ef : allExportFaces) {
+        if (ef.isQuad) {
+            ts << "1 " << ef.v[0] << " " << ef.v[1] << " " << ef.v[2] << " " << ef.v[3] << " " << ef.v[0] << " "
+               << ef.v[1] << " " << ef.v[2] << " " << ef.v[3] << "\n";
+        } else {
+            ts << "0 " << ef.v[0] << " " << ef.v[1] << " " << ef.v[2] << " 0 " << ef.v[0] << " " << ef.v[1] << " "
+               << ef.v[2] << " 0\n";
+        }
     }
 
     if (ts.status() != QTextStream::Ok) {

--- a/src/PS1/PS1PLY.cpp
+++ b/src/PS1/PS1PLY.cpp
@@ -17,6 +17,7 @@ The MIT License
 #include <OgrePass.h>
 #include <OgreSubMesh.h>
 #include <OgreTechnique.h>
+#include <OgreAny.h>
 #include <OgreVertexIndexData.h>
 
 #include <QColor>
@@ -386,9 +387,88 @@ static Ogre::MeshPtr buildMeshFromTriSoup(const std::string& meshName, const Tri
     return mesh;
 }
 
-static bool parsePsyqPlyLines(const QStringList& lines, TriSoup& outSoup, const QVector<QColor>* faceColors)
+static size_t triCountFromPsyqFaceLayout(const std::vector<uint8_t>& layout)
+{
+    size_t t = 0;
+    for (uint8_t c : layout) {
+        if (c == 3)
+            ++t;
+        else if (c == 4)
+            t += 2;
+    }
+    return t;
+}
+
+static std::string serializePsyqPlyFaceLayout(const std::vector<uint8_t>& layout)
+{
+    // Magic "QP1F" + little-endian uint32 count + raw bytes (each 3 or 4).
+    std::string s;
+    s.resize(8 + layout.size());
+    s[0] = 'Q';
+    s[1] = 'P';
+    s[2] = '1';
+    s[3] = 'F';
+    const uint32_t n = static_cast<uint32_t>(layout.size());
+    s[4] = static_cast<char>(n & 0xFF);
+    s[5] = static_cast<char>((n >> 8) & 0xFF);
+    s[6] = static_cast<char>((n >> 16) & 0xFF);
+    s[7] = static_cast<char>((n >> 24) & 0xFF);
+    for (size_t i = 0; i < layout.size(); ++i)
+        s[8 + i] = static_cast<char>(layout[i]);
+    return s;
+}
+
+static bool deserializePsyqPlyFaceLayout(const std::string& blob, std::vector<uint8_t>& outLayout)
+{
+    outLayout.clear();
+    if (blob.size() < 8 || blob[0] != 'Q' || blob[1] != 'P' || blob[2] != '1' || blob[3] != 'F')
+        return false;
+    const uint32_t n = static_cast<uint32_t>(static_cast<uint8_t>(blob[4]))
+                     | (static_cast<uint32_t>(static_cast<uint8_t>(blob[5])) << 8)
+                     | (static_cast<uint32_t>(static_cast<uint8_t>(blob[6])) << 16)
+                     | (static_cast<uint32_t>(static_cast<uint8_t>(blob[7])) << 24);
+    if (blob.size() != 8u + static_cast<size_t>(n))
+        return false;
+    outLayout.resize(n);
+    for (uint32_t i = 0; i < n; ++i) {
+        const uint8_t c = static_cast<uint8_t>(blob[8u + i]);
+        if (c != 3 && c != 4)
+            return false;
+        outLayout[i] = c;
+    }
+    return true;
+}
+
+static bool tryLoadPsyqPlyFaceLayoutFromMesh(const Ogre::MeshPtr& mesh, std::vector<uint8_t>& outLayout)
+{
+    outLayout.clear();
+    if (!mesh)
+        return false;
+    const Ogre::Any& a = mesh->getUserObjectBindings().getUserAny(PS1PLY::kPsyqPlyFaceLayoutUserKey);
+    if (a.isEmpty())
+        return false;
+    try {
+        const std::string& blob = Ogre::any_cast<std::string>(a);
+        return deserializePsyqPlyFaceLayout(blob, outLayout);
+    } catch (...) {
+        return false;
+    }
+}
+
+static void storePsyqPlyFaceLayoutOnMesh(const Ogre::MeshPtr& mesh, const std::vector<uint8_t>& layout)
+{
+    if (!mesh || layout.empty())
+        return;
+    mesh->getUserObjectBindings().setUserAny(PS1PLY::kPsyqPlyFaceLayoutUserKey,
+                                             Ogre::Any(serializePsyqPlyFaceLayout(layout)));
+}
+
+static bool parsePsyqPlyLines(const QStringList& lines, TriSoup& outSoup, const QVector<QColor>* faceColors,
+                              std::vector<uint8_t>* logicalFaceVertCounts = nullptr)
 {
     outSoup = {};
+    if (logicalFaceVertCounts)
+        logicalFaceVertCounts->clear();
     static const QRegularExpression kHeaderRe(QStringLiteral("^@PLY\\d*\\s*$"),
                                              QRegularExpression::CaseInsensitiveOption);
     int idx = 0;
@@ -471,6 +551,8 @@ static bool parsePsyqPlyLines(const QStringList& lines, TriSoup& outSoup, const 
                 return false;
             if (n0 >= nN || n1 >= nN || n2 >= nN)
                 return false;
+            if (logicalFaceVertCounts)
+                logicalFaceVertCounts->push_back(3);
             if (useFaceColors)
                 appendTriMaybeFlipColored(soup, verts, norms, v0, v1, v2, n0, n1, n2, faceRgba);
             else
@@ -489,6 +571,8 @@ static bool parsePsyqPlyLines(const QStringList& lines, TriSoup& outSoup, const 
                 return false;
             if (n0 >= nN || n1 >= nN || n2 >= nN || n3 >= nN)
                 return false;
+            if (logicalFaceVertCounts)
+                logicalFaceVertCounts->push_back(4);
             if (useFaceColors) {
                 appendTriMaybeFlipColored(soup, verts, norms, v0, v1, v2, n0, n1, n2, faceRgba);
                 appendTriMaybeFlipColored(soup, verts, norms, v1, v2, v3, n1, n2, n3, faceRgba);
@@ -530,11 +614,15 @@ static bool parsePsyqPlyLines(const QStringList& lines, TriSoup& outSoup, const 
                 return false;
 
             if (cnt == 3) {
+                if (logicalFaceVertCounts)
+                    logicalFaceVertCounts->push_back(3);
                 if (useFaceColors)
                     appendTriMaybeFlipColored(soup, verts, norms, v0, v1, v2, n0, n1, n2, faceRgba);
                 else
                     appendTri(soup, verts, norms, v0, v1, v2, n0, n1, n2);
             } else {
+                if (logicalFaceVertCounts)
+                    logicalFaceVertCounts->push_back(4);
                 if (useFaceColors) {
                     appendTriMaybeFlipColored(soup, verts, norms, v0, v1, v2, n0, n1, n2, faceRgba);
                     appendTriMaybeFlipColored(soup, verts, norms, v1, v2, v3, n1, n2, n3, faceRgba);
@@ -662,6 +750,79 @@ struct PsyqExportFace {
     bool hasColor = false;
 };
 
+/** Rebuild Psy-Q face list from stored import layout + current welded triangle indices (export order). */
+static bool buildExportFacesFromLayout(const std::vector<uint32_t>& I0,
+                                       const std::vector<uint32_t>& I1,
+                                       const std::vector<uint32_t>& I2,
+                                       const std::vector<uint8_t>& layout,
+                                       const QVector<QColor>* triFaceColors,
+                                       std::vector<PsyqExportFace>& outFaces)
+{
+    outFaces.clear();
+    size_t ti = 0;
+    const bool haveCol = triFaceColors && triFaceColors->size() == static_cast<int>(I0.size());
+
+    for (uint8_t nc : layout) {
+        if (nc == 3) {
+            if (ti >= I0.size())
+                return false;
+            PsyqExportFace f;
+            f.isQuad = false;
+            f.v[0] = I0[ti];
+            f.v[1] = I1[ti];
+            f.v[2] = I2[ti];
+            if (haveCol) {
+                f.color = (*triFaceColors)[static_cast<int>(ti)];
+                f.hasColor = true;
+            }
+            outFaces.push_back(f);
+            ++ti;
+        } else if (nc == 4) {
+            if (ti + 1 >= I0.size())
+                return false;
+            const uint32_t q0 = I0[ti], q1 = I1[ti], q2 = I2[ti];
+            const uint32_t b0 = I0[ti + 1], b1 = I1[ti + 1], b2 = I2[ti + 1];
+            if (q1 == b0 && q2 == b1) {
+                PsyqExportFace f;
+                f.isQuad = true;
+                f.v[0] = q0;
+                f.v[1] = q1;
+                f.v[2] = q2;
+                f.v[3] = b2;
+                if (haveCol) {
+                    const QColor& a = (*triFaceColors)[static_cast<int>(ti)];
+                    const QColor& b = (*triFaceColors)[static_cast<int>(ti + 1)];
+                    f.color = QColor((a.red() + b.red()) / 2, (a.green() + b.green()) / 2, (a.blue() + b.blue()) / 2);
+                    f.hasColor = true;
+                }
+                outFaces.push_back(f);
+            } else {
+                PsyqExportFace t1;
+                t1.isQuad = false;
+                t1.v[0] = q0;
+                t1.v[1] = q1;
+                t1.v[2] = q2;
+                PsyqExportFace t2;
+                t2.isQuad = false;
+                t2.v[0] = b0;
+                t2.v[1] = b1;
+                t2.v[2] = b2;
+                if (haveCol) {
+                    t1.color = (*triFaceColors)[static_cast<int>(ti)];
+                    t1.hasColor = true;
+                    t2.color = (*triFaceColors)[static_cast<int>(ti + 1)];
+                    t2.hasColor = true;
+                }
+                outFaces.push_back(t1);
+                outFaces.push_back(t2);
+            }
+            ti += 2;
+        } else
+            return false;
+    }
+    return ti == I0.size();
+}
+
 static void mergeSubmeshTrisToQuads(const std::vector<uint32_t>& I0,
                                     const std::vector<uint32_t>& I1,
                                     const std::vector<uint32_t>& I2,
@@ -674,7 +835,7 @@ static void mergeSubmeshTrisToQuads(const std::vector<uint32_t>& I0,
         return;
 
     std::vector<char> used(n, 0);
-    const float minDot = 0.98f;
+    const float minDot = 0.94f;
     const bool haveTriColors = (triFaceColors && triFaceColors->size() == static_cast<int>(n));
 
     auto triRgb = [&](size_t i) -> QColor {
@@ -750,10 +911,15 @@ Ogre::MeshPtr importPsyqPly(const QString& filePath, const std::string& meshName
     const QString text = QString::fromLatin1(f.readAll());
     const QStringList lines = readNonEmptyLines(text);
     TriSoup soup;
-    if (!parsePsyqPlyLines(lines, soup, nullptr))
+    std::vector<uint8_t> faceLayout;
+    if (!parsePsyqPlyLines(lines, soup, nullptr, &faceLayout))
         return {};
 
-    return buildMeshFromTriSoup(meshName, soup);
+    Ogre::MeshPtr mesh = buildMeshFromTriSoup(meshName, soup);
+    if (mesh && !faceLayout.empty()
+        && triCountFromPsyqFaceLayout(faceLayout) == soup.pos.size() / 3u)
+        storePsyqPlyFaceLayoutOnMesh(mesh, faceLayout);
+    return mesh;
 }
 
 Ogre::MeshPtr importPsyqPlyWithFaceColors(const QString& filePath,
@@ -766,9 +932,14 @@ Ogre::MeshPtr importPsyqPlyWithFaceColors(const QString& filePath,
     const QString text = QString::fromLatin1(f.readAll());
     const QStringList lines = readNonEmptyLines(text);
     TriSoup soup;
-    if (!parsePsyqPlyLines(lines, soup, &faceColors))
+    std::vector<uint8_t> faceLayout;
+    if (!parsePsyqPlyLines(lines, soup, &faceColors, &faceLayout))
         return {};
-    return buildMeshFromTriSoup(meshName, soup);
+    Ogre::MeshPtr mesh = buildMeshFromTriSoup(meshName, soup);
+    if (mesh && !faceLayout.empty()
+        && triCountFromPsyqFaceLayout(faceLayout) == soup.pos.size() / 3u)
+        storePsyqPlyFaceLayoutOnMesh(mesh, faceLayout);
+    return mesh;
 }
 
 bool exportPsyqPlyFromEntity(const Ogre::Entity* entity,
@@ -838,6 +1009,11 @@ bool exportPsyqPlyFromEntity(const Ogre::Entity* entity,
         return false;
     }
 
+    std::vector<uint8_t> meshFaceLayout;
+    const bool haveMeshLayout =
+        (numSub == 1u && tryLoadPsyqPlyFaceLayoutFromMesh(mesh, meshFaceLayout)
+         && triCountFromPsyqFaceLayout(meshFaceLayout) == static_cast<size_t>(totalFaces));
+
     std::vector<Ogre::Vector3> weldedPos;
     std::vector<Ogre::Vector3> weldedNrm;
     weldedPos.reserve(size_t(totalFaces) * 3u);
@@ -861,7 +1037,8 @@ bool exportPsyqPlyFromEntity(const Ogre::Entity* entity,
         return idx;
     };
 
-    for (SubData& sd : subs) {
+    for (unsigned si = 0; si < subs.size(); ++si) {
+        SubData& sd = subs[si];
         const uint8_t* posBase = static_cast<const uint8_t*>(sd.posBuf->lock(Ogre::HardwareBuffer::HBL_READ_ONLY));
         const uint8_t* nrmBase = nullptr;
         if (sd.nrmEl->getSource() == sd.posEl->getSource()) {
@@ -960,11 +1137,16 @@ bool exportPsyqPlyFromEntity(const Ogre::Entity* entity,
         }
 
         std::vector<PsyqExportFace> subFaces;
-        mergeSubmeshTrisToQuads(smI0, smI1, smI2, weldedPos,
-                                collectFaceColors && smFaceCols.size() == static_cast<int>(smI0.size())
-                                    ? &smFaceCols
-                                    : nullptr,
-                                subFaces);
+        QVector<QColor>* colorMerge =
+            collectFaceColors && smFaceCols.size() == static_cast<int>(smI0.size()) ? &smFaceCols : nullptr;
+
+        if (haveMeshLayout && numSub == 1u && si == 0u
+            && triCountFromPsyqFaceLayout(meshFaceLayout) == smI0.size()) {
+            if (!buildExportFacesFromLayout(smI0, smI1, smI2, meshFaceLayout, colorMerge, subFaces))
+                mergeSubmeshTrisToQuads(smI0, smI1, smI2, weldedPos, colorMerge, subFaces);
+        } else {
+            mergeSubmeshTrisToQuads(smI0, smI1, smI2, weldedPos, colorMerge, subFaces);
+        }
         allExportFaces.insert(allExportFaces.end(), subFaces.begin(), subFaces.end());
 
         ibuf->unlock();

--- a/src/PS1/PS1PLY.cpp
+++ b/src/PS1/PS1PLY.cpp
@@ -10,6 +10,8 @@ The MIT License
 
 #include "PS1/PS1PLY.h"
 
+#include "EditableMesh.h"
+
 #include <OgreHardwareBufferManager.h>
 #include <OgreLogManager.h>
 #include <OgreMaterialManager.h>
@@ -17,7 +19,6 @@ The MIT License
 #include <OgrePass.h>
 #include <OgreSubMesh.h>
 #include <OgreTechnique.h>
-#include <OgreAny.h>
 #include <OgreVertexIndexData.h>
 
 #include <QColor>
@@ -28,6 +29,7 @@ The MIT License
 
 #include <array>
 #include <cmath>
+#include <limits>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -243,7 +245,161 @@ static std::vector<int> parseIntTokens(const QString& line)
     return t;
 }
 
-static Ogre::MeshPtr buildMeshFromTriSoup(const std::string& meshName, const TriSoup& soup)
+static size_t triCountFromPsyqFaceLayout(const std::vector<uint8_t>& layout)
+{
+    size_t t = 0;
+    for (uint8_t c : layout) {
+        if (c == 3)
+            ++t;
+        else if (c == 4)
+            t += 2;
+    }
+    return t;
+}
+
+/** True if welded triangle (a0,a1,a2) is (c0,c1,c2) up to cyclic rotation and/or reversal. */
+static bool weldedTriMatchesCanonical(uint32_t a0, uint32_t a1, uint32_t a2, uint32_t c0, uint32_t c1, uint32_t c2)
+{
+    const uint32_t a[3] = {a0, a1, a2};
+    for (int r = 0; r < 3; ++r) {
+        if (a[r] == c0 && a[(r + 1) % 3] == c1 && a[(r + 2) % 3] == c2)
+            return true;
+        if (a[r] == c0 && a[(r + 2) % 3] == c1 && a[(r + 1) % 3] == c2)
+            return true;
+    }
+    return false;
+}
+
+/**
+ * Recover PS1/TMD quad corner order (v0,v1,v2,v3) from two welded triangles that were
+ * emitted as (v0,v1,v2) + (v1,v2,v3) before welding (each tri may be winding-flipped).
+ */
+static bool mergeWeldedTriPairToQuad(const std::vector<Ogre::Vector3>& pos,
+                                     const std::vector<Ogre::Vector3>& nrm,
+                                     uint32_t a0,
+                                     uint32_t a1,
+                                     uint32_t a2,
+                                     uint32_t b0,
+                                     uint32_t b1,
+                                     uint32_t b2,
+                                     std::vector<unsigned int>& quadOut)
+{
+    quadOut.clear();
+    const uint32_t triA[3] = {a0, a1, a2};
+    const uint32_t triB[3] = {b0, b1, b2};
+    const std::unordered_set<uint32_t> sb{triB[0], triB[1], triB[2]};
+    const std::unordered_set<uint32_t> sa{triA[0], triA[1], triA[2]};
+
+    uint32_t v0 = UINT32_MAX;
+    for (uint32_t x : triA) {
+        if (!sb.count(x))
+            v0 = x;
+    }
+    uint32_t v3 = UINT32_MAX;
+    for (uint32_t x : triB) {
+        if (!sa.count(x))
+            v3 = x;
+    }
+    if (v0 == UINT32_MAX || v3 == UINT32_MAX)
+        return false;
+
+    uint32_t p = UINT32_MAX, q = UINT32_MAX;
+    for (uint32_t x : triA) {
+        if (x != v0) {
+            if (p == UINT32_MAX)
+                p = x;
+            else
+                q = x;
+        }
+    }
+    if (p == UINT32_MAX || q == UINT32_MAX || p == q)
+        return false;
+    if (!sb.count(p) || !sb.count(q))
+        return false;
+
+    const std::unordered_set<uint32_t> uniq{v0, p, q, v3};
+    if (uniq.size() != 4)
+        return false;
+
+    auto scoreAgainstRef = [&](uint32_t cv0, uint32_t cv1, uint32_t cv2) -> float {
+        const Ogre::Vector3& P0 = pos[cv0];
+        const Ogre::Vector3& P1 = pos[cv1];
+        const Ogre::Vector3& P2 = pos[cv2];
+        Ogre::Vector3 fn = (P1 - P0).crossProduct(P2 - P0);
+        const float len = fn.length();
+        if (len > 1e-20f)
+            fn /= len;
+        Ogre::Vector3 an = nrm[cv0] + nrm[cv1] + nrm[cv2];
+        if (!an.isZeroLength())
+            an.normalise();
+        else
+            return 0.f;
+        return fn.dotProduct(an);
+    };
+
+    const std::array<std::array<uint32_t, 4>, 2> candidates{{{v0, p, q, v3}, {v0, q, p, v3}}};
+    int bestIdx = -1;
+    float bestScore = -2.f;
+    for (int ci = 0; ci < 2; ++ci) {
+        const uint32_t qv0 = candidates[ci][0];
+        const uint32_t qv1 = candidates[ci][1];
+        const uint32_t qv2 = candidates[ci][2];
+        const uint32_t qv3 = candidates[ci][3];
+        if (!weldedTriMatchesCanonical(a0, a1, a2, qv0, qv1, qv2))
+            continue;
+        if (!weldedTriMatchesCanonical(b0, b1, b2, qv1, qv2, qv3))
+            continue;
+        const float s = scoreAgainstRef(qv0, qv1, qv2) + scoreAgainstRef(qv1, qv2, qv3);
+        if (s > bestScore) {
+            bestScore = s;
+            bestIdx = ci;
+        }
+    }
+    if (bestIdx < 0)
+        return false;
+    quadOut.assign(candidates[static_cast<size_t>(bestIdx)].begin(), candidates[static_cast<size_t>(bestIdx)].end());
+    return true;
+}
+
+static bool buildNgonPayloadFromWeldedTriangles(const std::vector<uint32_t>& triIndices,
+                                                const std::vector<uint8_t>& layout,
+                                                const std::vector<Ogre::Vector3>& uniqPos,
+                                                const std::vector<Ogre::Vector3>& uniqNrm,
+                                                std::vector<std::vector<unsigned int>>& outFaces)
+{
+    outFaces.clear();
+    const size_t nTri = triIndices.size() / 3;
+    size_t triIdx = 0;
+    for (uint8_t nc : layout) {
+        if (nc == 3) {
+            if (triIdx >= nTri)
+                return false;
+            outFaces.push_back({static_cast<unsigned int>(triIndices[triIdx * 3]),
+                                static_cast<unsigned int>(triIndices[triIdx * 3 + 1]),
+                                static_cast<unsigned int>(triIndices[triIdx * 3 + 2])});
+            ++triIdx;
+        } else if (nc == 4) {
+            if (triIdx + 1 >= nTri)
+                return false;
+            const uint32_t a0 = triIndices[triIdx * 3], a1 = triIndices[triIdx * 3 + 1], a2 = triIndices[triIdx * 3 + 2];
+            const uint32_t b0 = triIndices[(triIdx + 1) * 3], b1 = triIndices[(triIdx + 1) * 3 + 1],
+                           b2 = triIndices[(triIdx + 1) * 3 + 2];
+            std::vector<unsigned int> quad;
+            if (mergeWeldedTriPairToQuad(uniqPos, uniqNrm, a0, a1, a2, b0, b1, b2, quad))
+                outFaces.push_back(std::move(quad));
+            else {
+                outFaces.push_back({a0, a1, a2});
+                outFaces.push_back({b0, b1, b2});
+            }
+            triIdx += 2;
+        } else
+            return false;
+    }
+    return triIdx == nTri;
+}
+
+static Ogre::MeshPtr buildMeshFromTriSoup(const std::string& meshName, const TriSoup& soup,
+                                          const std::vector<uint8_t>* psyqFaceLayoutForNgons = nullptr)
 {
     if (soup.pos.empty() || soup.pos.size() % 3u != 0 || soup.nrm.size() != soup.pos.size())
         return {};
@@ -384,83 +540,26 @@ static Ogre::MeshPtr buildMeshFromTriSoup(const std::string& meshName, const Tri
     mesh->_setBounds(bounds);
     mesh->_setBoundingSphereRadius(bounds.getHalfSize().length());
     mesh->load();
+
+    if (psyqFaceLayoutForNgons && !psyqFaceLayoutForNgons->empty()
+        && triCountFromPsyqFaceLayout(*psyqFaceLayoutForNgons) == nTri) {
+        std::vector<std::vector<unsigned int>> ngonPayload;
+        if (buildNgonPayloadFromWeldedTriangles(indices, *psyqFaceLayoutForNgons, uniqPos, uniqNrm, ngonPayload)
+            && !ngonPayload.empty()) {
+            std::vector<EditableSubMesh> es(1);
+            es[0].faces.reserve(ngonPayload.size());
+            for (auto& poly : ngonPayload) {
+                EditableFace ef;
+                ef.indices = std::move(poly);
+                if (ef.isValid())
+                    es[0].faces.push_back(std::move(ef));
+            }
+            if (!es[0].faces.empty())
+                writeNgonFacesToMesh(mesh.get(), es);
+        }
+    }
+
     return mesh;
-}
-
-static size_t triCountFromPsyqFaceLayout(const std::vector<uint8_t>& layout)
-{
-    size_t t = 0;
-    for (uint8_t c : layout) {
-        if (c == 3)
-            ++t;
-        else if (c == 4)
-            t += 2;
-    }
-    return t;
-}
-
-static std::string serializePsyqPlyFaceLayout(const std::vector<uint8_t>& layout)
-{
-    // Magic "QP1F" + little-endian uint32 count + raw bytes (each 3 or 4).
-    std::string s;
-    s.resize(8 + layout.size());
-    s[0] = 'Q';
-    s[1] = 'P';
-    s[2] = '1';
-    s[3] = 'F';
-    const uint32_t n = static_cast<uint32_t>(layout.size());
-    s[4] = static_cast<char>(n & 0xFF);
-    s[5] = static_cast<char>((n >> 8) & 0xFF);
-    s[6] = static_cast<char>((n >> 16) & 0xFF);
-    s[7] = static_cast<char>((n >> 24) & 0xFF);
-    for (size_t i = 0; i < layout.size(); ++i)
-        s[8 + i] = static_cast<char>(layout[i]);
-    return s;
-}
-
-static bool deserializePsyqPlyFaceLayout(const std::string& blob, std::vector<uint8_t>& outLayout)
-{
-    outLayout.clear();
-    if (blob.size() < 8 || blob[0] != 'Q' || blob[1] != 'P' || blob[2] != '1' || blob[3] != 'F')
-        return false;
-    const uint32_t n = static_cast<uint32_t>(static_cast<uint8_t>(blob[4]))
-                     | (static_cast<uint32_t>(static_cast<uint8_t>(blob[5])) << 8)
-                     | (static_cast<uint32_t>(static_cast<uint8_t>(blob[6])) << 16)
-                     | (static_cast<uint32_t>(static_cast<uint8_t>(blob[7])) << 24);
-    if (blob.size() != 8u + static_cast<size_t>(n))
-        return false;
-    outLayout.resize(n);
-    for (uint32_t i = 0; i < n; ++i) {
-        const uint8_t c = static_cast<uint8_t>(blob[8u + i]);
-        if (c != 3 && c != 4)
-            return false;
-        outLayout[i] = c;
-    }
-    return true;
-}
-
-static bool tryLoadPsyqPlyFaceLayoutFromMesh(const Ogre::MeshPtr& mesh, std::vector<uint8_t>& outLayout)
-{
-    outLayout.clear();
-    if (!mesh)
-        return false;
-    const Ogre::Any& a = mesh->getUserObjectBindings().getUserAny(PS1PLY::kPsyqPlyFaceLayoutUserKey);
-    if (a.isEmpty())
-        return false;
-    try {
-        const std::string& blob = Ogre::any_cast<std::string>(a);
-        return deserializePsyqPlyFaceLayout(blob, outLayout);
-    } catch (...) {
-        return false;
-    }
-}
-
-static void storePsyqPlyFaceLayoutOnMesh(const Ogre::MeshPtr& mesh, const std::vector<uint8_t>& layout)
-{
-    if (!mesh || layout.empty())
-        return;
-    mesh->getUserObjectBindings().setUserAny(PS1PLY::kPsyqPlyFaceLayoutUserKey,
-                                             Ogre::Any(serializePsyqPlyFaceLayout(layout)));
 }
 
 static bool parsePsyqPlyLines(const QStringList& lines, TriSoup& outSoup, const QVector<QColor>* faceColors,
@@ -750,79 +849,6 @@ struct PsyqExportFace {
     bool hasColor = false;
 };
 
-/** Rebuild Psy-Q face list from stored import layout + current welded triangle indices (export order). */
-static bool buildExportFacesFromLayout(const std::vector<uint32_t>& I0,
-                                       const std::vector<uint32_t>& I1,
-                                       const std::vector<uint32_t>& I2,
-                                       const std::vector<uint8_t>& layout,
-                                       const QVector<QColor>* triFaceColors,
-                                       std::vector<PsyqExportFace>& outFaces)
-{
-    outFaces.clear();
-    size_t ti = 0;
-    const bool haveCol = triFaceColors && triFaceColors->size() == static_cast<int>(I0.size());
-
-    for (uint8_t nc : layout) {
-        if (nc == 3) {
-            if (ti >= I0.size())
-                return false;
-            PsyqExportFace f;
-            f.isQuad = false;
-            f.v[0] = I0[ti];
-            f.v[1] = I1[ti];
-            f.v[2] = I2[ti];
-            if (haveCol) {
-                f.color = (*triFaceColors)[static_cast<int>(ti)];
-                f.hasColor = true;
-            }
-            outFaces.push_back(f);
-            ++ti;
-        } else if (nc == 4) {
-            if (ti + 1 >= I0.size())
-                return false;
-            const uint32_t q0 = I0[ti], q1 = I1[ti], q2 = I2[ti];
-            const uint32_t b0 = I0[ti + 1], b1 = I1[ti + 1], b2 = I2[ti + 1];
-            if (q1 == b0 && q2 == b1) {
-                PsyqExportFace f;
-                f.isQuad = true;
-                f.v[0] = q0;
-                f.v[1] = q1;
-                f.v[2] = q2;
-                f.v[3] = b2;
-                if (haveCol) {
-                    const QColor& a = (*triFaceColors)[static_cast<int>(ti)];
-                    const QColor& b = (*triFaceColors)[static_cast<int>(ti + 1)];
-                    f.color = QColor((a.red() + b.red()) / 2, (a.green() + b.green()) / 2, (a.blue() + b.blue()) / 2);
-                    f.hasColor = true;
-                }
-                outFaces.push_back(f);
-            } else {
-                PsyqExportFace t1;
-                t1.isQuad = false;
-                t1.v[0] = q0;
-                t1.v[1] = q1;
-                t1.v[2] = q2;
-                PsyqExportFace t2;
-                t2.isQuad = false;
-                t2.v[0] = b0;
-                t2.v[1] = b1;
-                t2.v[2] = b2;
-                if (haveCol) {
-                    t1.color = (*triFaceColors)[static_cast<int>(ti)];
-                    t1.hasColor = true;
-                    t2.color = (*triFaceColors)[static_cast<int>(ti + 1)];
-                    t2.hasColor = true;
-                }
-                outFaces.push_back(t1);
-                outFaces.push_back(t2);
-            }
-            ti += 2;
-        } else
-            return false;
-    }
-    return ti == I0.size();
-}
-
 static void mergeSubmeshTrisToQuads(const std::vector<uint32_t>& I0,
                                     const std::vector<uint32_t>& I1,
                                     const std::vector<uint32_t>& I2,
@@ -915,11 +941,10 @@ Ogre::MeshPtr importPsyqPly(const QString& filePath, const std::string& meshName
     if (!parsePsyqPlyLines(lines, soup, nullptr, &faceLayout))
         return {};
 
-    Ogre::MeshPtr mesh = buildMeshFromTriSoup(meshName, soup);
-    if (mesh && !faceLayout.empty()
-        && triCountFromPsyqFaceLayout(faceLayout) == soup.pos.size() / 3u)
-        storePsyqPlyFaceLayoutOnMesh(mesh, faceLayout);
-    return mesh;
+    const std::vector<uint8_t>* layoutPtr = nullptr;
+    if (!faceLayout.empty() && triCountFromPsyqFaceLayout(faceLayout) == soup.pos.size() / 3u)
+        layoutPtr = &faceLayout;
+    return buildMeshFromTriSoup(meshName, soup, layoutPtr);
 }
 
 Ogre::MeshPtr importPsyqPlyWithFaceColors(const QString& filePath,
@@ -935,11 +960,10 @@ Ogre::MeshPtr importPsyqPlyWithFaceColors(const QString& filePath,
     std::vector<uint8_t> faceLayout;
     if (!parsePsyqPlyLines(lines, soup, &faceColors, &faceLayout))
         return {};
-    Ogre::MeshPtr mesh = buildMeshFromTriSoup(meshName, soup);
-    if (mesh && !faceLayout.empty()
-        && triCountFromPsyqFaceLayout(faceLayout) == soup.pos.size() / 3u)
-        storePsyqPlyFaceLayoutOnMesh(mesh, faceLayout);
-    return mesh;
+    const std::vector<uint8_t>* layoutPtr = nullptr;
+    if (!faceLayout.empty() && triCountFromPsyqFaceLayout(faceLayout) == soup.pos.size() / 3u)
+        layoutPtr = &faceLayout;
+    return buildMeshFromTriSoup(meshName, soup, layoutPtr);
 }
 
 bool exportPsyqPlyFromEntity(const Ogre::Entity* entity,
@@ -1009,10 +1033,25 @@ bool exportPsyqPlyFromEntity(const Ogre::Entity* entity,
         return false;
     }
 
-    std::vector<uint8_t> meshFaceLayout;
-    const bool haveMeshLayout =
-        (numSub == 1u && tryLoadPsyqPlyFaceLayoutFromMesh(mesh, meshFaceLayout)
-         && triCountFromPsyqFaceLayout(meshFaceLayout) == static_cast<size_t>(totalFaces));
+    std::vector<std::vector<unsigned int>> ngonFaces;
+    bool useNgonExport =
+        (numSub == 1u && subs.size() == 1u && readNgonFacesFromMesh(mesh.get(), 0, ngonFaces));
+    if (useNgonExport) {
+        for (const auto& poly : ngonFaces) {
+            if (poly.size() < 3) {
+                useNgonExport = false;
+                break;
+            }
+            for (unsigned int vid : poly) {
+                if (vid >= subs[0].vCount) {
+                    useNgonExport = false;
+                    break;
+                }
+            }
+            if (!useNgonExport)
+                break;
+        }
+    }
 
     std::vector<Ogre::Vector3> weldedPos;
     std::vector<Ogre::Vector3> weldedNrm;
@@ -1037,8 +1076,8 @@ bool exportPsyqPlyFromEntity(const Ogre::Entity* entity,
         return idx;
     };
 
-    for (unsigned si = 0; si < subs.size(); ++si) {
-        SubData& sd = subs[si];
+    if (useNgonExport) {
+        SubData& sd = subs[0];
         const uint8_t* posBase = static_cast<const uint8_t*>(sd.posBuf->lock(Ogre::HardwareBuffer::HBL_READ_ONLY));
         const uint8_t* nrmBase = nullptr;
         if (sd.nrmEl->getSource() == sd.posEl->getSource()) {
@@ -1057,99 +1096,103 @@ bool exportPsyqPlyFromEntity(const Ogre::Entity* entity,
             }
         }
 
-        auto ibuf = sd.id->indexBuffer;
-        const uint8_t* idxBase = static_cast<const uint8_t*>(ibuf->lock(Ogre::HardwareBuffer::HBL_READ_ONLY));
-        const bool idx32 = (ibuf->getType() == Ogre::HardwareIndexBuffer::IT_32BIT);
-        const unsigned ist = sd.id->indexStart;
-        const size_t triCount = sd.id->indexCount / 3;
-
-        std::vector<uint32_t> smI0;
-        std::vector<uint32_t> smI1;
-        std::vector<uint32_t> smI2;
-        QVector<QColor> smFaceCols;
-        smI0.reserve(triCount);
-        smI1.reserve(triCount);
-        smI2.reserve(triCount);
         const bool collectFaceColors = (outFaceColors != nullptr && sd.colEl && colBase);
 
-        for (size_t t = 0; t < triCount; ++t) {
-            uint32_t i0, i1, i2;
-            if (idx32) {
-                const auto* ip = reinterpret_cast<const uint32_t*>(idxBase);
-                i0 = ip[ist + t * 3 + 0];
-                i1 = ip[ist + t * 3 + 1];
-                i2 = ip[ist + t * 3 + 2];
-            } else {
-                const auto* ip = reinterpret_cast<const uint16_t*>(idxBase);
-                i0 = ip[ist + t * 3 + 0];
-                i1 = ip[ist + t * 3 + 1];
-                i2 = ip[ist + t * 3 + 2];
-            }
-            if (i0 >= sd.vCount || i1 >= sd.vCount || i2 >= sd.vCount)
-                continue;
+        auto readPN = [&](uint32_t ii, Ogre::Vector3& p, Ogre::Vector3& n) {
+            const uint8_t* prow = posBase + size_t(ii) * sd.posStride;
+            Ogre::Real* pf = nullptr;
+            sd.posEl->baseVertexPointerToElement(const_cast<uint8_t*>(prow), &pf);
+            p = Ogre::Vector3(pf[0], pf[1], pf[2]);
+            applyPlyExportWorldTransform(p);
+            const uint8_t* nrow = nrmBase + size_t(ii) * sd.nrmStride;
+            Ogre::Real* nf = nullptr;
+            sd.nrmEl->baseVertexPointerToElement(const_cast<uint8_t*>(nrow), &nf);
+            n = Ogre::Vector3(nf[0], nf[1], nf[2]);
+            applyPlyExportWorldTransformNormal(n);
+        };
 
-            auto readPN = [&](uint32_t ii, Ogre::Vector3& p, Ogre::Vector3& n) {
-                const uint8_t* prow = posBase + size_t(ii) * sd.posStride;
-                Ogre::Real* pf = nullptr;
-                sd.posEl->baseVertexPointerToElement(const_cast<uint8_t*>(prow), &pf);
-                p = Ogre::Vector3(pf[0], pf[1], pf[2]);
-                applyPlyExportWorldTransform(p);
-                const uint8_t* nrow = nrmBase + size_t(ii) * sd.nrmStride;
-                Ogre::Real* nf = nullptr;
-                sd.nrmEl->baseVertexPointerToElement(const_cast<uint8_t*>(nrow), &nf);
-                n = Ogre::Vector3(nf[0], nf[1], nf[2]);
-                applyPlyExportWorldTransformNormal(n);
-            };
-
-            Ogre::Vector3 p0, p1, p2, n0, n1, n2;
-            readPN(i0, p0, n0);
-            readPN(i1, p1, n1);
-            readPN(i2, p2, n2);
-
-            int32_t c0 = 0, c1 = 0, c2 = 0;
+        auto cornerCrgba = [&](uint32_t vi) -> int32_t {
+            int32_t c = 0;
             if (sd.colEl && colBase) {
                 Ogre::RGBA* cp = nullptr;
-                sd.colEl->baseVertexPointerToElement(const_cast<uint8_t*>(colBase + size_t(i0) * sd.colStride), &cp);
-                c0 = static_cast<int32_t>(*cp);
-                sd.colEl->baseVertexPointerToElement(const_cast<uint8_t*>(colBase + size_t(i1) * sd.colStride), &cp);
-                c1 = static_cast<int32_t>(*cp);
-                sd.colEl->baseVertexPointerToElement(const_cast<uint8_t*>(colBase + size_t(i2) * sd.colStride), &cp);
-                c2 = static_cast<int32_t>(*cp);
+                sd.colEl->baseVertexPointerToElement(const_cast<uint8_t*>(colBase + size_t(vi) * sd.colStride), &cp);
+                c = static_cast<int32_t>(*cp);
             }
+            return c;
+        };
 
-            const uint32_t w0 = weldCorner(p0, n0, c0);
-            const uint32_t w1 = weldCorner(p1, n1, c1);
-            const uint32_t w2 = weldCorner(p2, n2, c2);
-            smI0.push_back(w0);
-            smI1.push_back(w1);
-            smI2.push_back(w2);
+        constexpr uint32_t kMeshVertUnwelded = std::numeric_limits<uint32_t>::max();
+        std::vector<uint32_t> meshToFile(sd.vCount, kMeshVertUnwelded);
 
-            if (collectFaceColors) {
-                const Ogre::ColourValue cv0 = decodePackedColour(sd.colEl, static_cast<Ogre::RGBA>(c0));
-                const Ogre::ColourValue cv1 = decodePackedColour(sd.colEl, static_cast<Ogre::RGBA>(c1));
-                const Ogre::ColourValue cv2 = decodePackedColour(sd.colEl, static_cast<Ogre::RGBA>(c2));
-                const Ogre::ColourValue ca((cv0.r + cv1.r + cv2.r) / 3.0f,
-                                           (cv0.g + cv1.g + cv2.g) / 3.0f,
-                                           (cv0.b + cv1.b + cv2.b) / 3.0f,
-                                           1.0f);
-                smFaceCols.push_back(QColor::fromRgbF(ca.r, ca.g, ca.b, 1.0));
+        auto fileWeldForMeshVert = [&](uint32_t vi) -> uint32_t {
+            if (meshToFile[vi] != kMeshVertUnwelded)
+                return meshToFile[vi];
+            Ogre::Vector3 p, n;
+            readPN(vi, p, n);
+            const uint32_t w = weldCorner(p, n, cornerCrgba(vi));
+            meshToFile[vi] = w;
+            return w;
+        };
+
+        auto avgRgbCorners = [&](const std::vector<unsigned int>& corners) -> QColor {
+            Ogre::ColourValue acc(0, 0, 0, 1.0f);
+            for (unsigned int vi : corners) {
+                const Ogre::ColourValue cv =
+                    decodePackedColour(sd.colEl, static_cast<Ogre::RGBA>(cornerCrgba(vi)));
+                acc.r += cv.r;
+                acc.g += cv.g;
+                acc.b += cv.b;
+            }
+            const float inv = 1.0f / float(corners.size());
+            return QColor::fromRgbF(acc.r * inv, acc.g * inv, acc.b * inv, 1.0f);
+        };
+
+        allExportFaces.reserve(ngonFaces.size() * 2);
+
+        for (const auto& poly : ngonFaces) {
+            const size_t ps = poly.size();
+            if (ps == 3) {
+                PsyqExportFace f;
+                f.isQuad = false;
+                f.v[0] = fileWeldForMeshVert(poly[0]);
+                f.v[1] = fileWeldForMeshVert(poly[1]);
+                f.v[2] = fileWeldForMeshVert(poly[2]);
+                if (collectFaceColors) {
+                    f.color = avgRgbCorners(poly);
+                    f.hasColor = true;
+                }
+                allExportFaces.push_back(f);
+            } else if (ps == 4) {
+                PsyqExportFace f;
+                f.isQuad = true;
+                f.v[0] = fileWeldForMeshVert(poly[0]);
+                f.v[1] = fileWeldForMeshVert(poly[1]);
+                f.v[2] = fileWeldForMeshVert(poly[2]);
+                f.v[3] = fileWeldForMeshVert(poly[3]);
+                if (collectFaceColors) {
+                    f.color = avgRgbCorners(poly);
+                    f.hasColor = true;
+                }
+                allExportFaces.push_back(f);
+            } else {
+                const uint32_t hub = fileWeldForMeshVert(poly[0]);
+                for (size_t k = 1; k + 1 < ps; ++k) {
+                    PsyqExportFace t;
+                    t.isQuad = false;
+                    t.v[0] = hub;
+                    t.v[1] = fileWeldForMeshVert(poly[k]);
+                    t.v[2] = fileWeldForMeshVert(poly[k + 1]);
+                    if (collectFaceColors) {
+                        const std::vector<unsigned int> tri{poly[0], poly[static_cast<size_t>(k)],
+                                                              poly[static_cast<size_t>(k + 1)]};
+                        t.color = avgRgbCorners(tri);
+                        t.hasColor = true;
+                    }
+                    allExportFaces.push_back(t);
+                }
             }
         }
 
-        std::vector<PsyqExportFace> subFaces;
-        QVector<QColor>* colorMerge =
-            collectFaceColors && smFaceCols.size() == static_cast<int>(smI0.size()) ? &smFaceCols : nullptr;
-
-        if (haveMeshLayout && numSub == 1u && si == 0u
-            && triCountFromPsyqFaceLayout(meshFaceLayout) == smI0.size()) {
-            if (!buildExportFacesFromLayout(smI0, smI1, smI2, meshFaceLayout, colorMerge, subFaces))
-                mergeSubmeshTrisToQuads(smI0, smI1, smI2, weldedPos, colorMerge, subFaces);
-        } else {
-            mergeSubmeshTrisToQuads(smI0, smI1, smI2, weldedPos, colorMerge, subFaces);
-        }
-        allExportFaces.insert(allExportFaces.end(), subFaces.begin(), subFaces.end());
-
-        ibuf->unlock();
         if (sd.colBuf && colBase && sd.colEl->getSource() != sd.posEl->getSource()
             && !(sd.colEl->getSource() == sd.nrmEl->getSource() && sd.nrmEl->getSource() != sd.posEl->getSource())) {
             sd.colBuf->unlock();
@@ -1157,6 +1200,124 @@ bool exportPsyqPlyFromEntity(const Ogre::Entity* entity,
         if (sd.nrmEl->getSource() != sd.posEl->getSource())
             sd.nrmBuf->unlock();
         sd.posBuf->unlock();
+    } else {
+        for (unsigned si = 0; si < subs.size(); ++si) {
+            SubData& sd = subs[si];
+            const uint8_t* posBase = static_cast<const uint8_t*>(sd.posBuf->lock(Ogre::HardwareBuffer::HBL_READ_ONLY));
+            const uint8_t* nrmBase = nullptr;
+            if (sd.nrmEl->getSource() == sd.posEl->getSource()) {
+                nrmBase = posBase;
+            } else {
+                nrmBase = static_cast<const uint8_t*>(sd.nrmBuf->lock(Ogre::HardwareBuffer::HBL_READ_ONLY));
+            }
+            const uint8_t* colBase = nullptr;
+            if (sd.colBuf) {
+                if (sd.colEl->getSource() == sd.posEl->getSource()) {
+                    colBase = posBase;
+                } else if (sd.colEl->getSource() == sd.nrmEl->getSource()
+                           && sd.nrmEl->getSource() != sd.posEl->getSource()) {
+                    colBase = nrmBase;
+                } else {
+                    colBase = static_cast<const uint8_t*>(sd.colBuf->lock(Ogre::HardwareBuffer::HBL_READ_ONLY));
+                }
+            }
+
+            auto ibuf = sd.id->indexBuffer;
+            const uint8_t* idxBase = static_cast<const uint8_t*>(ibuf->lock(Ogre::HardwareBuffer::HBL_READ_ONLY));
+            const bool idx32 = (ibuf->getType() == Ogre::HardwareIndexBuffer::IT_32BIT);
+            const unsigned ist = sd.id->indexStart;
+            const size_t triCount = sd.id->indexCount / 3;
+
+            std::vector<uint32_t> smI0;
+            std::vector<uint32_t> smI1;
+            std::vector<uint32_t> smI2;
+            QVector<QColor> smFaceCols;
+            smI0.reserve(triCount);
+            smI1.reserve(triCount);
+            smI2.reserve(triCount);
+            const bool collectFaceColors = (outFaceColors != nullptr && sd.colEl && colBase);
+
+            for (size_t t = 0; t < triCount; ++t) {
+                uint32_t i0, i1, i2;
+                if (idx32) {
+                    const auto* ip = reinterpret_cast<const uint32_t*>(idxBase);
+                    i0 = ip[ist + t * 3 + 0];
+                    i1 = ip[ist + t * 3 + 1];
+                    i2 = ip[ist + t * 3 + 2];
+                } else {
+                    const auto* ip = reinterpret_cast<const uint16_t*>(idxBase);
+                    i0 = ip[ist + t * 3 + 0];
+                    i1 = ip[ist + t * 3 + 1];
+                    i2 = ip[ist + t * 3 + 2];
+                }
+                if (i0 >= sd.vCount || i1 >= sd.vCount || i2 >= sd.vCount)
+                    continue;
+
+                auto readPN = [&](uint32_t ii, Ogre::Vector3& p, Ogre::Vector3& n) {
+                    const uint8_t* prow = posBase + size_t(ii) * sd.posStride;
+                    Ogre::Real* pf = nullptr;
+                    sd.posEl->baseVertexPointerToElement(const_cast<uint8_t*>(prow), &pf);
+                    p = Ogre::Vector3(pf[0], pf[1], pf[2]);
+                    applyPlyExportWorldTransform(p);
+                    const uint8_t* nrow = nrmBase + size_t(ii) * sd.nrmStride;
+                    Ogre::Real* nf = nullptr;
+                    sd.nrmEl->baseVertexPointerToElement(const_cast<uint8_t*>(nrow), &nf);
+                    n = Ogre::Vector3(nf[0], nf[1], nf[2]);
+                    applyPlyExportWorldTransformNormal(n);
+                };
+
+                Ogre::Vector3 p0, p1, p2, n0, n1, n2;
+                readPN(i0, p0, n0);
+                readPN(i1, p1, n1);
+                readPN(i2, p2, n2);
+
+                int32_t c0 = 0, c1 = 0, c2 = 0;
+                if (sd.colEl && colBase) {
+                    Ogre::RGBA* cp = nullptr;
+                    sd.colEl->baseVertexPointerToElement(const_cast<uint8_t*>(colBase + size_t(i0) * sd.colStride), &cp);
+                    c0 = static_cast<int32_t>(*cp);
+                    sd.colEl->baseVertexPointerToElement(const_cast<uint8_t*>(colBase + size_t(i1) * sd.colStride), &cp);
+                    c1 = static_cast<int32_t>(*cp);
+                    sd.colEl->baseVertexPointerToElement(const_cast<uint8_t*>(colBase + size_t(i2) * sd.colStride), &cp);
+                    c2 = static_cast<int32_t>(*cp);
+                }
+
+                const uint32_t w0 = weldCorner(p0, n0, c0);
+                const uint32_t w1 = weldCorner(p1, n1, c1);
+                const uint32_t w2 = weldCorner(p2, n2, c2);
+                smI0.push_back(w0);
+                smI1.push_back(w1);
+                smI2.push_back(w2);
+
+                if (collectFaceColors) {
+                    const Ogre::ColourValue cv0 = decodePackedColour(sd.colEl, static_cast<Ogre::RGBA>(c0));
+                    const Ogre::ColourValue cv1 = decodePackedColour(sd.colEl, static_cast<Ogre::RGBA>(c1));
+                    const Ogre::ColourValue cv2 = decodePackedColour(sd.colEl, static_cast<Ogre::RGBA>(c2));
+                    const Ogre::ColourValue ca((cv0.r + cv1.r + cv2.r) / 3.0f,
+                                               (cv0.g + cv1.g + cv2.g) / 3.0f,
+                                               (cv0.b + cv1.b + cv2.b) / 3.0f,
+                                               1.0f);
+                    smFaceCols.push_back(QColor::fromRgbF(ca.r, ca.g, ca.b, 1.0));
+                }
+            }
+
+            std::vector<PsyqExportFace> subFaces;
+            QVector<QColor>* colorMerge =
+                collectFaceColors && smFaceCols.size() == static_cast<int>(smI0.size()) ? &smFaceCols : nullptr;
+
+            mergeSubmeshTrisToQuads(smI0, smI1, smI2, weldedPos, colorMerge, subFaces);
+            allExportFaces.insert(allExportFaces.end(), subFaces.begin(), subFaces.end());
+
+            ibuf->unlock();
+            if (sd.colBuf && colBase && sd.colEl->getSource() != sd.posEl->getSource()
+                && !(sd.colEl->getSource() == sd.nrmEl->getSource()
+                     && sd.nrmEl->getSource() != sd.posEl->getSource())) {
+                sd.colBuf->unlock();
+            }
+            if (sd.nrmEl->getSource() != sd.posEl->getSource())
+                sd.nrmBuf->unlock();
+            sd.posBuf->unlock();
+        }
     }
 
     if (outFaceColors) {

--- a/src/PS1/PS1PLY.cpp
+++ b/src/PS1/PS1PLY.cpp
@@ -47,10 +47,44 @@ static int32_t quantizeWorld(Ogre::Real v)
     return static_cast<int32_t>(std::lround(double(v) * 100000.0));
 }
 
+struct PosWeldKey {
+    int32_t px, py, pz;
+    bool operator==(const PosWeldKey& o) const { return px == o.px && py == o.py && pz == o.pz; }
+};
+
+struct PosWeldKeyHash {
+    size_t operator()(const PosWeldKey& k) const noexcept
+    {
+        size_t h = 1469598103934665603ull;
+        auto mix = [&](int32_t x) { h ^= static_cast<size_t>(static_cast<uint32_t>(x)) * 1099511628211ull; };
+        mix(k.px);
+        mix(k.py);
+        mix(k.pz);
+        return h;
+    }
+};
+
+struct NrmWeldKey {
+    int32_t nx, ny, nz;
+    bool operator==(const NrmWeldKey& o) const { return nx == o.nx && ny == o.ny && nz == o.nz; }
+};
+
+struct NrmWeldKeyHash {
+    size_t operator()(const NrmWeldKey& k) const noexcept
+    {
+        size_t h = 1469598103934665603ull;
+        auto mix = [&](int32_t x) { h ^= static_cast<size_t>(static_cast<uint32_t>(x)) * 1099511628211ull; };
+        mix(k.nx);
+        mix(k.ny);
+        mix(k.nz);
+        return h;
+    }
+};
+
+/** Import-time corner weld: position + normal + optional colour (matches Ogre mesh corners). */
 struct WeldKey {
     int32_t px, py, pz, nx, ny, nz;
     int32_t crgba;
-
     bool operator==(const WeldKey& o) const
     {
         return px == o.px && py == o.py && pz == o.pz && nx == o.nx && ny == o.ny && nz == o.nz && crgba == o.crgba;
@@ -61,9 +95,7 @@ struct WeldKeyHash {
     size_t operator()(const WeldKey& k) const noexcept
     {
         size_t h = 1469598103934665603ull;
-        auto mix = [&](int32_t x) {
-            h ^= static_cast<size_t>(static_cast<uint32_t>(x)) * 1099511628211ull;
-        };
+        auto mix = [&](int32_t x) { h ^= static_cast<size_t>(static_cast<uint32_t>(x)) * 1099511628211ull; };
         mix(k.px);
         mix(k.py);
         mix(k.pz);
@@ -845,19 +877,52 @@ static bool tryMergeTrisToQuad(const std::array<uint32_t, 3>& A,
 struct PsyqExportFace {
     bool isQuad = false;
     uint32_t v[4] = {};
+    uint32_t n[4] = {};
     QColor color;
     bool hasColor = false;
 };
 
+static uint32_t normalIndexForWeldedPos(uint32_t posIdx,
+                                         uint32_t Ap0,
+                                         uint32_t Ap1,
+                                         uint32_t Ap2,
+                                         uint32_t An0,
+                                         uint32_t An1,
+                                         uint32_t An2,
+                                         uint32_t Bp0,
+                                         uint32_t Bp1,
+                                         uint32_t Bp2,
+                                         uint32_t Bn0,
+                                         uint32_t Bn1,
+                                         uint32_t Bn2)
+{
+    if (Ap0 == posIdx)
+        return An0;
+    if (Ap1 == posIdx)
+        return An1;
+    if (Ap2 == posIdx)
+        return An2;
+    if (Bp0 == posIdx)
+        return Bn0;
+    if (Bp1 == posIdx)
+        return Bn1;
+    if (Bp2 == posIdx)
+        return Bn2;
+    return 0;
+}
+
 static void mergeSubmeshTrisToQuads(const std::vector<uint32_t>& I0,
                                     const std::vector<uint32_t>& I1,
                                     const std::vector<uint32_t>& I2,
+                                    const std::vector<uint32_t>& N0,
+                                    const std::vector<uint32_t>& N1,
+                                    const std::vector<uint32_t>& N2,
                                     const std::vector<Ogre::Vector3>& weldPos,
                                     const QVector<QColor>* triFaceColors,
                                     std::vector<PsyqExportFace>& outFaces)
 {
     const size_t n = I0.size();
-    if (I1.size() != n || I2.size() != n || n == 0)
+    if (I1.size() != n || I2.size() != n || N0.size() != n || N1.size() != n || N2.size() != n || n == 0)
         return;
 
     std::vector<char> used(n, 0);
@@ -887,6 +952,11 @@ static void mergeSubmeshTrisToQuads(const std::vector<uint32_t>& I0,
             f.v[1] = q[1];
             f.v[2] = q[2];
             f.v[3] = q[3];
+            for (int k = 0; k < 4; ++k) {
+                f.n[static_cast<size_t>(k)] = normalIndexForWeldedPos(
+                    q[static_cast<size_t>(k)], I0[i], I1[i], I2[i], N0[i], N1[i], N2[i], I0[j], I1[j], I2[j], N0[j], N1[j],
+                    N2[j]);
+            }
             if (haveTriColors) {
                 const QColor a = triRgb(i);
                 const QColor b = triRgb(j);
@@ -904,6 +974,9 @@ static void mergeSubmeshTrisToQuads(const std::vector<uint32_t>& I0,
             f.v[0] = I0[i];
             f.v[1] = I1[i];
             f.v[2] = I2[i];
+            f.n[0] = N0[i];
+            f.n[1] = N1[i];
+            f.n[2] = N2[i];
             if (haveTriColors) {
                 f.color = triRgb(i);
                 f.hasColor = true;
@@ -1057,21 +1130,31 @@ bool exportPsyqPlyFromEntity(const Ogre::Entity* entity,
     std::vector<Ogre::Vector3> weldedNrm;
     weldedPos.reserve(size_t(totalFaces) * 3u);
     weldedNrm.reserve(size_t(totalFaces) * 3u);
-    std::unordered_map<WeldKey, uint32_t, WeldKeyHash> weld;
-    weld.reserve(size_t(totalFaces) * 3u);
+    std::unordered_map<PosWeldKey, uint32_t, PosWeldKeyHash> posWeld;
+    std::unordered_map<NrmWeldKey, uint32_t, NrmWeldKeyHash> nrmWeld;
+    posWeld.reserve(size_t(totalFaces) * 3u);
+    nrmWeld.reserve(size_t(totalFaces) * 3u);
 
     std::vector<PsyqExportFace> allExportFaces;
     allExportFaces.reserve(totalFaces);
 
-    auto weldCorner = [&](const Ogre::Vector3& p, const Ogre::Vector3& n, int32_t crgba) -> uint32_t {
-        const WeldKey key{quantizeWorld(p.x), quantizeWorld(p.y), quantizeWorld(p.z),
-                          quantizeWorld(n.x), quantizeWorld(n.y), quantizeWorld(n.z), crgba};
-        const auto it = weld.find(key);
-        if (it != weld.end())
+    auto weldPosOnly = [&](const Ogre::Vector3& p) -> uint32_t {
+        const PosWeldKey key{quantizeWorld(p.x), quantizeWorld(p.y), quantizeWorld(p.z)};
+        const auto it = posWeld.find(key);
+        if (it != posWeld.end())
             return it->second;
         const uint32_t idx = static_cast<uint32_t>(weldedPos.size());
-        weld.emplace(key, idx);
+        posWeld.emplace(key, idx);
         weldedPos.push_back(p);
+        return idx;
+    };
+    auto weldNrmOnly = [&](const Ogre::Vector3& n) -> uint32_t {
+        const NrmWeldKey key{quantizeWorld(n.x), quantizeWorld(n.y), quantizeWorld(n.z)};
+        const auto it = nrmWeld.find(key);
+        if (it != nrmWeld.end())
+            return it->second;
+        const uint32_t idx = static_cast<uint32_t>(weldedNrm.size());
+        nrmWeld.emplace(key, idx);
         weldedNrm.push_back(n);
         return idx;
     };
@@ -1121,17 +1204,20 @@ bool exportPsyqPlyFromEntity(const Ogre::Entity* entity,
             return c;
         };
 
-        constexpr uint32_t kMeshVertUnwelded = std::numeric_limits<uint32_t>::max();
-        std::vector<uint32_t> meshToFile(sd.vCount, kMeshVertUnwelded);
+        struct MeshCornerPools {
+            uint32_t posIdx = std::numeric_limits<uint32_t>::max();
+            uint32_t nrmIdx = std::numeric_limits<uint32_t>::max();
+        };
+        std::vector<MeshCornerPools> meshCorner(sd.vCount);
 
-        auto fileWeldForMeshVert = [&](uint32_t vi) -> uint32_t {
-            if (meshToFile[vi] != kMeshVertUnwelded)
-                return meshToFile[vi];
+        auto ensureMeshCorner = [&](uint32_t vi) {
+            MeshCornerPools& mc = meshCorner[vi];
+            if (mc.posIdx != std::numeric_limits<uint32_t>::max())
+                return;
             Ogre::Vector3 p, n;
             readPN(vi, p, n);
-            const uint32_t w = weldCorner(p, n, cornerCrgba(vi));
-            meshToFile[vi] = w;
-            return w;
+            mc.posIdx = weldPosOnly(p);
+            mc.nrmIdx = weldNrmOnly(n);
         };
 
         auto avgRgbCorners = [&](const std::vector<unsigned int>& corners) -> QColor {
@@ -1152,36 +1238,55 @@ bool exportPsyqPlyFromEntity(const Ogre::Entity* entity,
         for (const auto& poly : ngonFaces) {
             const size_t ps = poly.size();
             if (ps == 3) {
+                ensureMeshCorner(poly[0]);
+                ensureMeshCorner(poly[1]);
+                ensureMeshCorner(poly[2]);
                 PsyqExportFace f;
                 f.isQuad = false;
-                f.v[0] = fileWeldForMeshVert(poly[0]);
-                f.v[1] = fileWeldForMeshVert(poly[1]);
-                f.v[2] = fileWeldForMeshVert(poly[2]);
+                f.v[0] = meshCorner[poly[0]].posIdx;
+                f.v[1] = meshCorner[poly[1]].posIdx;
+                f.v[2] = meshCorner[poly[2]].posIdx;
+                f.n[0] = meshCorner[poly[0]].nrmIdx;
+                f.n[1] = meshCorner[poly[1]].nrmIdx;
+                f.n[2] = meshCorner[poly[2]].nrmIdx;
                 if (collectFaceColors) {
                     f.color = avgRgbCorners(poly);
                     f.hasColor = true;
                 }
                 allExportFaces.push_back(f);
             } else if (ps == 4) {
+                for (unsigned int c : poly)
+                    ensureMeshCorner(c);
                 PsyqExportFace f;
                 f.isQuad = true;
-                f.v[0] = fileWeldForMeshVert(poly[0]);
-                f.v[1] = fileWeldForMeshVert(poly[1]);
-                f.v[2] = fileWeldForMeshVert(poly[2]);
-                f.v[3] = fileWeldForMeshVert(poly[3]);
+                f.v[0] = meshCorner[poly[0]].posIdx;
+                f.v[1] = meshCorner[poly[1]].posIdx;
+                f.v[2] = meshCorner[poly[2]].posIdx;
+                f.v[3] = meshCorner[poly[3]].posIdx;
+                f.n[0] = meshCorner[poly[0]].nrmIdx;
+                f.n[1] = meshCorner[poly[1]].nrmIdx;
+                f.n[2] = meshCorner[poly[2]].nrmIdx;
+                f.n[3] = meshCorner[poly[3]].nrmIdx;
                 if (collectFaceColors) {
                     f.color = avgRgbCorners(poly);
                     f.hasColor = true;
                 }
                 allExportFaces.push_back(f);
             } else {
-                const uint32_t hub = fileWeldForMeshVert(poly[0]);
+                ensureMeshCorner(poly[0]);
+                const uint32_t hubP = meshCorner[poly[0]].posIdx;
+                const uint32_t hubN = meshCorner[poly[0]].nrmIdx;
                 for (size_t k = 1; k + 1 < ps; ++k) {
+                    ensureMeshCorner(poly[k]);
+                    ensureMeshCorner(poly[static_cast<size_t>(k + 1)]);
                     PsyqExportFace t;
                     t.isQuad = false;
-                    t.v[0] = hub;
-                    t.v[1] = fileWeldForMeshVert(poly[k]);
-                    t.v[2] = fileWeldForMeshVert(poly[k + 1]);
+                    t.v[0] = hubP;
+                    t.v[1] = meshCorner[poly[k]].posIdx;
+                    t.v[2] = meshCorner[poly[static_cast<size_t>(k + 1)]].posIdx;
+                    t.n[0] = hubN;
+                    t.n[1] = meshCorner[poly[k]].nrmIdx;
+                    t.n[2] = meshCorner[poly[static_cast<size_t>(k + 1)]].nrmIdx;
                     if (collectFaceColors) {
                         const std::vector<unsigned int> tri{poly[0], poly[static_cast<size_t>(k)],
                                                               poly[static_cast<size_t>(k + 1)]};
@@ -1231,10 +1336,16 @@ bool exportPsyqPlyFromEntity(const Ogre::Entity* entity,
             std::vector<uint32_t> smI0;
             std::vector<uint32_t> smI1;
             std::vector<uint32_t> smI2;
+            std::vector<uint32_t> smN0;
+            std::vector<uint32_t> smN1;
+            std::vector<uint32_t> smN2;
             QVector<QColor> smFaceCols;
             smI0.reserve(triCount);
             smI1.reserve(triCount);
             smI2.reserve(triCount);
+            smN0.reserve(triCount);
+            smN1.reserve(triCount);
+            smN2.reserve(triCount);
             const bool collectFaceColors = (outFaceColors != nullptr && sd.colEl && colBase);
 
             for (size_t t = 0; t < triCount; ++t) {
@@ -1282,12 +1393,18 @@ bool exportPsyqPlyFromEntity(const Ogre::Entity* entity,
                     c2 = static_cast<int32_t>(*cp);
                 }
 
-                const uint32_t w0 = weldCorner(p0, n0, c0);
-                const uint32_t w1 = weldCorner(p1, n1, c1);
-                const uint32_t w2 = weldCorner(p2, n2, c2);
-                smI0.push_back(w0);
-                smI1.push_back(w1);
-                smI2.push_back(w2);
+                const uint32_t wpos0 = weldPosOnly(p0);
+                const uint32_t wpos1 = weldPosOnly(p1);
+                const uint32_t wpos2 = weldPosOnly(p2);
+                const uint32_t wn0 = weldNrmOnly(n0);
+                const uint32_t wn1 = weldNrmOnly(n1);
+                const uint32_t wn2 = weldNrmOnly(n2);
+                smI0.push_back(wpos0);
+                smI1.push_back(wpos1);
+                smI2.push_back(wpos2);
+                smN0.push_back(wn0);
+                smN1.push_back(wn1);
+                smN2.push_back(wn2);
 
                 if (collectFaceColors) {
                     const Ogre::ColourValue cv0 = decodePackedColour(sd.colEl, static_cast<Ogre::RGBA>(c0));
@@ -1305,7 +1422,7 @@ bool exportPsyqPlyFromEntity(const Ogre::Entity* entity,
             QVector<QColor>* colorMerge =
                 collectFaceColors && smFaceCols.size() == static_cast<int>(smI0.size()) ? &smFaceCols : nullptr;
 
-            mergeSubmeshTrisToQuads(smI0, smI1, smI2, weldedPos, colorMerge, subFaces);
+            mergeSubmeshTrisToQuads(smI0, smI1, smI2, smN0, smN1, smN2, weldedPos, colorMerge, subFaces);
             allExportFaces.insert(allExportFaces.end(), subFaces.begin(), subFaces.end());
 
             ibuf->unlock();
@@ -1337,6 +1454,7 @@ bool exportPsyqPlyFromEntity(const Ogre::Entity* entity,
     }
 
     const uint32_t nV = static_cast<uint32_t>(weldedPos.size());
+    const uint32_t nN = static_cast<uint32_t>(weldedNrm.size());
     const uint32_t nWrittenFaces = static_cast<uint32_t>(allExportFaces.size());
 
     QFile f(plyPath);
@@ -1348,7 +1466,7 @@ bool exportPsyqPlyFromEntity(const Ogre::Entity* entity,
     QTextStream ts(&f);
     ts.setEncoding(QStringConverter::Latin1);
     ts << "@PLY940102\n";
-    ts << nV << " " << nV << " " << nWrittenFaces << "\n";
+    ts << nV << " " << nN << " " << nWrittenFaces << "\n";
 
     for (const Ogre::Vector3& p : weldedPos)
         ts << p.x << " " << p.y << " " << p.z << "\n";
@@ -1357,11 +1475,11 @@ bool exportPsyqPlyFromEntity(const Ogre::Entity* entity,
 
     for (const PsyqExportFace& ef : allExportFaces) {
         if (ef.isQuad) {
-            ts << "1 " << ef.v[0] << " " << ef.v[1] << " " << ef.v[2] << " " << ef.v[3] << " " << ef.v[0] << " "
-               << ef.v[1] << " " << ef.v[2] << " " << ef.v[3] << "\n";
+            ts << "1 " << ef.v[0] << " " << ef.v[1] << " " << ef.v[2] << " " << ef.v[3] << " " << ef.n[0] << " "
+               << ef.n[1] << " " << ef.n[2] << " " << ef.n[3] << "\n";
         } else {
-            ts << "0 " << ef.v[0] << " " << ef.v[1] << " " << ef.v[2] << " 0 " << ef.v[0] << " " << ef.v[1] << " "
-               << ef.v[2] << " 0\n";
+            ts << "0 " << ef.v[0] << " " << ef.v[1] << " " << ef.v[2] << " 0 " << ef.n[0] << " " << ef.n[1] << " "
+               << ef.n[2] << " 0\n";
         }
     }
 

--- a/src/PS1/PS1PLY.h
+++ b/src/PS1/PS1PLY.h
@@ -42,9 +42,11 @@ Ogre::MeshPtr importPsyqPlyWithFaceColors(const QString& filePath,
                                          const std::string& meshName,
                                          const QVector<QColor>& faceColors);
 
-/// Export an Ogre entity as Psy-Q PLY. Welds corners that share the same quantized
-/// position, normal, and (if present) vertex colour. For a single submesh, if
-/// `readNgonFacesFromMesh` finds `qtme.faces.0`, Psy-Q face lines follow those polygons
+/// Export an Ogre entity as Psy-Q PLY. Writes separate vertex and normal tables (counts
+/// `nV` and `nN` may differ): positions and normals are welded independently by quantized
+/// float, so shared 3D points can reuse one vertex index with distinct per-corner normals.
+/// For a single submesh, if `readNgonFacesFromMesh` finds `qtme.faces.0`, Psy-Q face lines
+/// follow those polygons
 /// (tri / quad / n-gon fanned to tris); otherwise coplanar triangle pairs are merged heuristically.
 /// If outFaceColors is provided and vertex colours exist on all submeshes, one RGB per
 /// written face is filled (for a MAT sidecar).

--- a/src/PS1/PS1PLY.h
+++ b/src/PS1/PS1PLY.h
@@ -23,8 +23,16 @@ The MIT License
  * PlayStation-RSD-Blender exporter: @PLY header, vertex/normal counts,
  * vertices, normals (per-vertex then per-face), face lines (0=triangle,
  * 1=quad) with separate normal indices.
+ *
+ * Rendering: Ogre stores triangle index buffers, so quads from a PLY are expanded to
+ * two triangles at import. The original face layout (triangle vs quad) is stored on
+ * the mesh (see kPsyqPlyFaceLayoutUserKey) so Psy-Q export can write quad lines back
+ * without guessing from topology.
  */
 namespace PS1PLY {
+
+/// Ogre::Mesh UserObjectBindings key: std::string blob (see PS1PLY.cpp) listing 3 or 4 per logical face.
+inline constexpr const char kPsyqPlyFaceLayoutUserKey[] = "qtme.psyq_ply_face_layout";
 
 /// Uniform scale for RSD sidecar Psy-Q PLY geometry (kept at 1× so ring-style assets stay editor-sized).
 constexpr float kPsyqPlyEditorUniformScale = 1.0f;
@@ -39,9 +47,11 @@ Ogre::MeshPtr importPsyqPlyWithFaceColors(const QString& filePath,
                                          const QVector<QColor>& faceColors);
 
 /// Export an Ogre entity as Psy-Q PLY. Welds corners that share the same quantized
-/// position, normal, and (if present) vertex colour, then merges coplanar triangle pairs
-/// into quad face records (type 1) where possible. If outFaceColors is provided and vertex
-/// colours exist on all submeshes, one RGB per written face is filled (for a MAT sidecar).
+/// position, normal, and (if present) vertex colour. If the mesh has kPsyqPlyFaceLayoutUserKey
+/// from a prior Psy-Q import and triangle order still matches, quad face records (type 1)
+/// are written from that layout; otherwise coplanar triangle pairs are merged heuristically.
+/// If outFaceColors is provided and vertex colours exist on all submeshes, one RGB per
+/// written face is filled (for a MAT sidecar).
 bool exportPsyqPlyFromEntity(const Ogre::Entity* entity,
                              const QString& plyPath,
                              QVector<QColor>* outFaceColors = nullptr,

--- a/src/PS1/PS1PLY.h
+++ b/src/PS1/PS1PLY.h
@@ -25,14 +25,10 @@ The MIT License
  * 1=quad) with separate normal indices.
  *
  * Rendering: Ogre stores triangle index buffers, so quads from a PLY are expanded to
- * two triangles at import. The original face layout (triangle vs quad) is stored on
- * the mesh (see kPsyqPlyFaceLayoutUserKey) so Psy-Q export can write quad lines back
- * without guessing from topology.
+ * two triangles at import. Polygon topology (tri/quad and higher) is written with
+ * the same `qtme.faces.<i>` n-gon binding as FBX (see EditableMesh / HalfEdgeMesh).
  */
 namespace PS1PLY {
-
-/// Ogre::Mesh UserObjectBindings key: std::string blob (see PS1PLY.cpp) listing 3 or 4 per logical face.
-inline constexpr const char kPsyqPlyFaceLayoutUserKey[] = "qtme.psyq_ply_face_layout";
 
 /// Uniform scale for RSD sidecar Psy-Q PLY geometry (kept at 1× so ring-style assets stay editor-sized).
 constexpr float kPsyqPlyEditorUniformScale = 1.0f;
@@ -47,9 +43,9 @@ Ogre::MeshPtr importPsyqPlyWithFaceColors(const QString& filePath,
                                          const QVector<QColor>& faceColors);
 
 /// Export an Ogre entity as Psy-Q PLY. Welds corners that share the same quantized
-/// position, normal, and (if present) vertex colour. If the mesh has kPsyqPlyFaceLayoutUserKey
-/// from a prior Psy-Q import and triangle order still matches, quad face records (type 1)
-/// are written from that layout; otherwise coplanar triangle pairs are merged heuristically.
+/// position, normal, and (if present) vertex colour. For a single submesh, if
+/// `readNgonFacesFromMesh` finds `qtme.faces.0`, Psy-Q face lines follow those polygons
+/// (tri / quad / n-gon fanned to tris); otherwise coplanar triangle pairs are merged heuristically.
 /// If outFaceColors is provided and vertex colours exist on all submeshes, one RGB per
 /// written face is filled (for a MAT sidecar).
 bool exportPsyqPlyFromEntity(const Ogre::Entity* entity,

--- a/src/PS1/PS1PLY.h
+++ b/src/PS1/PS1PLY.h
@@ -38,8 +38,10 @@ Ogre::MeshPtr importPsyqPlyWithFaceColors(const QString& filePath,
                                          const std::string& meshName,
                                          const QVector<QColor>& faceColors);
 
-/// Export an Ogre entity as Psy-Q PLY. If outFaceColors is provided and vertex colours exist,
-/// one averaged RGB entry per written face is appended (for writing a MAT sidecar).
+/// Export an Ogre entity as Psy-Q PLY. Welds corners that share the same quantized
+/// position, normal, and (if present) vertex colour, then merges coplanar triangle pairs
+/// into quad face records (type 1) where possible. If outFaceColors is provided and vertex
+/// colours exist on all submeshes, one RGB per written face is filled (for a MAT sidecar).
 bool exportPsyqPlyFromEntity(const Ogre::Entity* entity,
                              const QString& plyPath,
                              QVector<QColor>* outFaceColors = nullptr,

--- a/src/PS1/PS1PLY_test.cpp
+++ b/src/PS1/PS1PLY_test.cpp
@@ -32,8 +32,8 @@ static void ensureBaseMaterialForPlyImport()
     }
     Ogre::MaterialPtr m = Ogre::MaterialManager::getSingleton().create(
         "BaseMaterial", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    m->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
-    m->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1, 1);
+    m->getTechnique(0)->getPass(0)->setDiffuse(1.0f, 1.0f, 1.0f, 1.0f);
+    m->getTechnique(0)->getPass(0)->setAmbient(1.0f, 1.0f, 1.0f);
 }
 
 /** Two triangles (0,1,2) and (1,2,3) — PS1 quad split; flat +Z normal. */

--- a/src/PS1/PS1PLY_test.cpp
+++ b/src/PS1/PS1PLY_test.cpp
@@ -1,10 +1,141 @@
 #include <gtest/gtest.h>
 
+#include <QApplication>
+#include <QCoreApplication>
 #include <QDir>
 #include <QFile>
 #include <QTemporaryDir>
+#include <QTemporaryFile>
+#include <QTextStream>
+#include <QThread>
 
+#include <OgreHardwareBufferManager.h>
+#include <OgreMaterialManager.h>
+#include <OgreMeshManager.h>
+#include <OgreSubMesh.h>
+#include <OgreVertexIndexData.h>
+
+#include "Manager.h"
 #include "PS1/PS1PLY.h"
+#include "SelectionSet.h"
+#include "TestHelpers.h"
+
+namespace {
+
+constexpr unsigned long kSingletonSettleMs = 30;
+
+static void ensureBaseMaterialForPlyImport()
+{
+    if (Ogre::MaterialManager::getSingleton().getByName(
+            "BaseMaterial", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME)) {
+        return;
+    }
+    Ogre::MaterialPtr m = Ogre::MaterialManager::getSingleton().create(
+        "BaseMaterial", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+    m->getTechnique(0)->getPass(0)->setDiffuse(1, 1, 1, 1);
+    m->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1, 1);
+}
+
+/** Two triangles (0,1,2) and (1,2,3) — PS1 quad split; flat +Z normal. */
+static Ogre::MeshPtr createTwoTriQuadMesh(const std::string& name)
+{
+    if (auto old = Ogre::MeshManager::getSingleton().getByName(name))
+        Ogre::MeshManager::getSingleton().remove(old);
+
+    Ogre::MeshPtr mesh = Ogre::MeshManager::getSingleton().createManual(
+        name, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+    Ogre::SubMesh* sm = mesh->createSubMesh();
+    sm->setMaterialName("BaseWhite");
+    sm->useSharedVertices = false;
+
+    Ogre::VertexData* vd = new Ogre::VertexData();
+    sm->vertexData = vd;
+    vd->vertexCount = 4;
+    Ogre::VertexDeclaration* decl = vd->vertexDeclaration;
+    Ogre::VertexBufferBinding* bind = vd->vertexBufferBinding;
+    size_t off = 0;
+    decl->addElement(0, off, Ogre::VET_FLOAT3, Ogre::VES_POSITION);
+    off += Ogre::VertexElement::getTypeSize(Ogre::VET_FLOAT3);
+    decl->addElement(0, off, Ogre::VET_FLOAT3, Ogre::VES_NORMAL);
+    off += Ogre::VertexElement::getTypeSize(Ogre::VET_FLOAT3);
+    const size_t vsize = decl->getVertexSize(0);
+    auto vbuf = Ogre::HardwareBufferManager::getSingleton().createVertexBuffer(
+        vsize, 4, Ogre::HardwareBuffer::HBU_STATIC_WRITE_ONLY);
+    uint8_t* dst = static_cast<uint8_t*>(vbuf->lock(Ogre::HardwareBuffer::HBL_DISCARD));
+    const float corners[][6] = {
+        {0.f, 0.f, 0.f, 0.f, 0.f, 1.f},
+        {1.f, 0.f, 0.f, 0.f, 0.f, 1.f},
+        {1.f, 1.f, 0.f, 0.f, 0.f, 1.f},
+        {0.f, 1.f, 0.f, 0.f, 0.f, 1.f},
+    };
+    for (int i = 0; i < 4; ++i) {
+        uint8_t* row = dst + i * vsize;
+        float* pf = nullptr;
+        decl->findElementBySemantic(Ogre::VES_POSITION)->baseVertexPointerToElement(row, &pf);
+        pf[0] = corners[i][0];
+        pf[1] = corners[i][1];
+        pf[2] = corners[i][2];
+        decl->findElementBySemantic(Ogre::VES_NORMAL)->baseVertexPointerToElement(row, &pf);
+        pf[0] = corners[i][3];
+        pf[1] = corners[i][4];
+        pf[2] = corners[i][5];
+    }
+    vbuf->unlock();
+    bind->setBinding(0, vbuf);
+
+    auto ibuf = Ogre::HardwareBufferManager::getSingleton().createIndexBuffer(
+        Ogre::HardwareIndexBuffer::IT_16BIT, 6, Ogre::HardwareBuffer::HBU_STATIC_WRITE_ONLY);
+    const uint16_t idx[] = {0, 1, 2, 1, 2, 3};
+    ibuf->writeData(0, sizeof(idx), idx);
+    sm->indexData->indexBuffer = ibuf;
+    sm->indexData->indexCount = 6;
+    sm->indexData->indexStart = 0;
+
+    mesh->_setBounds(Ogre::AxisAlignedBox(0, 0, 0, 1, 1, 0));
+    mesh->_setBoundingSphereRadius(2.0f);
+    mesh->load();
+    return mesh;
+}
+
+static bool readPsyqPlyCountsAndFirstFace(const QString& path, int& nV, int& nN, int& nF, QString& firstFaceLine)
+{
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+        return false;
+    QTextStream ts(&file);
+    QStringList lines;
+    while (!ts.atEnd())
+        lines.append(ts.readLine().trimmed());
+
+    int idx = 0;
+    while (idx < lines.size() && !lines[idx].contains(QStringLiteral("@PLY"), Qt::CaseInsensitive))
+        ++idx;
+    if (idx >= lines.size())
+        return false;
+    ++idx;
+    while (idx < lines.size()
+           && (lines[idx].isEmpty() || lines[idx].startsWith(QLatin1Char('#'))))
+        ++idx;
+    if (idx >= lines.size())
+        return false;
+
+    const QStringList countParts = lines[idx].split(QLatin1Char(' '), Qt::SkipEmptyParts);
+    if (countParts.size() < 3)
+        return false;
+    nV = countParts[0].toInt();
+    nN = countParts[1].toInt();
+    nF = countParts[2].toInt();
+    ++idx;
+    idx += nV + nN;
+    while (idx < lines.size() && lines[idx].isEmpty())
+        ++idx;
+    if (idx >= lines.size())
+        return false;
+    firstFaceLine = lines[idx];
+    return nV > 0 && nN > 0 && nF > 0;
+}
+
+} // namespace
 
 TEST(PS1PLY, IsPsyqPlyFile_TrueWhenHeaderPresent)
 {
@@ -57,4 +188,119 @@ TEST(PS1PLY, IsPsyqPlyFile_FalseForStanfordPly)
     ASSERT_EQ(f.write(data), data.size());
     f.close();
     EXPECT_FALSE(PS1PLY::isPsyqPlyFile(path));
+}
+
+class PS1PLYOgreTest : public ::testing::Test {
+protected:
+    QApplication* app = nullptr;
+
+    void SetUp() override
+    {
+        SelectionSet::kill();
+        Manager::kill();
+        QThread::msleep(kSingletonSettleMs);
+
+        app = qobject_cast<QApplication*>(QCoreApplication::instance());
+        ASSERT_NE(app, nullptr);
+
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed";
+        createStandardOgreMaterials();
+        ensureBaseMaterialForPlyImport();
+    }
+
+    void TearDown() override
+    {
+        if (Manager::getSingletonPtr())
+            SelectionSet::getSingleton()->clear();
+        SelectionSet::kill();
+        Manager::kill();
+        if (app)
+            app->processEvents();
+        QThread::msleep(kSingletonSettleMs);
+    }
+};
+
+TEST_F(PS1PLYOgreTest, ExportHeuristicMergeProducesOneQuadAndSharedNormalPool)
+{
+    ASSERT_TRUE(canLoadMeshFiles());
+
+    const std::string meshName = "PS1PlyQuadHeuristicMesh";
+    Ogre::MeshPtr mesh = createTwoTriQuadMesh(meshName);
+    ASSERT_TRUE(mesh);
+
+    auto* mgr = Manager::getSingleton();
+    Ogre::SceneNode* node = mgr->addSceneNode(QStringLiteral("PS1PlyQuadHeuristicNode"));
+    ASSERT_NE(node, nullptr);
+    Ogre::Entity* ent = mgr->createEntity(node, mesh);
+    ASSERT_NE(ent, nullptr);
+
+    QTemporaryFile outPly(QDir::tempPath() + QStringLiteral("/qtmesh_ps1ply_heur_XXXXXX.ply"));
+    outPly.setAutoRemove(true);
+    ASSERT_TRUE(outPly.open());
+    outPly.close();
+    const QString path = outPly.fileName();
+
+    QString err;
+    ASSERT_TRUE(PS1PLY::exportPsyqPlyFromEntity(ent, path, nullptr, &err)) << err.toUtf8().constData();
+
+    mgr->destroySceneNode(QStringLiteral("PS1PlyQuadHeuristicNode"));
+    Ogre::MeshManager::getSingleton().remove(meshName);
+
+    int nV = 0, nN = 0, nF = 0;
+    QString face0;
+    ASSERT_TRUE(readPsyqPlyCountsAndFirstFace(path, nV, nN, nF, face0));
+    EXPECT_EQ(nF, 1);
+    EXPECT_EQ(nV, 4);
+    EXPECT_EQ(nN, 1);
+    EXPECT_TRUE(face0.startsWith(QLatin1String("1 ")));
+}
+
+TEST_F(PS1PLYOgreTest, ImportQuadThenExportKeepsSingleQuadFaceLine)
+{
+    ASSERT_TRUE(canLoadMeshFiles());
+
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString plyIn = QDir(dir.path()).filePath(QStringLiteral("quad_in.ply"));
+    {
+        QFile wf(plyIn);
+        ASSERT_TRUE(wf.open(QIODevice::WriteOnly | QIODevice::Text));
+        QTextStream ts(&wf);
+        ts << "@PLY940102\n";
+        ts << "4 4 1\n";
+        ts << "0 0 0\n1 0 0\n1 1 0\n0 1 0\n";
+        ts << "0 0 1\n0 0 1\n0 0 1\n0 0 1\n";
+        ts << "1 0 1 2 3 0 1 2 3\n";
+    }
+
+    const std::string meshName = "PS1PlyQuadImportMesh";
+    if (auto old = Ogre::MeshManager::getSingleton().getByName(meshName))
+        Ogre::MeshManager::getSingleton().remove(old);
+
+    Ogre::MeshPtr mesh = PS1PLY::importPsyqPly(plyIn, meshName);
+    ASSERT_TRUE(mesh);
+
+    auto* mgr = Manager::getSingleton();
+    Ogre::SceneNode* node = mgr->addSceneNode(QStringLiteral("PS1PlyQuadImportNode"));
+    ASSERT_NE(node, nullptr);
+    Ogre::Entity* ent = mgr->createEntity(node, mesh);
+    ASSERT_NE(ent, nullptr);
+
+    QTemporaryFile outPly(QDir::tempPath() + QStringLiteral("/qtmesh_ps1ply_ngon_XXXXXX.ply"));
+    outPly.setAutoRemove(true);
+    ASSERT_TRUE(outPly.open());
+    outPly.close();
+
+    QString err;
+    ASSERT_TRUE(PS1PLY::exportPsyqPlyFromEntity(ent, outPly.fileName(), nullptr, &err)) << err.toUtf8().constData();
+
+    mgr->destroySceneNode(QStringLiteral("PS1PlyQuadImportNode"));
+    Ogre::MeshManager::getSingleton().remove(meshName);
+
+    int nV = 0, nN = 0, nF = 0;
+    QString face0;
+    ASSERT_TRUE(readPsyqPlyCountsAndFirstFace(outPly.fileName(), nV, nN, nF, face0));
+    EXPECT_EQ(nF, 1);
+    EXPECT_LE(nN, 4);
+    EXPECT_TRUE(face0.startsWith(QLatin1String("1 ")));
 }

--- a/src/WelcomeDialog.cpp
+++ b/src/WelcomeDialog.cpp
@@ -68,7 +68,7 @@ WelcomeDialog::WelcomeDialog(QWidget* parent)
     connect(openFileBtn, &QPushButton::clicked, this, [this]() {
         QString file = QFileDialog::getOpenFileName(
             this, "Open 3D File", QString(),
-            "3D Files (*.fbx *.gltf *.glb *.vrm *.obj *.dae *.stl *.mesh *.3ds *.x *.tmd);;All Files (*)");
+            "3D Files (*.fbx *.gltf *.glb *.vrm *.obj *.dae *.stl *.mesh *.3ds *.x *.ply *.tmd *.rsd);;All Files (*)");
         if (!file.isEmpty()) {
             m_action = OpenFile;
             m_selectedFile = file;

--- a/website/src/DocsApp.jsx
+++ b/website/src/DocsApp.jsx
@@ -6,6 +6,7 @@ const NAV = [
   { section: 'Getting Started', items: [
     { id: 'installation', label: 'Installation' },
     { id: 'quick-start', label: 'Quick Start' },
+    { id: 'playstation-rsd-ply', label: 'PlayStation RSD / Psy-Q PLY' },
   ]},
   { section: 'CLI Commands', items: [
     { id: 'cmd-info', label: 'info' },
@@ -230,6 +231,31 @@ qtmesh scan ./assets --fail-on error`}</CodeBlock>
             </table>
           </section>
 
+          <section className={s.section} id="playstation-rsd-ply">
+            <h2 className={s.sectionTitle}>PlayStation RSD, Psy-Q PLY, and MAT</h2>
+            <p className={s.para}>
+              <strong>RSD</strong> (<Code>.rsd</Code>) is a PlayStation-era descriptor that references a mesh (often <Code>.tmd</Code> or Psy-Q <Code>.ply</Code>) plus optional <Code>.tim</Code> textures and <Code>.mat</Code> sidecars.
+              Import resolves those paths, loads geometry, and applies TIM-driven materials when possible. Export writes the <Code>.rsd</Code> and companion filenames next to the output.
+            </p>
+            <p className={s.para}>
+              <strong>Psy-Q PLY</strong> is not Stanford PLY: it uses an <Code>@PLY…</Code> header, separate <strong>vertex</strong> and <strong>normal</strong> count lines (<Code>nV nN nF</Code>), then face lines where type <Code>0</Code> is a triangle and <Code>1</Code> is a quad with independent v/n indices.
+              Quads use the classic split <Code>(v0,v1,v2)</Code> + <Code>(v1,v2,v3)</Code> when expanded to triangles in the engine.
+            </p>
+            <p className={s.para}>
+              <strong>Import</strong> welds corners (position + normal ± colour) and stores quad/ngon topology as <Code>qtme.faces.*</Code> when the file encodes it, so artist intent is preserved.
+            </p>
+            <p className={s.para}>
+              <strong>Export</strong> writes welded <strong>position</strong> and <strong>normal</strong> pools separately (quantized floats). Many corners share one quantized normal, so <Code>nN</Code> is often <strong>smaller than</strong> <Code>nV</Code> and smaller than in a verbose original — that is deduplication, not loss of shading, for flat or smooth regions.
+            </p>
+            <p className={s.para}>
+              If <Code>qtme.faces</Code> exists, face lines follow those polygons. Otherwise coplanar triangle pairs matching the PS1 adjacency pattern with nearly parallel normals (dot ≥ 0.94) are <strong>merged back into quads</strong>, which often recovers cleaner layouts than triangle-only dumps.
+            </p>
+            <p className={s.para}>
+              Full write-up in the repository:{' '}
+              <a href="https://github.com/fernandotonon/QtMeshEditor/blob/master/documentation/playstation-rsd-ply.md" target="_blank" rel="noreferrer">documentation/playstation-rsd-ply.md</a>.
+            </p>
+          </section>
+
           {/* ─── CLI Commands ─── */}
 
           <CmdSection id="cmd-info" name="info" description="Show detailed mesh information: vertex/face counts, materials, textures, skeleton, animations, bounding box."
@@ -273,8 +299,9 @@ qtmesh scan ./assets --fail-on error`}</CodeBlock>
                   ['.dae', 'Collada', 'Yes', 'Yes'],
                   ['.obj', 'Wavefront OBJ', 'Yes', 'Yes'],
                   ['.stl', 'STL', 'Yes', 'Yes'],
-                  ['.ply', 'Stanford PLY', 'Yes', 'Yes'],
+                  ['.ply', 'Stanford PLY or Psy-Q PLY (by content)', 'Yes', 'Yes'],
                   ['.tmd', 'PlayStation TMD', 'Yes', 'Yes'],
+                  ['.rsd', 'PlayStation RSD (descriptor + sidecars)', 'Yes', 'Yes'],
                   ['.3ds', '3D Studio', 'Yes', 'No'],
                   ['.mesh', 'Ogre Mesh', 'Yes', 'No'],
                 ].map(([ext, fmt, imp, exp], i) => <tr key={i}><td><Code>{ext}</Code></td><td>{fmt}</td><td>{imp}</td><td>{exp}</td></tr>)}


### PR DESCRIPTION
## Summary
- **Psy-Q PLY** round-trip: `qtme.faces.*` when present; otherwise **heuristic quad merge** for PS1-style triangle pairs (shared edge `(v1,v2)`, coplanar normals dot ≥ 0.94).
- Export uses **split vertex / normal pools** (`nV` and `nN` independent) with quantized welding — fewer normal lines than verbose originals when corners share the same quantized normal.
- **`EditableMesh`**: `readNgonFacesFromMesh` tolerates `std::bad_cast` in addition to `Ogre::Exception`.

## Documentation
- [documentation/playstation-rsd-ply.md](documentation/playstation-rsd-ply.md) — RSD descriptor, Psy-Q PLY vs Stanford, MAT sidecars, why `nN` can be smaller than `nV`, `qtme.faces` vs heuristic merge.
- README + [website docs](https://fernandotonon.github.io/QtMeshEditor/docs.html): format table (`.rsd`, PLY clarification), new nav section **PlayStation RSD / Psy-Q PLY**.

## Tests
- `PS1PLYOgreTest::ExportHeuristicMergeProducesOneQuadAndSharedNormalPool` — two flat tris → one quad line, `nN == 1`, `nV == 4`.
- `PS1PLYOgreTest::ImportQuadThenExportKeepsSingleQuadFaceLine` — hand-written quad PLY → import → export still one type-1 face.

## UX
- Welcome dialog open filter includes `*.ply` and `*.rsd`.