### PR TITLE
test: expand coverage with 103 new test cases

### DIFF
--- a/src/AppConsoleLog_test.cpp
+++ b/src/AppConsoleLog_test.cpp
@@ -1,0 +1,78 @@
+#include <gtest/gtest.h>
+#include <QApplication>
+#include <QCoreApplication>
+#include <QDebug>
+#include <QThread>
+
+#include "AppConsoleLog.h"
+
+class AppConsoleLogTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        ASSERT_NE(qobject_cast<QApplication*>(QCoreApplication::instance()), nullptr);
+    }
+};
+
+TEST_F(AppConsoleLogTest, InstallIsIdempotent)
+{
+    AppConsoleLog::install();
+    AppConsoleLog::install();    // second call must be a no-op
+    AppConsoleLog::install();
+    // Reaching here without crashing or recursing is enough.
+    SUCCEED();
+}
+
+TEST_F(AppConsoleLogTest, DetachNullDoesNothing)
+{
+    AppConsoleLog::detachMainWindow(nullptr);
+    SUCCEED();
+}
+
+TEST_F(AppConsoleLogTest, AttachNullIsIgnored)
+{
+    // Per the contract, attach with a null window must early-out.
+    AppConsoleLog::attachMainWindow(nullptr);
+    SUCCEED();
+}
+
+TEST_F(AppConsoleLogTest, FlushStdioChunksSafeWhenCaptureNotActive)
+{
+    // flushStdioChunks() should be a no-op when capture isn't running.
+    AppConsoleLog::flushStdioChunks();
+    SUCCEED();
+}
+
+TEST_F(AppConsoleLogTest, MessageHandlerSurvivesAllSeverityLevels)
+{
+    AppConsoleLog::install();
+    // Detach any previous attachment so messages go to the in-process buffer.
+    AppConsoleLog::detachMainWindow(nullptr);
+    qDebug()    << "test debug";
+    qInfo()     << "test info";
+    qWarning()  << "test warning";
+    QCoreApplication::processEvents();
+    SUCCEED();
+}
+
+#ifndef Q_OS_WIN
+TEST_F(AppConsoleLogTest, StdioCaptureInstallAndShutdownRoundTrip)
+{
+    // Stdio capture only makes sense in GUI builds; the function is built
+    // on POSIX dup2/pipe so we exercise it here to cover both the install
+    // and shutdown paths.
+    const bool ok = AppConsoleLog::installStdioCapture();
+    ASSERT_TRUE(ok);
+
+    // Write something through C stdio so the reader thread sees data.
+    std::fputs("hello-from-stdout\n", stdout);
+    std::fflush(stdout);
+    std::fputs("hello-from-stderr\n", stderr);
+    std::fflush(stderr);
+
+    // Give the reader thread time to drain the pipe.
+    QThread::msleep(50);
+
+    AppConsoleLog::shutdown();
+    SUCCEED();
+}
+#endif

--- a/src/Euler_test.cpp
+++ b/src/Euler_test.cpp
@@ -53,3 +53,227 @@ TEST(EulerTest, NormaliseWrapsLargeYaw)
     e.normalise(true, false, false);
     EXPECT_LT(std::abs(e.yaw().valueRadians()), Math::PI + 0.01f);
 }
+
+TEST(EulerTest, ConstructFromQuaternionDecomposesYPR)
+{
+    Quaternion q = Quaternion(Radian(0.3f), Vector3::UNIT_Y)
+                 * Quaternion(Radian(0.2f), Vector3::UNIT_X)
+                 * Quaternion(Radian(0.1f), Vector3::UNIT_Z);
+    Euler e(q);
+    EXPECT_NEAR(e.yaw().valueRadians(),   0.3f, 1e-4f);
+    EXPECT_NEAR(e.pitch().valueRadians(), 0.2f, 1e-4f);
+    EXPECT_NEAR(e.roll().valueRadians(),  0.1f, 1e-4f);
+}
+
+TEST(EulerTest, ConstructFromMatrixRoundTrip)
+{
+    Quaternion q(Radian(0.2f), Vector3::UNIT_Y);
+    Matrix3 m;
+    q.ToRotationMatrix(m);
+    Euler e(m);
+    EXPECT_NEAR(e.yaw().valueRadians(), 0.2f, 1e-4f);
+    EXPECT_NEAR(e.pitch().valueRadians(), 0.0f, 1e-4f);
+    EXPECT_NEAR(e.roll().valueRadians(), 0.0f, 1e-4f);
+}
+
+TEST(EulerTest, RealConstructorBuildsRadians)
+{
+    Euler e(1.0f, 2.0f, 3.0f);
+    EXPECT_NEAR(e.yaw().valueRadians(),   1.0f, 1e-6f);
+    EXPECT_NEAR(e.pitch().valueRadians(), 2.0f, 1e-6f);
+    EXPECT_NEAR(e.roll().valueRadians(),  3.0f, 1e-6f);
+}
+
+TEST(EulerTest, SettersUpdateValues)
+{
+    Euler e;
+    e.setYaw(Radian(1.0f));
+    e.setPitch(Radian(2.0f));
+    e.setRoll(Radian(3.0f));
+    EXPECT_NEAR(e.yaw().valueRadians(),   1.0f, 1e-6f);
+    EXPECT_NEAR(e.pitch().valueRadians(), 2.0f, 1e-6f);
+    EXPECT_NEAR(e.roll().valueRadians(),  3.0f, 1e-6f);
+}
+
+TEST(EulerTest, OrientationSetsAllAtOnce)
+{
+    Euler e;
+    e.orientation(Radian(0.1f), Radian(0.2f), Radian(0.3f));
+    EXPECT_NEAR(e.yaw().valueRadians(),   0.1f, 1e-6f);
+    EXPECT_NEAR(e.pitch().valueRadians(), 0.2f, 1e-6f);
+    EXPECT_NEAR(e.roll().valueRadians(),  0.3f, 1e-6f);
+}
+
+TEST(EulerTest, RotateAddsRelativeYPR)
+{
+    Euler e(Radian(0.1f), Radian(0.2f), Radian(0.3f));
+    e.rotate(Radian(0.5f), Radian(-0.1f), Radian(0.05f));
+    EXPECT_NEAR(e.yaw().valueRadians(),   0.6f,   1e-5f);
+    EXPECT_NEAR(e.pitch().valueRadians(), 0.1f,   1e-5f);
+    EXPECT_NEAR(e.roll().valueRadians(),  0.35f,  1e-5f);
+}
+
+TEST(EulerTest, NormaliseDoesNothingIfAlreadyInRange)
+{
+    Euler e(Radian(0.5f), Radian(0.5f), Radian(0.5f));
+    Euler before = e;
+    e.normalise();
+    EXPECT_NEAR(e.yaw().valueRadians(),   before.yaw().valueRadians(),   1e-6f);
+    EXPECT_NEAR(e.pitch().valueRadians(), before.pitch().valueRadians(), 1e-6f);
+    EXPECT_NEAR(e.roll().valueRadians(),  before.roll().valueRadians(),  1e-6f);
+}
+
+TEST(EulerTest, NormaliseWrapsNegativeAngles)
+{
+    Euler e;
+    e.setYaw(Radian(-Math::PI * 2.0f - 0.5f));
+    e.normalise(true, false, false);
+    EXPECT_LE(e.yaw().valueRadians(), Math::PI);
+    EXPECT_GE(e.yaw().valueRadians(), -Math::PI);
+}
+
+TEST(EulerTest, LimitYawClampsRange)
+{
+    Euler e(Radian(2.0f), Radian(0.0f), Radian(0.0f));
+    e.limitYaw(Radian(1.0f));
+    EXPECT_LE(std::abs(e.yaw().valueRadians()), 1.0f + 1e-5f);
+}
+
+TEST(EulerTest, LimitPitchClampsRange)
+{
+    Euler e(Radian(0.0f), Radian(2.5f), Radian(0.0f));
+    e.limitPitch(Radian(1.0f));
+    EXPECT_LE(std::abs(e.pitch().valueRadians()), 1.0f + 1e-5f);
+}
+
+TEST(EulerTest, LimitRollClampsRange)
+{
+    Euler e(Radian(0.0f), Radian(0.0f), Radian(-2.5f));
+    e.limitRoll(Radian(1.0f));
+    EXPECT_LE(std::abs(e.roll().valueRadians()), 1.0f + 1e-5f);
+}
+
+TEST(EulerTest, OperatorAddSubtract)
+{
+    Euler a(Radian(0.1f), Radian(0.2f), Radian(0.3f));
+    Euler b(Radian(1.0f), Radian(2.0f), Radian(3.0f));
+    Euler sum = a + b;
+    EXPECT_NEAR(sum.yaw().valueRadians(),   1.1f, 1e-6f);
+    EXPECT_NEAR(sum.pitch().valueRadians(), 2.2f, 1e-6f);
+    EXPECT_NEAR(sum.roll().valueRadians(),  3.3f, 1e-6f);
+
+    Euler diff = b - a;
+    EXPECT_NEAR(diff.yaw().valueRadians(),   0.9f, 1e-6f);
+    EXPECT_NEAR(diff.pitch().valueRadians(), 1.8f, 1e-6f);
+    EXPECT_NEAR(diff.roll().valueRadians(),  2.7f, 1e-6f);
+}
+
+TEST(EulerTest, OperatorScalarMultiply)
+{
+    Euler e(Radian(0.1f), Radian(0.2f), Radian(0.3f));
+    Euler scaled = e * 2.0f;
+    EXPECT_NEAR(scaled.yaw().valueRadians(),   0.2f, 1e-6f);
+    EXPECT_NEAR(scaled.pitch().valueRadians(), 0.4f, 1e-6f);
+    EXPECT_NEAR(scaled.roll().valueRadians(),  0.6f, 1e-6f);
+
+    Euler scaled2 = 2.0f * e;
+    EXPECT_NEAR(scaled2.yaw().valueRadians(), 0.2f, 1e-6f);
+}
+
+TEST(EulerTest, OperatorMultiplyEulersProducesCombinedQuaternion)
+{
+    Euler a(Radian(0.5f), Radian(0.0f), Radian(0.0f));
+    Euler b(Radian(0.3f), Radian(0.0f), Radian(0.0f));
+    Quaternion combined = a * b;
+    // Combined rotation around Y of 0.5 + 0.3 = 0.8 (approximately, for pure-Y).
+    Euler result(combined);
+    EXPECT_NEAR(result.yaw().valueRadians(), 0.8f, 1e-3f);
+}
+
+TEST(EulerTest, OperatorMultiplyVectorAppliesRotation)
+{
+    Euler e(Radian(Math::HALF_PI), Radian(0.0f), Radian(0.0f));
+    Vector3 forward = e * Vector3(0, 0, -1);
+    // 90° yaw rotates -Z to either -X or +X (Ogre convention).
+    EXPECT_NEAR(std::abs(forward.x), 1.0f, 1e-4f);
+    EXPECT_NEAR(forward.y, 0.0f, 1e-4f);
+}
+
+TEST(EulerTest, OperatorEqualityAndInequality)
+{
+    Euler a(Radian(0.1f), Radian(0.2f), Radian(0.3f));
+    Euler b(Radian(0.1f), Radian(0.2f), Radian(0.3f));
+    Euler c(Radian(0.4f), Radian(0.2f), Radian(0.3f));
+    EXPECT_TRUE(a == b);
+    EXPECT_FALSE(a == c);
+    EXPECT_TRUE(a != c);
+    EXPECT_FALSE(a != b);
+}
+
+TEST(EulerTest, AssignmentOperatorEuler)
+{
+    Euler a(Radian(0.1f), Radian(0.2f), Radian(0.3f));
+    Euler b;
+    b = a;
+    EXPECT_TRUE(a == b);
+}
+
+TEST(EulerTest, AssignmentOperatorQuaternion)
+{
+    Quaternion q(Radian(0.4f), Vector3::UNIT_Y);
+    Euler e;
+    e = q;
+    EXPECT_NEAR(e.yaw().valueRadians(), 0.4f, 1e-4f);
+}
+
+TEST(EulerTest, AssignmentOperatorMatrix3)
+{
+    Quaternion q(Radian(0.5f), Vector3::UNIT_Y);
+    Matrix3 m;
+    q.ToRotationMatrix(m);
+    Euler e;
+    e = m;
+    EXPECT_NEAR(e.yaw().valueRadians(), 0.5f, 1e-4f);
+}
+
+TEST(EulerTest, SameOrientationTrueForEquivalentRotations)
+{
+    Euler a(Radian(0.5f), Radian(0.0f), Radian(0.0f));
+    Euler b(Radian(0.5f + Math::TWO_PI), Radian(0.0f), Radian(0.0f));
+    EXPECT_TRUE(sameOrientation(a, b));
+}
+
+TEST(EulerTest, ImplicitConversionToQuaternionWorks)
+{
+    Euler e(Radian(0.5f), Radian(0.0f), Radian(0.0f));
+    Quaternion q = e;     // implicit operator Quaternion()
+    EXPECT_NEAR(q.getYaw().valueRadians(), 0.5f, 1e-4f);
+}
+
+TEST(EulerTest, DirectionSetYawOnlyLeavesPitchUntouched)
+{
+    Euler e(Radian(0.0f), Radian(0.5f), Radian(0.0f));
+    Radian origPitch = e.pitch();
+    e.direction(Vector3(1, 0, -1), /*setYaw=*/true, /*setPitch=*/false);
+    EXPECT_NEAR(e.pitch().valueRadians(), origPitch.valueRadians(), 1e-6f);
+}
+
+TEST(EulerTest, DirectionSetPitchOnlyLeavesYawUntouched)
+{
+    Euler e(Radian(0.5f), Radian(0.0f), Radian(0.0f));
+    Radian origYaw = e.yaw();
+    e.direction(Vector3(0, 1, -1), /*setYaw=*/false, /*setPitch=*/true);
+    EXPECT_NEAR(e.yaw().valueRadians(), origYaw.valueRadians(), 1e-6f);
+}
+
+TEST(EulerTest, RotationToProducesRelativeDelta)
+{
+    Euler current;
+    current.direction(Vector3(0, 0, -1)); // facing -Z
+    Euler delta = current.rotationTo(Vector3(1, 0, 0));
+    // Applying delta to current should orient us toward +X.
+    Euler combined = current + delta;
+    combined.normalise();
+    Vector3 fwd = combined.forward();
+    EXPECT_GT(fwd.x, 0.9f);  // mostly facing +X
+}

