### PR TITLE
docs(ci): sync 3.0.0 action pins with CMakeLists and enforce in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,10 +34,22 @@ jobs:
 #             SLACK_MESSAGE: "Building QtMeshEditor in GitHub Actions - works! :D"
 
 ####################################################################
+# Doc pins (README + website hook) must match CMakeLists project() VERSION
+####################################################################
+
+ verify-doc-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Pinned GitHub Action refs match CMakeLists.txt
+        run: ./scripts/sync-doc-versions-from-cmake.sh --check
+
+####################################################################
 # Asset Scan (runs first, before all builds)
 ####################################################################
 
  scan-assets-qtmesh:
+    needs: verify-doc-versions
     # Validate repo assets using the published Docker image (latest).
     # Runs on PRs, pushes to master, and releases.
     runs-on: ubuntu-latest

--- a/.github/workflows/pages-docs.yml
+++ b/.github/workflows/pages-docs.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Sync pinned action ref fallback from CMakeLists.txt (docs site)
+        run: ./scripts/sync-doc-versions-from-cmake.sh
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,7 +240,9 @@ All other version references are auto-generated from this via CMake template sub
 
 **To bump the version**, only edit the `VERSION` in `CMakeLists.txt` line 16. The rest updates automatically on rebuild.
 
-**Version format: `X.Y.Z` only — never prepend `v`.** GitHub release tags, update check comparisons, and all version strings use plain `X.Y.Z` (e.g., `2.21.0`, not `v2.21.0`). The update check feature compares the runtime version against the latest GitHub release tag, so a `v` prefix would break the comparison.
+**Version format: `X.Y.Z` only — never prepend `v`.** GitHub release tags, update check comparisons, and all version strings use plain `X.Y.Z` (e.g., `3.0.0`, not `v3.0.0`). The update check feature compares the runtime version against the latest GitHub release tag, so a `v` prefix would break the comparison.
+
+**Pinned CI doc examples:** After changing `project(QtMeshEditor VERSION …)`, run `./scripts/sync-doc-versions-from-cmake.sh` so `README.md` and `website/src/hooks/useQtmeshActionRef.js` stay aligned. CI runs `./scripts/sync-doc-versions-from-cmake.sh --check` in the `verify-doc-versions` job.
 
 Note: `MCPServer.h` has a separate `SERVER_VERSION` ("1.0.0") for the MCP protocol — only bump that if the MCP interface changes.
 
