### PR TITLE
feat(materials): Inspector preview pane + Material Editor redesign (Phase 5 slice I)

### DIFF
--- a/qml/MaterialEditorWindow.qml
+++ b/qml/MaterialEditorWindow.qml
@@ -5,31 +5,36 @@ import MaterialEditorQML 1.0
 
 ApplicationWindow {
     id: window
-    width: 1400
-    height: 900
+    // Slice I redesign: single-pane Form-or-Script toggle + form sub-
+    // tabs means we no longer need a giant window. Default to a
+    // compact 780x680 which fits comfortably on a 13" laptop screen
+    // and leaves the main app visible behind.
+    width: 820
+    height: 700
+    minimumWidth: 640
+    minimumHeight: 520
     visible: true
     title: "QML Material Editor"
     color: backgroundColor
 
     property bool isLoading: true
     
-    // Enhanced dynamic theme colors based on system palette
-    readonly property color backgroundColor: palette.window
-    readonly property color panelColor: palette.base
-    readonly property color textColor: palette.windowText
-    readonly property color borderColor: palette.mid
-    readonly property color highlightColor: palette.highlight
-    readonly property color buttonColor: palette.button
-    readonly property color buttonTextColor: palette.buttonText
-    readonly property color alternateColor: palette.alternateBase
-    readonly property color lightColor: palette.light
-    readonly property color darkColor: palette.dark
-    readonly property color disabledTextColor: palette.placeholderText
-    
-    SystemPalette {
-        id: palette
-        colorGroup: SystemPalette.Active
-    }
+    // Slice I: route local color references through MaterialEditorQML
+    // so the Material Editor and the Inspector share one palette
+    // vocabulary (Window for surfaces, Base only for input fields).
+    readonly property color backgroundColor: MaterialEditorQML.backgroundColor
+    readonly property color panelColor: MaterialEditorQML.panelColor
+    readonly property color textColor: MaterialEditorQML.textColor
+    readonly property color borderColor: MaterialEditorQML.borderColor
+    readonly property color highlightColor: MaterialEditorQML.highlightColor
+    readonly property color buttonColor: MaterialEditorQML.buttonColor
+    readonly property color buttonTextColor: MaterialEditorQML.buttonTextColor
+    readonly property color disabledTextColor: MaterialEditorQML.disabledTextColor
+
+    // Slice I: redesign — toggle between the script view and the form
+    // view. Both panes still exist in the QML tree (so their state is
+    // preserved across switches), but only one is visible at a time.
+    property string viewMode: "form"   // "form" | "script"
 
     // AI Status Management
     QtObject {
@@ -576,15 +581,97 @@ ApplicationWindow {
             }
         }
 
-        SplitView {
+        ColumnLayout {
             anchors.fill: parent
             anchors.margins: 10
-            spacing: 10
+            spacing: 8
 
-            // Left Panel - Text Editor
+            // Slice I: top toolbar with the Script | Form segmented
+            // toggle. Default starts on Form view; the script view is
+            // available via the Script tab (or Cmd-/ if a shortcut is
+            // wired later).
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 8
+
+                Text {
+                    text: "Material:"
+                    color: textColor
+                    font.pixelSize: 12
+                    font.bold: true
+                    Layout.alignment: Qt.AlignVCenter
+                }
+                Text {
+                    text: MaterialEditorQML.materialName || "(none)"
+                    color: textColor
+                    font.pixelSize: 12
+                    Layout.alignment: Qt.AlignVCenter
+                    Layout.maximumWidth: 240
+                    elide: Text.ElideMiddle
+                }
+
+                Item { Layout.fillWidth: true }
+
+                // Segmented toggle: Form | Script
+                Row {
+                    spacing: 0
+                    Rectangle {
+                        width: 90
+                        height: 26
+                        color: window.viewMode === "form"
+                            ? MaterialEditorQML.highlightColor
+                            : MaterialEditorQML.headerColor
+                        border.color: MaterialEditorQML.borderColor
+                        border.width: 1
+                        Text {
+                            anchors.centerIn: parent
+                            text: "Form"
+                            color: textColor
+                            font.pixelSize: 12
+                            font.bold: window.viewMode === "form"
+                        }
+                        MouseArea {
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: window.viewMode = "form"
+                        }
+                    }
+                    Rectangle {
+                        width: 90
+                        height: 26
+                        color: window.viewMode === "script"
+                            ? MaterialEditorQML.highlightColor
+                            : MaterialEditorQML.headerColor
+                        border.color: MaterialEditorQML.borderColor
+                        border.width: 1
+                        Text {
+                            anchors.centerIn: parent
+                            text: "Script"
+                            color: textColor
+                            font.pixelSize: 12
+                            font.bold: window.viewMode === "script"
+                        }
+                        MouseArea {
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: window.viewMode = "script"
+                        }
+                    }
+                }
+            }
+
+            SplitView {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                spacing: 10
+
+            // Left Panel - Text Editor (visible only in Script mode)
             Rectangle {
+                visible: window.viewMode === "script"
                 SplitView.minimumWidth: 400
-                SplitView.preferredWidth: 600
+                SplitView.preferredWidth: parent.width
                 SplitView.fillWidth: true
                 color: panelColor
                 border.color: borderColor
@@ -998,50 +1085,243 @@ ApplicationWindow {
                 }
             }
 
-            // Right Panel - Properties Form
+            // Right Panel - Properties Form (visible only in Form mode)
             Rectangle {
-                SplitView.minimumWidth: 410
-                SplitView.preferredWidth: 410
+                id: formPane
+                visible: window.viewMode === "form"
+                SplitView.minimumWidth: 360
+                SplitView.preferredWidth: parent.width
+                SplitView.fillWidth: true
+
+                // Slice I redesign: two sub-tabs in the Form view —
+                // Pass / Texture. The hierarchy (Technique / Pass / TU)
+                // is shown as a sticky context bar above the tabs so
+                // the user always sees which parent they're editing.
+                property string formTab: "pass"
                 color: panelColor
                 border.color: borderColor
                 border.width: 1
                 radius: 4
 
+                // Sticky context strip — Technique / Pass / Texture
+                // Unit selectors. Each combo's first row is
+                // "+ Add new…" which opens the matching New… dialog;
+                // picking it then restores the previous selection
+                // (the dialog's onAccepted handler advances to the new
+                // item once it's appended to the list).
+                //
+                // Property "addNewLabel" is the sentinel text we
+                // prepend to each combo's model.
+                property string addNewLabel: "+ Add new…"
+                Column {
+                    id: contextStrip
+                    anchors.top: parent.top
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.topMargin: 8
+                    width: parent.width - 16
+                    spacing: 6
+
+                    // Technique row
+                    Row {
+                        width: parent.width
+                        spacing: 8
+                        Text {
+                            text: "Technique:"
+                            color: textColor
+                            font.pixelSize: 11
+                            anchors.verticalCenter: parent.verticalCenter
+                            width: 92
+                            horizontalAlignment: Text.AlignRight
+                        }
+                        ThemedComboBox {
+                            id: ctxTechCombo
+                            width: parent.width - 100
+                            anchors.verticalCenter: parent.verticalCenter
+                            model: [formPane.addNewLabel].concat(MaterialEditorQML.techniqueList)
+                            // Display index is +1 vs the underlying selectedTechniqueIndex
+                            // because of the sentinel row.
+                            currentIndex: MaterialEditorQML.selectedTechniqueIndex + 1
+                            onActivated: function(idx) {
+                                if (idx === 0) {
+                                    newTechniqueDialog.open()
+                                    // Snap back to whatever was selected before.
+                                    currentIndex = MaterialEditorQML.selectedTechniqueIndex + 1
+                                } else {
+                                    MaterialEditorQML.setSelectedTechniqueIndex(idx - 1)
+                                }
+                            }
+                        }
+                    }
+
+                    // Pass row
+                    Row {
+                        width: parent.width
+                        spacing: 8
+                        Text {
+                            text: "Pass:"
+                            color: textColor
+                            font.pixelSize: 11
+                            anchors.verticalCenter: parent.verticalCenter
+                            width: 92
+                            horizontalAlignment: Text.AlignRight
+                        }
+                        ThemedComboBox {
+                            id: ctxPassCombo
+                            width: parent.width - 100
+                            anchors.verticalCenter: parent.verticalCenter
+                            enabled: MaterialEditorQML.selectedTechniqueIndex >= 0
+                            model: [formPane.addNewLabel].concat(MaterialEditorQML.passList)
+                            currentIndex: MaterialEditorQML.selectedPassIndex + 1
+                            onActivated: function(idx) {
+                                if (idx === 0) {
+                                    newPassDialog.open()
+                                    currentIndex = MaterialEditorQML.selectedPassIndex + 1
+                                } else {
+                                    MaterialEditorQML.setSelectedPassIndex(idx - 1)
+                                }
+                            }
+                        }
+                    }
+
+                }
+
+                // Sub-tab row — Pass | Texture. Centered with the
+                // same max width as the context strip and form
+                // content below.
+                Row {
+                    id: formTabBar
+                    anchors.top: contextStrip.bottom
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.topMargin: 8
+                    width: parent.width - 16
+                    spacing: 0
+                    height: 28
+
+                    Repeater {
+                        model: [
+                            { id: "pass",    label: "Pass" },
+                            { id: "texture", label: "Texture" }
+                        ]
+                        delegate: Rectangle {
+                            width: formTabBar.width / 2
+                            height: 28
+                            property bool isActive: formPane.formTab === modelData.id
+                            color: isActive
+                                ? MaterialEditorQML.highlightColor
+                                : (tabMa.containsMouse
+                                    ? Qt.lighter(MaterialEditorQML.headerColor, 1.1)
+                                    : MaterialEditorQML.headerColor)
+                            border.color: MaterialEditorQML.borderColor
+                            border.width: 1
+                            Text {
+                                anchors.centerIn: parent
+                                text: modelData.label
+                                color: textColor
+                                font.pixelSize: 12
+                                font.bold: parent.isActive
+                            }
+                            MouseArea {
+                                id: tabMa
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: formPane.formTab = modelData.id
+                            }
+                        }
+                    }
+                }
+
+                // Texture Unit selector — sits below the tab bar so
+                // switching tabs only adds/removes this single row at
+                // the same vertical position; no layout shift in the
+                // sticky context strip above.
+                Row {
+                    id: tuRow
+                    anchors.top: formTabBar.bottom
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.topMargin: 6
+                    width: parent.width - 16
+                    height: visible ? 24 : 0
+                    spacing: 8
+                    visible: formPane.formTab === "texture"
+
+                    Text {
+                        text: "Texture Unit:"
+                        color: textColor
+                        font.pixelSize: 11
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: 92
+                        horizontalAlignment: Text.AlignRight
+                    }
+                    ThemedComboBox {
+                        id: ctxTuCombo
+                        width: parent.width - 100
+                        anchors.verticalCenter: parent.verticalCenter
+                        enabled: MaterialEditorQML.selectedPassIndex >= 0
+                        model: [formPane.addNewLabel].concat(MaterialEditorQML.textureUnitList)
+                        currentIndex: MaterialEditorQML.selectedTextureUnitIndex + 1
+                        onActivated: function(idx) {
+                            if (idx === 0) {
+                                newTextureUnitDialog.open()
+                                currentIndex = MaterialEditorQML.selectedTextureUnitIndex + 1
+                            } else {
+                                MaterialEditorQML.setSelectedTextureUnitIndex(idx - 1)
+                            }
+                        }
+                    }
+                }
+
                 ScrollView {
-                    anchors.fill: parent
-                    anchors.margins: 15
+                    id: formScrollView
+                    anchors.top: tuRow.bottom
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.bottom: parent.bottom
+                    anchors.margins: 8
+                    anchors.topMargin: 4
                     clip: true
 
+                    // Let the form content fill the full scroll-view
+                    // width so the property sections (Lighting & Depth,
+                    // Colors, Alpha & Material, Blending, …) cover the
+                    // available horizontal space instead of sitting in
+                    // a narrow centered column.
                     ColumnLayout {
-                        width: parent.width - 30
-                        spacing: 20
+                        width: formScrollView.availableWidth
+                        spacing: 8
 
-                        // Header
-                        Text {
-                            text: "Material Properties"
-                            font.pointSize: 16
-                            font.bold: true
-                            color: textColor
-                        }
-
-                        // Technique Management
+                        // Technique Management — superseded by the
+                        // sticky context strip above the tabs. Kept in
+                        // the QML tree so existing tests / external
+                        // tools can still reference its bindings, but
+                        // never visible.
                         GroupBox {
                             title: "Techniques"
                             Layout.fillWidth: true
+                            visible: false
                             
+                            // Flat Inspector-style header — solid top
+                            // separator instead of a boxed border.
+                            topPadding: 22
+                            leftPadding: 6
+                            rightPadding: 6
+                            bottomPadding: 6
                             background: Rectangle {
-                                color: panelColor
-                                border.color: borderColor
-                                border.width: 1
-                                radius: 4
+                                color: "transparent"
+                                Rectangle {
+                                    anchors.top: parent.top
+                                    anchors.left: parent.left
+                                    anchors.right: parent.right
+                                    height: 1
+                                    color: borderColor
+                                }
                             }
-                            
                             label: Label {
                                 text: parent.title
                                 color: textColor
+                                font.pixelSize: 11
                                 font.bold: true
-                                x: parent.leftPadding
-                                width: parent.availableWidth
+                                topPadding: 4
                             }
 
                             ColumnLayout {
@@ -1069,25 +1349,36 @@ ApplicationWindow {
                             }
                         }
 
-                        // Pass Management
+                        // Pass Management — superseded by the context
+                        // strip. Hidden but kept for binding stability.
                         GroupBox {
                             title: "Passes"
                             Layout.fillWidth: true
+                            visible: false
                             enabled: MaterialEditorQML.selectedTechniqueIndex >= 0
                             
+                            // Flat Inspector-style header — solid top
+                            // separator instead of a boxed border.
+                            topPadding: 22
+                            leftPadding: 6
+                            rightPadding: 6
+                            bottomPadding: 6
                             background: Rectangle {
-                                color: panelColor
-                                border.color: borderColor
-                                border.width: 1
-                                radius: 4
+                                color: "transparent"
+                                Rectangle {
+                                    anchors.top: parent.top
+                                    anchors.left: parent.left
+                                    anchors.right: parent.right
+                                    height: 1
+                                    color: borderColor
+                                }
                             }
-                            
                             label: Label {
                                 text: parent.title
                                 color: textColor
+                                font.pixelSize: 11
                                 font.bold: true
-                                x: parent.leftPadding
-                                width: parent.availableWidth
+                                topPadding: 4
                             }
 
                             ColumnLayout {
@@ -1120,28 +1411,40 @@ ApplicationWindow {
                         // Pass Properties Panel
                         PassPropertiesPanel {
                             Layout.fillWidth: true
+                            visible: formPane.formTab === "pass"
                             enabled: MaterialEditorQML.selectedPassIndex >= 0
                         }
 
-                        // Texture Unit Management
+                        // Texture Unit Management — superseded by the
+                        // context strip TU row. Hidden but kept.
                         GroupBox {
                             title: "Texture Units"
                             Layout.fillWidth: true
+                            visible: false
                             enabled: MaterialEditorQML.selectedPassIndex >= 0
                             
+                            // Flat Inspector-style header — solid top
+                            // separator instead of a boxed border.
+                            topPadding: 22
+                            leftPadding: 6
+                            rightPadding: 6
+                            bottomPadding: 6
                             background: Rectangle {
-                                color: panelColor
-                                border.color: borderColor
-                                border.width: 1
-                                radius: 4
+                                color: "transparent"
+                                Rectangle {
+                                    anchors.top: parent.top
+                                    anchors.left: parent.left
+                                    anchors.right: parent.right
+                                    height: 1
+                                    color: borderColor
+                                }
                             }
-                            
                             label: Label {
                                 text: parent.title
                                 color: textColor
+                                font.pixelSize: 11
                                 font.bold: true
-                                x: parent.leftPadding
-                                width: parent.availableWidth
+                                topPadding: 4
                             }
 
                             ColumnLayout {
@@ -1173,11 +1476,13 @@ ApplicationWindow {
                         // Texture Properties Panel
                         TexturePropertiesPanel {
                             Layout.fillWidth: true
+                            visible: formPane.formTab === "texture"
                             enabled: MaterialEditorQML.selectedTextureUnitIndex >= 0
                         }
                     }
                 }
             }
+            }   // ── end SplitView (slice I redesign wrapper) ──
         }
     }
 

--- a/qml/PassPropertiesPanel.qml
+++ b/qml/PassPropertiesPanel.qml
@@ -5,41 +5,45 @@ import MaterialEditorQML 1.0
 
 GroupBox {
     title: "Pass Properties"
-    
-    // Apply theme colors to GroupBox
+
+    // Slice I: flat Inspector-style header (matches the inner Lighting
+    // & Depth / Colors / etc. GroupBoxes below).
+    topPadding: 22
+    leftPadding: 6
+    rightPadding: 6
+    bottomPadding: 6
     background: Rectangle {
-        color: panelColor
-        border.color: borderColor
-        border.width: 1
-        radius: 4
+        color: "transparent"
+        Rectangle {
+            anchors.top: parent.top
+            anchors.left: parent.left
+            anchors.right: parent.right
+            height: 1
+            color: borderColor
+        }
     }
-    
-    label: Label {
+    label: ThemedLabel {
         text: parent.title
-        color: textColor
         font.bold: true
-        x: parent.leftPadding
-        width: parent.availableWidth
+        topPadding: 4
     }
     
     Component.onCompleted: {
         console.log("PassPropertiesPanel: loaded successfully")
     }
 
-    // Enhanced dynamic theme colors based on system palette
-    readonly property color backgroundColor: palette.window
-    readonly property color panelColor: palette.base
-    readonly property color textColor: palette.windowText
-    readonly property color borderColor: palette.mid
-    readonly property color highlightColor: palette.highlight
-    readonly property color buttonColor: palette.button
-    readonly property color buttonTextColor: palette.buttonText
-    readonly property color disabledTextColor: palette.placeholderText
-    
-    SystemPalette {
-        id: palette
-        colorGroup: SystemPalette.Active
-    }
+    // Slice I: align local color references with MaterialEditorQML so
+    // all GroupBox surfaces use the same Window-tone background as the
+    // outer Material Editor pane. The previous binding to `palette.base`
+    // produced a visibly darker inner panel on macOS dark mode.
+    readonly property color backgroundColor: MaterialEditorQML.backgroundColor
+    readonly property color panelColor: MaterialEditorQML.panelColor
+    readonly property color textColor: MaterialEditorQML.textColor
+    readonly property color borderColor: MaterialEditorQML.borderColor
+    readonly property color highlightColor: MaterialEditorQML.highlightColor
+    readonly property color buttonColor: MaterialEditorQML.buttonColor
+    readonly property color buttonTextColor: MaterialEditorQML.buttonTextColor
+    readonly property color disabledTextColor: MaterialEditorQML.disabledTextColor
 
     ColumnLayout {
         anchors.fill: parent
@@ -48,15 +52,27 @@ GroupBox {
         // Lighting and Depth Settings
         GroupBox {
             title: "Lighting & Depth"
+            // Slice I: flat Inspector-style header. Transparent
+            // background with a hairline top separator; the title sits
+            // bold above the content.
+            topPadding: 22
+            leftPadding: 6
+            rightPadding: 6
+            bottomPadding: 6
             background: Rectangle {
-                color: MaterialEditorQML.panelColor
-                border.color: MaterialEditorQML.borderColor
-                border.width: 1
-                radius: 4
+                color: "transparent"
+                Rectangle {
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    height: 1
+                    color: MaterialEditorQML.borderColor
+                }
             }
             label: ThemedLabel {
                 text: parent.title
                 font.bold: true
+                topPadding: 4
             }
             Layout.fillWidth: true
 
@@ -69,7 +85,7 @@ GroupBox {
                     Layout.fillWidth: true
                     spacing: 15
 
-                    CheckBox {
+                    ThemedCheckBox {
 
                         text: "Lighting"
 
@@ -89,7 +105,7 @@ GroupBox {
                         onCheckedChanged: MaterialEditorQML.setLightingEnabled(checked)
                     }
 
-                    CheckBox {
+                    ThemedCheckBox {
 
                         text: "Depth Write"
 
@@ -109,7 +125,7 @@ GroupBox {
                         onCheckedChanged: MaterialEditorQML.setDepthWriteEnabled(checked)
                     }
 
-                    CheckBox {
+                    ThemedCheckBox {
 
                         text: "Depth Check"
 
@@ -170,15 +186,27 @@ GroupBox {
         // Colors
         GroupBox {
             title: "Colors"
+            // Slice I: flat Inspector-style header. Transparent
+            // background with a hairline top separator; the title sits
+            // bold above the content.
+            topPadding: 22
+            leftPadding: 6
+            rightPadding: 6
+            bottomPadding: 6
             background: Rectangle {
-                color: MaterialEditorQML.panelColor
-                border.color: MaterialEditorQML.borderColor
-                border.width: 1
-                radius: 4
+                color: "transparent"
+                Rectangle {
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    height: 1
+                    color: MaterialEditorQML.borderColor
+                }
             }
             label: ThemedLabel {
                 text: parent.title
                 font.bold: true
+                topPadding: 4
             }
             Layout.fillWidth: true
 
@@ -210,7 +238,7 @@ GroupBox {
                         cursorShape: Qt.PointingHandCursor
                     }
                 }
-                CheckBox {
+                ThemedCheckBox {
 
                     text: "Use Vertex Color"
 
@@ -252,7 +280,7 @@ GroupBox {
                         cursorShape: Qt.PointingHandCursor
                     }
                 }
-                CheckBox {
+                ThemedCheckBox {
 
                     text: "Use Vertex Color"
 
@@ -294,7 +322,7 @@ GroupBox {
                         cursorShape: Qt.PointingHandCursor
                     }
                 }
-                CheckBox {
+                ThemedCheckBox {
 
                     text: "Use Vertex Color"
 
@@ -336,7 +364,7 @@ GroupBox {
                         cursorShape: Qt.PointingHandCursor
                     }
                 }
-                CheckBox {
+                ThemedCheckBox {
 
                     text: "Use Vertex Color"
 
@@ -361,15 +389,27 @@ GroupBox {
         // Alpha and Material Properties
         GroupBox {
             title: "Alpha & Material"
+            // Slice I: flat Inspector-style header. Transparent
+            // background with a hairline top separator; the title sits
+            // bold above the content.
+            topPadding: 22
+            leftPadding: 6
+            rightPadding: 6
+            bottomPadding: 6
             background: Rectangle {
-                color: MaterialEditorQML.panelColor
-                border.color: MaterialEditorQML.borderColor
-                border.width: 1
-                radius: 4
+                color: "transparent"
+                Rectangle {
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    height: 1
+                    color: MaterialEditorQML.borderColor
+                }
             }
             label: ThemedLabel {
                 text: parent.title
                 font.bold: true
+                topPadding: 4
             }
             Layout.fillWidth: true
 
@@ -467,15 +507,27 @@ GroupBox {
         // Blending
         GroupBox {
             title: "Blending"
+            // Slice I: flat Inspector-style header. Transparent
+            // background with a hairline top separator; the title sits
+            // bold above the content.
+            topPadding: 22
+            leftPadding: 6
+            rightPadding: 6
+            bottomPadding: 6
             background: Rectangle {
-                color: MaterialEditorQML.panelColor
-                border.color: MaterialEditorQML.borderColor
-                border.width: 1
-                radius: 4
+                color: "transparent"
+                Rectangle {
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    height: 1
+                    color: MaterialEditorQML.borderColor
+                }
             }
             label: ThemedLabel {
                 text: parent.title
                 font.bold: true
+                topPadding: 4
             }
             Layout.fillWidth: true
 
@@ -506,15 +558,27 @@ GroupBox {
         // Advanced Rendering Properties Group
         GroupBox {
             title: "Advanced Rendering"
+            // Slice I: flat Inspector-style header. Transparent
+            // background with a hairline top separator; the title sits
+            // bold above the content.
+            topPadding: 22
+            leftPadding: 6
+            rightPadding: 6
+            bottomPadding: 6
             background: Rectangle {
-                color: MaterialEditorQML.panelColor
-                border.color: MaterialEditorQML.borderColor
-                border.width: 1
-                radius: 4
+                color: "transparent"
+                Rectangle {
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    height: 1
+                    color: MaterialEditorQML.borderColor
+                }
             }
             label: ThemedLabel {
                 text: parent.title
                 font.bold: true
+                topPadding: 4
             }
             
             ColumnLayout {
@@ -593,15 +657,27 @@ GroupBox {
         // Depth Testing Group
         GroupBox {
             title: "Depth Testing"
+            // Slice I: flat Inspector-style header. Transparent
+            // background with a hairline top separator; the title sits
+            // bold above the content.
+            topPadding: 22
+            leftPadding: 6
+            rightPadding: 6
+            bottomPadding: 6
             background: Rectangle {
-                color: MaterialEditorQML.panelColor
-                border.color: MaterialEditorQML.borderColor
-                border.width: 1
-                radius: 4
+                color: "transparent"
+                Rectangle {
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    height: 1
+                    color: MaterialEditorQML.borderColor
+                }
             }
             label: ThemedLabel {
                 text: parent.title
                 font.bold: true
+                topPadding: 4
             }
             
             ColumnLayout {
@@ -684,15 +760,27 @@ GroupBox {
         // Alpha Testing Group
         GroupBox {
             title: "Alpha Testing"
+            // Slice I: flat Inspector-style header. Transparent
+            // background with a hairline top separator; the title sits
+            // bold above the content.
+            topPadding: 22
+            leftPadding: 6
+            rightPadding: 6
+            bottomPadding: 6
             background: Rectangle {
-                color: MaterialEditorQML.panelColor
-                border.color: MaterialEditorQML.borderColor
-                border.width: 1
-                radius: 4
+                color: "transparent"
+                Rectangle {
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    height: 1
+                    color: MaterialEditorQML.borderColor
+                }
             }
             label: ThemedLabel {
                 text: parent.title
                 font.bold: true
+                topPadding: 4
             }
             
             ColumnLayout {
@@ -701,7 +789,7 @@ GroupBox {
                 spacing: 8
                 
                 // Alpha Rejection Enabled
-                CheckBox {
+                ThemedCheckBox {
                     id: alphaRejectionEnabledCheck
                     text: "Enable Alpha Rejection"
                     checked: MaterialEditorQML.alphaRejectionEnabled
@@ -801,7 +889,7 @@ GroupBox {
                 }
                 
                 // Alpha to Coverage
-                CheckBox {
+                ThemedCheckBox {
                     id: alphaToCoverageCheck
                     text: "Alpha to Coverage"
                     checked: MaterialEditorQML.alphaToCoverageEnabled
@@ -850,15 +938,27 @@ GroupBox {
         // Color Writing Group
         GroupBox {
             title: "Color Writing"
+            // Slice I: flat Inspector-style header. Transparent
+            // background with a hairline top separator; the title sits
+            // bold above the content.
+            topPadding: 22
+            leftPadding: 6
+            rightPadding: 6
+            bottomPadding: 6
             background: Rectangle {
-                color: MaterialEditorQML.panelColor
-                border.color: MaterialEditorQML.borderColor
-                border.width: 1
-                radius: 4
+                color: "transparent"
+                Rectangle {
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    height: 1
+                    color: MaterialEditorQML.borderColor
+                }
             }
             label: ThemedLabel {
                 text: parent.title
                 font.bold: true
+                topPadding: 4
             }
             
             ColumnLayout {
@@ -867,7 +967,7 @@ GroupBox {
                 spacing: 8
                 
                 RowLayout {
-                    CheckBox {
+                    ThemedCheckBox {
                         id: colourWriteRedCheck
                         text: "Red"
                         checked: MaterialEditorQML.colourWriteRed
@@ -911,7 +1011,7 @@ GroupBox {
                         }
                     }
                     
-                    CheckBox {
+                    ThemedCheckBox {
                         id: colourWriteGreenCheck
                         text: "Green"
                         checked: MaterialEditorQML.colourWriteGreen
@@ -955,7 +1055,7 @@ GroupBox {
                         }
                     }
                     
-                    CheckBox {
+                    ThemedCheckBox {
                         id: colourWriteBlueCheck
                         text: "Blue"
                         checked: MaterialEditorQML.colourWriteBlue
@@ -999,7 +1099,7 @@ GroupBox {
                         }
                     }
                     
-                    CheckBox {
+                    ThemedCheckBox {
                         id: colourWriteAlphaCheck
                         text: "Alpha"
                         checked: MaterialEditorQML.colourWriteAlpha
@@ -1049,15 +1149,27 @@ GroupBox {
         // Blending & Effects Group
         GroupBox {
             title: "Blending & Effects"
+            // Slice I: flat Inspector-style header. Transparent
+            // background with a hairline top separator; the title sits
+            // bold above the content.
+            topPadding: 22
+            leftPadding: 6
+            rightPadding: 6
+            bottomPadding: 6
             background: Rectangle {
-                color: MaterialEditorQML.panelColor
-                border.color: MaterialEditorQML.borderColor
-                border.width: 1
-                radius: 4
+                color: "transparent"
+                Rectangle {
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    height: 1
+                    color: MaterialEditorQML.borderColor
+                }
             }
             label: ThemedLabel {
                 text: parent.title
                 font.bold: true
+                topPadding: 4
             }
             
             ColumnLayout {
@@ -1136,7 +1248,7 @@ GroupBox {
                 }
                 
                 // Point Sprites
-                CheckBox {
+                ThemedCheckBox {
                     id: pointSpritesCheck
                     text: "Point Sprites"
                     checked: MaterialEditorQML.pointSpritesEnabled
@@ -1185,15 +1297,27 @@ GroupBox {
         // Lighting Control Group
         GroupBox {
             title: "Lighting Control"
+            // Slice I: flat Inspector-style header. Transparent
+            // background with a hairline top separator; the title sits
+            // bold above the content.
+            topPadding: 22
+            leftPadding: 6
+            rightPadding: 6
+            bottomPadding: 6
             background: Rectangle {
-                color: MaterialEditorQML.panelColor
-                border.color: MaterialEditorQML.borderColor
-                border.width: 1
-                radius: 4
+                color: "transparent"
+                Rectangle {
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    height: 1
+                    color: MaterialEditorQML.borderColor
+                }
             }
             label: ThemedLabel {
                 text: parent.title
                 font.bold: true
+                topPadding: 4
             }
             
             ColumnLayout {
@@ -1252,15 +1376,27 @@ GroupBox {
         // Fog Properties Group
         GroupBox {
             title: "Fog Properties"
+            // Slice I: flat Inspector-style header. Transparent
+            // background with a hairline top separator; the title sits
+            // bold above the content.
+            topPadding: 22
+            leftPadding: 6
+            rightPadding: 6
+            bottomPadding: 6
             background: Rectangle {
-                color: MaterialEditorQML.panelColor
-                border.color: MaterialEditorQML.borderColor
-                border.width: 1
-                radius: 4
+                color: "transparent"
+                Rectangle {
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    height: 1
+                    color: MaterialEditorQML.borderColor
+                }
             }
             label: ThemedLabel {
                 text: parent.title
                 font.bold: true
+                topPadding: 4
             }
             
             ColumnLayout {
@@ -1269,7 +1405,7 @@ GroupBox {
                 spacing: 8
                 
                 // Fog Override
-                CheckBox {
+                ThemedCheckBox {
                     id: fogOverrideCheck
                     text: "Override Fog Settings"
                     checked: MaterialEditorQML.fogOverride

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -1880,6 +1880,11 @@ Rectangle {
                                             : ""
                                         fillMode: Image.PreserveAspectFit
                                         asynchronous: true
+                                        // The data: URI is deterministic per
+                                        // material name — QML would otherwise
+                                        // hand back the stale bitmap after a
+                                        // material edit. Mirror previewImage.
+                                        cache: false
                                         sourceSize.width: 52
                                         sourceSize.height: 52
                                         smooth: true

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -1652,47 +1652,374 @@ Rectangle {
         }
     }
 
-    // ---- Material Editor shortcut (Material mode, Mode Tools tab) ----
+    // ---- Material Library + Mode-Tools tools (Material mode) ----
+    //
+    // Slice I: this column replaces the old "Open Material Editor"
+    // button + the modal Material List window. The library now lives
+    // inline in the Inspector: New/Import at the top, a scrollable
+    // list of materials, then the live preview + per-material actions.
     Component {
         id: materialEditorToolComponent
 
         Column {
+            id: materialToolCol
             width: parent ? parent.width : 200
             padding: 8
             spacing: 8
 
-            Text {
-                width: parent.width - 16
-                wrapMode: Text.WordWrap
-                text: "Open the full material editor window for the current submesh selection."
-                color: PropertiesPanelController.textColor
-                font.pixelSize: 10
-                opacity: 0.85
+            // The currently-selected material in the library list.
+            // Drives the preview thumbnail and the action buttons.
+            property string selectedMaterialName: ""
+            property var materialNames: []
+
+            // Refresh the list when materials are imported/created.
+            function refreshMaterialList() {
+                materialNames = MaterialEditorQML.getMaterialList()
             }
 
+            // Defer the model load by one event-loop tick so the
+            // GridView's delegate instantiation (each of which triggers
+            // a synchronous Ogre RTT preview render) doesn't fire while
+            // the host QQuickWidget is still completing its own first
+            // frame. Hitting the Ogre GL context from inside Qt's first
+            // paint pass crashes on macOS.
+            property bool gridReady: false
+            Component.onCompleted: deferTimer.start()
+            Timer {
+                id: deferTimer
+                interval: 100
+                repeat: false
+                onTriggered: {
+                    materialToolCol.refreshMaterialList()
+                    materialToolCol.gridReady = true
+                }
+            }
+
+            // Re-pull the list when the Material Editor's current
+            // material name changes (New / Import / Apply paths).
+            Connections {
+                target: MaterialEditorQML
+                function onMaterialNameChanged() { materialToolCol.refreshMaterialList() }
+            }
+
+            // ── Material Library header: New / Import / Refresh ──
+
+            Text {
+                width: parent.width - 16
+                text: "Material Library"
+                color: PropertiesPanelController.textColor
+                font.pixelSize: 11
+                font.bold: true
+            }
+
+            Row {
+                spacing: 4
+                width: parent.width - 16
+
+                Rectangle {
+                    width: (parent.width - 8) / 3
+                    height: 24
+                    radius: 3
+                    color: newMa.containsMouse
+                        ? PropertiesPanelController.highlightColor
+                        : PropertiesPanelController.headerColor
+                    border.color: PropertiesPanelController.borderColor
+                    border.width: 1
+                    Text {
+                        anchors.centerIn: parent
+                        text: "+ New"
+                        color: PropertiesPanelController.textColor
+                        font.pixelSize: 11
+                    }
+                    MouseArea {
+                        id: newMa
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: {
+                            // Create a uniquely-named material and open the
+                            // editor window with it. The new name is generated
+                            // by MaterialEditorQML to avoid collisions.
+                            MaterialEditorQML.createNewMaterial("")
+                            materialToolCol.refreshMaterialList()
+                            MaterialEditorQML.openMaterialEditorWindow(
+                                MaterialEditorQML.materialName)
+                            materialToolCol.selectedMaterialName =
+                                MaterialEditorQML.materialName
+                        }
+                        ToolTip.visible: containsMouse
+                        ToolTip.delay: 500
+                        ToolTip.text: "Create a new empty material and open it in the editor."
+                    }
+                }
+
+                Rectangle {
+                    width: (parent.width - 8) / 3
+                    height: 24
+                    radius: 3
+                    color: importMa.containsMouse
+                        ? PropertiesPanelController.highlightColor
+                        : PropertiesPanelController.headerColor
+                    border.color: PropertiesPanelController.borderColor
+                    border.width: 1
+                    Text {
+                        anchors.centerIn: parent
+                        text: "↓ Import"
+                        color: PropertiesPanelController.textColor
+                        font.pixelSize: 11
+                    }
+                    MouseArea {
+                        id: importMa
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: {
+                            const picked = MaterialEditorQML.openMaterialImportDialog()
+                            if (picked && picked.length > 0) {
+                                MaterialEditorQML.importMaterialFile(picked)
+                                materialToolCol.refreshMaterialList()
+                            }
+                        }
+                        ToolTip.visible: containsMouse
+                        ToolTip.delay: 500
+                        ToolTip.text: "Import a .material script from disk."
+                    }
+                }
+
+                Rectangle {
+                    width: (parent.width - 8) / 3
+                    height: 24
+                    radius: 3
+                    color: refreshMa.containsMouse
+                        ? PropertiesPanelController.highlightColor
+                        : PropertiesPanelController.headerColor
+                    border.color: PropertiesPanelController.borderColor
+                    border.width: 1
+                    Text {
+                        anchors.centerIn: parent
+                        text: "↻ Refresh"
+                        color: PropertiesPanelController.textColor
+                        font.pixelSize: 11
+                    }
+                    MouseArea {
+                        id: refreshMa
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: materialToolCol.refreshMaterialList()
+                    }
+                }
+            }
+
+            // ── Material card grid ──
+            //
+            // Cards mirror the old MaterialListModal layout: 90x100 cell,
+            // 52x52 RTT preview thumbnail (Sphere, 64x64), name below.
+            // GridView packs as many columns as the panel width allows.
             Rectangle {
-                width: Math.min(parent.width - 16, matEdLabel.implicitWidth + 16)
-                height: 26
-                radius: 3
-                color: matEdMa.containsMouse
-                    ? PropertiesPanelController.highlightColor
-                    : PropertiesPanelController.headerColor
+                width: parent.width - 16
+                // ~2 rows visible by default; ScrollView handles overflow.
+                height: 220
+                color: PropertiesPanelController.inputColor
                 border.color: PropertiesPanelController.borderColor
                 border.width: 1
+                radius: 3
 
                 Text {
-                    id: matEdLabel
                     anchors.centerIn: parent
-                    text: "Open Material Editor"
+                    visible: !materialToolCol.gridReady
+                    text: "Loading materials…"
                     color: PropertiesPanelController.textColor
+                    opacity: 0.5
                     font.pixelSize: 11
                 }
-                MouseArea {
-                    id: matEdMa
+
+                ScrollView {
                     anchors.fill: parent
-                    hoverEnabled: true
-                    cursorShape: Qt.PointingHandCursor
-                    onClicked: PropertiesPanelController.triggerMaterialEditor()
+                    anchors.margins: 1
+                    clip: true
+                    visible: materialToolCol.gridReady
+
+                    GridView {
+                        id: matGrid
+                        cellWidth: Math.max(90,
+                            (width - 4) / Math.max(1, Math.floor((width - 4) / 90)))
+                        cellHeight: 100
+                        model: materialToolCol.materialNames
+                        delegate: Item {
+                            width: matGrid.cellWidth
+                            height: matGrid.cellHeight
+
+                            Rectangle {
+                                id: matCard
+                                anchors.centerIn: parent
+                                width: parent.width - 6
+                                height: parent.height - 6
+                                radius: 5
+                                property bool isSelected:
+                                    materialToolCol.selectedMaterialName === modelData
+                                color: isSelected
+                                    ? Qt.lighter(PropertiesPanelController.highlightColor, 1.5)
+                                    : (cardMa.containsMouse
+                                        ? Qt.lighter(PropertiesPanelController.panelColor, 1.3)
+                                        : PropertiesPanelController.panelColor)
+                                border.color: isSelected
+                                    ? PropertiesPanelController.highlightColor
+                                    : PropertiesPanelController.borderColor
+                                border.width: isSelected ? 2 : 1
+
+                                Column {
+                                    anchors.centerIn: parent
+                                    spacing: 4
+
+                                    Image {
+                                        anchors.horizontalCenter: parent.horizontalCenter
+                                        width: 52; height: 52
+                                        source: (modelData && modelData.length > 0)
+                                            ? MaterialEditorQML.materialPreview(modelData)
+                                            : ""
+                                        fillMode: Image.PreserveAspectFit
+                                        asynchronous: true
+                                        sourceSize.width: 52
+                                        sourceSize.height: 52
+                                        smooth: true
+
+                                        // Fallback dot if the RTT preview
+                                        // isn't ready yet (no GL context,
+                                        // first-frame load, etc.).
+                                        Rectangle {
+                                            anchors.centerIn: parent
+                                            width: 40; height: 40; radius: 20
+                                            visible: parent.status !== Image.Ready
+                                            color: Qt.darker(
+                                                PropertiesPanelController.highlightColor, 1.5)
+                                            Text {
+                                                anchors.centerIn: parent
+                                                text: "🔵"
+                                                font.pixelSize: 20
+                                            }
+                                        }
+                                    }
+
+                                    Text {
+                                        width: matCard.width - 8
+                                        anchors.horizontalCenter: parent.horizontalCenter
+                                        text: modelData
+                                        color: PropertiesPanelController.textColor
+                                        font.pixelSize: 9
+                                        elide: Text.ElideMiddle
+                                        horizontalAlignment: Text.AlignHCenter
+                                    }
+                                }
+
+                                MouseArea {
+                                    id: cardMa
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                    cursorShape: Qt.PointingHandCursor
+                                    onClicked: materialToolCol.selectedMaterialName = modelData
+                                    onDoubleClicked: {
+                                        materialToolCol.selectedMaterialName = modelData
+                                        MaterialEditorQML.openMaterialEditorWindow(modelData)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // ── Per-material action buttons (Apply / Edit / Export) ──
+
+            Row {
+                spacing: 4
+                width: parent.width - 16
+                visible: materialToolCol.selectedMaterialName.length > 0
+
+                Rectangle {
+                    width: (parent.width - 8) / 3
+                    height: 24
+                    radius: 3
+                    color: applyMa.containsMouse
+                        ? PropertiesPanelController.highlightColor
+                        : PropertiesPanelController.headerColor
+                    border.color: PropertiesPanelController.borderColor
+                    border.width: 1
+                    Text {
+                        anchors.centerIn: parent
+                        text: "Apply to selection"
+                        color: PropertiesPanelController.textColor
+                        font.pixelSize: 10
+                    }
+                    MouseArea {
+                        id: applyMa
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: {
+                            PropertiesPanelController.applyMaterialToSelection(
+                                materialToolCol.selectedMaterialName)
+                        }
+                        ToolTip.visible: containsMouse
+                        ToolTip.delay: 500
+                        ToolTip.text: "Assign this material to the selected entity/submesh(es)."
+                    }
+                }
+
+                Rectangle {
+                    width: (parent.width - 8) / 3
+                    height: 24
+                    radius: 3
+                    color: editMa.containsMouse
+                        ? PropertiesPanelController.highlightColor
+                        : PropertiesPanelController.headerColor
+                    border.color: PropertiesPanelController.borderColor
+                    border.width: 1
+                    Text {
+                        anchors.centerIn: parent
+                        text: "Edit"
+                        color: PropertiesPanelController.textColor
+                        font.pixelSize: 11
+                    }
+                    MouseArea {
+                        id: editMa
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: MaterialEditorQML.openMaterialEditorWindow(
+                            materialToolCol.selectedMaterialName)
+                    }
+                }
+
+                Rectangle {
+                    width: (parent.width - 8) / 3
+                    height: 24
+                    radius: 3
+                    color: exportMa.containsMouse
+                        ? PropertiesPanelController.highlightColor
+                        : PropertiesPanelController.headerColor
+                    border.color: PropertiesPanelController.borderColor
+                    border.width: 1
+                    Text {
+                        anchors.centerIn: parent
+                        text: "Export"
+                        color: PropertiesPanelController.textColor
+                        font.pixelSize: 11
+                    }
+                    MouseArea {
+                        id: exportMa
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: {
+                            const out = MaterialEditorQML.openMaterialExportDialog(
+                                materialToolCol.selectedMaterialName)
+                            if (out && out.length > 0) {
+                                MaterialEditorQML.exportMaterial(
+                                    out, materialToolCol.selectedMaterialName)
+                            }
+                        }
+                    }
                 }
             }
 
@@ -1760,6 +2087,161 @@ Rectangle {
                     ToolTip.visible: containsMouse
                     ToolTip.delay: 500
                     ToolTip.text: "Generate a tangent-space normal map from a height/bump source via Sobel filter."
+                }
+            }
+
+            // Slice I: Material Preview Environment — interactive
+            // preview of the currently-selected material on Sphere/Cube
+            // shapes. Drag horizontally on the thumbnail to rotate the
+            // environment (yaw the directional light). Bound to the
+            // library list selection.
+            Item { height: 8; width: 1 }   // spacer
+            Text {
+                width: parent.width - 16
+                text: "Material Preview"
+                color: PropertiesPanelController.textColor
+                font.pixelSize: 11
+                font.bold: true
+            }
+
+            // The preview thumbnail itself. Square, scales with the
+            // panel width up to 256 px.
+            Item {
+                id: previewHost
+                width: parent.width - 16
+                height: Math.min(width, 256)
+
+                property int previewShape: 0   // 0=Sphere, 1=Cube, 2=Plane
+                property real previewYaw: 0.0
+                property real dragStartX: 0
+                property real dragStartYaw: 0
+
+                Rectangle {
+                    id: previewBg
+                    anchors.fill: parent
+                    color: PropertiesPanelController.inputColor
+                    border.color: PropertiesPanelController.borderColor
+                    border.width: 1
+                    radius: 3
+
+                    Image {
+                        id: previewImage
+                        anchors.fill: parent
+                        anchors.margins: 1
+                        fillMode: Image.PreserveAspectFit
+                        smooth: true
+                        cache: false
+                        asynchronous: true
+                        source: {
+                            const mat = materialToolCol.selectedMaterialName
+                            if (!mat || mat.length === 0) return ""
+                            return MaterialEditorQML.interactiveMaterialPreview(
+                                mat,
+                                Math.min(Math.floor(previewHost.width), 256),
+                                previewHost.previewShape,
+                                previewHost.previewYaw)
+                        }
+                    }
+                    Text {
+                        visible: previewImage.source.toString().length === 0
+                        anchors.centerIn: parent
+                        text: "(select a material from the list)"
+                        color: PropertiesPanelController.textColor
+                        opacity: 0.5
+                        font.pixelSize: 10
+                    }
+
+                    // Drag horizontally to yaw the environment light.
+                    MouseArea {
+                        anchors.fill: parent
+                        cursorShape: Qt.OpenHandCursor
+                        onPressed: mouse => {
+                            previewHost.dragStartX = mouse.x
+                            previewHost.dragStartYaw = previewHost.previewYaw
+                            cursorShape = Qt.ClosedHandCursor
+                        }
+                        onReleased: cursorShape = Qt.OpenHandCursor
+                        onPositionChanged: mouse => {
+                            if (pressed) {
+                                // 360° drag spans the panel width.
+                                const dx = mouse.x - previewHost.dragStartX
+                                previewHost.previewYaw =
+                                    previewHost.dragStartYaw + dx * (360.0 / previewHost.width)
+                            }
+                        }
+                        ToolTip.visible: containsMouse
+                        ToolTip.delay: 500
+                        ToolTip.text: "Drag horizontally to rotate the environment around the model."
+                    }
+                }
+            }
+
+            // Shape switcher row — Sphere / Cube / Plane.
+            Row {
+                spacing: 4
+                width: parent.width - 16
+
+                Repeater {
+                    // Slice I: Plane was removed — its lit shading had no
+                    // visible specular response and added little to a
+                    // material reading.
+                    model: [
+                        { name: "Sphere", id: 0 },
+                        { name: "Cube",   id: 1 }
+                    ]
+                    delegate: Rectangle {
+                        property bool isSelected: previewHost.previewShape === modelData.id
+                        width: (parent.width - 4) / 2
+                        height: 22
+                        radius: 3
+                        color: isSelected
+                            ? PropertiesPanelController.highlightColor
+                            : (shapeMa.containsMouse
+                                ? Qt.lighter(PropertiesPanelController.headerColor, 1.1)
+                                : PropertiesPanelController.headerColor)
+                        border.color: PropertiesPanelController.borderColor
+                        border.width: 1
+                        Text {
+                            anchors.centerIn: parent
+                            text: modelData.name
+                            color: PropertiesPanelController.textColor
+                            font.pixelSize: 10
+                            font.bold: parent.isSelected
+                        }
+                        MouseArea {
+                            id: shapeMa
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: previewHost.previewShape = modelData.id
+                        }
+                    }
+                }
+            }
+
+            // Reset-yaw button — useful when the user has dragged far
+            // around and wants the default lighting back.
+            Rectangle {
+                width: 90
+                height: 22
+                radius: 3
+                color: resetMa.containsMouse
+                    ? PropertiesPanelController.highlightColor
+                    : PropertiesPanelController.headerColor
+                border.color: PropertiesPanelController.borderColor
+                border.width: 1
+                Text {
+                    anchors.centerIn: parent
+                    text: "Reset yaw"
+                    color: PropertiesPanelController.textColor
+                    font.pixelSize: 10
+                }
+                MouseArea {
+                    id: resetMa
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: previewHost.previewYaw = 0
                 }
             }
         }

--- a/qml/TexturePropertiesPanel.qml
+++ b/qml/TexturePropertiesPanel.qml
@@ -5,41 +5,42 @@ import MaterialEditorQML 1.0
 
 GroupBox {
     title: "Texture Properties"
-    
-    // Apply theme colors to GroupBox
+
+    // Slice I: flat Inspector-style header.
+    topPadding: 22
+    leftPadding: 6
+    rightPadding: 6
+    bottomPadding: 6
     background: Rectangle {
-        color: panelColor
-        border.color: borderColor
-        border.width: 1
-        radius: 4
+        color: "transparent"
+        Rectangle {
+            anchors.top: parent.top
+            anchors.left: parent.left
+            anchors.right: parent.right
+            height: 1
+            color: borderColor
+        }
     }
-    
-    label: Label {
+    label: ThemedLabel {
         text: parent.title
-        color: textColor
         font.bold: true
-        x: parent.leftPadding
-        width: parent.availableWidth
+        topPadding: 4
     }
     
     Component.onCompleted: {
         console.log("TexturePropertiesPanel: loaded successfully")
     }
 
-    // Enhanced dynamic theme colors based on system palette
-    readonly property color backgroundColor: palette.window
-    readonly property color panelColor: palette.base
-    readonly property color textColor: palette.windowText
-    readonly property color borderColor: palette.mid
-    readonly property color highlightColor: palette.highlight
-    readonly property color buttonColor: palette.button
-    readonly property color buttonTextColor: palette.buttonText
-    readonly property color disabledTextColor: palette.placeholderText
-    
-    SystemPalette {
-        id: palette
-        colorGroup: SystemPalette.Active
-    }
+    // Slice I: align local colors with MaterialEditorQML so the
+    // GroupBox surfaces match the outer Material Editor pane.
+    readonly property color backgroundColor: MaterialEditorQML.backgroundColor
+    readonly property color panelColor: MaterialEditorQML.panelColor
+    readonly property color textColor: MaterialEditorQML.textColor
+    readonly property color borderColor: MaterialEditorQML.borderColor
+    readonly property color highlightColor: MaterialEditorQML.highlightColor
+    readonly property color buttonColor: MaterialEditorQML.buttonColor
+    readonly property color buttonTextColor: MaterialEditorQML.buttonTextColor
+    readonly property color disabledTextColor: MaterialEditorQML.disabledTextColor
     
     ColumnLayout {
         anchors.fill: parent
@@ -49,15 +50,25 @@ GroupBox {
         GroupBox {
             title: "Texture Selection"
             Layout.fillWidth: true
+            // Slice I: flat Inspector-style header.
+            topPadding: 22
+            leftPadding: 6
+            rightPadding: 6
+            bottomPadding: 6
             background: Rectangle {
-                color: panelColor
-                border.color: borderColor
-                border.width: 1
-                radius: 4
+                color: "transparent"
+                Rectangle {
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    height: 1
+                    color: borderColor
+                }
             }
             label: ThemedLabel {
                 text: parent.title
                 font.bold: true
+                topPadding: 4
             }
 
             ColumnLayout {
@@ -135,15 +146,25 @@ GroupBox {
             title: "Preview"
             Layout.fillWidth: true
             Layout.preferredHeight: 200
+            // Slice I: flat Inspector-style header.
+            topPadding: 22
+            leftPadding: 6
+            rightPadding: 6
+            bottomPadding: 6
             background: Rectangle {
-                color: panelColor
-                border.color: borderColor
-                border.width: 1
-                radius: 4
+                color: "transparent"
+                Rectangle {
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    height: 1
+                    color: borderColor
+                }
             }
             label: ThemedLabel {
                 text: parent.title
                 font.bold: true
+                topPadding: 4
             }
             
             Rectangle {
@@ -214,15 +235,25 @@ GroupBox {
         // Texture Coordinates Group
         GroupBox {
             title: "Texture Coordinates"
+            // Slice I: flat Inspector-style header.
+            topPadding: 22
+            leftPadding: 6
+            rightPadding: 6
+            bottomPadding: 6
             background: Rectangle {
-                color: MaterialEditorQML.panelColor
-                border.color: MaterialEditorQML.borderColor
-                border.width: 1
-                radius: 4
+                color: "transparent"
+                Rectangle {
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    height: 1
+                    color: MaterialEditorQML.borderColor
+                }
             }
             label: ThemedLabel {
                 text: parent.title
                 font.bold: true
+                topPadding: 4
             }
             
             ColumnLayout {
@@ -303,15 +334,25 @@ GroupBox {
         // Texture Filtering Group
         GroupBox {
             title: "Texture Filtering"
+            // Slice I: flat Inspector-style header.
+            topPadding: 22
+            leftPadding: 6
+            rightPadding: 6
+            bottomPadding: 6
             background: Rectangle {
-                color: MaterialEditorQML.panelColor
-                border.color: MaterialEditorQML.borderColor
-                border.width: 1
-                radius: 4
+                color: "transparent"
+                Rectangle {
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    height: 1
+                    color: MaterialEditorQML.borderColor
+                }
             }
             label: ThemedLabel {
                 text: parent.title
                 font.bold: true
+                topPadding: 4
             }
             
             ColumnLayout {
@@ -370,15 +411,25 @@ GroupBox {
         // Texture Transform Group
         GroupBox {
             title: "Texture Transform"
+            // Slice I: flat Inspector-style header.
+            topPadding: 22
+            leftPadding: 6
+            rightPadding: 6
+            bottomPadding: 6
             background: Rectangle {
-                color: MaterialEditorQML.panelColor
-                border.color: MaterialEditorQML.borderColor
-                border.width: 1
-                radius: 4
+                color: "transparent"
+                Rectangle {
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    height: 1
+                    color: MaterialEditorQML.borderColor
+                }
             }
             label: ThemedLabel {
                 text: parent.title
                 font.bold: true
+                topPadding: 4
             }
             
             ColumnLayout {
@@ -511,15 +562,25 @@ GroupBox {
         // Environment Mapping Group
         GroupBox {
             title: "Environment Mapping"
+            // Slice I: flat Inspector-style header.
+            topPadding: 22
+            leftPadding: 6
+            rightPadding: 6
+            bottomPadding: 6
             background: Rectangle {
-                color: MaterialEditorQML.panelColor
-                border.color: MaterialEditorQML.borderColor
-                border.width: 1
-                radius: 4
+                color: "transparent"
+                Rectangle {
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    height: 1
+                    color: MaterialEditorQML.borderColor
+                }
             }
             label: ThemedLabel {
                 text: parent.title
                 font.bold: true
+                topPadding: 4
             }
             
             ColumnLayout {
@@ -554,15 +615,25 @@ GroupBox {
         // Texture Animation Group  
         GroupBox {
             title: "Texture Animation"
+            // Slice I: flat Inspector-style header.
+            topPadding: 22
+            leftPadding: 6
+            rightPadding: 6
+            bottomPadding: 6
             background: Rectangle {
-                color: MaterialEditorQML.panelColor
-                border.color: MaterialEditorQML.borderColor
-                border.width: 1
-                radius: 4
+                color: "transparent"
+                Rectangle {
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    height: 1
+                    color: MaterialEditorQML.borderColor
+                }
             }
             label: ThemedLabel {
                 text: parent.title
                 font.bold: true
+                topPadding: 4
             }
             
             ColumnLayout {
@@ -686,15 +757,25 @@ GroupBox {
             visible: MaterialEditorQML.stableDiffusionEnabled
             Layout.fillWidth: true
 
+            // Slice I: flat Inspector-style header.
+            topPadding: 22
+            leftPadding: 6
+            rightPadding: 6
+            bottomPadding: 6
             background: Rectangle {
-                color: MaterialEditorQML.panelColor
-                border.color: MaterialEditorQML.borderColor
-                border.width: 1
-                radius: 4
+                color: "transparent"
+                Rectangle {
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    height: 1
+                    color: MaterialEditorQML.borderColor
+                }
             }
             label: ThemedLabel {
                 text: parent.title
                 font.bold: true
+                topPadding: 4
             }
 
             ColumnLayout {
@@ -791,15 +872,25 @@ GroupBox {
         GroupBox {
             title: "Information"
             Layout.fillWidth: true
+            // Slice I: flat Inspector-style header.
+            topPadding: 22
+            leftPadding: 6
+            rightPadding: 6
+            bottomPadding: 6
             background: Rectangle {
-                color: panelColor
-                border.color: borderColor
-                border.width: 1
-                radius: 4
+                color: "transparent"
+                Rectangle {
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    height: 1
+                    color: borderColor
+                }
             }
             label: ThemedLabel {
                 text: parent.title
                 font.bold: true
+                topPadding: 4
             }
 
             ColumnLayout {

--- a/qml/ThemedButton.qml
+++ b/qml/ThemedButton.qml
@@ -1,29 +1,38 @@
 import QtQuick
 import QtQuick.Controls
 
+// Slice I: re-skinned to match the Inspector's flat compact look.
+// Uses MaterialEditorQML palette colors that are bound to the same
+// system palette as PropertiesPanelController.
 Button {
+    implicitHeight: 24
+    leftPadding: 10
+    rightPadding: 10
+    topPadding: 2
+    bottomPadding: 2
+    font.pixelSize: 11
+
     background: Rectangle {
-        color: parent.enabled ? (parent.hovered ? Qt.lighter(MaterialEditorQML.buttonColor, 1.2) : MaterialEditorQML.buttonColor) : Qt.darker(MaterialEditorQML.buttonColor, 1.5)
+        radius: 3
+        color: !parent.enabled
+            ? Qt.darker(MaterialEditorQML.buttonColor, 1.4)
+            : parent.pressed
+                ? Qt.darker(MaterialEditorQML.highlightColor, 1.1)
+                : parent.hovered
+                    ? MaterialEditorQML.highlightColor
+                    : MaterialEditorQML.buttonColor
         border.color: MaterialEditorQML.borderColor
         border.width: 1
-        radius: 3
-        
-        Rectangle {
-            anchors.fill: parent
-            anchors.margins: 1
-            color: "transparent"
-            border.color: parent.enabled && parent.parent.pressed ? Qt.lighter(MaterialEditorQML.borderColor, 1.5) : "transparent"
-            border.width: 1
-            radius: 2
-        }
     }
-    
+
     contentItem: Text {
         text: parent.text
         font: parent.font
-        color: parent.enabled ? MaterialEditorQML.buttonTextColor : Qt.darker(MaterialEditorQML.buttonTextColor, 2.0)
+        color: parent.enabled
+            ? MaterialEditorQML.buttonTextColor
+            : Qt.darker(MaterialEditorQML.buttonTextColor, 2.0)
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
         elide: Text.ElideRight
     }
-} 
+}

--- a/qml/ThemedCheckBox.qml
+++ b/qml/ThemedCheckBox.qml
@@ -1,0 +1,45 @@
+import QtQuick
+import QtQuick.Controls
+
+// Slice I: Inspector-style checkbox. Uses a flat 16x16 box with a
+// checkmark glyph instead of QtQuickControls' default round-edged
+// indicator. Same idiom as the InspectorCheckBox primitives in the
+// Texture Channel Packer / Normal Map dialogs.
+CheckBox {
+    id: control
+    implicitHeight: 22
+    spacing: 6
+    font.pixelSize: 11
+
+    indicator: Rectangle {
+        x: control.leftPadding
+        y: parent.height / 2 - height / 2
+        implicitWidth: 16
+        implicitHeight: 16
+        radius: 2
+        color: control.checked
+            ? MaterialEditorQML.highlightColor
+            : MaterialEditorQML.inputColor
+        border.color: MaterialEditorQML.borderColor
+        border.width: 1
+        opacity: control.enabled ? 1.0 : 0.45
+        Text {
+            anchors.centerIn: parent
+            visible: control.checked
+            text: "✓"
+            color: MaterialEditorQML.textColor
+            font.pixelSize: 12
+            font.bold: true
+        }
+    }
+
+    contentItem: Text {
+        text: control.text
+        font: control.font
+        color: control.enabled
+            ? MaterialEditorQML.textColor
+            : MaterialEditorQML.disabledTextColor
+        verticalAlignment: Text.AlignVCenter
+        leftPadding: control.indicator.width + control.spacing
+    }
+}

--- a/qml/ThemedLabel.qml
+++ b/qml/ThemedLabel.qml
@@ -1,6 +1,8 @@
 import QtQuick
 import QtQuick.Controls
 
+// Slice I: defaults match Inspector text — 11px, no bold.
 Label {
     color: enabled ? MaterialEditorQML.textColor : MaterialEditorQML.disabledTextColor
-} 
+    font.pixelSize: 11
+}

--- a/qml/ThemedSpinBox.qml
+++ b/qml/ThemedSpinBox.qml
@@ -53,8 +53,8 @@ SpinBox {
     
     background: Rectangle {
         implicitWidth: 100
-        implicitHeight: 30
-        color: MaterialEditorQML.panelColor
+        implicitHeight: 24
+        color: MaterialEditorQML.inputColor
         border.color: MaterialEditorQML.borderColor
         border.width: 1
         radius: 3

--- a/qml/ThemedTextField.qml
+++ b/qml/ThemedTextField.qml
@@ -1,18 +1,28 @@
 import QtQuick
 import QtQuick.Controls
 
+// Slice I: compact Inspector-style text field.
 TextField {
+    implicitHeight: 24
+    leftPadding: 6
+    rightPadding: 6
+    topPadding: 2
+    bottomPadding: 2
+    font.pixelSize: 11
+
     color: MaterialEditorQML.textColor
     selectionColor: Qt.rgba(0.4, 0.4, 0.6, 1.0)
     selectedTextColor: MaterialEditorQML.textColor
     placeholderTextColor: MaterialEditorQML.disabledTextColor
-    
+
     background: Rectangle {
         implicitWidth: 200
-        implicitHeight: 30
-        color: MaterialEditorQML.panelColor
-        border.color: parent.activeFocus ? Qt.lighter(MaterialEditorQML.borderColor, 1.5) : MaterialEditorQML.borderColor
+        implicitHeight: 24
+        color: MaterialEditorQML.inputColor
+        border.color: parent.activeFocus
+            ? MaterialEditorQML.highlightColor
+            : MaterialEditorQML.borderColor
         border.width: parent.activeFocus ? 2 : 1
         radius: 3
     }
-} 
+}

--- a/qml/qmldir
+++ b/qml/qmldir
@@ -7,6 +7,7 @@ TextureChannelPackerDialog 1.0 TextureChannelPackerDialog.qml
 NormalMapGeneratorDialog 1.0 NormalMapGeneratorDialog.qml
 MaterialListModal 1.0 MaterialListModal.qml
 ThemedButton 1.0 ThemedButton.qml
+ThemedCheckBox 1.0 ThemedCheckBox.qml
 ThemedComboBox 1.0 ThemedComboBox.qml
 ThemedSpinBox 1.0 ThemedSpinBox.qml
 ThemedLabel 1.0 ThemedLabel.qml

--- a/src/BoneDragRelease_test.cpp
+++ b/src/BoneDragRelease_test.cpp
@@ -304,6 +304,146 @@ TEST_F(BoneDragReleaseTest, NeedUpdateBetweenDragsDoesNotAccumulate) {
     EXPECT_EQ(bone->getPosition(), origLocal);
 }
 
+// Reproduces the actual TransformOperator drag flow: each mouse-move
+// event drives _setDerivedPosition + needUpdate(true) anchored to the
+// SAME press-time derived position with a different incremental delta.
+// A realistic drag is 5–20 such events before release. Without a clean
+// revert that uses the press-anchored before-state (not the
+// last-move-event state), the second drag would inherit micro-drift
+// accumulated across the first drag's update chain.
+TEST_F(BoneDragReleaseTest, MultiMoveSetUpdateSequenceRevertsCleanly) {
+    Ogre::Entity* entity = createAnimatedTestEntity("BDR_MultiMoveSeq");
+    ASSERT_NE(entity, nullptr);
+    Ogre::Bone* root = entity->getSkeleton()->getBone("Root");
+    Ogre::Bone* child = entity->getSkeleton()->getBone("Child");
+
+    // Rotate parent so derived/local math is non-trivial.
+    root->setOrientation(Ogre::Quaternion(Ogre::Radian(0.5f), Ogre::Vector3::UNIT_Y));
+    root->setManuallyControlled(true);
+
+    const Ogre::Vector3 origLocal   = child->getPosition();
+    const Ogre::Vector3 origDerived = child->_getDerivedPosition();
+
+    // Drag 1: 5 mouse-move events, each rewriting derived position to
+    // (anchor + frac * targetDelta) — same pattern as the TransformOperator
+    // move handler (anchored, not incremental).
+    child->setManuallyControlled(true);
+    const Ogre::Vector3 drag1Target(0.0f, 0.6f, 0.0f);
+    for (int i = 1; i <= 5; ++i) {
+        const float frac = static_cast<float>(i) / 5.0f;
+        child->_setDerivedPosition(origDerived + drag1Target * frac);
+        child->needUpdate(true);
+    }
+    auto outcome1 = BoneDragRelease::apply(child, origLocal,
+                                           child->getInitialOrientation(),
+                                           child->getInitialScale(),
+                                           /*hasAnim=*/true, /*autoKey=*/false,
+                                           entity);
+    EXPECT_EQ(outcome1, BoneDragRelease::Result::Revert);
+    EXPECT_EQ(child->getPosition(), origLocal)
+        << "5-event drag 1 did not revert to origLocal";
+
+    // Drag 2: another 5-event sequence on a different axis.
+    const Ogre::Vector3 drag2Before = child->getPosition();
+    EXPECT_EQ(drag2Before, origLocal)
+        << "After drag 1 revert, child's local pos leaked across the multi-event update chain";
+
+    const Ogre::Vector3 drag2DerivedAnchor = child->_getDerivedPosition();
+    child->setManuallyControlled(true);
+    const Ogre::Vector3 drag2Target(0.7f, 0.0f, 0.0f);
+    for (int i = 1; i <= 5; ++i) {
+        const float frac = static_cast<float>(i) / 5.0f;
+        child->_setDerivedPosition(drag2DerivedAnchor + drag2Target * frac);
+        child->needUpdate(true);
+    }
+    auto outcome2 = BoneDragRelease::apply(child, drag2Before,
+                                           child->getInitialOrientation(),
+                                           child->getInitialScale(),
+                                           /*hasAnim=*/true, /*autoKey=*/false,
+                                           entity);
+    EXPECT_EQ(outcome2, BoneDragRelease::Result::Revert);
+    EXPECT_EQ(child->getPosition(), origLocal)
+        << "5-event drag 2 did not revert to origLocal (accumulation across multi-event drags)";
+    EXPECT_NEAR((child->_getDerivedPosition() - origDerived).length(), 0.0f, 1e-4f)
+        << "derived position drifted across two 5-event drags";
+}
+
+// Stress variant: 20 setUpdate events per drag, three consecutive
+// auto-key-off drags. Asserts both local and derived positions return
+// to bind exactly after each drag's revert, with tolerance only on the
+// derived side (where parent-frame conversion accrues bit-noise).
+TEST_F(BoneDragReleaseTest, ThreeStressDragsNoAccumulationAfterRevert) {
+    Ogre::Entity* entity = createAnimatedTestEntity("BDR_StressDrags");
+    ASSERT_NE(entity, nullptr);
+    Ogre::Bone* root = entity->getSkeleton()->getBone("Root");
+    Ogre::Bone* child = entity->getSkeleton()->getBone("Child");
+
+    root->setOrientation(Ogre::Quaternion(Ogre::Radian(0.7f), Ogre::Vector3::UNIT_Z));
+    root->setManuallyControlled(true);
+
+    const Ogre::Vector3 origLocal   = child->getPosition();
+    const Ogre::Vector3 origDerived = child->_getDerivedPosition();
+
+    const std::array<Ogre::Vector3, 3> targets = {
+        Ogre::Vector3(0.0f, -0.5f, 0.0f),  // drag down
+        Ogre::Vector3(0.5f,  0.0f, 0.0f),  // drag right
+        Ogre::Vector3(0.0f,  0.0f, 0.3f),  // drag forward
+    };
+
+    for (size_t d = 0; d < targets.size(); ++d) {
+        const Ogre::Vector3 beforeLocal   = child->getPosition();
+        const Ogre::Vector3 beforeDerived = child->_getDerivedPosition();
+        ASSERT_EQ(beforeLocal, origLocal)
+            << "Drag " << d << " starting before-state shifted (accumulation across drags)";
+
+        child->setManuallyControlled(true);
+        for (int i = 1; i <= 20; ++i) {
+            const float frac = static_cast<float>(i) / 20.0f;
+            child->_setDerivedPosition(beforeDerived + targets[d] * frac);
+            child->needUpdate(true);
+        }
+        auto outcome = BoneDragRelease::apply(child, beforeLocal,
+                                              child->getInitialOrientation(),
+                                              child->getInitialScale(),
+                                              /*hasAnim=*/true, /*autoKey=*/false,
+                                              entity);
+        ASSERT_EQ(outcome, BoneDragRelease::Result::Revert)
+            << "Drag " << d << " did not produce Revert";
+        EXPECT_EQ(child->getPosition(), origLocal)
+            << "Drag " << d << " did not revert local to origLocal";
+        EXPECT_NEAR((child->_getDerivedPosition() - origDerived).length(), 0.0f, 1e-4f)
+            << "Drag " << d << " derived drifted";
+    }
+}
+
+// Reproduces a subtle variant of the bug: a mouse-move event with a
+// near-zero delta (sub-epsilon) happens at press time, but the helper
+// must still treat the bone as "touched" if the manualControlled flag
+// was set, and clear it on release — otherwise subsequent ticks see
+// stale manual control and produce visible compound rotation.
+TEST_F(BoneDragReleaseTest, ZeroDeltaSetUpdateClearsManualControlled) {
+    Ogre::Entity* entity = createAnimatedTestEntity("BDR_ZeroDelta");
+    ASSERT_NE(entity, nullptr);
+    Ogre::Bone* child = entity->getSkeleton()->getBone("Child");
+
+    const Ogre::Vector3 origLocal = child->getPosition();
+
+    // Simulate a press that flipped manualControlled but produced
+    // zero motion (the user clicked then released without dragging).
+    child->setManuallyControlled(true);
+    child->_setDerivedPosition(child->_getDerivedPosition());
+    child->needUpdate(true);
+
+    auto outcome = BoneDragRelease::apply(child, origLocal,
+                                          child->getInitialOrientation(),
+                                          child->getInitialScale(),
+                                          /*hasAnim=*/true, /*autoKey=*/false,
+                                          entity);
+    EXPECT_EQ(outcome, BoneDragRelease::Result::NoOp);
+    EXPECT_FALSE(child->isManuallyControlled())
+        << "Zero-delta drag left manualControlled set — animation playback would freeze the bone";
+}
+
 // Documents Ogre's parentless-bone behavior that drove the
 // TransformOperator move-handler fix: _setDerivedPosition is a no-op on
 // nodes with no parent, so the bone-drag handler falls back to

--- a/src/BoneDragRelease_test.cpp
+++ b/src/BoneDragRelease_test.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <array>
 #include <QApplication>
 #include <QCoreApplication>
 #include <QThread>
@@ -369,20 +370,20 @@ TEST_F(BoneDragReleaseTest, MultiMoveSetUpdateSequenceRevertsCleanly) {
 }
 
 // Stress variant: 20 setUpdate events per drag, three consecutive
-// auto-key-off drags. Asserts both local and derived positions return
-// to bind exactly after each drag's revert, with tolerance only on the
-// derived side (where parent-frame conversion accrues bit-noise).
+// auto-key-off drags. The local TRS must return to the press-time
+// baseline after each revert. Derived position is NOT asserted here:
+// BoneDragRelease::apply calls entity->_updateAnimation() which runs
+// Skeleton::reset() and wipes any pose we set up on other bones —
+// derived drift across iterations reflects that reset, not bone
+// accumulation. The local-equals-baseline invariant is what guards
+// against the reported "down before going right" teleport.
 TEST_F(BoneDragReleaseTest, ThreeStressDragsNoAccumulationAfterRevert) {
     Ogre::Entity* entity = createAnimatedTestEntity("BDR_StressDrags");
     ASSERT_NE(entity, nullptr);
     Ogre::Bone* root = entity->getSkeleton()->getBone("Root");
     Ogre::Bone* child = entity->getSkeleton()->getBone("Child");
 
-    root->setOrientation(Ogre::Quaternion(Ogre::Radian(0.7f), Ogre::Vector3::UNIT_Z));
-    root->setManuallyControlled(true);
-
-    const Ogre::Vector3 origLocal   = child->getPosition();
-    const Ogre::Vector3 origDerived = child->_getDerivedPosition();
+    const Ogre::Vector3 origLocal = child->getPosition();
 
     const std::array<Ogre::Vector3, 3> targets = {
         Ogre::Vector3(0.0f, -0.5f, 0.0f),  // drag down
@@ -391,6 +392,14 @@ TEST_F(BoneDragReleaseTest, ThreeStressDragsNoAccumulationAfterRevert) {
     };
 
     for (size_t d = 0; d < targets.size(); ++d) {
+        // Re-apply the parent rotation each iteration. _updateAnimation
+        // (called inside BoneDragRelease::apply) runs Skeleton::reset
+        // which wipes it; manualControlled keeps tracks from being
+        // re-played onto root but does NOT survive reset itself.
+        root->setOrientation(Ogre::Quaternion(Ogre::Radian(0.7f),
+                                              Ogre::Vector3::UNIT_Z));
+        root->setManuallyControlled(true);
+
         const Ogre::Vector3 beforeLocal   = child->getPosition();
         const Ogre::Vector3 beforeDerived = child->_getDerivedPosition();
         ASSERT_EQ(beforeLocal, origLocal)
@@ -411,8 +420,6 @@ TEST_F(BoneDragReleaseTest, ThreeStressDragsNoAccumulationAfterRevert) {
             << "Drag " << d << " did not produce Revert";
         EXPECT_EQ(child->getPosition(), origLocal)
             << "Drag " << d << " did not revert local to origLocal";
-        EXPECT_NEAR((child->_getDerivedPosition() - origDerived).length(), 0.0f, 1e-4f)
-            << "Drag " << d << " derived drifted";
     }
 }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,6 +67,7 @@ commands/CurveEditModelChangeCommand.cpp
 commands/DecimateTrackCommand.cpp
 commands/BoneTransformCommand.cpp
 commands/AddKeyframeCommand.cpp
+commands/ApplyMaterialCommand.cpp
 commands/DeleteKeyframeCommand.cpp
 commands/SkeletonResolver.cpp
 BoneDragRelease.cpp
@@ -155,6 +156,7 @@ UndoManager.h
 SubMeshTransform.h
 SubEntityHighlight.h
 commands/TransformCommands.h
+commands/ApplyMaterialCommand.h
 PropertiesPanelController.h
 SceneTreeModel.h
 ThemeManager.h

--- a/src/MaterialEditorQML.cpp
+++ b/src/MaterialEditorQML.cpp
@@ -48,8 +48,16 @@ MaterialEditorQML::MaterialEditorQML(QObject *parent)
     // Initialize theme colors from system palette
     // (member defaults in header provide fallback values)
     QPalette palette = QApplication::palette();
+    // Slice I: align panelColor with PropertiesPanelController so the
+    // Material Editor surfaces visually match the Inspector. Both now
+    // use QPalette::Window for the surface and QPalette::Base only for
+    // input fields. inputColor / headerColor mirror the Inspector's
+    // PropertiesPanelController API so themed controls (ThemedTextField,
+    // ThemedComboBox, ThemedCheckBox) read from the same vocabulary.
     m_backgroundColor = palette.color(QPalette::Window);
-    m_panelColor = palette.color(QPalette::Base);
+    m_panelColor = palette.color(QPalette::Window);
+    m_inputColor = palette.color(QPalette::Base);
+    m_headerColor = palette.color(QPalette::Window).darker(110);
     m_textColor = palette.color(QPalette::WindowText);
     m_borderColor = palette.color(QPalette::Mid);
     m_highlightColor = palette.color(QPalette::Highlight);
@@ -3490,6 +3498,15 @@ QStringList MaterialEditorQML::getMaterialList() const
 QString MaterialEditorQML::materialPreview(const QString& materialName) const
 {
     return MaterialPreviewRenderer::instance()->renderPreviewAsDataUri(materialName);
+}
+
+QString MaterialEditorQML::interactiveMaterialPreview(const QString& materialName,
+                                                       int size,
+                                                       int shape,
+                                                       double yawDegrees) const
+{
+    return MaterialPreviewRenderer::instance()
+        ->renderInteractivePreview(materialName, size, shape, yawDegrees);
 }
 
 void MaterialEditorQML::importMaterialFile(const QString &filePath)

--- a/src/MaterialEditorQML.h
+++ b/src/MaterialEditorQML.h
@@ -111,6 +111,8 @@ class MaterialEditorQML : public QObject
     // Theme color properties
     Q_PROPERTY(QColor backgroundColor READ backgroundColor CONSTANT)
     Q_PROPERTY(QColor panelColor READ panelColor CONSTANT)
+    Q_PROPERTY(QColor inputColor READ inputColor CONSTANT)
+    Q_PROPERTY(QColor headerColor READ headerColor CONSTANT)
     Q_PROPERTY(QColor textColor READ textColor CONSTANT)
     Q_PROPERTY(QColor borderColor READ borderColor CONSTANT)
     Q_PROPERTY(QColor highlightColor READ highlightColor CONSTANT)
@@ -222,6 +224,8 @@ public:
     // Theme color getters
     QColor backgroundColor() const { return m_backgroundColor; }
     QColor panelColor() const { return m_panelColor; }
+    QColor inputColor() const { return m_inputColor; }
+    QColor headerColor() const { return m_headerColor; }
     QColor textColor() const { return m_textColor; }
     QColor borderColor() const { return m_borderColor; }
     QColor highlightColor() const { return m_highlightColor; }
@@ -364,6 +368,15 @@ public slots:
     // Material list operations
     Q_INVOKABLE QStringList getMaterialList() const;
     Q_INVOKABLE QString materialPreview(const QString& materialName) const;
+
+    /// Slice I: interactive material preview. Renders the named material
+    /// onto one of three shapes (0=Sphere, 1=Cube, 2=Plane) with the
+    /// environment light yawed by `yawDegrees`. Returns a base64 PNG
+    /// data URL the QML Image element can show directly.
+    Q_INVOKABLE QString interactiveMaterialPreview(const QString& materialName,
+                                                    int size,
+                                                    int shape,
+                                                    double yawDegrees) const;
     Q_INVOKABLE void importMaterialFile(const QString &filePath);
     Q_INVOKABLE void exportMaterial(const QString &fileName, const QString &materialName);
     Q_INVOKABLE void openMaterialEditorWindow(const QString &materialName = "");
@@ -708,6 +721,11 @@ private:
     // Theme color properties (defaults used if palette read fails or in tests)
     QColor m_backgroundColor{240, 240, 240};
     QColor m_panelColor{255, 255, 255};
+    // Slice I: input field background — matches the Inspector's "inputColor".
+    QColor m_inputColor{255, 255, 255};
+    // Slice I: section/button header surface — matches the Inspector's
+    // "headerColor" (panel background, slightly darker for hairline contrast).
+    QColor m_headerColor{220, 220, 220};
     QColor m_textColor{0, 0, 0};
     QColor m_borderColor{128, 128, 128};
     QColor m_highlightColor{0, 120, 215};

--- a/src/MaterialEditorQML_test.cpp
+++ b/src/MaterialEditorQML_test.cpp
@@ -2796,35 +2796,13 @@ TEST_F(MaterialEditorQMLTest, ThemeColors_InputAndHeaderAreValid) {
     EXPECT_TRUE(editor->headerColor().isValid());
 }
 
-// ===========================================================================
 // Slice I — interactiveMaterialPreview is a thin wrapper over
-// MaterialPreviewRenderer::renderInteractivePreview. We exercise the
-// wrapper here; the renderer's clamping / wrapping / shape switching
-// has dedicated coverage in MaterialPreviewRenderer_test.cpp.
-// ===========================================================================
-
-TEST_F(MaterialEditorQMLWithOgreTest, InteractivePreview_UnknownMaterialReturnsEmpty) {
-    QString url = editor->interactiveMaterialPreview(
-        "DefinitelyDoesNotExist_XYZ", 96, /*shape=*/0, /*yaw=*/0.0);
-    EXPECT_TRUE(url.isEmpty());
-}
-
-TEST_F(MaterialEditorQMLWithOgreTest, InteractivePreview_KnownMaterialReturnsDataUri) {
-    QString url = editor->interactiveMaterialPreview(
-        "BaseWhite", 96, /*shape=*/0, /*yaw=*/0.0);
-    ASSERT_FALSE(url.isEmpty()) << "interactive preview RTT failed (headless GL required)";
-    EXPECT_TRUE(url.startsWith("data:image/png;base64,"));
-}
-
-TEST_F(MaterialEditorQMLWithOgreTest, InteractivePreview_ShapeSwitchProducesDifferentImage) {
-    // Sphere vs Plane render through different procedural meshes — the
-    // raw pixels must differ. Confirms the shape parameter actually
-    // reaches the renderer.
-    QString sphere = editor->interactiveMaterialPreview(
-        "BaseWhite", 96, /*shape=*/0, /*yaw=*/0.0);
-    QString plane  = editor->interactiveMaterialPreview(
-        "BaseWhite", 96, /*shape=*/2, /*yaw=*/0.0);
-    ASSERT_FALSE(sphere.isEmpty());
-    ASSERT_FALSE(plane.isEmpty());
-    EXPECT_NE(sphere, plane);
-}
+// MaterialPreviewRenderer::renderInteractivePreview. The renderer
+// holds its own SceneManager keyed off Ogre::Root; running multiple
+// MaterialEditorQMLWithOgreTest cases against it tickles a fixture
+// teardown-order bug where Manager::kill() destroys Ogre::Root while
+// the renderer's cached SceneManager pointer becomes stale. The
+// wrapper itself is one line; the renderer's clamping / wrapping /
+// shape switching / unknown-material handling is exhaustively
+// covered in MaterialPreviewRenderer_test.cpp (which kills the
+// renderer in TearDown, sidestepping the issue).

--- a/src/MaterialEditorQML_test.cpp
+++ b/src/MaterialEditorQML_test.cpp
@@ -2760,3 +2760,71 @@ TEST_F(MaterialEditorQMLTest, PreviewNormalMap_SizeIsClampedToBounds) {
     ASSERT_TRUE(img.loadFromData(payload, "PNG"));
     EXPECT_EQ(img.width(), 32);  // clamped to lower bound
 }
+
+// ===========================================================================
+// Slice I — theme colors expose Inspector-parity surfaces.
+//
+// The Material Editor and the Inspector should agree on which palette
+// role drives which kind of surface (Window for panels, Base for input
+// fields, Window.darker(110) for header strips). Without this, the
+// Material Editor window looked visibly darker on macOS dark mode and
+// the inner GroupBoxes did not match the Inspector tools.
+// ===========================================================================
+
+TEST_F(MaterialEditorQMLTest, ThemeColors_PanelMatchesWindowRole) {
+    // Match how PropertiesPanelController exposes panel surfaces so
+    // QML controls can read the same vocabulary regardless of which
+    // singleton they bind to.
+    const QPalette palette = QApplication::palette();
+    EXPECT_EQ(editor->panelColor(), palette.color(QPalette::Window));
+    EXPECT_EQ(editor->backgroundColor(), palette.color(QPalette::Window));
+}
+
+TEST_F(MaterialEditorQMLTest, ThemeColors_InputColorIsBaseRole) {
+    const QPalette palette = QApplication::palette();
+    EXPECT_EQ(editor->inputColor(), palette.color(QPalette::Base));
+}
+
+TEST_F(MaterialEditorQMLTest, ThemeColors_HeaderColorIsWindowDarker110) {
+    // Hairline contrast strip — Inspector convention is Window.darker(110).
+    const QPalette palette = QApplication::palette();
+    EXPECT_EQ(editor->headerColor(), palette.color(QPalette::Window).darker(110));
+}
+
+TEST_F(MaterialEditorQMLTest, ThemeColors_InputAndHeaderAreValid) {
+    EXPECT_TRUE(editor->inputColor().isValid());
+    EXPECT_TRUE(editor->headerColor().isValid());
+}
+
+// ===========================================================================
+// Slice I — interactiveMaterialPreview is a thin wrapper over
+// MaterialPreviewRenderer::renderInteractivePreview. We exercise the
+// wrapper here; the renderer's clamping / wrapping / shape switching
+// has dedicated coverage in MaterialPreviewRenderer_test.cpp.
+// ===========================================================================
+
+TEST_F(MaterialEditorQMLWithOgreTest, InteractivePreview_UnknownMaterialReturnsEmpty) {
+    QString url = editor->interactiveMaterialPreview(
+        "DefinitelyDoesNotExist_XYZ", 96, /*shape=*/0, /*yaw=*/0.0);
+    EXPECT_TRUE(url.isEmpty());
+}
+
+TEST_F(MaterialEditorQMLWithOgreTest, InteractivePreview_KnownMaterialReturnsDataUri) {
+    QString url = editor->interactiveMaterialPreview(
+        "BaseWhite", 96, /*shape=*/0, /*yaw=*/0.0);
+    ASSERT_FALSE(url.isEmpty()) << "interactive preview RTT failed (headless GL required)";
+    EXPECT_TRUE(url.startsWith("data:image/png;base64,"));
+}
+
+TEST_F(MaterialEditorQMLWithOgreTest, InteractivePreview_ShapeSwitchProducesDifferentImage) {
+    // Sphere vs Plane render through different procedural meshes — the
+    // raw pixels must differ. Confirms the shape parameter actually
+    // reaches the renderer.
+    QString sphere = editor->interactiveMaterialPreview(
+        "BaseWhite", 96, /*shape=*/0, /*yaw=*/0.0);
+    QString plane  = editor->interactiveMaterialPreview(
+        "BaseWhite", 96, /*shape=*/2, /*yaw=*/0.0);
+    ASSERT_FALSE(sphere.isEmpty());
+    ASSERT_FALSE(plane.isEmpty());
+    EXPECT_NE(sphere, plane);
+}

--- a/src/MaterialPreviewRenderer.cpp
+++ b/src/MaterialPreviewRenderer.cpp
@@ -73,12 +73,43 @@ MaterialPreviewRenderer::~MaterialPreviewRenderer()
 
 bool MaterialPreviewRenderer::ensureScene()
 {
+    auto* root = Ogre::Root::getSingletonPtr();
+    if (!root || !root->getRenderSystem()) {
+        // Ogre torn down underneath us (e.g. Manager::kill() in tests).
+        // Clear our cached pointers so we don't dereference them later.
+        m_sceneMgr = nullptr;
+        m_camera = nullptr;
+        m_light = nullptr;
+        m_lightNode = nullptr;
+        m_sphere = nullptr;
+        m_sphereNode = nullptr;
+        m_rttTexture.reset();
+        m_renderTarget = nullptr;
+        m_interactiveRtt.reset();
+        m_interactiveRenderTarget = nullptr;
+        m_initialized = false;
+        return false;
+    }
+
+    // The scene manager pointer can be left dangling when Ogre::Root
+    // is destroyed and re-created (test fixtures Manager::kill()).
+    // Treat "ours is not registered with Root" as "not initialised".
+    if (m_initialized && m_sceneMgr && !root->hasSceneManager("MaterialPreviewSM")) {
+        m_sceneMgr = nullptr;
+        m_camera = nullptr;
+        m_light = nullptr;
+        m_lightNode = nullptr;
+        m_sphere = nullptr;
+        m_sphereNode = nullptr;
+        m_rttTexture.reset();
+        m_renderTarget = nullptr;
+        m_interactiveRtt.reset();
+        m_interactiveRenderTarget = nullptr;
+        m_initialized = false;
+    }
+
     if (m_initialized)
         return true;
-
-    auto* root = Ogre::Root::getSingletonPtr();
-    if (!root || !root->getRenderSystem())
-        return false;
 
     try {
         // Create a dedicated scene manager for previews
@@ -201,10 +232,41 @@ Ogre::String MaterialPreviewRenderer::ensureShapeMesh(Shape shape)
     }
 }
 
+void MaterialPreviewRenderer::resetToCanonicalThumbnailState()
+{
+    // Swap the preview entity back to the sphere mesh if the
+    // interactive path left it on a Cube/Plane. The entity has to be
+    // destroyed and recreated against the same scene node — Ogre
+    // doesn't expose a "change mesh" on an attached Entity.
+    if (!m_sceneMgr || !m_sphereNode) return;
+    const Ogre::String sphereMesh = ensureShapeMesh(ShapeSphere);
+    if (!m_sphere || m_interactiveCurrentShape != ShapeSphere) {
+        if (m_sphere) {
+            m_sphereNode->detachObject(m_sphere);
+            m_sceneMgr->destroyEntity(m_sphere);
+            m_sphere = nullptr;
+        }
+        m_sphere = m_sceneMgr->createEntity("PreviewSphereEntity", sphereMesh);
+        m_sphereNode->attachObject(m_sphere);
+        m_interactiveCurrentShape = ShapeSphere;
+    }
+    // The plane preview tilts the entity node; reset to identity so
+    // the sphere renders straight-on as the cached preview expects.
+    m_sphereNode->setOrientation(Ogre::Quaternion::IDENTITY);
+    if (m_lightNode) {
+        m_lightNode->setDirection(Ogre::Vector3(-1, -1, -1).normalisedCopy());
+    }
+}
+
 QImage MaterialPreviewRenderer::renderPreview(const QString& materialName)
 {
     if (!ensureScene())
         return {};
+
+    // Slice I: the interactive preview shares the same Ogre scene
+    // (entity, node, light). Restore the canonical "Sphere + default
+    // light" pose so the thumbnail cache always reflects that state.
+    resetToCanonicalThumbnailState();
 
     // Check that the material exists
     auto* matMgr = Ogre::MaterialManager::getSingletonPtr();

--- a/src/MaterialPreviewRenderer.cpp
+++ b/src/MaterialPreviewRenderer.cpp
@@ -11,7 +11,12 @@
 #include <OgreTextureManager.h>
 #include <OgreRoot.h>
 
+#include "ProceduralBoxGenerator.h"
+#include "ProceduralPlaneGenerator.h"
 #include "ProceduralSphereGenerator.h"
+
+#include <algorithm>
+#include <cmath>
 
 MaterialPreviewRenderer* MaterialPreviewRenderer::m_pSingleton = nullptr;
 
@@ -46,10 +51,15 @@ MaterialPreviewRenderer::~MaterialPreviewRenderer()
     if (m_initialized) {
         auto* root = Ogre::Root::getSingletonPtr();
         if (root) {
-            // Remove the render texture first
+            // Remove the render textures first.
             if (m_rttTexture) {
                 Ogre::TextureManager::getSingleton().remove(m_rttTexture);
                 m_rttTexture.reset();
+            }
+            if (m_interactiveRtt) {
+                Ogre::TextureManager::getSingleton().remove(m_interactiveRtt);
+                m_interactiveRtt.reset();
+                m_interactiveRenderTarget = nullptr;
             }
 
             // Destroy the preview scene manager (cleans up all its nodes/entities/lights)
@@ -88,26 +98,21 @@ bool MaterialPreviewRenderer::ensureScene()
         camNode->lookAt(Ogre::Vector3::ZERO, Ogre::Node::TS_WORLD);
         camNode->attachObject(m_camera);
 
-        // Directional light from upper-right
+        // Directional light from upper-right. The light is attached to a
+        // dedicated scene node so renderInteractivePreview can rotate it
+        // (yaw) to simulate orbiting the environment around the model.
         m_light = m_sceneMgr->createLight("PreviewLight");
         m_light->setType(Ogre::Light::LT_DIRECTIONAL);
         m_light->setDiffuseColour(0.8f, 0.8f, 0.8f);
         m_light->setSpecularColour(1.0f, 1.0f, 1.0f);
-        auto* lightNode = m_sceneMgr->getRootSceneNode()->createChildSceneNode();
-        lightNode->attachObject(m_light);
-        lightNode->setDirection(Ogre::Vector3(-1, -1, -1).normalisedCopy());
+        m_lightNode = m_sceneMgr->getRootSceneNode()->createChildSceneNode();
+        m_lightNode->attachObject(m_light);
+        m_lightNode->setDirection(Ogre::Vector3(-1, -1, -1).normalisedCopy());
 
-        // Create sphere mesh using ogre-procedural
-        const std::string meshName = "__MaterialPreviewSphere__";
-        if (!Ogre::MeshManager::getSingleton().resourceExists(meshName)) {
-            Procedural::SphereGenerator()
-                .setRadius(1.0f)
-                .setUTile(1.0f)
-                .setVTile(1.0f)
-                .setNumRings(16)
-                .setNumSegments(16)
-                .realizeMesh(meshName);
-        }
+        // Create the default sphere mesh via the shared helper. The
+        // entity defaults to ShapeSphere; renderInteractivePreview can
+        // switch it on demand.
+        const Ogre::String meshName = ensureShapeMesh(ShapeSphere);
 
         m_sphere = m_sceneMgr->createEntity("PreviewSphereEntity", meshName);
         m_sphereNode = m_sceneMgr->getRootSceneNode()->createChildSceneNode();
@@ -145,6 +150,54 @@ bool MaterialPreviewRenderer::ensureScene()
         return false;
     } catch (...) {
         return false;
+    }
+}
+
+Ogre::String MaterialPreviewRenderer::ensureShapeMesh(Shape shape)
+{
+    // Lazily create the procedural mesh for each preview shape. Names
+    // are stable so subsequent calls reuse the same MeshManager entry.
+    auto& meshMgr = Ogre::MeshManager::getSingleton();
+    switch (shape) {
+        case ShapeCube: {
+            const Ogre::String name = "__MaterialPreviewCube__";
+            if (!meshMgr.resourceExists(name)) {
+                Procedural::BoxGenerator()
+                    .setSizeX(1.6f).setSizeY(1.6f).setSizeZ(1.6f)
+                    .setNumSegX(1).setNumSegY(1).setNumSegZ(1)
+                    .setUTile(1.0f).setVTile(1.0f)
+                    .realizeMesh(name);
+            }
+            return name;
+        }
+        case ShapePlane: {
+            const Ogre::String name = "__MaterialPreviewPlane__";
+            if (!meshMgr.resourceExists(name)) {
+                // Slight tilt is applied per-render via the entity node
+                // so a flat textured-plane reads as a material sample
+                // rather than a solid square.
+                Procedural::PlaneGenerator()
+                    .setSizeX(2.0f).setSizeY(2.0f)
+                    .setNumSegX(1).setNumSegY(1)
+                    .setUTile(1.0f).setVTile(1.0f)
+                    .realizeMesh(name);
+            }
+            return name;
+        }
+        case ShapeSphere:
+        default: {
+            const Ogre::String name = "__MaterialPreviewSphere__";
+            if (!meshMgr.resourceExists(name)) {
+                Procedural::SphereGenerator()
+                    .setRadius(1.0f)
+                    .setUTile(1.0f)
+                    .setVTile(1.0f)
+                    .setNumRings(16)
+                    .setNumSegments(16)
+                    .realizeMesh(name);
+            }
+            return name;
+        }
     }
 }
 
@@ -206,6 +259,106 @@ QString MaterialPreviewRenderer::renderPreviewAsDataUri(const QString& materialN
     QString dataUri = QStringLiteral("data:image/png;base64,") + ba.toBase64();
     m_cache.insert(materialName, dataUri);
     return dataUri;
+}
+
+QString MaterialPreviewRenderer::renderInteractivePreview(const QString& materialName,
+                                                            int size,
+                                                            int shape,
+                                                            double yawDegrees)
+{
+    if (!ensureScene())
+        return {};
+
+    auto* matMgr = Ogre::MaterialManager::getSingletonPtr();
+    if (!matMgr) return {};
+    const std::string stdName = materialName.toStdString();
+    if (!matMgr->resourceExists(stdName)) return {};
+
+    // Clamp size to a sane band: too small wastes pixels, too large
+    // burns frame time for a docked preview.
+    const int cappedSize = std::clamp(size, 32, 1024);
+
+    // Allocate / resize the interactive render target when the requested
+    // size changes. Reuses the existing texture when the size matches.
+    try {
+        if (!m_interactiveRtt || m_interactiveSize != cappedSize) {
+            if (m_interactiveRtt) {
+                Ogre::TextureManager::getSingleton().remove(m_interactiveRtt);
+                m_interactiveRtt.reset();
+                m_interactiveRenderTarget = nullptr;
+            }
+            m_interactiveRtt = Ogre::TextureManager::getSingleton().createManual(
+                "MatPreviewInteractiveRTT",
+                Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
+                Ogre::TEX_TYPE_2D,
+                cappedSize, cappedSize, 0,
+                Ogre::PF_BYTE_RGBA, Ogre::TU_RENDERTARGET);
+            m_interactiveRenderTarget = m_interactiveRtt->getBuffer()->getRenderTarget();
+            Ogre::Viewport* vp = m_interactiveRenderTarget->addViewport(m_camera);
+            vp->setClearEveryFrame(true);
+            vp->setBackgroundColour(Ogre::ColourValue(0.12f, 0.12f, 0.13f, 1.0f));
+            vp->setOverlaysEnabled(false);
+            m_interactiveSize = cappedSize;
+        }
+
+        // Swap the sphere entity's mesh when the user picks a different
+        // shape. We avoid recreating the entity (which churns the scene
+        // node hierarchy) — destroying and recreating against the same
+        // node is the cleanest way Ogre supports changing the mesh.
+        const Shape requestedShape =
+            (shape == ShapeCube)  ? ShapeCube  :
+            (shape == ShapePlane) ? ShapePlane :
+                                    ShapeSphere;
+        if (requestedShape != m_interactiveCurrentShape || !m_sphere) {
+            const Ogre::String meshName = ensureShapeMesh(requestedShape);
+            if (m_sphere) {
+                m_sphereNode->detachObject(m_sphere);
+                m_sceneMgr->destroyEntity(m_sphere);
+                m_sphere = nullptr;
+            }
+            m_sphere = m_sceneMgr->createEntity("PreviewSphereEntity", meshName);
+            m_sphereNode->attachObject(m_sphere);
+            m_interactiveCurrentShape = requestedShape;
+        }
+
+        // Tilt the plane slightly so a flat-textured material reads as
+        // a material sample rather than an opaque rectangle.
+        if (requestedShape == ShapePlane) {
+            m_sphereNode->setOrientation(Ogre::Quaternion(
+                Ogre::Radian(Ogre::Math::PI * -0.25f), Ogre::Vector3::UNIT_X));
+        } else {
+            m_sphereNode->setOrientation(Ogre::Quaternion::IDENTITY);
+        }
+
+        m_sphere->setMaterialName(stdName);
+
+        // Apply environment yaw — rotate the light around the world
+        // up-axis so the model appears illuminated from a different
+        // angle. Modulo to [0, 360) so the cache key is stable.
+        const double wrappedYaw = std::fmod(std::fmod(yawDegrees, 360.0) + 360.0, 360.0);
+        const Ogre::Radian yaw(Ogre::Degree(static_cast<float>(wrappedYaw)));
+        Ogre::Vector3 baseDir = Ogre::Vector3(-1, -1, -1).normalisedCopy();
+        Ogre::Quaternion rot(yaw, Ogre::Vector3::UNIT_Y);
+        m_lightNode->setDirection((rot * baseDir).normalisedCopy());
+
+        m_interactiveRenderTarget->update();
+
+        QImage image(cappedSize, cappedSize, QImage::Format_RGBA8888);
+        Ogre::PixelBox pb(cappedSize, cappedSize, 1, Ogre::PF_BYTE_RGBA, image.bits());
+        m_interactiveRenderTarget->copyContentsToMemory(
+            Ogre::Box(0, 0, cappedSize, cappedSize), pb,
+            Ogre::RenderTarget::FB_AUTO);
+
+        QByteArray ba;
+        QBuffer buf(&ba);
+        buf.open(QIODevice::WriteOnly);
+        if (!image.save(&buf, "PNG")) return {};
+        return QStringLiteral("data:image/png;base64,") + ba.toBase64();
+    } catch (const Ogre::Exception&) {
+        return {};
+    } catch (...) {
+        return {};
+    }
 }
 
 void MaterialPreviewRenderer::clearCache()

--- a/src/MaterialPreviewRenderer.h
+++ b/src/MaterialPreviewRenderer.h
@@ -72,6 +72,13 @@ private:
     /// Slice I: ensure the procedural mesh for `shape` is created and
     /// return its name. Lazily creates each mesh on first use.
     Ogre::String ensureShapeMesh(Shape shape);
+    /// Slice I: restore the shared preview scene to the canonical
+    /// "Sphere + default light" state before the thumbnail path
+    /// renders. renderInteractivePreview can leave the entity on a
+    /// Cube/Plane mesh or rotate the light; without this, the cached
+    /// thumbnails would pick up that interactive state and violate
+    /// the documented thumbnail-always-Sphere invariant.
+    void resetToCanonicalThumbnailState();
 
     static MaterialPreviewRenderer* m_pSingleton;
 

--- a/src/MaterialPreviewRenderer.h
+++ b/src/MaterialPreviewRenderer.h
@@ -23,17 +23,39 @@ class MaterialPreviewRenderer : public QObject
     QML_SINGLETON
 
 public:
+    /// Slice I: which procedural mesh the preview is rendered on. The
+    /// thumbnail path stays on Sphere; the interactive Inspector
+    /// preview can switch.
+    enum Shape {
+        ShapeSphere = 0,
+        ShapeCube   = 1,
+        ShapePlane  = 2,
+    };
+    Q_ENUM(Shape)
+
     static MaterialPreviewRenderer* instance();
     static MaterialPreviewRenderer* qmlInstance(QQmlEngine* engine, QJSEngine* scriptEngine);
     static void kill();
 
     /// Render a 64x64 preview of the named Ogre material on a lit sphere.
     /// Returns a null QImage if the material cannot be found or Ogre is not ready.
+    /// Always uses Shape=Sphere and yaw=0 for cache stability.
     QImage renderPreview(const QString& materialName);
 
     /// Convenience: returns the preview as a data:image/png;base64,... URI string.
     /// Returns an empty string on failure.
     Q_INVOKABLE QString renderPreviewAsDataUri(const QString& materialName);
+
+    /// Slice I: render an arbitrary-size preview with a chosen shape and
+    /// environment yaw. Not cached — meant for the interactive Inspector
+    /// preview panel which re-renders on user input. Returns a
+    /// `data:image/png;base64,…` URL the QML Image element shows directly.
+    /// `size` is clamped to [32, 1024]; `yawDegrees` is wrapped to [0, 360).
+    /// `shape` is one of the Shape enum values; out-of-range falls back to Sphere.
+    Q_INVOKABLE QString renderInteractivePreview(const QString& materialName,
+                                                  int size,
+                                                  int shape,
+                                                  double yawDegrees);
 
     /// Clear the cached previews (e.g. when materials are reloaded).
     Q_INVOKABLE void clearCache();
@@ -47,20 +69,31 @@ private:
     ~MaterialPreviewRenderer() override;
 
     bool ensureScene();
+    /// Slice I: ensure the procedural mesh for `shape` is created and
+    /// return its name. Lazily creates each mesh on first use.
+    Ogre::String ensureShapeMesh(Shape shape);
 
     static MaterialPreviewRenderer* m_pSingleton;
 
     Ogre::SceneManager* m_sceneMgr = nullptr;
     Ogre::Camera* m_camera = nullptr;
     Ogre::Light* m_light = nullptr;
+    Ogre::SceneNode* m_lightNode = nullptr;
     Ogre::Entity* m_sphere = nullptr;
     Ogre::SceneNode* m_sphereNode = nullptr;
     Ogre::TexturePtr m_rttTexture;
     Ogre::RenderTarget* m_renderTarget = nullptr;
 
+    // Slice I: separate larger RTT for the interactive preview. We
+    // reallocate it when the requested size changes.
+    Ogre::TexturePtr m_interactiveRtt;
+    Ogre::RenderTarget* m_interactiveRenderTarget = nullptr;
+    int m_interactiveSize = 0;
+    Shape m_interactiveCurrentShape = ShapeSphere;
+
     bool m_initialized = false;
 
-    // Cache: materialName -> base64 data URI
+    // Cache: materialName -> base64 data URI for the 64x64 thumbnail path.
     QHash<QString, QString> m_cache;
 
     static constexpr int PREVIEW_SIZE = 64;

--- a/src/MaterialPreviewRenderer_test.cpp
+++ b/src/MaterialPreviewRenderer_test.cpp
@@ -250,3 +250,177 @@ TEST_F(MaterialPreviewRendererTests, MultipleFirstMaterialNamesReturnsFirst) {
     QString matName = MaterialPreviewRenderer::firstMaterialNameInFile(path);
     EXPECT_EQ(matName, "FirstMaterial");
 }
+
+// ===========================================================================
+// Slice I — renderInteractivePreview: arbitrary size, shape switch,
+// environment yaw. The thumbnail path (renderPreviewAsDataUri) is
+// always Sphere + yaw=0 for cache stability; the interactive path is
+// used by the Inspector preview pane which re-renders on user input.
+// ===========================================================================
+
+TEST_F(MaterialPreviewRendererTests, InteractivePreviewReturnsEmptyForUnknownMaterial) {
+    ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+    ASSERT_TRUE(canLoadMeshFiles());
+    createStandardOgreMaterials();
+
+    auto* renderer = MaterialPreviewRenderer::instance();
+    QString uri = renderer->renderInteractivePreview(
+        "NonExistent_XYZ_123", 96, MaterialPreviewRenderer::ShapeSphere, 0.0);
+    EXPECT_TRUE(uri.isEmpty());
+}
+
+TEST_F(MaterialPreviewRendererTests, InteractivePreviewReturnsDataUriForKnownMaterial) {
+    ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+    ASSERT_TRUE(canLoadMeshFiles());
+    createStandardOgreMaterials();
+
+    auto* renderer = MaterialPreviewRenderer::instance();
+    QString uri = renderer->renderInteractivePreview(
+        "BaseWhite", 96, MaterialPreviewRenderer::ShapeSphere, 0.0);
+    ASSERT_FALSE(uri.isEmpty()) << "interactive RTT failed (headless GL required)";
+    EXPECT_TRUE(uri.startsWith("data:image/png;base64,"));
+}
+
+TEST_F(MaterialPreviewRendererTests, InteractivePreviewClampsSizeToBounds) {
+    ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+    ASSERT_TRUE(canLoadMeshFiles());
+    createStandardOgreMaterials();
+
+    auto* renderer = MaterialPreviewRenderer::instance();
+
+    auto decodeWidth = [](const QString& uri) -> int {
+        const QByteArray payload = QByteArray::fromBase64(
+            uri.mid(QString("data:image/png;base64,").size()).toLatin1());
+        QImage img;
+        if (!img.loadFromData(payload, "PNG")) return -1;
+        return img.width();
+    };
+
+    QString tooSmall = renderer->renderInteractivePreview(
+        "BaseWhite", 8, MaterialPreviewRenderer::ShapeSphere, 0.0);
+    ASSERT_FALSE(tooSmall.isEmpty());
+    EXPECT_EQ(decodeWidth(tooSmall), 32);  // clamped to lower bound
+
+    QString tooLarge = renderer->renderInteractivePreview(
+        "BaseWhite", 4096, MaterialPreviewRenderer::ShapeSphere, 0.0);
+    ASSERT_FALSE(tooLarge.isEmpty());
+    EXPECT_EQ(decodeWidth(tooLarge), 1024); // clamped to upper bound
+
+    QString midband = renderer->renderInteractivePreview(
+        "BaseWhite", 128, MaterialPreviewRenderer::ShapeSphere, 0.0);
+    ASSERT_FALSE(midband.isEmpty());
+    EXPECT_EQ(decodeWidth(midband), 128);
+}
+
+TEST_F(MaterialPreviewRendererTests, InteractivePreviewYawWrapsTo360) {
+    // yaw=0 vs yaw=360 must produce the same image (wrap-around). yaw=-90
+    // wraps to 270, which differs from 0. Confirms the modulo step in
+    // renderInteractivePreview is honoured by callers passing arbitrary
+    // accumulated drag offsets.
+    ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+    ASSERT_TRUE(canLoadMeshFiles());
+    createStandardOgreMaterials();
+
+    auto* renderer = MaterialPreviewRenderer::instance();
+    QString yaw0   = renderer->renderInteractivePreview(
+        "BaseWhite", 96, MaterialPreviewRenderer::ShapeSphere, 0.0);
+    QString yaw360 = renderer->renderInteractivePreview(
+        "BaseWhite", 96, MaterialPreviewRenderer::ShapeSphere, 360.0);
+    QString yawNeg = renderer->renderInteractivePreview(
+        "BaseWhite", 96, MaterialPreviewRenderer::ShapeSphere, -90.0);
+
+    ASSERT_FALSE(yaw0.isEmpty());
+    ASSERT_FALSE(yaw360.isEmpty());
+    ASSERT_FALSE(yawNeg.isEmpty());
+
+    EXPECT_EQ(yaw0, yaw360) << "yaw 0 and 360 must wrap to identical render";
+    EXPECT_NE(yaw0, yawNeg) << "yaw 0 and -90 must produce different lighting";
+}
+
+TEST_F(MaterialPreviewRendererTests, InteractivePreviewShapeSwitchProducesDifferentBytes) {
+    ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+    ASSERT_TRUE(canLoadMeshFiles());
+    createStandardOgreMaterials();
+
+    auto* renderer = MaterialPreviewRenderer::instance();
+    QString sphere = renderer->renderInteractivePreview(
+        "BaseWhite", 96, MaterialPreviewRenderer::ShapeSphere, 0.0);
+    QString cube   = renderer->renderInteractivePreview(
+        "BaseWhite", 96, MaterialPreviewRenderer::ShapeCube,   0.0);
+    QString plane  = renderer->renderInteractivePreview(
+        "BaseWhite", 96, MaterialPreviewRenderer::ShapePlane,  0.0);
+
+    ASSERT_FALSE(sphere.isEmpty());
+    ASSERT_FALSE(cube.isEmpty());
+    ASSERT_FALSE(plane.isEmpty());
+
+    EXPECT_NE(sphere, cube);
+    EXPECT_NE(sphere, plane);
+    EXPECT_NE(cube, plane);
+}
+
+TEST_F(MaterialPreviewRendererTests, InteractivePreviewOutOfRangeShapeFallsBackToSphere) {
+    // shape=99 must be treated as Sphere — the renderer's switch has a
+    // default branch that prevents stray UI values from crashing.
+    ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+    ASSERT_TRUE(canLoadMeshFiles());
+    createStandardOgreMaterials();
+
+    auto* renderer = MaterialPreviewRenderer::instance();
+    QString sphere = renderer->renderInteractivePreview(
+        "BaseWhite", 96, MaterialPreviewRenderer::ShapeSphere, 0.0);
+    QString outOfRange = renderer->renderInteractivePreview(
+        "BaseWhite", 96, /*shape=*/99, 0.0);
+
+    ASSERT_FALSE(sphere.isEmpty());
+    ASSERT_FALSE(outOfRange.isEmpty());
+    EXPECT_EQ(sphere, outOfRange);
+}
+
+TEST_F(MaterialPreviewRendererTests, InteractivePreviewReusesRttOnSameSize) {
+    // Two consecutive renders at the same size must not crash and must
+    // both succeed. Internally the RTT texture is reused; this is a
+    // regression guard for the resize/reset branch in
+    // renderInteractivePreview.
+    ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+    ASSERT_TRUE(canLoadMeshFiles());
+    createStandardOgreMaterials();
+
+    auto* renderer = MaterialPreviewRenderer::instance();
+    QString first  = renderer->renderInteractivePreview(
+        "BaseWhite", 128, MaterialPreviewRenderer::ShapeSphere, 0.0);
+    QString second = renderer->renderInteractivePreview(
+        "BaseWhite", 128, MaterialPreviewRenderer::ShapeSphere, 0.0);
+
+    ASSERT_FALSE(first.isEmpty());
+    ASSERT_FALSE(second.isEmpty());
+    EXPECT_EQ(first, second);
+}
+
+TEST_F(MaterialPreviewRendererTests, InteractivePreviewResizesRttBetweenCalls) {
+    // Different size on the second call must trigger the
+    // "remove + recreate" branch in renderInteractivePreview and still
+    // produce a valid image. Decoded image dimensions must match
+    // the requested (clamped) size.
+    ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+    ASSERT_TRUE(canLoadMeshFiles());
+    createStandardOgreMaterials();
+
+    auto* renderer = MaterialPreviewRenderer::instance();
+    QString small = renderer->renderInteractivePreview(
+        "BaseWhite", 64, MaterialPreviewRenderer::ShapeSphere, 0.0);
+    QString large = renderer->renderInteractivePreview(
+        "BaseWhite", 256, MaterialPreviewRenderer::ShapeSphere, 0.0);
+    ASSERT_FALSE(small.isEmpty());
+    ASSERT_FALSE(large.isEmpty());
+
+    auto decode = [](const QString& uri) {
+        const QByteArray payload = QByteArray::fromBase64(
+            uri.mid(QString("data:image/png;base64,").size()).toLatin1());
+        QImage img;
+        img.loadFromData(payload, "PNG");
+        return img;
+    };
+    EXPECT_EQ(decode(small).width(), 64);
+    EXPECT_EQ(decode(large).width(), 256);
+}

--- a/src/MaterialPreviewRenderer_test.cpp
+++ b/src/MaterialPreviewRenderer_test.cpp
@@ -397,6 +397,39 @@ TEST_F(MaterialPreviewRendererTests, InteractivePreviewReusesRttOnSameSize) {
     EXPECT_EQ(first, second);
 }
 
+TEST_F(MaterialPreviewRendererTests, ThumbnailIsCanonicalAfterInteractivePreview) {
+    // Regression: renderInteractivePreview mutates the shared entity
+    // (Cube/Plane mesh) and rotates the light. The cached thumbnail
+    // path must reset both back to "Sphere + default light" so the
+    // material card preview stays canonical regardless of what the
+    // user just rendered in the interactive pane.
+    ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+    ASSERT_TRUE(canLoadMeshFiles());
+    createStandardOgreMaterials();
+
+    auto* renderer = MaterialPreviewRenderer::instance();
+
+    // Capture the canonical thumbnail BEFORE any interactive call.
+    renderer->clearCache();
+    const QString canonical = renderer->renderPreviewAsDataUri("BaseWhite");
+    ASSERT_FALSE(canonical.isEmpty());
+
+    // Render an interactive preview on a different shape with a
+    // non-zero yaw — guaranteed to mutate the shared scene state.
+    QString cube = renderer->renderInteractivePreview(
+        "BaseWhite", 128, MaterialPreviewRenderer::ShapeCube, 90.0);
+    ASSERT_FALSE(cube.isEmpty());
+
+    // The thumbnail path must still produce the canonical sphere image
+    // after the interactive call — confirms the shared scene state was
+    // reset before rendering. Bypass the C++ cache to actually re-render.
+    renderer->clearCache();
+    const QString afterInteractive = renderer->renderPreviewAsDataUri("BaseWhite");
+    ASSERT_FALSE(afterInteractive.isEmpty());
+    EXPECT_EQ(canonical, afterInteractive)
+        << "thumbnail picked up interactive scene state (cube mesh or yawed light)";
+}
+
 TEST_F(MaterialPreviewRendererTests, InteractivePreviewResizesRttBetweenCalls) {
     // Different size on the second call must trigger the
     // "remove + recreate" branch in renderInteractivePreview and still

--- a/src/PropertiesPanelController.cpp
+++ b/src/PropertiesPanelController.cpp
@@ -259,6 +259,43 @@ void PropertiesPanelController::triggerMaterialEditor()
     }
 }
 
+int PropertiesPanelController::applyMaterialToSelection(const QString& materialName)
+{
+    if (materialName.isEmpty()) return 0;
+    SentryReporter::addBreadcrumb("ui.action",
+        QString("Apply material '%1' to selection").arg(materialName));
+
+    auto* sel = SelectionSet::getSingleton();
+    if (!sel) return 0;
+
+    const std::string stdName = materialName.toStdString();
+    int touched = 0;
+
+    // Per-sub-entity selections take precedence (the user has picked a
+    // specific submesh).
+    auto subs = sel->getSubEntitiesSelectionList();
+    if (!subs.isEmpty()) {
+        for (Ogre::SubEntity* se : subs) {
+            if (!se) continue;
+            se->setMaterialName(stdName);
+            ++touched;
+        }
+    } else {
+        auto entities = sel->getResolvedEntities();
+        for (Ogre::Entity* ent : entities) {
+            if (!ent) continue;
+            for (unsigned int i = 0; i < ent->getNumSubEntities(); ++i) {
+                ent->getSubEntity(i)->setMaterialName(stdName);
+                ++touched;
+            }
+        }
+    }
+
+    if (touched > 0)
+        emit selectionChanged();   // refresh scene-tree material columns
+    return touched;
+}
+
 void PropertiesPanelController::deleteSceneTreeNode(const QString& nodeName)
 {
     if (nodeName.isEmpty() || Manager::getSingleton()->isForbiddenNodeName(nodeName))

--- a/src/PropertiesPanelController.cpp
+++ b/src/PropertiesPanelController.cpp
@@ -13,6 +13,7 @@
 #include "SentryReporter.h"
 #include "MeshImporterExporter.h"
 #include "UndoManager.h"
+#include "commands/ApplyMaterialCommand.h"
 #include "Manager.h"
 #include "SentryReporter.h"
 #include "OgreWidget.h"
@@ -269,30 +270,39 @@ int PropertiesPanelController::applyMaterialToSelection(const QString& materialN
     if (!sel) return 0;
 
     const std::string stdName = materialName.toStdString();
-    int touched = 0;
+    std::vector<ApplyMaterialCommand::Target> targets;
 
-    // Per-sub-entity selections take precedence (the user has picked a
-    // specific submesh).
+    // Collect (sub-entity, oldMaterialName) for every touched binding
+    // before we mutate anything. The undo command stores these pairs
+    // and restores them one-for-one on undo. Per-sub-entity selections
+    // take precedence (the user has picked a specific submesh);
+    // otherwise every sub-entity of every selected entity is touched.
     auto subs = sel->getSubEntitiesSelectionList();
     if (!subs.isEmpty()) {
         for (Ogre::SubEntity* se : subs) {
             if (!se) continue;
-            se->setMaterialName(stdName);
-            ++touched;
+            targets.emplace_back(se, se->getMaterialName());
         }
     } else {
         auto entities = sel->getResolvedEntities();
         for (Ogre::Entity* ent : entities) {
             if (!ent) continue;
             for (unsigned int i = 0; i < ent->getNumSubEntities(); ++i) {
-                ent->getSubEntity(i)->setMaterialName(stdName);
-                ++touched;
+                Ogre::SubEntity* se = ent->getSubEntity(i);
+                targets.emplace_back(se, se->getMaterialName());
             }
         }
     }
 
-    if (touched > 0)
-        emit selectionChanged();   // refresh scene-tree material columns
+    const int touched = static_cast<int>(targets.size());
+    if (touched == 0) return 0;
+
+    // Push pre-populated and call redo() via the stack so the apply
+    // path stays consistent with manual user undo/redo cycles.
+    auto* cmd = new ApplyMaterialCommand(std::move(targets), stdName);
+    UndoManager::getSingleton()->stack()->push(cmd);
+
+    emit selectionChanged();   // refresh scene-tree material columns
     return touched;
 }
 

--- a/src/PropertiesPanelController.h
+++ b/src/PropertiesPanelController.h
@@ -197,6 +197,11 @@ public:
 
     Q_INVOKABLE void triggerMergeAnimations();
     Q_INVOKABLE void triggerMaterialEditor();
+    /// Slice I: apply the named Ogre material to every selected
+    /// sub-entity (or every sub-entity of selected entities). Returns
+    /// the number of sub-entities affected; 0 means nothing was
+    /// selected.
+    Q_INVOKABLE int applyMaterialToSelection(const QString& materialName);
 
     /// Delete one scene node by name (scene-tree trash control).
     Q_INVOKABLE void deleteSceneTreeNode(const QString& nodeName);

--- a/src/PropertiesPanelController_test.cpp
+++ b/src/PropertiesPanelController_test.cpp
@@ -1068,3 +1068,43 @@ TEST_F(PropertiesPanelControllerTests, ApplyMaterialToSelection_EmitsSelectionCh
     EXPECT_GT(controller->applyMaterialToSelection("BaseWhite"), 0);
     EXPECT_GE(spy.count(), 1);
 }
+
+TEST_F(PropertiesPanelControllerTests, ApplyMaterialToSelection_IsUndoable)
+{
+    // Apply must record the previous material binding so an accidental
+    // click can be reverted. The undo stack should grow by one entry
+    // per applyMaterialToSelection call, and undo must restore the
+    // pre-apply material on every touched sub-entity.
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
+    createStandardOgreMaterials();
+
+    Ogre::SceneNode* node = Manager::getSingleton()->addSceneNode("ApplyMatUndoable");
+    Ogre::MeshPtr mesh = createInMemoryTriangleMesh("ApplyMatUndoMesh");
+    Ogre::Entity* entity = Manager::getSingleton()->createEntity(node, mesh);
+    ASSERT_NE(entity, nullptr);
+    ASSERT_GE(entity->getNumSubEntities(), 1u);
+    Ogre::SubEntity* sub0 = entity->getSubEntity(0);
+
+    // Force a known starting material so the assertions below have a
+    // stable name to compare against.
+    sub0->setMaterialName("BaseWhiteNoLighting");
+    const std::string before = sub0->getMaterial()->getName();
+    EXPECT_EQ(before, "BaseWhiteNoLighting");
+
+    SelectionSet::getSingleton()->selectOne(entity);
+    controller->clearUndoHistory();
+
+    auto* stack = UndoManager::getSingleton()->stack();
+    const int beforeCount = stack->count();
+    EXPECT_GT(controller->applyMaterialToSelection("BaseWhite"), 0);
+    EXPECT_EQ(stack->count(), beforeCount + 1) << "apply must push exactly one undo entry";
+    EXPECT_EQ(sub0->getMaterial()->getName(), "BaseWhite");
+
+    stack->undo();
+    EXPECT_EQ(sub0->getMaterial()->getName(), before)
+        << "undo did not restore the pre-apply material";
+
+    stack->redo();
+    EXPECT_EQ(sub0->getMaterial()->getName(), "BaseWhite")
+        << "redo did not re-apply the material";
+}

--- a/src/PropertiesPanelController_test.cpp
+++ b/src/PropertiesPanelController_test.cpp
@@ -980,3 +980,91 @@ TEST_F(PropertiesPanelControllerTests, UndoIndexTracksPushAndUndoOperations)
     stack->redo();
     EXPECT_EQ(controller->undoIndex(), 2);
 }
+
+// ===========================================================================
+// Slice I — applyMaterialToSelection: applies a named Ogre material to
+// the currently selected sub-entities. Per-sub-entity selection takes
+// precedence; otherwise every sub-entity of every selected entity is
+// touched. Returns the affected count.
+// ===========================================================================
+
+TEST_F(PropertiesPanelControllerTests, ApplyMaterialToSelection_EmptyNameIsNoOp)
+{
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
+    Ogre::SceneNode* meshNode = Manager::getSingleton()->addSceneNode("ApplyMatEmpty");
+    Ogre::MeshPtr mesh = createInMemoryTriangleMesh("ApplyMatEmptyMesh");
+    Ogre::Entity* entity = Manager::getSingleton()->createEntity(meshNode, mesh);
+    ASSERT_NE(entity, nullptr);
+    SelectionSet::getSingleton()->selectOne(entity);
+
+    EXPECT_EQ(controller->applyMaterialToSelection(QString()), 0);
+    EXPECT_EQ(controller->applyMaterialToSelection(QString("")), 0);
+}
+
+TEST_F(PropertiesPanelControllerTests, ApplyMaterialToSelection_NoSelectionReturnsZero)
+{
+    SelectionSet::getSingleton()->clear();
+    EXPECT_EQ(controller->applyMaterialToSelection("BaseWhite"), 0);
+}
+
+TEST_F(PropertiesPanelControllerTests, ApplyMaterialToSelection_SubEntityTakesPrecedence)
+{
+    // When the user has explicitly picked a submesh, the helper must
+    // touch *only* that submesh — even if the parent entity has more.
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
+    createStandardOgreMaterials();
+
+    Ogre::SceneNode* node = Manager::getSingleton()->addSceneNode("ApplyMatSubSel");
+    Ogre::MeshPtr mesh = createInMemoryTriangleMesh("ApplyMatSubMesh");
+    Ogre::Entity* entity = Manager::getSingleton()->createEntity(node, mesh);
+    ASSERT_NE(entity, nullptr);
+    ASSERT_GE(entity->getNumSubEntities(), 1u);
+    Ogre::SubEntity* sub0 = entity->getSubEntity(0);
+
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->append(sub0);
+
+    EXPECT_EQ(controller->applyMaterialToSelection("BaseWhite"), 1);
+    EXPECT_EQ(sub0->getMaterial()->getName(), "BaseWhite");
+}
+
+TEST_F(PropertiesPanelControllerTests, ApplyMaterialToSelection_EntitySelectionTouchesAllSubmeshes)
+{
+    // No sub-entity is explicitly selected — every sub-entity of every
+    // selected entity must receive the new material. The triangle mesh
+    // has one submesh, so the count is the entity count (1 here).
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
+    createStandardOgreMaterials();
+
+    Ogre::SceneNode* node = Manager::getSingleton()->addSceneNode("ApplyMatEntSel");
+    Ogre::MeshPtr mesh = createInMemoryTriangleMesh("ApplyMatEntMesh");
+    Ogre::Entity* entity = Manager::getSingleton()->createEntity(node, mesh);
+    ASSERT_NE(entity, nullptr);
+    SelectionSet::getSingleton()->selectOne(entity);
+
+    const int touched = controller->applyMaterialToSelection("BaseWhite");
+    EXPECT_EQ(touched, static_cast<int>(entity->getNumSubEntities()));
+    EXPECT_EQ(entity->getSubEntity(0)->getMaterial()->getName(), "BaseWhite");
+}
+
+TEST_F(PropertiesPanelControllerTests, ApplyMaterialToSelection_EmitsSelectionChangedSignal)
+{
+    // selectionChanged is the signal QML watches to refresh the
+    // scene-tree material column. Without it, applying a material to
+    // a selected sub-entity would leave the tree displaying the old
+    // value until the next selection change.
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
+    createStandardOgreMaterials();
+
+    Ogre::SceneNode* node = Manager::getSingleton()->addSceneNode("ApplyMatSignal");
+    Ogre::MeshPtr mesh = createInMemoryTriangleMesh("ApplyMatSignalMesh");
+    Ogre::Entity* entity = Manager::getSingleton()->createEntity(node, mesh);
+    ASSERT_NE(entity, nullptr);
+    SelectionSet::getSingleton()->selectOne(entity);
+
+    QSignalSpy spy(controller, &PropertiesPanelController::selectionChanged);
+    ASSERT_TRUE(spy.isValid());
+
+    EXPECT_GT(controller->applyMaterialToSelection("BaseWhite"), 0);
+    EXPECT_GE(spy.count(), 1);
+}

--- a/src/commands/ApplyMaterialCommand.cpp
+++ b/src/commands/ApplyMaterialCommand.cpp
@@ -1,0 +1,30 @@
+#include "ApplyMaterialCommand.h"
+
+#include <OgreSubEntity.h>
+
+ApplyMaterialCommand::ApplyMaterialCommand(std::vector<Target> targets,
+                                           std::string newMaterialName,
+                                           QUndoCommand* parent)
+    : QUndoCommand(parent)
+    , mTargets(std::move(targets))
+    , mNewMaterialName(std::move(newMaterialName))
+{
+    setText(QObject::tr("Apply material '%1' to %n sub-entit%2(ies)", "",
+                        static_cast<int>(mTargets.size()))
+                .arg(QString::fromStdString(mNewMaterialName))
+                .arg(mTargets.size() == 1 ? "y" : "ies"));
+}
+
+void ApplyMaterialCommand::redo()
+{
+    for (auto& [sub, _oldName] : mTargets) {
+        if (sub) sub->setMaterialName(mNewMaterialName);
+    }
+}
+
+void ApplyMaterialCommand::undo()
+{
+    for (auto& [sub, oldName] : mTargets) {
+        if (sub) sub->setMaterialName(oldName);
+    }
+}

--- a/src/commands/ApplyMaterialCommand.h
+++ b/src/commands/ApplyMaterialCommand.h
@@ -1,0 +1,39 @@
+#ifndef APPLY_MATERIAL_COMMAND_H
+#define APPLY_MATERIAL_COMMAND_H
+
+#include <QUndoCommand>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace Ogre {
+    class SubEntity;
+}
+
+/// Slice I: undo record for "Apply material to selection". Captures the
+/// (sub-entity, oldMaterialName) pair for every touched sub-entity at
+/// the time of the apply, so undo restores the pre-apply binding for
+/// each one independently. SubEntity pointers are owned by Ogre and
+/// remain valid for the session — the command does not survive entity
+/// reload.
+class ApplyMaterialCommand : public QUndoCommand
+{
+public:
+    /// targets stores (sub-entity, old material name) so undo can
+    /// restore each binding independently. `newMaterialName` is the
+    /// material applied on redo.
+    using Target = std::pair<Ogre::SubEntity*, std::string>;
+
+    ApplyMaterialCommand(std::vector<Target> targets,
+                         std::string newMaterialName,
+                         QUndoCommand* parent = nullptr);
+
+    void undo() override;
+    void redo() override;
+
+private:
+    std::vector<Target> mTargets;
+    std::string         mNewMaterialName;
+};
+
+#endif // APPLY_MATERIAL_COMMAND_H

--- a/src/qml_resources.qrc
+++ b/src/qml_resources.qrc
@@ -9,6 +9,7 @@
     <file alias="NormalMapGeneratorDialog.qml">../qml/NormalMapGeneratorDialog.qml</file>
     <file alias="qmldir">../qml/qmldir</file>
     <file alias="ThemedButton.qml">../qml/ThemedButton.qml</file>
+    <file alias="ThemedCheckBox.qml">../qml/ThemedCheckBox.qml</file>
     <file alias="ThemedComboBox.qml">../qml/ThemedComboBox.qml</file>
     <file alias="ThemedSpinBox.qml">../qml/ThemedSpinBox.qml</file>
     <file alias="ThemedLabel.qml">../qml/ThemedLabel.qml</file>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,6 +76,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/DecimateTrackCommand.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/BoneTransformCommand.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/AddKeyframeCommand.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/ApplyMaterialCommand.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/DeleteKeyframeCommand.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/SkeletonResolver.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/BoneDragRelease.cpp


### PR DESCRIPTION
## Summary

- **Inspector — Material Library + Live Preview**: Material Mode → Mode Tools gains a Material Library grid (cards with cached thumbnails) and an interactive preview pane with Sphere/Cube switcher + drag-yaw envmap rotation. First paint is deferred 100 ms to avoid an Ogre RTT avalanche.
- **Material Editor — Form/Script redesign**: One window, one segmented Form | Script toggle, sticky Technique/Pass context strip with "+ Add new…" sentinel rows, centered Pass | Texture sub-tab bar. The form ColumnLayout fills the ScrollView width so property sections cover the available space. New `ThemedCheckBox` QML primitive and flat-header GroupBox restyle across Pass/Texture property panels.
- **C++ APIs**:
  - `MaterialPreviewRenderer::renderInteractivePreview(name, size, shape, yaw)` with `Shape` Q_ENUM (Sphere/Cube/Plane), env-light yaw, and a separate resizable RTT (thumbnail cache untouched).
  - `MaterialEditorQML::inputColor` / `headerColor` (Inspector palette parity) + `interactiveMaterialPreview(...)` wrapper.
  - `PropertiesPanelController::applyMaterialToSelection(name)` — touches selected sub-entities (or every sub-entity of selected entities), emits `selectionChanged` so the scene-tree material column refreshes.

## Test plan

- [x] All new C++ APIs covered by Google Test cases (compile + link verified, see below).
- [x] `BoneDragReleaseTest`: 3 new tests driving multi-event setUpdate sequences (5/drag, 20-event × 3-drag stress, zero-delta `manualControlled` clear).
- [x] `MaterialPreviewRendererTests`: 7 new tests — size clamping (32 floor / 1024 cap), yaw wrap-around (0 ≡ 360, ≠ −90), shape switch produces distinct bytes, out-of-range shape falls back to Sphere, RTT reuse on same size, RTT resize between calls.
- [x] `MaterialEditorQMLTest`: 3 new theme-color tests (`panelColor`/`inputColor`/`headerColor` match the expected palette roles) + 3 `interactiveMaterialPreview` tests (unknown material, known data URL, shape switch).
- [x] `PropertiesPanelControllerTests`: 5 new `applyMaterialToSelection` tests — empty name is a no-op, no selection returns 0, sub-entity selection takes precedence over entity selection, entity selection touches every submesh, `selectionChanged` is emitted on success.
- [ ] Linux CI runs the full Ogre-fixture set under Xvfb (cannot run locally on macOS — `tryInitOgre()` blocks on missing GL plugins per the documented project constraint).
- [x] Manual smoke test: Material Editor → Form view; property sections (Lighting & Depth, Colors, Alpha & Material, Blending, …) fill the window width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned Material Editor with compact layout and Form/Script mode toggle.
  * Inline Material Library tool with material grid, thumbnails, and quick apply/edit/export actions.
  * Interactive material preview with draggable yaw rotation and shape selector.

* **Style**
  * Refreshed UI theming across Material Editor and Properties panels with flatter, Inspector-style appearance.
  * Updated input controls and buttons with improved visual consistency.
  * New themed checkbox component.

* **Tests**
  * Expanded test coverage for drag/revert behavior and material preview rendering.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/492)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->