--- a/src/MeshDecimatorController_test.cpp
+++ b/src/MeshDecimatorController_test.cpp
@@ -1,0 +1,74 @@
+#include <gtest/gtest.h>
+#include <QApplication>
+#include <QCoreApplication>
+#include <QSignalSpy>
+#include <QThread>
+
+#include "Manager.h"
+#include "MeshDecimatorController.h"
+#include "SelectionSet.h"
+#include "TestHelpers.h"
+
+// Most of the MeshDecimatorController is wrapped in LCOV_EXCL_START/STOP
+// (the LOD-generator paths), so this suite focuses on the small portion
+// that is *not* excluded: singleton lifecycle and selection-driven state.
+
+class MeshDecimatorControllerTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        Manager::kill();
+        SelectionSet::kill();
+        MeshDecimatorController::kill();
+        QThread::msleep(20);
+        app = qobject_cast<QApplication*>(QCoreApplication::instance());
+        ASSERT_NE(app, nullptr);
+        ASSERT_TRUE(tryInitOgre());
+        ASSERT_TRUE(canLoadMeshFiles());
+    }
+    void TearDown() override {
+        MeshDecimatorController::kill();
+        SelectionSet::kill();
+        Manager::kill();
+        if (app) app->processEvents();
+        QThread::msleep(20);
+    }
+    QApplication* app = nullptr;
+};
+
+TEST_F(MeshDecimatorControllerTest, InstanceReturnsSameSingleton)
+{
+    auto* a = MeshDecimatorController::instance();
+    auto* b = MeshDecimatorController::instance();
+    EXPECT_EQ(a, b);
+}
+
+TEST_F(MeshDecimatorControllerTest, NoSelectionMeansNoSelection)
+{
+    // Bring SelectionSet up (so the connect() inside the controller
+    // resolves) but do not select anything.
+    SelectionSet::getSingleton();
+    auto* ctrl = MeshDecimatorController::instance();
+    EXPECT_FALSE(ctrl->hasSelection());
+    EXPECT_EQ(ctrl->baseTriangleCount(), 0);
+    EXPECT_EQ(ctrl->previewTriangleCount(), 0);
+    EXPECT_FALSE(ctrl->hasActivePreview());
+}
+
+TEST_F(MeshDecimatorControllerTest, PrimeBaselineEmitsBaseChangedEvenWithoutSelection)
+{
+    SelectionSet::getSingleton();
+    auto* ctrl = MeshDecimatorController::instance();
+    QSignalSpy spy(ctrl, &MeshDecimatorController::baseChanged);
+    ctrl->primeBaseline();
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(MeshDecimatorControllerTest, ClearPreviewIsNoopWhenInactive)
+{
+    SelectionSet::getSingleton();
+    auto* ctrl = MeshDecimatorController::instance();
+    QSignalSpy spy(ctrl, &MeshDecimatorController::previewChanged);
+    ctrl->clearPreview();
+    // m_hasPreview is false from the constructor; clearPreview returns early.
+    EXPECT_EQ(spy.count(), 0);
+}

--- a/src/QtMeshCloudClient_test.cpp
+++ b/src/QtMeshCloudClient_test.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <QCoreApplication>
 #include <QJsonObject>
 #include "QtMeshCloudClient.h"
 
@@ -43,4 +44,77 @@ TEST(QtMeshCloudClientValidate, RejectsBoolVersion)
     o["scan"] = QJsonObject{};
     o["rules"] = QJsonObject{};
     EXPECT_FALSE(QtMeshCloudClient::validateCloudConfigJson(o));
+}
+
+TEST(QtMeshCloudClientValidate, RejectsNonObjectScan)
+{
+    QJsonObject o;
+    o["version"] = 1;
+    o["scan"] = 42;       // not an object
+    o["rules"] = QJsonObject{};
+    EXPECT_FALSE(QtMeshCloudClient::validateCloudConfigJson(o));
+}
+
+TEST(QtMeshCloudClientValidate, RejectsNonObjectRules)
+{
+    QJsonObject o;
+    o["version"] = 1;
+    o["scan"] = QJsonObject{};
+    o["rules"] = QStringLiteral("invalid");
+    EXPECT_FALSE(QtMeshCloudClient::validateCloudConfigJson(o));
+}
+
+TEST(QtMeshCloudClientValidate, AcceptsNumericVersionFloat)
+{
+    QJsonObject o;
+    o["version"] = 1.5;    // doubles are allowed (JSON numbers)
+    o["scan"] = QJsonObject{};
+    o["rules"] = QJsonObject{};
+    EXPECT_TRUE(QtMeshCloudClient::validateCloudConfigJson(o));
+}
+
+TEST(QtMeshCloudClientApiBaseUrl, DefaultUrlWhenEnvUnset)
+{
+    qunsetenv("QTMESH_API_BASE");
+    EXPECT_EQ(QtMeshCloudClient::apiBaseUrl(),
+              QStringLiteral("https://api.qtmesh.dev"));
+}
+
+TEST(QtMeshCloudClientApiBaseUrl, EnvOverride)
+{
+    qputenv("QTMESH_API_BASE", "https://my-host.example.com");
+    EXPECT_EQ(QtMeshCloudClient::apiBaseUrl(),
+              QStringLiteral("https://my-host.example.com"));
+    qunsetenv("QTMESH_API_BASE");
+}
+
+TEST(QtMeshCloudClientApiBaseUrl, TrailingSlashesStripped)
+{
+    qputenv("QTMESH_API_BASE", "https://my-host.example.com///");
+    EXPECT_EQ(QtMeshCloudClient::apiBaseUrl(),
+              QStringLiteral("https://my-host.example.com"));
+    qunsetenv("QTMESH_API_BASE");
+}
+
+TEST(QtMeshCloudClientApiBaseUrl, WhitespaceTrimmed)
+{
+    qputenv("QTMESH_API_BASE", "  https://api.test.com/  ");
+    EXPECT_EQ(QtMeshCloudClient::apiBaseUrl(),
+              QStringLiteral("https://api.test.com"));
+    qunsetenv("QTMESH_API_BASE");
+}
+
+TEST(QtMeshCloudClientFetchRules, MissingTokenReturnsErrorImmediately)
+{
+    auto result = QtMeshCloudClient::fetchRules(QString(), /*timeoutMs=*/100);
+    EXPECT_FALSE(result.ok);
+    EXPECT_TRUE(result.errorString.contains("missing bearer token", Qt::CaseInsensitive));
+}
+
+TEST(QtMeshCloudClientUploadScan, MissingTokenReturnsErrorImmediately)
+{
+    QJsonObject empty;
+    auto result = QtMeshCloudClient::uploadScanReport(QString(), empty, /*timeoutMs=*/100);
+    EXPECT_FALSE(result.ok);
+    EXPECT_TRUE(result.errorString.contains("missing bearer token", Qt::CaseInsensitive));
 }

--- a/src/QtMeshCloudClient_test.cpp
+++ b/src/QtMeshCloudClient_test.cpp
@@ -73,35 +73,52 @@ TEST(QtMeshCloudClientValidate, AcceptsNumericVersionFloat)
     EXPECT_TRUE(QtMeshCloudClient::validateCloudConfigJson(o));
 }
 
-TEST(QtMeshCloudClientApiBaseUrl, DefaultUrlWhenEnvUnset)
+// Snapshots QTMESH_API_BASE in SetUp and restores it in TearDown so individual
+// tests can freely mutate the env var without leaking state into the rest of
+// the UnitTests run (other suites may rely on the original value).
+class QtMeshCloudClientApiBaseUrlTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        m_hadOriginal = qEnvironmentVariableIsSet("QTMESH_API_BASE");
+        if (m_hadOriginal)
+            m_original = qgetenv("QTMESH_API_BASE");
+    }
+    void TearDown() override {
+        if (m_hadOriginal)
+            qputenv("QTMESH_API_BASE", m_original);
+        else
+            qunsetenv("QTMESH_API_BASE");
+    }
+    QByteArray m_original;
+    bool m_hadOriginal = false;
+};
+
+TEST_F(QtMeshCloudClientApiBaseUrlTest, DefaultUrlWhenEnvUnset)
 {
     qunsetenv("QTMESH_API_BASE");
     EXPECT_EQ(QtMeshCloudClient::apiBaseUrl(),
               QStringLiteral("https://api.qtmesh.dev"));
 }
 
-TEST(QtMeshCloudClientApiBaseUrl, EnvOverride)
+TEST_F(QtMeshCloudClientApiBaseUrlTest, EnvOverride)
 {
     qputenv("QTMESH_API_BASE", "https://my-host.example.com");
     EXPECT_EQ(QtMeshCloudClient::apiBaseUrl(),
               QStringLiteral("https://my-host.example.com"));
-    qunsetenv("QTMESH_API_BASE");
 }
 
