### PR TITLE
fix: Material Editor dark mode on Linux + opt-in scan simplify (v3.0.1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 3.0.0 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 3.0.1 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run QtMesh scan
-        uses: fernandotonon/QtMeshEditor@3.0.0
+        uses: fernandotonon/QtMeshEditor@3.0.1
         with:
           command: scan
           image-tag: "3.0.0"
@@ -79,14 +79,14 @@ Release tags are listed on the [releases page](https://github.com/fernandotonon/
 
 ```yaml
 # Validate a specific mesh
-- uses: fernandotonon/QtMeshEditor@3.0.0
+- uses: fernandotonon/QtMeshEditor@3.0.1
   with:
     command: validate
     input-file: ./models/character.fbx
     image-tag: "3.0.0"
 
 # Convert FBX → glTF
-- uses: fernandotonon/QtMeshEditor@3.0.0
+- uses: fernandotonon/QtMeshEditor@3.0.1
   with:
     command: convert
     input-file: ./models/character.fbx
@@ -94,7 +94,7 @@ Release tags are listed on the [releases page](https://github.com/fernandotonon/
     image-tag: "3.0.0"
 
 # Resample Mixamo animations (200+ keyframes → 30)
-- uses: fernandotonon/QtMeshEditor@3.0.0
+- uses: fernandotonon/QtMeshEditor@3.0.1
   with:
     command: anim
     input-file: ./animations/dance.fbx
@@ -103,7 +103,7 @@ Release tags are listed on the [releases page](https://github.com/fernandotonon/
     image-tag: "3.0.0"
 
 # Get mesh info as JSON
-- uses: fernandotonon/QtMeshEditor@3.0.0
+- uses: fernandotonon/QtMeshEditor@3.0.1
   id: info
   with:
     command: info

--- a/qtmesh.example.yml
+++ b/qtmesh.example.yml
@@ -50,6 +50,18 @@ rules:
   max_anim_keyframes: 500
   max_anim_duration: 30.0
 
+  # Redundant-keyframe / animation simplification (opt-in)
+  # Walks each animation's atomic node keys under the configured tolerances
+  # and warns when >= N% of keyframes could be folded out (same maths as
+  # `qtmesh anim --simplify`). `qtmesh scan ... --fix` will then rewrite
+  # the asset (currently FBX) to drop those keys — this is destructive,
+  # so the rule is disabled by default. Set the threshold to any positive
+  # value to enable. Recommended starting point: 40 (warns at >=40%).
+  # redundant_keyframes_pct: 40
+  # redundant_keyframes_translation_tol: 0.001   # ~1mm
+  # redundant_keyframes_rotation_deg_tol: 0.5
+  # redundant_keyframes_scale_tol: 0.001
+
   # Animation & bone name requirements (wildcard: * = any, ? = one char)
   # These are checked globally. Use scopes for path-specific requirements.
   # require_animation_names: [idle, walk, run]

--- a/src/MaterialEditorQML.cpp
+++ b/src/MaterialEditorQML.cpp
@@ -45,27 +45,18 @@
 MaterialEditorQML::MaterialEditorQML(QObject *parent)
     : QObject(parent)
 {
-    // Initialize theme colors from system palette
-    // (member defaults in header provide fallback values)
-    QPalette palette = QApplication::palette();
-    // Slice I: align panelColor with PropertiesPanelController so the
-    // Material Editor surfaces visually match the Inspector. Both now
-    // use QPalette::Window for the surface and QPalette::Base only for
-    // input fields. inputColor / headerColor mirror the Inspector's
-    // PropertiesPanelController API so themed controls (ThemedTextField,
-    // ThemedComboBox, ThemedCheckBox) read from the same vocabulary.
-    m_backgroundColor = palette.color(QPalette::Window);
-    m_panelColor = palette.color(QPalette::Window);
-    m_inputColor = palette.color(QPalette::Base);
-    m_headerColor = palette.color(QPalette::Window).darker(110);
-    m_textColor = palette.color(QPalette::WindowText);
-    m_borderColor = palette.color(QPalette::Mid);
-    m_highlightColor = palette.color(QPalette::Highlight);
-    m_buttonColor = palette.color(QPalette::Button);
-    m_buttonTextColor = palette.color(QPalette::ButtonText);
-    m_disabledTextColor = palette.color(QPalette::PlaceholderText);
-    m_accentColor = palette.color(QPalette::Highlight);
-    
+    // Track runtime palette swaps (Options → Theme: Light/Dark/Custom).
+    // Without this, opening the Material Editor in a separate
+    // QQmlApplicationEngine left the window stuck on whatever palette
+    // existed when the singleton was first cached — most visibly broken
+    // on Linux/Fusion where the Material Editor opened light while the
+    // rest of the app was dark.
+    if (qApp) {
+        connect(qApp, &QApplication::paletteChanged, this, [this]() {
+            emit themeChanged();
+        });
+    }
+
     // Initialize material color properties with defaults
     m_ambientColor = QColor(128, 128, 128);  // Gray
     m_diffuseColor = QColor(255, 255, 255);  // White
@@ -127,6 +118,67 @@ MaterialEditorQML* MaterialEditorQML::qmlInstance(QQmlEngine *engine, QJSEngine 
     // independently, and without this a later engine could delete the shared instance
     QQmlEngine::setObjectOwnership(instance, QQmlEngine::CppOwnership);
     return instance;
+}
+
+// -----------------------------------------------------------------------
+// Theme color getters — derive live from QApplication::palette() so the
+// Material Editor follows runtime Light/Dark/Custom palette swaps. The
+// role mapping matches PropertiesPanelController / ThemeManager so the
+// Material Editor and the Inspector keep a single palette vocabulary.
+// -----------------------------------------------------------------------
+QColor MaterialEditorQML::backgroundColor() const
+{
+    return QApplication::palette().color(QPalette::Window);
+}
+
+QColor MaterialEditorQML::panelColor() const
+{
+    return QApplication::palette().color(QPalette::Window);
+}
+
+QColor MaterialEditorQML::inputColor() const
+{
+    return QApplication::palette().color(QPalette::Base);
+}
+
+QColor MaterialEditorQML::headerColor() const
+{
+    return QApplication::palette().color(QPalette::Window).darker(110);
+}
+
+QColor MaterialEditorQML::textColor() const
+{
+    return QApplication::palette().color(QPalette::WindowText);
+}
+
+QColor MaterialEditorQML::borderColor() const
+{
+    return QApplication::palette().color(QPalette::Mid);
+}
+
+QColor MaterialEditorQML::highlightColor() const
+{
+    return QApplication::palette().color(QPalette::Highlight);
+}
+
+QColor MaterialEditorQML::buttonColor() const
+{
+    return QApplication::palette().color(QPalette::Button);
+}
+
+QColor MaterialEditorQML::buttonTextColor() const
+{
+    return QApplication::palette().color(QPalette::ButtonText);
+}
+
+QColor MaterialEditorQML::disabledTextColor() const
+{
+    return QApplication::palette().color(QPalette::PlaceholderText);
+}
+
+QColor MaterialEditorQML::accentColor() const
+{
+    return QApplication::palette().color(QPalette::Highlight);
 }
 
 void MaterialEditorQML::loadMaterial(const QString &materialName)

--- a/src/MaterialEditorQML.h
+++ b/src/MaterialEditorQML.h
@@ -108,18 +108,23 @@ class MaterialEditorQML : public QObject
     Q_PROPERTY(int environmentMapping READ environmentMapping WRITE setEnvironmentMapping NOTIFY environmentMappingChanged)
     Q_PROPERTY(double rotateAnimSpeed READ rotateAnimSpeed WRITE setRotateAnimSpeed NOTIFY rotateAnimSpeedChanged)
 
-    // Theme color properties
-    Q_PROPERTY(QColor backgroundColor READ backgroundColor CONSTANT)
-    Q_PROPERTY(QColor panelColor READ panelColor CONSTANT)
-    Q_PROPERTY(QColor inputColor READ inputColor CONSTANT)
-    Q_PROPERTY(QColor headerColor READ headerColor CONSTANT)
-    Q_PROPERTY(QColor textColor READ textColor CONSTANT)
-    Q_PROPERTY(QColor borderColor READ borderColor CONSTANT)
-    Q_PROPERTY(QColor highlightColor READ highlightColor CONSTANT)
-    Q_PROPERTY(QColor buttonColor READ buttonColor CONSTANT)
-    Q_PROPERTY(QColor buttonTextColor READ buttonTextColor CONSTANT)
-    Q_PROPERTY(QColor disabledTextColor READ disabledTextColor CONSTANT)
-    Q_PROPERTY(QColor accentColor READ accentColor CONSTANT)
+    // Theme color properties — derived live from QApplication::palette()
+    // so the Material Editor follows runtime dark/light/custom switches
+    // (the previous CONSTANT variant cached colors at first construction,
+    // which left a separate-engine ApplicationWindow stuck on whatever
+    // palette was active when the singleton was first instantiated and
+    // broke dark mode on Linux + Fusion).
+    Q_PROPERTY(QColor backgroundColor READ backgroundColor NOTIFY themeChanged)
+    Q_PROPERTY(QColor panelColor READ panelColor NOTIFY themeChanged)
+    Q_PROPERTY(QColor inputColor READ inputColor NOTIFY themeChanged)
+    Q_PROPERTY(QColor headerColor READ headerColor NOTIFY themeChanged)
+    Q_PROPERTY(QColor textColor READ textColor NOTIFY themeChanged)
+    Q_PROPERTY(QColor borderColor READ borderColor NOTIFY themeChanged)
+    Q_PROPERTY(QColor highlightColor READ highlightColor NOTIFY themeChanged)
+    Q_PROPERTY(QColor buttonColor READ buttonColor NOTIFY themeChanged)
+    Q_PROPERTY(QColor buttonTextColor READ buttonTextColor NOTIFY themeChanged)
+    Q_PROPERTY(QColor disabledTextColor READ disabledTextColor NOTIFY themeChanged)
+    Q_PROPERTY(QColor accentColor READ accentColor NOTIFY themeChanged)
 
     // Undo/Redo properties
     Q_PROPERTY(bool canUndo READ canUndo NOTIFY undoRedoStateChanged)
@@ -221,18 +226,19 @@ public:
     int environmentMapping() const { return m_environmentMapping; }
     double rotateAnimSpeed() const { return m_rotateAnimSpeed; }
 
-    // Theme color getters
-    QColor backgroundColor() const { return m_backgroundColor; }
-    QColor panelColor() const { return m_panelColor; }
-    QColor inputColor() const { return m_inputColor; }
-    QColor headerColor() const { return m_headerColor; }
-    QColor textColor() const { return m_textColor; }
-    QColor borderColor() const { return m_borderColor; }
-    QColor highlightColor() const { return m_highlightColor; }
-    QColor buttonColor() const { return m_buttonColor; }
-    QColor buttonTextColor() const { return m_buttonTextColor; }
-    QColor disabledTextColor() const { return m_disabledTextColor; }
-    QColor accentColor() const { return m_accentColor; }
+    // Theme color getters — read the live QApplication::palette() so the
+    // Material Editor tracks runtime palette swaps (Light/Dark/Custom).
+    QColor backgroundColor() const;
+    QColor panelColor() const;
+    QColor inputColor() const;
+    QColor headerColor() const;
+    QColor textColor() const;
+    QColor borderColor() const;
+    QColor highlightColor() const;
+    QColor buttonColor() const;
+    QColor buttonTextColor() const;
+    QColor disabledTextColor() const;
+    QColor accentColor() const;
 
     // Undo/Redo getters
     bool canUndo() const { return m_undoStack.size() > 0; }
@@ -582,6 +588,10 @@ signals:
     void sdGenerationError(const QString &error);
     void sdPendingForMaterialChanged();
 
+    // Theme palette signal — fired when QApplication::paletteChanged so
+    // QML bindings on backgroundColor/panelColor/textColor/… refresh.
+    void themeChanged();
+
 private:
     void updateTechniqueList();
     void updatePassList();
@@ -717,22 +727,6 @@ private slots:
     void onSDModelLoadedChanged();
 #endif
 
-private:
-    // Theme color properties (defaults used if palette read fails or in tests)
-    QColor m_backgroundColor{240, 240, 240};
-    QColor m_panelColor{255, 255, 255};
-    // Slice I: input field background — matches the Inspector's "inputColor".
-    QColor m_inputColor{255, 255, 255};
-    // Slice I: section/button header surface — matches the Inspector's
-    // "headerColor" (panel background, slightly darker for hairline contrast).
-    QColor m_headerColor{220, 220, 220};
-    QColor m_textColor{0, 0, 0};
-    QColor m_borderColor{128, 128, 128};
-    QColor m_highlightColor{0, 120, 215};
-    QColor m_buttonColor{225, 225, 225};
-    QColor m_buttonTextColor{0, 0, 0};
-    QColor m_disabledTextColor{128, 128, 128};
-    QColor m_accentColor{0, 120, 215};
 };
 
 #endif // MATERIALEDITORQML_H 

--- a/src/ScanConfig.h
+++ b/src/ScanConfig.h
@@ -60,8 +60,8 @@ struct ScanConfig {
     // destructive (it rewrites the FBX with a new keyframe distribution
     // and drops redundant samples), so the rule only fires — and the
     // `--fix` path only runs — when the user explicitly sets the
-    // threshold in their `qtmesh.yml`/`.json` config. To enable the
-    // default behavior, set `redundant_keyframes_pct: 40` in the config.
+    // threshold in their `qtmesh.yml`/`.json` config. To restore the
+    // previous behavior, set `redundant_keyframes_pct: 40` in the config.
     double redundantKeyframesPctThreshold = 0.0; // 0 = disabled; opt in via qtmesh.yml to warn / auto-simplify
     double redundantKeyframesTranslationTol = 1e-3;  // Balanced preset (~1mm)
     double redundantKeyframesRotationDegTol = 0.5;

--- a/src/ScanConfig.h
+++ b/src/ScanConfig.h
@@ -54,8 +54,15 @@ struct ScanConfig {
 
     // Redundant-keyframe detection. When enabled, the scanner analyzes each
     // animation's keyframes and warns if a meaningful share could be safely
-    // removed via tolerance-based simplification. Defaults disable the check.
-    double redundantKeyframesPctThreshold = 40.0; // 0 = disabled; default warns at >=40% redundant keys
+    // removed via tolerance-based simplification.
+    //
+    // Opt-in: defaults to 0.0 (disabled). The simplify auto-fix is
+    // destructive (it rewrites the FBX with a new keyframe distribution
+    // and drops redundant samples), so the rule only fires — and the
+    // `--fix` path only runs — when the user explicitly sets the
+    // threshold in their `qtmesh.yml`/`.json` config. To enable the
+    // default behavior, set `redundant_keyframes_pct: 40` in the config.
+    double redundantKeyframesPctThreshold = 0.0; // 0 = disabled; opt in via qtmesh.yml to warn / auto-simplify
     double redundantKeyframesTranslationTol = 1e-3;  // Balanced preset (~1mm)
     double redundantKeyframesRotationDegTol = 0.5;
     double redundantKeyframesScaleTol = 1e-3;

--- a/src/ScanEngine_test.cpp
+++ b/src/ScanEngine_test.cpp
@@ -237,7 +237,10 @@ TEST(ScanConfigTest, YamlExplicitInclude_DoesNotDuplicatePly)
 TEST(ScanConfigTest, DefaultConstructorIncludesAssimpGlobPatterns)
 {
     const ScanConfig c;
-    EXPECT_DOUBLE_EQ(c.redundantKeyframesPctThreshold, 40.0);
+    // Redundant-keyframe / simplify rule is opt-in by default — the
+    // auto-fix is destructive (rewrites the FBX), so it should never
+    // run unless the user explicitly enables it in qtmesh.yml.
+    EXPECT_DOUBLE_EQ(c.redundantKeyframesPctThreshold, 0.0);
     EXPECT_GT(c.includePatterns.size(), 8);
     bool hasMeshGlob = false;
     bool hasFbxGlob = false;

--- a/website/src/hooks/useQtmeshActionRef.js
+++ b/website/src/hooks/useQtmeshActionRef.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 const QTMESH_RELEASES_LATEST_API = 'https://api.github.com/repos/fernandotonon/QtMeshEditor/releases/latest';
-const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.0.0';
+const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.0.1';
 const CACHE_KEY = 'qtmesh.actionRef.cache.v1';
 const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 


### PR DESCRIPTION
## Summary

- **Material Editor dark mode (Linux)** — the editor opened light while the rest of the app was dark on Linux/Fusion. `MaterialEditorQML`'s theme color properties were `CONSTANT` and cached at first construction, so the standalone `QQmlApplicationEngine` that hosts the editor window got stuck on whatever palette was active when the singleton was first instantiated. Switched the 11 theme color `Q_PROPERTY`s to `NOTIFY themeChanged`, made the getters read the live `QApplication::palette()`, and emit `themeChanged` on `QApplication::paletteChanged` — matching the existing `ThemeManager` / `PropertiesPanelController` / `AnimationControlController` pattern.
- **Scan `simplify` is now opt-in** — `redundant_keyframes_pct` (the rule the `qtmesh scan ... --fix` path uses to rewrite FBX files via `AnimationMerger::simplifyAnimation`) used to run by default at a 40% threshold. Since the auto-fix is destructive, the default is now `0.0` (disabled). The rule fires (and `--fix` applies) only when the user explicitly sets the threshold in `qtmesh.yml`. `qtmesh.example.yml` now documents the opt-in knob with a commented-out example.
- Version bumped to **3.0.1**, README + website action pins synced via `scripts/sync-doc-versions-from-cmake.sh`.

## Test plan
- [x] `MaterialEditorQML*` suite (206 tests) passes under headless Xvfb.
- [x] `ScanConfigTest*` + `ScanEngineTest.EvaluateRules_RedundantKeyframes*` + `ScanEngineTest.ApplyFixes_RedundantKeyframesPctDryRun` pass.
- [x] `ThemeManagerTests`, `PropertiesPanelControllerTests`, `AnimationControlControllerTests` still pass (no regression in shared palette plumbing).
- [x] Full `ScanEngineTest.*` (79 tests) green.
- [ ] Manual: open Material Editor on Linux with Dark theme active → window is dark; switch to Light at runtime → editor surfaces refresh to light.
- [ ] Manual: `qtmesh scan ./assets` with no config → no `redundant_keyframes_pct` findings; with `redundant_keyframes_pct: 40` in `qtmesh.yml` → warnings appear and `--fix` simplifies as before.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Material editor theme now updates live with system/app palette changes.

* **Chores**
  * Release version updated to 3.0.1.
  * Default keyframe simplification is now opt-in to avoid destructive automatic changes.

* **Documentation**
  * CI/workflow examples and docs updated to reference the new release.
  * Added a disabled example config block documenting the optional simplification rule.

* **Tests**
  * Tests updated to reflect the new opt-in default.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/495)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->