### PR TITLE
fix(info): surface RTSS-wired normal map textures (#510)

### DIFF
--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -797,22 +797,45 @@ MeshInfo CLIPipeline::extractMeshInfo(const Ogre::Entity* entity, const QString&
         }
     }
 
-    // Textures
+    // Textures. The straightforward pass walks every CONTENT_NAMED
+    // TextureUnitState. That covers diffuse/albedo/metallic/roughness/ao/
+    // emissive — every PBR slot MaterialProcessor binds as a plain TUS.
+    // It does NOT cover the normal map: MaterialProcessor wires that one
+    // through RTSS's render-state side channel (see RTShaderHelper::
+    // applyNormalMap), which creates a transient TUS during shader-state
+    // resolution that's not visible on the base pass. To recover that
+    // texture name we read the qtme.normal_map UOB hint the importer
+    // leaves on the pass (the same hint slice #507 added so FBX export
+    // could round-trip the normal map). Issue #510.
     std::set<std::string, std::less<>> seenTex;
-    for (unsigned int i = 0; i < entity->getNumSubEntities(); ++i) {
-        auto mat = entity->getSubEntity(i)->getMaterial();
-        if (!mat) continue;
-        for (auto* tech : mat->getTechniques()) {
-            for (auto* pass : tech->getPasses()) {
-                for (auto* tus : pass->getTextureUnitStates()) {
-                    if (tus->getContentType() == Ogre::TextureUnitState::CONTENT_NAMED) {
-                        auto name = tus->getTextureName();
-                        if (seenTex.insert(name).second)
-                            info.textures << QString::fromStdString(name);
-                    }
-                }
-            }
+    const auto collectFromPass = [&](const Ogre::Pass* pass) {
+        if (!pass) return;
+        for (auto* tus : pass->getTextureUnitStates()) {
+            if (tus->getContentType() != Ogre::TextureUnitState::CONTENT_NAMED)
+                continue;
+            const auto& name = tus->getTextureName();
+            if (!name.empty() && seenTex.insert(name).second)
+                info.textures << QString::fromStdString(name);
         }
+        // Recover RTSS-wired normal map from the UOB hint. Use the
+        // pointer variant of any_cast (returns nullptr on type mismatch
+        // — older assets / payload-type drift / a future writer with a
+        // different shape) so we don't have to catch std::bad_cast just
+        // to swallow it.
+        const Ogre::Any& nh =
+            pass->getUserObjectBindings().getUserAny("qtme.normal_map");
+        if (!nh.has_value()) return;
+        if (const Ogre::String* n = Ogre::any_cast<Ogre::String>(&nh)) {
+            if (!n->empty() && seenTex.insert(*n).second)
+                info.textures << QString::fromStdString(*n);
+        }
+    };
+    for (unsigned int i = 0; i < entity->getNumSubEntities(); ++i) {
+        const auto mat = entity->getSubEntity(i)->getMaterial();
+        if (!mat) continue;
+        for (const Ogre::Technique* tech : mat->getTechniques())
+            for (const Ogre::Pass* pass : tech->getPasses())
+                collectFromPass(pass);
     }
 
     // Skeleton & animations

--- a/src/CLIPipeline_test.cpp
+++ b/src/CLIPipeline_test.cpp
@@ -319,6 +319,37 @@ TEST_F(CLIPipelineOgreTest, ExtractMeshInfo_DeduplicatesMaterialAndTextureNames)
     EXPECT_TRUE(info.textures.contains("normal.png"));
 }
 
+TEST_F(CLIPipelineOgreTest, ExtractMeshInfo_SurfacesRTSSNormalMapHint)
+{
+    // RTSS-wired normal maps don't appear as CONTENT_NAMED TUSes — the
+    // shader-system routes them through a render-state side channel. The
+    // importer leaves the texture name on a "qtme.normal_map" UOB so
+    // FBX export can round-trip it (#508). extractMeshInfo should also
+    // surface that hint so qtmesh info reports the normal map (#510).
+    auto mesh = createInMemoryTriangleMesh("cli_test_uob_normal");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = Manager::getSingleton()->addSceneNode("cli_test_uob_normal_node");
+    auto* entity = sceneMgr->createEntity("cli_test_uob_normal_entity", mesh);
+    node->attachObject(entity);
+
+    Ogre::MaterialPtr material = Ogre::MaterialManager::getSingleton().create(
+        "cli_test_uob_normal_mat",
+        Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+    auto* pass = material->getTechnique(0)->getPass(0);
+    pass->createTextureUnitState("Boss_diffuse.png");
+    // Mirror MaterialProcessor::applyRTSSNormalMap — stash on UOB without
+    // adding a TUS, so the test verifies the UOB recovery path specifically.
+    pass->getUserObjectBindings().setUserAny(
+        "qtme.normal_map", Ogre::Any(Ogre::String("Boss_normal.png")));
+    entity->getSubEntity(0)->setMaterial(material);
+
+    MeshInfo info = CLIPipeline::extractMeshInfo(entity, "with_normal.fbx");
+
+    EXPECT_TRUE(info.textures.contains("Boss_diffuse.png"));
+    EXPECT_TRUE(info.textures.contains("Boss_normal.png"))
+        << "RTSS-wired normal map should surface via the qtme.normal_map UOB hint";
+}
+
 TEST_F(CLIPipelineOgreTest, ExtractMeshInfo_NullEntity)
 {
     MeshInfo info = CLIPipeline::extractMeshInfo(nullptr, "null.mesh");


### PR DESCRIPTION
## Summary
- \`extractMeshInfo\` only walked CONTENT_NAMED TUSes, missing the RTSS-wired normal map (routed via render-state side channel by \`RTShaderHelper::applyNormalMap\`).
- Recover the texture name from the \`qtme.normal_map\` UOB hint the importer already stashes (slice #507) so \`qtmesh info\` / scan / overlay all report it.
- Closes #510.

## Test plan
- [x] \`qtmesh info Rumba\\ Dancing.fbx\` → \`Textures: Boss_diffuse.png, Boss_normal.png\`.
- [x] JSON output includes both.
- [x] New unit test \`ExtractMeshInfo_SurfacesRTSSNormalMapHint\` builds a triangle entity, stashes the UOB without adding a TUS, asserts the texture surfaces.
- [ ] Linux CI runs the test under Xvfb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Mesh extraction now correctly identifies and recovers normal map textures stored in alternate binding locations, complementing the existing texture enumeration process.

* **Tests**
  * Added test coverage to validate normal map texture recovery during mesh extraction for various material configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/512)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->