-TEST(QtMeshCloudClientApiBaseUrl, TrailingSlashesStripped)
+TEST_F(QtMeshCloudClientApiBaseUrlTest, TrailingSlashesStripped)
 {
     qputenv("QTMESH_API_BASE", "https://my-host.example.com///");
     EXPECT_EQ(QtMeshCloudClient::apiBaseUrl(),
               QStringLiteral("https://my-host.example.com"));
-    qunsetenv("QTMESH_API_BASE");
 }
 
-TEST(QtMeshCloudClientApiBaseUrl, WhitespaceTrimmed)
+TEST_F(QtMeshCloudClientApiBaseUrlTest, WhitespaceTrimmed)
 {
     qputenv("QTMESH_API_BASE", "  https://api.test.com/  ");
     EXPECT_EQ(QtMeshCloudClient::apiBaseUrl(),
               QStringLiteral("https://api.test.com"));
-    qunsetenv("QTMESH_API_BASE");
 }
 
 TEST(QtMeshCloudClientFetchRules, MissingTokenReturnsErrorImmediately)

--- a/src/ScanConfig_test.cpp
+++ b/src/ScanConfig_test.cpp
@@ -276,7 +276,14 @@ TEST(ScanConfigFromVariantMapTest, PopulatesAllRuleFields)
 
     EXPECT_EQ(cfg.version, 2);
     EXPECT_EQ(cfg.roots, (QStringList{QStringLiteral("./assets")}));
-    EXPECT_EQ(cfg.includePatterns, (QStringList{QStringLiteral("**/*.fbx")}));
+    // fromVariantMap injects editor-only mesh globs (tmd/rsd/ply) when the
+    // explicit include list omits them — assert the user's pattern survives
+    // and the auto-injected extras are present, without coupling to the
+    // injection list's exact contents/order.
+    EXPECT_TRUE(cfg.includePatterns.contains(QStringLiteral("**/*.fbx")));
+    EXPECT_TRUE(cfg.includePatterns.contains(QStringLiteral("**/*.tmd")));
+    EXPECT_TRUE(cfg.includePatterns.contains(QStringLiteral("**/*.rsd")));
+    EXPECT_TRUE(cfg.includePatterns.contains(QStringLiteral("**/*.ply")));
     EXPECT_EQ(cfg.excludePatterns, (QStringList{QStringLiteral("**/legacy/**")}));
 
     EXPECT_EQ(cfg.allowedFormats, (QStringList{QStringLiteral("fbx"), QStringLiteral("glb")}));