@@ -302,7 +304,7 @@ The `qtmesh` CLI is published as a GitHub Action on the [GitHub Actions Marketpl
 - Docker image name/registry changes → update the `docker run` command
 - **No update needed** for: bug fixes, GUI changes, MCP tools, or features that don't change CLI interface
 
-The action uses `image-tag: latest` by default, so users automatically get fixes without version bumps.
+The action uses `image-tag: latest` by default, so users automatically get fixes without version bumps. For reproducible CI, pin both `uses: fernandotonon/QtMeshEditor@X.Y.Z` and `image-tag: 'X.Y.Z'` to the same semver as `CMakeLists.txt` (kept in sync via `scripts/sync-doc-versions-from-cmake.sh`).
 
 **Marketplace publishing:** When creating a GitHub Release, check "Publish this Action to the GitHub Marketplace". The `v1` tag should be kept pointing to the latest stable commit (force-push tag on each release).
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,12 @@ Available on the [GitHub Actions Marketplace](https://github.com/marketplace/act
 
 [![Latest action release](https://img.shields.io/github/v/release/fernandotonon/QtMeshEditor?label=latest%20action)](https://github.com/fernandotonon/QtMeshEditor/releases/latest)
 
-Use this workflow template:
+**Versioning**
+
+- **Always follow the latest GitHub release** — use the Marketplace floating tag `fernandotonon/QtMeshEditor@v1` (same pattern as the [Marketplace example](https://github.com/marketplace/actions/qtmesheditor)). The composite action defaults to `image-tag: latest`, so the Docker CLI tracks the newest published `ghcr.io/fernandotonon/qtmesh` image.
+- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.0.0**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
+
+Pinned workflow template (action + `ghcr.io` image aligned):
 
 ```yaml
 name: QtMesh Scan
@@ -46,54 +51,68 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run QtMesh scan
-        uses: fernandotonon/QtMeshEditor@2.32.1
+        uses: fernandotonon/QtMeshEditor@3.0.0
         with:
           command: scan
+          image-tag: "3.0.0"
         env:
           QTMESH_CLOUD_TOKEN: ${{ secrets.QTMESH_CLOUD_TOKEN }}
+```
+
+Floating ref (auto-updates when the `v1` tag moves on release):
+
+```yaml
+      - name: Run QtMesh scan
+        uses: fernandotonon/QtMeshEditor@v1
+        with:
+          command: scan
 ```
 
 `QTMESH_CLOUD_TOKEN` is forwarded into the container and used by `scan` upload. GitHub Actions metadata (`GITHUB_*`) is also forwarded so uploads include `meta` fields (branch/commit/run and context used by QtMesh Cloud).
 
 To fail CI when upload fails, add `qtmesh-strict-upload: true` (or pass `--strict-upload` in `options`).
 
-Use the latest action release tag from the [releases page](https://github.com/fernandotonon/QtMeshEditor/releases/latest) (also shown in QtMesh Cloud onboarding step 3) when updating this workflow.
+Release tags are listed on the [releases page](https://github.com/fernandotonon/QtMeshEditor/releases/latest) (also referenced in QtMesh Cloud onboarding).
 
 <details>
 <summary>More CI examples</summary>
 
 ```yaml
 # Validate a specific mesh
-- uses: fernandotonon/QtMeshEditor@2.32.1
+- uses: fernandotonon/QtMeshEditor@3.0.0
   with:
     command: validate
     input-file: ./models/character.fbx
+    image-tag: "3.0.0"
 
 # Convert FBX → glTF
-- uses: fernandotonon/QtMeshEditor@2.32.1
+- uses: fernandotonon/QtMeshEditor@3.0.0
   with:
     command: convert
     input-file: ./models/character.fbx
     output-file: ./output/character.gltf2
+    image-tag: "3.0.0"
 
 # Resample Mixamo animations (200+ keyframes → 30)
-- uses: fernandotonon/QtMeshEditor@2.32.1
+- uses: fernandotonon/QtMeshEditor@3.0.0
   with:
     command: anim
     input-file: ./animations/dance.fbx
     output-file: ./output/dance_optimized.fbx
     options: --resample 30
+    image-tag: "3.0.0"
 
 # Get mesh info as JSON
-- uses: fernandotonon/QtMeshEditor@2.32.1
+- uses: fernandotonon/QtMeshEditor@3.0.0
   id: info
   with:
     command: info
     input-file: ./models/character.fbx
     options: --json
+    image-tag: "3.0.0"
 
-# Docker (alternative)
-docker run --rm -v $(pwd):/workspace ghcr.io/fernandotonon/qtmesh scan ./assets --fail-on error
+# Docker (alternative — :latest tracks newest image; pin :3.0.0 to match semver action ref)
+docker run --rm -v $(pwd):/workspace ghcr.io/fernandotonon/qtmesh:latest scan ./assets --fail-on error
 ```
 
 </details>

--- a/scripts/sync-doc-versions-from-cmake.sh
+++ b/scripts/sync-doc-versions-from-cmake.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Keep pinned GitHub Action refs in docs aligned with project(QtMeshEditor VERSION …)
+# in CMakeLists.txt. Floating refs (@v1, Docker :latest) are documented separately.
+#
+# Usage:
+#   ./scripts/sync-doc-versions-from-cmake.sh          # apply in-repo edits
+#   ./scripts/sync-doc-versions-from-cmake.sh --check  # exit 1 if anything would change
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CMAKE="$ROOT/CMakeLists.txt"
+
+if [[ ! -f "$CMAKE" ]]; then
+  echo "sync-doc-versions-from-cmake: missing $CMAKE" >&2
+  exit 1
+fi
+
+VERSION="$(
+  grep -E '^[[:space:]]*project\([[:space:]]*QtMeshEditor[[:space:]]+VERSION[[:space:]]+[0-9.]+' "$CMAKE" \
+    | head -1 \
+    | sed -E 's/.*VERSION[[:space:]]+([0-9.]+).*/\1/'
+)"
+if [[ -z "${VERSION}" ]] || [[ "${VERSION}" != *.*.* ]]; then
+  echo "sync-doc-versions-from-cmake: could not parse X.Y.Z from $CMAKE" >&2
+  exit 1
+fi
+
+EXPECTED="fernandotonon/QtMeshEditor@${VERSION}"
+CHECK=0
+if [[ "${1:-}" == "--check" ]]; then
+  CHECK=1
+fi
+
+DOC_FILES=(
+  "$ROOT/README.md"
+  "$ROOT/website/src/hooks/useQtmeshActionRef.js"
+)
+
+verify_no_stale_pins() {
+  local bad=0
+  for f in "${DOC_FILES[@]}"; do
+    [[ -f "$f" ]] || continue
+    local refs
+    refs="$(grep -ohE 'fernandotonon/QtMeshEditor@[0-9]+\.[0-9]+\.[0-9]+' "$f" 2>/dev/null | sort -u || true)"
+    if [[ -z "${refs}" ]]; then
+      continue
+    fi
+    while IFS= read -r r; do
+      [[ -z "${r}" ]] && continue
+      if [[ "${r}" != "${EXPECTED}" ]]; then
+        echo "sync-doc-versions-from-cmake: ${f} contains pinned ref '${r}' (expected only '${EXPECTED}')" >&2
+        bad=1
+      fi
+    done <<< "${refs}"
+  done
+  return "${bad}"
+}
+
+apply_perl_replace() {
+  local f="$1"
+  # Build replacement with q{} + concat so Perl never parses @3 in 3.0.0 as an array.
+  QTMESH_DOC_VERSION="${VERSION}" perl -i -pe \
+    'BEGIN { $v = $ENV{QTMESH_DOC_VERSION}; } s/fernandotonon\/QtMeshEditor@\d+\.\d+\.\d+/q{fernandotonon\/QtMeshEditor@} . $v/ge' \
+    "$f"
+}
+
+if [[ "${CHECK}" -eq 1 ]]; then
+  if ! verify_no_stale_pins; then
+    echo "sync-doc-versions-from-cmake: run without --check to fix, or bump project() VERSION in CMakeLists.txt." >&2
+    exit 1
+  fi
+  echo "sync-doc-versions-from-cmake: OK (pinned refs match CMakeLists.txt ${VERSION})"
+  exit 0
+fi
+
+for f in "${DOC_FILES[@]}"; do
+  if [[ -f "$f" ]] && grep -qE 'fernandotonon/QtMeshEditor@[0-9]+\.[0-9]+\.[0-9]+' "$f"; then
+    apply_perl_replace "$f"
+  fi
+done
+
+echo "sync-doc-versions-from-cmake: updated pinned refs to ${VERSION}"

--- a/website/README.md
+++ b/website/README.md
@@ -34,6 +34,7 @@ npm run build:docs
 
 ## Notes
 
+- Pinned GitHub Action examples in the docs app fall back to the semver in `CMakeLists.txt` (`website/src/hooks/useQtmeshActionRef.js`). Run `../scripts/sync-doc-versions-from-cmake.sh` from the repo root after bumping `project(QtMeshEditor VERSION …)`; GitHub Pages runs the same script before `npm run build`.
 - `vite.config.js` uses `base: './'` so assets resolve correctly for static hosting.
 - SEO/social metadata and JSON-LD structured data live in `website/index.html`.
 - Most media is referenced from existing GitHub-hosted assets to keep repo size small.

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -98,7 +98,7 @@ async function copyText(text) {
 function App() {
   const [isInstallPortalOpen, setIsInstallPortalOpen] = useState(false);
   const [copyState, setCopyState] = useState('idle');
-  const qtmeshActionRef = useQtmeshActionRef();
+  const { actionRef: qtmeshActionRef, imageTag: qtmeshImageTag } = useQtmeshActionRef();
   const [activeCliTab, setActiveCliTab] = useState('scan');
   const portalDialogRef = useRef(null);
   const portalTriggerRef = useRef(null);
@@ -111,8 +111,10 @@ function App() {
   );
   const recommendedStore = recommendedInstall ? getStoreLabel(recommendedInstall.method) : null;
   const githubActionExample = useMemo(
-    () => pipelineExamples.githubAction.replace('__QTMESH_ACTION_REF__', qtmeshActionRef),
-    [qtmeshActionRef]
+    () => pipelineExamples.githubAction
+      .replace('__QTMESH_ACTION_REF__', qtmeshActionRef)
+      .replace('__QTMESH_IMAGE_TAG__', qtmeshImageTag),
+    [qtmeshActionRef, qtmeshImageTag]
   );
 
   const cliTabs = useMemo(

--- a/website/src/DocsApp.jsx
+++ b/website/src/DocsApp.jsx
@@ -97,7 +97,7 @@ function CmdSection({ id, name, synopsis, description, examples, options, childr
 export default function DocsApp() {
   const [active, setActive] = useState('installation');
   const [menuOpen, setMenuOpen] = useState(false);
-  const qtmeshActionRef = useQtmeshActionRef();
+  const { actionRef: qtmeshActionRef, imageTag: qtmeshImageTag } = useQtmeshActionRef();
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -793,7 +793,9 @@ docker run --rm -v $(pwd):/workspace ghcr.io/fernandotonon/qtmesh \\
           <section className={s.section} id="github-actions">
             <h2 className={s.sectionTitle}>GitHub Actions</h2>
             <p className={s.para}>
-              The <Code>qtmesh</Code> action is available on the <a href="https://github.com/marketplace/actions/qtmesheditor" className={s.link}>GitHub Actions Marketplace</a>. This page resolves the latest release ref automatically: <Code>{qtmeshActionRef}</Code>.
+              The <Code>qtmesh</Code> action is available on the <a href="https://github.com/marketplace/actions/qtmesheditor" className={s.link}>GitHub Actions Marketplace</a>.
+              The snippets below substitute the latest GitHub release tag via the GitHub API (cached in the browser). Offline or rate-limited fallbacks use the semver pinned in <Code>CMakeLists.txt</Code> and kept in sync by <Code>scripts/sync-doc-versions-from-cmake.sh</Code>.
+              Current resolved ref: <Code>{qtmeshActionRef}</Code>.
             </p>
 
             <h3 className={s.subsection}>Onboarding Step 3 template</h3>
@@ -813,6 +815,7 @@ jobs:
         uses: ${qtmeshActionRef}
         with:
           command: scan
+          image-tag: '${qtmeshImageTag}'
         env:
           QTMESH_CLOUD_TOKEN: \${{ secrets.QTMESH_CLOUD_TOKEN }}`}</CodeBlock>
             <p className={s.para}>
@@ -825,19 +828,22 @@ jobs:
   with:
     command: validate
     input-file: ./models/character.fbx
+    image-tag: '${qtmeshImageTag}'
 
 - uses: ${qtmeshActionRef}
   with:
     command: convert
     input-file: ./models/character.fbx
     output-file: ./output/character.glb2
+    image-tag: '${qtmeshImageTag}'
 
 - uses: ${qtmeshActionRef}
   with:
     command: anim
     input-file: ./animations/dance.fbx
     output-file: ./output/dance_optimized.fbx
-    options: --resample 30`}</CodeBlock>
+    options: --resample 30
+    image-tag: '${qtmeshImageTag}'`}</CodeBlock>
 
             <h3 className={s.subsection}>Get mesh info as JSON</h3>
             <CodeBlock lang="yaml">{`- uses: ${qtmeshActionRef}
@@ -846,6 +852,7 @@ jobs:
     command: info
     input-file: ./models/character.fbx
     options: --json
+    image-tag: '${qtmeshImageTag}'
 
 - run: echo "\${{ steps.info.outputs.result }}"`}</CodeBlock>
 
@@ -856,6 +863,7 @@ jobs:
     command: scan
     input-file: .
     options: --config /workspace/qtmesh.yml --json
+    image-tag: '${qtmeshImageTag}'
     generate-badges: true
     badge-output-dir: badges
     badge-label-prefix: qtmesh
@@ -899,7 +907,7 @@ jobs:
 
 asset_scan:
   stage: lint
-  image: ghcr.io/fernandotonon/qtmesh:2.32.0
+  image: ghcr.io/fernandotonon/qtmesh:latest
   entrypoint: [""]
   script:
     - qtmesheditor --cli scan \${CI_PROJECT_DIR}/assets \\

--- a/website/src/data/content.js
+++ b/website/src/data/content.js
@@ -108,7 +108,7 @@ export const pipelineExamples = {
   convert: `qtmesh convert model.fbx -o model.glb2\nqtmesh convert model.dae -o model.mesh`,
   merge: `qtmesh anim base.fbx \\\n  --merge walk.fbx run.fbx jump.fbx idle.fbx \\\n  -o merged.fbx`,
   docker: `docker run --rm --user "$(id -u):$(id -g)" -v $(pwd):/workspace \\\n  ghcr.io/fernandotonon/qtmesh scan ./assets --fail-on error`,
-  githubAction: `name: QtMesh Scan\n\non:\n  push:\n    branches: [ "master" ]\n\njobs:\n  scan-assets-qtmesh:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n\n      - name: Run QtMesh scan\n        uses: __QTMESH_ACTION_REF__\n        with:\n          command: scan\n        env:\n          QTMESH_CLOUD_TOKEN: \${{ secrets.QTMESH_CLOUD_TOKEN }}`,
+  githubAction: `name: QtMesh Scan\n\non:\n  push:\n    branches: [ "master" ]\n\njobs:\n  scan-assets-qtmesh:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n\n      - name: Run QtMesh scan\n        uses: __QTMESH_ACTION_REF__\n        with:\n          command: scan\n          image-tag: "__QTMESH_IMAGE_TAG__"\n        env:\n          QTMESH_CLOUD_TOKEN: \${{ secrets.QTMESH_CLOUD_TOKEN }}`,
   scanFixConvert: `qtmesh scan ./assets --fail-on error\nqtmesh fix character.fbx --all -o character_fixed.fbx\nqtmesh convert character_fixed.fbx -o character.glb2`
 };
 

--- a/website/src/hooks/useQtmeshActionRef.js
+++ b/website/src/hooks/useQtmeshActionRef.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 const QTMESH_RELEASES_LATEST_API = 'https://api.github.com/repos/fernandotonon/QtMeshEditor/releases/latest';
-const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@2.32.1';
+const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.0.0';
 const CACHE_KEY = 'qtmesh.actionRef.cache.v1';
 const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 
@@ -12,6 +12,13 @@ function actionRefFromTag(tagName) {
   const tag = String(tagName || '').trim();
   if (!tag || !/^v?\d/.test(tag)) return QTMESH_ACTION_REF_FALLBACK;
   return `fernandotonon/QtMeshEditor@${tag}`;
+}
+
+/** Semver-ish action refs pin the ghcr image; everything else (e.g. @v1) tracks :latest. */
+export function imageTagFromActionRef(ref) {
+  const m = /^fernandotonon\/QtMeshEditor@(v?\d+\.\d+\.\d+)$/.exec(String(ref || ''));
+  if (!m) return 'latest';
+  return m[1].replace(/^v/, '');
 }
 
 function isValidCache(payload, now) {
@@ -105,5 +112,8 @@ export default function useQtmeshActionRef() {
     };
   }, []);
 
-  return qtmeshActionRef;
+  return {
+    actionRef: qtmeshActionRef,
+    imageTag: imageTagFromActionRef(qtmeshActionRef),
+  };
 }


### PR DESCRIPTION
This pull request aligns pinned GitHub Action and Docker examples with **3.0.0** (the version in `CMakeLists.txt`) and adds automation so they stay in sync.

### Changes
- **`scripts/sync-doc-versions-from-cmake.sh`** — reads `project(QtMeshEditor VERSION …)`, updates `README.md` and `website/src/hooks/useQtmeshActionRef.js`; `--check` for CI only.
- **Deploy workflow** — new `verify-doc-versions` job; `scan-assets-qtmesh` `needs` it so mismatches fail fast.
- **Pages workflow** — runs the sync script before `npm run build` so the docs site fallback matches CMake on the branch.
- **README** — documents `@v1` / `latest` vs semver pins, adds `image-tag` to pinned examples.
- **Website** — `useQtmeshActionRef` returns `{ actionRef, imageTag }`; docs and landing examples include `image-tag`; GitLab sample uses `:latest`.
- **CLAUDE.md** / **website README** — note the script and CI check.

### After merge
When bumping the app version, run `./scripts/sync-doc-versions-from-cmake.sh` and commit, or CI will fail on `verify-doc-versions`.

Made with [Cursor](https://cursor.com)