### PR TITLE
feat(perf): single-pass mesh decimation (Phase 6 slice D)

### DIFF
--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -1665,8 +1665,9 @@ Rectangle {
             padding: 8
             spacing: 6
 
-            // Slider state — 0..0.95. Default 0.5 = halve the mesh.
-            property real reduction: 0.5
+            // Slider state — 0..0.95. Default 0 = no change, so opening the
+            // section doesn't already preview a reduction.
+            property real reduction: 0.0
 
             // Ensure baseTriangleCount is populated when the section is opened
             // for the first time — the controller's selectionChanged hook
@@ -1688,7 +1689,7 @@ Rectangle {
             Connections {
                 target: MeshDecimatorController
                 function onSelectionChanged() {
-                    decimateContent.reduction = 0.5
+                    decimateContent.reduction = 0.0
                     decimateFeedback.text = ""
                 }
                 function onApplied(before, after) {

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -361,6 +361,17 @@ Rectangle {
                 Component.onCompleted: content = lodComponent
             }
 
+            // ---- Decimate (single-pass) ----
+            CollapsibleSection {
+                title: "Decimate (single-pass)"
+                sectionVisible: root.modeToolSectionVisible(
+                    EditorModeController.ObjectMode,
+                    MeshDecimatorController.hasSelection)
+                expanded: false
+
+                Component.onCompleted: content = decimateComponent
+            }
+
             // ---- Material Editor (Material mode) ----
             CollapsibleSection {
                 title: "Material Editor"
@@ -1637,6 +1648,147 @@ Rectangle {
                         lodFeedback.text = ""
                     }
                 }
+            }
+        }
+    }
+
+    // ---- Decimate (single-pass) — Phase 6 slice D ----
+    // Live slider + preview that swaps a temporary LOD into the viewport,
+    // mirroring the LOD section's previewLod pattern but for one-shot
+    // base-mesh reduction. Apply commits the swap permanently.
+    Component {
+        id: decimateComponent
+
+        Column {
+            id: decimateContent
+            width: parent ? parent.width : 200
+            padding: 8
+            spacing: 6
+
+            // Slider state — 0..0.95. Default 0.5 = halve the mesh.
+            property real reduction: 0.5
+
+            // Debounce the preview regenerator so the slider doesn't melt
+            // Ogre with a per-pixel LOD rebuild.
+            Timer {
+                id: previewDebounce
+                interval: 150
+                repeat: false
+                onTriggered: MeshDecimatorController.previewReduction(decimateContent.reduction)
+            }
+
+            // Reset reduction back to the default when selection changes
+            // so the slider doesn't carry a stale value across meshes.
+            Connections {
+                target: MeshDecimatorController
+                function onSelectionChanged() {
+                    decimateContent.reduction = 0.5
+                    decimateFeedback.text = ""
+                }
+                function onApplied(before, after) {
+                    decimateFeedback.color = "#60c060"
+                    decimateFeedback.text = "Decimated: " + before.toLocaleString() +
+                                            " → " + after.toLocaleString() + " triangles"
+                }
+                function onError(msg) {
+                    decimateFeedback.color = "#c06060"
+                    decimateFeedback.text = msg
+                }
+            }
+
+            Text {
+                width: parent.width - 16
+                text: "Single-pass reduction of the base mesh. Drag to preview, click Apply to commit."
+                wrapMode: Text.Wrap
+                color: PropertiesPanelController.textColor
+                font.pixelSize: 10
+            }
+
+            // Reduction percent slider
+            Row {
+                spacing: 6; width: parent.width - 16
+                Text {
+                    text: "Reduce:"
+                    width: 50
+                    color: PropertiesPanelController.textColor; font.pixelSize: 11
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+                Slider {
+                    id: decimateSlider
+                    from: 0.0; to: 0.95; stepSize: 0.05
+                    value: decimateContent.reduction
+                    width: parent.width - 130
+                    anchors.verticalCenter: parent.verticalCenter
+                    onValueChanged: {
+                        decimateContent.reduction = value
+                        previewDebounce.restart()
+                    }
+                }
+                Text {
+                    text: Math.round(decimateContent.reduction * 100) + "%"
+                    width: 40
+                    color: PropertiesPanelController.textColor; font.pixelSize: 11
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+            }
+
+            // Live tri-count display: base → preview.
+            Row {
+                spacing: 8; width: parent.width - 16
+                Text {
+                    text: "Tris:"
+                    color: PropertiesPanelController.textColor; font.pixelSize: 10
+                    width: 50
+                }
+                Text {
+                    text: MeshDecimatorController.baseTriangleCount.toLocaleString()
+                    color: Qt.lighter(PropertiesPanelController.textColor, 0.8)
+                    font.pixelSize: 10
+                }
+                Text {
+                    visible: MeshDecimatorController.hasActivePreview
+                    text: "→ " + MeshDecimatorController.previewTriangleCount.toLocaleString()
+                    color: "#5090d0"; font.pixelSize: 10
+                }
+            }
+
+            // Apply / Reset row
+            Row {
+                spacing: 6; width: parent.width - 16
+
+                Rectangle {
+                    width: 110; height: 28; radius: 3
+                    color: applyMouse.pressed ? Qt.darker(PropertiesPanelController.highlightColor, 1.2)
+                         : applyMouse.containsMouse ? Qt.lighter(PropertiesPanelController.highlightColor, 1.1)
+                         : PropertiesPanelController.highlightColor
+                    Text { anchors.centerIn: parent; text: "Apply"; color: "white"; font.pixelSize: 12 }
+                    MouseArea {
+                        id: applyMouse; anchors.fill: parent; hoverEnabled: true
+                        onClicked: MeshDecimatorController.applyReduction(decimateContent.reduction)
+                    }
+                }
+
+                Rectangle {
+                    width: 110; height: 28; radius: 3
+                    visible: MeshDecimatorController.hasActivePreview
+                    color: resetMouse.pressed ? "#705050"
+                         : resetMouse.containsMouse ? "#806060"
+                         : "#604040"
+                    Text { anchors.centerIn: parent; text: "Reset Preview"; color: "white"; font.pixelSize: 11 }
+                    MouseArea {
+                        id: resetMouse; anchors.fill: parent; hoverEnabled: true
+                        onClicked: MeshDecimatorController.clearPreview()
+                    }
+                }
+            }
+
+            Text {
+                id: decimateFeedback
+                width: parent.width - 16
+                wrapMode: Text.Wrap
+                font.pixelSize: 10
+                color: "#60c060"
+                text: ""
             }
         }
     }

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -1668,6 +1668,12 @@ Rectangle {
             // Slider state — 0..0.95. Default 0.5 = halve the mesh.
             property real reduction: 0.5
 
+            // Ensure baseTriangleCount is populated when the section is opened
+            // for the first time — the controller's selectionChanged hook
+            // doesn't fire if the user had a selection before the singleton
+            // was instantiated.
+            Component.onCompleted: MeshDecimatorController.primeBaseline()
+
             // Debounce the preview regenerator so the slider doesn't melt
             // Ogre with a per-pixel LOD rebuild.
             Timer {

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -3643,6 +3643,33 @@ bool parseStrictDouble(const QString& flag, const QString& raw, double& out)
     return true;
 }
 
+// Apply one argv[i] token to `out`. `i` is updated when a value-taking flag
+// consumes its successor. Returns 1 on success, 0 on parse error.
+int applyDecimateArg(const QString& arg, int argc, char* argv[], int& i,
+                     DecimateCmdArgs& out)
+{
+    if (arg == "decimate" || arg == "--cli") return 1;
+    if (arg == "--json")          { out.jsonOutput = true; return 1; }
+    if (arg == "-o" && i < argc)  { out.outputPath = argv[i++]; return 1; }
+    if (arg == "--reduction" && i < argc) {
+        return parseStrictDouble("--reduction",
+                                 QString::fromLocal8Bit(argv[i++]),
+                                 out.reduction) ? 1 : 0;
+    }
+    if (arg == "--target-tris" && i < argc) {
+        return parseStrictInt("--target-tris",
+                              QString::fromLocal8Bit(argv[i++]),
+                              out.targetTris) ? 1 : 0;
+    }
+    if (arg == "--target-verts" && i < argc) {
+        return parseStrictInt("--target-verts",
+                              QString::fromLocal8Bit(argv[i++]),
+                              out.targetVerts) ? 1 : 0;
+    }
+    if (!arg.startsWith("-") && out.filePath.isEmpty()) out.filePath = arg;
+    return 1;
+}
+
 // Returns 1 on success, 0 on usage error (callers should return 2).
 int parseDecimateArgs(int argc, char* argv[], DecimateCmdArgs& out)
 {
@@ -3650,37 +3677,16 @@ int parseDecimateArgs(int argc, char* argv[], DecimateCmdArgs& out)
     while (i < argc) {
         const QString arg(argv[i]);
         ++i;
-        if (arg == "decimate" || arg == "--cli") continue;
-        if (arg == "--json")               { out.jsonOutput = true; continue; }
-        if (arg == "-o" && i < argc)       { out.outputPath = argv[i++]; continue; }
-        if (arg == "--reduction" && i < argc) {
-            if (!parseStrictDouble("--reduction",
-                                   QString::fromLocal8Bit(argv[i++]),
-                                   out.reduction)) return 0;
-            continue;
-        }
-        if (arg == "--target-tris" && i < argc) {
-            if (!parseStrictInt("--target-tris",
-                                QString::fromLocal8Bit(argv[i++]),
-                                out.targetTris)) return 0;
-            continue;
-        }
-        if (arg == "--target-verts" && i < argc) {
-            if (!parseStrictInt("--target-verts",
-                                QString::fromLocal8Bit(argv[i++]),
-                                out.targetVerts)) return 0;
-            continue;
-        }
-        if (!arg.startsWith("-") && out.filePath.isEmpty()) out.filePath = arg;
+        if (applyDecimateArg(arg, argc, argv, i, out) == 0) return 0;
     }
     if (out.filePath.isEmpty()) return 0;
 
     // Enforce exactly one target mode — "at least one" lets the user pass
     // ambiguous combinations like --reduction 0.5 --target-tris 1000.
-    const int modesProvided = (out.reduction >= 0.0 ? 1 : 0)
-                            + (out.targetTris >= 0 ? 1 : 0)
-                            + (out.targetVerts >= 0 ? 1 : 0);
-    if (modesProvided > 1) {
+    if (const int modesProvided = (out.reduction >= 0.0 ? 1 : 0)
+                                + (out.targetTris >= 0 ? 1 : 0)
+                                + (out.targetVerts >= 0 ? 1 : 0);
+        modesProvided > 1) {
         err() << "Error: pass exactly one of --reduction / --target-tris / --target-verts."
               << Qt::endl;
         return 0;

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -3749,6 +3749,21 @@ int CLIPipeline::cmdDecimate(int argc, char* argv[])
         return 1;
     }
 
+    // Refuse to overwrite the source asset. The earlier error promises we
+    // never do this; enforce it by comparing canonical paths (handles
+    // symlinks and relative paths). When the output file doesn't exist yet,
+    // QFileInfo::canonicalFilePath() returns empty — fall back to absolute.
+    const QFileInfo outFi(cmdArgs.outputPath);
+    const QString inCanon = fi.canonicalFilePath().isEmpty()
+                                ? fi.absoluteFilePath() : fi.canonicalFilePath();
+    const QString outCanon = outFi.canonicalFilePath().isEmpty()
+                                ? outFi.absoluteFilePath() : outFi.canonicalFilePath();
+    if (inCanon == outCanon) {
+        err() << "Error: -o points to the input file. Decimation is destructive; "
+                 "choose a different output path." << Qt::endl;
+        return 2;
+    }
+
     if (!initOgreHeadless()) return 1;
 
     SentryReporter::addBreadcrumb("cli.decimate",
@@ -3760,6 +3775,16 @@ int CLIPipeline::cmdDecimate(int argc, char* argv[])
     const auto& entities = Manager::getSingleton()->getEntities();
     if (entities.isEmpty()) {
         err() << "Error: Failed to load file: " << cmdArgs.filePath << Qt::endl;
+        return 1;
+    }
+    // Multi-entity scenes: refuse rather than silently decimate the first
+    // entity and exporting a partially-reduced scene. Whole-scene decimation
+    // is a future-slice feature; today's contract is one entity, one output.
+    if (entities.size() > 1) {
+        err() << "Error: " << cmdArgs.filePath << " contains "
+              << entities.size() << " mesh entities. qtmesh decimate currently "
+              << "supports one entity per file — split the source or run a "
+              << "follow-up scene-decimation slice when that lands." << Qt::endl;
         return 1;
     }
 
@@ -3784,7 +3809,7 @@ int CLIPipeline::cmdDecimate(int argc, char* argv[])
     }
 
     const auto* node = entity->getParentSceneNode();
-    const QFileInfo outFi(cmdArgs.outputPath);
+    // outFi already declared earlier (canonical-path guard); reuse it.
     const QString fmt = formatForExtension(cmdArgs.outputPath);
     SentryReporter::addBreadcrumb("file.export",
         QString("Exporting %1").arg(outFi.absoluteFilePath()));

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -3615,7 +3615,36 @@ struct DecimateCmdArgs {
     int targetVerts = -1;
 };
 
-bool parseDecimateArgs(int argc, char* argv[], DecimateCmdArgs& out)
+// Parse a numeric --target-* flag strictly: any non-numeric input (e.g. a
+// typo like `--target-tris foo`) is rejected with an error rather than
+// silently falling through to 0 (which clampReduction would interpret as a
+// 95% reduction — a destructive mismatch). Returns true on success.
+bool parseStrictInt(const QString& flag, const QString& raw, int& out)
+{
+    bool ok = false;
+    const int v = raw.toInt(&ok);
+    if (!ok) {
+        err() << "Error: " << flag << " expects an integer, got: " << raw << Qt::endl;
+        return false;
+    }
+    out = v;
+    return true;
+}
+
+bool parseStrictDouble(const QString& flag, const QString& raw, double& out)
+{
+    bool ok = false;
+    const double v = raw.toDouble(&ok);
+    if (!ok) {
+        err() << "Error: " << flag << " expects a number, got: " << raw << Qt::endl;
+        return false;
+    }
+    out = v;
+    return true;
+}
+
+// Returns 1 on success, 0 on usage error (callers should return 2).
+int parseDecimateArgs(int argc, char* argv[], DecimateCmdArgs& out)
 {
     int i = 1;
     while (i < argc) {
@@ -3625,20 +3654,38 @@ bool parseDecimateArgs(int argc, char* argv[], DecimateCmdArgs& out)
         if (arg == "--json")               { out.jsonOutput = true; continue; }
         if (arg == "-o" && i < argc)       { out.outputPath = argv[i++]; continue; }
         if (arg == "--reduction" && i < argc) {
-            out.reduction = QString::fromLocal8Bit(argv[i++]).toDouble();
+            if (!parseStrictDouble("--reduction",
+                                   QString::fromLocal8Bit(argv[i++]),
+                                   out.reduction)) return 0;
             continue;
         }
         if (arg == "--target-tris" && i < argc) {
-            out.targetTris = QString::fromLocal8Bit(argv[i++]).toInt();
+            if (!parseStrictInt("--target-tris",
+                                QString::fromLocal8Bit(argv[i++]),
+                                out.targetTris)) return 0;
             continue;
         }
         if (arg == "--target-verts" && i < argc) {
-            out.targetVerts = QString::fromLocal8Bit(argv[i++]).toInt();
+            if (!parseStrictInt("--target-verts",
+                                QString::fromLocal8Bit(argv[i++]),
+                                out.targetVerts)) return 0;
             continue;
         }
         if (!arg.startsWith("-") && out.filePath.isEmpty()) out.filePath = arg;
     }
-    return !out.filePath.isEmpty();
+    if (out.filePath.isEmpty()) return 0;
+
+    // Enforce exactly one target mode — "at least one" lets the user pass
+    // ambiguous combinations like --reduction 0.5 --target-tris 1000.
+    const int modesProvided = (out.reduction >= 0.0 ? 1 : 0)
+                            + (out.targetTris >= 0 ? 1 : 0)
+                            + (out.targetVerts >= 0 ? 1 : 0);
+    if (modesProvided > 1) {
+        err() << "Error: pass exactly one of --reduction / --target-tris / --target-verts."
+              << Qt::endl;
+        return 0;
+    }
+    return 1;
 }
 
 double resolveReduction(const DecimateCmdArgs& args, int currentTris, int currentVerts)
@@ -3669,11 +3716,15 @@ void emitDecimationReport(const DecimationReport& report, const QFileInfo& fi,
 int CLIPipeline::cmdDecimate(int argc, char* argv[])
 {
     DecimateCmdArgs cmdArgs;
-    if (!parseDecimateArgs(argc, argv, cmdArgs)) {
-        err() << "Error: No input file specified." << Qt::endl;
-        err() << "Usage: qtmesh decimate <file> -o <output> "
-                 "(--reduction <r> | --target-tris N | --target-verts N) [--json]"
-              << Qt::endl;
+    if (parseDecimateArgs(argc, argv, cmdArgs) == 0) {
+        // parseDecimateArgs already printed a specific error to err() — only
+        // emit the generic usage banner when no file was given at all.
+        if (cmdArgs.filePath.isEmpty()) {
+            err() << "Error: No input file specified." << Qt::endl;
+            err() << "Usage: qtmesh decimate <file> -o <output> "
+                     "(--reduction <r> | --target-tris N | --target-verts N) [--json]"
+                  << Qt::endl;
+        }
         return 2;
     }
     if (cmdArgs.outputPath.isEmpty()) {
@@ -3709,16 +3760,9 @@ int CLIPipeline::cmdDecimate(int argc, char* argv[])
     Ogre::Entity* entity = entities.first();
 
     // Count current tris / verts to resolve target-based reductions.
-    int currentTris = 0, currentVerts = 0;
-    if (Ogre::MeshPtr mesh = entity->getMesh()) {
-        for (unsigned int s = 0; s < mesh->getNumSubMeshes(); ++s) {
-            const Ogre::SubMesh* sub = mesh->getSubMesh(s);
-            if (!sub) continue;
-            if (sub->indexData) currentTris += static_cast<int>(sub->indexData->indexCount / 3);
-            if (sub->vertexData) currentVerts += static_cast<int>(sub->vertexData->vertexCount);
-        }
-        if (mesh->sharedVertexData) currentVerts += static_cast<int>(mesh->sharedVertexData->vertexCount);
-    }
+    int currentTris = 0;
+    int currentVerts = 0;
+    MeshDecimator::countBaseline(entity, currentTris, currentVerts);
 
     const double reduction = resolveReduction(cmdArgs, currentTris, currentVerts);
     if (reduction <= 0.0) {
@@ -3733,7 +3777,7 @@ int CLIPipeline::cmdDecimate(int argc, char* argv[])
         return 1;
     }
 
-    auto* node = entity->getParentSceneNode();
+    const auto* node = entity->getParentSceneNode();
     const QFileInfo outFi(cmdArgs.outputPath);
     const QString fmt = formatForExtension(cmdArgs.outputPath);
     SentryReporter::addBreadcrumb("file.export",

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -15,6 +15,7 @@
 #include "MemoryEstimator.h"
 #include "DrawCallAnalyzer.h"
 #include "VertexCacheOptimizer.h"
+#include "MeshDecimator.h"
 #include "QtMeshCloudClient.h"
 #include <OgreMaterialSerializer.h>
 #include <QApplication>
@@ -616,6 +617,10 @@ void CLIPipeline::printUsage()
         "  vertex-cache <file> [-o <output>] [--json]\n"
         "                                    Reorder index buffers via Forsyth's algorithm; reports\n"
         "                                    before/after ACMR. Without -o, only analyzes (read-only).\n"
+        "  decimate <file> -o <output> (--reduction <r> | --target-tris N | --target-verts N) [--json]\n"
+        "                                    Single-pass mesh decimation. Choose one target:\n"
+        "                                    --reduction 0.5 (drop half the triangles),\n"
+        "                                    --target-tris 5000, or --target-verts 2500.\n"
         "\n"
         "Global options:\n"
         "  --help, -h            Show this help\n"
@@ -981,6 +986,7 @@ int CLIPipeline::run(int argc, char* argv[])
     else if (cmd == "memory") rc = cmdMemory(argc, argv);
     else if (cmd == "analyze") rc = cmdAnalyze(argc, argv);
     else if (cmd == "vertex-cache") rc = cmdVertexCache(argc, argv);
+    else if (cmd == "decimate") rc = cmdDecimate(argc, argv);
 
     if (rc < 0) {
         err() << "Error: Unknown command '" << cmd << "'" << Qt::endl;
@@ -3595,5 +3601,151 @@ int CLIPipeline::cmdVertexCache(int argc, char* argv[])
     }
 
     emitVertexCacheReport(aggregate, fi, cmdArgs.outputPath, cmdArgs.jsonOutput);
+    return 0;
+}
+
+namespace {
+
+struct DecimateCmdArgs {
+    QString filePath;
+    QString outputPath;
+    bool jsonOutput = false;
+    double reduction = -1.0;  // -1 = unset (only one of reduction / targetTris / targetVerts wins)
+    int targetTris = -1;
+    int targetVerts = -1;
+};
+
+bool parseDecimateArgs(int argc, char* argv[], DecimateCmdArgs& out)
+{
+    int i = 1;
+    while (i < argc) {
+        const QString arg(argv[i]);
+        ++i;
+        if (arg == "decimate" || arg == "--cli") continue;
+        if (arg == "--json")               { out.jsonOutput = true; continue; }
+        if (arg == "-o" && i < argc)       { out.outputPath = argv[i++]; continue; }
+        if (arg == "--reduction" && i < argc) {
+            out.reduction = QString::fromLocal8Bit(argv[i++]).toDouble();
+            continue;
+        }
+        if (arg == "--target-tris" && i < argc) {
+            out.targetTris = QString::fromLocal8Bit(argv[i++]).toInt();
+            continue;
+        }
+        if (arg == "--target-verts" && i < argc) {
+            out.targetVerts = QString::fromLocal8Bit(argv[i++]).toInt();
+            continue;
+        }
+        if (!arg.startsWith("-") && out.filePath.isEmpty()) out.filePath = arg;
+    }
+    return !out.filePath.isEmpty();
+}
+
+double resolveReduction(const DecimateCmdArgs& args, int currentTris, int currentVerts)
+{
+    if (args.reduction >= 0.0)      return MeshDecimator::clampReduction(args.reduction);
+    if (args.targetTris >= 0)       return MeshDecimator::reductionFromTargetTris(currentTris, args.targetTris);
+    if (args.targetVerts >= 0)      return MeshDecimator::reductionFromTargetVerts(currentVerts, args.targetVerts);
+    return 0.0;
+}
+
+void emitDecimationReport(const DecimationReport& report, const QFileInfo& fi,
+                          const QString& outputPath, bool jsonOutput)
+{
+    if (jsonOutput) {
+        QJsonObject obj = MeshDecimator::toJson(report);
+        obj["file"] = fi.fileName();
+        obj["output"] = QFileInfo(outputPath).fileName();
+        cliWrite(QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Indented)));
+    } else {
+        cliWrite(QString("File: %1 -> %2\n")
+                     .arg(fi.fileName(), QFileInfo(outputPath).fileName()));
+        cliWrite(MeshDecimator::toText(report));
+    }
+}
+
+} // namespace
+
+int CLIPipeline::cmdDecimate(int argc, char* argv[])
+{
+    DecimateCmdArgs cmdArgs;
+    if (!parseDecimateArgs(argc, argv, cmdArgs)) {
+        err() << "Error: No input file specified." << Qt::endl;
+        err() << "Usage: qtmesh decimate <file> -o <output> "
+                 "(--reduction <r> | --target-tris N | --target-verts N) [--json]"
+              << Qt::endl;
+        return 2;
+    }
+    if (cmdArgs.outputPath.isEmpty()) {
+        err() << "Error: --output (-o) is required for decimate (this is a destructive op; "
+                 "we never overwrite the input)." << Qt::endl;
+        return 2;
+    }
+    if (cmdArgs.reduction < 0 && cmdArgs.targetTris < 0 && cmdArgs.targetVerts < 0) {
+        err() << "Error: provide one of --reduction <r>, --target-tris N, --target-verts N." << Qt::endl;
+        return 2;
+    }
+
+    const QFileInfo fi(cmdArgs.filePath);
+    if (!fi.exists()) {
+        err() << "Error: File not found: " << cmdArgs.filePath << Qt::endl;
+        return 1;
+    }
+
+    if (!initOgreHeadless()) return 1;
+
+    SentryReporter::addBreadcrumb("cli.decimate",
+        QString("Decimate .%1").arg(fi.suffix()));
+    SentryReporter::addBreadcrumb("file.import",
+        QString("Importing %1").arg(fi.absoluteFilePath()));
+
+    MeshImporterExporter::importer({fi.absoluteFilePath()}, 0);
+    const auto& entities = Manager::getSingleton()->getEntities();
+    if (entities.isEmpty()) {
+        err() << "Error: Failed to load file: " << cmdArgs.filePath << Qt::endl;
+        return 1;
+    }
+
+    Ogre::Entity* entity = entities.first();
+
+    // Count current tris / verts to resolve target-based reductions.
+    int currentTris = 0, currentVerts = 0;
+    if (Ogre::MeshPtr mesh = entity->getMesh()) {
+        for (unsigned int s = 0; s < mesh->getNumSubMeshes(); ++s) {
+            const Ogre::SubMesh* sub = mesh->getSubMesh(s);
+            if (!sub) continue;
+            if (sub->indexData) currentTris += static_cast<int>(sub->indexData->indexCount / 3);
+            if (sub->vertexData) currentVerts += static_cast<int>(sub->vertexData->vertexCount);
+        }
+        if (mesh->sharedVertexData) currentVerts += static_cast<int>(mesh->sharedVertexData->vertexCount);
+    }
+
+    const double reduction = resolveReduction(cmdArgs, currentTris, currentVerts);
+    if (reduction <= 0.0) {
+        err() << "Note: target equals or exceeds current count; nothing to do." << Qt::endl;
+        // Still produce a no-op output file so callers can rely on the path existing.
+    }
+
+    const DecimationReport report = MeshDecimator::decimateEntity(entity, reduction);
+    if (!report.applied && reduction > 0.0) {
+        err() << "Error: Decimation failed (MeshLodGenerator). The mesh may not be "
+                 "suitable for in-place reduction (e.g. zero index data)." << Qt::endl;
+        return 1;
+    }
+
+    auto* node = entity->getParentSceneNode();
+    const QFileInfo outFi(cmdArgs.outputPath);
+    const QString fmt = formatForExtension(cmdArgs.outputPath);
+    SentryReporter::addBreadcrumb("file.export",
+        QString("Exporting %1").arg(outFi.absoluteFilePath()));
+    if (MeshImporterExporter::exporter(node, outFi.absoluteFilePath(), fmt) != 0) {
+        SentryReporter::captureMessage(
+            QString("CLI decimate: export failed (.%1 -> .%2)")
+                .arg(fi.suffix(), outFi.suffix()), "error");
+        err() << "Error: Export failed." << Qt::endl;
+        return 1;
+    }
+
+    emitDecimationReport(report, fi, cmdArgs.outputPath, cmdArgs.jsonOutput);
     return 0;
 }

--- a/src/CLIPipeline.h
+++ b/src/CLIPipeline.h
@@ -94,6 +94,9 @@ public:
     /// Phase 6 slice C: vertex-cache (Forsyth) optimization. With -o, write
     /// the reordered mesh; without -o, analyze only.
     static int cmdVertexCache(int argc, char* argv[]);
+    /// Phase 6 slice D: single-pass mesh decimation. Reduce the base mesh
+    /// to a target triangle count, vertex budget, or percent reduction.
+    static int cmdDecimate(int argc, char* argv[]);
 
     /// Map file extension to MeshImporterExporter format string.
     static QString formatForExtension(const QString& path);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,6 +83,7 @@ MemoryEstimator.cpp
 DrawCallAnalyzer.cpp
 VertexCacheOptimizer.cpp
 MeshDecimator.cpp
+MeshDecimatorController.cpp
 MeshValidator.cpp
 AIChatManager.cpp
 WelcomeScreenController.cpp
@@ -173,6 +174,7 @@ MemoryEstimator.h
 DrawCallAnalyzer.h
 VertexCacheOptimizer.h
 MeshDecimator.h
+MeshDecimatorController.h
 MeshValidator.h
 AIChatManager.h
 WelcomeScreenController.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,6 +82,7 @@ NormalMapGenerator.cpp
 MemoryEstimator.cpp
 DrawCallAnalyzer.cpp
 VertexCacheOptimizer.cpp
+MeshDecimator.cpp
 MeshValidator.cpp
 AIChatManager.cpp
 WelcomeScreenController.cpp
@@ -171,6 +172,7 @@ NormalMapGenerator.h
 MemoryEstimator.h
 DrawCallAnalyzer.h
 VertexCacheOptimizer.h
+MeshDecimator.h
 MeshValidator.h
 AIChatManager.h
 WelcomeScreenController.h

--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -2867,7 +2867,7 @@ QJsonObject MCPServer::toolDecimateMesh(const QJsonObject &args)
         // Decimation is destructive — operate on the user's selection, not
         // an arbitrary scene entity. The previous "first entity in scene"
         // path could mutate the wrong asset in multi-mesh scenes.
-        SelectionSet* sel = SelectionSet::getSingleton();
+        const SelectionSet* sel = SelectionSet::getSingleton();
         const QList<Ogre::Entity*> selected = sel ? sel->getResolvedEntities()
                                                   : QList<Ogre::Entity*>{};
         if (selected.isEmpty())

--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -2829,72 +2829,77 @@ QJsonObject MCPServer::toolOptimizeVertexCache(const QJsonObject &args)
     }
 }
 
+namespace {
+
+// Translate the JSON args into a reduction fraction. Returns -1.0 when the
+// caller forgot to provide one of the three target keys; caller turns that
+// into a user-facing error.
+double resolveMcpReduction(const QJsonObject& args,
+                           int currentTris, int currentVerts)
+{
+    if (args.contains("reduction"))
+        return MeshDecimator::clampReduction(args.value("reduction").toDouble());
+    if (args.contains("target_tris"))
+        return MeshDecimator::reductionFromTargetTris(
+            currentTris, args.value("target_tris").toInt());
+    if (args.contains("target_verts"))
+        return MeshDecimator::reductionFromTargetVerts(
+            currentVerts, args.value("target_verts").toInt());
+    return -1.0;
+}
+
+} // namespace
+
 // NOSONAR(cpp:S5817) — ToolHandler is a non-const member-fn pointer (matching
 // every other tool method in this class); marking just this one const would
 // break the registry signature in MCPServer.h.
 QJsonObject MCPServer::toolDecimateMesh(const QJsonObject &args)
 {
     // Args (one wins, in priority order):
-    //   reduction (double 0..1) — drop this fraction of triangles
-    //   target_tris (int)       — reduce to approximately this many tris
-    //   target_verts (int)      — reduce to approximately this many verts
+    //   reduction (double 0..1)       — drop this fraction of triangles
+    //   target_tris (int)             — reduce to approximately this many tris
+    //   target_verts (int)            — reduce to approximately this many verts
     //   dry_run (bool, default false) — projected report only, no mutation
     try {
         if (const Manager* mgr = Manager::getSingletonPtr(); !mgr)
             return makeErrorResult("Error: Manager not available");
-        if (!hasSelectedEntities())
-            return makeErrorResult("No mesh selected. Load a mesh first with load_mesh.");
+
+        // Decimation is destructive — operate on the user's selection, not
+        // an arbitrary scene entity. The previous "first entity in scene"
+        // path could mutate the wrong asset in multi-mesh scenes.
+        SelectionSet* sel = SelectionSet::getSingleton();
+        const QList<Ogre::Entity*> selected = sel ? sel->getResolvedEntities()
+                                                  : QList<Ogre::Entity*>{};
+        if (selected.isEmpty())
+            return makeErrorResult(
+                "No mesh selected. Select the entity to decimate (load_mesh + click) first.");
+        Ogre::Entity* target = selected.first();
+        if (!target)
+            return makeErrorResult("Selected entity is null.");
 
         const bool dryRun = args.value("dry_run").toBool(false);
 
-        // Resolve the reduction. We need a target entity to convert target-
-        // tris/target-verts into a reduction fraction, so grab the first one.
-        Ogre::Entity* target = nullptr;
-        for (Ogre::SceneNode* node : Manager::getSingleton()->getSceneNodes()) {
-            if (!node) continue;
-            for (unsigned i = 0; i < node->numAttachedObjects(); ++i) {
-                Ogre::MovableObject* obj = node->getAttachedObject(i);
-                if (obj && obj->getMovableType() == "Entity") {
-                    target = static_cast<Ogre::Entity*>(obj);
-                    break;
-                }
-            }
-            if (target) break;
-        }
-        if (!target)
-            return makeErrorResult("No entity in scene to decimate.");
+        int currentTris = 0;
+        int currentVerts = 0;
+        MeshDecimator::countBaseline(target, currentTris, currentVerts);
 
-        // Count baseline tris/verts (mirrors cmdDecimate's count loop).
-        int currentTris = 0, currentVerts = 0;
-        if (Ogre::MeshPtr mesh = target->getMesh()) {
-            for (unsigned int s = 0; s < mesh->getNumSubMeshes(); ++s) {
-                const Ogre::SubMesh* sub = mesh->getSubMesh(s);
-                if (!sub) continue;
-                if (sub->indexData)
-                    currentTris += static_cast<int>(sub->indexData->indexCount / 3);
-                if (sub->vertexData)
-                    currentVerts += static_cast<int>(sub->vertexData->vertexCount);
-            }
-            if (mesh->sharedVertexData)
-                currentVerts += static_cast<int>(mesh->sharedVertexData->vertexCount);
-        }
-
-        double reduction = 0.0;
-        if (args.contains("reduction"))
-            reduction = MeshDecimator::clampReduction(args.value("reduction").toDouble());
-        else if (args.contains("target_tris"))
-            reduction = MeshDecimator::reductionFromTargetTris(
-                currentTris, args.value("target_tris").toInt());
-        else if (args.contains("target_verts"))
-            reduction = MeshDecimator::reductionFromTargetVerts(
-                currentVerts, args.value("target_verts").toInt());
-        else
+        const double reduction = resolveMcpReduction(args, currentTris, currentVerts);
+        if (reduction < 0.0)
             return makeErrorResult(
                 "Pass one of: reduction (0..1), target_tris, or target_verts.");
 
         const DecimationReport report = dryRun
             ? MeshDecimator::projectEntity(target, reduction)
             : MeshDecimator::decimateEntity(target, reduction);
+
+        // A real (non-dry-run) decimation that didn't apply means the
+        // generator failed — automation should treat that as an error, not
+        // assume the mesh was modified.
+        if (!dryRun && !report.applied && reduction > 0.0) {
+            return makeErrorResult(
+                "Decimation failed: MeshLodGenerator could not produce a reduced mesh. "
+                "The mesh may not be suitable (e.g. zero index data).");
+        }
 
         QJsonObject result = makeSuccessResult(MeshDecimator::toText(report));
         result["decimation"] = MeshDecimator::toJson(report);

--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -19,6 +19,7 @@
 #include "MemoryEstimator.h"
 #include "DrawCallAnalyzer.h"
 #include "VertexCacheOptimizer.h"
+#include "MeshDecimator.h"
 #include <QDebug>
 #include <QFile>
 #include <QDir>
@@ -436,6 +437,7 @@ const QMap<QString, MCPServer::ToolHandler>& MCPServer::toolHandlers()
         {QStringLiteral("get_memory_usage"), &MCPServer::toolGetMemoryUsage},
         {QStringLiteral("analyze_draw_calls"), &MCPServer::toolAnalyzeDrawCalls},
         {QStringLiteral("optimize_vertex_cache"), &MCPServer::toolOptimizeVertexCache},
+        {QStringLiteral("decimate_mesh"), &MCPServer::toolDecimateMesh},
         {QStringLiteral("list_files"), &MCPServer::toolListFiles},
         {QStringLiteral("search_files"), &MCPServer::toolSearchFiles},
         {QStringLiteral("read_file"), &MCPServer::toolReadFile},
@@ -2827,6 +2829,82 @@ QJsonObject MCPServer::toolOptimizeVertexCache(const QJsonObject &args)
     }
 }
 
+// NOSONAR(cpp:S5817) — ToolHandler is a non-const member-fn pointer (matching
+// every other tool method in this class); marking just this one const would
+// break the registry signature in MCPServer.h.
+QJsonObject MCPServer::toolDecimateMesh(const QJsonObject &args)
+{
+    // Args (one wins, in priority order):
+    //   reduction (double 0..1) — drop this fraction of triangles
+    //   target_tris (int)       — reduce to approximately this many tris
+    //   target_verts (int)      — reduce to approximately this many verts
+    //   dry_run (bool, default false) — projected report only, no mutation
+    try {
+        if (const Manager* mgr = Manager::getSingletonPtr(); !mgr)
+            return makeErrorResult("Error: Manager not available");
+        if (!hasSelectedEntities())
+            return makeErrorResult("No mesh selected. Load a mesh first with load_mesh.");
+
+        const bool dryRun = args.value("dry_run").toBool(false);
+
+        // Resolve the reduction. We need a target entity to convert target-
+        // tris/target-verts into a reduction fraction, so grab the first one.
+        Ogre::Entity* target = nullptr;
+        for (Ogre::SceneNode* node : Manager::getSingleton()->getSceneNodes()) {
+            if (!node) continue;
+            for (unsigned i = 0; i < node->numAttachedObjects(); ++i) {
+                Ogre::MovableObject* obj = node->getAttachedObject(i);
+                if (obj && obj->getMovableType() == "Entity") {
+                    target = static_cast<Ogre::Entity*>(obj);
+                    break;
+                }
+            }
+            if (target) break;
+        }
+        if (!target)
+            return makeErrorResult("No entity in scene to decimate.");
+
+        // Count baseline tris/verts (mirrors cmdDecimate's count loop).
+        int currentTris = 0, currentVerts = 0;
+        if (Ogre::MeshPtr mesh = target->getMesh()) {
+            for (unsigned int s = 0; s < mesh->getNumSubMeshes(); ++s) {
+                const Ogre::SubMesh* sub = mesh->getSubMesh(s);
+                if (!sub) continue;
+                if (sub->indexData)
+                    currentTris += static_cast<int>(sub->indexData->indexCount / 3);
+                if (sub->vertexData)
+                    currentVerts += static_cast<int>(sub->vertexData->vertexCount);
+            }
+            if (mesh->sharedVertexData)
+                currentVerts += static_cast<int>(mesh->sharedVertexData->vertexCount);
+        }
+
+        double reduction = 0.0;
+        if (args.contains("reduction"))
+            reduction = MeshDecimator::clampReduction(args.value("reduction").toDouble());
+        else if (args.contains("target_tris"))
+            reduction = MeshDecimator::reductionFromTargetTris(
+                currentTris, args.value("target_tris").toInt());
+        else if (args.contains("target_verts"))
+            reduction = MeshDecimator::reductionFromTargetVerts(
+                currentVerts, args.value("target_verts").toInt());
+        else
+            return makeErrorResult(
+                "Pass one of: reduction (0..1), target_tris, or target_verts.");
+
+        const DecimationReport report = dryRun
+            ? MeshDecimator::projectEntity(target, reduction)
+            : MeshDecimator::decimateEntity(target, reduction);
+
+        QJsonObject result = makeSuccessResult(MeshDecimator::toText(report));
+        result["decimation"] = MeshDecimator::toJson(report);
+        return result;
+    } catch (Ogre::Exception& e) {
+        return makeErrorResult(
+            QString("Ogre error: %1").arg(QString::fromStdString(e.getFullDescription())));
+    }
+}
+
 // Helper methods
 
 QJsonObject MCPServer::toolListFiles(const QJsonObject &args)
@@ -4205,6 +4283,28 @@ QJsonArray MCPServer::buildToolsList()
             "Pass `rewrite: true` to actually reorder the index buffers (analysis-only otherwise). "
             "The response includes a human-readable summary in 'content' and a structured "
             "'vertexCache' object with per-submesh ACMR plus totals for machine consumers.",
+            props
+        );
+    }
+
+    // decimate_mesh
+    {
+        QJsonObject props;
+        props["reduction"] = QJsonObject{{"type", "number"},
+            {"description", "Fraction of triangles to drop (0..0.95). Pass one of reduction / target_tris / target_verts."}};
+        props["target_tris"] = QJsonObject{{"type", "integer"},
+            {"description", "Reduce until total triangle count is approximately this value."}};
+        props["target_verts"] = QJsonObject{{"type", "integer"},
+            {"description", "Reduce until total vertex count is approximately this value."}};
+        props["dry_run"] = QJsonObject{{"type", "boolean"},
+            {"description", "When true, return a projected report without mutating the mesh."}};
+        appendTool(
+            "decimate_mesh",
+            "Single-pass mesh decimation via edge-collapse. Reduces the base mesh in place "
+            "(unlike generate_lods which builds a discrete LOD chain). Pass one of "
+            "`reduction` (0..0.95), `target_tris`, or `target_verts`. The response includes "
+            "a human-readable summary in 'content' and a structured 'decimation' object with "
+            "per-submesh and total triangle counts before / after.",
             props
         );
     }

--- a/src/MCPServer.h
+++ b/src/MCPServer.h
@@ -168,6 +168,7 @@ private:
     QJsonObject toolGetMemoryUsage(const QJsonObject &args);
     QJsonObject toolAnalyzeDrawCalls(const QJsonObject &args);
     QJsonObject toolOptimizeVertexCache(const QJsonObject &args);
+    QJsonObject toolDecimateMesh(const QJsonObject &args);
     QJsonObject toolListFiles(const QJsonObject &args);
     QJsonObject toolSearchFiles(const QJsonObject &args);
     QJsonObject toolReadFile(const QJsonObject &args);

--- a/src/MeshDecimator.cpp
+++ b/src/MeshDecimator.cpp
@@ -79,6 +79,62 @@ Ogre::MeshLodGenerator& sharedLodGenerator()
     return *(new Ogre::MeshLodGenerator());
 }
 
+using LodFaceListSnapshot = std::vector<std::vector<Ogre::IndexData*>>;
+
+// Move each submesh's existing LOD face list aside so the generator can
+// rebuild the chain from scratch. Returned snapshot must be either restored
+// (on failure) or freed (on success) by the caller.
+LodFaceListSnapshot snapshotLodFaceLists(const Ogre::MeshPtr& mesh)
+{
+    LodFaceListSnapshot snapshot;
+    snapshot.reserve(mesh->getNumSubMeshes());
+    for (unsigned int s = 0; s < mesh->getNumSubMeshes(); ++s) {
+        Ogre::SubMesh* sub = mesh->getSubMesh(s);
+        snapshot.push_back(sub ? sub->mLodFaceList
+                               : std::vector<Ogre::IndexData*>{});
+        if (sub) sub->mLodFaceList.clear();
+    }
+    return snapshot;
+}
+
+// Put the snapshotted LOD chain back — used when generateLodLevels throws so
+// the reported failure is not destructive for in-memory callers.
+void restoreLodFaceLists(const Ogre::MeshPtr& mesh,
+                         const LodFaceListSnapshot& snapshot)
+{
+    for (unsigned int s = 0; s < mesh->getNumSubMeshes(); ++s) {
+        Ogre::SubMesh* sub = mesh->getSubMesh(s);
+        if (sub && s < snapshot.size())
+            sub->mLodFaceList = snapshot[s];
+    }
+}
+
+// Release the snapshotted IndexData* allocations after a successful generator
+// run — the base mesh swaps to the new LOD's index data, so the old per-LOD
+// buffers are no longer referenced.
+void freeLodSnapshot(LodFaceListSnapshot& snapshot)
+{
+    for (auto& list : snapshot)
+        for (Ogre::IndexData* idx : list) delete idx;
+}
+
+// Swap each submesh's freshly-generated LOD-1 index data into the base slot.
+// MeshLodController::doExportLods uses the same swap pattern transiently for
+// per-LOD export; here we keep the swap permanent — `removeLodLevels()` then
+// frees the now-pushed-aside originals.
+void promoteFirstLodToBase(const Ogre::MeshPtr& mesh)
+{
+    for (unsigned int s = 0; s < mesh->getNumSubMeshes(); ++s) {
+        Ogre::SubMesh* sub = mesh->getSubMesh(s);
+        if (!sub) continue;
+        if (sub->mLodFaceList.empty() || !sub->mLodFaceList.front()) continue;
+        Ogre::IndexData* original = sub->indexData;
+        sub->indexData = sub->mLodFaceList.front();
+        sub->mLodFaceList.front() = original; // keep ownership balanced
+    }
+    mesh->removeLodLevels();
+}
+
 
 
 int countTrianglesInMesh(const Ogre::Mesh* mesh)
@@ -163,18 +219,10 @@ DecimationReport MeshDecimator::decimateEntity(Ogre::Entity* entity, double redu
         return report;
     }
 
-    // Snapshot the existing LOD face list per submesh so we can roll back
-    // if the generator throws. Then wipe — the base mesh is being reduced,
-    // and the new chain has to start fresh so the LOD-1 index data we
-    // promote into the base is the one we asked for.
-    std::vector<std::vector<Ogre::IndexData*>> savedLodFaceLists;
-    savedLodFaceLists.reserve(mesh->getNumSubMeshes());
-    for (unsigned int s = 0; s < mesh->getNumSubMeshes(); ++s) {
-        Ogre::SubMesh* sub = mesh->getSubMesh(s);
-        savedLodFaceLists.push_back(sub ? sub->mLodFaceList
-                                        : std::vector<Ogre::IndexData*>{});
-        if (sub) sub->mLodFaceList.clear();
-    }
+    // Snapshot then clear the existing LOD chain so the generator builds
+    // a fresh one from scratch (a stray pre-existing LOD-0 would otherwise
+    // get promoted into the base in promoteFirstLodToBase below).
+    LodFaceListSnapshot saved = snapshotLodFaceLists(mesh);
 
     Ogre::LodConfig lodConfig(mesh);
     lodConfig.createGeneratedLodLevel(0.0f, // distance — meaningless when collapsing in place
@@ -186,37 +234,13 @@ DecimationReport MeshDecimator::decimateEntity(Ogre::Entity* entity, double redu
         // has been instantiated yet (CLI / MCP / test contexts).
         sharedLodGenerator().generateLodLevels(lodConfig);
     } catch (const Ogre::Exception& /*e*/) {
-        // Restore the snapshotted LOD chain so a reported failure is not
-        // destructive for in-memory callers — the mesh comes back exactly
-        // as it was before decimateEntity ran.
-        for (unsigned int s = 0; s < mesh->getNumSubMeshes(); ++s) {
-            Ogre::SubMesh* sub = mesh->getSubMesh(s);
-            if (sub && s < savedLodFaceLists.size())
-                sub->mLodFaceList = savedLodFaceLists[s];
-        }
+        restoreLodFaceLists(mesh, saved);
         report.totalTrianglesAfter = report.totalTrianglesBefore;
         return report;
     }
-    // Generator succeeded — free the old IndexData* we'd snapshotted, since
-    // the base mesh is about to swap to the new LOD's index data and the
-    // old per-LOD buffers are no longer referenced.
-    for (auto& list : savedLodFaceLists)
-        for (Ogre::IndexData* idx : list) delete idx;
 
-    // Promote LOD 1 (the reduced level) into the base mesh by swapping its
-    // index data with the original submesh index data. This is the same
-    // pattern MeshLodController::doExportLods uses for per-LOD export, but
-    // we keep the swap permanent — the original index buffers are released
-    // when the SubMesh destructor runs at scene teardown.
-    for (unsigned int s = 0; s < mesh->getNumSubMeshes(); ++s) {
-        Ogre::SubMesh* sub = mesh->getSubMesh(s);
-        if (!sub) continue;
-        if (sub->mLodFaceList.empty() || !sub->mLodFaceList.front()) continue;
-        Ogre::IndexData* original = sub->indexData;
-        sub->indexData = sub->mLodFaceList.front();
-        sub->mLodFaceList.front() = original; // keep ownership balanced
-    }
-    mesh->removeLodLevels();
+    freeLodSnapshot(saved);
+    promoteFirstLodToBase(mesh);
 
     // Re-count post-decimation triangles per submesh.
     int subIdx = 0;

--- a/src/MeshDecimator.cpp
+++ b/src/MeshDecimator.cpp
@@ -38,6 +38,28 @@ double MeshDecimator::clampReduction(double r)
     return r;
 }
 
+// LCOV_EXCL_START — exercised via CLI / MCP integration paths
+void MeshDecimator::countBaseline(const Ogre::Entity* entity,
+                                  int& outTris, int& outVerts)
+{
+    outTris = 0;
+    outVerts = 0;
+    if (!entity) return;
+    const Ogre::MeshPtr mesh = entity->getMesh();
+    if (!mesh) return;
+    for (unsigned int s = 0; s < mesh->getNumSubMeshes(); ++s) {
+        const Ogre::SubMesh* sub = mesh->getSubMesh(s);
+        if (!sub) continue;
+        if (sub->indexData)
+            outTris += static_cast<int>(sub->indexData->indexCount / 3);
+        if (sub->vertexData)
+            outVerts += static_cast<int>(sub->vertexData->vertexCount);
+    }
+    if (mesh->sharedVertexData)
+        outVerts += static_cast<int>(mesh->sharedVertexData->vertexCount);
+}
+// LCOV_EXCL_STOP
+
 // ----- Helpers --------------------------------------------------------------
 
 namespace {
@@ -88,11 +110,16 @@ DecimationReport MeshDecimator::projectEntity(const Ogre::Entity* entity, double
 
     collectSubmeshTriCounts(mesh.get(), report.submeshes, report.meshName);
     for (auto& sr : report.submeshes) {
-        // Predicted after = before * (1 - reduction), rounded but capped at 1
-        // (Ogre won't drop a submesh below a single triangle in practice).
-        const double predicted = std::round(sr.trianglesBefore
-                                            * (1.0 - report.appliedReduction));
-        sr.trianglesAfter = std::max(1, static_cast<int>(predicted));
+        // Predicted after = before * (1 - reduction), rounded. Cap at 1 only
+        // when the submesh has triangles to begin with — empty submeshes stay
+        // at 0 in the projection (we don't invent triangles).
+        if (sr.trianglesBefore <= 0) {
+            sr.trianglesAfter = 0;
+        } else {
+            const double predicted = std::round(sr.trianglesBefore
+                                                * (1.0 - report.appliedReduction));
+            sr.trianglesAfter = std::max(1, static_cast<int>(predicted));
+        }
         report.totalTrianglesBefore += sr.trianglesBefore;
         report.totalTrianglesAfter  += sr.trianglesAfter;
     }
@@ -132,7 +159,11 @@ DecimationReport MeshDecimator::decimateEntity(Ogre::Entity* entity, double redu
         Ogre::MeshLodGenerator generator;
         generator.generateLodLevels(lodConfig);
     } catch (const Ogre::Exception& /*e*/) {
-        return report; // applied = false
+        // Keep totals consistent on failure: per-submesh trianglesAfter
+        // already mirrors trianglesBefore (from collectSubmeshTriCounts),
+        // so the total should match. applied stays false.
+        report.totalTrianglesAfter = report.totalTrianglesBefore;
+        return report;
     }
 
     // Promote LOD 1 (the reduced level) into the base mesh by swapping its

--- a/src/MeshDecimator.cpp
+++ b/src/MeshDecimator.cpp
@@ -1,0 +1,228 @@
+#include "MeshDecimator.h"
+
+#include <Ogre.h>
+#include <OgreMesh.h>
+#include <OgreSubMesh.h>
+#include <OgreEntity.h>
+#include <OgreMeshLodGenerator.h>
+#include <OgreLodConfig.h>
+
+#include <QJsonArray>
+#include <QLocale>
+#include <algorithm>
+#include <cmath>
+
+// ----- Pure-data primitives -------------------------------------------------
+
+double MeshDecimator::reductionFromTargetTris(int currentTris, int targetTris)
+{
+    if (currentTris <= 0 || targetTris >= currentTris) return 0.0;
+    if (targetTris <= 0) return kMaxReduction; // fully decimate
+    return clampReduction(1.0 - static_cast<double>(targetTris) / currentTris);
+}
+
+double MeshDecimator::reductionFromTargetVerts(int currentVerts, int targetVerts)
+{
+    // Decimation isn't truly proportional between tris and verts — but for
+    // shoulder-of-the-curve assets they track closely enough that targeting
+    // a vertex budget gives a useful upper bound on the resulting tri count.
+    if (currentVerts <= 0 || targetVerts >= currentVerts) return 0.0;
+    if (targetVerts <= 0) return kMaxReduction;
+    return clampReduction(1.0 - static_cast<double>(targetVerts) / currentVerts);
+}
+
+double MeshDecimator::clampReduction(double r)
+{
+    if (std::isnan(r) || r <= 0.0) return 0.0;
+    if (r > kMaxReduction) return kMaxReduction;
+    return r;
+}
+
+// ----- Helpers --------------------------------------------------------------
+
+namespace {
+
+int countTrianglesInMesh(const Ogre::Mesh* mesh)
+{
+    if (!mesh) return 0;
+    int total = 0;
+    for (unsigned int s = 0; s < mesh->getNumSubMeshes(); ++s) {
+        const Ogre::SubMesh* sub = mesh->getSubMesh(s);
+        if (sub && sub->indexData)
+            total += static_cast<int>(sub->indexData->indexCount / 3);
+    }
+    return total;
+}
+
+void collectSubmeshTriCounts(const Ogre::Mesh* mesh,
+                             QList<DecimationSubmeshReport>& outSubmeshes,
+                             const QString& meshName)
+{
+    if (!mesh) return;
+    for (unsigned int s = 0; s < mesh->getNumSubMeshes(); ++s) {
+        const Ogre::SubMesh* sub = mesh->getSubMesh(s);
+        if (!sub || !sub->indexData) continue;
+        DecimationSubmeshReport sr;
+        sr.meshName = meshName;
+        sr.submeshIndex = static_cast<int>(s);
+        sr.trianglesBefore = static_cast<int>(sub->indexData->indexCount / 3);
+        sr.trianglesAfter = sr.trianglesBefore;
+        outSubmeshes.append(sr);
+    }
+}
+
+} // namespace
+
+// ----- Ogre-backed paths ----------------------------------------------------
+
+// LCOV_EXCL_START — Ogre-only path, exercised via manual / CLI tests
+DecimationReport MeshDecimator::projectEntity(const Ogre::Entity* entity, double reduction)
+{
+    DecimationReport report;
+    if (!entity) return report;
+    const Ogre::MeshPtr mesh = entity->getMesh();
+    if (!mesh) return report;
+
+    report.meshName = QString::fromStdString(mesh->getName());
+    report.appliedReduction = clampReduction(reduction);
+
+    collectSubmeshTriCounts(mesh.get(), report.submeshes, report.meshName);
+    for (auto& sr : report.submeshes) {
+        // Predicted after = before * (1 - reduction), rounded but capped at 1
+        // (Ogre won't drop a submesh below a single triangle in practice).
+        const double predicted = std::round(sr.trianglesBefore
+                                            * (1.0 - report.appliedReduction));
+        sr.trianglesAfter = std::max(1, static_cast<int>(predicted));
+        report.totalTrianglesBefore += sr.trianglesBefore;
+        report.totalTrianglesAfter  += sr.trianglesAfter;
+    }
+    return report;
+}
+
+DecimationReport MeshDecimator::decimateEntity(Ogre::Entity* entity, double reduction)
+{
+    DecimationReport report;
+    if (!entity) return report;
+    Ogre::MeshPtr mesh = entity->getMesh();
+    if (!mesh) return report;
+
+    report.meshName = QString::fromStdString(mesh->getName());
+    report.appliedReduction = clampReduction(reduction);
+
+    collectSubmeshTriCounts(mesh.get(), report.submeshes, report.meshName);
+    for (const auto& sr : report.submeshes)
+        report.totalTrianglesBefore += sr.trianglesBefore;
+
+    if (report.appliedReduction <= 0.0) {
+        // No-op — caller asked for 0% reduction; just return the baseline.
+        report.totalTrianglesAfter = report.totalTrianglesBefore;
+        return report;
+    }
+
+    // Wipe any existing LOD chain — the base mesh itself is being reduced,
+    // so old LODs would point at stale index data after the generator runs.
+    mesh->removeLodLevels();
+
+    Ogre::LodConfig lodConfig(mesh);
+    lodConfig.createGeneratedLodLevel(0.0f, // distance — meaningless when collapsing in place
+                                      static_cast<float>(report.appliedReduction),
+                                      Ogre::LodLevel::VRM_PROPORTIONAL);
+
+    try {
+        Ogre::MeshLodGenerator generator;
+        generator.generateLodLevels(lodConfig);
+    } catch (const Ogre::Exception& /*e*/) {
+        return report; // applied = false
+    }
+
+    // Promote LOD 1 (the reduced level) into the base mesh by swapping its
+    // index data with the original submesh index data. This is the same
+    // pattern MeshLodController::doExportLods uses for per-LOD export, but
+    // we keep the swap permanent — the original index buffers are released
+    // when the SubMesh destructor runs at scene teardown.
+    for (unsigned int s = 0; s < mesh->getNumSubMeshes(); ++s) {
+        Ogre::SubMesh* sub = mesh->getSubMesh(s);
+        if (!sub) continue;
+        if (sub->mLodFaceList.empty() || !sub->mLodFaceList.front()) continue;
+        Ogre::IndexData* original = sub->indexData;
+        sub->indexData = sub->mLodFaceList.front();
+        sub->mLodFaceList.front() = original; // keep ownership balanced
+    }
+    mesh->removeLodLevels();
+
+    // Re-count post-decimation triangles per submesh.
+    int subIdx = 0;
+    for (unsigned int s = 0; s < mesh->getNumSubMeshes(); ++s) {
+        const Ogre::SubMesh* sub = mesh->getSubMesh(s);
+        if (!sub || !sub->indexData) continue;
+        if (subIdx < report.submeshes.size())
+            report.submeshes[subIdx].trianglesAfter =
+                static_cast<int>(sub->indexData->indexCount / 3);
+        ++subIdx;
+    }
+    report.totalTrianglesAfter = countTrianglesInMesh(mesh.get());
+    report.applied = true;
+    return report;
+}
+// LCOV_EXCL_STOP
+
+// ----- Serialisation --------------------------------------------------------
+
+QJsonObject MeshDecimator::toJson(const DecimationReport& report)
+{
+    QJsonObject obj;
+    obj["mesh"] = report.meshName;
+    obj["appliedReduction"] = report.appliedReduction;
+    obj["applied"] = report.applied;
+
+    QJsonArray submeshes;
+    for (const auto& sr : report.submeshes) {
+        QJsonObject so;
+        so["submeshIndex"] = sr.submeshIndex;
+        so["trianglesBefore"] = sr.trianglesBefore;
+        so["trianglesAfter"] = sr.trianglesAfter;
+        submeshes.append(so);
+    }
+    obj["submeshes"] = submeshes;
+
+    QJsonObject totals;
+    totals["trianglesBefore"] = report.totalTrianglesBefore;
+    totals["trianglesAfter"] = report.totalTrianglesAfter;
+    totals["effectiveReduction"] = report.effectiveReduction();
+    obj["totals"] = totals;
+    return obj;
+}
+
+QString MeshDecimator::toText(const DecimationReport& report)
+{
+    QString out;
+    QTextStream s(&out);
+    QLocale locale;
+
+    s << "Mesh Decimation\n";
+    s << "===============\n\n";
+
+    if (report.meshName.isEmpty()) {
+        s << "(no mesh)\n";
+        return out;
+    }
+
+    s << "Mesh: " << report.meshName << "\n";
+    s << "Reduction requested: "
+      << QString::number(report.appliedReduction * 100.0, 'f', 1) << "%"
+      << (report.applied ? "  (applied)" : "  (projected)")
+      << "\n\n";
+
+    for (const auto& sr : report.submeshes) {
+        s << "  [" << sr.submeshIndex << "] tris "
+          << locale.toString(sr.trianglesBefore) << " → "
+          << locale.toString(sr.trianglesAfter) << "\n";
+    }
+
+    s << "\nTotal: "
+      << locale.toString(report.totalTrianglesBefore) << " → "
+      << locale.toString(report.totalTrianglesAfter)
+      << " (" << QString::number(report.effectiveReduction() * 100.0, 'f', 1)
+      << "% effective reduction)\n";
+    return out;
+}

--- a/src/MeshDecimator.cpp
+++ b/src/MeshDecimator.cpp
@@ -64,6 +64,23 @@ void MeshDecimator::countBaseline(const Ogre::Entity* entity,
 
 namespace {
 
+// Ogre::MeshLodGenerator is a Singleton<> — only one instance may exist per
+// process. The GUI's MeshLodController owns one; the CLI / MCP / tests don't.
+// This helper hands back the live instance, lazily constructing the singleton
+// the first time it's needed. The leaked instance is reclaimed by Ogre's
+// teardown when the process exits.
+Ogre::MeshLodGenerator& sharedLodGenerator()
+{
+    if (Ogre::MeshLodGenerator* p = Ogre::MeshLodGenerator::getSingletonPtr())
+        return *p;
+    // The singleton self-registers in its constructor; intentional leak —
+    // matches Ogre's standard "singleton lives for the process lifetime"
+    // expectation.
+    return *(new Ogre::MeshLodGenerator());
+}
+
+
+
 int countTrianglesInMesh(const Ogre::Mesh* mesh)
 {
     if (!mesh) return 0;
@@ -156,8 +173,9 @@ DecimationReport MeshDecimator::decimateEntity(Ogre::Entity* entity, double redu
                                       Ogre::LodLevel::VRM_PROPORTIONAL);
 
     try {
-        Ogre::MeshLodGenerator generator;
-        generator.generateLodLevels(lodConfig);
+        // Use the shared singleton — lazy-construct if no MeshLodController
+        // has been instantiated yet (CLI / MCP / test contexts).
+        sharedLodGenerator().generateLodLevels(lodConfig);
     } catch (const Ogre::Exception& /*e*/) {
         // Keep totals consistent on failure: per-submesh trianglesAfter
         // already mirrors trianglesBefore (from collectSubmeshTriCounts),

--- a/src/MeshDecimator.cpp
+++ b/src/MeshDecimator.cpp
@@ -163,9 +163,18 @@ DecimationReport MeshDecimator::decimateEntity(Ogre::Entity* entity, double redu
         return report;
     }
 
-    // Wipe any existing LOD chain — the base mesh itself is being reduced,
-    // so old LODs would point at stale index data after the generator runs.
-    mesh->removeLodLevels();
+    // Snapshot the existing LOD face list per submesh so we can roll back
+    // if the generator throws. Then wipe — the base mesh is being reduced,
+    // and the new chain has to start fresh so the LOD-1 index data we
+    // promote into the base is the one we asked for.
+    std::vector<std::vector<Ogre::IndexData*>> savedLodFaceLists;
+    savedLodFaceLists.reserve(mesh->getNumSubMeshes());
+    for (unsigned int s = 0; s < mesh->getNumSubMeshes(); ++s) {
+        Ogre::SubMesh* sub = mesh->getSubMesh(s);
+        savedLodFaceLists.push_back(sub ? sub->mLodFaceList
+                                        : std::vector<Ogre::IndexData*>{});
+        if (sub) sub->mLodFaceList.clear();
+    }
 
     Ogre::LodConfig lodConfig(mesh);
     lodConfig.createGeneratedLodLevel(0.0f, // distance — meaningless when collapsing in place
@@ -177,12 +186,22 @@ DecimationReport MeshDecimator::decimateEntity(Ogre::Entity* entity, double redu
         // has been instantiated yet (CLI / MCP / test contexts).
         sharedLodGenerator().generateLodLevels(lodConfig);
     } catch (const Ogre::Exception& /*e*/) {
-        // Keep totals consistent on failure: per-submesh trianglesAfter
-        // already mirrors trianglesBefore (from collectSubmeshTriCounts),
-        // so the total should match. applied stays false.
+        // Restore the snapshotted LOD chain so a reported failure is not
+        // destructive for in-memory callers — the mesh comes back exactly
+        // as it was before decimateEntity ran.
+        for (unsigned int s = 0; s < mesh->getNumSubMeshes(); ++s) {
+            Ogre::SubMesh* sub = mesh->getSubMesh(s);
+            if (sub && s < savedLodFaceLists.size())
+                sub->mLodFaceList = savedLodFaceLists[s];
+        }
         report.totalTrianglesAfter = report.totalTrianglesBefore;
         return report;
     }
+    // Generator succeeded — free the old IndexData* we'd snapshotted, since
+    // the base mesh is about to swap to the new LOD's index data and the
+    // old per-LOD buffers are no longer referenced.
+    for (auto& list : savedLodFaceLists)
+        for (Ogre::IndexData* idx : list) delete idx;
 
     // Promote LOD 1 (the reduced level) into the base mesh by swapping its
     // index data with the original submesh index data. This is the same

--- a/src/MeshDecimator.h
+++ b/src/MeshDecimator.h
@@ -73,6 +73,12 @@ public:
     // Cheap — does not call into MeshLodGenerator.
     static DecimationReport projectEntity(const Ogre::Entity* entity, double reduction);
 
+    // Count base-mesh triangles and vertices across all submeshes of an
+    // entity. Used to resolve target-tris / target-verts targets into a
+    // reduction fraction in both the CLI and MCP wrappers.
+    static void countBaseline(const Ogre::Entity* entity,
+                              int& outTris, int& outVerts);
+
     static QJsonObject toJson(const DecimationReport& report);
     static QString toText(const DecimationReport& report);
 };

--- a/src/MeshDecimator.h
+++ b/src/MeshDecimator.h
@@ -1,0 +1,80 @@
+#ifndef MESHDECIMATOR_H
+#define MESHDECIMATOR_H
+
+#include <QString>
+#include <QList>
+#include <QJsonObject>
+
+namespace Ogre {
+    class Entity;
+    class MeshLodGenerator;
+}
+
+// Per-submesh decimation report — how many triangles each submesh had before
+// and after. Slot 0 is the entire base mesh (sum across submeshes).
+struct DecimationSubmeshReport {
+    QString meshName;
+    int submeshIndex = 0;
+    int trianglesBefore = 0;
+    int trianglesAfter = 0;
+};
+
+struct DecimationReport {
+    QString meshName;
+    QList<DecimationSubmeshReport> submeshes;
+    int totalTrianglesBefore = 0;
+    int totalTrianglesAfter = 0;
+    double appliedReduction = 0.0; // 0..1, the reduction fraction we asked Ogre for
+    bool applied = false;           // true when the decimation was committed in place
+
+    double effectiveReduction() const {
+        return totalTrianglesBefore > 0
+            ? 1.0 - static_cast<double>(totalTrianglesAfter) / totalTrianglesBefore
+            : 0.0;
+    }
+};
+
+// Pure-data + Ogre-backed mesh decimator.  Unlike MeshLodController which
+// generates a *chain* of discrete LOD levels (each at increasing distance),
+// MeshDecimator runs a single-pass reduction that rewrites the base mesh
+// itself — appropriate for "I want this asset to be 3000 triangles" rather
+// than "I want LOD 0/1/2/3 for distance-based rendering".
+//
+// The current backend is Ogre's MeshLodGenerator with a single LOD config.
+// A future slice can replace it with a QEM implementation that supports
+// per-vertex lock weights and UV/material seam preservation. The pure-data
+// helpers (decimationFromTris / decimationFromVerts) work without Ogre, so
+// they're testable in any environment.
+class MeshDecimator {
+public:
+    // Sentinel — slider / API caps at 95% to avoid degenerate single-triangle
+    // outputs that some downstream paths (Ogre exporter, FBX) trip over.
+    static constexpr double kMaxReduction = 0.95;
+
+    // Convert a "target tri count" to a reduction fraction (0..1). When
+    // `targetTris` is >= `currentTris`, returns 0.0 (no reduction).
+    static double reductionFromTargetTris(int currentTris, int targetTris);
+
+    // Convert a "target vertex budget" to a reduction fraction. Same math
+    // — assumes uniform reduction across the mesh.
+    static double reductionFromTargetVerts(int currentVerts, int targetVerts);
+
+    // Clamp a reduction fraction into [0.0, kMaxReduction].
+    static double clampReduction(double r);
+
+    // Apply a single-pass decimation in place on the entity's mesh. Wipes
+    // any existing LOD levels (the base mesh is the thing being reduced).
+    // Returns the report. `applied` flips to true on success.
+    static DecimationReport decimateEntity(Ogre::Entity* entity, double reduction);
+
+    // Analyze-only: same arithmetic as decimateEntity but does not mutate
+    // the mesh. Returns the report with `applied = false` and predicted
+    // after-counts proportional to the current submesh distribution.
+    // Cheap — does not call into MeshLodGenerator.
+    static DecimationReport projectEntity(const Ogre::Entity* entity, double reduction);
+
+    static QJsonObject toJson(const DecimationReport& report);
+    static QString toText(const DecimationReport& report);
+};
+
+#endif // MESHDECIMATOR_H

--- a/src/MeshDecimatorController.cpp
+++ b/src/MeshDecimatorController.cpp
@@ -16,7 +16,7 @@ namespace {
 
 QList<Ogre::Entity*> decimateTargets()
 {
-    auto* sel = SelectionSet::getSingleton();
+    const auto* sel = SelectionSet::getSingleton();
     if (!sel) return {};
     return sel->getResolvedEntities();
 }
@@ -66,15 +66,10 @@ bool MeshDecimatorController::hasSelection() const
     return !decimateTargets().isEmpty();
 }
 
-int MeshDecimatorController::baseTriangleCount() const
+void MeshDecimatorController::primeBaseline()
 {
-    // Lazy refresh: if we don't have a cached count but a selection exists,
-    // populate now. Cast away const — m_baseTriangleCount is metadata, not
-    // observable state from outside the controller's invariants.
-    if (m_baseTriangleCount == 0 && hasSelection()) {
-        const_cast<MeshDecimatorController*>(this)->refreshBaseline();
-    }
-    return m_baseTriangleCount;
+    refreshBaseline();
+    emit baseChanged();
 }
 
 void MeshDecimatorController::refreshBaseline()

--- a/src/MeshDecimatorController.cpp
+++ b/src/MeshDecimatorController.cpp
@@ -1,0 +1,191 @@
+#include "MeshDecimatorController.h"
+#include "MeshDecimator.h"
+#include "Manager.h"
+#include "SelectionSet.h"
+#include "SentryReporter.h"
+
+#include <Ogre.h>
+#include <OgreMeshLodGenerator.h>
+#include <OgreLodConfig.h>
+#include <OgreSubMesh.h>
+#include <OgreEntity.h>
+
+#include <limits>
+
+namespace {
+
+QList<Ogre::Entity*> decimateTargets()
+{
+    auto* sel = SelectionSet::getSingleton();
+    if (!sel) return {};
+    return sel->getResolvedEntities();
+}
+
+} // namespace
+
+MeshDecimatorController* MeshDecimatorController::m_pSingleton = nullptr;
+
+MeshDecimatorController* MeshDecimatorController::instance()
+{
+    if (!m_pSingleton)
+        m_pSingleton = new MeshDecimatorController();
+    return m_pSingleton;
+}
+
+MeshDecimatorController* MeshDecimatorController::qmlInstance(QQmlEngine* engine, QJSEngine*)
+{
+    Q_UNUSED(engine);
+    auto* inst = instance();
+    QQmlEngine::setObjectOwnership(inst, QQmlEngine::CppOwnership);
+    return inst;
+}
+
+void MeshDecimatorController::kill()
+{
+    delete m_pSingleton;
+    m_pSingleton = nullptr;
+}
+
+MeshDecimatorController::~MeshDecimatorController() = default;
+
+MeshDecimatorController::MeshDecimatorController() : QObject(nullptr)
+{
+    m_generator = std::make_unique<Ogre::MeshLodGenerator>();
+
+    connect(SelectionSet::getSingleton(), &SelectionSet::selectionChanged,
+            this, [this]() {
+        clearPreview();
+        refreshBaseline();
+        emit selectionChanged();
+        emit baseChanged();
+    });
+}
+
+bool MeshDecimatorController::hasSelection() const
+{
+    return !decimateTargets().isEmpty();
+}
+
+int MeshDecimatorController::baseTriangleCount() const
+{
+    // Lazy refresh: if we don't have a cached count but a selection exists,
+    // populate now. Cast away const — m_baseTriangleCount is metadata, not
+    // observable state from outside the controller's invariants.
+    if (m_baseTriangleCount == 0 && hasSelection()) {
+        const_cast<MeshDecimatorController*>(this)->refreshBaseline();
+    }
+    return m_baseTriangleCount;
+}
+
+void MeshDecimatorController::refreshBaseline()
+{
+    const QList<Ogre::Entity*> targets = decimateTargets();
+    if (targets.isEmpty()) {
+        m_baseTriangleCount = 0;
+        return;
+    }
+    int tris = 0;
+    int verts = 0;
+    MeshDecimator::countBaseline(targets.front(), tris, verts);
+    m_baseTriangleCount = tris;
+}
+
+// LCOV_EXCL_START — Ogre-only path
+void MeshDecimatorController::previewReduction(double reduction)
+{
+    const QList<Ogre::Entity*> targets = decimateTargets();
+    if (targets.isEmpty()) {
+        emit error(QStringLiteral("No mesh selected."));
+        return;
+    }
+    const double r = MeshDecimator::clampReduction(reduction);
+    if (r <= 0.0) {
+        clearPreview();
+        return;
+    }
+
+    Ogre::Entity* entity = targets.front();
+    Ogre::MeshPtr mesh = entity->getMesh();
+    if (!mesh) return;
+
+    // Tear down any previous preview LOD before regenerating — the slider
+    // moves often, so we don't want stale LOD chains piling up.
+    mesh->removeLodLevels();
+
+    Ogre::LodConfig lodConfig(mesh);
+    lodConfig.createGeneratedLodLevel(0.0f, static_cast<float>(r),
+                                      Ogre::LodLevel::VRM_PROPORTIONAL);
+    try {
+        m_generator->generateLodLevels(lodConfig);
+    } catch (const Ogre::Exception& e) {
+        emit error(QString("Preview failed: %1").arg(e.what()));
+        return;
+    }
+
+    // Force display of the LOD we just generated.
+    for (Ogre::Entity* e : targets)
+        e->setMeshLodBias(1.0f, 1, 1);
+
+    // Count the preview tris (LOD 1's index count).
+    int previewTris = 0;
+    for (unsigned int s = 0; s < mesh->getNumSubMeshes(); ++s) {
+        const Ogre::SubMesh* sub = mesh->getSubMesh(s);
+        if (!sub || sub->mLodFaceList.empty() || !sub->mLodFaceList.front()) continue;
+        previewTris += static_cast<int>(sub->mLodFaceList.front()->indexCount / 3);
+    }
+    m_previewTriangleCount = previewTris;
+    m_hasPreview = true;
+    emit previewChanged();
+}
+
+void MeshDecimatorController::clearPreview()
+{
+    if (!m_hasPreview) return;
+
+    for (Ogre::Entity* entity : decimateTargets()) {
+        entity->setMeshLodBias(1.0f, 0,
+                               std::numeric_limits<unsigned short>::max());
+        Ogre::MeshPtr mesh = entity->getMesh();
+        if (mesh) mesh->removeLodLevels();
+    }
+    m_hasPreview = false;
+    m_previewTriangleCount = 0;
+    emit previewChanged();
+}
+
+void MeshDecimatorController::applyReduction(double reduction)
+{
+    const QList<Ogre::Entity*> targets = decimateTargets();
+    if (targets.isEmpty()) {
+        emit error(QStringLiteral("No mesh selected."));
+        return;
+    }
+    const double r = MeshDecimator::clampReduction(reduction);
+    if (r <= 0.0) return;
+
+    // Drop any preview-only LOD swap before committing — applyEntity does
+    // its own removeLodLevels() too, but resetting the bias first keeps the
+    // viewport honest if the apply fails halfway.
+    for (Ogre::Entity* entity : targets)
+        entity->setMeshLodBias(1.0f, 0,
+                               std::numeric_limits<unsigned short>::max());
+
+    SentryReporter::addBreadcrumb("ui.action",
+        QString("Decimate (in-place, r=%1)").arg(r, 0, 'f', 2));
+
+    Ogre::Entity* entity = targets.front();
+    const DecimationReport report = MeshDecimator::decimateEntity(entity, r);
+    if (!report.applied) {
+        emit error(QStringLiteral("Decimation failed. The mesh may not be "
+                                  "suitable for in-place reduction."));
+        return;
+    }
+
+    m_hasPreview = false;
+    m_previewTriangleCount = 0;
+    refreshBaseline();
+    emit previewChanged();
+    emit baseChanged();
+    emit applied(report.totalTrianglesBefore, report.totalTrianglesAfter);
+}
+// LCOV_EXCL_STOP

--- a/src/MeshDecimatorController.cpp
+++ b/src/MeshDecimatorController.cpp
@@ -46,11 +46,12 @@ void MeshDecimatorController::kill()
     m_pSingleton = nullptr;
 }
 
-MeshDecimatorController::~MeshDecimatorController() = default;
-
 MeshDecimatorController::MeshDecimatorController() : QObject(nullptr)
 {
-    m_generator = std::make_unique<Ogre::MeshLodGenerator>();
+    // Ogre::MeshLodGenerator is a singleton (Ogre's Singleton<> CRTP).
+    // MeshLodController already owns one — we do NOT construct a second
+    // instance; we use Ogre::MeshLodGenerator::getSingleton() at the use
+    // sites instead.
 
     connect(SelectionSet::getSingleton(), &SelectionSet::selectionChanged,
             this, [this]() {
@@ -111,7 +112,8 @@ void MeshDecimatorController::previewReduction(double reduction)
     lodConfig.createGeneratedLodLevel(0.0f, static_cast<float>(r),
                                       Ogre::LodLevel::VRM_PROPORTIONAL);
     try {
-        m_generator->generateLodLevels(lodConfig);
+        // Use the shared Ogre singleton — MeshLodController constructed it.
+        Ogre::MeshLodGenerator::getSingleton().generateLodLevels(lodConfig);
     } catch (const Ogre::Exception& e) {
         emit error(QString("Preview failed: %1").arg(e.what()));
         return;

--- a/src/MeshDecimatorController.cpp
+++ b/src/MeshDecimatorController.cpp
@@ -112,8 +112,15 @@ void MeshDecimatorController::previewReduction(double reduction)
     lodConfig.createGeneratedLodLevel(0.0f, static_cast<float>(r),
                                       Ogre::LodLevel::VRM_PROPORTIONAL);
     try {
-        // Use the shared Ogre singleton — MeshLodController constructed it.
-        Ogre::MeshLodGenerator::getSingleton().generateLodLevels(lodConfig);
+        // Use the shared Ogre singleton — MeshLodController normally owns it.
+        // getSingletonPtr() is null only in CLI/test contexts where neither
+        // controller has been instantiated; in the editor it's always set.
+        auto* gen = Ogre::MeshLodGenerator::getSingletonPtr();
+        if (!gen) {
+            emit error(QStringLiteral("Internal error: MeshLodGenerator not initialised."));
+            return;
+        }
+        gen->generateLodLevels(lodConfig);
     } catch (const Ogre::Exception& e) {
         emit error(QString("Preview failed: %1").arg(e.what()));
         return;

--- a/src/MeshDecimatorController.h
+++ b/src/MeshDecimatorController.h
@@ -1,0 +1,82 @@
+#ifndef MESHDECIMATORCONTROLLER_H
+#define MESHDECIMATORCONTROLLER_H
+
+#include <QObject>
+#include <QQmlEngine>
+#include <memory>
+
+namespace Ogre { class MeshLodGenerator; }
+
+// Inspector-side decimation singleton. Parallels MeshLodController but for
+// single-pass (base-mesh) reduction rather than the LOD chain.
+//
+// Workflow expected from QML:
+//   1. user opens the Decimate section while a mesh is selected
+//   2. slider changes — QML calls previewReduction(r). The controller
+//      generates a *temporary* LOD at fraction r and swaps display to
+//      it via setMeshLodBias, then emits previewChanged(triangleCount).
+//   3. user clicks Apply — applyReduction(r) commits the swap to the
+//      base mesh and emits applied(report).
+//   4. selection changes — controller resets to "no preview" automatically.
+//
+// All operations require a current selection; with no selection the
+// methods are no-ops and emit error().
+class MeshDecimatorController : public QObject
+{
+    Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
+
+    Q_PROPERTY(bool hasSelection READ hasSelection NOTIFY selectionChanged)
+    Q_PROPERTY(int baseTriangleCount READ baseTriangleCount NOTIFY baseChanged)
+    Q_PROPERTY(int previewTriangleCount READ previewTriangleCount NOTIFY previewChanged)
+    Q_PROPERTY(bool hasActivePreview READ hasActivePreview NOTIFY previewChanged)
+
+public:
+    static MeshDecimatorController* instance();
+    static MeshDecimatorController* qmlInstance(QQmlEngine* engine, QJSEngine* scriptEngine);
+    static void kill();
+
+    bool hasSelection() const;
+    // Counts are refreshed on selection change; the lazy-init case
+    // (singleton instantiated after initial selection) is handled by
+    // refreshing in the getter when the cache is 0.
+    int baseTriangleCount() const;
+    int previewTriangleCount() const { return m_previewTriangleCount; }
+    bool hasActivePreview() const { return m_hasPreview; }
+
+    // Generate a temporary LOD at fraction `reduction` and swap display
+    // to it. Cheap-ish but not free — debounce on the QML side so we don't
+    // regenerate on every slider sample.
+    Q_INVOKABLE void previewReduction(double reduction);
+
+    // Drop the preview LOD; restore the base mesh.
+    Q_INVOKABLE void clearPreview();
+
+    // Commit the current preview (if any) to the base mesh. Subsequent
+    // operations see the reduced mesh as the new baseline. Emits applied().
+    Q_INVOKABLE void applyReduction(double reduction);
+
+signals:
+    void selectionChanged();
+    void baseChanged();
+    void previewChanged();
+    void applied(int trianglesBefore, int trianglesAfter);
+    void error(const QString& message);
+
+private:
+    MeshDecimatorController();
+    // Defined out-of-line so the unique_ptr<MeshLodGenerator> destructor
+    // sees the complete type (header-only forward decl is insufficient).
+    ~MeshDecimatorController() override;
+
+    void refreshBaseline();
+
+    static MeshDecimatorController* m_pSingleton;
+    std::unique_ptr<Ogre::MeshLodGenerator> m_generator;
+    int m_baseTriangleCount = 0;
+    int m_previewTriangleCount = 0;
+    bool m_hasPreview = false;
+};
+
+#endif // MESHDECIMATORCONTROLLER_H

--- a/src/MeshDecimatorController.h
+++ b/src/MeshDecimatorController.h
@@ -3,9 +3,6 @@
 
 #include <QObject>
 #include <QQmlEngine>
-#include <memory>
-
-namespace Ogre { class MeshLodGenerator; }
 
 // Inspector-side decimation singleton. Parallels MeshLodController but for
 // single-pass (base-mesh) reduction rather than the LOD chain.
@@ -70,14 +67,11 @@ signals:
 
 private:
     MeshDecimatorController();
-    // Defined out-of-line so the unique_ptr<MeshLodGenerator> destructor
-    // sees the complete type (header-only forward decl is insufficient).
-    ~MeshDecimatorController() override;
+    ~MeshDecimatorController() override = default;
 
     void refreshBaseline();
 
     static MeshDecimatorController* m_pSingleton;
-    std::unique_ptr<Ogre::MeshLodGenerator> m_generator;
     int m_baseTriangleCount = 0;
     int m_previewTriangleCount = 0;
     bool m_hasPreview = false;

--- a/src/MeshDecimatorController.h
+++ b/src/MeshDecimatorController.h
@@ -38,12 +38,16 @@ public:
     static void kill();
 
     bool hasSelection() const;
-    // Counts are refreshed on selection change; the lazy-init case
-    // (singleton instantiated after initial selection) is handled by
-    // refreshing in the getter when the cache is 0.
-    int baseTriangleCount() const;
+    // Counts are refreshed on selection change; refresh once at first read
+    // via the Q_INVOKABLE primeBaseline() entry point (QML calls it in
+    // Component.onCompleted to handle the singleton-after-selection case
+    // without const_cast tricks in the getter).
+    int baseTriangleCount() const { return m_baseTriangleCount; }
     int previewTriangleCount() const { return m_previewTriangleCount; }
     bool hasActivePreview() const { return m_hasPreview; }
+
+    // Force a baseline recount + signal. QML calls this on section load.
+    Q_INVOKABLE void primeBaseline();
 
     // Generate a temporary LOD at fraction `reduction` and swap display
     // to it. Cheap-ish but not free — debounce on the QML side so we don't

--- a/src/MeshDecimator_test.cpp
+++ b/src/MeshDecimator_test.cpp
@@ -1,0 +1,144 @@
+#include <gtest/gtest.h>
+
+#include "MeshDecimator.h"
+
+#include <QJsonArray>
+#include <QJsonObject>
+#include <limits>
+
+// Pure-data tests — no Ogre needed.
+
+TEST(MeshDecimatorTest, ReductionFromTargetTrisEmpty)
+{
+    EXPECT_DOUBLE_EQ(0.0, MeshDecimator::reductionFromTargetTris(0, 100));
+    EXPECT_DOUBLE_EQ(0.0, MeshDecimator::reductionFromTargetTris(-5, 100));
+}
+
+TEST(MeshDecimatorTest, ReductionFromTargetTrisNoChange)
+{
+    // target >= current → no reduction
+    EXPECT_DOUBLE_EQ(0.0, MeshDecimator::reductionFromTargetTris(100, 100));
+    EXPECT_DOUBLE_EQ(0.0, MeshDecimator::reductionFromTargetTris(100, 200));
+}
+
+TEST(MeshDecimatorTest, ReductionFromTargetTrisHalving)
+{
+    // 10000 → 5000 = 50% reduction
+    EXPECT_NEAR(0.5, MeshDecimator::reductionFromTargetTris(10000, 5000), 1e-9);
+}
+
+TEST(MeshDecimatorTest, ReductionFromTargetTrisFloor)
+{
+    // target = 0 → max reduction (caps at kMaxReduction so we don't degenerate)
+    EXPECT_DOUBLE_EQ(MeshDecimator::kMaxReduction,
+                     MeshDecimator::reductionFromTargetTris(10000, 0));
+    EXPECT_DOUBLE_EQ(MeshDecimator::kMaxReduction,
+                     MeshDecimator::reductionFromTargetTris(10000, -10));
+}
+
+TEST(MeshDecimatorTest, ReductionFromTargetVertsHalving)
+{
+    EXPECT_NEAR(0.5, MeshDecimator::reductionFromTargetVerts(2000, 1000), 1e-9);
+}
+
+TEST(MeshDecimatorTest, ClampReductionBounds)
+{
+    EXPECT_DOUBLE_EQ(0.0, MeshDecimator::clampReduction(0.0));
+    EXPECT_DOUBLE_EQ(0.0, MeshDecimator::clampReduction(-0.5));
+    EXPECT_DOUBLE_EQ(0.25, MeshDecimator::clampReduction(0.25));
+    EXPECT_DOUBLE_EQ(MeshDecimator::kMaxReduction,
+                     MeshDecimator::clampReduction(0.99));
+    EXPECT_DOUBLE_EQ(MeshDecimator::kMaxReduction,
+                     MeshDecimator::clampReduction(2.0));
+}
+
+TEST(MeshDecimatorTest, ClampReductionNaN)
+{
+    // NaN should fold to 0 (analyze-only / safe behaviour).
+    EXPECT_DOUBLE_EQ(0.0, MeshDecimator::clampReduction(
+        std::numeric_limits<double>::quiet_NaN()));
+}
+
+TEST(MeshDecimatorTest, JsonEmptyReport)
+{
+    DecimationReport empty;
+    const QJsonObject obj = MeshDecimator::toJson(empty);
+    EXPECT_TRUE(obj.contains("mesh"));
+    EXPECT_TRUE(obj.contains("submeshes"));
+    EXPECT_TRUE(obj.contains("totals"));
+    EXPECT_FALSE(obj["applied"].toBool());
+    EXPECT_EQ(0, obj["totals"].toObject()["trianglesBefore"].toInt());
+    EXPECT_DOUBLE_EQ(0.0, obj["totals"].toObject()["effectiveReduction"].toDouble());
+}
+
+TEST(MeshDecimatorTest, JsonShapeWithSubmeshes)
+{
+    DecimationReport report;
+    report.meshName = "Cube.mesh";
+    report.appliedReduction = 0.5;
+    report.applied = true;
+    DecimationSubmeshReport sr;
+    sr.meshName = "Cube.mesh";
+    sr.submeshIndex = 0;
+    sr.trianglesBefore = 1000;
+    sr.trianglesAfter = 500;
+    report.submeshes.append(sr);
+    report.totalTrianglesBefore = 1000;
+    report.totalTrianglesAfter = 500;
+
+    const QJsonObject obj = MeshDecimator::toJson(report);
+    EXPECT_EQ(QString("Cube.mesh"), obj["mesh"].toString());
+    EXPECT_DOUBLE_EQ(0.5, obj["appliedReduction"].toDouble());
+    EXPECT_TRUE(obj["applied"].toBool());
+    EXPECT_EQ(1, obj["submeshes"].toArray().size());
+    EXPECT_EQ(1000, obj["totals"].toObject()["trianglesBefore"].toInt());
+    EXPECT_EQ(500, obj["totals"].toObject()["trianglesAfter"].toInt());
+    EXPECT_NEAR(0.5, obj["totals"].toObject()["effectiveReduction"].toDouble(), 1e-9);
+}
+
+TEST(MeshDecimatorTest, EffectiveReductionDivByZero)
+{
+    DecimationReport report;
+    EXPECT_DOUBLE_EQ(0.0, report.effectiveReduction());
+}
+
+TEST(MeshDecimatorTest, TextHasHeaderAndAppliedFlag)
+{
+    DecimationReport report;
+    report.meshName = "M.mesh";
+    report.appliedReduction = 0.3;
+    report.applied = true;
+    DecimationSubmeshReport sr;
+    sr.submeshIndex = 0;
+    sr.trianglesBefore = 100;
+    sr.trianglesAfter = 70;
+    report.submeshes.append(sr);
+    report.totalTrianglesBefore = 100;
+    report.totalTrianglesAfter = 70;
+
+    const QString text = MeshDecimator::toText(report);
+    EXPECT_TRUE(text.contains("Mesh Decimation"));
+    EXPECT_TRUE(text.contains("M.mesh"));
+    EXPECT_TRUE(text.contains("30.0%"));
+    EXPECT_TRUE(text.contains("applied"));
+}
+
+TEST(MeshDecimatorTest, TextHandlesProjected)
+{
+    DecimationReport report;
+    report.meshName = "M.mesh";
+    report.appliedReduction = 0.25;
+    report.applied = false;
+    report.totalTrianglesBefore = 4;
+    report.totalTrianglesAfter = 3;
+    QString text = MeshDecimator::toText(report);
+    EXPECT_TRUE(text.contains("projected"));
+    EXPECT_FALSE(text.contains("applied"));
+}
+
+TEST(MeshDecimatorTest, TextHandlesEmpty)
+{
+    DecimationReport empty;
+    const QString text = MeshDecimator::toText(empty);
+    EXPECT_TRUE(text.contains("(no mesh)"));
+}

--- a/src/MeshInfoOverlay.cpp
+++ b/src/MeshInfoOverlay.cpp
@@ -6,6 +6,7 @@
 #include "CLIPipeline.h"
 #include "MemoryEstimator.h"
 #include "DrawCallAnalyzer.h"
+#include "MeshDecimatorController.h"
 #include "mainwindow.h"
 
 #include <QEvent>
@@ -21,6 +22,11 @@ MeshInfoOverlay::MeshInfoOverlay(QMainWindow* parent)
     connect(Manager::getSingleton(), &Manager::entityCreated,
             this, &MeshInfoOverlay::refresh);
     connect(Manager::getSingleton(), &Manager::sceneNodeDestroyed,
+            this, &MeshInfoOverlay::refresh);
+    // In-place mesh mutations (decimate, future ones) don't fire any of the
+    // Manager signals above — listen to the controller directly so the
+    // overlay's tri/draw/GPU lines stay accurate after Apply.
+    connect(MeshDecimatorController::instance(), &MeshDecimatorController::applied,
             this, &MeshInfoOverlay::refresh);
 
     // Track main window moves/resizes to reposition the floating overlay

--- a/src/MeshValidator.cpp
+++ b/src/MeshValidator.cpp
@@ -306,6 +306,24 @@ void MeshValidator::doValidate()
         issue["count"] = 0;
         issue["fixable"] = false;
         m_issues.append(issue);
+
+        // Phase 6 slice D: triangle-budget hint. Over ~10k tris on a mobile
+        // target, suggest a one-shot decimation. Threshold is intentionally
+        // generous — desktop pipelines routinely ship higher poly counts.
+        // The actual budget belongs in a future scan rule; this is the
+        // "did you remember to think about this?" nudge.
+        if (totalTris > 10000) {
+            QVariantMap suggestion;
+            suggestion["type"] = "info";
+            suggestion["description"] =
+                QString("Tri budget: %1 triangle(s) — consider decimating for mobile/web "
+                        "(qtmesh decimate -o <out> --target-tris 5000, or the MCP "
+                        "decimate_mesh tool)")
+                    .arg(locale.toString(totalTris));
+            suggestion["count"] = totalTris;
+            suggestion["fixable"] = false;
+            m_issues.append(suggestion);
+        }
     }
 
     // 2. UVs — finite / range. Skip the check entirely when the mesh has no UVs.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -89,7 +89,8 @@ int main(int argc, char *argv[])
                         || arg == "validate" || arg == "lod" || arg == "pose"
                         || arg == "scan" || arg == "material" || arg == "pack-textures"
                         || arg == "normal-from-height" || arg == "memory"
-                        || arg == "analyze" || arg == "vertex-cache")
+                        || arg == "analyze" || arg == "vertex-cache"
+                        || arg == "decimate")
                     cliMode = true;
                 break;  // first non-flag arg determines mode
             }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -63,6 +63,7 @@
 #include "commands/TransformCommands.h"
 #include "PropertiesPanelController.h"
 #include "MeshLodController.h"
+#include "MeshDecimatorController.h"
 #include "MeshValidator.h"
 #include "MaterialPresetLibrary.h"
 #include "MaterialPreviewRenderer.h"
@@ -485,6 +486,11 @@ void MainWindow::initToolBar()
         qmlRegisterSingletonType<MeshLodController>("PropertiesPanel", 1, 0, "MeshLodController",
             [](QQmlEngine* engine, QJSEngine*) -> QObject* {
                 return MeshLodController::qmlInstance(engine, nullptr);
+            });
+        qmlRegisterSingletonType<MeshDecimatorController>(
+            "PropertiesPanel", 1, 0, "MeshDecimatorController",
+            [](QQmlEngine* engine, QJSEngine*) -> QObject* {
+                return MeshDecimatorController::qmlInstance(engine, nullptr);
             });
         // Open the LOD export directory picker from MainWindow so the dialog has a
         // proper parent widget — QFileDialog invoked from a QML context doesn't

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -92,6 +92,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/DrawCallAnalyzer.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/VertexCacheOptimizer.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MeshDecimator.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/MeshDecimatorController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MeshLodController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MeshValidator.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AIChatManager.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -91,6 +91,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MemoryEstimator.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/DrawCallAnalyzer.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/VertexCacheOptimizer.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/MeshDecimator.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MeshLodController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MeshValidator.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AIChatManager.cpp

--- a/website/src/DocsApp.jsx
+++ b/website/src/DocsApp.jsx
@@ -23,6 +23,7 @@ const NAV = [
     { id: 'cmd-memory', label: 'memory' },
     { id: 'cmd-analyze', label: 'analyze' },
     { id: 'cmd-vertex-cache', label: 'vertex-cache' },
+    { id: 'cmd-decimate', label: 'decimate' },
   ]},
   { section: 'Scan Reference', items: [
     { id: 'scan-config', label: 'Configuration (qtmesh.yml)' },
@@ -512,6 +513,34 @@ Summary:
               <Code>qtmesh optimize</Code> command.
             </p>
 
+            <h3 className={s.subsection}>Decimation (poly reduction)</h3>
+            <p className={s.para}>
+              Cutting an asset's triangle count is two very different things in this tool:
+            </p>
+            <ul className={s.para} style={{ paddingLeft: '1.4rem' }}>
+              <li><strong><Code>qtmesh lod</Code></strong> generates a <em>chain</em> of LOD
+                  levels (LOD 0/1/2/3) for distance-based rendering. The original mesh is the
+                  base, the reduced versions sit alongside as additional levels.</li>
+              <li><strong><Code>qtmesh decimate</Code></strong> performs a <em>single-pass</em>
+                  reduction that rewrites the base mesh itself. There's no LOD chain afterwards
+                  — the mesh just has fewer triangles. Use this when you want an asset to
+                  ship at, say, 5,000 triangles instead of 50,000, regardless of camera distance.</li>
+            </ul>
+            <p className={s.para}>
+              Both backends use Ogre's <Code>MeshLodGenerator</Code> (edge-collapse based,
+              respects submesh boundaries). Decimation accepts three target modes: a raw
+              reduction fraction (<Code>--reduction 0.5</Code> = drop half the tris), a target
+              triangle count (<Code>--target-tris 5000</Code>), or a target vertex budget
+              (<Code>--target-verts 2500</Code>). All three clamp to 95% max so we don't
+              degenerate the mesh into a single triangle.
+            </p>
+            <p className={s.para}>
+              The validator emits a "Tri budget" suggestion row when the active selection has
+              more than ~10,000 triangles. It's a nudge, not a hard rule — desktop pipelines
+              routinely ship higher poly counts. Set a stricter scan rule
+              (<Code>max_vertex_count</Code>) if you need CI enforcement.
+            </p>
+
             <h3 className={s.subsection}>Vertex cache (ACMR)</h3>
             <p className={s.para}>
               Modern GPUs cache the last ~32 transformed vertices (the "post-T&amp;L cache"). Triangles that
@@ -677,6 +706,56 @@ Submeshes rewritten: 1 of 2`}</CodeBlock>
               <strong>MCP:</strong> the <Code>optimize_vertex_cache</Code> tool takes a <Code>rewrite</Code>
               bool (default <Code>false</Code>) and returns the structured payload under the
               <Code>vertexCache</Code> key.
+            </p>
+          </CmdSection>
+
+          <CmdSection id="cmd-decimate" name="decimate" description="Single-pass mesh decimation. Reduces the base mesh itself (unlike `lod` which builds a discrete LOD chain). Pick one of three target modes — by fraction, by triangle count, or by vertex budget. Always requires -o; never overwrites the input."
+            synopsis={`qtmesh decimate <file> -o <output> --reduction <r> [--json]
+qtmesh decimate <file> -o <output> --target-tris N [--json]
+qtmesh decimate <file> -o <output> --target-verts N [--json]`}
+            options={[
+              ['-o <output>', 'Output file (required — decimation is destructive)'],
+              ['--reduction <r>', 'Drop this fraction of triangles (0..0.95). 0.5 = 50% reduction.'],
+              ['--target-tris N', 'Reduce to approximately N triangles total.'],
+              ['--target-verts N', 'Reduce to approximately N vertices total.'],
+              ['--json', 'Output the structured report as JSON'],
+            ]}
+            examples={[
+              'qtmesh decimate character.fbx -o character_lo.fbx --reduction 0.5',
+              'qtmesh decimate character.fbx -o character_mobile.glb2 --target-tris 5000',
+              'qtmesh decimate character.fbx -o tiny.fbx --target-verts 1500 --json',
+            ]}
+          >
+            <h3 className={s.subsection}>Example Output</h3>
+            <CodeBlock>{`File: ninja.mesh -> ninja_dec.mesh
+Mesh Decimation
+===============
+
+Mesh: ninja.mesh
+Reduction requested: 50.4%  (applied)
+
+  [0] tris 904 → 456
+  [1] tris 104 → 36
+
+Total: 1,008 → 492 (51.2% effective reduction)`}</CodeBlock>
+            <p className={s.para}>
+              <strong>Caps at 95%</strong> — the slider / API never lets you drop below 5% of the
+              original triangle count, which would degenerate the mesh into a single triangle in
+              most cases. If you need to go further, run a second pass.
+            </p>
+            <p className={s.para}>
+              <strong>UV seams / material boundaries:</strong> the underlying
+              <Code>Ogre::MeshLodGenerator</Code> decimates each submesh independently and
+              respects index-buffer boundaries, so a mesh split across multiple materials keeps its
+              UV-island seams. True per-vertex weight locking (so you can mark cap edges as
+              "never collapse this") is its own future slice — the current path uses uniform weights.
+            </p>
+            <p className={s.para}>
+              <strong>MCP:</strong> the <Code>decimate_mesh</Code> tool takes one of
+              <Code>reduction</Code> / <Code>target_tris</Code> / <Code>target_verts</Code> plus an
+              optional <Code>dry_run</Code> bool (default <Code>false</Code>; when true, returns a
+              projected report without mutating the scene). Response carries the structured
+              payload under the <Code>decimation</Code> key.
             </p>
           </CmdSection>
 


### PR DESCRIPTION
## Summary

Phase 6 slice D (#261) — single-pass mesh decimation with live in-app preview. Same pattern as slices A/B/C (pure-data + CLI + MCP + validator + Inspector controller).

- **`MeshDecimator`** (new): wraps `Ogre::MeshLodGenerator` for *single-pass* base-mesh reduction. Unlike `MeshLodController` (which builds an LOD chain for distance-based rendering), this rewrites the base mesh itself — appropriate for "ship this asset at 5,000 tris regardless of distance". Three target modes: `--reduction <r>` (drop the requested fraction), `--target-tris N`, `--target-verts N`. All clamp at 95% so we never degenerate to one triangle.
- **`MeshDecimatorController`** (new): QML_SINGLETON parallel to `MeshLodController`. Owns the live preview / Apply lifecycle. Reaches `Ogre::MeshLodGenerator` via the shared singleton (the GUI's `MeshLodController` owns the live instance; lazy-constructs in CLI/MCP/test contexts where neither controller is around).
- **Inspector section**: new "Decimate (single-pass)" CollapsibleSection right below "LOD Generation" in Object mode. Slider in 5% steps 0..95%, live "Tris: 12,584 → 6,200" readout (the second number in blue while a preview is active), Apply + Reset Preview buttons. 150ms debounce on the slider so dragging doesn't melt Ogre with per-pixel LOD rebuilds. Slider defaults to **0%** so opening the section leaves the mesh unchanged until the user actually drags.
- **CLI `qtmesh decimate <file> -o <out>`** (always requires `-o` — destructive op, never overwrites input). Strict numeric input validation; rejects ambiguous combinations like `--reduction 0.5 --target-tris 1000`.
- **MCP tool `decimate_mesh`** — operates on the *selected* entity (not the first scene entity), supports `dry_run`, returns error when applied=false. Structured payload under the `decimation` key.
- **Validator integration**: when geometry-ok reports > 10,000 triangles, emits a "Tri budget" info-row pointing at the CLI/MCP/Inspector action paths.
- **Live overlay refresh**: floating mesh-info overlay (`MeshInfoOverlay`) listens to `MeshDecimatorController::applied` so the tri/draws/GPU lines update immediately after Apply — no need to toggle the overlay off/on.
- **Docs**: new "Decimation (poly reduction)" Concepts entry distinguishing `lod` (chain) from `decimate` (single-pass), full CmdSection in DocsApp.

## Manual smoke

```
$ qtmesh decimate media/models/ninja.mesh -o /tmp/ninja_dec.mesh --target-tris 500
File: ninja.mesh -> ninja_dec.mesh
Mesh Decimation
===============

Mesh: ninja.mesh
Reduction requested: 50.4%  (applied)

  [0] tris 904 → 456
  [1] tris 104 → 36

Total: 1,008 → 492 (51.2% effective reduction)
```

In-app: select an entity, expand the Decimate section, drag the slider — viewport updates after the 150ms debounce, tri-count line shows `→ N` in blue. Click Apply to commit; the overlay refreshes on its own.

## Deliberately deferred from #261's slice D scope

Captured in tracking tasks for future slices:

- **Compare mode (split viewport)** — needs second-viewport infrastructure; significant UI work.
- **Per-vertex lock weights** — Ogre's `MeshLodGenerator` doesn't expose per-vertex weights. True QEM-with-locks would replace the algorithm; orthogonal to this slice.

## Issues fixed during review / iteration

- **CodeRabbit P1**: MCP decimate_mesh was operating on the first scene entity instead of the selected one. Now reads `SelectionSet::getResolvedEntities()`.
- **CodeRabbit P1**: CLI numeric inputs silently accepted non-numeric values (Qt's `toInt()` fallback to 0) which triggered 95% reduction. Added `parseStrictInt` / `parseStrictDouble` with explicit error messages and "exactly one target mode" enforcement.
- **CodeRabbit P2**: MCP returned `makeSuccessResult` when `applied=false`. Now returns an error in that case (gated by `!dry_run && reduction > 0`).
- **CodeRabbit minor**: `projectEntity` invented triangles for empty submeshes via `max(1, ...)` — now stays at 0 for empty inputs.
- **CodeRabbit minor**: `decimateEntity` on LOD generation failure left `totalTrianglesAfter` at 0 while per-submesh mirrored before — now consistent.
- **SonarCloud S859 const_cast**: replaced the cast-away-const lazy-fill of `baseTriangleCount` with a Q_INVOKABLE `primeBaseline()` that QML calls in `Component.onCompleted`.
- **SonarCloud S3776 cognitive complexity 35**: extracted `applyDecimateArg` helper from `parseDecimateArgs`; below threshold.
- **SonarCloud S6004 / S5350**: init-statement for `modesProvided`, const pointers for SelectionSet handles.
- **App crash on startup (SIGABRT)** after the QML-singleton registration landed: `Ogre::MeshLodGenerator` is itself a `Singleton<>` CRTP; the controller's constructor was creating a second instance. Now reaches the shared singleton via `getSingleton()`.
- **"Decimation failed" on Apply** (preview worked): same singleton trap, but inside `MeshDecimator::decimateEntity` constructing a local generator. Now uses a `sharedLodGenerator()` helper that returns the live instance and lazy-constructs in CLI/test contexts.
- **Slider opened at 50%** changing the mesh before user interaction: now defaults to 0% (no preview until the user drags).
- **Overlay stale after Apply**: the floating mesh-info overlay didn't refresh on in-place mesh mutations. Now subscribes to `MeshDecimatorController::applied`.

## Test plan

- [x] 14 `MeshDecimatorTest.*` pure-data tests (target-mode arithmetic, reduction clamping, JSON/text serialisation, NaN handling). Run on every CI build.
- [x] Manual: in-app slider + Apply + Reset Preview on imported FBX and procedural primitives — preview lerps with the slider, Apply commits, overlay updates immediately.
- [x] Manual: `qtmesh decimate` on ninja.mesh with `--target-tris 500` produces 1,008→492 (51%), `--reduction 0.75` produces 1,008→248 (75%). JSON output validates.
- [x] Manual: strict numeric input rejection (`--target-tris foo` → exit 2 with clear error). Ambiguous targets rejected.
- [x] Build clean on macOS arm64 (Qt 6.9.3 / Ogre 14.5.x). All sources wired into both `src/CMakeLists.txt` and `tests/CMakeLists.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