--- a/src/ScanConfig_test.cpp
+++ b/src/ScanConfig_test.cpp
@@ -1,0 +1,596 @@
+#include <gtest/gtest.h>
+
+#include "ScanConfig.h"
+
+#include <QDir>
+#include <QFile>
+#include <QTemporaryFile>
+#include <QTemporaryDir>
+
+namespace {
+
+void writeFile(const QString& path, const QByteArray& content)
+{
+    QFile f(path);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly | QIODevice::Truncate));
+    ASSERT_EQ(f.write(content), content.size());
+    f.close();
+}
+
+} // namespace
+
+// -------------------- parseSimpleYaml --------------------
+
+TEST(ParseSimpleYamlTest, EmptyContent)
+{
+    const QVariantMap m = parseSimpleYaml(QString());
+    EXPECT_TRUE(m.isEmpty());
+}
+
+TEST(ParseSimpleYamlTest, TopLevelScalars)
+{
+    const QString yaml = QStringLiteral(
+        "version: 1\n"
+        "name: \"my-scan\"\n");
+    const QVariantMap m = parseSimpleYaml(yaml);
+    EXPECT_EQ(m.value("version").toInt(), 1);
+    EXPECT_EQ(m.value("name").toString(), QStringLiteral("my-scan"));
+}
+
+TEST(ParseSimpleYamlTest, ScalarTypes)
+{
+    const QString yaml = QStringLiteral(
+        "anInt: 42\n"
+        "aDouble: 3.14\n"
+        "aTrue: true\n"
+        "aYes: yes\n"
+        "aOn: on\n"
+        "aFalse: false\n"
+        "aNo: no\n"
+        "aOff: off\n"
+        "aString: hello\n"
+        "quotedString: \"with spaces\"\n"
+        "singleQuoted: 'sq'\n");
+    const QVariantMap m = parseSimpleYaml(yaml);
+    EXPECT_EQ(m.value("anInt").toInt(), 42);
+    EXPECT_DOUBLE_EQ(m.value("aDouble").toDouble(), 3.14);
+    EXPECT_TRUE(m.value("aTrue").toBool());
+    EXPECT_TRUE(m.value("aYes").toBool());
+    EXPECT_TRUE(m.value("aOn").toBool());
+    EXPECT_FALSE(m.value("aFalse").toBool());
+    EXPECT_FALSE(m.value("aNo").toBool());
+    EXPECT_FALSE(m.value("aOff").toBool());
+    EXPECT_EQ(m.value("aString").toString(), QStringLiteral("hello"));
+    EXPECT_EQ(m.value("quotedString").toString(), QStringLiteral("with spaces"));
+    EXPECT_EQ(m.value("singleQuoted").toString(), QStringLiteral("sq"));
+}
+
+TEST(ParseSimpleYamlTest, SectionWithInlineList)
+{
+    const QString yaml = QStringLiteral(
+        "scan:\n"
+        "  roots: [./a, ./b]\n");
+    const QVariantMap m = parseSimpleYaml(yaml);
+    const QVariantMap scan = m.value("scan").toMap();
+    const QStringList roots = scan.value("roots").toStringList();
+    ASSERT_EQ(roots.size(), 2);
+    EXPECT_EQ(roots[0], QStringLiteral("./a"));
+    EXPECT_EQ(roots[1], QStringLiteral("./b"));
+}
+
+TEST(ParseSimpleYamlTest, SectionWithBlockList)
+{
+    const QString yaml = QStringLiteral(
+        "scan:\n"
+        "  roots:\n"
+        "    - ./first\n"
+        "    - ./second\n");
+    const QVariantMap m = parseSimpleYaml(yaml);
+    const QVariantMap scan = m.value("scan").toMap();
+    const QStringList roots = scan.value("roots").toStringList();
+    ASSERT_EQ(roots.size(), 2);
+    EXPECT_EQ(roots[0], QStringLiteral("./first"));
+    EXPECT_EQ(roots[1], QStringLiteral("./second"));
+}
+
+TEST(ParseSimpleYamlTest, CommentsAreStripped)
+{
+    const QString yaml = QStringLiteral(
+        "version: 1  # trailing comment\n"
+        "# full line\n"
+        "name: bob\n");
+    const QVariantMap m = parseSimpleYaml(yaml);
+    EXPECT_EQ(m.value("version").toInt(), 1);
+    EXPECT_EQ(m.value("name").toString(), QStringLiteral("bob"));
+}
+
+TEST(ParseSimpleYamlTest, HashInsideQuotesIsKept)
+{
+    // # inside a quoted string should not start a comment
+    const QString yaml = QStringLiteral(
+        "name: \"a # b\"\n");
+    const QVariantMap m = parseSimpleYaml(yaml);
+    EXPECT_EQ(m.value("name").toString(), QStringLiteral("a # b"));
+}
+
+TEST(ParseSimpleYamlTest, NestedScopesWithOrderPreserved)
+{
+    // Two scopes with different rule overrides — _order must reflect declaration order.
+    const QString yaml = QStringLiteral(
+        "scopes:\n"
+        "  \"characters/**\":\n"
+        "    max_vertex_count: 5000\n"
+        "  \"props/**\":\n"
+        "    max_vertex_count: 1000\n");
+    const QVariantMap m = parseSimpleYaml(yaml);
+    const QVariantMap scopes = m.value("scopes").toMap();
+    const QStringList order = scopes.value("_order").toStringList();
+    ASSERT_EQ(order.size(), 2);
+    EXPECT_EQ(order[0], QStringLiteral("characters/**"));
+    EXPECT_EQ(order[1], QStringLiteral("props/**"));
+
+    const QVariantMap chars = scopes.value("characters/**").toMap();
+    EXPECT_EQ(chars.value("max_vertex_count").toInt(), 5000);
+
+    const QVariantMap props = scopes.value("props/**").toMap();
+    EXPECT_EQ(props.value("max_vertex_count").toInt(), 1000);
+}
+
+TEST(ParseSimpleYamlTest, EmptyKeyFollowedByNothingIsTreatedAsScalar)
+{
+    // A key with no value that isn't followed by list items or a subsection
+    // should not break parsing of the next top-level key.
+    const QString yaml = QStringLiteral(
+        "section:\n"
+        "  emptyKey:\n"
+        "version: 7\n");
+    const QVariantMap m = parseSimpleYaml(yaml);
+    EXPECT_EQ(m.value("version").toInt(), 7);
+}
+
+// -------------------- ScanConfig defaults --------------------
+
+TEST(ScanConfigDefaultsTest, DefaultsHaveExpectedValues)
+{
+    const ScanConfig cfg = ScanConfig::defaults();
+    EXPECT_EQ(cfg.version, 1);
+    EXPECT_FALSE(cfg.includePatterns.isEmpty());
+    EXPECT_FALSE(cfg.excludePatterns.isEmpty());
+    EXPECT_EQ(cfg.maxFileSizeMb, 0);
+    EXPECT_EQ(cfg.maxMeshCount, 0);
+    EXPECT_FALSE(cfg.requireSkeleton);
+    EXPECT_FALSE(cfg.requireAnimations);
+    EXPECT_TRUE(cfg.allowEmbeddedTextures);
+    EXPECT_FALSE(cfg.requireTexturesExist);
+    EXPECT_TRUE(cfg.allowMissingMaterials);
+    EXPECT_FALSE(cfg.fixEnabled);
+    EXPECT_FALSE(cfg.dryRun);
+    EXPECT_EQ(cfg.reportFormat, QStringLiteral("text"));
+    EXPECT_EQ(cfg.failOn, QStringLiteral("error"));
+    EXPECT_EQ(cfg.maxAcmr, 0.0);
+    EXPECT_EQ(cfg.redundantKeyframesPctThreshold, 0.0);
+    EXPECT_EQ(cfg.maxTextureResolution, 0);
+    EXPECT_EQ(cfg.requireUvChannels, 0);
+    EXPECT_FALSE(cfg.detectZeroWeightBones);
+}
+
+TEST(ScanConfigDefaultsTest, IncludePatternsContainCommonExtensions)
+{
+    const QStringList globs = ScanConfig::defaultIncludePatternsForAssimpImports();
+    // Should contain a few well-known ones: mesh, tmd, rsd, fbx (from Assimp)
+    auto contains = [&](const QString& tail) {
+        for (const QString& g : globs)
+            if (g.endsWith(tail, Qt::CaseInsensitive))
+                return true;
+        return false;
+    };
+    EXPECT_TRUE(contains(QStringLiteral(".mesh")));
+    EXPECT_TRUE(contains(QStringLiteral(".tmd")));
+    EXPECT_TRUE(contains(QStringLiteral(".rsd")));
+    // FBX is registered through Assimp on standard builds.
+    EXPECT_TRUE(contains(QStringLiteral(".fbx")));
+}
+
+TEST(ScanConfigDefaultsTest, IncludePatternsAreSorted)
+{
+    QStringList globs = ScanConfig::defaultIncludePatternsForAssimpImports();
+    QStringList sorted = globs;
+    sorted.sort(Qt::CaseInsensitive);
+    EXPECT_EQ(globs, sorted);
+}
+
+// -------------------- fromVariantMap --------------------
+
+TEST(ScanConfigFromVariantMapTest, EmptyMapReturnsDefaults)
+{
+    const ScanConfig cfg = ScanConfig::fromVariantMap({});
+    const ScanConfig def = ScanConfig::defaults();
+    EXPECT_EQ(cfg.version, def.version);
+    EXPECT_EQ(cfg.maxFileSizeMb, def.maxFileSizeMb);
+    EXPECT_EQ(cfg.failOn, def.failOn);
+}
+
+TEST(ScanConfigFromVariantMapTest, PopulatesAllRuleFields)
+{
+    QVariantMap root;
+    root["version"] = 2;
+
+    QVariantMap scan;
+    scan["roots"] = QStringList{QStringLiteral("./assets")};
+    scan["include"] = QStringList{QStringLiteral("**/*.fbx")};
+    scan["exclude"] = QStringList{QStringLiteral("**/legacy/**")};
+    root["scan"] = scan;
+
+    QVariantMap rules;
+    rules["allowed_formats"]         = QStringList{QStringLiteral("fbx"), QStringLiteral("glb")};
+    rules["forbidden_extensions"]    = QStringList{QStringLiteral("dae")};
+    rules["max_file_size_mb"]        = 25.5;
+    rules["min_file_size_mb"]        = 0.05;
+    rules["max_mesh_count"]          = 16;
+    rules["min_mesh_count"]          = 1;
+    rules["max_material_count"]      = 4;
+    rules["min_material_count"]      = 1;
+    rules["max_vertex_count"]        = 50000;
+    rules["min_vertex_count"]        = 8;
+    rules["max_acmr"]                = 1.5;
+    rules["require_skeleton"]        = true;
+    rules["require_animations"]      = true;
+    rules["allow_embedded_textures"] = false;
+    rules["require_textures_exist"]  = true;
+    rules["allow_missing_materials"] = false;
+    rules["file_name_case"]          = QStringLiteral("snake_case");
+    rules["max_anim_keyframes"]      = 200;
+    rules["min_anim_keyframes"]      = 2;
+    rules["max_anim_duration"]       = 30.0;
+    rules["min_anim_duration"]       = 0.2;
+    rules["require_animation_names"] = QStringList{QStringLiteral("walk"), QStringLiteral("attack*")};
+    rules["require_bone_names"]      = QStringList{QStringLiteral("root_*")};
+    rules["redundant_keyframes_pct"]                  = 40.0;
+    rules["redundant_keyframes_translation_tol"]      = 1e-3;
+    rules["redundant_keyframes_rotation_deg_tol"]     = 1.0;
+    rules["redundant_keyframes_scale_tol"]            = 1e-3;
+    rules["max_texture_resolution"]   = 4096;
+    rules["require_uv_channels"]      = 2;
+    rules["detect_zero_weight_bones"] = true;
+    rules["detect_overlapping_uvs_pct"] = 5.0;
+    rules["detect_non_manifold_edges_pct"] = 1.0;
+    root["rules"] = rules;
+
+    QVariantMap fix;
+    fix["enabled"]           = true;
+    fix["dry_run"]           = true;
+    fix["optimize_meshes"]   = true;
+    fix["rename_animations"] = true;
+    fix["convert_to_format"] = QStringLiteral("glb");
+    fix["output_dir"]        = QStringLiteral("./out");
+    root["fix"] = fix;
+
+    QVariantMap report;
+    report["format"]       = QStringLiteral("json");
+    report["output"]       = QStringLiteral("report.json");
+    report["sarif_output"] = QStringLiteral("report.sarif");
+    report["fail_on"]      = QStringLiteral("warning");
+    root["report"] = report;
+
+    const ScanConfig cfg = ScanConfig::fromVariantMap(root);
+
+    EXPECT_EQ(cfg.version, 2);
+    EXPECT_EQ(cfg.roots, (QStringList{QStringLiteral("./assets")}));
+    EXPECT_EQ(cfg.includePatterns, (QStringList{QStringLiteral("**/*.fbx")}));
+    EXPECT_EQ(cfg.excludePatterns, (QStringList{QStringLiteral("**/legacy/**")}));
+
+    EXPECT_EQ(cfg.allowedFormats, (QStringList{QStringLiteral("fbx"), QStringLiteral("glb")}));
+    EXPECT_EQ(cfg.forbiddenExtensions, (QStringList{QStringLiteral("dae")}));
+    EXPECT_DOUBLE_EQ(cfg.maxFileSizeMb, 25.5);
+    EXPECT_DOUBLE_EQ(cfg.minFileSizeMb, 0.05);
+    EXPECT_EQ(cfg.maxMeshCount, 16);
+    EXPECT_EQ(cfg.minMeshCount, 1);
+    EXPECT_EQ(cfg.maxMaterialCount, 4);
+    EXPECT_EQ(cfg.minMaterialCount, 1);
+    EXPECT_EQ(cfg.maxVertexCount, 50000);
+    EXPECT_EQ(cfg.minVertexCount, 8);
+    EXPECT_DOUBLE_EQ(cfg.maxAcmr, 1.5);
+    EXPECT_TRUE(cfg.requireSkeleton);
+    EXPECT_TRUE(cfg.requireAnimations);
+    EXPECT_FALSE(cfg.allowEmbeddedTextures);
+    EXPECT_TRUE(cfg.requireTexturesExist);
+    EXPECT_FALSE(cfg.allowMissingMaterials);
+    EXPECT_EQ(cfg.fileNameCase, QStringLiteral("snake_case"));
+    EXPECT_EQ(cfg.maxAnimKeyframes, 200);
+    EXPECT_EQ(cfg.minAnimKeyframes, 2);
+    EXPECT_DOUBLE_EQ(cfg.maxAnimDuration, 30.0);
+    EXPECT_DOUBLE_EQ(cfg.minAnimDuration, 0.2);
+    EXPECT_EQ(cfg.requireAnimationNames, (QStringList{QStringLiteral("walk"), QStringLiteral("attack*")}));
+    EXPECT_EQ(cfg.requireBoneNames, (QStringList{QStringLiteral("root_*")}));
+    EXPECT_DOUBLE_EQ(cfg.redundantKeyframesPctThreshold, 40.0);
+    EXPECT_DOUBLE_EQ(cfg.redundantKeyframesTranslationTol, 1e-3);
+    EXPECT_DOUBLE_EQ(cfg.redundantKeyframesRotationDegTol, 1.0);
+    EXPECT_DOUBLE_EQ(cfg.redundantKeyframesScaleTol, 1e-3);
+    EXPECT_EQ(cfg.maxTextureResolution, 4096);
+    EXPECT_EQ(cfg.requireUvChannels, 2);
+    EXPECT_TRUE(cfg.detectZeroWeightBones);
+    EXPECT_DOUBLE_EQ(cfg.detectOverlappingUvsPct, 5.0);
+    EXPECT_DOUBLE_EQ(cfg.detectNonManifoldEdgesPct, 1.0);
+
+    EXPECT_TRUE(cfg.fixEnabled);
+    EXPECT_TRUE(cfg.dryRun);
+    EXPECT_TRUE(cfg.optimizeMeshes);
+    EXPECT_TRUE(cfg.renameAnimations);
+    EXPECT_EQ(cfg.convertToFormat, QStringLiteral("glb"));
+    EXPECT_EQ(cfg.outputDir, QStringLiteral("./out"));
+
+    EXPECT_EQ(cfg.reportFormat, QStringLiteral("json"));
+    EXPECT_EQ(cfg.reportOutput, QStringLiteral("report.json"));
+    EXPECT_EQ(cfg.sarifOutput, QStringLiteral("report.sarif"));
+    EXPECT_EQ(cfg.failOn, QStringLiteral("warning"));
+}
+
+TEST(ScanConfigFromVariantMapTest, ScopesFromMapWithoutOrderUseAlphabetical)
+{
+    // JSON path: no _order key. Iteration order is alphabetical via QMap.
+    QVariantMap root;
+    QVariantMap scopes;
+    QVariantMap chars;  chars["max_vertex_count"] = 5000;
+    QVariantMap props; props["max_vertex_count"] = 1000;
+    scopes["characters/**"] = chars;
+    scopes["props/**"] = props;
+    root["scopes"] = scopes;
+
+    const ScanConfig cfg = ScanConfig::fromVariantMap(root);
+    ASSERT_EQ(cfg.scopes.size(), 2);
+    // QVariantMap iterates alphabetically: characters/** before props/**
+    EXPECT_EQ(cfg.scopes[0].pathPattern, QStringLiteral("characters/**"));
+    EXPECT_EQ(cfg.scopes[1].pathPattern, QStringLiteral("props/**"));
+    EXPECT_EQ(cfg.scopes[0].rules.value("max_vertex_count").toInt(), 5000);
+    EXPECT_EQ(cfg.scopes[1].rules.value("max_vertex_count").toInt(), 1000);
+}
+
+TEST(ScanConfigFromVariantMapTest, ScopesWithOrderHonorDeclarationOrder)
+{
+    QVariantMap root;
+    QVariantMap scopes;
+    QVariantMap chars;  chars["max_vertex_count"] = 5000;
+    QVariantMap props; props["max_vertex_count"] = 1000;
+    scopes["characters/**"] = chars;
+    scopes["props/**"] = props;
+    scopes["_order"] = QStringList{QStringLiteral("props/**"), QStringLiteral("characters/**")};
+    root["scopes"] = scopes;
+
+    const ScanConfig cfg = ScanConfig::fromVariantMap(root);
+    ASSERT_EQ(cfg.scopes.size(), 2);
+    EXPECT_EQ(cfg.scopes[0].pathPattern, QStringLiteral("props/**"));
+    EXPECT_EQ(cfg.scopes[1].pathPattern, QStringLiteral("characters/**"));
+}
+
+// -------------------- fromJson --------------------
+
+TEST(ScanConfigFromJsonTest, ParsesJsonObject)
+{
+    const QByteArray json = R"({
+        "version": 3,
+        "rules": { "max_mesh_count": 9 },
+        "report": { "format": "json" }
+    })";
+    QJsonDocument doc = QJsonDocument::fromJson(json);
+    ASSERT_FALSE(doc.isNull());
+    const ScanConfig cfg = ScanConfig::fromJson(doc.object());
+    EXPECT_EQ(cfg.version, 3);
+    EXPECT_EQ(cfg.maxMeshCount, 9);
+    EXPECT_EQ(cfg.reportFormat, QStringLiteral("json"));
+}
+
+// -------------------- loadFromFile --------------------
+
+TEST(ScanConfigLoadFromFileTest, MissingFileReturnsDefaults)
+{
+    const ScanConfig cfg = ScanConfig::loadFromFile(QStringLiteral("/nonexistent/path/qtmesh.yml"));
+    const ScanConfig def = ScanConfig::defaults();
+    EXPECT_EQ(cfg.version, def.version);
+    EXPECT_EQ(cfg.maxMeshCount, def.maxMeshCount);
+    EXPECT_EQ(cfg.failOn, def.failOn);
+}
+
+TEST(ScanConfigLoadFromFileTest, LoadYamlFile)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString path = dir.filePath("qtmesh.yml");
+    writeFile(path, QByteArrayLiteral(
+        "version: 2\n"
+        "rules:\n"
+        "  max_mesh_count: 5\n"
+        "  require_skeleton: true\n"
+        "report:\n"
+        "  format: json\n"));
+    const ScanConfig cfg = ScanConfig::loadFromFile(path);
+    EXPECT_EQ(cfg.version, 2);
+    EXPECT_EQ(cfg.maxMeshCount, 5);
+    EXPECT_TRUE(cfg.requireSkeleton);
+    EXPECT_EQ(cfg.reportFormat, QStringLiteral("json"));
+}
+
+TEST(ScanConfigLoadFromFileTest, LoadJsonFile)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString path = dir.filePath("qtmesh.json");
+    writeFile(path, R"({
+        "version": 1,
+        "rules": { "max_vertex_count": 100 },
+        "fix":   { "dry_run": true }
+    })");
+    const ScanConfig cfg = ScanConfig::loadFromFile(path);
+    EXPECT_EQ(cfg.maxVertexCount, 100);
+    EXPECT_TRUE(cfg.dryRun);
+}
+
+TEST(ScanConfigLoadFromFileTest, InvalidJsonReturnsDefaults)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString path = dir.filePath("bad.json");
+    writeFile(path, QByteArrayLiteral("{ this is not json"));
+    const ScanConfig cfg = ScanConfig::loadFromFile(path);
+    // Falls back to defaults
+    EXPECT_EQ(cfg.maxVertexCount, 0);
+}
+
+TEST(ScanConfigLoadFromFileTest, YamlMergesEditorOnlyMeshGlobsWhenIncludeMissingThem)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString path = dir.filePath("qtmesh.yml");
+    // User declares ONLY fbx — engine should still inject tmd / rsd / ply
+    // so those non-Assimp formats keep getting scanned.
+    writeFile(path, QByteArrayLiteral(
+        "scan:\n"
+        "  include: [\"**/*.fbx\"]\n"));
+    const ScanConfig cfg = ScanConfig::loadFromFile(path);
+    auto contains = [&](const QString& tail) {
+        for (const QString& g : cfg.includePatterns)
+            if (g.endsWith(tail, Qt::CaseInsensitive))
+                return true;
+        return false;
+    };
+    EXPECT_TRUE(contains(QStringLiteral(".fbx")));
+    EXPECT_TRUE(contains(QStringLiteral(".tmd")));
+    EXPECT_TRUE(contains(QStringLiteral(".rsd")));
+    EXPECT_TRUE(contains(QStringLiteral(".ply")));
+}
+
+// -------------------- applyRuleOverrides + withScopeOverrides --------------------
+
+TEST(ScanConfigApplyOverridesTest, ApplyRuleOverridesAffectsAllFields)
+{
+    ScanConfig cfg = ScanConfig::defaults();
+    QVariantMap r;
+    r["max_file_size_mb"]            = 99.0;
+    r["min_file_size_mb"]            = 0.1;
+    r["max_mesh_count"]              = 99;
+    r["min_mesh_count"]              = 1;
+    r["max_material_count"]          = 99;
+    r["min_material_count"]          = 1;
+    r["max_vertex_count"]            = 99;
+    r["min_vertex_count"]            = 1;
+    r["max_acmr"]                    = 2.5;
+    r["require_skeleton"]            = true;
+    r["require_animations"]          = true;
+    r["allow_embedded_textures"]     = false;
+    r["require_textures_exist"]      = true;
+    r["allow_missing_materials"]     = false;
+    r["file_name_case"]              = QStringLiteral("PascalCase");
+    r["max_anim_keyframes"]          = 50;
+    r["min_anim_keyframes"]          = 1;
+    r["max_anim_duration"]           = 5.0;
+    r["min_anim_duration"]           = 0.1;
+    r["allowed_formats"]             = QStringList{QStringLiteral("fbx")};
+    r["forbidden_extensions"]        = QStringList{QStringLiteral("3ds")};
+    r["require_animation_names"]     = QStringList{QStringLiteral("idle")};
+    r["require_bone_names"]          = QStringList{QStringLiteral("hip")};
+    r["redundant_keyframes_pct"]              = 30.0;
+    r["redundant_keyframes_translation_tol"]  = 1e-2;
+    r["redundant_keyframes_rotation_deg_tol"] = 0.5;
+    r["redundant_keyframes_scale_tol"]        = 1e-2;
+    r["max_texture_resolution"]      = 2048;
+    r["require_uv_channels"]         = 1;
+    r["detect_zero_weight_bones"]    = true;
+    r["detect_overlapping_uvs_pct"]  = 2.0;
+    r["detect_non_manifold_edges_pct"] = 0.5;
+
+    cfg.applyRuleOverrides(r);
+    EXPECT_DOUBLE_EQ(cfg.maxFileSizeMb, 99.0);
+    EXPECT_DOUBLE_EQ(cfg.minFileSizeMb, 0.1);
+    EXPECT_EQ(cfg.maxMeshCount, 99);
+    EXPECT_EQ(cfg.minMeshCount, 1);
+    EXPECT_EQ(cfg.maxMaterialCount, 99);
+    EXPECT_EQ(cfg.minMaterialCount, 1);
+    EXPECT_EQ(cfg.maxVertexCount, 99);
+    EXPECT_EQ(cfg.minVertexCount, 1);
+    EXPECT_DOUBLE_EQ(cfg.maxAcmr, 2.5);
+    EXPECT_TRUE(cfg.requireSkeleton);
+    EXPECT_TRUE(cfg.requireAnimations);
+    EXPECT_FALSE(cfg.allowEmbeddedTextures);
+    EXPECT_TRUE(cfg.requireTexturesExist);
+    EXPECT_FALSE(cfg.allowMissingMaterials);
+    EXPECT_EQ(cfg.fileNameCase, QStringLiteral("PascalCase"));
+    EXPECT_EQ(cfg.maxAnimKeyframes, 50);
+    EXPECT_EQ(cfg.minAnimKeyframes, 1);
+    EXPECT_DOUBLE_EQ(cfg.maxAnimDuration, 5.0);
+    EXPECT_DOUBLE_EQ(cfg.minAnimDuration, 0.1);
+    EXPECT_EQ(cfg.allowedFormats, (QStringList{QStringLiteral("fbx")}));
+    EXPECT_EQ(cfg.forbiddenExtensions, (QStringList{QStringLiteral("3ds")}));
+    EXPECT_EQ(cfg.requireAnimationNames, (QStringList{QStringLiteral("idle")}));
+    EXPECT_EQ(cfg.requireBoneNames, (QStringList{QStringLiteral("hip")}));
+    EXPECT_DOUBLE_EQ(cfg.redundantKeyframesPctThreshold, 30.0);
+    EXPECT_DOUBLE_EQ(cfg.redundantKeyframesTranslationTol, 1e-2);
+    EXPECT_DOUBLE_EQ(cfg.redundantKeyframesRotationDegTol, 0.5);
+    EXPECT_DOUBLE_EQ(cfg.redundantKeyframesScaleTol, 1e-2);
+    EXPECT_EQ(cfg.maxTextureResolution, 2048);
+    EXPECT_EQ(cfg.requireUvChannels, 1);
+    EXPECT_TRUE(cfg.detectZeroWeightBones);
+    EXPECT_DOUBLE_EQ(cfg.detectOverlappingUvsPct, 2.0);
+    EXPECT_DOUBLE_EQ(cfg.detectNonManifoldEdgesPct, 0.5);
+}
+
+TEST(ScanConfigApplyOverridesTest, ApplyRuleOverridesIgnoresUnknownKeys)
+{
+    ScanConfig cfg = ScanConfig::defaults();
+    const int origMax = cfg.maxMeshCount;
+    QVariantMap r;
+    r["totally_unknown_key"] = 999;
+    cfg.applyRuleOverrides(r);
+    EXPECT_EQ(cfg.maxMeshCount, origMax);
+}
+
+TEST(ScanConfigApplyOverridesTest, WithScopeOverridesAppliesMatchingScope)
+{
+    ScanConfig cfg = ScanConfig::defaults();
+    cfg.maxVertexCount = 1000;
+
+    ScanScope s1;
+    s1.pathPattern = QStringLiteral("characters/**");
+    s1.rules.insert(QStringLiteral("max_vertex_count"), 5000);
+    cfg.scopes.append(s1);
+
+    ScanScope s2;
+    s2.pathPattern = QStringLiteral("props/**");
+    s2.rules.insert(QStringLiteral("max_vertex_count"), 200);
+    cfg.scopes.append(s2);
+
+    const ScanConfig chars = cfg.withScopeOverrides(QStringLiteral("characters/hero.fbx"));
+    EXPECT_EQ(chars.maxVertexCount, 5000);
+
+    const ScanConfig props = cfg.withScopeOverrides(QStringLiteral("props/barrel.fbx"));
+    EXPECT_EQ(props.maxVertexCount, 200);
+
+    const ScanConfig other = cfg.withScopeOverrides(QStringLiteral("other/door.fbx"));
+    EXPECT_EQ(other.maxVertexCount, 1000);
+}
+
+TEST(ScanConfigApplyOverridesTest, LaterScopesOverrideEarlierWhenBothMatch)
+{
+    ScanConfig cfg = ScanConfig::defaults();
+    cfg.maxVertexCount = 1000;
+
+    ScanScope general;
+    general.pathPattern = QStringLiteral("**");
+    general.rules.insert(QStringLiteral("max_vertex_count"), 2000);
+    cfg.scopes.append(general);
+
+    ScanScope specific;
+    specific.pathPattern = QStringLiteral("hero/**");
+    specific.rules.insert(QStringLiteral("max_vertex_count"), 9000);
+    cfg.scopes.append(specific);
+
+    const ScanConfig result = cfg.withScopeOverrides(QStringLiteral("hero/x.fbx"));
+    // Both match; later wins.
+    EXPECT_EQ(result.maxVertexCount, 9000);
+}
+
+TEST(ScanConfigApplyOverridesTest, NoScopesLeavesConfigUntouched)
+{
+    ScanConfig cfg = ScanConfig::defaults();
+    cfg.maxVertexCount = 1234;
+    const ScanConfig out = cfg.withScopeOverrides(QStringLiteral("anything.fbx"));
+    EXPECT_EQ(out.maxVertexCount, 1234);
+}

