### PR TITLE
feat(paint): per-tool toolbar + square brush + brush outlines (v3.2.0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 3.1.0 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 3.2.0 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run QtMesh scan
-        uses: fernandotonon/QtMeshEditor@3.1.0
+        uses: fernandotonon/QtMeshEditor@3.2.0
         with:
           command: scan
           image-tag: "3.1.0"
@@ -79,14 +79,14 @@ Release tags are listed on the [releases page](https://github.com/fernandotonon/
 
 ```yaml
 # Validate a specific mesh
-- uses: fernandotonon/QtMeshEditor@3.1.0
+- uses: fernandotonon/QtMeshEditor@3.2.0
   with:
     command: validate
     input-file: ./models/character.fbx
     image-tag: "3.1.0"
 
 # Convert FBX → glTF
-- uses: fernandotonon/QtMeshEditor@3.1.0
+- uses: fernandotonon/QtMeshEditor@3.2.0
   with:
     command: convert
     input-file: ./models/character.fbx
@@ -94,7 +94,7 @@ Release tags are listed on the [releases page](https://github.com/fernandotonon/
     image-tag: "3.1.0"
 
 # Resample Mixamo animations (200+ keyframes → 30)
-- uses: fernandotonon/QtMeshEditor@3.1.0
+- uses: fernandotonon/QtMeshEditor@3.2.0
   with:
     command: anim
     input-file: ./animations/dance.fbx
@@ -103,7 +103,7 @@ Release tags are listed on the [releases page](https://github.com/fernandotonon/
     image-tag: "3.1.0"
 
 # Get mesh info as JSON
-- uses: fernandotonon/QtMeshEditor@3.1.0
+- uses: fernandotonon/QtMeshEditor@3.2.0
   id: info
   with:
     command: info

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -1190,41 +1190,11 @@ Rectangle {
                 }
             }
 
-            // Tool selector \u2014 Paint, Erase, Fill, Picker, Smudge.
-            // Wand is intentionally NOT here; it lives in the left
-            // toolbar (under the paint brush) so it can have its own
-            // green icon + enabled/disabled treatment without
-            // duplicating UI in the right panel.
-            Row {
-                spacing: 4
-                Repeater {
-                    model: [
-                        { tool: 0, label: "Paint",  glyph: "\u270f" },
-                        { tool: 1, label: "Erase",  glyph: "\u232b" },
-                        { tool: 2, label: "Fill",   glyph: "\u29c9" },
-                        { tool: 3, label: "Pick",   glyph: "\u22b0" },
-                        { tool: 4, label: "Smudge", glyph: "\u223f" }
-                    ]
-                    Rectangle {
-                        width: 52; height: 26; radius: 3
-                        color: texPaintCol.brushTool === modelData.tool
-                            ? PropertiesPanelController.highlightColor
-                            : (toolMa.containsMouse ? Qt.lighter(PropertiesPanelController.panelColor, 1.5)
-                                                    : PropertiesPanelController.headerColor)
-                        border.color: PropertiesPanelController.borderColor; border.width: 1
-                        Text {
-                            anchors.centerIn: parent
-                            text: modelData.glyph + " " + modelData.label
-                            color: PropertiesPanelController.textColor
-                            font.pixelSize: 10
-                        }
-                        MouseArea {
-                            id: toolMa; anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor
-                            onClicked: TexturePaintController.brushTool = modelData.tool
-                        }
-                    }
-                }
-            }
+            // Tool selector deliberately not in the right panel anymore.
+            // All paint tools (Paint / Bucket / Eraser / Pick / Smudge
+            // / Wand) live in the left toolbar \u2014 see mainwindow.cpp
+            // \u2014 so the user picks the tool with the same buttons
+            // regardless of which target they're painting.
 
             // Smart-select panel. Visible whenever there's an active
             // session \u2014 tolerance is always meaningful, and once the
@@ -1470,6 +1440,30 @@ Rectangle {
                     color: "#ff3030"
                     x: 1
                     y: 1 + Math.round(texPaintCol.hoverV * (parent.height - 2))
+                }
+
+                // Brush footprint outline — circle for Round, square
+                // for Square. Diameter / side comes from the controller's
+                // UV-space radius (same scaling the painter uses) so the
+                // outline matches the actual stamp.
+                Rectangle {
+                    id: brushOutline
+                    visible: texPaintCol.hoverU >= 0 && texPaintCol.hoverV >= 0
+                             && TexturePaintController.texturePaintRadiusUV > 0
+                    color: "transparent"
+                    border.color: "#ff3030"
+                    border.width: 1
+                    // Diameter in pixels of the 254x254 inner image area
+                    // (parent is 256x256 with 1px margins on each side).
+                    property real diameterPx: Math.max(2,
+                        Math.round(TexturePaintController.texturePaintRadiusUV * 2 * (parent.width - 2)))
+                    width: diameterPx
+                    height: diameterPx
+                    radius: TexturePaintController.brushShape === 1 ? 0 : diameterPx / 2
+                    // Centred on the hover point. width/2 is the offset
+                    // so the outline is symmetric around the crosshair.
+                    x: 1 + Math.round(texPaintCol.hoverU * (parent.width - 2)) - diameterPx / 2
+                    y: 1 + Math.round(texPaintCol.hoverV * (parent.height - 2)) - diameterPx / 2
                 }
 
                 MouseArea {

--- a/qml/TextureEditorWindow.qml
+++ b/qml/TextureEditorWindow.qml
@@ -146,6 +146,32 @@ Window {
 
         Item { width: 16; height: 1 } // spacer
 
+        // UV wireframe overlay toggle. Mirrors the same toggle in
+        // PropertiesPanel.qml so the user can flip the island wires
+        // on from either window. State is shared via the singleton.
+        Rectangle {
+            width: 56; height: 28; radius: 3
+            color: TexturePaintController.uvOverlayVisible
+                ? "#5b8def"
+                : (uvToggleMa.containsMouse ? "#3a3a3a" : "#2a2a2a")
+            border.color: "#555"; border.width: 1
+            anchors.verticalCenter: parent.verticalCenter
+            Text {
+                anchors.centerIn: parent
+                text: (TexturePaintController.uvOverlayVisible ? "✓ " : "") + "UV"
+                color: "white"; font.pixelSize: 11
+            }
+            MouseArea {
+                id: uvToggleMa
+                anchors.fill: parent; hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: TexturePaintController.uvOverlayVisible
+                    = !TexturePaintController.uvOverlayVisible
+            }
+        }
+
+        Item { width: 8; height: 1 } // spacer
+
         Text {
             text: editorWindow.hasMask ? (editorWindow.maskCount + " px") : ""
             color: "#ddd"
@@ -181,6 +207,19 @@ Window {
             cache: false
             onSourceChanged: canvasImg.update()
         }
+        // UV-island wireframe overlay (toggleable). Same source as
+        // the inspector thumbnail so toggling it from either window
+        // is reflected everywhere.
+        Image {
+            anchors.fill: canvasImg
+            visible: TexturePaintController.uvOverlayVisible
+            opacity: 0.7
+            source: TexturePaintController.uvOverlayDataUri
+            fillMode: Image.PreserveAspectFit
+            smooth: false
+            cache: false
+        }
+
         // Mask overlay (selection bounds rendered as a yellow tint).
         Image {
             anchors.fill: canvasImg
@@ -218,6 +257,26 @@ Window {
             width: paintedRect.width; height: 1
             x: paintedRect.x
             y: paintedRect.y + Math.round(editorWindow.hoverV * paintedRect.height)
+        }
+
+        // Brush footprint outline (circle for Round, square for Square).
+        // Mirrors the same overlay rendered in PropertiesPanel.qml — the
+        // detached editor should show identical UI for the same paint
+        // pipeline.
+        Rectangle {
+            id: brushOutline
+            visible: editorWindow.hoverU >= 0 && editorWindow.hoverV >= 0
+                     && TexturePaintController.texturePaintRadiusUV > 0
+            color: "transparent"
+            border.color: "#ff3030"
+            border.width: 1
+            property real diameterPx: Math.max(2,
+                Math.round(TexturePaintController.texturePaintRadiusUV * 2 * paintedRect.width))
+            width: diameterPx
+            height: diameterPx
+            radius: TexturePaintController.brushShape === 1 ? 0 : diameterPx / 2
+            x: paintedRect.x + Math.round(editorWindow.hoverU * paintedRect.width) - diameterPx / 2
+            y: paintedRect.y + Math.round(editorWindow.hoverV * paintedRect.height) - diameterPx / 2
         }
 
         MouseArea {

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -390,6 +390,18 @@ void EditModeController::setVertexPaintFalloff(double f)
     emit vertexPaintChanged();
 }
 
+void EditModeController::setVertexPaintShape(int shape)
+{
+    const BrushShape s = static_cast<BrushShape>(shape);
+    if (s != ShapeRound && s != ShapeSquare) return;
+    if (m_vertexPaintShape == s) return;
+    m_vertexPaintShape = s;
+    SentryReporter::addBreadcrumb(
+        "ui.action",
+        QStringLiteral("Vertex paint shape: %1").arg(s == ShapeSquare ? "square" : "round"));
+    emit vertexPaintChanged();
+}
+
 bool EditModeController::canEnterEditMode() const
 {
     // Edit mode requires exactly one entity selected (either directly or via node)
@@ -1167,7 +1179,8 @@ bool EditModeController::applyVertexColorBrush(EditableMesh& mesh,
                                                float radius,
                                                const Ogre::ColourValue& color,
                                                float strength,
-                                               float falloff)
+                                               float falloff,
+                                               bool square)
 {
     if (radius <= 0.0f)
         return false;
@@ -1187,14 +1200,22 @@ bool EditModeController::applyVertexColorBrush(EditableMesh& mesh,
         auto& sub = mesh.subMeshes()[si];
         for (size_t vi = 0; vi < sub.vertices.size(); ++vi) {
             auto& v = sub.vertices[vi];
-            const float d = v.position.distance(localCenter);
-            if (d > radius)
-                continue;
-
-            // Distance falloff: w = (1 - d/r)^exp
-            const float t = 1.0f - (d * invR);
-            const float w = std::pow(std::max(0.0f, t), exp);
-            const float a = strength * w;
+            float a = 0.0f;
+            if (square) {
+                // AABB cube: constant strength inside, no falloff.
+                const Ogre::Vector3 d = v.position - localCenter;
+                if (std::fabs(d.x) > radius || std::fabs(d.y) > radius || std::fabs(d.z) > radius)
+                    continue;
+                a = strength;
+            } else {
+                const float d = v.position.distance(localCenter);
+                if (d > radius)
+                    continue;
+                // Distance falloff: w = (1 - d/r)^exp
+                const float t = 1.0f - (d * invR);
+                const float w = std::pow(std::max(0.0f, t), exp);
+                a = strength * w;
+            }
             if (a <= 0.0f)
                 continue;
 
@@ -1714,7 +1735,8 @@ void EditModeController::updateVertexPaintStroke(OgreWidget* widget, const QPoin
         static_cast<float>(m_vertexPaintRadius),
         paint,
         static_cast<float>(m_vertexPaintStrength),
-        static_cast<float>(m_vertexPaintFalloff));
+        static_cast<float>(m_vertexPaintFalloff),
+        m_vertexPaintShape == ShapeSquare);
 
     if (changed) {
         m_vertexPaintStrokeDirty = true;

--- a/src/EditModeController.h
+++ b/src/EditModeController.h
@@ -108,6 +108,7 @@ class EditModeController : public QObject
     Q_PROPERTY(double vertexPaintRadius READ vertexPaintRadius WRITE setVertexPaintRadius NOTIFY vertexPaintChanged)
     Q_PROPERTY(double vertexPaintStrength READ vertexPaintStrength WRITE setVertexPaintStrength NOTIFY vertexPaintChanged)
     Q_PROPERTY(double vertexPaintFalloff READ vertexPaintFalloff WRITE setVertexPaintFalloff NOTIFY vertexPaintChanged)
+    Q_PROPERTY(int vertexPaintShape READ vertexPaintShape WRITE setVertexPaintShape NOTIFY vertexPaintChanged)
     Q_PROPERTY(bool vertexColorPreviewEnabled READ vertexColorPreviewEnabled WRITE setVertexColorPreviewEnabled NOTIFY vertexColorPreviewChanged)
 
 public:
@@ -237,6 +238,15 @@ public:
     /// the bottom of the class so the documentation cannot drift
     /// from the actual reset behaviour.
     Q_INVOKABLE void resetPaintColors();
+
+    /// Brush footprint shape. Round = circular falloff (the default);
+    /// Square = constant-strength axis-aligned rectangle, no falloff.
+    /// Falloff slider has no effect in Square mode — the brush stays
+    /// crisp like a pixel-art tool. Exposed as an int property to QML.
+    enum BrushShape { ShapeRound = 0, ShapeSquare = 1 };
+    Q_ENUM(BrushShape)
+    int vertexPaintShape() const { return static_cast<int>(m_vertexPaintShape); }
+    void setVertexPaintShape(int shape);
     double vertexPaintRadius() const { return m_vertexPaintRadius; }
     void setVertexPaintRadius(double r);
     double vertexPaintStrength() const { return m_vertexPaintStrength; }
@@ -774,12 +784,17 @@ public:
     static Ogre::ColourValue weightToColor(float weight);
 
     /// Apply a vertex color brush in local space. Returns true if any vertex changed.
+    /// `square` switches the footprint from a sphere (default) to an
+    /// axis-aligned cube of side 2*radius with constant strength (no
+    /// falloff). Matches the 2D TexturePaintBuffer::BrushShape::Square
+    /// model in 3D.
     static bool applyVertexColorBrush(EditableMesh& mesh,
                                       const Ogre::Vector3& localCenter,
                                       float radius,
                                       const Ogre::ColourValue& color,
                                       float strength,
-                                      float falloff);
+                                      float falloff,
+                                      bool square = false);
 
     /// Convert a global vertex index to (subMeshIndex, localVertexIndex) pair.
     std::pair<size_t, size_t> globalToLocal(int globalIndex) const;
@@ -962,6 +977,9 @@ private:
     // washes or down to 0.001 for pixel-level precision via the
     // toolbar slider / brush popup.
     double m_vertexPaintRadius = 0.02;
+    // Brush footprint shape. Default Round = circular falloff,
+    // Square = axis-aligned constant-strength rectangle (pixel-art).
+    BrushShape m_vertexPaintShape = ShapeRound;
     double m_vertexPaintStrength = 0.5;  // 0..1
     double m_vertexPaintFalloff = 0.5;   // 0..1
     bool m_vertexPaintStrokeActive = false;

--- a/src/EditableMesh_test.cpp
+++ b/src/EditableMesh_test.cpp
@@ -102,6 +102,80 @@ TEST(EditableMeshStandalone, VertexColorBrushFalloffHigherExponentWeakerAtEdge)
     EXPECT_GT(gHi, gLo);
 }
 
+// ---- Square (AABB cube) brush shape ----
+
+TEST(EditableMeshStandalone, VertexColorBrushSquareCoversAABBCorners)
+{
+    // The sphere brush excludes corners of a unit-radius cube
+    // (their distance to centre is sqrt(3) ≈ 1.73). The square
+    // brush includes them because the test is per-axis |d| <= radius.
+    EditableMesh mesh;
+    EditableSubMesh sub;
+    // Cube corner at (1,1,1) — outside the sphere of radius 1.
+    sub.vertices.push_back(makeV(1.0f, 1.0f, 1.0f));
+    mesh.subMeshes().push_back(std::move(sub));
+
+    const Ogre::ColourValue red(1, 0, 0, 1);
+    const Ogre::Vector3 center(0, 0, 0);
+    // Round brush should not reach this corner.
+    EXPECT_FALSE(EditModeController::applyVertexColorBrush(
+        mesh, center, 1.0f, red, 1.0f, 0.0f, /*square=*/false));
+
+    // Square brush with same radius DOES reach the corner.
+    EXPECT_TRUE(EditModeController::applyVertexColorBrush(
+        mesh, center, 1.0f, red, 1.0f, 0.0f, /*square=*/true));
+    EXPECT_NEAR(mesh.subMeshes()[0].vertices[0].color.r, 1.0f, 1e-3f);
+}
+
+TEST(EditableMeshStandalone, VertexColorBrushSquareConstantStrengthNoFalloff)
+{
+    // Falloff has no effect on the square brush — every vertex
+    // inside the AABB gets the same blend weight, regardless of
+    // distance to centre.
+    EditableMesh meshLo;
+    EditableMesh meshHi;
+    EditableSubMesh subLo;
+    EditableSubMesh subHi;
+    // One vertex near centre, one at the cube edge.
+    subLo.vertices.push_back(makeV(0.1f, 0.0f, 0.0f));
+    subLo.vertices.push_back(makeV(0.9f, 0.0f, 0.0f));
+    subHi.vertices = subLo.vertices;
+    meshLo.subMeshes().push_back(std::move(subLo));
+    meshHi.subMeshes().push_back(std::move(subHi));
+
+    const Ogre::ColourValue red(1, 0, 0, 1);
+    const Ogre::Vector3 center(0, 0, 0);
+    ASSERT_TRUE(EditModeController::applyVertexColorBrush(
+        meshLo, center, 1.0f, red, 1.0f, 0.0f, /*square=*/true));
+    ASSERT_TRUE(EditModeController::applyVertexColorBrush(
+        meshHi, center, 1.0f, red, 1.0f, 1.0f, /*square=*/true));
+
+    // Both vertices in both runs should converge on red (same blend).
+    EXPECT_NEAR(meshLo.subMeshes()[0].vertices[0].color.r, 1.0f, 1e-3f);
+    EXPECT_NEAR(meshLo.subMeshes()[0].vertices[1].color.r, 1.0f, 1e-3f);
+    EXPECT_NEAR(meshHi.subMeshes()[0].vertices[0].color.r, 1.0f, 1e-3f);
+    EXPECT_NEAR(meshHi.subMeshes()[0].vertices[1].color.r, 1.0f, 1e-3f);
+}
+
+TEST(EditableMeshStandalone, VertexColorBrushSquareSkipsOutsideAABB)
+{
+    EditableMesh mesh;
+    EditableSubMesh sub;
+    // Inside the cube of radius 1, and outside.
+    sub.vertices.push_back(makeV(0.0f, 0.0f, 0.0f));   // dead-center
+    sub.vertices.push_back(makeV(2.0f, 0.0f, 0.0f));   // outside on +X
+    mesh.subMeshes().push_back(std::move(sub));
+
+    const Ogre::ColourValue red(1, 0, 0, 1);
+    const Ogre::Vector3 center(0, 0, 0);
+    EXPECT_TRUE(EditModeController::applyVertexColorBrush(
+        mesh, center, 1.0f, red, 1.0f, 0.5f, /*square=*/true));
+
+    EXPECT_NEAR(mesh.subMeshes()[0].vertices[0].color.r, 1.0f, 1e-3f);
+    // The outside vertex still has no color set.
+    EXPECT_FALSE(mesh.subMeshes()[0].vertices[1].hasColor);
+}
+
 TEST(EditableMeshStandalone, WeldByPositionMergesCoincidentVerts) {
     EditableMesh em;
     EditableSubMesh sub;

--- a/src/TexturePaintBuffer.cpp
+++ b/src/TexturePaintBuffer.cpp
@@ -103,7 +103,8 @@ int TexturePaintBuffer::paintBrush(const Ogre::Vector2& uv,
                                    float radiusUV,
                                    const Ogre::ColourValue& color,
                                    float strength,
-                                   float falloff)
+                                   float falloff,
+                                   BrushShape shape)
 {
     if (m_width <= 0 || m_height <= 0) return 0;
     if (radiusUV <= 0.0f) return 0;
@@ -135,14 +136,23 @@ int TexturePaintBuffer::paintBrush(const Ogre::Vector2& uv,
     int touchedY0 = y1;
     int touchedY1 = y0;
 
+    const bool square = (shape == BrushShape::Square);
     for (int y = y0; y < y1; ++y) {
         const float dy = (static_cast<float>(y) + 0.5f - centerYf) * invRy;
         for (int x = x0; x < x1; ++x) {
             const float dx = (static_cast<float>(x) + 0.5f - centerXf) * invRx;
-            const float r2 = dx * dx + dy * dy;
-            if (r2 >= 1.0f) continue;
-            const float w = std::pow(1.0f - r2, p);
-            const float blend = strength * w;
+            float blend;
+            if (square) {
+                // Constant strength inside the AABB — no falloff, no
+                // circular cull. Half-side equals radius.
+                if (std::fabs(dx) > 1.0f || std::fabs(dy) > 1.0f) continue;
+                blend = strength;
+            } else {
+                const float r2 = dx * dx + dy * dy;
+                if (r2 >= 1.0f) continue;
+                const float w = std::pow(1.0f - r2, p);
+                blend = strength * w;
+            }
             if (blend <= 0.0f) continue;
             const size_t off = (static_cast<size_t>(y) * static_cast<size_t>(m_width) + static_cast<size_t>(x)) * 4u;
             const float prevR = byteToFloat(m_pixels[off + 0]);

--- a/src/TexturePaintBuffer.h
+++ b/src/TexturePaintBuffer.h
@@ -75,29 +75,37 @@ public:
     /// Write pixel (clamped to bounds). Expands dirty rect.
     void setPixel(int x, int y, const Ogre::ColourValue& color);
 
+    /// Brush footprint. Round = circular falloff (default), Square =
+    /// axis-aligned constant-strength rectangle (no falloff, like a
+    /// pixel-art tool).
+    enum class BrushShape { Round = 0, Square = 1 };
+
     /**
-     * @brief Paint a circular brush stamp at UV coordinate.
+     * @brief Paint a brush stamp at UV coordinate.
      *
      * @param uv         Center UV in [0..1]^2 (top-left origin: uv.y=0 → top).
-     * @param radiusUV   Brush radius in UV-space units.
+     * @param radiusUV   Brush radius in UV-space units. For Square,
+     *                   this is half the side length.
      * @param color      Brush color (alpha is interpreted as flow).
      * @param strength   0..1 — how much the brush moves the pixel toward `color`.
      * @param falloff    0 = hard, 1 = full quadratic falloff at the edge.
+     *                   Ignored when `shape == Square`.
+     * @param shape      Round (default) or Square.
      * @return Number of pixels modified.
      *
-     * Each pixel inside the brush footprint is lerped:
-     *
+     * Round mode lerps each pixel in the circular footprint:
      *     out = lerp(prev, color, strength * weight)
+     * where weight = (1 - r^2)^p, p = 1 + falloff * 3.
      *
-     * where `weight = 1` at center and falls off to `0` at the edge. The
-     * falloff curve is `(1 - r^2)^p` with `p = 1 + falloff * 3`, matching
-     * the vertex-paint brush in EditModeController.
+     * Square mode lerps every pixel inside the axis-aligned bounding
+     * box with weight = 1 (constant strength).
      */
     int paintBrush(const Ogre::Vector2& uv,
                    float radiusUV,
                    const Ogre::ColourValue& color,
                    float strength = 1.0f,
-                   float falloff = 0.5f);
+                   float falloff = 0.5f,
+                   BrushShape shape = BrushShape::Round);
 
     /**
      * @brief Save the buffer to disk as a PNG/JPEG/TGA/BMP/etc.

--- a/src/TexturePaintBuffer_test.cpp
+++ b/src/TexturePaintBuffer_test.cpp
@@ -172,6 +172,70 @@ TEST(TexturePaintBufferTest, PaintBrushClampsToBufferBounds)
     EXPECT_LE(d.y1, 8);
 }
 
+// ---- Square brush shape ----
+
+TEST(TexturePaintBufferTest, SquareBrushPaintsFullAabbWithConstantStrength)
+{
+    // Square should fill every pixel in the radius-side AABB at full
+    // strength regardless of distance-from-center — falloff is
+    // ignored. With a 16x16 buffer and radius 0.125 (= 2px), the
+    // brush at center should fill a 4x4 AABB.
+    TexturePaintBuffer buf(16, 16);
+    const int painted = buf.paintBrush(Ogre::Vector2(0.5f, 0.5f),
+                                       0.125f,
+                                       Ogre::ColourValue::Red,
+                                       1.0f, 0.5f,
+                                       TexturePaintBuffer::BrushShape::Square);
+    EXPECT_EQ(painted, 16); // 4×4
+    // Every pixel inside the AABB should be ~exact red — no falloff.
+    int cx = 0, cy = 0;
+    buf.uvToPixel(Ogre::Vector2(0.5f, 0.5f), cx, cy);
+    EXPECT_NEAR(buf.pixel(cx, cy).r, 1.0f, 1e-3f);
+    // Corner of the AABB stays exact red too (constant strength).
+    EXPECT_NEAR(buf.pixel(cx - 1, cy - 1).r, 1.0f, 1e-3f);
+    EXPECT_NEAR(buf.pixel(cx + 1, cy + 1).r, 1.0f, 1e-3f);
+    // One pixel outside the AABB is untouched.
+    EXPECT_NEAR(buf.pixel(cx + 3, cy).r, 1.0f, 1e-3f);  // still white
+    EXPECT_NEAR(buf.pixel(cx + 3, cy).g, 1.0f, 1e-3f);
+}
+
+TEST(TexturePaintBufferTest, SquareBrushIgnoresFalloffParameter)
+{
+    // With Round, falloff softens the edge — center is full strength
+    // but a pixel near the edge gets a fractional weight. Square
+    // mode should produce identical results for any falloff value
+    // because the parameter is unused.
+    TexturePaintBuffer bufA(16, 16);
+    TexturePaintBuffer bufB(16, 16);
+    bufA.paintBrush(Ogre::Vector2(0.5f, 0.5f), 0.125f,
+                    Ogre::ColourValue::Red, 1.0f, 0.0f,
+                    TexturePaintBuffer::BrushShape::Square);
+    bufB.paintBrush(Ogre::Vector2(0.5f, 0.5f), 0.125f,
+                    Ogre::ColourValue::Red, 1.0f, 1.0f,
+                    TexturePaintBuffer::BrushShape::Square);
+    EXPECT_EQ(bufA.data(), bufB.data());
+}
+
+TEST(TexturePaintBufferTest, RoundBrushIsCircularNotRectangular)
+{
+    // Sanity check the Round path: a pixel at the AABB corner is
+    // outside the unit circle and should be untouched, where Square
+    // would have filled it.
+    TexturePaintBuffer buf(16, 16);
+    buf.paintBrush(Ogre::Vector2(0.5f, 0.5f), 0.125f,
+                   Ogre::ColourValue::Red, 1.0f, 0.0f,
+                   TexturePaintBuffer::BrushShape::Round);
+    int cx = 0, cy = 0;
+    buf.uvToPixel(Ogre::Vector2(0.5f, 0.5f), cx, cy);
+    // (cx-1, cy-1) is at radius sqrt(0.5^2 + 0.5^2) / 2 ≈ 0.35 of
+    // brush radius — inside the unit circle, so painted.
+    EXPECT_NEAR(buf.pixel(cx, cy).r, 1.0f, 0.1f);
+    // Diagonal corner pixel ~ (cx-2, cy-2) lies just outside the
+    // unit circle in pixel-center units → unpainted (still white).
+    EXPECT_NEAR(buf.pixel(cx - 2, cy - 2).r, 1.0f, 1e-3f);
+    EXPECT_NEAR(buf.pixel(cx - 2, cy - 2).g, 1.0f, 1e-3f);
+}
+
 TEST(TexturePaintBufferTest, UvToPixelRoundTrip)
 {
     // UV origin = top-left (Ogre + Qt convention).

--- a/src/TexturePaintController.cpp
+++ b/src/TexturePaintController.cpp
@@ -363,6 +363,31 @@ double TexturePaintController::texturePaintRadius() const
     return em ? em->vertexPaintRadius() : 0.05;
 }
 
+double TexturePaintController::texturePaintRadiusUV() const
+{
+    // Same mapping the texture-paint dispatch uses (see applyBrushAt)
+    // — divide the mesh-local radius by the mesh bounding-box half-
+    // size. When no paint mesh is available yet (no session) the raw
+    // mesh-local value is returned; the QML overlay treats anything
+    // > 0.5 as "clamp visually".
+    const double raw = texturePaintRadius();
+    if (!m_paintMesh) return raw;
+    const auto bbox = m_paintMesh->calculateBounds();
+    if (!bbox.isFinite()) return raw;
+    const float meshExtent = bbox.getSize().length() * 0.5f;
+    if (meshExtent <= 0.0f) return raw;
+    double uv = raw / static_cast<double>(meshExtent);
+    if (uv < 0.005) uv = 0.005;
+    if (uv > 1.0)  uv = 1.0;
+    return uv;
+}
+
+int TexturePaintController::brushShape() const
+{
+    auto* em = EditModeController::instance();
+    return em ? em->vertexPaintShape() : 0;
+}
+
 QColor TexturePaintController::bgPaintColor() const
 {
     auto* em = EditModeController::instance();
@@ -1172,12 +1197,15 @@ void TexturePaintController::updateStroke(OgreWidget* widget, const QPoint& scre
         drawHoverRingAt(localPos, localNormal);
         const QColor c = texturePaintColor();
         const Ogre::ColourValue paint(c.redF(), c.greenF(), c.blueF(), c.alphaF());
+        const auto* em = EditModeController::instance();
+        const bool square = em && em->vertexPaintShape() == EditModeController::ShapeSquare;
         const bool changed = EditModeController::applyVertexColorBrush(
             *m_paintMesh, localPos,
             static_cast<float>(texturePaintRadius()),
             paint,
             static_cast<float>(texturePaintStrength()),
-            static_cast<float>(texturePaintFalloff()));
+            static_cast<float>(texturePaintFalloff()),
+            square);
         if (changed)
             m_paintMesh->commitVertexColorsToEntity(m_paintMeshEntity);
         return;
@@ -1218,12 +1246,21 @@ bool TexturePaintController::applyBrushAtUV(const Ogre::Vector2& uv)
     radius = std::clamp(radius, 0.005f, 1.0f);
     const float strength = static_cast<float>(texturePaintStrength());
     const float falloff = static_cast<float>(texturePaintFalloff());
+    // Shape is sourced from EditModeController (the canonical brush
+    // settings owner). Default Round = circular falloff; Square is
+    // an axis-aligned constant-strength rectangle for pixel-art
+    // style hard edges.
+    const auto* em = EditModeController::instance();
+    const TexturePaintBuffer::BrushShape shape =
+        (em && em->vertexPaintShape() == EditModeController::ShapeSquare)
+            ? TexturePaintBuffer::BrushShape::Square
+            : TexturePaintBuffer::BrushShape::Round;
 
     switch (m_tool) {
     case ToolPaint: {
         const QColor c = texturePaintColor();
         const Ogre::ColourValue paint(c.redF(), c.greenF(), c.blueF(), c.alphaF());
-        return m_buffer.paintBrush(uv, radius, paint, strength, falloff) > 0;
+        return m_buffer.paintBrush(uv, radius, paint, strength, falloff, shape) > 0;
     }
     case ToolErase: {
         // Erase = paint with the user-chosen background color. The BG
@@ -1238,7 +1275,7 @@ bool TexturePaintController::applyBrushAtUV(const Ogre::Vector2& uv)
             static_cast<float>(bg.greenF()),
             static_cast<float>(bg.blueF()),
             static_cast<float>(bg.alphaF()));
-        return m_buffer.paintBrush(uv, radius, eraseTo, strength, falloff) > 0;
+        return m_buffer.paintBrush(uv, radius, eraseTo, strength, falloff, shape) > 0;
     }
     case ToolFill: {
         // Fill is a single-stamp operation — apply once per stroke
@@ -2190,22 +2227,50 @@ void TexturePaintController::drawHoverRingAt(const Ogre::Vector3& localPos,
 
     const QColor c = texturePaintColor();
     const Ogre::ColourValue ringCol(c.redF(), c.greenF(), c.blueF(), 0.95f);
-    constexpr int kSegments = 64;
     // The brush radius is in local mesh units (shared with vertex paint).
-    // 0.8 narrows the ring slightly so it visually matches the painted
-    // footprint (a softly-falloff brush doesn't quite touch the ring edge).
-    const float radius = static_cast<float>(texturePaintRadius()) * 0.8f;
+    // For the circular overlay we narrow it slightly (0.8x) so the ring
+    // visually matches the painted footprint — a softly-falloff brush
+    // doesn't quite touch the ring edge. The square overlay represents
+    // the AABB cube footprint exactly, so it uses the full radius.
     const Ogre::Vector3 center = localPos + normal * 0.001f;
-    m_ringObj->begin(kMatName, Ogre::RenderOperation::OT_LINE_STRIP);
-    for (int i = 0; i <= kSegments; ++i) {
-        const float t = static_cast<float>(i) / kSegments;
-        const float a = Ogre::Math::TWO_PI * t;
-        const Ogre::Vector3 p = center
-            + (tangent * Ogre::Math::Cos(a) + bitangent * Ogre::Math::Sin(a)) * radius;
-        m_ringObj->position(p);
-        m_ringObj->colour(ringCol);
+
+    const auto* em = EditModeController::instance();
+    const bool square = em && em->vertexPaintShape() == EditModeController::ShapeSquare;
+    if (square) {
+        const float radius = static_cast<float>(texturePaintRadius());
+        // Four corners of the local tangent-plane square, drawn as a
+        // closed line strip. Tangent + bitangent are perpendicular by
+        // construction so the corners are axis-aligned in the surface
+        // frame. NB: applyVertexColorBrush uses an AABB in mesh-local
+        // X/Y/Z space, not the surface frame — this overlay is a
+        // close visual approximation that stays simple, not an exact
+        // projection of that cube. Users want a hint of "square
+        // brush", which this delivers.
+        const Ogre::Vector3 p0 = center + ( tangent + bitangent) * radius;
+        const Ogre::Vector3 p1 = center + (-tangent + bitangent) * radius;
+        const Ogre::Vector3 p2 = center + (-tangent - bitangent) * radius;
+        const Ogre::Vector3 p3 = center + ( tangent - bitangent) * radius;
+        m_ringObj->begin(kMatName, Ogre::RenderOperation::OT_LINE_STRIP);
+        m_ringObj->position(p0); m_ringObj->colour(ringCol);
+        m_ringObj->position(p1); m_ringObj->colour(ringCol);
+        m_ringObj->position(p2); m_ringObj->colour(ringCol);
+        m_ringObj->position(p3); m_ringObj->colour(ringCol);
+        m_ringObj->position(p0); m_ringObj->colour(ringCol);
+        m_ringObj->end();
+    } else {
+        const float radius = static_cast<float>(texturePaintRadius()) * 0.8f;
+        constexpr int kSegments = 64;
+        m_ringObj->begin(kMatName, Ogre::RenderOperation::OT_LINE_STRIP);
+        for (int i = 0; i <= kSegments; ++i) {
+            const float t = static_cast<float>(i) / kSegments;
+            const float a = Ogre::Math::TWO_PI * t;
+            const Ogre::Vector3 p = center
+                + (tangent * Ogre::Math::Cos(a) + bitangent * Ogre::Math::Sin(a)) * radius;
+            m_ringObj->position(p);
+            m_ringObj->colour(ringCol);
+        }
+        m_ringObj->end();
     }
-    m_ringObj->end();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/TexturePaintController.h
+++ b/src/TexturePaintController.h
@@ -60,6 +60,15 @@ class TexturePaintController : public QObject
     // live preview text in the Texture Paint section.
     Q_PROPERTY(QColor texturePaintColor READ texturePaintColor NOTIFY texturePaintChanged)
     Q_PROPERTY(double texturePaintRadius READ texturePaintRadius NOTIFY texturePaintChanged)
+    /// Brush radius mapped into UV space (0..1). Same calculation
+    /// the texture-paint dispatch uses to convert the mesh-local
+    /// radius via `bbox half-size`. Drives the 2D thumbnail brush
+    /// outline. Emits texturePaintChanged on radius / session change.
+    Q_PROPERTY(double texturePaintRadiusUV READ texturePaintRadiusUV NOTIFY texturePaintChanged)
+    /// Brush shape: 0 = Round, 1 = Square. Mirror of
+    /// EditModeController::vertexPaintShape so QML doesn't need both
+    /// singletons to draw a brush outline.
+    Q_PROPERTY(int brushShape READ brushShape NOTIFY texturePaintChanged)
     Q_PROPERTY(double texturePaintStrength READ texturePaintStrength NOTIFY texturePaintChanged)
     Q_PROPERTY(double texturePaintFalloff READ texturePaintFalloff NOTIFY texturePaintChanged)
     Q_PROPERTY(int textureResolution READ textureResolution NOTIFY sessionChanged)
@@ -119,6 +128,13 @@ public:
     ///   - mask "fill with BG" action
     QColor bgPaintColor() const;
     double texturePaintRadius() const;
+    /// Same brush radius mapped into UV space. Mirrors the conversion
+    /// done by the texture-paint dispatch (mesh-local / bbox half-
+    /// size). Returns the raw radius when no mesh is available.
+    double texturePaintRadiusUV() const;
+    /// Current brush shape (int form of EditModeController::BrushShape).
+    /// 0 = Round, 1 = Square.
+    int brushShape() const;
     double texturePaintStrength() const;
     double texturePaintFalloff() const;
     /// @}

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1314,6 +1314,40 @@ void MainWindow::initToolBar()
     paintLay->addWidget(falloffLabel);
     paintLay->addWidget(falloffSlider);
 
+    // Brush shape selector: Round (circular falloff) vs Square
+    // (axis-aligned constant strength, no falloff). Falloff slider
+    // is ignored when Square is selected — kept enabled for
+    // discoverability of "switch back to Round".
+    auto* shapeRow = new QHBoxLayout();
+    shapeRow->addWidget(new QLabel(tr("Shape:"), paintSettings));
+    auto* shapeRound = new QPushButton(tr("Round"), paintSettings);
+    auto* shapeSquare = new QPushButton(tr("Square"), paintSettings);
+    shapeRound->setCheckable(true);
+    shapeSquare->setCheckable(true);
+    shapeRound->setAutoExclusive(true);
+    shapeSquare->setAutoExclusive(true);
+    shapeRound->setFixedHeight(22);
+    shapeSquare->setFixedHeight(22);
+    auto syncShape = [shapeRound, shapeSquare, emPaint]() {
+        const bool square = emPaint->vertexPaintShape() == EditModeController::ShapeSquare;
+        QSignalBlocker br(shapeRound);
+        QSignalBlocker bs(shapeSquare);
+        shapeRound->setChecked(!square);
+        shapeSquare->setChecked(square);
+    };
+    syncShape();
+    connect(shapeRound, &QPushButton::clicked, this, [emPaint]() {
+        emPaint->setVertexPaintShape(static_cast<int>(EditModeController::ShapeRound));
+    });
+    connect(shapeSquare, &QPushButton::clicked, this, [emPaint]() {
+        emPaint->setVertexPaintShape(static_cast<int>(EditModeController::ShapeSquare));
+    });
+    connect(emPaint, &EditModeController::vertexPaintChanged, this, syncShape);
+    shapeRow->addWidget(shapeRound);
+    shapeRow->addWidget(shapeSquare);
+    shapeRow->addStretch();
+    paintLay->addLayout(shapeRow);
+
     auto* paintWa = new QWidgetAction(vertexPaintMenu);
     paintWa->setDefaultWidget(paintSettings);
     vertexPaintMenu->addAction(paintWa);
@@ -1325,23 +1359,30 @@ void MainWindow::initToolBar()
         syncFalloff();
     });
 
-    connect(vertexPaintButton, &QToolButton::toggled, this, [this](bool on) {
-        SentryReporter::addBreadcrumb("ui.action",
-            QStringLiteral("Toolbar: Paint brush %1").arg(on ? "on" : "off"));
-        // All painting goes through TexturePaintController. The
-        // controller's "paint target" enum picks between texture
-        // paint and vertex paint per stroke.
-        TexturePaintController::instance()->setTexturePaintEnabled(on);
-        if (on)
-            setTransformState(TransformOperator::TS_SELECT);
+    // The brush button is now a TOOL SELECTOR, not the paint-mode
+    // master toggle. The Off/Vertex/Texture switch in the right
+    // panel is the gate for enabling paint mode; the toolbar buttons
+    // only pick which tool the user is using. Clicking the brush
+    // button selects ToolPaint (or no-ops if it was already
+    // selected — autoExclusive in spirit, the QToolButton group
+    // logic is in syncBrushChecked below).
+    connect(vertexPaintButton, &QToolButton::clicked, this, []() {
+        SentryReporter::addBreadcrumb("ui.action", "Toolbar: tool = Paint");
+        TexturePaintController::instance()->setBrushTool(
+            static_cast<int>(TexturePaintController::ToolPaint));
     });
+    // Tool button reflects "this tool is selected" rather than "paint
+    // mode is on" — matches the wand button's pattern.
     auto syncPaintBtnChecked = [vertexPaintButton]() {
-        const bool on = TexturePaintController::instance()->texturePaintEnabled();
+        const bool selected =
+            TexturePaintController::instance()->brushTool()
+                == static_cast<int>(TexturePaintController::ToolPaint);
         QSignalBlocker b(vertexPaintButton);
-        vertexPaintButton->setChecked(on);
+        vertexPaintButton->setChecked(selected);
     };
-    connect(TexturePaintController::instance(), &TexturePaintController::texturePaintChanged,
-            this, syncPaintBtnChecked);
+    syncPaintBtnChecked();
+    connect(TexturePaintController::instance(),
+            &TexturePaintController::brushToolChanged, this, syncPaintBtnChecked);
 
     QAction* vertexPaintAction = ui->objectsToolbar->addWidget(vertexPaintButton);
     vertexPaintAction->setObjectName("modeMaterialPaintBrushAction");
@@ -1444,6 +1485,187 @@ void MainWindow::initToolBar()
 
     QAction* wandAction = ui->objectsToolbar->addWidget(wandButton);
     wandAction->setObjectName("modeMaterialWandAction");
+
+    // Per-tool toolbar buttons (Bucket / Eraser / Eyedropper / Smudge)
+    // below the wand. Same green-active / grey-disabled treatment as
+    // the wand. Each is a TexturePaintController tool selector — it
+    // doesn't enable paint mode; the Off/Vertex/Texture switch in
+    // the right panel is the master gate.
+    struct ToolButtonEntry {
+        int tool;
+        const char* label;
+        const char* objectName;
+        std::function<void(QPainter&, const QColor&)> paint;
+    };
+
+    // Drawing helpers. Same green/grey palette as the wand, drawn at
+    // 18x18 — keep the icons high-contrast and silhouette-distinct so
+    // users can pick them out in a vertical column without reading
+    // tooltips.
+    const std::vector<ToolButtonEntry> tools = {
+        {
+            static_cast<int>(TexturePaintController::ToolFill),
+            "Bucket", "modeMaterialBucketAction",
+            [](QPainter& p, const QColor& c) {
+                // Bucket: trapezoid body + handle, with a paint drip.
+                p.setPen(QPen(c, 1.6, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+                p.setBrush(Qt::NoBrush);
+                QPainterPath bucket;
+                bucket.moveTo(3.5, 6.5);
+                bucket.lineTo(14.5, 6.5);
+                bucket.lineTo(13.5, 14.5);
+                bucket.lineTo(4.5, 14.5);
+                bucket.closeSubpath();
+                p.drawPath(bucket);
+                // Rim
+                p.drawLine(QPointF(2.8, 6.5), QPointF(15.2, 6.5));
+                // Handle arc
+                p.drawArc(QRectF(5.5, 2.5, 7, 5), 30 * 16, 120 * 16);
+                // Drip
+                p.setBrush(c);
+                p.setPen(Qt::NoPen);
+                p.drawEllipse(QPointF(11.5, 10.5), 1.5, 2.0);
+            }
+        },
+        {
+            static_cast<int>(TexturePaintController::ToolErase),
+            "Eraser", "modeMaterialEraserAction",
+            [](QPainter& p, const QColor& c) {
+                // Eraser block: rounded rect with a diagonal split
+                // between the rubber and the metal ferrule.
+                p.setPen(QPen(c, 1.6, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+                p.setBrush(Qt::NoBrush);
+                p.save();
+                p.translate(9, 9);
+                p.rotate(-30);
+                p.drawRoundedRect(QRectF(-6, -3, 12, 6), 1.5, 1.5);
+                // Inner ferrule line
+                p.drawLine(QPointF(0, -3), QPointF(0, 3));
+                p.restore();
+            }
+        },
+        {
+            static_cast<int>(TexturePaintController::ToolColorPicker),
+            "Pick", "modeMaterialPickAction",
+            [](QPainter& p, const QColor& c) {
+                // Eyedropper: long diagonal pipette + bulb.
+                p.setPen(QPen(c, 1.8, Qt::SolidLine, Qt::RoundCap));
+                p.drawLine(QPointF(3.0, 15.0), QPointF(10.0, 8.0));
+                p.setBrush(c);
+                p.setPen(Qt::NoPen);
+                // Bulb (top end)
+                p.save();
+                p.translate(13, 5);
+                p.rotate(45);
+                p.drawRoundedRect(QRectF(-3, -2, 6, 4), 1, 1);
+                p.restore();
+                // Drip tip
+                p.drawEllipse(QPointF(3.0, 15.0), 1.1, 1.1);
+            }
+        },
+        {
+            static_cast<int>(TexturePaintController::ToolSmudge),
+            "Smudge", "modeMaterialSmudgeAction",
+            [](QPainter& p, const QColor& c) {
+                // Smudge: finger-tip outline + wavy smear trail.
+                p.setPen(QPen(c, 1.6, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+                p.setBrush(Qt::NoBrush);
+                // Finger pad as a rotated tear-drop
+                QPainterPath finger;
+                finger.moveTo(12, 4);
+                finger.cubicTo(14, 6, 14, 10, 11, 12);
+                finger.cubicTo(8, 13, 6, 10, 8, 8);
+                finger.cubicTo(9, 6, 11, 4, 12, 4);
+                p.drawPath(finger);
+                // Smear trail
+                QPainterPath smear;
+                smear.moveTo(3, 14);
+                smear.cubicTo(5, 12, 7, 16, 9, 14);
+                p.drawPath(smear);
+            }
+        }
+    };
+
+    std::vector<QToolButton*> toolButtons;
+    std::vector<QAction*> toolActions;
+    toolButtons.reserve(tools.size());
+    toolActions.reserve(tools.size());
+
+    for (const auto& tdef : tools) {
+        auto makeIcon = [paint = tdef.paint](const QColor& color) -> QPixmap {
+            QPixmap pm(18, 18);
+            pm.fill(Qt::transparent);
+            QPainter p(&pm);
+            p.setRenderHint(QPainter::Antialiasing, true);
+            paint(p, color);
+            return pm;
+        };
+        const QColor green(0x7B, 0xBD, 0x2A);
+        const QColor disabled(0xB8, 0xB8, 0xB8);
+        QIcon icon;
+        const QPixmap onPm = makeIcon(green);
+        const QPixmap offPm = makeIcon(disabled);
+        icon.addPixmap(onPm,  QIcon::Normal,   QIcon::Off);
+        icon.addPixmap(onPm,  QIcon::Active,   QIcon::Off);
+        icon.addPixmap(onPm,  QIcon::Selected, QIcon::Off);
+        icon.addPixmap(onPm,  QIcon::Normal,   QIcon::On);
+        icon.addPixmap(offPm, QIcon::Disabled, QIcon::Off);
+        icon.addPixmap(offPm, QIcon::Disabled, QIcon::On);
+
+        auto* btn = new QToolButton(ui->objectsToolbar);
+        btn->setCheckable(true);
+        btn->setIcon(icon);
+        btn->setIconSize(QSize(18, 18));
+        btn->setToolTip(tr("%1 — paint tool").arg(tr(tdef.label)));
+        btn->setFont(topoFont);
+        btn->setStyleSheet(topoBtnStyle);
+
+        const int targetTool = tdef.tool;
+        connect(btn, &QToolButton::clicked, this, [targetTool, label = tdef.label]() {
+            SentryReporter::addBreadcrumb("ui.action",
+                QStringLiteral("Toolbar: tool = %1").arg(label));
+            TexturePaintController::instance()->setBrushTool(targetTool);
+        });
+
+        QAction* act = ui->objectsToolbar->addWidget(btn);
+        act->setObjectName(tdef.objectName);
+        toolButtons.push_back(btn);
+        toolActions.push_back(act);
+    }
+
+    // Sync the per-tool button check / enabled state. Tools other than
+    // Paint and Wand only make sense when paint mode is on AND target
+    // is Texture (vertex paint doesn't use flood-fill, picker, etc).
+    //
+    // Capture toolButtons AND the tool int IDs *by value* — the `tools`
+    // descriptor vector is a local that disappears at the end of the
+    // ctor, so binding it by reference would crash the next time the
+    // user changed paint target / enable (the lambda would deref a
+    // freed std::vector). Bug found mid-iteration: the Texture-button
+    // click hit exactly this path.
+    std::vector<int> toolIds;
+    toolIds.reserve(tools.size());
+    for (const auto& t : tools) toolIds.push_back(t.tool);
+
+    auto syncToolButtons = [toolButtons, toolIds]() {
+        auto* tpc = TexturePaintController::instance();
+        const int cur = tpc->brushTool();
+        const bool canTextureTool =
+            tpc->texturePaintEnabled()
+            && tpc->paintTarget() == static_cast<int>(TexturePaintController::TargetTexture);
+        for (size_t i = 0; i < toolButtons.size() && i < toolIds.size(); ++i) {
+            QSignalBlocker b(toolButtons[i]);
+            toolButtons[i]->setChecked(cur == toolIds[i]);
+            toolButtons[i]->setEnabled(canTextureTool);
+        }
+    };
+    syncToolButtons();
+    connect(TexturePaintController::instance(),
+            &TexturePaintController::brushToolChanged, this, syncToolButtons);
+    connect(TexturePaintController::instance(),
+            &TexturePaintController::texturePaintChanged, this, syncToolButtons);
+    connect(TexturePaintController::instance(),
+            &TexturePaintController::paintTargetChanged, this, syncToolButtons);
 
     // FG/BG color swatch widget — Photoshop / GIMP style. Two overlapping
     // rectangles showing the foreground and background colors. The user
@@ -1557,7 +1779,8 @@ void MainWindow::initToolBar()
     // Switching modes turns the previous mode's brush off so we don't
     // leave a stale checked state.
     auto refreshPaintBrushVisibility = [vertexPaintButton, vertexPaintAction,
-                                        paintColorsAction, wandButton, wandAction]() {
+                                        paintColorsAction, wandButton, wandAction,
+                                        toolActions]() {
         const auto mode = EditorModeController::instance()->currentMode();
         const bool material = mode == EditorModeController::MaterialMode;
         // Paint brush lives in Material Mode only. The user chooses
@@ -1572,6 +1795,8 @@ void MainWindow::initToolBar()
         const bool edit = mode == EditorModeController::EditMode;
         paintColorsAction->setVisible(material || edit);
         wandAction->setVisible(material);
+        for (auto* a : toolActions)
+            if (a) a->setVisible(material);
         // wandButton enabled state is driven by syncWandEnabled —
         // paint-on + target=Texture. Hide here when out of Material
         // Mode but don't overrule enabled.
@@ -1584,8 +1809,6 @@ void MainWindow::initToolBar()
         SentryReporter::addBreadcrumb(
             "ui.action",
             QStringLiteral("Mode switch: paint state reset"));
-        QSignalBlocker b(vertexPaintButton);
-        vertexPaintButton->setChecked(false);
         // Reset the tool to Paint on every mode entry so the wand
         // toolbar button starts unchecked too.
         TexturePaintController::instance()->setBrushTool(

--- a/website/src/hooks/useQtmeshActionRef.js
+++ b/website/src/hooks/useQtmeshActionRef.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 const QTMESH_RELEASES_LATEST_API = 'https://api.github.com/repos/fernandotonon/QtMeshEditor/releases/latest';
-const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.1.0';
+const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.2.0';
 const CACHE_KEY = 'qtmesh.actionRef.cache.v1';
 const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 


### PR DESCRIPTION
## Summary

- Paint tools moved to the **left toolbar**, GIMP/Krita-style. Brush button no longer toggles paint mode — the Off/Vertex/Texture switch in the right inspector is the only master gate.
- New toolbar buttons: Brush, Wand, Bucket, Eraser, Eyedropper, Smudge. All five share the wand's green/grey active/disabled treatment.
- Right-panel tool selector row removed (toolbar is canonical).
- **Square brush shape** added to the brush popup (Round/Square). Square = axis-aligned constant-strength stamp in 2D, cube AABB in 3D.
- Hover overlays match the shape: a square outline on the 3D mesh and the 2D thumbnail when Square is selected; circular outline otherwise.
- UV-island toggle added to the detached **Texture Editor** window.
- New `TexturePaintController.texturePaintRadiusUV` + `brushShape` properties feed the QML overlays.

## Bug fixes

- Crash on switching to Texture mode: the toolbar wiring captured a local `std::vector<ToolButtonEntry>` by reference into a Qt connect lambda. The vector went out of scope at the end of `MainWindow`'s constructor, so every later signal firing dereferenced freed memory. Now captures the tool IDs by value.

## Tests

- `TexturePaintBuffer_test`: 3 new tests for the Square brush path (full-AABB constant fill, falloff ignored, Round still excludes corners).
- `EditableMesh_test`: 3 new tests for the cube-AABB vertex brush (corners reached, constant strength regardless of falloff, outside-AABB vertices skipped).

## Version

- Bumped to **3.2.0** in `CMakeLists.txt`; doc versions synced via `scripts/sync-doc-versions-from-cmake.sh`.

## Test plan

- [x] Build green on macOS arm64
- [x] App boots, paint mode + tools verified locally
- [ ] CI: Linux unit tests, macOS / Linux / Windows builds, SonarCloud, CodeRabbit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added brush shape options (round and square) for vertex and texture painting with distinct falloff behaviors
  * UV wireframe overlay toggle for texture editing with live visualization
  * Brush footprint preview showing exact painting area in texture editor
  * New dedicated tool buttons for Paint, Erase, Pick, Smudge, and Bucket operations
  * Enhanced brush hover feedback with shape-aware visualization

* **UI/UX Improvements**
  * Reorganized painting tool selection from right panel to left toolbar for better workflow

* **Chores**
  * Version bumped to 3.2.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/531?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->