### PR TITLE
feat(materials): Sobel-filter normal map generator (Phase 5 slice H)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,9 +74,11 @@ qtmesh scan ./assets --fail-on warning         # exit 1 on warnings or errors
 qtmesh pack-textures --r ao.png --g rough.png --b metal.png -o orm.png  # pack 3 grayscale maps into RGB (Unity ORM)
 qtmesh pack-textures --r metal.png --g rough.png --bc 0 --no-alpha -o mr.png  # Unreal MR (constant blue)
 qtmesh pack-textures --r rough.png --invert-r -o gloss.png  # invert: roughness → glossiness
+qtmesh normal-from-height --src bump.png -o normal.png  # Sobel: height/bump → tangent-space normal map
+qtmesh normal-from-height --src bump.png --strength 4 --invert-g -o dx_normal.png  # DirectX +Y-down convention
 ```
 
-CLI mode is activated by: (1) invoking via the `qtmesh` symlink, (2) passing `--cli`, or (3) using a recognized subcommand (`info`, `fix`, `convert`, `anim`, `validate`, `lod`, `pose`, `scan`, `material`, `pack-textures`) as the first argument. Use `--verbose` to see Ogre/engine debug output. Use `--no-telemetry` to permanently opt out of anonymous usage data collection.
+CLI mode is activated by: (1) invoking via the `qtmesh` symlink, (2) passing `--cli`, or (3) using a recognized subcommand (`info`, `fix`, `convert`, `anim`, `validate`, `lod`, `pose`, `scan`, `material`, `pack-textures`, `normal-from-height`) as the first argument. Use `--verbose` to see Ogre/engine debug output. Use `--no-telemetry` to permanently opt out of anonymous usage data collection.
 
 If Xcode SDK is updated, clear CMake cache (`rm build_local/CMakeCache.txt`) and reconfigure.
 
@@ -163,6 +165,7 @@ Three singletons manage core state. All run on the main thread. Access via `Clas
 - **BatchExporter** (`src/BatchExporter.h/cpp`): Multi-file conversion wrapping CLIPipeline. Supports progress reporting.
 - **MaterialPresetLibrary** (`src/MaterialPresetLibrary.h/cpp`): QML_SINGLETON providing one-click material presets (Plastic, Metal, Wood, Glass, Unlit, Wireframe).
 - **TextureChannelPacker** (`src/TextureChannelPacker.h/cpp`, slice G): pure-data packer that takes 1-4 grayscale source images (or constants) and writes a single packed RGBA texture (PNG/TGA/JPG). Each output channel is sampled via Rec.601 luminance from its source image, with an optional invert flag (useful for roughness↔glossiness). Smaller sources are bilinear-scaled up to match the largest input. Surfaced via the `qtmesh pack-textures` CLI subcommand, the `pack_textures` MCP tool, and the "Pack Texture Channels…" button in Material Mode → Mode Tools (slice G/G2/G3). The dialog (`qml/TextureChannelPackerDialog.qml`) is a top-level Inspector-styled `Window` with a 256×256 live preview thumbnail (slice G2 — `MaterialEditorQML::previewPackedTextureChannels` returns a `data:image/png;base64,…` URL the QML Image element shows directly), `DropArea` on each channel row for drag-and-drop from Finder/Explorer, three one-click presets (Unity ORM, Unreal MR, Spec→Gloss invert) that filename-heuristically wire existing source paths to the right channels, and per-row trash-can reset buttons (slice G3).
+- **NormalMapGenerator** (`src/NormalMapGenerator.h/cpp`, slice H): pure-data generator that produces a tangent-space normal map from a grayscale height/bump source via a 3×3 Sobel filter. `strength` scales the gradient (clamped to [0..32]); `invertR` and `invertG` flip the corresponding channels — `invertG` is the OpenGL (+Y up, default) ↔ DirectX (+Y down) switch. Output is RGB8. Surfaced via `qtmesh normal-from-height` CLI subcommand, the `generate_normal_map` MCP tool, and the "Generate Normal Map…" button in Material Mode → Mode Tools. Dialog (`qml/NormalMapGeneratorDialog.qml`) reuses the Inspector primitive style from the channel packer with a strength slider, OpenGL/DirectX toggle, source DropArea, and 256×256 live preview thumbnail.
 
 ### MCP Server
 