--- a/src/SubMeshTransform_test.cpp
+++ b/src/SubMeshTransform_test.cpp
@@ -1,0 +1,266 @@
+#include <gtest/gtest.h>
+#include <QApplication>
+#include <QCoreApplication>
+#include <QThread>
+
+#include <OgreEntity.h>
+#include <OgreMesh.h>
+#include <OgreSubMesh.h>
+#include <OgreHardwareBufferManager.h>
+#include <OgreSceneManager.h>
+
+#include "Manager.h"
+#include "SubMeshTransform.h"
+#include "TestHelpers.h"
+
+#include <cmath>
+
+class SubMeshTransformTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        Manager::kill();
+        QThread::msleep(20);
+        app = qobject_cast<QApplication*>(QCoreApplication::instance());
+        ASSERT_NE(app, nullptr);
+        ASSERT_TRUE(tryInitOgre());
+        createStandardOgreMaterials();
+        ASSERT_TRUE(canLoadMeshFiles());
+    }
+    void TearDown() override {
+        Manager::kill();
+        if (app) app->processEvents();
+        QThread::msleep(20);
+    }
+    QApplication* app = nullptr;
+
+    // Build a triangle entity. The TestHelpers triangle has vertices
+    // {(0,0,0), (1,0,0), (0,1,0)} so the centroid is (1/3, 1/3, 0).
+    Ogre::Entity* makeTriangle(const std::string& name) {
+        auto mesh = createInMemoryTriangleMesh(name + "_mesh");
+        auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+        auto* entity = sceneMgr->createEntity(name, mesh);
+        return entity;
+    }
+};
+
+// -------------------- getSubMeshCenter --------------------
+
+TEST_F(SubMeshTransformTest, GetSubMeshCenterReturnsCentroid)
+{
+    auto* entity = makeTriangle("centroid_e");
+    const auto center = SubMeshTransform::getSubMeshCenter(entity, 0);
+    EXPECT_NEAR(center.x, 1.0f / 3.0f, 1e-4f);
+    EXPECT_NEAR(center.y, 1.0f / 3.0f, 1e-4f);
+    EXPECT_NEAR(center.z, 0.0f, 1e-4f);
+}
+
+TEST_F(SubMeshTransformTest, GetSubMeshCenterNullEntityReturnsZero)
+{
+    const auto center = SubMeshTransform::getSubMeshCenter(nullptr, 0);
+    EXPECT_EQ(center, Ogre::Vector3::ZERO);
+}
+
+TEST_F(SubMeshTransformTest, GetSubMeshCenterOutOfRangeIndexReturnsZero)
+{
+    auto* entity = makeTriangle("oor_e");
+    const auto center = SubMeshTransform::getSubMeshCenter(entity, 42);
+    EXPECT_EQ(center, Ogre::Vector3::ZERO);
+}
+
+// -------------------- readPositions --------------------
+
+TEST_F(SubMeshTransformTest, ReadPositionsReturnsAllVertices)
+{
+    auto* entity = makeTriangle("read_e");
+    const auto pos = SubMeshTransform::readPositions(entity, 0);
+    ASSERT_EQ(pos.size(), 3u);
+    EXPECT_EQ(pos[0], Ogre::Vector3(0, 0, 0));
+    EXPECT_EQ(pos[1], Ogre::Vector3(1, 0, 0));
+    EXPECT_EQ(pos[2], Ogre::Vector3(0, 1, 0));
+}
+
+TEST_F(SubMeshTransformTest, ReadPositionsNullEntityReturnsEmpty)
+{
+    const auto pos = SubMeshTransform::readPositions(nullptr, 0);
+    EXPECT_TRUE(pos.empty());
+}
+
+TEST_F(SubMeshTransformTest, ReadPositionsOutOfRangeIndexReturnsEmpty)
+{
+    auto* entity = makeTriangle("read_oor");
+    const auto pos = SubMeshTransform::readPositions(entity, 99);
+    EXPECT_TRUE(pos.empty());
+}
+
+// -------------------- writePositions --------------------
+
+TEST_F(SubMeshTransformTest, WritePositionsUpdatesBuffer)
+{
+    auto* entity = makeTriangle("write_e");
+    std::vector<Ogre::Vector3> newPos{
+        Ogre::Vector3(10, 20, 30),
+        Ogre::Vector3(40, 50, 60),
+        Ogre::Vector3(70, 80, 90),
+    };
+    SubMeshTransform::writePositions(entity, 0, newPos);
+    const auto pos = SubMeshTransform::readPositions(entity, 0);
+    ASSERT_EQ(pos.size(), 3u);
+    EXPECT_EQ(pos[0], Ogre::Vector3(10, 20, 30));
+    EXPECT_EQ(pos[1], Ogre::Vector3(40, 50, 60));
+    EXPECT_EQ(pos[2], Ogre::Vector3(70, 80, 90));
+}
+
+TEST_F(SubMeshTransformTest, WritePositionsHandlesShortInput)
+{
+    // Fewer positions than vertex count — only first N updated, the rest untouched.
+    auto* entity = makeTriangle("write_short_e");
+    std::vector<Ogre::Vector3> shortIn{
+        Ogre::Vector3(99, 99, 99),
+    };
+    SubMeshTransform::writePositions(entity, 0, shortIn);
+    const auto pos = SubMeshTransform::readPositions(entity, 0);
+    ASSERT_EQ(pos.size(), 3u);
+    EXPECT_EQ(pos[0], Ogre::Vector3(99, 99, 99));
+    EXPECT_EQ(pos[1], Ogre::Vector3(1, 0, 0));
+    EXPECT_EQ(pos[2], Ogre::Vector3(0, 1, 0));
+}
+
+TEST_F(SubMeshTransformTest, WritePositionsRecalculatesBounds)
+{
+    auto* entity = makeTriangle("write_bounds_e");
+    std::vector<Ogre::Vector3> bigPos{
+        Ogre::Vector3(-5, -5, -5),
+        Ogre::Vector3( 5,  5,  5),
+        Ogre::Vector3( 0,  0,  0),
+    };
+    SubMeshTransform::writePositions(entity, 0, bigPos);
+    const Ogre::AxisAlignedBox bb = entity->getMesh()->getBounds();
+    EXPECT_NEAR(bb.getMinimum().x, -5.0f, 1e-4f);
+    EXPECT_NEAR(bb.getMaximum().x,  5.0f, 1e-4f);
+}
+
+TEST_F(SubMeshTransformTest, WritePositionsNullEntityDoesNothing)
+{
+    // Just ensure no crash.
+    SubMeshTransform::writePositions(nullptr, 0, {Ogre::Vector3::ZERO});
+}
+
+// -------------------- translateSubMesh --------------------
+
+TEST_F(SubMeshTransformTest, TranslateMovesAllVertices)
+{
+    auto* entity = makeTriangle("trans_e");
+    SubMeshTransform::translateSubMesh(entity, 0, Ogre::Vector3(5, 0, -2));
+    const auto pos = SubMeshTransform::readPositions(entity, 0);
+    ASSERT_EQ(pos.size(), 3u);
+    EXPECT_EQ(pos[0], Ogre::Vector3(5, 0, -2));
+    EXPECT_EQ(pos[1], Ogre::Vector3(6, 0, -2));
+    EXPECT_EQ(pos[2], Ogre::Vector3(5, 1, -2));
+}
+
+TEST_F(SubMeshTransformTest, TranslateNullEntityIsNoop)
+{
+    SubMeshTransform::translateSubMesh(nullptr, 0, Ogre::Vector3(1, 1, 1));
+    // No crash = success.
+}
+
+TEST_F(SubMeshTransformTest, TranslateOutOfRangeIsNoop)
+{
+    auto* entity = makeTriangle("trans_oor_e");
+    SubMeshTransform::translateSubMesh(entity, 99, Ogre::Vector3(5, 5, 5));
+    const auto pos = SubMeshTransform::readPositions(entity, 0);
+    EXPECT_EQ(pos[1], Ogre::Vector3(1, 0, 0));
+}
+
+// -------------------- scaleSubMesh --------------------
+
+TEST_F(SubMeshTransformTest, ScaleAroundCentroid)
+{
+    auto* entity = makeTriangle("scale_e");
+    const Ogre::Vector3 centerBefore = SubMeshTransform::getSubMeshCenter(entity, 0);
+    SubMeshTransform::scaleSubMesh(entity, 0, Ogre::Vector3(2, 2, 2));
+    const Ogre::Vector3 centerAfter = SubMeshTransform::getSubMeshCenter(entity, 0);
+    EXPECT_NEAR(centerAfter.x, centerBefore.x, 1e-4f);
+    EXPECT_NEAR(centerAfter.y, centerBefore.y, 1e-4f);
+    EXPECT_NEAR(centerAfter.z, centerBefore.z, 1e-4f);
+
+    // Each vertex's distance to the centroid should have doubled.
+    const auto pos = SubMeshTransform::readPositions(entity, 0);
+    const auto orig = std::vector<Ogre::Vector3>{
+        Ogre::Vector3(0, 0, 0), Ogre::Vector3(1, 0, 0), Ogre::Vector3(0, 1, 0)};
+    for (size_t i = 0; i < 3; ++i) {
+        const auto expected = centerBefore + (orig[i] - centerBefore) * Ogre::Vector3(2, 2, 2);
+        EXPECT_NEAR(pos[i].x, expected.x, 1e-4f);
+        EXPECT_NEAR(pos[i].y, expected.y, 1e-4f);
+        EXPECT_NEAR(pos[i].z, expected.z, 1e-4f);
+    }
+}
+
+TEST_F(SubMeshTransformTest, ScaleNullEntityIsNoop)
+{
+    SubMeshTransform::scaleSubMesh(nullptr, 0, Ogre::Vector3(2, 2, 2));
+}
+
+// -------------------- rotateSubMesh --------------------
+
+TEST_F(SubMeshTransformTest, Rotate180DegreesAroundY)
+{
+    auto* entity = makeTriangle("rot_e");
+    const Ogre::Vector3 centerBefore = SubMeshTransform::getSubMeshCenter(entity, 0);
+    Ogre::Quaternion q(Ogre::Radian(Ogre::Math::PI), Ogre::Vector3::UNIT_Y);
+    SubMeshTransform::rotateSubMesh(entity, 0, q);
+
+    const Ogre::Vector3 centerAfter = SubMeshTransform::getSubMeshCenter(entity, 0);
+    // Center is preserved under rotation around centroid.
+    EXPECT_NEAR(centerAfter.x, centerBefore.x, 1e-4f);
+    EXPECT_NEAR(centerAfter.y, centerBefore.y, 1e-4f);
+    EXPECT_NEAR(centerAfter.z, centerBefore.z, 1e-4f);
+
+    // The original (1,0,0)→(0,0,0) edge in X should now point in -X.
+    const auto pos = SubMeshTransform::readPositions(entity, 0);
+    // (1,0,0) reflected through centroid (1/3,1/3,0) along XZ → x' = 2*(1/3) - 1 = -1/3
+    EXPECT_NEAR(pos[1].x, -1.0f / 3.0f, 1e-4f);
+}
+
+TEST_F(SubMeshTransformTest, RotationRotatesNormals)
+{
+    auto* entity = makeTriangle("rot_norm_e");
+    // 90° about X: normal (0,0,1) should become (0,-1,0) (Ogre right-handed convention check
+    // is what the function uses; we just check the magnitude is preserved and the direction
+    // has changed from purely +Z).
+    Ogre::Quaternion q(Ogre::Radian(Ogre::Math::HALF_PI), Ogre::Vector3::UNIT_X);
+    SubMeshTransform::rotateSubMesh(entity, 0, q);
+
+    // Read normals back.
+    auto* mesh = entity->getMesh().get();
+    Ogre::VertexData* vdata = mesh->sharedVertexData;
+    const auto* normElem = vdata->vertexDeclaration->findElementBySemantic(Ogre::VES_NORMAL);
+    ASSERT_NE(normElem, nullptr);
+    auto nbuf = vdata->vertexBufferBinding->getBuffer(normElem->getSource());
+    auto* vp = static_cast<unsigned char*>(nbuf->lock(Ogre::HardwareBuffer::HBL_READ_ONLY));
+    Ogre::Real* n;
+    normElem->baseVertexPointerToElement(vp, &n);
+    Ogre::Vector3 norm(n[0], n[1], n[2]);
+    nbuf->unlock();
+    // Magnitude preserved
+    EXPECT_NEAR(norm.length(), 1.0f, 1e-3f);
+    // Not equal to original (0,0,1)
+    EXPECT_GT((norm - Ogre::Vector3(0, 0, 1)).length(), 0.1f);
+}
+
+TEST_F(SubMeshTransformTest, RotateNullEntityIsNoop)
+{
+    SubMeshTransform::rotateSubMesh(nullptr, 0, Ogre::Quaternion::IDENTITY);
+}
+
+// -------------------- recalculateMeshBounds --------------------
+
+TEST_F(SubMeshTransformTest, RecalculateMeshBoundsHandlesMultiSubmeshAndShared)
+{
+    auto mesh = createInMemoryMeshSharedVertsPlusLocalSubmesh("rcb_mesh");
+    // Shared verts span x in [0..1], local submesh x in [10..11].
+    SubMeshTransform::recalculateMeshBounds(mesh.get());
+    const Ogre::AxisAlignedBox bb = mesh->getBounds();
+    EXPECT_NEAR(bb.getMinimum().x, 0.0f, 1e-4f);
+    EXPECT_NEAR(bb.getMaximum().x, 11.0f, 1e-4f);
+}

