### PR TITLE
feat(vat): slice 2 — RGBA16 encoding + normal texture

### DIFF
--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -4757,15 +4757,29 @@ int CLIPipeline::cmdBakeVertexColors(int argc, char* argv[])
 
 int CLIPipeline::cmdVat(int argc, char* argv[])
 {
-    // Parse: vat <file> --anim <name> [--fps N] [-o <dir>] [--json]
+    // Parse: vat <file> --anim <name> [--fps N] [--encoding rgba8|rgba16]
+    //                                 [--normals] [-o <dir>] [--json]
     QString filePath, animName, outDir;
     double fps = 30.0;
     bool jsonOutput = false;
+    bool bakeNormals = false;
+    VATBaker::Encoding encoding = VATBaker::Encoding::RGBA8;
 
     for (int i = 1; i < argc; ++i) {
         QString arg(argv[i]);
         if (arg == "vat" || arg == "--cli") continue;
         if (arg == "--json") { jsonOutput = true; continue; }
+        if (arg == "--normals") { bakeNormals = true; continue; }
+        if (arg == "--encoding" && i + 1 < argc) {
+            const QString enc = QString(argv[++i]).toLower();
+            if (enc == "rgba8")      encoding = VATBaker::Encoding::RGBA8;
+            else if (enc == "rgba16") encoding = VATBaker::Encoding::RGBA16;
+            else {
+                err() << "Error: --encoding must be one of: rgba8, rgba16" << Qt::endl;
+                return 2;
+            }
+            continue;
+        }
         if ((arg == "--anim" || arg == "--animation") && i + 1 < argc) {
             animName = QString(argv[++i]); continue;
         }
@@ -4788,7 +4802,7 @@ int CLIPipeline::cmdVat(int argc, char* argv[])
 
     if (filePath.isEmpty()) {
         err() << "Error: No input file specified." << Qt::endl;
-        err() << "Usage: qtmesh vat <file> --anim <name> [--fps N] [-o <dir>] [--json]" << Qt::endl;
+        err() << "Usage: qtmesh vat <file> --anim <name> [--fps N] [--encoding rgba8|rgba16] [--normals] [-o <dir>] [--json]" << Qt::endl;
         return 2;
     }
     if (animName.isEmpty()) {
@@ -4838,6 +4852,8 @@ int CLIPipeline::cmdVat(int argc, char* argv[])
     opts.fps = fps;
     opts.outputDir = outDir;
     opts.basename = animName;
+    opts.encoding = encoding;
+    opts.bakeNormals = bakeNormals;
 
     VATBaker::BakeResult result = VATBaker::bake(entity, opts);
     if (!result.ok) {
@@ -4847,15 +4863,22 @@ int CLIPipeline::cmdVat(int argc, char* argv[])
         return 1;
     }
 
+    const QString encStr = (encoding == VATBaker::Encoding::RGBA16)
+                               ? QStringLiteral("rgba16")
+                               : QStringLiteral("rgba8");
+
     if (jsonOutput) {
         QJsonObject obj;
         obj["ok"]          = true;
         obj["posTexture"]  = result.posTexPath;
+        if (!result.nrmTexPath.isEmpty())
+            obj["nrmTexture"] = result.nrmTexPath;
         obj["sidecar"]     = result.jsonPath;
         obj["frameCount"]  = result.frameCount;
         obj["vertexCount"] = result.vertexCount;
         obj["animation"]   = animName;
         obj["fps"]         = fps;
+        obj["encoding"]    = encStr;
         QJsonObject bounds;
         QJsonObject lo, hi;
         lo["x"] = result.minBound.x; lo["y"] = result.minBound.y; lo["z"] = result.minBound.z;
@@ -4864,9 +4887,11 @@ int CLIPipeline::cmdVat(int argc, char* argv[])
         obj["bounds"] = bounds;
         cliWrite(QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Indented)));
     } else {
-        cliWrite(QStringLiteral("Baked VAT for '%1' (%2 frames × %3 vertices)\n")
-                     .arg(animName).arg(result.frameCount).arg(result.vertexCount));
+        cliWrite(QStringLiteral("Baked VAT for '%1' (%2 frames × %3 vertices, %4)\n")
+                     .arg(animName).arg(result.frameCount).arg(result.vertexCount).arg(encStr));
         cliWrite(QStringLiteral("  position texture: %1\n").arg(result.posTexPath));
+        if (!result.nrmTexPath.isEmpty())
+            cliWrite(QStringLiteral("  normal texture:   %1\n").arg(result.nrmTexPath));
         cliWrite(QStringLiteral("  sidecar:          %1\n").arg(result.jsonPath));
         cliWrite(QStringLiteral("  bounds: min=(%1, %2, %3) max=(%4, %5, %6)\n")
                      .arg(result.minBound.x, 0, 'f', 3)

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -4825,6 +4825,8 @@ int CLIPipeline::cmdVat(int argc, char* argv[])
 
     SentryReporter::addBreadcrumb("cli.vat",
         QString("VAT bake .%1 anim=%2 fps=%3").arg(fi.suffix(), animName).arg(fps));
+    SentryReporter::addBreadcrumb("file.import",
+        QString("Importing %1").arg(fi.absoluteFilePath()));
 
     MeshImporterExporter::importer({fi.absoluteFilePath()});
 
@@ -4855,6 +4857,11 @@ int CLIPipeline::cmdVat(int argc, char* argv[])
     opts.encoding = encoding;
     opts.bakeNormals = bakeNormals;
 
+    SentryReporter::addBreadcrumb("file.export",
+        QString("Writing VAT outputs to %1 (anim=%2, encoding=%3%4)")
+            .arg(QDir(outDir).absolutePath(), animName,
+                 (encoding == VATBaker::Encoding::RGBA16) ? "rgba16" : "rgba8",
+                 bakeNormals ? ", normals" : ""));
     VATBaker::BakeResult result = VATBaker::bake(entity, opts);
     if (!result.ok) {
         SentryReporter::captureMessage(

--- a/src/VATBaker.cpp
+++ b/src/VATBaker.cpp
@@ -17,6 +17,8 @@ The MIT License
 #include <QJsonDocument>
 #include <QJsonObject>
 
+#include <cstring>
+
 #include <OgreAnimationState.h>
 #include <OgreEntity.h>
 #include <OgreHardwareVertexBuffer.h>
@@ -120,6 +122,15 @@ inline float fromShortNormalised(uint16_t s, float lo, float hi)
 // separate so the position-only path (slice 1) doesn't lock the normal
 // buffer when no one will read it — the second lock acquisition on the
 // same vbuf is cheap but pointless.
+//
+// On a submesh without `VES_NORMAL`, returns SIZE_MAX as a sentinel so
+// the caller can fail the bake with a clear error. We deliberately do
+// NOT pad with fabricated up-vectors — that produces a normal texture
+// that looks plausible but lights the mesh wrong while reporting
+// success, which is worse than refusing to bake.
+constexpr size_t kCollectNormalsMissingSentinel =
+    std::numeric_limits<size_t>::max();
+
 size_t collectPostSkinNormals(Ogre::Entity* entity,
                               std::vector<Ogre::Vector3>& out)
 {
@@ -142,15 +153,10 @@ size_t collectPostSkinNormals(Ogre::Entity* entity,
         const auto* normElem = animData->vertexDeclaration->findElementBySemantic(
             Ogre::VES_NORMAL);
         if (!normElem) {
-            // No normals on this mesh — pad with up-vectors so the
-            // texture stays rectangular and downstream consumers don't
-            // hit a frameCount × vertexCount mismatch.
-            for (size_t j = 0; j < animData->vertexCount; ++j) {
-                out.emplace_back(0.0f, 1.0f, 0.0f);
-                ++appended;
-            }
-            if (sub->useSharedVertices) sharedAppended = true;
-            continue;
+            // Missing-normal submesh: surface as a hard failure rather
+            // than fabricate up-vectors. The caller's error message
+            // identifies which submesh hit this.
+            return kCollectNormalsMissingSentinel;
         }
 
         auto vbuf = animData->vertexBufferBinding->getBuffer(normElem->getSource());
@@ -501,8 +507,16 @@ VATBaker::BakeResult VATBaker::bake(Ogre::Entity* entity, const Options& opts)
         }
 
         if (opts.bakeNormals) {
-            const size_t nrmBefore = normals.size();
             const size_t nrmAppended = collectPostSkinNormals(entity, normals);
+            if (nrmAppended == kCollectNormalsMissingSentinel) {
+                entity->removeSoftwareAnimationRequest(true);
+                result.error = QStringLiteral(
+                    "frame %1 has a submesh without VES_NORMAL — "
+                    "cannot bake normals (regenerate normals on the source mesh "
+                    "or omit --normals)")
+                        .arg(f);
+                return result;
+            }
             if (nrmAppended != static_cast<size_t>(frameVerts)) {
                 entity->removeSoftwareAnimationRequest(true);
                 result.error = QStringLiteral(
@@ -510,7 +524,6 @@ VATBaker::BakeResult VATBaker::bake(Ogre::Entity* entity, const Options& opts)
                         .arg(f).arg(nrmAppended).arg(frameVerts);
                 return result;
             }
-            (void)nrmBefore;
         }
     }
 

--- a/src/VATBaker.cpp
+++ b/src/VATBaker.cpp
@@ -103,6 +103,78 @@ inline float fromByteNormalised(unsigned char b, float lo, float hi)
     return lo + (static_cast<float>(b) / 255.0f) * (hi - lo);
 }
 
+inline uint16_t toShortNormalised(float v, float lo, float hi)
+{
+    if (hi <= lo) return 0;
+    const float t = (v - lo) / (hi - lo);
+    const float clamped = std::clamp(t, 0.0f, 1.0f);
+    return static_cast<uint16_t>(std::lround(clamped * 65535.0f));
+}
+
+inline float fromShortNormalised(uint16_t s, float lo, float hi)
+{
+    return lo + (static_cast<float>(s) / 65535.0f) * (hi - lo);
+}
+
+// Same submesh walk as collectPostSkinPositions but for normals. Kept
+// separate so the position-only path (slice 1) doesn't lock the normal
+// buffer when no one will read it — the second lock acquisition on the
+// same vbuf is cheap but pointless.
+size_t collectPostSkinNormals(Ogre::Entity* entity,
+                              std::vector<Ogre::Vector3>& out)
+{
+    Ogre::MeshPtr mesh = entity->getMesh();
+    if (!mesh) return 0;
+
+    size_t appended = 0;
+    bool sharedAppended = false;
+
+    for (unsigned short si = 0; si < mesh->getNumSubMeshes(); ++si) {
+        Ogre::SubMesh* sub = mesh->getSubMesh(si);
+        if (!sub) continue;
+        if (sub->useSharedVertices && sharedAppended) continue;
+
+        Ogre::VertexData* animData = sub->useSharedVertices
+            ? entity->_getSkelAnimVertexData()
+            : entity->getSubEntity(si)->_getSkelAnimVertexData();
+        if (!animData) continue;
+
+        const auto* normElem = animData->vertexDeclaration->findElementBySemantic(
+            Ogre::VES_NORMAL);
+        if (!normElem) {
+            // No normals on this mesh — pad with up-vectors so the
+            // texture stays rectangular and downstream consumers don't
+            // hit a frameCount × vertexCount mismatch.
+            for (size_t j = 0; j < animData->vertexCount; ++j) {
+                out.emplace_back(0.0f, 1.0f, 0.0f);
+                ++appended;
+            }
+            if (sub->useSharedVertices) sharedAppended = true;
+            continue;
+        }
+
+        auto vbuf = animData->vertexBufferBinding->getBuffer(normElem->getSource());
+        if (!vbuf) continue;
+
+        auto* bytes = static_cast<unsigned char*>(
+            vbuf->lock(Ogre::HardwareBuffer::HBL_READ_ONLY));
+        const size_t vstride = vbuf->getVertexSize();
+
+        for (size_t j = 0; j < animData->vertexCount; ++j) {
+            Ogre::Real* pNorm = nullptr;
+            normElem->baseVertexPointerToElement(bytes + j * vstride, &pNorm);
+            out.emplace_back(pNorm[0], pNorm[1], pNorm[2]);
+            ++appended;
+        }
+
+        vbuf->unlock();
+
+        if (sub->useSharedVertices) sharedAppended = true;
+    }
+
+    return appended;
+}
+
 } // namespace
 
 // ---------------------------------------------------------------------------
@@ -155,6 +227,144 @@ std::vector<Ogre::Vector3> VATBaker::decodeRGBA8(
     return out;
 }
 
+std::vector<uint16_t> VATBaker::encodeRGBA16(
+    const std::vector<Ogre::Vector3>& flatPositions,
+    int frameCount,
+    int vertexCount,
+    const Ogre::Vector3& minBound,
+    const Ogre::Vector3& maxBound)
+{
+    const size_t expected = static_cast<size_t>(frameCount)
+                          * static_cast<size_t>(vertexCount);
+    std::vector<uint16_t> out;
+    if (frameCount <= 0 || vertexCount <= 0) return out;
+    if (flatPositions.size() != expected) return out;
+    out.resize(expected * 4u, 0);
+    for (size_t i = 0; i < expected; ++i) {
+        const auto& p = flatPositions[i];
+        out[i * 4 + 0] = toShortNormalised(p.x, minBound.x, maxBound.x);
+        out[i * 4 + 1] = toShortNormalised(p.y, minBound.y, maxBound.y);
+        out[i * 4 + 2] = toShortNormalised(p.z, minBound.z, maxBound.z);
+        out[i * 4 + 3] = 65535;
+    }
+    return out;
+}
+
+std::vector<Ogre::Vector3> VATBaker::decodeRGBA16(
+    const std::vector<uint16_t>& pixels,
+    int frameCount,
+    int vertexCount,
+    const Ogre::Vector3& minBound,
+    const Ogre::Vector3& maxBound)
+{
+    const size_t expected = static_cast<size_t>(frameCount)
+                          * static_cast<size_t>(vertexCount);
+    std::vector<Ogre::Vector3> out;
+    if (frameCount <= 0 || vertexCount <= 0) return out;
+    if (pixels.size() != expected * 4u) return out;
+    out.reserve(expected);
+    for (size_t i = 0; i < expected; ++i) {
+        Ogre::Vector3 p;
+        p.x = fromShortNormalised(pixels[i * 4 + 0], minBound.x, maxBound.x);
+        p.y = fromShortNormalised(pixels[i * 4 + 1], minBound.y, maxBound.y);
+        p.z = fromShortNormalised(pixels[i * 4 + 2], minBound.z, maxBound.z);
+        out.push_back(p);
+    }
+    return out;
+}
+
+std::vector<unsigned char> VATBaker::encodeNormalsRGBA8(
+    const std::vector<Ogre::Vector3>& flatNormals,
+    int frameCount,
+    int vertexCount)
+{
+    const size_t expected = static_cast<size_t>(frameCount)
+                          * static_cast<size_t>(vertexCount);
+    std::vector<unsigned char> out;
+    if (frameCount <= 0 || vertexCount <= 0) return out;
+    if (flatNormals.size() != expected) return out;
+    out.resize(expected * 4u, 0);
+    for (size_t i = 0; i < expected; ++i) {
+        // Normals come in as unit vectors in [-1, 1]; remap to [0, 1]
+        // for the unsigned byte channel.
+        const auto& n = flatNormals[i];
+        const float nx = std::clamp((n.x + 1.0f) * 0.5f, 0.0f, 1.0f);
+        const float ny = std::clamp((n.y + 1.0f) * 0.5f, 0.0f, 1.0f);
+        const float nz = std::clamp((n.z + 1.0f) * 0.5f, 0.0f, 1.0f);
+        out[i * 4 + 0] = static_cast<unsigned char>(std::lround(nx * 255.0f));
+        out[i * 4 + 1] = static_cast<unsigned char>(std::lround(ny * 255.0f));
+        out[i * 4 + 2] = static_cast<unsigned char>(std::lround(nz * 255.0f));
+        out[i * 4 + 3] = 255;
+    }
+    return out;
+}
+
+std::vector<Ogre::Vector3> VATBaker::decodeNormalsRGBA8(
+    const std::vector<unsigned char>& pixels,
+    int frameCount,
+    int vertexCount)
+{
+    const size_t expected = static_cast<size_t>(frameCount)
+                          * static_cast<size_t>(vertexCount);
+    std::vector<Ogre::Vector3> out;
+    if (frameCount <= 0 || vertexCount <= 0) return out;
+    if (pixels.size() != expected * 4u) return out;
+    out.reserve(expected);
+    for (size_t i = 0; i < expected; ++i) {
+        Ogre::Vector3 n;
+        n.x = (static_cast<float>(pixels[i * 4 + 0]) / 255.0f) * 2.0f - 1.0f;
+        n.y = (static_cast<float>(pixels[i * 4 + 1]) / 255.0f) * 2.0f - 1.0f;
+        n.z = (static_cast<float>(pixels[i * 4 + 2]) / 255.0f) * 2.0f - 1.0f;
+        out.push_back(n);
+    }
+    return out;
+}
+
+std::vector<uint16_t> VATBaker::encodeNormalsRGBA16(
+    const std::vector<Ogre::Vector3>& flatNormals,
+    int frameCount,
+    int vertexCount)
+{
+    const size_t expected = static_cast<size_t>(frameCount)
+                          * static_cast<size_t>(vertexCount);
+    std::vector<uint16_t> out;
+    if (frameCount <= 0 || vertexCount <= 0) return out;
+    if (flatNormals.size() != expected) return out;
+    out.resize(expected * 4u, 0);
+    for (size_t i = 0; i < expected; ++i) {
+        const auto& n = flatNormals[i];
+        const float nx = std::clamp((n.x + 1.0f) * 0.5f, 0.0f, 1.0f);
+        const float ny = std::clamp((n.y + 1.0f) * 0.5f, 0.0f, 1.0f);
+        const float nz = std::clamp((n.z + 1.0f) * 0.5f, 0.0f, 1.0f);
+        out[i * 4 + 0] = static_cast<uint16_t>(std::lround(nx * 65535.0f));
+        out[i * 4 + 1] = static_cast<uint16_t>(std::lround(ny * 65535.0f));
+        out[i * 4 + 2] = static_cast<uint16_t>(std::lround(nz * 65535.0f));
+        out[i * 4 + 3] = 65535;
+    }
+    return out;
+}
+
+std::vector<Ogre::Vector3> VATBaker::decodeNormalsRGBA16(
+    const std::vector<uint16_t>& pixels,
+    int frameCount,
+    int vertexCount)
+{
+    const size_t expected = static_cast<size_t>(frameCount)
+                          * static_cast<size_t>(vertexCount);
+    std::vector<Ogre::Vector3> out;
+    if (frameCount <= 0 || vertexCount <= 0) return out;
+    if (pixels.size() != expected * 4u) return out;
+    out.reserve(expected);
+    for (size_t i = 0; i < expected; ++i) {
+        Ogre::Vector3 n;
+        n.x = (static_cast<float>(pixels[i * 4 + 0]) / 65535.0f) * 2.0f - 1.0f;
+        n.y = (static_cast<float>(pixels[i * 4 + 1]) / 65535.0f) * 2.0f - 1.0f;
+        n.z = (static_cast<float>(pixels[i * 4 + 2]) / 65535.0f) * 2.0f - 1.0f;
+        out.push_back(n);
+    }
+    return out;
+}
+
 QString VATBaker::buildSidecarJson(const BakeResult& result, const Options& opts)
 {
     QJsonObject bounds;
@@ -164,16 +374,24 @@ QString VATBaker::buildSidecarJson(const BakeResult& result, const Options& opts
     bounds["min"] = lo;
     bounds["max"] = hi;
 
+    QString encStr;
+    switch (opts.encoding) {
+        case Encoding::RGBA8:  encStr = QStringLiteral("rgba8");  break;
+        case Encoding::RGBA16: encStr = QStringLiteral("rgba16"); break;
+    }
+
     QJsonObject root;
     root["version"]     = 1;
     root["target"]      = "agnostic";
-    root["encoding"]    = "rgba8";
+    root["encoding"]    = encStr;
     root["frameCount"]  = result.frameCount;
     root["vertexCount"] = result.vertexCount;
     root["fps"]         = opts.fps;
     root["animation"]   = opts.animationName;
     root["bounds"]      = bounds;
     root["posTexture"]  = QFileInfo(result.posTexPath).fileName();
+    if (!result.nrmTexPath.isEmpty())
+        root["nrmTexture"] = QFileInfo(result.nrmTexPath).fileName();
 
     QJsonDocument doc(root);
     return QString::fromUtf8(doc.toJson(QJsonDocument::Indented));
@@ -244,9 +462,12 @@ VATBaker::BakeResult VATBaker::bake(Ogre::Entity* entity, const Options& opts)
 
     // First sample to discover the vertex count + seed the bounds.
     std::vector<Ogre::Vector3> flat;
+    std::vector<Ogre::Vector3> normals;  // populated only when opts.bakeNormals
     Ogre::Vector3 lo(std::numeric_limits<float>::infinity());
     Ogre::Vector3 hi(-std::numeric_limits<float>::infinity());
     flat.reserve(static_cast<size_t>(frameCount) * 1024);
+    if (opts.bakeNormals)
+        normals.reserve(static_cast<size_t>(frameCount) * 1024);
 
     int vertexCount = -1;
     for (int f = 0; f < frameCount; ++f) {
@@ -278,6 +499,19 @@ VATBaker::BakeResult VATBaker::bake(Ogre::Entity* entity, const Options& opts)
             lo.x = std::min(lo.x, p.x); lo.y = std::min(lo.y, p.y); lo.z = std::min(lo.z, p.z);
             hi.x = std::max(hi.x, p.x); hi.y = std::max(hi.y, p.y); hi.z = std::max(hi.z, p.z);
         }
+
+        if (opts.bakeNormals) {
+            const size_t nrmBefore = normals.size();
+            const size_t nrmAppended = collectPostSkinNormals(entity, normals);
+            if (nrmAppended != static_cast<size_t>(frameVerts)) {
+                entity->removeSoftwareAnimationRequest(true);
+                result.error = QStringLiteral(
+                    "frame %1 normals count (%2) differs from positions (%3)")
+                        .arg(f).arg(nrmAppended).arg(frameVerts);
+                return result;
+            }
+            (void)nrmBefore;
+        }
     }
 
     entity->removeSoftwareAnimationRequest(true);
@@ -301,24 +535,85 @@ VATBaker::BakeResult VATBaker::bake(Ogre::Entity* entity, const Options& opts)
     result.posTexPath = QDir(opts.outputDir).filePath(base + "_pos.png");
     result.jsonPath   = QDir(opts.outputDir).filePath(base + ".json");
 
-    // Encode + write the position texture.
-    auto rgba = encodeRGBA8(flat, frameCount, vertexCount, lo, hi);
-    if (rgba.empty()) {
-        result.error = QStringLiteral("encodeRGBA8 produced empty buffer");
-        return result;
+    // Encode + write the position texture. PNG preserves both 8-bit
+    // and 16-bit channel depths; QImage handles the format switch for us.
+    if (opts.encoding == Encoding::RGBA8) {
+        auto rgba = encodeRGBA8(flat, frameCount, vertexCount, lo, hi);
+        if (rgba.empty()) {
+            result.error = QStringLiteral("encodeRGBA8 produced empty buffer");
+            return result;
+        }
+        QImage img(vertexCount, frameCount, QImage::Format_RGBA8888);
+        for (int y = 0; y < frameCount; ++y) {
+            const unsigned char* src = rgba.data() + static_cast<size_t>(y)
+                                                      * static_cast<size_t>(vertexCount) * 4u;
+            std::memcpy(img.scanLine(y), src, static_cast<size_t>(vertexCount) * 4u);
+        }
+        if (!img.save(result.posTexPath, "PNG")) {
+            result.error = QStringLiteral("failed to write position texture: %1")
+                               .arg(result.posTexPath);
+            return result;
+        }
+    } else {  // RGBA16
+        auto rgba = encodeRGBA16(flat, frameCount, vertexCount, lo, hi);
+        if (rgba.empty()) {
+            result.error = QStringLiteral("encodeRGBA16 produced empty buffer");
+            return result;
+        }
+        // Format_RGBA64 is 16 bits per channel — Qt's `save("PNG")` writes
+        // a 16-bit PNG which Godot/Unity/Unreal all read losslessly.
+        QImage img(vertexCount, frameCount, QImage::Format_RGBA64);
+        for (int y = 0; y < frameCount; ++y) {
+            const uint16_t* src = rgba.data() + static_cast<size_t>(y)
+                                                * static_cast<size_t>(vertexCount) * 4u;
+            std::memcpy(img.scanLine(y), src, static_cast<size_t>(vertexCount) * 4u * sizeof(uint16_t));
+        }
+        if (!img.save(result.posTexPath, "PNG")) {
+            result.error = QStringLiteral("failed to write 16-bit position texture: %1")
+                               .arg(result.posTexPath);
+            return result;
+        }
     }
-    QImage img(vertexCount, frameCount, QImage::Format_RGBA8888);
-    // Row-by-row copy. QImage's stride may differ from the packed
-    // `vertexCount * 4` we generate, so copy line-by-line.
-    for (int y = 0; y < frameCount; ++y) {
-        const unsigned char* src = rgba.data() + static_cast<size_t>(y)
-                                                  * static_cast<size_t>(vertexCount) * 4u;
-        std::memcpy(img.scanLine(y), src, static_cast<size_t>(vertexCount) * 4u);
-    }
-    if (!img.save(result.posTexPath, "PNG")) {
-        result.error = QStringLiteral("failed to write position texture: %1")
-                           .arg(result.posTexPath);
-        return result;
+
+    // Normal texture — only when requested. Same layout / size, normals
+    // mapped from [-1, 1] → [0, MAX] per channel.
+    if (opts.bakeNormals) {
+        result.nrmTexPath = QDir(opts.outputDir).filePath(base + "_nrm.png");
+        if (opts.encoding == Encoding::RGBA8) {
+            auto rgba = encodeNormalsRGBA8(normals, frameCount, vertexCount);
+            if (rgba.empty()) {
+                result.error = QStringLiteral("encodeNormalsRGBA8 produced empty buffer");
+                return result;
+            }
+            QImage img(vertexCount, frameCount, QImage::Format_RGBA8888);
+            for (int y = 0; y < frameCount; ++y) {
+                const unsigned char* src = rgba.data() + static_cast<size_t>(y)
+                                                          * static_cast<size_t>(vertexCount) * 4u;
+                std::memcpy(img.scanLine(y), src, static_cast<size_t>(vertexCount) * 4u);
+            }
+            if (!img.save(result.nrmTexPath, "PNG")) {
+                result.error = QStringLiteral("failed to write normal texture: %1")
+                                   .arg(result.nrmTexPath);
+                return result;
+            }
+        } else {  // RGBA16
+            auto rgba = encodeNormalsRGBA16(normals, frameCount, vertexCount);
+            if (rgba.empty()) {
+                result.error = QStringLiteral("encodeNormalsRGBA16 produced empty buffer");
+                return result;
+            }
+            QImage img(vertexCount, frameCount, QImage::Format_RGBA64);
+            for (int y = 0; y < frameCount; ++y) {
+                const uint16_t* src = rgba.data() + static_cast<size_t>(y)
+                                                    * static_cast<size_t>(vertexCount) * 4u;
+                std::memcpy(img.scanLine(y), src, static_cast<size_t>(vertexCount) * 4u * sizeof(uint16_t));
+            }
+            if (!img.save(result.nrmTexPath, "PNG")) {
+                result.error = QStringLiteral("failed to write 16-bit normal texture: %1")
+                                   .arg(result.nrmTexPath);
+                return result;
+            }
+        }
     }
 
     // Sidecar.

--- a/src/VATBaker.h
+++ b/src/VATBaker.h
@@ -15,6 +15,7 @@ The MIT License
 
 #include <OgreVector.h>
 
+#include <cstdint>
 #include <vector>
 
 namespace Ogre { class Entity; }
@@ -48,10 +49,9 @@ class VATBaker
 {
 public:
     enum class Encoding {
-        RGBA8 = 0,  ///< 8-bit per channel, normalised against bounds.
-        // Reserved for slice 2:
-        // RGBA16,
-        // RGBAF,
+        RGBA8  = 0,  ///< 8-bit per channel, normalised against bounds.   ~3 mm error on 1 m model.
+        RGBA16 = 1,  ///< 16-bit per channel, normalised against bounds. ~50× more precise than RGBA8.
+        // Reserved for follow-up: RGBAF (EXR via TinyEXR), pending vendor approval.
     };
 
     enum class Target {
@@ -69,6 +69,7 @@ public:
         double   endTime      = -1.0;     ///< < 0 → animation length.
         Encoding encoding     = Encoding::RGBA8;
         Target   target       = Target::Agnostic;
+        bool     bakeNormals  = false;    ///< Also emit `<basename>_nrm.png`.
         QString  outputDir;               ///< Required.
         QString  basename;                ///< Without extension. Defaults to animationName when empty.
     };
@@ -77,6 +78,7 @@ public:
         bool      ok = false;
         QString   error;            ///< Populated when !ok.
         QString   posTexPath;       ///< On-disk path to the position texture.
+        QString   nrmTexPath;       ///< On-disk path to the normal texture (empty when not requested).
         QString   jsonPath;         ///< On-disk path to the sidecar JSON.
         int       frameCount = 0;
         int       vertexCount = 0;
@@ -128,6 +130,51 @@ public:
         int vertexCount,
         const Ogre::Vector3& minBound,
         const Ogre::Vector3& maxBound);
+
+    /// 16-bit-per-channel variant. ~50× more precise than RGBA8 on
+    /// the same bounds (one ULP ≈ span/65535 vs span/255). Channel
+    /// order is the same; alpha is reserved at 65535.
+    static std::vector<uint16_t> encodeRGBA16(
+        const std::vector<Ogre::Vector3>& flatPositions,
+        int frameCount,
+        int vertexCount,
+        const Ogre::Vector3& minBound,
+        const Ogre::Vector3& maxBound);
+
+    /// Inverse of `encodeRGBA16`.
+    static std::vector<Ogre::Vector3> decodeRGBA16(
+        const std::vector<uint16_t>& pixels,
+        int frameCount,
+        int vertexCount,
+        const Ogre::Vector3& minBound,
+        const Ogre::Vector3& maxBound);
+
+    /// Encode unit normals (each component in [-1, 1]) into 8-bit
+    /// RGBA. Mapping: `(component + 1) * 0.5 → byte`. Alpha 255.
+    /// Same layout convention as positions.
+    static std::vector<unsigned char> encodeNormalsRGBA8(
+        const std::vector<Ogre::Vector3>& flatNormals,
+        int frameCount,
+        int vertexCount);
+
+    /// Decode normals back to unit vectors. Not re-normalised — the
+    /// caller can choose whether to renormalise.
+    static std::vector<Ogre::Vector3> decodeNormalsRGBA8(
+        const std::vector<unsigned char>& pixels,
+        int frameCount,
+        int vertexCount);
+
+    /// 16-bit-per-channel variant of `encodeNormalsRGBA8`.
+    static std::vector<uint16_t> encodeNormalsRGBA16(
+        const std::vector<Ogre::Vector3>& flatNormals,
+        int frameCount,
+        int vertexCount);
+
+    /// Inverse of `encodeNormalsRGBA16`.
+    static std::vector<Ogre::Vector3> decodeNormalsRGBA16(
+        const std::vector<uint16_t>& pixels,
+        int frameCount,
+        int vertexCount);
 
     /// Build the JSON sidecar string. Public so tests can snapshot it
     /// without writing to disk.

--- a/src/VATBaker_test.cpp
+++ b/src/VATBaker_test.cpp
@@ -285,3 +285,191 @@ TEST_F(VATBakerEndToEndTest, FrameCountDerivedFromFpsAndDuration) {
     EXPECT_GE(r.frameCount, 28);
     EXPECT_LE(r.frameCount, 32);
 }
+
+// ===========================================================================
+// Slice 2 — RGBA16 + normals + sidecar fields.
+// ===========================================================================
+
+TEST(VATBakerStandalone, EncodeRGBA16RoundTrip) {
+    // 16-bit channels: ~50× more precise than RGBA8 on the same bounds.
+    const Ogre::Vector3 lo(-10.0f, -10.0f, -10.0f);
+    const Ogre::Vector3 hi( 10.0f,  10.0f,  10.0f);
+    std::vector<Ogre::Vector3> flat = {
+        { -10.0f, -10.0f, -10.0f },
+        {  10.0f,  10.0f,  10.0f },
+        {  0.0f,   0.0f,   0.0f  },
+        {  3.14159f, -2.71828f, 1.41421f },
+    };
+    auto rgba = VATBaker::encodeRGBA16(flat, 2, 2, lo, hi);
+    ASSERT_EQ(rgba.size(), 2u * 2u * 4u);
+    // Alpha reserved at 65535.
+    for (size_t i = 3; i < rgba.size(); i += 4) {
+        EXPECT_EQ(rgba[i], 65535);
+    }
+    auto round = VATBaker::decodeRGBA16(rgba, 2, 2, lo, hi);
+    ASSERT_EQ(round.size(), flat.size());
+    // One ULP at span=20 over 65535 levels ≈ 3e-4. Test loosely at 1e-3.
+    constexpr float kRGBA16Err = 1e-3f;
+    for (size_t i = 0; i < flat.size(); ++i) {
+        EXPECT_NEAR(round[i].x, flat[i].x, kRGBA16Err);
+        EXPECT_NEAR(round[i].y, flat[i].y, kRGBA16Err);
+        EXPECT_NEAR(round[i].z, flat[i].z, kRGBA16Err);
+    }
+}
+
+TEST(VATBakerStandalone, EncodeRGBA16BeatsRGBA8OnSamePoints) {
+    // The whole point of slice 2: 16-bit encoding should produce
+    // substantially smaller round-trip error than the 8-bit path.
+    const Ogre::Vector3 lo(-100.0f, -100.0f, -100.0f);
+    const Ogre::Vector3 hi( 100.0f,  100.0f,  100.0f);
+    std::vector<Ogre::Vector3> flat = {
+        { 0.0f, 0.0f, 0.0f },
+        { 12.345f, -67.89f, 42.42f },
+        { -99.9f, 0.0001f, 50.0f },
+    };
+    auto rgba8  = VATBaker::encodeRGBA8(flat, 1, 3, lo, hi);
+    auto rgba16 = VATBaker::encodeRGBA16(flat, 1, 3, lo, hi);
+    auto back8  = VATBaker::decodeRGBA8(rgba8,  1, 3, lo, hi);
+    auto back16 = VATBaker::decodeRGBA16(rgba16, 1, 3, lo, hi);
+    float worst8 = 0.0f, worst16 = 0.0f;
+    for (size_t i = 0; i < flat.size(); ++i) {
+        worst8  = std::max(worst8,  (back8[i]  - flat[i]).length());
+        worst16 = std::max(worst16, (back16[i] - flat[i]).length());
+    }
+    EXPECT_LT(worst16 * 10.0f, worst8)
+        << "RGBA16 should be >10× more accurate than RGBA8 (16=" << worst16
+        << " vs 8=" << worst8 << ")";
+}
+
+TEST(VATBakerStandalone, EncodeNormalsRGBA8RoundTrip) {
+    // Standard basis vectors round-trip cleanly within ~1/255 (no
+    // normalisation needed, just channel mapping).
+    std::vector<Ogre::Vector3> normals = {
+        Ogre::Vector3::UNIT_X,
+        Ogre::Vector3::UNIT_Y,
+        Ogre::Vector3::UNIT_Z,
+        -Ogre::Vector3::UNIT_X,
+        Ogre::Vector3::ZERO,
+    };
+    auto rgba = VATBaker::encodeNormalsRGBA8(normals, 1, 5);
+    ASSERT_EQ(rgba.size(), 5u * 4u);
+    auto round = VATBaker::decodeNormalsRGBA8(rgba, 1, 5);
+    ASSERT_EQ(round.size(), normals.size());
+    constexpr float kErr = 2.0f / 255.0f;  // 2 ULP at signed remap
+    for (size_t i = 0; i < normals.size(); ++i) {
+        EXPECT_NEAR(round[i].x, normals[i].x, kErr);
+        EXPECT_NEAR(round[i].y, normals[i].y, kErr);
+        EXPECT_NEAR(round[i].z, normals[i].z, kErr);
+    }
+}
+
+TEST(VATBakerStandalone, EncodeNormalsRGBA8ClampsOutOfRange) {
+    std::vector<Ogre::Vector3> normals = {
+        { -2.0f, 2.0f, 0.0f },  // out of [-1, 1]
+    };
+    auto rgba = VATBaker::encodeNormalsRGBA8(normals, 1, 1);
+    ASSERT_EQ(rgba.size(), 4u);
+    EXPECT_EQ(rgba[0], 0);    // -2 → -1 → 0
+    EXPECT_EQ(rgba[1], 255);  //  2 →  1 → 255
+}
+
+TEST(VATBakerStandalone, EncodeNormalsRGBA16RoundTrip) {
+    std::vector<Ogre::Vector3> normals = {
+        { 0.123456f, -0.789012f, 0.345678f },
+        Ogre::Vector3::UNIT_Y,
+    };
+    auto rgba = VATBaker::encodeNormalsRGBA16(normals, 1, 2);
+    ASSERT_EQ(rgba.size(), 2u * 4u);
+    auto round = VATBaker::decodeNormalsRGBA16(rgba, 1, 2);
+    constexpr float kErr = 2.0f / 65535.0f;
+    for (size_t i = 0; i < normals.size(); ++i) {
+        EXPECT_NEAR(round[i].x, normals[i].x, kErr);
+        EXPECT_NEAR(round[i].y, normals[i].y, kErr);
+        EXPECT_NEAR(round[i].z, normals[i].z, kErr);
+    }
+}
+
+TEST(VATBakerStandalone, EncodeNormalsReturnsEmptyOnMismatchedSize) {
+    std::vector<Ogre::Vector3> normals = { Ogre::Vector3::UNIT_X };
+    EXPECT_TRUE(VATBaker::encodeNormalsRGBA8(normals, 2, 2).empty());
+    EXPECT_TRUE(VATBaker::encodeNormalsRGBA16(normals, 2, 2).empty());
+    EXPECT_TRUE(VATBaker::decodeNormalsRGBA8({}, 1, 1).empty());
+    EXPECT_TRUE(VATBaker::decodeNormalsRGBA16({}, 1, 1).empty());
+}
+
+TEST(VATBakerStandalone, SidecarMentionsEncodingAndOptionalNrmTexture) {
+    VATBaker::BakeResult r;
+    r.frameCount  = 10;
+    r.vertexCount = 100;
+    r.posTexPath  = QStringLiteral("/tmp/Walk_pos.png");
+
+    VATBaker::Options opts;
+    opts.animationName = QStringLiteral("Walk");
+    opts.fps           = 60.0;
+    opts.encoding      = VATBaker::Encoding::RGBA16;
+
+    // Without normals — sidecar should NOT include nrmTexture.
+    QString json = VATBaker::buildSidecarJson(r, opts);
+    auto root = QJsonDocument::fromJson(json.toUtf8()).object();
+    EXPECT_EQ(root["encoding"].toString(), QStringLiteral("rgba16"));
+    EXPECT_FALSE(root.contains(QStringLiteral("nrmTexture")));
+
+    // With normals — sidecar should include the filename (not the abs path).
+    r.nrmTexPath = QStringLiteral("/tmp/Walk_nrm.png");
+    json = VATBaker::buildSidecarJson(r, opts);
+    root = QJsonDocument::fromJson(json.toUtf8()).object();
+    EXPECT_EQ(root["nrmTexture"].toString(), QStringLiteral("Walk_nrm.png"));
+}
+
+TEST_F(VATBakerEndToEndTest, BakeWithRGBA16WritesSixteenBitPng) {
+    auto* entity = createAnimatedTestEntity("VAT_E2E_RGBA16");
+    ASSERT_NE(entity, nullptr);
+
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+
+    VATBaker::Options opts;
+    opts.animationName = QStringLiteral("TestAnim");
+    opts.fps = 10.0;
+    opts.outputDir = tmp.path();
+    opts.basename = QStringLiteral("R16");
+    opts.encoding = VATBaker::Encoding::RGBA16;
+
+    auto r = VATBaker::bake(entity, opts);
+    ASSERT_TRUE(r.ok) << r.error.toStdString();
+    QImage png(r.posTexPath);
+    ASSERT_FALSE(png.isNull());
+    // Qt promotes a 16-bit PNG to RGBA64; the format check is the
+    // closest the standard API gets to "this PNG is 16-bit per channel".
+    EXPECT_EQ(png.format(), QImage::Format_RGBA64);
+}
+
+TEST_F(VATBakerEndToEndTest, BakeWithNormalsWritesNormalTexture) {
+    auto* entity = createAnimatedTestEntity("VAT_E2E_Normals");
+    ASSERT_NE(entity, nullptr);
+
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+
+    VATBaker::Options opts;
+    opts.animationName = QStringLiteral("TestAnim");
+    opts.fps = 10.0;
+    opts.outputDir = tmp.path();
+    opts.basename = QStringLiteral("N");
+    opts.bakeNormals = true;
+
+    auto r = VATBaker::bake(entity, opts);
+    ASSERT_TRUE(r.ok) << r.error.toStdString();
+    ASSERT_FALSE(r.nrmTexPath.isEmpty());
+    EXPECT_TRUE(QFile::exists(r.nrmTexPath));
+    QImage png(r.nrmTexPath);
+    ASSERT_FALSE(png.isNull());
+    EXPECT_EQ(png.width(),  r.vertexCount);
+    EXPECT_EQ(png.height(), r.frameCount);
+
+    // Sidecar should reference both textures.
+    QFile jf(r.jsonPath);
+    ASSERT_TRUE(jf.open(QIODevice::ReadOnly));
+    auto root = QJsonDocument::fromJson(jf.readAll()).object();
+    EXPECT_TRUE(root.contains(QStringLiteral("nrmTexture")));
+}


### PR DESCRIPTION
Closes more of #371. Slice 2 of 4. EXR (`Encoding::RGBAF`) is deferred — vendoring TinyEXR needs explicit authorization, so it'll come in its own follow-up PR.

## What ships in slice 2
- **`Encoding::RGBA16`** — 16-bit per channel, written as a Qt `Format_RGBA64` PNG. Same channel layout as RGBA8, alpha reserved at 65535. Round-trip error drops from ~3 mm (RGBA8 over ±1 m bounds) to ~50 µm.
- **`Options::bakeNormals`** — when true, samples post-skin normals via `VES_NORMAL` and writes `<basename>_nrm.png` next to the position texture. Same row-per-frame layout. Normals are mapped from [-1, 1] → [0, MAX] per channel; the unpacker just runs the inverse map (no re-normalisation, leaves that choice to the runtime shader).
- **Sidecar additions** — `encoding` field reflects the chosen encoding; `nrmTexture` filename appears when normals were baked.
- **CLI flags** — `--encoding rgba8|rgba16` (default `rgba8`) and `--normals`.

## 9 new tests
- RGBA16 round-trip at 1e-3 tolerance
- RGBA16 must be >10× more accurate than RGBA8 on the same inputs (quantitative)
- Normals (RGBA8 / RGBA16) round-trip within their ULP bounds
- Out-of-[-1,1] normals clamp rather than wrap
- Defensive sizing
- Sidecar snapshot (encoding string + optional nrmTexture key)
- E2E: RGBA16 PNG comes back as `QImage::Format_RGBA64`
- E2E: normal texture exists and is referenced in the sidecar

## Manual smoke
\`\`\`
$ ./build_local/bin/qtmesh vat media/models/robot.mesh \\
    --anim Idle --fps 20 --encoding rgba16 --normals -o /tmp/vat
Baked VAT for 'Idle' (57 frames × 295 vertices, rgba16)
  position texture: /tmp/vat/Idle_pos.png
  normal texture:   /tmp/vat/Idle_nrm.png
  sidecar:          /tmp/vat/Idle.json
\`\`\`

## Test plan
- [ ] CI Linux/Xvfb: all `VATBakerStandalone.*` and `VATBakerEndToEndTest.*` pass (10 → 19 tests).
- [ ] CI macOS/Windows: build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--encoding` option to select output texture format (RGBA8 or RGBA16)
  * Added `--normals` flag to enable normal texture generation
  * Output reporting now includes selected encoding and generated normal texture paths

* **Tests**
  * Added comprehensive validation tests for encoding/decoding functionality and normal texture generation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/566?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->