@@ -175,7 +178,7 @@ Three singletons manage core state. All run on the main thread. Access via `Clas
 ### CLI Pipeline
 
 - **CLIPipeline** (`src/CLIPipeline.h/cpp`): Headless command-line interface for mesh operations. All static methods — entry point is `CLIPipeline::run(argc, argv)`.
-- Subcommands: `info`, `fix`, `convert`, `anim` (list/rename/merge), `validate`, `lod`, `pose`, `scan`, `material`, `pack-textures`.
+- Subcommands: `info`, `fix`, `convert`, `anim` (list/rename/merge), `validate`, `lod`, `pose`, `scan`, `material`, `pack-textures`, `normal-from-height`.
 - Activated via `qtmesh` symlink (created at build time), `--cli` flag, or recognized subcommand as first arg.
 - Redirects stdout to stderr (Ogre/Qt noise) and writes CLI output to the original stdout fd. Uses `_exit()` to avoid Ogre static destructor crashes on macOS.
 - **AnimationMerger** (`src/AnimationMerger.h/cpp`): Public `renameAnimation()` static method used by both CLI and GUI for animation renaming.

--- a/qml/NormalMapGeneratorDialog.qml
+++ b/qml/NormalMapGeneratorDialog.qml
@@ -1,0 +1,426 @@
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Window
+import MaterialEditorQML 1.0
+import PropertiesPanel 1.0
+
+// Slice H: top-level Window for generating tangent-space normal maps
+// from a height/bump source. Same Inspector-styled idiom as
+// TextureChannelPackerDialog (Rectangle + Text + MouseArea primitives
+// over PropertiesPanelController.* colors).
+Window {
+    id: dialog
+    title: "Generate Normal Map"
+    width: 660
+    height: 410
+    minimumWidth: 540
+    minimumHeight: 360
+    flags: Qt.Dialog
+    modality: Qt.ApplicationModal
+    color: PropertiesPanelController.panelColor
+
+    property string sourcePath: ""
+    property real   strength:    2.0
+    property bool   invertR:     false
+    property bool   invertG:     false   // OpenGL +Y up by default
+    property string outputPath:  ""
+    property string previewDataUrl: ""
+
+    function open() {
+        dialog.show()
+        dialog.raise()
+        dialog.requestActivate()
+        refreshPreview()
+    }
+
+    function normaliseDroppedPath(url) {
+        const s = url.toString()
+        return s.startsWith("file://") ? s.substring(7) : s
+    }
+
+    function refreshPreview() {
+        previewDataUrl = MaterialEditorQML.previewNormalMap(
+            sourcePath, strength, invertR, invertG, 256)
+    }
+    onSourcePathChanged: refreshPreview()
+    onStrengthChanged:   refreshPreview()
+    onInvertRChanged:    refreshPreview()
+    onInvertGChanged:    refreshPreview()
+
+    // ── Inline Inspector primitives (same as TextureChannelPackerDialog) ──
+
+    component InspectorButton: Rectangle {
+        id: btn
+        property string label: ""
+        property bool buttonEnabled: true
+        signal clicked()
+        height: 24
+        radius: 3
+        color: btnMa.containsMouse && buttonEnabled
+            ? PropertiesPanelController.highlightColor
+            : PropertiesPanelController.headerColor
+        border.color: PropertiesPanelController.borderColor
+        border.width: 1
+        opacity: buttonEnabled ? 1.0 : 0.45
+        Text {
+            anchors.centerIn: parent
+            text: btn.label
+            color: PropertiesPanelController.textColor
+            font.pixelSize: 11
+        }
+        MouseArea {
+            id: btnMa
+            anchors.fill: parent
+            hoverEnabled: true
+            enabled: btn.buttonEnabled
+            cursorShape: btn.buttonEnabled ? Qt.PointingHandCursor : Qt.ForbiddenCursor
+            onClicked: btn.clicked()
+        }
+    }
+
+    component InspectorLabel: Text {
+        color: PropertiesPanelController.textColor
+        font.pixelSize: 11
+    }
+
+    component InspectorReadOnlyField: Rectangle {
+        property alias text: t.text
+        property string placeholderText: ""
+        height: 24
+        color: PropertiesPanelController.inputColor
+        border.color: PropertiesPanelController.borderColor
+        border.width: 1
+        radius: 3
+        Text {
+            id: t
+            anchors.fill: parent
+            anchors.leftMargin: 6
+            anchors.rightMargin: 6
+            color: PropertiesPanelController.textColor
+            font.pixelSize: 11
+            verticalAlignment: Text.AlignVCenter
+            elide: Text.ElideMiddle
+        }
+        Text {
+            text: parent.placeholderText
+            visible: t.text.length === 0
+            anchors.fill: parent
+            anchors.leftMargin: 6
+            color: PropertiesPanelController.textColor
+            opacity: 0.45
+            font.pixelSize: 11
+            verticalAlignment: Text.AlignVCenter
+        }
+    }
+
+    component InspectorTextField: Rectangle {
+        id: tfRoot
+        property alias text: input.text
+        property string placeholderText: ""
+        signal editedText(string newText)
+        height: 24
+        color: PropertiesPanelController.inputColor
+        border.color: input.activeFocus
+            ? PropertiesPanelController.highlightColor
+            : PropertiesPanelController.borderColor
+        border.width: 1
+        radius: 3
+        TextInput {
+            id: input
+            anchors.fill: parent
+            anchors.leftMargin: 6
+            anchors.rightMargin: 6
+            color: PropertiesPanelController.textColor
+            font.pixelSize: 11
+            verticalAlignment: TextInput.AlignVCenter
+            selectByMouse: true
+            clip: true
+            onTextEdited: tfRoot.editedText(text)
+        }
+        Text {
+            text: tfRoot.placeholderText
+            visible: input.text.length === 0 && !input.activeFocus
+            anchors.fill: parent
+            anchors.leftMargin: 6
+            color: PropertiesPanelController.textColor
+            opacity: 0.45
+            font.pixelSize: 11
+            verticalAlignment: Text.AlignVCenter
+        }
+    }
+
+    component InspectorCheckBox: Rectangle {
+        id: cbRoot
+        property bool checked: false
+        property string label: ""
+        signal toggled(bool newChecked)
+        height: 22
+        color: "transparent"
+        Row {
+            spacing: 6
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.left: parent.left
+            Rectangle {
+                width: 16; height: 16
+                anchors.verticalCenter: parent.verticalCenter
+                color: cbRoot.checked
+                    ? PropertiesPanelController.highlightColor
+                    : PropertiesPanelController.inputColor
+                border.color: PropertiesPanelController.borderColor
+                border.width: 1
+                radius: 2
+                Text {
+                    anchors.centerIn: parent
+                    visible: cbRoot.checked
+                    text: "✓"
+                    color: PropertiesPanelController.textColor
+                    font.pixelSize: 12
+                    font.bold: true
+                }
+            }
+            Text {
+                visible: cbRoot.label.length > 0
+                anchors.verticalCenter: parent.verticalCenter
+                text: cbRoot.label
+                color: PropertiesPanelController.textColor
+                font.pixelSize: 11
+            }
+        }
+        MouseArea {
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            onClicked: cbRoot.toggled(!cbRoot.checked)
+        }
+    }
+
+    // Strength slider — track + thumb + readout. Mirrors the inspector
+    // primitive pattern but tailored to a 0..10 float range.
+    component StrengthSlider: Rectangle {
+        id: sl
+        property real value: 2.0
+        property real minValue: 0.0
+        property real maxValue: 10.0
+        signal newValue(real v)
+        height: 22
+        color: PropertiesPanelController.inputColor
+        border.color: PropertiesPanelController.borderColor
+        border.width: 1
+        radius: 3
+        function clampVal(v) { return Math.max(sl.minValue, Math.min(sl.maxValue, v)) }
+        function pctToVal(p) { return sl.minValue + p * (sl.maxValue - sl.minValue) }
+        function valToPct(v) { return (v - sl.minValue) / (sl.maxValue - sl.minValue) }
+
+        Rectangle {
+            id: fill
+            anchors.left: parent.left
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            anchors.margins: 1
+            width: Math.max(0, (parent.width - 2) * sl.valToPct(sl.value))
+            color: PropertiesPanelController.highlightColor
+            opacity: 0.5
+            radius: 2
+        }
+        Text {
+            anchors.centerIn: parent
+            text: sl.value.toFixed(2)
+            color: PropertiesPanelController.textColor
+            font.pixelSize: 11
+        }
+        MouseArea {
+            anchors.fill: parent
+            hoverEnabled: true
+            onPressed: mouse => {
+                const pct = Math.max(0, Math.min(1, mouse.x / parent.width))
+                sl.newValue(sl.clampVal(sl.pctToVal(pct)))
+            }
+            onPositionChanged: mouse => {
+                if (pressed) {
+                    const pct = Math.max(0, Math.min(1, mouse.x / parent.width))
+                    sl.newValue(sl.clampVal(sl.pctToVal(pct)))
+                }
+            }
+        }
+    }
+
+    // ── Layout ────────────────────────────────────────────────────
+
+    RowLayout {
+        anchors.fill: parent
+        anchors.margins: 16
+        spacing: 16
+
+        // Left: form
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            spacing: 10
+
+            InspectorLabel {
+                text: "Generate a tangent-space normal map from a grayscale " +
+                      "height/bump source. Drop a file onto the source field, " +
+                      "or click Browse."
+                wrapMode: Text.WordWrap
+                Layout.fillWidth: true
+                opacity: 0.85
+            }
+
+            // Source row
+            RowLayout {
+                spacing: 8
+                Layout.fillWidth: true
+                InspectorLabel { text: "Source:"; Layout.preferredWidth: 64; font.bold: true }
+                InspectorReadOnlyField {
+                    Layout.fillWidth: true
+                    text: dialog.sourcePath
+                    placeholderText: "(drop a height/bump map or click Browse)"
+                    DropArea {
+                        anchors.fill: parent
+                        onDropped: drop => {
+                            if (drop.hasUrls && drop.urls.length > 0)
+                                dialog.sourcePath = dialog.normaliseDroppedPath(drop.urls[0])
+                        }
+                    }
+                }
+                InspectorButton {
+                    label: "Browse…"
+                    Layout.preferredWidth: 80
+                    onClicked: {
+                        const picked = MaterialEditorQML.openFileDialog()
+                        if (picked && picked.length > 0) dialog.sourcePath = picked
+                    }
+                }
+            }
+
+            // Strength row
+            RowLayout {
+                spacing: 8
+                Layout.fillWidth: true
+                InspectorLabel { text: "Strength:"; Layout.preferredWidth: 64; font.bold: true }
+                StrengthSlider {
+                    Layout.fillWidth: true
+                    value: dialog.strength
+                    onNewValue: dialog.strength = v
+                }
+            }
+
+            // Invert toggles
+            RowLayout {
+                spacing: 16
+                Layout.fillWidth: true
+                InspectorCheckBox {
+                    Layout.preferredWidth: 130
+                    checked: dialog.invertR
+                    label: "Invert R"
+                    onToggled: dialog.invertR = newChecked
+                }
+                InspectorCheckBox {
+                    Layout.preferredWidth: 200
+                    checked: dialog.invertG
+                    label: "Invert G (DirectX +Y down)"
+                    onToggled: dialog.invertG = newChecked
+                }
+                Item { Layout.fillWidth: true }
+            }
+
+            Rectangle { Layout.fillWidth: true; height: 1; color: PropertiesPanelController.borderColor }
+
+            // Output path
+            RowLayout {
+                spacing: 8
+                Layout.fillWidth: true
+                InspectorLabel { text: "Output:"; Layout.preferredWidth: 64; font.bold: true }
+                InspectorTextField {
+                    Layout.fillWidth: true
+                    text: dialog.outputPath
+                    placeholderText: "/path/to/normal.png"
+                    onEditedText: dialog.outputPath = newText
+                }
+                InspectorButton {
+                    label: "Save As…"
+                    Layout.preferredWidth: 80
+                    onClicked: {
+                        const picked = MaterialEditorQML.saveNormalMapDialog()
+                        if (picked && picked.length > 0) dialog.outputPath = picked
+                    }
+                }
+            }
+
+            InspectorLabel {
+                id: statusLabel
+                wrapMode: Text.WordWrap
+                Layout.fillWidth: true
+            }
+
+            Item { Layout.fillHeight: true }
+
+            // Action buttons
+            RowLayout {
+                spacing: 8
+                Layout.fillWidth: true
+                Item { Layout.fillWidth: true }
+                InspectorButton {
+                    label: "Close"
+                    Layout.preferredWidth: 80
+                    onClicked: dialog.close()
+                }
+                InspectorButton {
+                    label: "Generate"
+                    Layout.preferredWidth: 90
+                    buttonEnabled: dialog.sourcePath !== "" && dialog.outputPath !== ""
+                    onClicked: {
+                        const err = MaterialEditorQML.generateNormalMap(
+                            dialog.sourcePath, dialog.strength,
+                            dialog.invertR, dialog.invertG,
+                            dialog.outputPath)
+                        if (err.length > 0) {
+                            statusLabel.text = "Error: " + err
+                            statusLabel.color = "#ee5555"
+                        } else {
+                            statusLabel.text = "Saved to " + dialog.outputPath
+                            statusLabel.color = "#55cc55"
+                        }
+                    }
+                }
+            }
+        }
+
+        // Right: preview thumbnail
+        ColumnLayout {
+            Layout.preferredWidth: 256
+            Layout.fillHeight: true
+            spacing: 8
+            InspectorLabel {
+                text: "Preview"
+                font.bold: true
+                Layout.alignment: Qt.AlignHCenter
+            }
+            Rectangle {
+                Layout.preferredWidth: 256
+                Layout.preferredHeight: 256
+                Layout.alignment: Qt.AlignHCenter
+                color: PropertiesPanelController.inputColor
+                border.color: PropertiesPanelController.borderColor
+                border.width: 1
+                radius: 3
+                Image {
+                    anchors.fill: parent
+                    anchors.margins: 1
+                    source: dialog.previewDataUrl
+                    fillMode: Image.PreserveAspectFit
+                    smooth: false
+                    cache: false
+                    asynchronous: true
+                }
+                InspectorLabel {
+                    visible: dialog.previewDataUrl.length === 0
+                    anchors.centerIn: parent
+                    text: "(pick a source)"
+                    opacity: 0.5
+                }
+            }
+            Item { Layout.fillHeight: true }
+        }
+    }
+}

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -1729,6 +1729,39 @@ Rectangle {
                     ToolTip.text: "Pack 1–4 grayscale source images into a single RGBA texture (e.g. Unity ORM = AO+Roughness+Metallic, Unreal MR)."
                 }
             }
+
+            // Slice H: Normal Map Generator — Sobel-filter a height/bump
+            // source into a tangent-space normal map. Same Mode-Tools
+            // placement as Pack Texture Channels (operates on disk
+            // files, not the selection's TUS).
+            Rectangle {
+                width: Math.min(parent.width - 16, normalLabel.implicitWidth + 16)
+                height: 26
+                radius: 3
+                color: normalMa.containsMouse
+                    ? PropertiesPanelController.highlightColor
+                    : PropertiesPanelController.headerColor
+                border.color: PropertiesPanelController.borderColor
+                border.width: 1
+
+                Text {
+                    id: normalLabel
+                    anchors.centerIn: parent
+                    text: "Generate Normal Map…"
+                    color: PropertiesPanelController.textColor
+                    font.pixelSize: 11
+                }
+                MouseArea {
+                    id: normalMa
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: root.openNormalMapGeneratorDialog()
+                    ToolTip.visible: containsMouse
+                    ToolTip.delay: 500
+                    ToolTip.text: "Generate a tangent-space normal map from a height/bump source via Sobel filter."
+                }
+            }
         }
     }
 
@@ -1751,6 +1784,23 @@ Rectangle {
             textureChannelPackerLoader.active = true
         } else if (textureChannelPackerLoader.item) {
             textureChannelPackerLoader.item.open()
+        }
+    }
+
+    // Slice H: Normal Map Generator dialog — same Loader pattern.
+    Loader {
+        id: normalMapGeneratorLoader
+        active: false
+        anchors.centerIn: parent
+        source: "qrc:/MaterialEditorQML/NormalMapGeneratorDialog.qml"
+        onLoaded: if (item && item.open) item.open()
+    }
+
+    function openNormalMapGeneratorDialog() {
+        if (!normalMapGeneratorLoader.active) {
+            normalMapGeneratorLoader.active = true
+        } else if (normalMapGeneratorLoader.item) {
+            normalMapGeneratorLoader.item.open()
         }
     }
 

--- a/qml/qmldir
+++ b/qml/qmldir
@@ -4,6 +4,7 @@ PassPropertiesPanel 1.0 PassPropertiesPanel.qml
 TexturePropertiesPanel 1.0 TexturePropertiesPanel.qml
 AISettingsDialog 1.0 AISettingsDialog.qml
 TextureChannelPackerDialog 1.0 TextureChannelPackerDialog.qml
+NormalMapGeneratorDialog 1.0 NormalMapGeneratorDialog.qml
 MaterialListModal 1.0 MaterialListModal.qml
 ThemedButton 1.0 ThemedButton.qml
 ThemedComboBox 1.0 ThemedComboBox.qml

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -11,6 +11,7 @@
 #include "FBX/FBXExporter.h"
 #include "MaterialPresetLibrary.h"
 #include "TextureChannelPacker.h"
+#include "NormalMapGenerator.h"
 #include "QtMeshCloudClient.h"
 #include <OgreMaterialSerializer.h>
 #include <QApplication>
@@ -960,6 +961,7 @@ int CLIPipeline::run(int argc, char* argv[])
     else if (cmd == "scan") rc = cmdScan(argc, argv);
     else if (cmd == "material") rc = cmdMaterial(argc, argv);
     else if (cmd == "pack-textures") rc = cmdPackTextures(argc, argv);
+    else if (cmd == "normal-from-height") rc = cmdNormalFromHeight(argc, argv);
 
     if (rc < 0) {
         err() << "Error: Unknown command '" << cmd << "'" << Qt::endl;
@@ -2660,6 +2662,57 @@ int CLIPipeline::cmdPackTextures(int argc, char* argv[])
     }
 
     cliWrite(QString("Packed %1x%2 -> %3\n")
+                 .arg(r.usedWidth)
+                 .arg(r.usedHeight)
+                 .arg(QFileInfo(outputPath).fileName()));
+    return 0;
+}
+
+int CLIPipeline::cmdNormalFromHeight(int argc, char* argv[])
+{
+    // Parse:
+    //   normal-from-height --src <bump.png> [--strength N]
+    //                      [--invert-r] [--invert-g]
+    //                      [--width N] [--height N]
+    //                      -o <out.png>
+    NormalMapGenerator::GenSpec spec;
+    QString outputPath;
+
+    for (int i = 1; i < argc; ++i) {
+        QString arg(argv[i]);
+        if (arg == "normal-from-height" || arg == "--cli") continue;
+        if (arg == "--src" && i + 1 < argc) { spec.sourcePath = QString(argv[++i]); continue; }
+        if (arg == "--strength" && i + 1 < argc) { spec.strength = QString(argv[++i]).toFloat(); continue; }
+        if (arg == "--width"  && i + 1 < argc) { spec.outputWidth  = QString(argv[++i]).toInt(); continue; }
+        if (arg == "--height" && i + 1 < argc) { spec.outputHeight = QString(argv[++i]).toInt(); continue; }
+        if (arg == "--invert-r") { spec.invertR = true; continue; }
+        if (arg == "--invert-g" || arg == "--directx") { spec.invertG = true; continue; }
+        if ((arg == "-o" || arg == "--output") && i + 1 < argc) {
+            outputPath = QString(argv[++i]);
+            continue;
+        }
+    }
+
+    if (spec.sourcePath.isEmpty() || outputPath.isEmpty()) {
+        err() << "Error: missing --src or -o." << Qt::endl;
+        err() << "Usage: qtmesh normal-from-height --src <height.png>" << Qt::endl;
+        err() << "                                 [--strength N] [--invert-r] [--invert-g]" << Qt::endl;
+        err() << "                                 [--width N --height N]" << Qt::endl;
+        err() << "                                 -o <normal.png>" << Qt::endl;
+        return 2;
+    }
+
+    SentryReporter::addBreadcrumb("cli.normal-from-height",
+        QString("Normal map from %1 -> %2")
+            .arg(QFileInfo(spec.sourcePath).fileName(),
+                 QFileInfo(outputPath).fileName()));
+
+    auto r = NormalMapGenerator::generateToFile(spec, outputPath);
+    if (!r.ok) {
+        err() << "Error: " << r.error << Qt::endl;
+        return 1;
+    }
+    cliWrite(QString("Normal map %1x%2 -> %3\n")
                  .arg(r.usedWidth)
                  .arg(r.usedHeight)
                  .arg(QFileInfo(outputPath).fileName()));

--- a/src/CLIPipeline.h
+++ b/src/CLIPipeline.h
@@ -81,6 +81,10 @@ public:
     /// output texture. Headless / scriptable equivalent of the GUI
     /// "Pack Channels…" dialog.
     static int cmdPackTextures(int argc, char* argv[]);
+    /// Slice H: generate a tangent-space normal map from a height/bump
+    /// source via Sobel filter. Headless equivalent of the GUI
+    /// "Generate Normal Map…" dialog.
+    static int cmdNormalFromHeight(int argc, char* argv[]);
 
     /// Map file extension to MeshImporterExporter format string.
     static QString formatForExtension(const QString& path);

--- a/src/CLIPipeline_test.cpp
+++ b/src/CLIPipeline_test.cpp
@@ -3037,3 +3037,86 @@ TEST(CLIPipelineCmdPackTextures, InvertFlagFlipsConstantSource)
     ASSERT_FALSE(img.isNull());
     EXPECT_EQ(qRed(img.pixel(4, 4)), 0);
 }
+
+// -- cmdNormalFromHeight (slice H) --
+
+namespace {
+
+// Helper: write an N×M grayscale PNG with the given per-pixel value
+// function, return the path. Mirrors the helper in
+// NormalMapGenerator_test but kept local to avoid cross-test deps.
+template <class F>
+QString writeGreyPng(const QTemporaryDir& dir, const QString& name,
+                     int w, int h, F valueFn)
+{
+    QImage img(w, h, QImage::Format_RGBA8888);
+    for (int y = 0; y < h; ++y) {
+        for (int x = 0; x < w; ++x) {
+            const int v = valueFn(x, y);
+            img.setPixel(x, y, qRgba(v, v, v, 255));
+        }
+    }
+    const QString path = dir.filePath(name);
+    img.save(path, "PNG");
+    return path;
+}
+
+} // namespace
+
+TEST(CLIPipelineCmdNormalFromHeight, MissingArgsFails)
+{
+    TestArgv args({"qtmesh", "normal-from-height"});
+    EXPECT_EQ(CLIPipeline::cmdNormalFromHeight(args.argc(), args.argv()), 2);
+}
+
+TEST(CLIPipelineCmdNormalFromHeight, MissingSourceFileReturnsRuntimeError)
+{
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    const QByteArray outPath = tmp.filePath("never.png").toUtf8();
+    TestArgv args({"qtmesh", "normal-from-height",
+                   "--src", "/nonexistent/missing_for_test.png",
+                   "-o", outPath.constData()});
+    EXPECT_EQ(CLIPipeline::cmdNormalFromHeight(args.argc(), args.argv()), 1);
+}
+
+TEST(CLIPipelineCmdNormalFromHeight, FlatHeightProducesStraightUpNormalMap)
+{
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    const QByteArray src = writeGreyPng(tmp, "flat.png", 16, 16,
+                                         [](int, int){ return 128; }).toUtf8();
+    const QByteArray outPath = tmp.filePath("normal.png").toUtf8();
+    TestArgv args({"qtmesh", "normal-from-height",
+                   "--src", src.constData(),
+                   "-o", outPath.constData()});
+    EXPECT_EQ(CLIPipeline::cmdNormalFromHeight(args.argc(), args.argv()), 0);
+
+    QImage img(outPath);
+    ASSERT_FALSE(img.isNull());
+    EXPECT_EQ(img.width(), 16);
+    EXPECT_NEAR(qRed(img.pixel(8, 8)),   128, 2);
+    EXPECT_NEAR(qGreen(img.pixel(8, 8)), 128, 2);
+    EXPECT_EQ(qBlue(img.pixel(8, 8)),    255);
+}
+
+TEST(CLIPipelineCmdNormalFromHeight, InvertGFlipsGreenChannel)
+{
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    // Vertical ramp → ny < 0 by default → green < 128. With --invert-g
+    // it should flip above 128.
+    const QByteArray src = writeGreyPng(tmp, "ramp_y.png", 16, 16,
+                                         [](int, int y){ return std::min(255, y * 16); }).toUtf8();
+    const QByteArray outPath = tmp.filePath("normal_dx.png").toUtf8();
+    TestArgv args({"qtmesh", "normal-from-height",
+                   "--src", src.constData(),
+                   "--strength", "2.0",
+                   "--invert-g",
+                   "-o", outPath.constData()});
+    EXPECT_EQ(CLIPipeline::cmdNormalFromHeight(args.argc(), args.argv()), 0);
+
+    QImage img(outPath);
+    ASSERT_FALSE(img.isNull());
+    EXPECT_GT(qGreen(img.pixel(8, 8)), 135);
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,6 +77,7 @@ BatchExporter.cpp
 MaterialPresetLibrary.cpp
 MeshLodController.cpp
 TextureChannelPacker.cpp
+NormalMapGenerator.cpp
 MeshValidator.cpp
 AIChatManager.cpp
 WelcomeScreenController.cpp
@@ -161,6 +162,7 @@ BatchExporter.h
 MaterialPresetLibrary.h
 MeshLodController.h
 TextureChannelPacker.h
+NormalMapGenerator.h
 MeshValidator.h
 AIChatManager.h
 WelcomeScreenController.h

--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -4,6 +4,7 @@
 #include "MaterialEditorQML.h"
 #include "MaterialPresetLibrary.h"
 #include "TextureChannelPacker.h"
+#include "NormalMapGenerator.h"
 #include "PrimitiveObject.h"
 #include "SelectionSet.h"
 #include "TransformOperator.h"
@@ -444,7 +445,8 @@ const QMap<QString, MCPServer::ToolHandler>& MCPServer::toolHandlers()
         {QStringLiteral("reparent_node"), &MCPServer::toolReparentNode},
         {QStringLiteral("set_pivot_mode"), &MCPServer::toolSetPivotMode},
         {QStringLiteral("get_pivot_mode"), &MCPServer::toolGetPivotMode},
-        {QStringLiteral("pack_textures"), &MCPServer::toolPackTextures}
+        {QStringLiteral("pack_textures"), &MCPServer::toolPackTextures},
+        {QStringLiteral("generate_normal_map"), &MCPServer::toolGenerateNormalMap}
     };
     return handlers;
 }
@@ -3394,6 +3396,43 @@ QJsonObject MCPServer::toolPackTextures(const QJsonObject &args)
     return result;
 }
 
+QJsonObject MCPServer::toolGenerateNormalMap(const QJsonObject &args)
+{
+    SentryReporter::addBreadcrumb("ai.tool_call", "generate_normal_map");
+
+    NormalMapGenerator::GenSpec spec;
+    spec.sourcePath = args.value("source").toString();
+    if (args.contains("strength"))
+        spec.strength = static_cast<float>(args.value("strength").toDouble());
+    if (args.contains("width"))
+        spec.outputWidth = args.value("width").toInt();
+    if (args.contains("height"))
+        spec.outputHeight = args.value("height").toInt();
+    if (args.contains("invert_r"))
+        spec.invertR = args.value("invert_r").toBool();
+    if (args.contains("invert_g"))
+        spec.invertG = args.value("invert_g").toBool();
+    if (args.contains("directx") && args.value("directx").toBool())
+        spec.invertG = true;  // alias for invert_g
+
+    const QString outPath = args.value("output").toString();
+    if (spec.sourcePath.isEmpty() || outPath.isEmpty())
+        return makeErrorResult("Error: missing required 'source' and 'output' arguments");
+
+    auto r = NormalMapGenerator::generateToFile(spec, outPath);
+    if (!r.ok)
+        return makeErrorResult(QString("Error: %1").arg(r.error));
+
+    QJsonObject result;
+    result["content"] = QJsonArray{QJsonObject{
+        {"type", "text"},
+        {"text", QString("Normal map %1x%2 -> %3").arg(r.usedWidth).arg(r.usedHeight).arg(outPath)}}};
+    result["width"]  = r.usedWidth;
+    result["height"] = r.usedHeight;
+    result["output"] = outPath;
+    return result;
+}
+
 QJsonArray MCPServer::buildToolsList()
 {
     QJsonArray tools;
@@ -4252,6 +4291,40 @@ QJsonArray MCPServer::buildToolsList()
             "Unreal MR = Metallic+Roughness). Each output channel takes either a source image (sampled "
             "as luminance) or a constant 0..1 value. Smaller sources are bilinear-scaled to match the "
             "largest input. Returns the output dimensions on success.",
+            props,
+            required
+        );
+    }
+
+    // generate_normal_map (slice H)
+    {
+        QJsonObject props;
+        props["source"] = QJsonObject{
+            {"type", "string"},
+            {"description", "Path to the grayscale height/bump source image (PNG/TGA/JPG/BMP)."}};
+        props["output"] = QJsonObject{
+            {"type", "string"},
+            {"description", "Output file path. Extension determines format (PNG/TGA/JPG/BMP)."}};
+        props["strength"] = QJsonObject{
+            {"type", "number"},
+            {"description", "Sobel gradient multiplier — effective bump intensity. Default 2.0; clamped to 0..32."}};
+        props["width"]  = QJsonObject{{"type", "integer"},
+            {"description", "Optional output width. Defaults to the source width."}};
+        props["height"] = QJsonObject{{"type", "integer"}};
+        props["invert_r"] = QJsonObject{{"type", "boolean"},
+            {"description", "Flip the red channel — rare; kept for pipeline parity."}};
+        props["invert_g"] = QJsonObject{{"type", "boolean"},
+            {"description", "Flip the green channel — switches OpenGL (+Y up, default) ↔ DirectX (+Y down)."}};
+        props["directx"] = QJsonObject{{"type", "boolean"},
+            {"description", "Alias for invert_g — DirectX convention output."}};
+        QJsonArray required;
+        required.append("source");
+        required.append("output");
+        appendTool(
+            "generate_normal_map",
+            "Generate a tangent-space normal map from a grayscale height/bump source via a 3x3 Sobel "
+            "filter. Output is RGB8 with the OpenGL +Y-up convention by default; set invert_g (or "
+            "directx) for DirectX +Y-down output. Returns the output dimensions on success.",
             props,
             required
         );

--- a/src/MCPServer.h
+++ b/src/MCPServer.h
@@ -183,6 +183,9 @@ private:
     /// Slice G: pack 1-4 grayscale source images into a single RGBA
     /// output texture (e.g. ORM = AO+Roughness+Metallic).
     QJsonObject toolPackTextures(const QJsonObject &args);
+    /// Slice H: generate a tangent-space normal map from a height/bump
+    /// source via Sobel filter.
+    QJsonObject toolGenerateNormalMap(const QJsonObject &args);
 
     // Animation
     struct NodeAnimation {
@@ -237,7 +240,7 @@ private:
     // 1.4.0 — added simplify_animation / analyze_animation tools
     // 1.5.0 — added bake_animation_fps tool
     // 1.6.0 — added list_material_presets / apply_material_preset (incl. PBR templates)
-    static constexpr const char* SERVER_VERSION = "1.6.0";
+    static constexpr const char* SERVER_VERSION = "1.7.0";
 };
 
 #endif // MCPSERVER_H

--- a/src/MCPServer_test.cpp
+++ b/src/MCPServer_test.cpp
@@ -5903,3 +5903,100 @@ TEST_F(MCPServerTest, PackTextures_AppearsInToolList)
     }
     EXPECT_TRUE(found) << "pack_textures must be exposed in tools/list";
 }
+
+// ==========================================================================
+// SLICE H: generate_normal_map tool
+// ==========================================================================
+
+namespace {
+QString writeGreyPngForMcp(const QTemporaryDir& dir, const QString& name,
+                            int w, int h, int grey)
+{
+    QImage img(w, h, QImage::Format_RGBA8888);
+    img.fill(qRgba(grey, grey, grey, 255));
+    const QString path = dir.filePath(name);
+    img.save(path, "PNG");
+    return path;
+}
+} // namespace
+
+TEST_F(MCPServerTest, GenerateNormalMap_MissingArgsReturnsError)
+{
+    QJsonObject args;
+    QJsonObject result = server->callTool("generate_normal_map", args);
+    EXPECT_TRUE(isError(result));
+    EXPECT_TRUE(getResultText(result).contains("source", Qt::CaseInsensitive));
+}
+
+TEST_F(MCPServerTest, GenerateNormalMap_FlatHeightWritesPng)
+{
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    const QString src = writeGreyPngForMcp(tmp, "flat.png", 16, 16, 128);
+    const QString out = tmp.filePath("normal.png");
+
+    QJsonObject args;
+    args["source"] = src;
+    args["output"] = out;
+    args["strength"] = 2.0;
+    QJsonObject result = server->callTool("generate_normal_map", args);
+    EXPECT_FALSE(isError(result));
+    EXPECT_EQ(result["width"].toInt(), 16);
+    EXPECT_EQ(result["height"].toInt(), 16);
+
+    QImage img(out);
+    ASSERT_FALSE(img.isNull());
+    EXPECT_NEAR(qRed(img.pixel(8, 8)),   128, 2);
+    EXPECT_EQ(qBlue(img.pixel(8, 8)),    255);
+}
+
+TEST_F(MCPServerTest, GenerateNormalMap_MissingSourceReportsError)
+{
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    QJsonObject args;
+    args["source"] = "/nonexistent/should_not_resolve.png";
+    args["output"] = tmp.filePath("nope.png");
+    QJsonObject result = server->callTool("generate_normal_map", args);
+    EXPECT_TRUE(isError(result));
+}
+
+TEST_F(MCPServerTest, GenerateNormalMap_AppearsInToolList)
+{
+    QJsonArray tools = server->buildToolsList();
+    bool found = false;
+    for (const auto& t : tools) {
+        if (t.toObject()["name"].toString() == "generate_normal_map") {
+            found = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(found) << "generate_normal_map must be exposed in tools/list";
+}
+
+TEST_F(MCPServerTest, GenerateNormalMap_DirectxAliasInvertsGreen)
+{
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    // Vertical ramp — green channel goes <128 by default.
+    QImage img(16, 16, QImage::Format_RGBA8888);
+    for (int y = 0; y < 16; ++y) {
+        const int v = std::min(255, y * 16);
+        for (int x = 0; x < 16; ++x) img.setPixel(x, y, qRgba(v, v, v, 255));
+    }
+    const QString src = tmp.filePath("ramp_y.png");
+    img.save(src, "PNG");
+    const QString out = tmp.filePath("dx.png");
+
+    QJsonObject args;
+    args["source"] = src;
+    args["output"] = out;
+    args["strength"] = 2.0;
+    args["directx"] = true;   // alias for invert_g
+    QJsonObject result = server->callTool("generate_normal_map", args);
+    EXPECT_FALSE(isError(result));
+
+    QImage gen(out);
+    ASSERT_FALSE(gen.isNull());
+    EXPECT_GT(qGreen(gen.pixel(8, 8)), 135);
+}

--- a/src/MaterialEditorQML.cpp
+++ b/src/MaterialEditorQML.cpp
@@ -10,6 +10,7 @@
 #include "ModelDownloader.h"
 #include "RTShaderHelper.h"
 #include "TextureChannelPacker.h"
+#include "NormalMapGenerator.h"
 #include "PS1/PS1TIM.h"
 #include <OgreRTShaderSystem.h>
 #include <QDebug>
@@ -2917,6 +2918,74 @@ QString MaterialEditorQML::packTextureChannels(const QString& redPath,
     spec.includeAlpha    = includeAlpha;
 
     auto r = TextureChannelPacker::packToFile(spec, outputPath);
+    return r.ok ? QString() : r.error;
+}
+
+QString MaterialEditorQML::saveNormalMapDialog()
+{
+    QString texturesPath = "./media/materials/textures";
+    QDir texturesDir(texturesPath);
+    QString startDir = texturesDir.exists() ? texturesDir.absolutePath() : QDir::currentPath();
+
+    QApplication::processEvents();
+    if (QWidget *activeWin = QApplication::activeWindow()) {
+        activeWin->raise();
+        activeWin->activateWindow();
+    }
+    QApplication::processEvents();
+
+    QString selectedFile = QFileDialog::getSaveFileName(
+        QApplication::activeWindow(),
+        "Save Normal Map",
+        startDir + "/normal.png",
+        "PNG (*.png);;TGA (*.tga);;JPEG (*.jpg *.jpeg);;BMP (*.bmp)",
+        nullptr,
+        QFileDialog::DontUseNativeDialog | QFileDialog::DontUseCustomDirectoryIcons
+    );
+    return selectedFile;
+}
+
+QString MaterialEditorQML::previewNormalMap(const QString& sourcePath,
+                                             double strength,
+                                             bool invertR,
+                                             bool invertG,
+                                             int previewSize)
+{
+    NormalMapGenerator::GenSpec spec;
+    spec.sourcePath = sourcePath;
+    spec.strength = static_cast<float>(strength);
+    spec.invertR = invertR;
+    spec.invertG = invertG;
+    // Cap preview size so live updates are cheap.
+    const int cappedSize = std::clamp(previewSize, 32, 512);
+    spec.outputWidth = cappedSize;
+    spec.outputHeight = cappedSize;
+
+    auto r = NormalMapGenerator::generate(spec);
+    if (!r.ok) return QString();
+
+    QByteArray bytes;
+    QBuffer buf(&bytes);
+    buf.open(QIODevice::WriteOnly);
+    if (!r.image.save(&buf, "PNG")) return QString();
+    return QStringLiteral("data:image/png;base64,") + bytes.toBase64();
+}
+
+QString MaterialEditorQML::generateNormalMap(const QString& sourcePath,
+                                              double strength,
+                                              bool invertR,
+                                              bool invertG,
+                                              const QString& outputPath)
+{
+    SentryReporter::addBreadcrumb("ui.action", "Generate normal map");
+
+    NormalMapGenerator::GenSpec spec;
+    spec.sourcePath = sourcePath;
+    spec.strength = static_cast<float>(strength);
+    spec.invertR = invertR;
+    spec.invertG = invertG;
+
+    auto r = NormalMapGenerator::generateToFile(spec, outputPath);
     return r.ok ? QString() : r.error;
 }
 

--- a/src/MaterialEditorQML.h
+++ b/src/MaterialEditorQML.h
@@ -425,6 +425,27 @@ public slots:
                                             bool invertAlpha,
                                             bool includeAlpha,
                                             const QString& outputPath);
+
+    /// Slice H: open a native save-as dialog for the generated normal
+    /// map output path. Mirrors savePackedTextureDialog().
+    Q_INVOKABLE QString saveNormalMapDialog();
+
+    /// Slice H: render a small preview of the generated normal map
+    /// without writing to disk. Returns a `data:image/png;base64,…`
+    /// URL or empty on failure. Mirrors previewPackedTextureChannels.
+    Q_INVOKABLE QString previewNormalMap(const QString& sourcePath,
+                                         double strength,
+                                         bool invertR,
+                                         bool invertG,
+                                         int previewSize);
+
+    /// Slice H: generate a tangent-space normal map and write it to
+    /// disk. Returns empty string on success or an error message.
+    Q_INVOKABLE QString generateNormalMap(const QString& sourcePath,
+                                          double strength,
+                                          bool invertR,
+                                          bool invertG,
+                                          const QString& outputPath);
     
     // Color picker
     void openColorPicker(const QString &colorType);

--- a/src/MaterialEditorQML_test.cpp
+++ b/src/MaterialEditorQML_test.cpp
@@ -2686,3 +2686,77 @@ TEST_F(MaterialEditorQMLTest, PreviewPackedTextureChannels_SizeIsClampedToBounds
     ASSERT_TRUE(img.loadFromData(payload, "PNG"));
     EXPECT_EQ(img.width(), 32);
 }
+
+// ---------------------------------------------------------------------------
+// Slice H: Q_INVOKABLE wrappers for the normal map generator
+// ---------------------------------------------------------------------------
+
+namespace {
+QString writeGreyPngForNormal(const QTemporaryDir& dir, const QString& name,
+                               int w, int h, int grey)
+{
+    QImage img(w, h, QImage::Format_RGBA8888);
+    img.fill(qRgba(grey, grey, grey, 255));
+    const QString path = dir.filePath(name);
+    img.save(path, "PNG");
+    return path;
+}
+} // namespace
+
+TEST_F(MaterialEditorQMLTest, GenerateNormalMap_FlatHeightWritesPng) {
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    const QString src = writeGreyPngForNormal(tmp, "flat.png", 8, 8, 128);
+    const QString out = tmp.filePath("normal.png");
+
+    QString err = editor->generateNormalMap(src, 2.0, false, false, out);
+    EXPECT_TRUE(err.isEmpty()) << err.toStdString();
+    EXPECT_TRUE(QFile::exists(out));
+    QImage img(out);
+    ASSERT_FALSE(img.isNull());
+    EXPECT_EQ(qBlue(img.pixel(4, 4)), 255);
+}
+
+TEST_F(MaterialEditorQMLTest, GenerateNormalMap_MissingSourceReturnsError) {
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    QString err = editor->generateNormalMap(
+        "/nonexistent/missing_for_test.png", 2.0, false, false,
+        tmp.filePath("never.png"));
+    EXPECT_FALSE(err.isEmpty());
+}
+
+TEST_F(MaterialEditorQMLTest, PreviewNormalMap_FlatHeightReturnsDataUrl) {
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    const QString src = writeGreyPngForNormal(tmp, "flat.png", 32, 32, 128);
+
+    QString url = editor->previewNormalMap(src, 2.0, false, false, 64);
+    ASSERT_TRUE(url.startsWith("data:image/png;base64,")) << url.toStdString();
+
+    const QByteArray payload = QByteArray::fromBase64(
+        url.mid(QString("data:image/png;base64,").size()).toLatin1());
+    QImage img;
+    ASSERT_TRUE(img.loadFromData(payload, "PNG"));
+    EXPECT_EQ(img.width(), 64);
+    EXPECT_NEAR(qRed(img.pixel(32, 32)), 128, 2);
+}
+
+TEST_F(MaterialEditorQMLTest, PreviewNormalMap_MissingSourceReturnsEmpty) {
+    QString url = editor->previewNormalMap(
+        "/nonexistent/missing.png", 2.0, false, false, 64);
+    EXPECT_TRUE(url.isEmpty());
+}
+
+TEST_F(MaterialEditorQMLTest, PreviewNormalMap_SizeIsClampedToBounds) {
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    const QString src = writeGreyPngForNormal(tmp, "flat.png", 8, 8, 128);
+    QString url = editor->previewNormalMap(src, 2.0, false, false, 8);
+    ASSERT_TRUE(url.startsWith("data:image/png;base64,"));
+    const QByteArray payload = QByteArray::fromBase64(
+        url.mid(QString("data:image/png;base64,").size()).toLatin1());
+    QImage img;
+    ASSERT_TRUE(img.loadFromData(payload, "PNG"));
+    EXPECT_EQ(img.width(), 32);  // clamped to lower bound
+}

--- a/src/NormalMapGenerator.cpp
+++ b/src/NormalMapGenerator.cpp
@@ -1,0 +1,169 @@
+#include "NormalMapGenerator.h"
+
+#include <QFileInfo>
+#include <QImageReader>
+#include <QImageWriter>
+#include <algorithm>
+#include <cmath>
+
+namespace NormalMapGenerator {
+
+namespace {
+
+// Rec.601 luminance, fixed-point — matches TextureChannelPacker so
+// behaviour is consistent across the two utilities.
+inline uint8_t luminance(QRgb px)
+{
+    const int r = qRed(px);
+    const int g = qGreen(px);
+    const int b = qBlue(px);
+    return static_cast<uint8_t>((r * 77 + g * 150 + b * 29 + 128) >> 8);
+}
+
+// Edge-clamp height sample. The image is in RGBA8888; we sample its
+// luminance and normalise to [0..1].
+inline float sampleHeight(const QImage& img, int x, int y)
+{
+    const int w = img.width();
+    const int h = img.height();
+    const int cx = std::clamp(x, 0, w - 1);
+    const int cy = std::clamp(y, 0, h - 1);
+    return luminance(img.pixel(cx, cy)) / 255.0f;
+}
+
+// Encode a unit-length normal (components in [-1..1]) to RGB8.
+inline void encodeNormal(uchar* outRow, int x, float nx, float ny, float nz)
+{
+    auto encode = [](float c) {
+        // (c + 1) * 0.5 → [0..1] → [0..255]
+        const float v = (c + 1.0f) * 0.5f * 255.0f;
+        return static_cast<uint8_t>(std::clamp(std::lround(v), 0L, 255L));
+    };
+    outRow[x*3 + 0] = encode(nx);
+    outRow[x*3 + 1] = encode(ny);
+    outRow[x*3 + 2] = encode(nz);
+}
+
+} // namespace
+
+GenResult generate(const GenSpec& spec)
+{
+    GenResult res;
+
+    if (spec.sourcePath.isEmpty()) {
+        res.error = QStringLiteral("source path is empty");
+        return res;
+    }
+
+    QImageReader reader(spec.sourcePath);
+    QImage src = reader.read();
+    if (src.isNull()) {
+        res.error = QStringLiteral("failed to read '%1': %2")
+                        .arg(spec.sourcePath, reader.errorString());
+        return res;
+    }
+    src = src.convertToFormat(QImage::Format_RGBA8888);
+
+    // Resolve output dimensions: explicit override beats source size.
+    int outW = spec.outputWidth  > 0 ? spec.outputWidth  : src.width();
+    int outH = spec.outputHeight > 0 ? spec.outputHeight : src.height();
+    if (outW <= 0 || outH <= 0) {
+        res.error = QStringLiteral("invalid output dimensions");
+        return res;
+    }
+
+    // Resize the source to the output dimensions up-front so the Sobel
+    // sampler can stay a simple per-pixel lookup.
+    if (src.size() != QSize(outW, outH)) {
+        src = src.scaled(outW, outH, Qt::IgnoreAspectRatio,
+                          Qt::SmoothTransformation);
+        if (src.format() != QImage::Format_RGBA8888)
+            src = src.convertToFormat(QImage::Format_RGBA8888);
+    }
+
+    QImage out(outW, outH, QImage::Format_RGB888);
+    if (out.isNull()) {
+        res.error = QStringLiteral("failed to allocate %1x%2 output image")
+                        .arg(outW).arg(outH);
+        return res;
+    }
+
+    // Strength gates how aggressively we lift the gradient. The user-
+    // facing slider is 0..10ish; clamp to a sane band so a runaway
+    // value can't produce all-saturated output.
+    const float strength = std::clamp(spec.strength, 0.0f, 32.0f);
+
+    // Per-pixel Sobel. dx and dy are in [-4..+4] before strength scaling
+    // (a uniform-luminance-difference 1×8 windowed gradient).
+    for (int y = 0; y < outH; ++y) {
+        uchar* row = out.scanLine(y);
+        for (int x = 0; x < outW; ++x) {
+            const float h00 = sampleHeight(src, x - 1, y - 1);
+            const float h10 = sampleHeight(src, x,     y - 1);
+            const float h20 = sampleHeight(src, x + 1, y - 1);
+            const float h01 = sampleHeight(src, x - 1, y);
+            const float h21 = sampleHeight(src, x + 1, y);
+            const float h02 = sampleHeight(src, x - 1, y + 1);
+            const float h12 = sampleHeight(src, x,     y + 1);
+            const float h22 = sampleHeight(src, x + 1, y + 1);
+
+            const float dx = (h20 + 2.0f * h21 + h22) - (h00 + 2.0f * h01 + h02);
+            const float dy = (h02 + 2.0f * h12 + h22) - (h00 + 2.0f * h10 + h20);
+
+            // Tangent-space normal: -gradient gives "bumps point at the
+            // viewer". Z=1 keeps the normal pointing up out of the
+            // surface; strength scales the in-plane components.
+            float nx = -dx * strength;
+            float ny = -dy * strength;
+            float nz = 1.0f;
+            const float len = std::sqrt(nx * nx + ny * ny + nz * nz);
+            if (len > 1e-6f) {
+                nx /= len;
+                ny /= len;
+                nz /= len;
+            } else {
+                nx = 0.0f; ny = 0.0f; nz = 1.0f;
+            }
+
+            if (spec.invertR) nx = -nx;
+            // OpenGL convention is +Y up. invertG flips for DirectX
+            // pipelines that expect +Y down.
+            if (spec.invertG) ny = -ny;
+
+            encodeNormal(row, x, nx, ny, nz);
+        }
+    }
+
+    res.ok = true;
+    res.image = std::move(out);
+    res.usedWidth = outW;
+    res.usedHeight = outH;
+    return res;
+}
+
+GenResult generateToFile(const GenSpec& spec, const QString& outPath)
+{
+    GenResult r = generate(spec);
+    if (!r.ok) return r;
+
+    if (outPath.isEmpty()) {
+        r.ok = false;
+        r.error = QStringLiteral("output path is empty");
+        return r;
+    }
+    QImageWriter writer(outPath);
+    if (!writer.canWrite()) {
+        r.ok = false;
+        r.error = QStringLiteral("cannot write '%1': format unsupported")
+                      .arg(QFileInfo(outPath).suffix());
+        return r;
+    }
+    if (!writer.write(r.image)) {
+        r.ok = false;
+        r.error = QStringLiteral("write failed: %1").arg(writer.errorString());
+        return r;
+    }
+    return r;
+}
+
+} // namespace NormalMapGenerator

--- a/src/NormalMapGenerator.h
+++ b/src/NormalMapGenerator.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <QImage>
+#include <QString>
+
+/// Slice H: tangent-space normal map generator from a grayscale
+/// height/bump source via a 3×3 Sobel kernel. Pure-data, no Ogre — same
+/// shape as TextureChannelPacker so it can be unit-tested without GL.
+///
+/// Convention notes:
+///  - Output is RGB8 (no alpha) by default. The Z component of the
+///    surface normal is always positive in tangent space, so the blue
+///    channel sits in [128..255]. This matches the Ogre/glTF convention
+///    and what most engines expect.
+///  - `invertR` flips the red channel (rare; some pipelines flip it for
+///    handedness consistency).
+///  - `invertG` is the **DirectX vs OpenGL** difference. Default is
+///    OpenGL (+Y up). Set true for DirectX-flavoured normal maps
+///    (e.g. Unity / Unreal default sometimes ship DX-flavour assets).
+namespace NormalMapGenerator {
+
+struct GenSpec {
+    QString sourcePath;        // grayscale height/bump map
+    float   strength = 2.0f;   // Sobel gradient multiplier (effective bump intensity)
+    int     outputWidth = 0;   // 0 → use source size
+    int     outputHeight = 0;
+    bool    invertR = false;
+    bool    invertG = false;   // ← DirectX (+Y down) when true
+};
+
+struct GenResult {
+    bool ok = false;
+    QString error;
+    QImage  image;             // RGB8 — empty on failure
+    int     usedWidth = 0;
+    int     usedHeight = 0;
+};
+
+/// Generate a tangent-space normal map. Returns the image and an `ok`
+/// flag; check `error` on failure.
+GenResult generate(const GenSpec& spec);
+
+/// Convenience: generate and save to `outPath`. Extension drives format.
+GenResult generateToFile(const GenSpec& spec, const QString& outPath);
+
+} // namespace NormalMapGenerator

--- a/src/NormalMapGenerator_test.cpp
+++ b/src/NormalMapGenerator_test.cpp
@@ -1,0 +1,220 @@
+#include <gtest/gtest.h>
+
+#include <QImage>
+#include <QTemporaryDir>
+
+#include "NormalMapGenerator.h"
+
+using namespace NormalMapGenerator;
+
+namespace {
+
+// Write an N×M PNG with `gradientFn(x, y)` returning a 0..255 grey
+// value per pixel. Returns the on-disk path.
+template <class F>
+QString writePng(const QTemporaryDir& dir, const QString& name,
+                 int w, int h, F gradientFn)
+{
+    QImage img(w, h, QImage::Format_RGBA8888);
+    for (int y = 0; y < h; ++y) {
+        for (int x = 0; x < w; ++x) {
+            const int v = gradientFn(x, y);
+            img.setPixel(x, y, qRgba(v, v, v, 255));
+        }
+    }
+    const QString path = dir.filePath(name);
+    [&]() { ASSERT_TRUE(img.save(path, "PNG")) << path.toStdString(); }();
+    return path;
+}
+
+} // namespace
+
+TEST(NormalMapGeneratorTest, FlatHeightProducesStraightUpNormals) {
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    const QString src = writePng(tmp, "flat.png", 16, 16,
+                                  [](int, int){ return 128; });
+
+    GenSpec spec;
+    spec.sourcePath = src;
+    spec.strength = 2.0f;
+    GenResult r = generate(spec);
+    ASSERT_TRUE(r.ok) << r.error.toStdString();
+    EXPECT_EQ(r.usedWidth, 16);
+    EXPECT_EQ(r.usedHeight, 16);
+
+    // Flat heightmap → gradient zero → normal = (0, 0, 1) → encoded
+    // as (~128, ~128, 255). Sample the centre pixel where edge effects
+    // are absent.
+    const QRgb px = r.image.pixel(8, 8);
+    EXPECT_NEAR(qRed(px),   128, 2);
+    EXPECT_NEAR(qGreen(px), 128, 2);
+    EXPECT_EQ(qBlue(px),    255);
+}
+
+TEST(NormalMapGeneratorTest, HorizontalGradientTiltsRedChannel) {
+    // x increases left-to-right → ∂h/∂x positive → nx = -dx*strength
+    // is negative → red channel encodes to less than 128.
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    const QString src = writePng(tmp, "ramp_x.png", 16, 16,
+                                  [](int x, int){ return std::min(255, x * 16); });
+
+    GenSpec spec;
+    spec.sourcePath = src;
+    spec.strength = 2.0f;
+    GenResult r = generate(spec);
+    ASSERT_TRUE(r.ok);
+
+    const QRgb px = r.image.pixel(8, 8);
+    EXPECT_LT(qRed(px), 120);   // tilted toward -X
+    EXPECT_NEAR(qGreen(px), 128, 4);  // no Y gradient
+}
+
+TEST(NormalMapGeneratorTest, VerticalGradientTiltsGreenChannel) {
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    // y increases top-to-bottom → ∂h/∂y positive → ny negative →
+    // green encodes to less than 128.
+    const QString src = writePng(tmp, "ramp_y.png", 16, 16,
+                                  [](int, int y){ return std::min(255, y * 16); });
+
+    GenSpec spec;
+    spec.sourcePath = src;
+    spec.strength = 2.0f;
+    GenResult r = generate(spec);
+    ASSERT_TRUE(r.ok);
+
+    const QRgb px = r.image.pixel(8, 8);
+    EXPECT_NEAR(qRed(px), 128, 4);
+    EXPECT_LT(qGreen(px), 120);
+}
+
+TEST(NormalMapGeneratorTest, InvertGFlipsGreenChannel) {
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    const QString src = writePng(tmp, "ramp_y.png", 16, 16,
+                                  [](int, int y){ return std::min(255, y * 16); });
+
+    GenSpec spec;
+    spec.sourcePath = src;
+    spec.strength = 2.0f;
+    spec.invertG = true;
+    GenResult r = generate(spec);
+    ASSERT_TRUE(r.ok);
+
+    // Was <120 without invert; should now be >135.
+    const QRgb px = r.image.pixel(8, 8);
+    EXPECT_GT(qGreen(px), 135);
+}
+
+TEST(NormalMapGeneratorTest, InvertRFlipsRedChannel) {
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    const QString src = writePng(tmp, "ramp_x.png", 16, 16,
+                                  [](int x, int){ return std::min(255, x * 16); });
+
+    GenSpec spec;
+    spec.sourcePath = src;
+    spec.strength = 2.0f;
+    spec.invertR = true;
+    GenResult r = generate(spec);
+    ASSERT_TRUE(r.ok);
+
+    const QRgb px = r.image.pixel(8, 8);
+    EXPECT_GT(qRed(px), 135);
+}
+
+TEST(NormalMapGeneratorTest, ZeroStrengthGivesFlatNormals) {
+    // Even with a steep gradient, strength=0 should collapse the
+    // in-plane components to zero → straight-up normal everywhere.
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    const QString src = writePng(tmp, "ramp_x.png", 8, 8,
+                                  [](int x, int){ return x * 32; });
+
+    GenSpec spec;
+    spec.sourcePath = src;
+    spec.strength = 0.0f;
+    GenResult r = generate(spec);
+    ASSERT_TRUE(r.ok);
+
+    const QRgb px = r.image.pixel(4, 4);
+    EXPECT_EQ(qRed(px),   128);
+    EXPECT_EQ(qGreen(px), 128);
+    EXPECT_EQ(qBlue(px),  255);
+}
+
+TEST(NormalMapGeneratorTest, MissingSourceReturnsError) {
+    GenSpec spec;
+    spec.sourcePath = "/nonexistent/should_not_resolve.png";
+    GenResult r = generate(spec);
+    EXPECT_FALSE(r.ok);
+    EXPECT_FALSE(r.error.isEmpty());
+}
+
+TEST(NormalMapGeneratorTest, EmptySourcePathReturnsError) {
+    GenSpec spec;
+    GenResult r = generate(spec);
+    EXPECT_FALSE(r.ok);
+}
+
+TEST(NormalMapGeneratorTest, OutputDimensionsOverrideSource) {
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    const QString src = writePng(tmp, "flat.png", 32, 32,
+                                  [](int, int){ return 128; });
+
+    GenSpec spec;
+    spec.sourcePath = src;
+    spec.outputWidth = 64;
+    spec.outputHeight = 64;
+    GenResult r = generate(spec);
+    ASSERT_TRUE(r.ok);
+    EXPECT_EQ(r.usedWidth, 64);
+    EXPECT_EQ(r.usedHeight, 64);
+    EXPECT_EQ(r.image.width(), 64);
+    EXPECT_EQ(r.image.height(), 64);
+}
+
+TEST(NormalMapGeneratorTest, OutputFormatIsRgb888) {
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    const QString src = writePng(tmp, "flat.png", 8, 8,
+                                  [](int, int){ return 128; });
+
+    GenSpec spec;
+    spec.sourcePath = src;
+    GenResult r = generate(spec);
+    ASSERT_TRUE(r.ok);
+    EXPECT_EQ(r.image.format(), QImage::Format_RGB888);
+}
+
+TEST(NormalMapGeneratorTest, GenerateToFileWritesPng) {
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    const QString src = writePng(tmp, "flat.png", 8, 8,
+                                  [](int, int){ return 128; });
+    const QString out = tmp.filePath("normal.png");
+
+    GenSpec spec;
+    spec.sourcePath = src;
+    GenResult r = generateToFile(spec, out);
+    ASSERT_TRUE(r.ok) << r.error.toStdString();
+
+    QImage reloaded(out);
+    ASSERT_FALSE(reloaded.isNull());
+    EXPECT_EQ(reloaded.width(), 8);
+    EXPECT_EQ(reloaded.height(), 8);
+}
+
+TEST(NormalMapGeneratorTest, GenerateToFile_EmptyOutputPathFails) {
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    const QString src = writePng(tmp, "flat.png", 4, 4,
+                                  [](int, int){ return 128; });
+    GenSpec spec;
+    spec.sourcePath = src;
+    GenResult r = generateToFile(spec, QString());
+    EXPECT_FALSE(r.ok);
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,7 +87,8 @@ int main(int argc, char *argv[])
                     continue;  // skip flags like --verbose
                 if (arg == "info" || arg == "fix" || arg == "convert" || arg == "anim"
                         || arg == "validate" || arg == "lod" || arg == "pose"
-                        || arg == "scan" || arg == "material" || arg == "pack-textures")
+                        || arg == "scan" || arg == "material" || arg == "pack-textures"
+                        || arg == "normal-from-height")
                     cliMode = true;
                 break;  // first non-flag arg determines mode
             }

--- a/src/qml_resources.qrc
+++ b/src/qml_resources.qrc
@@ -6,6 +6,7 @@
     <file alias="TexturePropertiesPanel.qml">../qml/TexturePropertiesPanel.qml</file>
     <file alias="AISettingsDialog.qml">../qml/AISettingsDialog.qml</file>
     <file alias="TextureChannelPackerDialog.qml">../qml/TextureChannelPackerDialog.qml</file>
+    <file alias="NormalMapGeneratorDialog.qml">../qml/NormalMapGeneratorDialog.qml</file>
     <file alias="qmldir">../qml/qmldir</file>
     <file alias="ThemedButton.qml">../qml/ThemedButton.qml</file>
     <file alias="ThemedComboBox.qml">../qml/ThemedComboBox.qml</file>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -86,6 +86,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/BatchExporter.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MaterialPresetLibrary.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/TextureChannelPacker.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/NormalMapGenerator.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MeshLodController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MeshValidator.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AIChatManager.cpp


### PR DESCRIPTION
## Summary

Phase 5 slice H — Sobel-filter normal map generator. Closes one of the two remaining Phase 5 epic acceptance items for **Normal Map Generation**:

| Epic item | Status |
|---|---|
| Generate from height/bump map (Sobel filter) | ✅ this PR |
| Strength/intensity with real-time preview | ✅ this PR |
| Invert R/G channels for DirectX ↔ OpenGL convention | ✅ this PR |
| AI-assisted from diffuse texture (SD) | ⏳ future slice (depends on SD enabled) |

## What ships

| Surface | What | Where |
|---|---|---|
| Pure-data generator | `generate()`, `generateToFile()` | `src/NormalMapGenerator.{h,cpp}` |
| CLI | `qtmesh normal-from-height --src bump.png [--strength N] [--invert-r] [--invert-g/--directx] [--width N --height N] -o normal.png` | `src/CLIPipeline.cpp` |
| MCP tool | `generate_normal_map` (with `directx` alias). SERVER_VERSION 1.6.0 → **1.7.0** | `src/MCPServer.cpp` |
| GUI | "Generate Normal Map…" button in Material Mode → Mode Tools | `qml/PropertiesPanel.qml` + `qml/NormalMapGeneratorDialog.qml` |

## Design notes

- 3×3 Sobel applied to Rec.601 luminance with edge-clamped sampling. Tangent-space normal: `n = normalize(-dx*strength, -dy*strength, 1)`.
- Output is **RGB8** (no alpha). The Z component is always positive in tangent space, so the blue channel sits in [128..255] — matches the Ogre/glTF convention.
- `invertG` flips the green channel: that's the OpenGL (+Y up, **default**) ↔ DirectX (+Y down) switch. MCP/CLI also accept `--directx` / `"directx": true` as an alias.
- Strength clamped to `[0, 32]` so a runaway value can't produce all-saturated output.
- Dialog is a top-level `Window` styled with Inspector primitives (`Rectangle + Text + MouseArea` over `PropertiesPanelController.*` colors) — same idiom as `TextureChannelPackerDialog`.

## CLI examples

```bash
qtmesh normal-from-height --src bump.png -o normal.png
qtmesh normal-from-height --src bump.png --strength 4 --invert-g -o dx_normal.png
qtmesh normal-from-height --src bump.png --width 1024 --height 1024 -o resized.png
```

End-to-end smoke-tested:
- CLI on a 2048×2048 heightmap (default, `--strength 5`, `--invert-g`, resized to 256, missing-file error). DirectX flip verified pixel-perfect: `G_dx + G_gl = 255`.
- MCP via HTTP `POST /api/tools/generate_normal_map`: happy path, `directx` alias, missing source error, missing-args error — all match expected behaviour.

## Test plan

- [x] 12 pure-data `NormalMapGeneratorTest` cases (flat→up-normals, H/V gradient tilts R/G, invert flags, zero strength, missing/empty source, output size override, RGB888 format, file-write round-trip, error paths)
- [x] 4 `CLIPipelineCmdNormalFromHeight` tests (missing args, missing source, flat-input correctness, `--invert-g` flips green)
- [x] 5 `MCPServerTest.GenerateNormalMap*` tests (missing args, flat-input write with width/height in result, missing source, tools/list registration, `directx` alias)
- [x] 5 `MaterialEditorQMLTest` wrapper tests (generate happy/missing-source, preview happy/missing/size-clamp)
- [x] Build clean on macOS arm64
- [x] CLI + MCP smoke tests on real 2048×2048 heightmap
- [ ] Linux CI runs the new gtests under Xvfb

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added normal map generation from height/bump maps across the Material Editor UI, CLI (`normal-from-height` command), and programmatic access
- Supports adjustable strength and channel inversion options
- Live preview available in the UI dialog with drag-and-drop source file support
- Version updated to 1.7.0

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/480)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->