--- a/src/ViewportTitleBar_test.cpp
+++ b/src/ViewportTitleBar_test.cpp
@@ -1,0 +1,142 @@
+#include <gtest/gtest.h>
+#include <QAction>
+#include <QApplication>
+#include <QCoreApplication>
+#include <QDockWidget>
+#include <QLabel>
+#include <QSignalSpy>
+#include <QToolButton>
+
+#include "ViewportTitleBar.h"
+
+class ViewportTitleBarTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        ASSERT_NE(qobject_cast<QApplication*>(QCoreApplication::instance()), nullptr);
+    }
+};
+
+TEST_F(ViewportTitleBarTest, NullActionsProduceNullButtons)
+{
+    QDockWidget dock(QStringLiteral("Test Viewport"));
+    ViewportTitleBar bar(&dock, nullptr, nullptr, nullptr, nullptr);
+    EXPECT_EQ(bar.gridButton(), nullptr);
+    EXPECT_EQ(bar.normalsButton(), nullptr);
+    EXPECT_EQ(bar.meshInfoButton(), nullptr);
+    EXPECT_EQ(bar.viewCubeButton(), nullptr);
+    // Float / close still created because dock is non-null
+    EXPECT_NE(bar.floatButton(), nullptr);
+    EXPECT_NE(bar.closeButton(), nullptr);
+}
+
+TEST_F(ViewportTitleBarTest, NullDockMeansNoFloatOrCloseButtons)
+{
+    ViewportTitleBar bar(nullptr, nullptr, nullptr, nullptr, nullptr);
+    EXPECT_EQ(bar.floatButton(), nullptr);
+    EXPECT_EQ(bar.closeButton(), nullptr);
+    // Title label always exists
+    EXPECT_NE(bar.titleLabel(), nullptr);
+}
+
+TEST_F(ViewportTitleBarTest, TitleLabelMirrorsDockTitle)
+{
+    QDockWidget dock(QStringLiteral("My Title"));
+    ViewportTitleBar bar(&dock, nullptr, nullptr, nullptr, nullptr);
+    ASSERT_NE(bar.titleLabel(), nullptr);
+    EXPECT_EQ(bar.titleLabel()->text(), QStringLiteral("My Title"));
+
+    // Changing the dock's title should propagate to the bar's label.
+    dock.setWindowTitle(QStringLiteral("New Title"));
+    QCoreApplication::processEvents();
+    EXPECT_EQ(bar.titleLabel()->text(), QStringLiteral("New Title"));
+}
+
+TEST_F(ViewportTitleBarTest, ButtonReflectsActionInitialState)
+{
+    QDockWidget dock;
+    QAction grid;
+    grid.setCheckable(true);
+    grid.setChecked(true);
+    grid.setText(QStringLiteral("Grid"));
+    ViewportTitleBar bar(&dock, &grid, nullptr, nullptr, nullptr);
+    ASSERT_NE(bar.gridButton(), nullptr);
+    EXPECT_TRUE(bar.gridButton()->isCheckable());
+    EXPECT_TRUE(bar.gridButton()->isChecked());
+    EXPECT_EQ(bar.gridButton()->text(), QStringLiteral("G"));
+}
+
+TEST_F(ViewportTitleBarTest, ActionToggleSyncsToButton)
+{
+    QDockWidget dock;
+    QAction grid;
+    grid.setCheckable(true);
+    grid.setChecked(false);
+    ViewportTitleBar bar(&dock, &grid, nullptr, nullptr, nullptr);
+    ASSERT_NE(bar.gridButton(), nullptr);
+    EXPECT_FALSE(bar.gridButton()->isChecked());
+
+    grid.setChecked(true);
+    EXPECT_TRUE(bar.gridButton()->isChecked());
+
+    grid.setEnabled(false);
+    EXPECT_FALSE(bar.gridButton()->isEnabled());
+}
+
+TEST_F(ViewportTitleBarTest, ButtonClickTriggersAction)
+{
+    QDockWidget dock;
+    QAction normals;
+    normals.setCheckable(true);
+    QSignalSpy triggered(&normals, &QAction::triggered);
+    ViewportTitleBar bar(&dock, nullptr, &normals, nullptr, nullptr);
+    ASSERT_NE(bar.normalsButton(), nullptr);
+    bar.normalsButton()->click();
+    EXPECT_EQ(triggered.count(), 1);
+}
+
+TEST_F(ViewportTitleBarTest, CloseButtonClosesDock)
+{
+    QDockWidget dock(QStringLiteral("Vis"));
+    dock.show();
+    ViewportTitleBar bar(&dock, nullptr, nullptr, nullptr, nullptr);
+    bar.closeButton()->click();
+    QCoreApplication::processEvents();
+    EXPECT_FALSE(dock.isVisible());
+}
+
+TEST_F(ViewportTitleBarTest, FloatButtonTogglesFloating)
+{
+    QDockWidget dock;
+    // Without a parent QMainWindow the dock is already floating; verify the
+    // toggle flips state regardless of starting value.
+    const bool before = dock.isFloating();
+    ViewportTitleBar bar(&dock, nullptr, nullptr, nullptr, nullptr);
+    bar.floatButton()->click();
+    QCoreApplication::processEvents();
+    EXPECT_NE(dock.isFloating(), before);
+}
+
+TEST_F(ViewportTitleBarTest, ActionToolTipPropagatesToButton)
+{
+    QDockWidget dock;
+    QAction info;
+    info.setCheckable(true);
+    info.setText(QStringLiteral("Mesh Info"));
+    info.setToolTip(QStringLiteral("Toggle the floating mesh-info overlay"));
+    ViewportTitleBar bar(&dock, nullptr, nullptr, &info, nullptr);
+    ASSERT_NE(bar.meshInfoButton(), nullptr);
+    EXPECT_EQ(bar.meshInfoButton()->toolTip(),
+              QStringLiteral("Toggle the floating mesh-info overlay"));
+}
+
+TEST_F(ViewportTitleBarTest, EmptyTooltipFallsBackToActionText)
+{
+    QDockWidget dock;
+    QAction cube;
+    cube.setCheckable(true);
+    cube.setText(QStringLiteral("View Cube"));
+    // No setToolTip — should fall back to action text.
+    ViewportTitleBar bar(&dock, nullptr, nullptr, nullptr, &cube);
+    ASSERT_NE(bar.viewCubeButton(), nullptr);
+    EXPECT_EQ(bar.viewCubeButton()->toolTip(), QStringLiteral("View Cube"));
+}

