### PR TITLE
feat(import): auto-scale sub-unit meshes to ~3 units

### DIFF
--- a/src/MeshImporterExporter.cpp
+++ b/src/MeshImporterExporter.cpp
@@ -2104,13 +2104,13 @@ void MeshImporterExporter::importer(const QStringList &_uriList, unsigned int ad
             // bounding-box extents <0.01 — the entity loads but sits
             // entirely inside the default near-clip distance and never
             // renders. Scale the parent SceneNode so the largest
-            // dimension lands at ~1 unit. Threshold of 0.01 avoids
+            // dimension lands at ~3 units. Threshold of 0.01 avoids
             // touching sensible-scale assets (anything from a few cm up).
             if (en && en->getMesh()) {
                 const auto& bbSize = en->getBoundingBox().getSize();
                 const Ogre::Real maxExtent = std::max({bbSize.x, bbSize.y, bbSize.z});
                 if (maxExtent > 0.0f && maxExtent < 0.01f) {
-                    const Ogre::Real factor = 1.0f / maxExtent;
+                    const Ogre::Real factor = 3.0f / maxExtent;
                     sn->setScale(factor, factor, factor);
                     Ogre::LogManager::getSingleton().logMessage(
                         "MeshImporterExporter: auto-scaled '" + en->getName() +

--- a/src/MeshImporterExporter_test.cpp
+++ b/src/MeshImporterExporter_test.cpp
@@ -1695,7 +1695,7 @@ TEST(MeshImporterExporterStandaloneTest, FormatFileURI_ShortAliasUppercaseIsAppe
 // can come in with bounding-box extents below the camera near-clip
 // distance — they load but render invisible. The importer should detect
 // this and scale the parent SceneNode so the largest dimension lands
-// at ~1 unit.
+// at ~3 units.
 TEST_F(MeshImporterExporterTest, Importer_SubUnitMesh_AutoScalesParentNode) {
     ASSERT_TRUE(canLoadMeshFiles()) << "GL/hardware buffers required (Xvfb in CI)";
 
@@ -1730,8 +1730,8 @@ TEST_F(MeshImporterExporterTest, Importer_SubUnitMesh_AutoScalesParentNode) {
     auto* importedNode = manager->getSceneNodes().last();
     const Ogre::Vector3 scale = importedNode->getScale();
 
-    // Auto-scale should bring the largest dim to ~1. With a 0.005-unit
-    // extent the factor is ~200, but we test loosely (>= 50) to stay
+    // Auto-scale should bring the largest dim to ~3. With a 0.005-unit
+    // extent the factor is ~600, but we test loosely (>= 50) to stay
     // robust against future tweaks to the threshold.
     EXPECT_GE(scale.x, 50.0f) << "Sub-unit mesh did not get auto-scaled (x)";
     EXPECT_GE(scale.y, 50.0f) << "Sub-unit mesh did not get auto-scaled (y)";


### PR DESCRIPTION
## Summary
- Bump the sub-unit auto-scale target from ~1 unit to ~3 units so mm-scale FBX / photogrammetry imports come in at a more comfortable working size (users were manually scaling up after every such import).
- Threshold (`maxExtent < 0.01`) and behavior for sensible-scale assets unchanged.
- Test comments + expected factor description updated; the existing `EXPECT_GE(scale, 50.0f)` assertion still holds (factor for 0.005 extent: ~200 → ~600).

## Test plan
- [ ] CI: `Importer_SubUnitMesh_AutoScalesParentNode` still passes.
- [ ] CI: `Importer_NormalSizedMesh_KeepsScale1` still passes (corollary — above-threshold meshes are not touched).
- [ ] Manual: load a known sub-unit FBX (e.g. mm-scale photogrammetry asset) and confirm it lands ~3× larger than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of very small mesh imports to prevent camera clipping issues. Small meshes are now auto-scaled to a more appropriate target size during import.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/539?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->