### PR TITLE
[codex] Fix scene-save n-gon round-trip and bump 3.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 3.0.1 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 3.1.0 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Available on the [GitHub Actions Marketplace](https://github.com/marketplace/act
 **Versioning**
 
 - **Always follow the latest GitHub release** — use the Marketplace floating tag `fernandotonon/QtMeshEditor@v1` (same pattern as the [Marketplace example](https://github.com/marketplace/actions/qtmesheditor)). The composite action defaults to `image-tag: latest`, so the Docker CLI tracks the newest published `ghcr.io/fernandotonon/qtmesh` image.
-- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.0.0**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
+- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.1.0**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
 
 Pinned workflow template (action + `ghcr.io` image aligned):
 
@@ -51,10 +51,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run QtMesh scan
-        uses: fernandotonon/QtMeshEditor@3.0.1
+        uses: fernandotonon/QtMeshEditor@3.1.0
         with:
           command: scan
-          image-tag: "3.0.0"
+          image-tag: "3.1.0"
         env:
           QTMESH_CLOUD_TOKEN: ${{ secrets.QTMESH_CLOUD_TOKEN }}
 ```
@@ -79,39 +79,39 @@ Release tags are listed on the [releases page](https://github.com/fernandotonon/
 
 ```yaml
 # Validate a specific mesh
-- uses: fernandotonon/QtMeshEditor@3.0.1
+- uses: fernandotonon/QtMeshEditor@3.1.0
   with:
     command: validate
     input-file: ./models/character.fbx
-    image-tag: "3.0.0"
+    image-tag: "3.1.0"
 
 # Convert FBX → glTF
-- uses: fernandotonon/QtMeshEditor@3.0.1
+- uses: fernandotonon/QtMeshEditor@3.1.0
   with:
     command: convert
     input-file: ./models/character.fbx
     output-file: ./output/character.gltf2
-    image-tag: "3.0.0"
+    image-tag: "3.1.0"
 
 # Resample Mixamo animations (200+ keyframes → 30)
-- uses: fernandotonon/QtMeshEditor@3.0.1
+- uses: fernandotonon/QtMeshEditor@3.1.0
   with:
     command: anim
     input-file: ./animations/dance.fbx
     output-file: ./output/dance_optimized.fbx
     options: --resample 30
-    image-tag: "3.0.0"
+    image-tag: "3.1.0"
 
 # Get mesh info as JSON
-- uses: fernandotonon/QtMeshEditor@3.0.1
+- uses: fernandotonon/QtMeshEditor@3.1.0
   id: info
   with:
     command: info
     input-file: ./models/character.fbx
     options: --json
-    image-tag: "3.0.0"
+    image-tag: "3.1.0"
 
-# Docker (alternative — :latest tracks newest image; pin :3.0.0 to match semver action ref)
+# Docker (alternative — :latest tracks newest image; pin :3.1.0 to match semver action ref)
 docker run --rm -v $(pwd):/workspace ghcr.io/fernandotonon/qtmesh:latest scan ./assets --fail-on error
 ```
 

--- a/src/MeshImporterExporter.cpp
+++ b/src/MeshImporterExporter.cpp
@@ -39,6 +39,8 @@ THE SOFTWARE.
 #include <QFile>
 #include <QDir>
 #include <QRegularExpression>
+#include <QJsonArray>
+#include <QJsonDocument>
 #include <set>
 #include <cmath>
 #include <cstring>
@@ -322,7 +324,8 @@ static void readSubmeshGeometry(
     const Ogre::SubMesh* subMesh,
     const Ogre::Entity* entity,
     unsigned int subIndex,
-    const std::map<std::string, unsigned int, std::less<>>& matIndexMap)
+    const std::map<std::string, unsigned int, std::less<>>& matIndexMap,
+    bool preferNgonFaces = true)
 {
     aiM->mPrimitiveTypes = aiPrimitiveType_TRIANGLE;
     aiM->mNumVertices = static_cast<unsigned int>(vData->vertexCount);
@@ -414,7 +417,7 @@ static void readSubmeshGeometry(
     // that have never carried n-gon data — fall back to reading the
     // triangle index buffer directly.
     std::vector<std::vector<unsigned int>> ngonFaces;
-    const bool hasNgon = readNgonFacesFromMesh(
+    const bool hasNgon = preferNgonFaces && readNgonFacesFromMesh(
         entity->getMesh().get(), subIndex, ngonFaces);
     if (hasNgon)
     {
@@ -466,6 +469,80 @@ static void readSubmeshGeometry(
             ibuf->unlock();
         }
     }
+}
+
+static std::string sceneNgonFacesMetaKey(unsigned int subIndex)
+{
+    return std::string("qtme.faces.") + std::to_string(subIndex);
+}
+
+static aiString encodeSceneNgonFacesMetadata(const std::vector<std::vector<unsigned int>>& faces)
+{
+    QJsonArray outer;
+    for (const auto& face : faces)
+    {
+        if (face.size() < 3)
+            continue;
+        QJsonArray poly;
+        for (unsigned int idx : face)
+            poly.append(static_cast<int>(idx));
+        outer.append(poly);
+    }
+    const QByteArray json = QJsonDocument(outer).toJson(QJsonDocument::Compact);
+    return aiString(json.constData());
+}
+
+static bool decodeSceneNgonFacesMetadata(const aiMetadata* metadata,
+                                         unsigned int subIndex,
+                                         std::vector<std::vector<unsigned int>>& outFaces)
+{
+    outFaces.clear();
+    if (!metadata)
+        return false;
+
+    aiString encoded;
+    bool found = false;
+    const std::string key = sceneNgonFacesMetaKey(subIndex);
+    for (unsigned int i = 0; i < metadata->mNumProperties; ++i)
+    {
+        if (std::string(metadata->mKeys[i].C_Str()) != key)
+            continue;
+        if (!metadata->Get(i, encoded))
+            return false;
+        found = true;
+        break;
+    }
+    if (!found)
+        return false;
+
+    const QJsonDocument doc = QJsonDocument::fromJson(QByteArray(encoded.C_Str()));
+    if (!doc.isArray())
+        return false;
+
+    const QJsonArray outer = doc.array();
+    outFaces.reserve(static_cast<size_t>(outer.size()));
+    for (const QJsonValue& faceValue : outer)
+    {
+        if (!faceValue.isArray())
+            return false;
+        const QJsonArray poly = faceValue.toArray();
+        if (poly.size() < 3)
+            return false;
+        std::vector<unsigned int> face;
+        face.reserve(static_cast<size_t>(poly.size()));
+        for (const QJsonValue& idxValue : poly)
+        {
+            if (!idxValue.isDouble())
+                return false;
+            const int idx = idxValue.toInt(-1);
+            if (idx < 0)
+                return false;
+            face.push_back(static_cast<unsigned int>(idx));
+        }
+        outFaces.push_back(std::move(face));
+    }
+
+    return !outFaces.empty();
 }
 
 // Assign bone weights from Ogre bone assignments to an aiMesh
@@ -2989,6 +3066,7 @@ static aiScene* buildSceneAiScene()
 
         // Create the scene node's aiNode
         aiNode* entityNode;
+        aiNode* meshOwnerNode = nullptr;
         if (hasSkeleton)
         {
             entityNode = new aiNode(std::string(sn->getName()));
@@ -3010,6 +3088,7 @@ static aiScene* buildSceneAiScene()
             meshNode->mMeshes = new unsigned int[numSub];
             for (unsigned int si = 0; si < numSub; ++si)
                 meshNode->mMeshes[si] = globalMeshIdx + si;
+            meshOwnerNode = meshNode;
 
             entityNode->mNumChildren = static_cast<unsigned int>(rootBoneNodes.size()) + 1;
             entityNode->mChildren = new aiNode*[entityNode->mNumChildren];
@@ -3025,6 +3104,7 @@ static aiScene* buildSceneAiScene()
             entityNode->mMeshes = new unsigned int[numSub];
             for (unsigned int si = 0; si < numSub; ++si)
                 entityNode->mMeshes[si] = globalMeshIdx + si;
+            meshOwnerNode = entityNode;
         }
 
         Ogre::Matrix4 nodeTransform;
@@ -3034,6 +3114,7 @@ static aiScene* buildSceneAiScene()
         scene->mRootNode->mChildren[ni] = entityNode;
 
         // --- Build meshes for this entity ---
+        std::vector<std::pair<unsigned int, aiString>> ngonMetadataEntries;
         for (unsigned int si = 0; si < numSub; ++si)
         {
             const Ogre::SubMesh* subMesh = mesh->getSubMesh(si);
@@ -3043,12 +3124,29 @@ static aiScene* buildSceneAiScene()
 
             auto* aiM = new aiMesh();
             scene->mMeshes[globalMeshIdx + si] = aiM;
-            readSubmeshGeometry(aiM, vData, subMesh, entity, si, matIndexMap);
+            readSubmeshGeometry(aiM, vData, subMesh, entity, si, matIndexMap, false);
+
+            std::vector<std::vector<unsigned int>> ngonFaces;
+            if (readNgonFacesFromMesh(mesh.get(), si, ngonFaces) && !ngonFaces.empty())
+                ngonMetadataEntries.emplace_back(si, encodeSceneNgonFacesMetadata(ngonFaces));
 
             if (hasSkeleton)
                 assignBoneWeights(aiM, subMesh, mesh, skeleton, boneHandleToName);
 
             compactAiMesh(aiM);
+        }
+
+        if (meshOwnerNode && !ngonMetadataEntries.empty())
+        {
+            meshOwnerNode->mMetaData = aiMetadata::Alloc(
+                static_cast<unsigned int>(ngonMetadataEntries.size()));
+            for (unsigned int mi = 0; mi < ngonMetadataEntries.size(); ++mi)
+            {
+                meshOwnerNode->mMetaData->Set(
+                    mi,
+                    sceneNgonFacesMetaKey(ngonMetadataEntries[mi].first),
+                    ngonMetadataEntries[mi].second);
+            }
         }
 
         // --- Animations ---
@@ -3516,6 +3614,28 @@ bool MeshImporterExporter::sceneImporter(const QString &_uri)
             Ogre::MeshPtr ogreMesh = meshProcessor.createMesh(
                 meshName, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
                 materialProcessor);
+
+            std::vector<EditableSubMesh> importedNgonFaces(ogreMesh->getNumSubMeshes());
+            bool haveImportedNgons = false;
+            const unsigned int importedSubCount =
+                std::min<unsigned int>(node->mNumMeshes, ogreMesh->getNumSubMeshes());
+            for (unsigned int subIdx = 0; subIdx < importedSubCount; ++subIdx)
+            {
+                std::vector<std::vector<unsigned int>> faces;
+                if (!decodeSceneNgonFacesMetadata(node->mMetaData, subIdx, faces))
+                    continue;
+
+                importedNgonFaces[subIdx].faces.reserve(faces.size());
+                for (auto& poly : faces)
+                {
+                    EditableFace face;
+                    face.indices = std::move(poly);
+                    importedNgonFaces[subIdx].faces.push_back(std::move(face));
+                }
+                haveImportedNgons = haveImportedNgons || !importedNgonFaces[subIdx].faces.empty();
+            }
+            if (haveImportedNgons)
+                writeNgonFacesToMesh(ogreMesh.get(), importedNgonFaces);
 
             // Create scene node with decomposed world transform
             Ogre::SceneNode* sn = manager->addSceneNode(nodeName);

--- a/src/MeshImporterExporter.cpp
+++ b/src/MeshImporterExporter.cpp
@@ -39,10 +39,9 @@ THE SOFTWARE.
 #include <QFile>
 #include <QDir>
 #include <QRegularExpression>
-#include <QJsonArray>
-#include <QJsonDocument>
 #include <set>
 #include <cmath>
+#include <cstdlib>
 #include <cstring>
 #include <algorithm>
 
@@ -476,20 +475,66 @@ static std::string sceneNgonFacesMetaKey(unsigned int subIndex)
     return std::string("qtme.faces.") + std::to_string(subIndex);
 }
 
-static aiString encodeSceneNgonFacesMetadata(const std::vector<std::vector<unsigned int>>& faces)
+static std::string sceneNgonFaceMetaKey(unsigned int subIndex, unsigned int faceIndex)
 {
-    QJsonArray outer;
-    for (const auto& face : faces)
+    return sceneNgonFacesMetaKey(subIndex) + ".face." + std::to_string(faceIndex);
+}
+
+static aiString encodeSceneNgonFaceMetadata(const std::vector<unsigned int>& face)
+{
+    std::string encoded;
+    for (size_t vertexIndex = 0; vertexIndex < face.size(); ++vertexIndex)
     {
-        if (face.size() < 3)
-            continue;
-        QJsonArray poly;
-        for (unsigned int idx : face)
-            poly.append(static_cast<int>(idx));
-        outer.append(poly);
+        if (!encoded.empty())
+            encoded.push_back(',');
+        encoded += std::to_string(face[vertexIndex]);
     }
-    const QByteArray json = QJsonDocument(outer).toJson(QJsonDocument::Compact);
-    return aiString(json.constData());
+    return aiString(encoded);
+}
+
+static bool decodeSceneNgonFaceMetadata(const aiString& encoded, std::vector<unsigned int>& outFace)
+{
+    outFace.clear();
+    const std::string value = encoded.C_Str();
+    if (value.empty())
+        return false;
+
+    size_t start = 0;
+    while (start < value.size())
+    {
+        const size_t end = value.find(',', start);
+        const std::string token = value.substr(start, end == std::string::npos ? std::string::npos : end - start);
+        if (token.empty())
+            return false;
+        char* tail = nullptr;
+        const unsigned long parsed = std::strtoul(token.c_str(), &tail, 10);
+        if (!tail || *tail != '\0')
+            return false;
+        outFace.push_back(static_cast<unsigned int>(parsed));
+        if (end == std::string::npos)
+            break;
+        start = end + 1;
+    }
+
+    return outFace.size() >= 3;
+}
+
+static bool remapNgonFaces(const std::vector<unsigned int>& remap,
+                           std::vector<std::vector<unsigned int>>& faces)
+{
+    if (remap.empty())
+        return true;
+
+    for (auto& face : faces)
+    {
+        for (auto& idx : face)
+        {
+            if (idx >= remap.size() || remap[idx] == UINT_MAX)
+                return false;
+            idx = remap[idx];
+        }
+    }
+    return true;
 }
 
 static bool decodeSceneNgonFacesMetadata(const aiMetadata* metadata,
@@ -500,49 +545,40 @@ static bool decodeSceneNgonFacesMetadata(const aiMetadata* metadata,
     if (!metadata)
         return false;
 
-    aiString encoded;
-    bool found = false;
-    const std::string key = sceneNgonFacesMetaKey(subIndex);
+    const std::string prefix = sceneNgonFacesMetaKey(subIndex) + ".face.";
+    std::map<unsigned int, std::vector<unsigned int>> orderedFaces;
     for (unsigned int i = 0; i < metadata->mNumProperties; ++i)
     {
-        if (std::string(metadata->mKeys[i].C_Str()) != key)
+        const std::string key = metadata->mKeys[i].C_Str();
+        if (key.rfind(prefix, 0) != 0)
             continue;
+
+        const std::string suffix = key.substr(prefix.size());
+        if (suffix.empty())
+            return false;
+        char* tail = nullptr;
+        const unsigned long faceIndex = std::strtoul(suffix.c_str(), &tail, 10);
+        if (!tail || *tail != '\0')
+            return false;
+
+        aiString encoded;
         if (!metadata->Get(i, encoded))
             return false;
-        found = true;
-        break;
-    }
-    if (!found)
-        return false;
 
-    const QJsonDocument doc = QJsonDocument::fromJson(QByteArray(encoded.C_Str()));
-    if (!doc.isArray())
-        return false;
-
-    const QJsonArray outer = doc.array();
-    outFaces.reserve(static_cast<size_t>(outer.size()));
-    for (const QJsonValue& faceValue : outer)
-    {
-        if (!faceValue.isArray())
-            return false;
-        const QJsonArray poly = faceValue.toArray();
-        if (poly.size() < 3)
-            return false;
         std::vector<unsigned int> face;
-        face.reserve(static_cast<size_t>(poly.size()));
-        for (const QJsonValue& idxValue : poly)
-        {
-            if (!idxValue.isDouble())
-                return false;
-            const int idx = idxValue.toInt(-1);
-            if (idx < 0)
-                return false;
-            face.push_back(static_cast<unsigned int>(idx));
-        }
-        outFaces.push_back(std::move(face));
+        if (!decodeSceneNgonFaceMetadata(encoded, face))
+            return false;
+        orderedFaces[static_cast<unsigned int>(faceIndex)] = std::move(face);
     }
 
-    return !outFaces.empty();
+    if (orderedFaces.empty())
+        return false;
+
+    outFaces.reserve(orderedFaces.size());
+    for (auto& [faceIndex, face] : orderedFaces)
+        outFaces.push_back(std::move(face));
+
+    return true;
 }
 
 // Assign bone weights from Ogre bone assignments to an aiMesh
@@ -594,9 +630,10 @@ static void assignBoneWeights(
 // weights. Required when exporting LOD-reduced geometry (full vertex buffer but
 // only a fraction of triangles), which otherwise causes expensive post-processing
 // (aiProcess_JoinIdenticalVertices, aiProcess_OptimizeMeshes) on import.
-static void compactAiMesh(aiMesh* aiM)
+static std::vector<unsigned int> compactAiMesh(aiMesh* aiM)
 {
-    if (!aiM || aiM->mNumVertices == 0 || aiM->mNumFaces == 0) return;
+    if (!aiM || aiM->mNumVertices == 0 || aiM->mNumFaces == 0)
+        return {};
 
     std::vector<bool> used(aiM->mNumVertices, false);
     for (unsigned int f = 0; f < aiM->mNumFaces; ++f)
@@ -609,7 +646,8 @@ static void compactAiMesh(aiMesh* aiM)
     for (unsigned int i = 0; i < aiM->mNumVertices; ++i)
         if (used[i]) remap[i] = newCount++;
 
-    if (newCount == aiM->mNumVertices) return; // nothing to compact
+    if (newCount == aiM->mNumVertices)
+        return remap; // nothing to compact
 
     for (unsigned int i = 0; i < aiM->mNumVertices; ++i) {
         if (!used[i]) continue;
@@ -642,6 +680,8 @@ static void compactAiMesh(aiMesh* aiM)
         }
         bone->mNumWeights = kept;
     }
+
+    return remap;
 }
 
 // Convert an Ogre skeleton animation to an aiAnimation
@@ -3114,7 +3154,6 @@ static aiScene* buildSceneAiScene()
         scene->mRootNode->mChildren[ni] = entityNode;
 
         // --- Build meshes for this entity ---
-        std::vector<std::pair<unsigned int, aiString>> ngonMetadataEntries;
         for (unsigned int si = 0; si < numSub; ++si)
         {
             const Ogre::SubMesh* subMesh = mesh->getSubMesh(si);
@@ -3126,26 +3165,27 @@ static aiScene* buildSceneAiScene()
             scene->mMeshes[globalMeshIdx + si] = aiM;
             readSubmeshGeometry(aiM, vData, subMesh, entity, si, matIndexMap, false);
 
-            std::vector<std::vector<unsigned int>> ngonFaces;
-            if (readNgonFacesFromMesh(mesh.get(), si, ngonFaces) && !ngonFaces.empty())
-                ngonMetadataEntries.emplace_back(si, encodeSceneNgonFacesMetadata(ngonFaces));
-
             if (hasSkeleton)
                 assignBoneWeights(aiM, subMesh, mesh, skeleton, boneHandleToName);
 
-            compactAiMesh(aiM);
-        }
+            const std::vector<unsigned int> remap = compactAiMesh(aiM);
 
-        if (meshOwnerNode && !ngonMetadataEntries.empty())
-        {
-            meshOwnerNode->mMetaData = aiMetadata::Alloc(
-                static_cast<unsigned int>(ngonMetadataEntries.size()));
-            for (unsigned int mi = 0; mi < ngonMetadataEntries.size(); ++mi)
+            std::vector<std::vector<unsigned int>> ngonFaces;
+            if (meshOwnerNode
+                && readNgonFacesFromMesh(mesh.get(), si, ngonFaces)
+                && !ngonFaces.empty()
+                && remapNgonFaces(remap, ngonFaces))
             {
-                meshOwnerNode->mMetaData->Set(
-                    mi,
-                    sceneNgonFacesMetaKey(ngonMetadataEntries[mi].first),
-                    ngonMetadataEntries[mi].second);
+                if (!meshOwnerNode->mMetaData)
+                    meshOwnerNode->mMetaData = new aiMetadata();
+                for (size_t faceIndex = 0; faceIndex < ngonFaces.size(); ++faceIndex)
+                {
+                    if (ngonFaces[faceIndex].size() < 3)
+                        continue;
+                    meshOwnerNode->mMetaData->Add(
+                        sceneNgonFaceMetaKey(si, static_cast<unsigned int>(faceIndex)),
+                        encodeSceneNgonFaceMetadata(ngonFaces[faceIndex]));
+                }
             }
         }
 

--- a/src/MeshImporterExporter.cpp
+++ b/src/MeshImporterExporter.cpp
@@ -40,7 +40,9 @@ THE SOFTWARE.
 #include <QDir>
 #include <QRegularExpression>
 #include <set>
+#include <limits>
 #include <cmath>
+#include <cerrno>
 #include <cstdlib>
 #include <cstring>
 #include <algorithm>
@@ -506,9 +508,11 @@ static bool decodeSceneNgonFaceMetadata(const aiString& encoded, std::vector<uns
         const std::string token = value.substr(start, end == std::string::npos ? std::string::npos : end - start);
         if (token.empty())
             return false;
+        errno = 0;
         char* tail = nullptr;
         const unsigned long parsed = std::strtoul(token.c_str(), &tail, 10);
-        if (!tail || *tail != '\0')
+        if (!tail || *tail != '\0' || errno == ERANGE ||
+            parsed > std::numeric_limits<unsigned int>::max())
             return false;
         outFace.push_back(static_cast<unsigned int>(parsed));
         if (end == std::string::npos)
@@ -556,9 +560,11 @@ static bool decodeSceneNgonFacesMetadata(const aiMetadata* metadata,
         const std::string suffix = key.substr(prefix.size());
         if (suffix.empty())
             return false;
+        errno = 0;
         char* tail = nullptr;
         const unsigned long faceIndex = std::strtoul(suffix.c_str(), &tail, 10);
-        if (!tail || *tail != '\0')
+        if (!tail || *tail != '\0' || errno == ERANGE ||
+            faceIndex > std::numeric_limits<unsigned int>::max())
             return false;
 
         aiString encoded;
@@ -3309,8 +3315,10 @@ bool MeshImporterExporter::sceneImporter(const QString &_uri)
     Assimp::Importer assimpImporter;
     assimpImporter.SetPropertyBool(AI_CONFIG_IMPORT_FBX_PRESERVE_PIVOTS, false);
 
+    // Preserve the vertex/submesh indexing encoded in qtme.faces metadata.
+    // Topology-rewriting post-process steps like JoinIdenticalVertices and
+    // OptimizeMeshes can invalidate those indices before we restore them.
     unsigned int flags = aiProcess_CalcTangentSpace |
-                         aiProcess_JoinIdenticalVertices |
                          aiProcess_Triangulate |
                          aiProcess_RemoveComponent |
                          aiProcess_GenSmoothNormals |
@@ -3320,7 +3328,6 @@ bool MeshImporterExporter::sceneImporter(const QString &_uri)
                          aiProcess_ImproveCacheLocality |
                          aiProcess_FixInfacingNormals |
                          aiProcess_PopulateArmatureData |
-                         aiProcess_OptimizeMeshes |
                          aiProcess_GlobalScale;
 
     const aiScene* scene = assimpImporter.ReadFile(file.filePath().toStdString(), flags);

--- a/src/MeshImporterExporter_test.cpp
+++ b/src/MeshImporterExporter_test.cpp
@@ -17,6 +17,8 @@
 #include <QVector>
 #include <cstdint>
 #include <set>
+#include <OgreMeshManager.h>
+#include <OgreHardwareBufferManager.h>
 #include <OgreTextureManager.h>
 #include <OgreHardwarePixelBuffer.h>
 #include "Manager.h"
@@ -680,6 +682,73 @@ QString writeQuadObjForScene(const QString& baseName)
     f.close();
     return path;
 }
+
+Ogre::MeshPtr createQuadMeshWithUnusedSharedVertex(const std::string& name)
+{
+    auto mesh = Ogre::MeshManager::getSingleton().createManual(
+        name, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+
+    auto* sub = mesh->createSubMesh();
+    mesh->sharedVertexData = new Ogre::VertexData();
+    auto* decl = mesh->sharedVertexData->vertexDeclaration;
+
+    size_t offset = 0;
+    decl->addElement(0, offset, Ogre::VET_FLOAT3, Ogre::VES_POSITION);
+    offset += Ogre::VertexElement::getTypeSize(Ogre::VET_FLOAT3);
+    decl->addElement(0, offset, Ogre::VET_FLOAT3, Ogre::VES_NORMAL);
+    offset += Ogre::VertexElement::getTypeSize(Ogre::VET_FLOAT3);
+    decl->addElement(0, offset, Ogre::VET_FLOAT2, Ogre::VES_TEXTURE_COORDINATES);
+
+    mesh->sharedVertexData->vertexCount = 5;
+    auto vbuf = Ogre::HardwareBufferManager::getSingleton().createVertexBuffer(
+        decl->getVertexSize(0), mesh->sharedVertexData->vertexCount,
+        Ogre::HardwareBuffer::HBU_STATIC_WRITE_ONLY);
+    const float verts[] = {
+        0,0,0,   0,0,1,  0.0f,0.0f,
+        5,5,5,   0,0,1,  0.5f,0.5f, // intentionally unused to force compaction remap
+        1,0,0,   0,0,1,  1.0f,0.0f,
+        1,1,0,   0,0,1,  1.0f,1.0f,
+        0,1,0,   0,0,1,  0.0f,1.0f,
+    };
+    vbuf->writeData(0, sizeof(verts), verts);
+    mesh->sharedVertexData->vertexBufferBinding->setBinding(0, vbuf);
+
+    auto ibuf = Ogre::HardwareBufferManager::getSingleton().createIndexBuffer(
+        Ogre::HardwareIndexBuffer::IT_16BIT, 6,
+        Ogre::HardwareBuffer::HBU_STATIC_WRITE_ONLY);
+    const uint16_t idx[] = {0, 2, 3, 0, 3, 4};
+    ibuf->writeData(0, sizeof(idx), idx);
+    sub->useSharedVertices = true;
+    sub->indexData->indexBuffer = ibuf;
+    sub->indexData->indexCount = 6;
+
+    std::vector<EditableSubMesh> subs(1);
+    subs[0].faces.push_back(EditableFace{{0, 2, 3, 4}});
+    writeNgonFacesToMesh(mesh.get(), subs);
+
+    mesh->_setBounds(Ogre::AxisAlignedBox(-1,-1,-1,6,6,1));
+    mesh->_setBoundingSphereRadius(9.0);
+    mesh->load();
+    return mesh;
+}
+
+void expectEntityHasSingleQuadBinding(Ogre::Entity* entity,
+                                      const std::vector<unsigned int>& expectedFace)
+{
+    ASSERT_NE(entity, nullptr);
+
+    std::vector<std::vector<unsigned int>> faces;
+    ASSERT_TRUE(readNgonFacesFromMesh(entity->getMesh().get(), 0, faces));
+    ASSERT_EQ(faces.size(), 1u);
+    EXPECT_EQ(faces[0], expectedFace);
+
+    EditableMesh mesh;
+    ASSERT_TRUE(mesh.loadFromEntity(entity));
+    ASSERT_EQ(mesh.subMeshes().size(), 1u);
+    ASSERT_EQ(mesh.subMeshes()[0].faces.size(), 1u);
+    EXPECT_EQ(mesh.subMeshes()[0].faces[0].indices, expectedFace);
+    EXPECT_EQ(mesh.subMeshes()[0].triangles.size(), 2u);
+}
 } // namespace
 
 TEST_F(SceneSaveLoadTest, RoundTrip_TwoEntities_PreservesTransforms) {
@@ -744,7 +813,7 @@ TEST_F(SceneSaveLoadTest, RoundTrip_TwoEntities_PreservesTransforms) {
     EXPECT_TRUE(foundNode2) << "Second node with position (-1,0,5) not found";
 }
 
-TEST_F(SceneSaveLoadTest, RoundTrip_QuadMesh_PreservesNgonFaceBinding)
+TEST_F(SceneSaveLoadTest, RoundTrip_QuadMesh_PreservesNgonFaceBinding_Gltf)
 {
     const QString objPath = writeQuadObjForScene("scene_ngon_roundtrip");
     ASSERT_FALSE(objPath.isEmpty());
@@ -756,7 +825,6 @@ TEST_F(SceneSaveLoadTest, RoundTrip_QuadMesh_PreservesNgonFaceBinding)
     auto* node = manager->getSceneNodes().front();
     ASSERT_TRUE(manager->getSceneMgr()->hasEntity(node->getName()));
     auto* entity = manager->getSceneMgr()->getEntity(node->getName());
-    ASSERT_NE(entity, nullptr);
 
     std::vector<std::vector<unsigned int>> facesBefore;
     ASSERT_TRUE(readNgonFacesFromMesh(entity->getMesh().get(), 0, facesBefore));
@@ -774,22 +842,69 @@ TEST_F(SceneSaveLoadTest, RoundTrip_QuadMesh_PreservesNgonFaceBinding)
     node = manager->getSceneNodes().front();
     ASSERT_TRUE(manager->getSceneMgr()->hasEntity(node->getName()));
     entity = manager->getSceneMgr()->getEntity(node->getName());
-    ASSERT_NE(entity, nullptr);
-
-    std::vector<std::vector<unsigned int>> facesAfter;
-    ASSERT_TRUE(readNgonFacesFromMesh(entity->getMesh().get(), 0, facesAfter));
-    ASSERT_EQ(facesAfter.size(), 1u);
-    EXPECT_EQ(facesAfter[0].size(), 4u);
-    EXPECT_EQ(facesAfter[0], facesBefore[0]);
-
-    EditableMesh mesh;
-    ASSERT_TRUE(mesh.loadFromEntity(entity));
-    ASSERT_EQ(mesh.subMeshes().size(), 1u);
-    ASSERT_EQ(mesh.subMeshes()[0].faces.size(), 1u);
-    EXPECT_EQ(mesh.subMeshes()[0].faces[0].indices.size(), 4u);
-    EXPECT_EQ(mesh.subMeshes()[0].triangles.size(), 2u);
+    expectEntityHasSingleQuadBinding(entity, facesBefore[0]);
 
     QFile::remove(objPath);
+}
+
+TEST_F(SceneSaveLoadTest, RoundTrip_QuadMesh_PreservesNgonFaceBinding_Glb)
+{
+    const QString objPath = writeQuadObjForScene("scene_ngon_roundtrip_glb");
+    ASSERT_FALSE(objPath.isEmpty());
+
+    MeshImporterExporter::importer(QStringList{objPath});
+
+    auto* manager = Manager::getSingleton();
+    ASSERT_EQ(manager->getSceneNodes().size(), 1);
+    auto* node = manager->getSceneNodes().front();
+    ASSERT_TRUE(manager->getSceneMgr()->hasEntity(node->getName()));
+    auto* entity = manager->getSceneMgr()->getEntity(node->getName());
+
+    std::vector<std::vector<unsigned int>> facesBefore;
+    ASSERT_TRUE(readNgonFacesFromMesh(entity->getMesh().get(), 0, facesBefore));
+    ASSERT_EQ(facesBefore.size(), 1u);
+
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+    const QString sceneFile = tmpDir.filePath("ngon.scene.glb");
+    ASSERT_EQ(MeshImporterExporter::sceneExporter(sceneFile), 0);
+
+    ASSERT_TRUE(MeshImporterExporter::sceneImporter(sceneFile));
+    ASSERT_EQ(manager->getSceneNodes().size(), 1);
+
+    node = manager->getSceneNodes().front();
+    ASSERT_TRUE(manager->getSceneMgr()->hasEntity(node->getName()));
+    entity = manager->getSceneMgr()->getEntity(node->getName());
+    expectEntityHasSingleQuadBinding(entity, facesBefore[0]);
+
+    QFile::remove(objPath);
+}
+
+TEST_F(SceneSaveLoadTest, RoundTrip_QuadMeshWithUnusedSharedVertex_RemapPreservesNgonFaceBinding)
+{
+    auto* manager = Manager::getSingleton();
+    Ogre::MeshPtr mesh = createQuadMeshWithUnusedSharedVertex("SceneQuadUnusedSharedVertex");
+    ASSERT_TRUE(mesh);
+
+    Ogre::SceneNode* node = manager->addSceneNode("SceneQuadUnusedSharedVertex");
+    ASSERT_NE(node, nullptr);
+    Ogre::Entity* entity = manager->createEntity(node, mesh);
+    ASSERT_NE(entity, nullptr);
+
+    expectEntityHasSingleQuadBinding(entity, {0, 2, 3, 4});
+
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+    const QString sceneFile = tmpDir.filePath("ngon_compacted.scene.gltf");
+    ASSERT_EQ(MeshImporterExporter::sceneExporter(sceneFile), 0);
+
+    ASSERT_TRUE(MeshImporterExporter::sceneImporter(sceneFile));
+    ASSERT_EQ(manager->getSceneNodes().size(), 1);
+
+    node = manager->getSceneNodes().front();
+    ASSERT_TRUE(manager->getSceneMgr()->hasEntity(node->getName()));
+    entity = manager->getSceneMgr()->getEntity(node->getName());
+    expectEntityHasSingleQuadBinding(entity, {0, 1, 2, 3});
 }
 
 // Slice F3 export-side PBR slot dispatch:

--- a/src/MeshImporterExporter_test.cpp
+++ b/src/MeshImporterExporter_test.cpp
@@ -671,9 +671,11 @@ protected:
 };
 
 namespace {
-QString writeQuadObjForScene(const QString& baseName)
+QString writeQuadObjForScene(const QTemporaryDir& dir, const QString& fileName)
 {
-    const QString path = QDir::tempPath() + "/" + baseName + ".obj";
+    if (!dir.isValid())
+        return {};
+    const QString path = dir.filePath(fileName);
     QFile f(path);
     if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate))
         return {};
@@ -815,7 +817,9 @@ TEST_F(SceneSaveLoadTest, RoundTrip_TwoEntities_PreservesTransforms) {
 
 TEST_F(SceneSaveLoadTest, RoundTrip_QuadMesh_PreservesNgonFaceBinding_Gltf)
 {
-    const QString objPath = writeQuadObjForScene("scene_ngon_roundtrip");
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+    const QString objPath = writeQuadObjForScene(tmpDir, "scene_ngon_roundtrip.obj");
     ASSERT_FALSE(objPath.isEmpty());
 
     MeshImporterExporter::importer(QStringList{objPath});
@@ -831,8 +835,6 @@ TEST_F(SceneSaveLoadTest, RoundTrip_QuadMesh_PreservesNgonFaceBinding_Gltf)
     ASSERT_EQ(facesBefore.size(), 1u);
     EXPECT_EQ(facesBefore[0].size(), 4u);
 
-    QTemporaryDir tmpDir;
-    ASSERT_TRUE(tmpDir.isValid());
     const QString sceneFile = tmpDir.filePath("ngon.scene.gltf");
     ASSERT_EQ(MeshImporterExporter::sceneExporter(sceneFile), 0);
 
@@ -843,13 +845,13 @@ TEST_F(SceneSaveLoadTest, RoundTrip_QuadMesh_PreservesNgonFaceBinding_Gltf)
     ASSERT_TRUE(manager->getSceneMgr()->hasEntity(node->getName()));
     entity = manager->getSceneMgr()->getEntity(node->getName());
     expectEntityHasSingleQuadBinding(entity, facesBefore[0]);
-
-    QFile::remove(objPath);
 }
 
 TEST_F(SceneSaveLoadTest, RoundTrip_QuadMesh_PreservesNgonFaceBinding_Glb)
 {
-    const QString objPath = writeQuadObjForScene("scene_ngon_roundtrip_glb");
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+    const QString objPath = writeQuadObjForScene(tmpDir, "scene_ngon_roundtrip_glb.obj");
     ASSERT_FALSE(objPath.isEmpty());
 
     MeshImporterExporter::importer(QStringList{objPath});
@@ -864,8 +866,6 @@ TEST_F(SceneSaveLoadTest, RoundTrip_QuadMesh_PreservesNgonFaceBinding_Glb)
     ASSERT_TRUE(readNgonFacesFromMesh(entity->getMesh().get(), 0, facesBefore));
     ASSERT_EQ(facesBefore.size(), 1u);
 
-    QTemporaryDir tmpDir;
-    ASSERT_TRUE(tmpDir.isValid());
     const QString sceneFile = tmpDir.filePath("ngon.scene.glb");
     ASSERT_EQ(MeshImporterExporter::sceneExporter(sceneFile), 0);
 
@@ -876,8 +876,6 @@ TEST_F(SceneSaveLoadTest, RoundTrip_QuadMesh_PreservesNgonFaceBinding_Glb)
     ASSERT_TRUE(manager->getSceneMgr()->hasEntity(node->getName()));
     entity = manager->getSceneMgr()->getEntity(node->getName());
     expectEntityHasSingleQuadBinding(entity, facesBefore[0]);
-
-    QFile::remove(objPath);
 }
 
 TEST_F(SceneSaveLoadTest, RoundTrip_QuadMeshWithUnusedSharedVertex_RemapPreservesNgonFaceBinding)

--- a/src/MeshImporterExporter_test.cpp
+++ b/src/MeshImporterExporter_test.cpp
@@ -13,6 +13,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
+#include <QTextStream>
 #include <QVector>
 #include <cstdint>
 #include <set>
@@ -20,6 +21,7 @@
 #include <OgreHardwarePixelBuffer.h>
 #include "Manager.h"
 #include "MeshImporterExporter.h"
+#include "EditableMesh.h"
 #include "SelectionSet.h"
 #include "OgreXML/OgreXMLSkeletonSerializer.h"
 #include <OgreException.h>
@@ -666,6 +668,20 @@ protected:
     }
 };
 
+namespace {
+QString writeQuadObjForScene(const QString& baseName)
+{
+    const QString path = QDir::tempPath() + "/" + baseName + ".obj";
+    QFile f(path);
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate))
+        return {};
+    QTextStream out(&f);
+    out << "v 0 0 0\nv 1 0 0\nv 1 1 0\nv 0 1 0\nf 1 2 3 4\n";
+    f.close();
+    return path;
+}
+} // namespace
+
 TEST_F(SceneSaveLoadTest, RoundTrip_TwoEntities_PreservesTransforms) {
     auto* manager = Manager::getSingleton();
 
@@ -726,6 +742,54 @@ TEST_F(SceneSaveLoadTest, RoundTrip_TwoEntities_PreservesTransforms) {
     }
     EXPECT_TRUE(foundNode1) << "First node with position (1,2,3) not found";
     EXPECT_TRUE(foundNode2) << "Second node with position (-1,0,5) not found";
+}
+
+TEST_F(SceneSaveLoadTest, RoundTrip_QuadMesh_PreservesNgonFaceBinding)
+{
+    const QString objPath = writeQuadObjForScene("scene_ngon_roundtrip");
+    ASSERT_FALSE(objPath.isEmpty());
+
+    MeshImporterExporter::importer(QStringList{objPath});
+
+    auto* manager = Manager::getSingleton();
+    ASSERT_EQ(manager->getSceneNodes().size(), 1);
+    auto* node = manager->getSceneNodes().front();
+    ASSERT_TRUE(manager->getSceneMgr()->hasEntity(node->getName()));
+    auto* entity = manager->getSceneMgr()->getEntity(node->getName());
+    ASSERT_NE(entity, nullptr);
+
+    std::vector<std::vector<unsigned int>> facesBefore;
+    ASSERT_TRUE(readNgonFacesFromMesh(entity->getMesh().get(), 0, facesBefore));
+    ASSERT_EQ(facesBefore.size(), 1u);
+    EXPECT_EQ(facesBefore[0].size(), 4u);
+
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+    const QString sceneFile = tmpDir.filePath("ngon.scene.gltf");
+    ASSERT_EQ(MeshImporterExporter::sceneExporter(sceneFile), 0);
+
+    ASSERT_TRUE(MeshImporterExporter::sceneImporter(sceneFile));
+    ASSERT_EQ(manager->getSceneNodes().size(), 1);
+
+    node = manager->getSceneNodes().front();
+    ASSERT_TRUE(manager->getSceneMgr()->hasEntity(node->getName()));
+    entity = manager->getSceneMgr()->getEntity(node->getName());
+    ASSERT_NE(entity, nullptr);
+
+    std::vector<std::vector<unsigned int>> facesAfter;
+    ASSERT_TRUE(readNgonFacesFromMesh(entity->getMesh().get(), 0, facesAfter));
+    ASSERT_EQ(facesAfter.size(), 1u);
+    EXPECT_EQ(facesAfter[0].size(), 4u);
+    EXPECT_EQ(facesAfter[0], facesBefore[0]);
+
+    EditableMesh mesh;
+    ASSERT_TRUE(mesh.loadFromEntity(entity));
+    ASSERT_EQ(mesh.subMeshes().size(), 1u);
+    ASSERT_EQ(mesh.subMeshes()[0].faces.size(), 1u);
+    EXPECT_EQ(mesh.subMeshes()[0].faces[0].indices.size(), 4u);
+    EXPECT_EQ(mesh.subMeshes()[0].triangles.size(), 2u);
+
+    QFile::remove(objPath);
 }
 
 // Slice F3 export-side PBR slot dispatch:

--- a/website/src/hooks/useQtmeshActionRef.js
+++ b/website/src/hooks/useQtmeshActionRef.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 const QTMESH_RELEASES_LATEST_API = 'https://api.github.com/repos/fernandotonon/QtMeshEditor/releases/latest';
-const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.0.1';
+const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.1.0';
 const CACHE_KEY = 'qtmesh.actionRef.cache.v1';
 const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 


### PR DESCRIPTION
## Summary

Fix scene save/load so `.scene.gltf` / `.scene.glb` preserves n-gon topology metadata for edited quad meshes, and bump the app version to `3.1.0` with aligned docs examples.

## Root Cause

Scene export already knew how to preserve `qtme.faces` on live Ogre meshes, but the scene-level glTF export path relied on Assimp face emission alone. glTF import returns triangulated geometry, so without carrying `qtme.faces` through the scene file, a saved quad could come back with only triangle topology data available to edit mode.

## What Changed

- Scene export now writes triangulated glTF geometry while storing per-submesh `qtme.faces.<i>` metadata on the mesh-bearing Assimp node.
- Scene import restores that metadata back onto the imported Ogre mesh so `EditableMesh` can rehydrate quads/n-gons after scene round-trip.
- Added a regression test that imports a real quad OBJ, saves it as a scene, reloads it, and verifies the quad face binding survives.
- Bumped `project(QtMeshEditor VERSION ...)` to `3.1.0`.
- Updated pinned docs examples in `README.md` and `website/src/hooks/useQtmeshActionRef.js` to match `3.1.0`.

## Validation

- `./scripts/sync-doc-versions-from-cmake.sh --check`
- `QT_QPA_PLATFORM=offscreen ./bin/UnitTests --gtest_filter='SceneSaveLoadTest.RoundTrip_QuadMesh_PreservesNgonFaceBinding:SceneSaveLoadTest.RoundTrip_TwoEntities_PreservesTransforms:SceneSaveLoadTest.RoundTrip_MixedSkeletalAndNonSkeletal:AboutTest.VersionTextIsCorrect:CLIPipelineSmoke.PrintVersionDoesNotCrash:CLIPipelineRun.VersionFlag:CLIPipelineRun.VersionFlagShort'`

## Notes

- Left the existing untracked `src/dependencies/ogre-procedural` worktree content untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export/import now preserve per-submesh n‑gon face topology across round-trips using encoded scene metadata.

* **Tests**
  * Added round-trip tests validating n‑gon preservation and remap/compaction scenarios for multiple formats.

* **Chores**
  * Project version bumped to 3.1.0; documentation, CI examples, and action reference updated to match.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/503)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->