--- a/src/ViewportTitleBar_test.cpp
+++ b/src/ViewportTitleBar_test.cpp
@@ -4,6 +4,7 @@
 #include <QCoreApplication>
 #include <QDockWidget>
 #include <QLabel>
+#include <QMainWindow>
 #include <QSignalSpy>
 #include <QToolButton>
 
@@ -99,6 +100,7 @@ TEST_F(ViewportTitleBarTest, CloseButtonClosesDock)
     QDockWidget dock(QStringLiteral("Vis"));
     dock.show();
     ViewportTitleBar bar(&dock, nullptr, nullptr, nullptr, nullptr);
+    ASSERT_NE(bar.closeButton(), nullptr);
     bar.closeButton()->click();
     QCoreApplication::processEvents();
     EXPECT_FALSE(dock.isVisible());
@@ -106,14 +108,22 @@ TEST_F(ViewportTitleBarTest, CloseButtonClosesDock)
 
 TEST_F(ViewportTitleBarTest, FloatButtonTogglesFloating)
 {
-    QDockWidget dock;
-    // Without a parent QMainWindow the dock is already floating; verify the
-    // toggle flips state regardless of starting value.
-    const bool before = dock.isFloating();
-    ViewportTitleBar bar(&dock, nullptr, nullptr, nullptr, nullptr);
+    // Dock needs a real QMainWindow parent: a parentless dock is permanently
+    // floating, and toggling it has no observable effect (nowhere to dock to).
+    QMainWindow window;
+    auto* dock = new QDockWidget(QStringLiteral("Vis"), &window);
+    window.addDockWidget(Qt::RightDockWidgetArea, dock);
+    ViewportTitleBar bar(dock, nullptr, nullptr, nullptr, nullptr);
+    ASSERT_NE(bar.floatButton(), nullptr);
+
+    const bool before = dock->isFloating();   // false — docked into window
     bar.floatButton()->click();
     QCoreApplication::processEvents();
-    EXPECT_NE(dock.isFloating(), before);
+    EXPECT_NE(dock->isFloating(), before);    // toggled to true
+
+    bar.floatButton()->click();
+    QCoreApplication::processEvents();
+    EXPECT_EQ(dock->isFloating(), before);    // toggled back
 }
 
 TEST_F(ViewportTitleBarTest, ActionToolTipPropagatesToButton)

--- a/src/commands/ApplyMaterialCommand_test.cpp
+++ b/src/commands/ApplyMaterialCommand_test.cpp
@@ -1,0 +1,124 @@
+#include <gtest/gtest.h>
+#include <QApplication>
+#include <QCoreApplication>
+#include <QThread>
+
+#include <OgreEntity.h>
+#include <OgreSubEntity.h>
+#include <OgreMaterialManager.h>
+#include <OgreResourceGroupManager.h>
+#include <OgreSceneManager.h>
+
+#include "Manager.h"
+#include "commands/ApplyMaterialCommand.h"
+#include "TestHelpers.h"
+
+class ApplyMaterialCommandTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        Manager::kill();
+        QThread::msleep(20);
+        app = qobject_cast<QApplication*>(QCoreApplication::instance());
+        ASSERT_NE(app, nullptr);
+        ASSERT_TRUE(tryInitOgre());
+        createStandardOgreMaterials();
+        ASSERT_TRUE(canLoadMeshFiles());
+
+        // Two test materials so we can swap and assert.
+        auto& mm = Ogre::MaterialManager::getSingleton();
+        const auto group = Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME;
+        if (!mm.getByName("MatA", group)) mm.create("MatA", group);
+        if (!mm.getByName("MatB", group)) mm.create("MatB", group);
+    }
+    void TearDown() override {
+        Manager::kill();
+        if (app) app->processEvents();
+        QThread::msleep(20);
+    }
+    QApplication* app = nullptr;
+};
+
+TEST_F(ApplyMaterialCommandTest, RedoAppliesNewMaterial)
+{
+    auto mesh = createInMemoryTriangleMesh("AMC_redo_mesh");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* entity = sceneMgr->createEntity("AMC_redo", mesh);
+
+    ASSERT_GT(entity->getNumSubEntities(), 0u);
+    auto* sub = entity->getSubEntity(0);
+    sub->setMaterialName("MatA");
+    EXPECT_EQ(sub->getMaterialName(), std::string("MatA"));
+
+    std::vector<ApplyMaterialCommand::Target> targets = {{sub, "MatA"}};
+    ApplyMaterialCommand cmd(std::move(targets), std::string("MatB"));
+    cmd.redo();
+    EXPECT_EQ(sub->getMaterialName(), std::string("MatB"));
+}
+
+TEST_F(ApplyMaterialCommandTest, UndoRestoresOriginalMaterial)
+{
+    auto mesh = createInMemoryTriangleMesh("AMC_undo_mesh");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* entity = sceneMgr->createEntity("AMC_undo", mesh);
+
+    auto* sub = entity->getSubEntity(0);
+    sub->setMaterialName("MatA");
+
+    std::vector<ApplyMaterialCommand::Target> targets = {{sub, "MatA"}};
+    ApplyMaterialCommand cmd(std::move(targets), std::string("MatB"));
+    cmd.redo();
+    EXPECT_EQ(sub->getMaterialName(), std::string("MatB"));
+    cmd.undo();
+    EXPECT_EQ(sub->getMaterialName(), std::string("MatA"));
+}
+
+TEST_F(ApplyMaterialCommandTest, NullTargetIsSkippedNotCrash)
+{
+    // The command iterates and skips nullptr targets.
+    std::vector<ApplyMaterialCommand::Target> targets = {
+        {nullptr, std::string{"WhateverOld"}},
+    };
+    ApplyMaterialCommand cmd(std::move(targets), std::string("MatA"));
+    cmd.redo();
+    cmd.undo();
+    // No crash = success.
+}
+
+TEST_F(ApplyMaterialCommandTest, MultipleTargetsApplyIndependently)
+{
+    // Two sub-entities should each remember their own old name.
+    auto mesh = createInMemoryMeshSharedVertsPlusLocalSubmesh("AMC_multi_mesh");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* entity = sceneMgr->createEntity("AMC_multi", mesh);
+    ASSERT_GE(entity->getNumSubEntities(), 2u);
+    auto* sub0 = entity->getSubEntity(0);
+    auto* sub1 = entity->getSubEntity(1);
+    sub0->setMaterialName("MatA");
+    sub1->setMaterialName("MatB");
+
+    std::vector<ApplyMaterialCommand::Target> targets = {
+        {sub0, "MatA"},
+        {sub1, "MatB"},
+    };
+    ApplyMaterialCommand cmd(std::move(targets), std::string("MatA"));
+    cmd.redo();
+    EXPECT_EQ(sub0->getMaterialName(), std::string("MatA"));
+    EXPECT_EQ(sub1->getMaterialName(), std::string("MatA"));
+
+    cmd.undo();
+    EXPECT_EQ(sub0->getMaterialName(), std::string("MatA"));
+    EXPECT_EQ(sub1->getMaterialName(), std::string("MatB"));
+}
+
+TEST_F(ApplyMaterialCommandTest, ConstructorSetsCommandText)
+{
+    std::vector<ApplyMaterialCommand::Target> oneTarget = {{nullptr, "MatA"}};
+    ApplyMaterialCommand cmdOne(std::move(oneTarget), std::string("MatB"));
+    EXPECT_FALSE(cmdOne.text().isEmpty());
+    EXPECT_TRUE(cmdOne.text().contains("MatB"));
+
+    std::vector<ApplyMaterialCommand::Target> twoTargets = {
+        {nullptr, "MatA"}, {nullptr, "MatA"}};
+    ApplyMaterialCommand cmdTwo(std::move(twoTargets), std::string("MatB"));
+    EXPECT_FALSE(cmdTwo.text().isEmpty());
+}

--- a/src/commands/BoneTransformCommand_test.cpp
+++ b/src/commands/BoneTransformCommand_test.cpp
@@ -1,0 +1,154 @@
+#include <gtest/gtest.h>
+#include <QApplication>
+#include <QCoreApplication>
+#include <QThread>
+
+#include <OgreEntity.h>
+#include <OgreSkeletonInstance.h>
+#include <OgreBone.h>
+
+#include "Manager.h"
+#include "commands/BoneTransformCommand.h"
+#include "TestHelpers.h"
+
+class BoneTransformCommandTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        Manager::kill();
+        QThread::msleep(20);
+        app = qobject_cast<QApplication*>(QCoreApplication::instance());
+        ASSERT_NE(app, nullptr);
+        ASSERT_TRUE(tryInitOgre());
+        createStandardOgreMaterials();
+        ASSERT_TRUE(canLoadMeshFiles());
+    }
+    void TearDown() override {
+        Manager::kill();
+        if (app) app->processEvents();
+        QThread::msleep(20);
+    }
+    QApplication* app = nullptr;
+};
+
+TEST_F(BoneTransformCommandTest, RedoAppliesAfterState)
+{
+    auto* entity = createAnimatedTestEntity("BTC_redo");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+    ASSERT_TRUE(skel->hasBone("Child"));
+    auto* bone = skel->getBone("Child");
+    bone->setManuallyControlled(true);
+    const Ogre::Vector3 beforePos = bone->getPosition();
+    const Ogre::Quaternion beforeOrient = bone->getOrientation();
+    const Ogre::Vector3 beforeScale = bone->getScale();
+
+    const Ogre::Vector3 afterPos(5, 6, 7);
+    const Ogre::Quaternion afterOrient(Ogre::Radian(Ogre::Math::HALF_PI), Ogre::Vector3::UNIT_Y);
+    const Ogre::Vector3 afterScale(2, 2, 2);
+
+    BoneTransformCommand cmd(entity->getName(), "Child",
+                              beforePos, beforeOrient, beforeScale,
+                              afterPos,  afterOrient,  afterScale);
+    cmd.redo();
+    EXPECT_EQ(bone->getPosition(), afterPos);
+    EXPECT_EQ(bone->getScale(), afterScale);
+}
+
+TEST_F(BoneTransformCommandTest, UndoRestoresBeforeState)
+{
+    auto* entity = createAnimatedTestEntity("BTC_undo");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+    auto* bone = skel->getBone("Child");
+    bone->setManuallyControlled(true);
+    const Ogre::Vector3 beforePos = bone->getPosition();
+    const Ogre::Quaternion beforeOrient = bone->getOrientation();
+    const Ogre::Vector3 beforeScale = bone->getScale();
+
+    BoneTransformCommand cmd(entity->getName(), "Child",
+                              beforePos, beforeOrient, beforeScale,
+                              Ogre::Vector3(9, 9, 9),
+                              Ogre::Quaternion::IDENTITY,
+                              Ogre::Vector3(3, 3, 3));
+    cmd.redo();
+    EXPECT_EQ(bone->getPosition(), Ogre::Vector3(9, 9, 9));
+    cmd.undo();
+    EXPECT_EQ(bone->getPosition(), beforePos);
+    EXPECT_EQ(bone->getScale(), beforeScale);
+}
+
+TEST_F(BoneTransformCommandTest, MissingEntityIsNoCrash)
+{
+    // No entity registered with this name → resolve returns nullptr →
+    // command is a silent no-op. We just need to not crash.
+    BoneTransformCommand cmd(std::string("NoSuchEntity"), std::string("NoBone"),
+                              Ogre::Vector3::ZERO, Ogre::Quaternion::IDENTITY, Ogre::Vector3::UNIT_SCALE,
+                              Ogre::Vector3::UNIT_X, Ogre::Quaternion::IDENTITY, Ogre::Vector3::UNIT_SCALE);
+    cmd.redo();
+    cmd.undo();
+}
+
+TEST_F(BoneTransformCommandTest, MissingBoneIsNoCrash)
+{
+    auto* entity = createAnimatedTestEntity("BTC_no_bone");
+    ASSERT_NE(entity, nullptr);
+    BoneTransformCommand cmd(entity->getName(), std::string("ThisBoneDoesNotExist"),
+                              Ogre::Vector3::ZERO, Ogre::Quaternion::IDENTITY, Ogre::Vector3::UNIT_SCALE,
+                              Ogre::Vector3::UNIT_X, Ogre::Quaternion::IDENTITY, Ogre::Vector3::UNIT_SCALE);
+    cmd.redo();
+    cmd.undo();
+}
+
+TEST_F(BoneTransformCommandTest, BindModeSetsInitialState)
+{
+    auto* entity = createAnimatedTestEntity("BTC_bind");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+    auto* bone = skel->getBone("Child");
+    bone->setManuallyControlled(true);
+    const Ogre::Vector3 origInitialPos = bone->getInitialPosition();
+    const Ogre::Vector3 newBindPos(2.5f, 0, 0);
+
+    BoneTransformCommand cmd(entity->getName(), "Child",
+                              bone->getPosition(), bone->getOrientation(), bone->getScale(),
+                              newBindPos, bone->getOrientation(), bone->getScale(),
+                              /*bindMode=*/true);
+    cmd.redo();
+    // setInitialState() should have captured the new local as the new initial pose.
+    EXPECT_EQ(bone->getInitialPosition(), newBindPos);
+
+    cmd.undo();
+    // After undo, the bind pose returns to the original initial pos.
+    EXPECT_EQ(bone->getInitialPosition(), origInitialPos);
+}
+
+TEST_F(BoneTransformCommandTest, NonBindModeDoesNotChangeInitialState)
+{
+    auto* entity = createAnimatedTestEntity("BTC_nonbind");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+    auto* bone = skel->getBone("Child");
+    bone->setManuallyControlled(true);
+    const Ogre::Vector3 origInitialPos = bone->getInitialPosition();
+
+    BoneTransformCommand cmd(entity->getName(), "Child",
+                              bone->getPosition(), bone->getOrientation(), bone->getScale(),
+                              Ogre::Vector3(3, 3, 3), bone->getOrientation(), bone->getScale(),
+                              /*bindMode=*/false);
+    cmd.redo();
+    // Initial pose remains untouched in non-bind mode.
+    EXPECT_EQ(bone->getInitialPosition(), origInitialPos);
+}
+
+TEST_F(BoneTransformCommandTest, CommandTextDifferentForBindMode)
+{
+    BoneTransformCommand normal(std::string("E"), std::string("B"),
+                                 Ogre::Vector3::ZERO, Ogre::Quaternion::IDENTITY, Ogre::Vector3::UNIT_SCALE,
+                                 Ogre::Vector3::ZERO, Ogre::Quaternion::IDENTITY, Ogre::Vector3::UNIT_SCALE,
+                                 /*bindMode=*/false);
+    BoneTransformCommand bind  (std::string("E"), std::string("B"),
+                                 Ogre::Vector3::ZERO, Ogre::Quaternion::IDENTITY, Ogre::Vector3::UNIT_SCALE,
+                                 Ogre::Vector3::ZERO, Ogre::Quaternion::IDENTITY, Ogre::Vector3::UNIT_SCALE,
+                                 /*bindMode=*/true);
+    EXPECT_NE(normal.text(), bind.text());
+}


### PR DESCRIPTION
## Summary
- Adds 7 new `_test.cpp` files for previously untested pure-data and command-pattern classes (ScanConfig, SubMeshTransform, ApplyMaterialCommand, BoneTransformCommand, MeshDecimatorController, ViewportTitleBar, AppConsoleLog)
- Expands 2 thin existing suites: Euler (5 → 30 cases) and QtMeshCloudClient (5 → 14 cases)
- Net: 103 new test cases, ~1.7k LOC of test code

Target areas were chosen to maximize coverage gain without dragging in widget UI or live GL paths already excluded by `LCOV_EXCL_*` markers. Pure-data classes (ScanConfig YAML/JSON parsing, Euler math, QtMeshCloudClient validation) run anywhere; the Ogre-dependent suites (SubMeshTransform, ApplyMaterialCommand, BoneTransformCommand, MeshDecimatorController) follow the existing `tryInitOgre()` + `canLoadMeshFiles()` pattern so they exercise on Linux CI under Xvfb.

## Test plan
- [x] `cmake --build build_local --target UnitTests -j4` clean (0 errors, 0 new warnings)
- [x] `strings build_local/bin/UnitTests | grep -E "(SubMeshTransform|ViewportTitleBar|...)"` confirms new fixtures are registered
- [ ] Linux CI passes all new suites under Xvfb
- [ ] SonarCloud overall coverage advances toward the 90% target

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded comprehensive test coverage across core components, including configuration parsing, mesh operations, viewport UI interactions, and command execution workflows. No user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/516)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->