### PR TITLE
feat(vat): slice 3 — Unity / Unreal / Godot targets + sidecars

### DIFF
--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -4782,7 +4782,11 @@ int CLIPipeline::cmdVat(int argc, char* argv[])
             }
             continue;
         }
-        if (arg == "--target" && i + 1 < argc) {
+        if (arg == "--target") {
+            if (i + 1 >= argc) {
+                err() << "Error: --target requires a value (agnostic|unity|unreal|godot)" << Qt::endl;
+                return 2;
+            }
             const QString tgt = QString(argv[++i]).toLower();
             if      (tgt == "agnostic") target = VATBaker::Target::Agnostic;
             else if (tgt == "unity")    target = VATBaker::Target::Unity;

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -4758,12 +4758,14 @@ int CLIPipeline::cmdBakeVertexColors(int argc, char* argv[])
 int CLIPipeline::cmdVat(int argc, char* argv[])
 {
     // Parse: vat <file> --anim <name> [--fps N] [--encoding rgba8|rgba16]
+    //                                 [--target agnostic|unity|unreal|godot]
     //                                 [--normals] [-o <dir>] [--json]
     QString filePath, animName, outDir;
     double fps = 30.0;
     bool jsonOutput = false;
     bool bakeNormals = false;
     VATBaker::Encoding encoding = VATBaker::Encoding::RGBA8;
+    VATBaker::Target target = VATBaker::Target::Agnostic;
 
     for (int i = 1; i < argc; ++i) {
         QString arg(argv[i]);
@@ -4776,6 +4778,18 @@ int CLIPipeline::cmdVat(int argc, char* argv[])
             else if (enc == "rgba16") encoding = VATBaker::Encoding::RGBA16;
             else {
                 err() << "Error: --encoding must be one of: rgba8, rgba16" << Qt::endl;
+                return 2;
+            }
+            continue;
+        }
+        if (arg == "--target" && i + 1 < argc) {
+            const QString tgt = QString(argv[++i]).toLower();
+            if      (tgt == "agnostic") target = VATBaker::Target::Agnostic;
+            else if (tgt == "unity")    target = VATBaker::Target::Unity;
+            else if (tgt == "unreal")   target = VATBaker::Target::Unreal;
+            else if (tgt == "godot")    target = VATBaker::Target::Godot;
+            else {
+                err() << "Error: --target must be one of: agnostic, unity, unreal, godot" << Qt::endl;
                 return 2;
             }
             continue;
@@ -4802,7 +4816,7 @@ int CLIPipeline::cmdVat(int argc, char* argv[])
 
     if (filePath.isEmpty()) {
         err() << "Error: No input file specified." << Qt::endl;
-        err() << "Usage: qtmesh vat <file> --anim <name> [--fps N] [--encoding rgba8|rgba16] [--normals] [-o <dir>] [--json]" << Qt::endl;
+        err() << "Usage: qtmesh vat <file> --anim <name> [--fps N] [--encoding rgba8|rgba16] [--target agnostic|unity|unreal|godot] [--normals] [-o <dir>] [--json]" << Qt::endl;
         return 2;
     }
     if (animName.isEmpty()) {
@@ -4856,11 +4870,19 @@ int CLIPipeline::cmdVat(int argc, char* argv[])
     opts.basename = animName;
     opts.encoding = encoding;
     opts.bakeNormals = bakeNormals;
+    opts.target = target;
+
+    const QString targetStr =
+        (target == VATBaker::Target::Unity)  ? QStringLiteral("unity")  :
+        (target == VATBaker::Target::Unreal) ? QStringLiteral("unreal") :
+        (target == VATBaker::Target::Godot)  ? QStringLiteral("godot")  :
+                                               QStringLiteral("agnostic");
 
     SentryReporter::addBreadcrumb("file.export",
-        QString("Writing VAT outputs to %1 (anim=%2, encoding=%3%4)")
+        QString("Writing VAT outputs to %1 (anim=%2, encoding=%3, target=%4%5)")
             .arg(QDir(outDir).absolutePath(), animName,
                  (encoding == VATBaker::Encoding::RGBA16) ? "rgba16" : "rgba8",
+                 targetStr,
                  bakeNormals ? ", normals" : ""));
     VATBaker::BakeResult result = VATBaker::bake(entity, opts);
     if (!result.ok) {
@@ -4881,11 +4903,16 @@ int CLIPipeline::cmdVat(int argc, char* argv[])
         if (!result.nrmTexPath.isEmpty())
             obj["nrmTexture"] = result.nrmTexPath;
         obj["sidecar"]     = result.jsonPath;
+        if (!result.unityMetaPath.isEmpty())
+            obj["unityMeta"] = result.unityMetaPath;
+        if (!result.godotShaderPath.isEmpty())
+            obj["godotShader"] = result.godotShaderPath;
         obj["frameCount"]  = result.frameCount;
         obj["vertexCount"] = result.vertexCount;
         obj["animation"]   = animName;
         obj["fps"]         = fps;
         obj["encoding"]    = encStr;
+        obj["target"]      = targetStr;
         QJsonObject bounds;
         QJsonObject lo, hi;
         lo["x"] = result.minBound.x; lo["y"] = result.minBound.y; lo["z"] = result.minBound.z;
@@ -4894,12 +4921,17 @@ int CLIPipeline::cmdVat(int argc, char* argv[])
         obj["bounds"] = bounds;
         cliWrite(QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Indented)));
     } else {
-        cliWrite(QStringLiteral("Baked VAT for '%1' (%2 frames × %3 vertices, %4)\n")
-                     .arg(animName).arg(result.frameCount).arg(result.vertexCount).arg(encStr));
+        cliWrite(QStringLiteral("Baked VAT for '%1' (%2 frames × %3 vertices, %4, target=%5)\n")
+                     .arg(animName).arg(result.frameCount).arg(result.vertexCount)
+                     .arg(encStr, targetStr));
         cliWrite(QStringLiteral("  position texture: %1\n").arg(result.posTexPath));
         if (!result.nrmTexPath.isEmpty())
             cliWrite(QStringLiteral("  normal texture:   %1\n").arg(result.nrmTexPath));
         cliWrite(QStringLiteral("  sidecar:          %1\n").arg(result.jsonPath));
+        if (!result.unityMetaPath.isEmpty())
+            cliWrite(QStringLiteral("  unity .meta:      %1\n").arg(result.unityMetaPath));
+        if (!result.godotShaderPath.isEmpty())
+            cliWrite(QStringLiteral("  godot .gdshader:  %1\n").arg(result.godotShaderPath));
         cliWrite(QStringLiteral("  bounds: min=(%1, %2, %3) max=(%4, %5, %6)\n")
                      .arg(result.minBound.x, 0, 'f', 3)
                      .arg(result.minBound.y, 0, 'f', 3)

--- a/src/VATBaker.cpp
+++ b/src/VATBaker.cpp
@@ -16,6 +16,7 @@ The MIT License
 #include <QImage>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QUuid>
 
 #include <cstring>
 
@@ -452,6 +453,10 @@ inline bool targetFlipsRowsAtWriteTime(VATBaker::Target t)
 // Minimal Unity `.meta` sidecar. Hand-written rather than full Unity
 // YAML — Unity's importer is happy with the standard texture-asset
 // shape and rejects unknown keys silently. The values matter:
+//   - `guid` must be a unique 32-char hex string. Sharing a GUID
+//     between assets causes Unity to silently remap references at
+//     import time or refuse to import the duplicate altogether.
+//     We generate a fresh random GUID per bake.
 //   - `sRGBTexture: 0`  → data texture, no gamma curve.
 //   - `textureCompression: 0`  → uncompressed, lossless.
 //   - `filterMode: 0`  → point/nearest, no bilinear smearing
@@ -459,16 +464,21 @@ inline bool targetFlipsRowsAtWriteTime(VATBaker::Target t)
 //   - `wrapU: 1` / `wrapV: 1`  → clamp, so OOB UVs don't wrap.
 QString buildUnityMeta()
 {
+    // QUuid::toString returns `{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}`;
+    // strip the braces and dashes to land on Unity's 32-hex-char shape.
+    const QString guid = QUuid::createUuid()
+                             .toString(QUuid::WithoutBraces)
+                             .remove(QChar('-'));
     return QStringLiteral(
         "fileFormatVersion: 2\n"
-        "guid: 00000000000000000000000000000000\n"
+        "guid: %1\n"
         "TextureImporter:\n"
         "  serializedVersion: 11\n"
         "  sRGBTexture: 0\n"
         "  textureCompression: 0\n"
         "  filterMode: 0\n"
         "  wrapU: 1\n"
-        "  wrapV: 1\n");
+        "  wrapV: 1\n").arg(guid);
 }
 
 // Minimal Godot 4 spatial shader that samples the position texture

--- a/src/VATBaker.cpp
+++ b/src/VATBaker.cpp
@@ -385,10 +385,17 @@ QString VATBaker::buildSidecarJson(const BakeResult& result, const Options& opts
         case Encoding::RGBA8:  encStr = QStringLiteral("rgba8");  break;
         case Encoding::RGBA16: encStr = QStringLiteral("rgba16"); break;
     }
+    QString tgtStr;
+    switch (opts.target) {
+        case Target::Agnostic: tgtStr = QStringLiteral("agnostic"); break;
+        case Target::Unity:    tgtStr = QStringLiteral("unity");    break;
+        case Target::Unreal:   tgtStr = QStringLiteral("unreal");   break;
+        case Target::Godot:    tgtStr = QStringLiteral("godot");    break;
+    }
 
     QJsonObject root;
     root["version"]     = 1;
-    root["target"]      = "agnostic";
+    root["target"]      = tgtStr;
     root["encoding"]    = encStr;
     root["frameCount"]  = result.frameCount;
     root["vertexCount"] = result.vertexCount;
@@ -402,6 +409,100 @@ QString VATBaker::buildSidecarJson(const BakeResult& result, const Options& opts
     QJsonDocument doc(root);
     return QString::fromUtf8(doc.toJson(QJsonDocument::Indented));
 }
+
+// ---------------------------------------------------------------------------
+// Per-target conventions.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Apply per-engine axis swizzle to a single position vector. Sampling
+// happens in Ogre space (Y-up, right-handed); the resulting texture
+// has to be readable by the target engine without runtime fix-ups, so
+// the swizzle happens once at encode time and is documented in the
+// sidecar.
+//
+// - Agnostic / Unity / Godot — no swizzle. All three are Y-up + right-
+//   handed (Unity is Y-up; Godot is Y-up; agnostic is whatever the
+//   downstream tooling expects). Unity's vertical-flip is handled by
+//   reversing the row order, not the axes.
+// - Unreal — Z-up + left-handed. Standard Ogre→Unreal remap is
+//   `(x, y, z) → (x, z, y)` (swap Y/Z to lift "up" onto Z). Unreal
+//   handles its own LH chirality in the importer.
+inline Ogre::Vector3 swizzleForTarget(VATBaker::Target t, const Ogre::Vector3& v)
+{
+    switch (t) {
+        case VATBaker::Target::Unreal: return { v.x, v.z, v.y };
+        default:                       return v;
+    }
+}
+
+// Unity's PNG loader treats row 0 as the top of the image, whereas
+// the VAT layout has frame 0 at the top already — but Unity's auto-
+// generated UV convention then flips V again at sample time. The
+// net effect is that *for Unity*, the runtime shader would have to
+// compute `frameIndex` as `frameCount - 1 - row` if we wrote frames
+// top-down. Pre-flip the rows here so the shader can use the plain
+// `row / frameCount` indexing on every target.
+inline bool targetFlipsRowsAtWriteTime(VATBaker::Target t)
+{
+    return t == VATBaker::Target::Unity;
+}
+
+// Minimal Unity `.meta` sidecar. Hand-written rather than full Unity
+// YAML — Unity's importer is happy with the standard texture-asset
+// shape and rejects unknown keys silently. The values matter:
+//   - `sRGBTexture: 0`  → data texture, no gamma curve.
+//   - `textureCompression: 0`  → uncompressed, lossless.
+//   - `filterMode: 0`  → point/nearest, no bilinear smearing
+//     between vertex columns.
+//   - `wrapU: 1` / `wrapV: 1`  → clamp, so OOB UVs don't wrap.
+QString buildUnityMeta()
+{
+    return QStringLiteral(
+        "fileFormatVersion: 2\n"
+        "guid: 00000000000000000000000000000000\n"
+        "TextureImporter:\n"
+        "  serializedVersion: 11\n"
+        "  sRGBTexture: 0\n"
+        "  textureCompression: 0\n"
+        "  filterMode: 0\n"
+        "  wrapU: 1\n"
+        "  wrapV: 1\n");
+}
+
+// Minimal Godot 4 spatial shader that samples the position texture
+// and applies the per-vertex offset. Users typically copy this into
+// a Material on a MeshInstance3D. Bounds + frame count are encoded
+// as uniform defaults pulled from the sidecar at bake time.
+QString buildGodotShader(int frameCount,
+                         int vertexCount,
+                         const Ogre::Vector3& lo,
+                         const Ogre::Vector3& hi)
+{
+    return QStringLiteral(
+        "shader_type spatial;\n"
+        "render_mode unshaded;\n"
+        "\n"
+        "uniform sampler2D pos_tex : filter_nearest;\n"
+        "uniform float current_frame = 0.0;\n"
+        "uniform int frame_count = %1;\n"
+        "uniform int vertex_count = %2;\n"
+        "uniform vec3 bounds_min = vec3(%3, %4, %5);\n"
+        "uniform vec3 bounds_max = vec3(%6, %7, %8);\n"
+        "\n"
+        "void vertex() {\n"
+        "    float u = (float(VERTEX_ID) + 0.5) / float(vertex_count);\n"
+        "    float v = (current_frame + 0.5) / float(frame_count);\n"
+        "    vec3 t = texture(pos_tex, vec2(u, v)).rgb;\n"
+        "    VERTEX = bounds_min + t * (bounds_max - bounds_min);\n"
+        "}\n")
+        .arg(frameCount).arg(vertexCount)
+        .arg(lo.x, 0, 'f', 6).arg(lo.y, 0, 'f', 6).arg(lo.z, 0, 'f', 6)
+        .arg(hi.x, 0, 'f', 6).arg(hi.y, 0, 'f', 6).arg(hi.z, 0, 'f', 6);
+}
+
+} // namespace
 
 // ---------------------------------------------------------------------------
 // bake()
@@ -500,13 +601,19 @@ VATBaker::BakeResult VATBaker::bake(Ogre::Entity* entity, const Options& opts)
             return result;
         }
 
+        // Apply per-target axis swizzle in-place on the just-appended
+        // positions so the bounds computed below match the encoded
+        // space. (Cheaper than walking the buffer twice — and keeps
+        // the bounds → encoder → decoder chain consistent.)
         for (size_t i = before; i < flat.size(); ++i) {
+            flat[i] = swizzleForTarget(opts.target, flat[i]);
             const auto& p = flat[i];
             lo.x = std::min(lo.x, p.x); lo.y = std::min(lo.y, p.y); lo.z = std::min(lo.z, p.z);
             hi.x = std::max(hi.x, p.x); hi.y = std::max(hi.y, p.y); hi.z = std::max(hi.z, p.z);
         }
 
         if (opts.bakeNormals) {
+            const size_t nrmBefore = normals.size();
             const size_t nrmAppended = collectPostSkinNormals(entity, normals);
             if (nrmAppended == kCollectNormalsMissingSentinel) {
                 entity->removeSoftwareAnimationRequest(true);
@@ -523,6 +630,13 @@ VATBaker::BakeResult VATBaker::bake(Ogre::Entity* entity, const Options& opts)
                     "frame %1 normals count (%2) differs from positions (%3)")
                         .arg(f).arg(nrmAppended).arg(frameVerts);
                 return result;
+            }
+            // Apply the same axis swizzle to normals — they live in
+            // the same coordinate frame as positions. (Direction
+            // vectors don't have a separate translation component, so
+            // the swizzle is exactly the same operation.)
+            for (size_t i = nrmBefore; i < normals.size(); ++i) {
+                normals[i] = swizzleForTarget(opts.target, normals[i]);
             }
         }
     }
@@ -548,6 +662,8 @@ VATBaker::BakeResult VATBaker::bake(Ogre::Entity* entity, const Options& opts)
     result.posTexPath = QDir(opts.outputDir).filePath(base + "_pos.png");
     result.jsonPath   = QDir(opts.outputDir).filePath(base + ".json");
 
+    const bool flipRows = targetFlipsRowsAtWriteTime(opts.target);
+
     // Encode + write the position texture. PNG preserves both 8-bit
     // and 16-bit channel depths; QImage handles the format switch for us.
     if (opts.encoding == Encoding::RGBA8) {
@@ -558,7 +674,8 @@ VATBaker::BakeResult VATBaker::bake(Ogre::Entity* entity, const Options& opts)
         }
         QImage img(vertexCount, frameCount, QImage::Format_RGBA8888);
         for (int y = 0; y < frameCount; ++y) {
-            const unsigned char* src = rgba.data() + static_cast<size_t>(y)
+            const int srcRow = flipRows ? (frameCount - 1 - y) : y;
+            const unsigned char* src = rgba.data() + static_cast<size_t>(srcRow)
                                                       * static_cast<size_t>(vertexCount) * 4u;
             std::memcpy(img.scanLine(y), src, static_cast<size_t>(vertexCount) * 4u);
         }
@@ -577,7 +694,8 @@ VATBaker::BakeResult VATBaker::bake(Ogre::Entity* entity, const Options& opts)
         // a 16-bit PNG which Godot/Unity/Unreal all read losslessly.
         QImage img(vertexCount, frameCount, QImage::Format_RGBA64);
         for (int y = 0; y < frameCount; ++y) {
-            const uint16_t* src = rgba.data() + static_cast<size_t>(y)
+            const int srcRow = flipRows ? (frameCount - 1 - y) : y;
+            const uint16_t* src = rgba.data() + static_cast<size_t>(srcRow)
                                                 * static_cast<size_t>(vertexCount) * 4u;
             std::memcpy(img.scanLine(y), src, static_cast<size_t>(vertexCount) * 4u * sizeof(uint16_t));
         }
@@ -600,7 +718,8 @@ VATBaker::BakeResult VATBaker::bake(Ogre::Entity* entity, const Options& opts)
             }
             QImage img(vertexCount, frameCount, QImage::Format_RGBA8888);
             for (int y = 0; y < frameCount; ++y) {
-                const unsigned char* src = rgba.data() + static_cast<size_t>(y)
+                const int srcRow = flipRows ? (frameCount - 1 - y) : y;
+                const unsigned char* src = rgba.data() + static_cast<size_t>(srcRow)
                                                           * static_cast<size_t>(vertexCount) * 4u;
                 std::memcpy(img.scanLine(y), src, static_cast<size_t>(vertexCount) * 4u);
             }
@@ -617,7 +736,8 @@ VATBaker::BakeResult VATBaker::bake(Ogre::Entity* entity, const Options& opts)
             }
             QImage img(vertexCount, frameCount, QImage::Format_RGBA64);
             for (int y = 0; y < frameCount; ++y) {
-                const uint16_t* src = rgba.data() + static_cast<size_t>(y)
+                const int srcRow = flipRows ? (frameCount - 1 - y) : y;
+                const uint16_t* src = rgba.data() + static_cast<size_t>(srcRow)
                                                     * static_cast<size_t>(vertexCount) * 4u;
                 std::memcpy(img.scanLine(y), src, static_cast<size_t>(vertexCount) * 4u * sizeof(uint16_t));
             }
@@ -639,6 +759,33 @@ VATBaker::BakeResult VATBaker::bake(Ogre::Entity* entity, const Options& opts)
     }
     jf.write(sidecar.toUtf8());
     jf.close();
+
+    // Per-engine extras — emitted alongside the JSON sidecar so a
+    // dropped-in asset folder is engine-ready without further tooling.
+    if (opts.target == Target::Unity) {
+        result.unityMetaPath = result.posTexPath + QStringLiteral(".meta");
+        QFile mf(result.unityMetaPath);
+        if (!mf.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+            result.error = QStringLiteral("failed to open .meta for write: %1")
+                               .arg(result.unityMetaPath);
+            return result;
+        }
+        mf.write(buildUnityMeta().toUtf8());
+        mf.close();
+    } else if (opts.target == Target::Godot) {
+        result.godotShaderPath = QDir(opts.outputDir).filePath(base + ".gdshader");
+        QFile sf(result.godotShaderPath);
+        if (!sf.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+            result.error = QStringLiteral("failed to open .gdshader for write: %1")
+                               .arg(result.godotShaderPath);
+            return result;
+        }
+        sf.write(buildGodotShader(frameCount, vertexCount, lo, hi).toUtf8());
+        sf.close();
+    }
+    // Target::Unreal — no extra sidecar; users wire the texture into a
+    // Niagara VAT module which references it by name. Documenting in
+    // future slice 4 (Inspector) which sidecar to expect.
 
     result.ok = true;
     return result;

--- a/src/VATBaker.h
+++ b/src/VATBaker.h
@@ -55,11 +55,10 @@ public:
     };
 
     enum class Target {
-        Agnostic = 0,
-        // Reserved for slice 3:
-        // Unity,
-        // Unreal,
-        // Godot,
+        Agnostic = 0,  ///< No axis swizzle, no per-engine sidecar.
+        Unity    = 1,  ///< Y-up (same as Ogre); UV-V flipped (Unity convention). Emits `.png.meta`.
+        Unreal   = 2,  ///< Z-up axis remap (x, z, y); Niagara-style U=vertex / V=frame.
+        Godot    = 3,  ///< Y-up + right-handed (same as Ogre). Emits a `.gdshader` snippet.
     };
 
     struct Options {
@@ -80,6 +79,8 @@ public:
         QString   posTexPath;       ///< On-disk path to the position texture.
         QString   nrmTexPath;       ///< On-disk path to the normal texture (empty when not requested).
         QString   jsonPath;         ///< On-disk path to the sidecar JSON.
+        QString   unityMetaPath;    ///< `.meta` sidecar, only when target=Unity.
+        QString   godotShaderPath;  ///< `.gdshader` snippet, only when target=Godot.
         int       frameCount = 0;
         int       vertexCount = 0;
         Ogre::Vector3 minBound = Ogre::Vector3::ZERO;

--- a/src/VATBaker_test.cpp
+++ b/src/VATBaker_test.cpp
@@ -473,3 +473,165 @@ TEST_F(VATBakerEndToEndTest, BakeWithNormalsWritesNormalTexture) {
     auto root = QJsonDocument::fromJson(jf.readAll()).object();
     EXPECT_TRUE(root.contains(QStringLiteral("nrmTexture")));
 }
+
+// ===========================================================================
+// Slice 3 — per-engine targets.
+// ===========================================================================
+
+TEST(VATBakerStandalone, SidecarTargetFieldReflectsOption) {
+    // Sidecar should encode the target name so the runtime shader and
+    // any asset-pipeline tooling knows the convention the bake used.
+    VATBaker::BakeResult r;
+    r.frameCount = 10; r.vertexCount = 100;
+    r.posTexPath = QStringLiteral("/tmp/Walk_pos.png");
+
+    VATBaker::Options opts;
+    opts.animationName = QStringLiteral("Walk");
+    opts.fps = 30.0;
+
+    for (auto [t, want] : std::initializer_list<std::pair<VATBaker::Target, QString>>{
+            {VATBaker::Target::Agnostic, QStringLiteral("agnostic")},
+            {VATBaker::Target::Unity,    QStringLiteral("unity")},
+            {VATBaker::Target::Unreal,   QStringLiteral("unreal")},
+            {VATBaker::Target::Godot,    QStringLiteral("godot")}}) {
+        opts.target = t;
+        const QString json = VATBaker::buildSidecarJson(r, opts);
+        auto root = QJsonDocument::fromJson(json.toUtf8()).object();
+        EXPECT_EQ(root["target"].toString(), want)
+            << "target enum " << static_cast<int>(t) << " should serialise as '" << want.toStdString() << "'";
+    }
+}
+
+TEST_F(VATBakerEndToEndTest, UnityTargetWritesPngMetaSidecar) {
+    auto* entity = createAnimatedTestEntity("VAT_E2E_Unity");
+    ASSERT_NE(entity, nullptr);
+
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+
+    VATBaker::Options opts;
+    opts.animationName = QStringLiteral("TestAnim");
+    opts.fps = 10.0;
+    opts.outputDir = tmp.path();
+    opts.basename = QStringLiteral("U");
+    opts.target = VATBaker::Target::Unity;
+
+    auto r = VATBaker::bake(entity, opts);
+    ASSERT_TRUE(r.ok) << r.error.toStdString();
+    ASSERT_FALSE(r.unityMetaPath.isEmpty());
+    EXPECT_TRUE(QFile::exists(r.unityMetaPath));
+    // Quick sanity check on contents — Unity's importer treats the
+    // file as YAML; we wrote the standard texture-asset section.
+    QFile mf(r.unityMetaPath);
+    ASSERT_TRUE(mf.open(QIODevice::ReadOnly));
+    const QByteArray body = mf.readAll();
+    EXPECT_TRUE(body.contains("TextureImporter:"));
+    EXPECT_TRUE(body.contains("sRGBTexture: 0"));
+    EXPECT_TRUE(body.contains("filterMode: 0"));
+}
+
+TEST_F(VATBakerEndToEndTest, GodotTargetWritesShaderTemplate) {
+    auto* entity = createAnimatedTestEntity("VAT_E2E_Godot");
+    ASSERT_NE(entity, nullptr);
+
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+
+    VATBaker::Options opts;
+    opts.animationName = QStringLiteral("TestAnim");
+    opts.fps = 10.0;
+    opts.outputDir = tmp.path();
+    opts.basename = QStringLiteral("G");
+    opts.target = VATBaker::Target::Godot;
+
+    auto r = VATBaker::bake(entity, opts);
+    ASSERT_TRUE(r.ok) << r.error.toStdString();
+    ASSERT_FALSE(r.godotShaderPath.isEmpty());
+    EXPECT_TRUE(QFile::exists(r.godotShaderPath));
+    QFile sf(r.godotShaderPath);
+    ASSERT_TRUE(sf.open(QIODevice::ReadOnly));
+    const QByteArray body = sf.readAll();
+    // Spot-check the shader has the expected entry point + uniforms.
+    EXPECT_TRUE(body.contains("shader_type spatial"));
+    EXPECT_TRUE(body.contains("uniform sampler2D pos_tex"));
+    EXPECT_TRUE(body.contains("void vertex()"));
+    // Frame + vertex counts are template-substituted from the bake.
+    EXPECT_TRUE(body.contains("frame_count = "
+                              + QByteArray::number(r.frameCount)));
+    EXPECT_TRUE(body.contains("vertex_count = "
+                              + QByteArray::number(r.vertexCount)));
+}
+
+TEST_F(VATBakerEndToEndTest, UnrealTargetSwizzlesPositionsXZY) {
+    // Unreal target swaps Y/Z (Ogre Y-up → Unreal Z-up). The bake's
+    // bounds should reflect that the *output* space has Y/Z swapped
+    // versus the source mesh's local AABB. The animated test entity
+    // moves a vertex along X+ during the keyframe, so X is non-zero
+    // and Y/Z stay near zero in Ogre space — after the swap, Z
+    // should be > Y in the bounds extent.
+    auto* entity = createAnimatedTestEntity("VAT_E2E_Unreal");
+    ASSERT_NE(entity, nullptr);
+
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+
+    VATBaker::Options agnosticOpts;
+    agnosticOpts.animationName = QStringLiteral("TestAnim");
+    agnosticOpts.fps = 10.0;
+    agnosticOpts.outputDir = tmp.path();
+    agnosticOpts.basename = QStringLiteral("A");
+    auto agnostic = VATBaker::bake(entity, agnosticOpts);
+    ASSERT_TRUE(agnostic.ok) << agnostic.error.toStdString();
+
+    VATBaker::Options unrealOpts = agnosticOpts;
+    unrealOpts.basename = QStringLiteral("UE");
+    unrealOpts.target = VATBaker::Target::Unreal;
+    auto unreal = VATBaker::bake(entity, unrealOpts);
+    ASSERT_TRUE(unreal.ok) << unreal.error.toStdString();
+
+    // Y and Z bounds should swap between agnostic and unreal.
+    EXPECT_NEAR(unreal.minBound.x, agnostic.minBound.x, 1e-4);
+    EXPECT_NEAR(unreal.minBound.y, agnostic.minBound.z, 1e-4)
+        << "Unreal target should put Ogre.Z into output.Y";
+    EXPECT_NEAR(unreal.minBound.z, agnostic.minBound.y, 1e-4)
+        << "Unreal target should put Ogre.Y into output.Z";
+    EXPECT_NEAR(unreal.maxBound.y, agnostic.maxBound.z, 1e-4);
+    EXPECT_NEAR(unreal.maxBound.z, agnostic.maxBound.y, 1e-4);
+}
+
+TEST_F(VATBakerEndToEndTest, UnityRowsAreVerticallyFlipped) {
+    // Unity convention: pre-flip rows so the runtime shader uses
+    // plain `frameIndex / frameCount` indexing. Compare the agnostic
+    // and unity PNGs — row 0 of unity should equal row (frameCount-1)
+    // of agnostic.
+    auto* entity = createAnimatedTestEntity("VAT_E2E_UnityFlip");
+    ASSERT_NE(entity, nullptr);
+
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+
+    VATBaker::Options a; a.animationName = QStringLiteral("TestAnim");
+    a.fps = 10.0; a.outputDir = tmp.path(); a.basename = QStringLiteral("AG");
+    auto agnostic = VATBaker::bake(entity, a);
+    ASSERT_TRUE(agnostic.ok);
+
+    VATBaker::Options u = a;
+    u.basename = QStringLiteral("UNI");
+    u.target = VATBaker::Target::Unity;
+    auto unity = VATBaker::bake(entity, u);
+    ASSERT_TRUE(unity.ok);
+
+    QImage ag(agnostic.posTexPath);
+    QImage un(unity.posTexPath);
+    ASSERT_FALSE(ag.isNull());
+    ASSERT_FALSE(un.isNull());
+    ASSERT_EQ(ag.width(),  un.width());
+    ASSERT_EQ(ag.height(), un.height());
+
+    // Unity row 0 == agnostic last row.
+    const int lastRow = ag.height() - 1;
+    for (int x = 0; x < ag.width(); ++x) {
+        EXPECT_EQ(ag.pixel(x, lastRow), un.pixel(x, 0))
+            << "Unity row 0 should match agnostic last row at x=" << x;
+    }
+}

--- a/src/VATBaker_test.cpp
+++ b/src/VATBaker_test.cpp
@@ -528,6 +528,47 @@ TEST_F(VATBakerEndToEndTest, UnityTargetWritesPngMetaSidecar) {
     EXPECT_TRUE(body.contains("TextureImporter:"));
     EXPECT_TRUE(body.contains("sRGBTexture: 0"));
     EXPECT_TRUE(body.contains("filterMode: 0"));
+    EXPECT_FALSE(body.contains("guid: 00000000000000000000000000000000"))
+        << ".meta must use a unique GUID — sharing one with another asset "
+           "causes Unity to silently remap references at import time";
+}
+
+TEST_F(VATBakerEndToEndTest, UnityMetaGuidIsUniquePerBake) {
+    // Unity asset GUIDs must be globally unique; two bakes with the
+    // same target should never produce the same GUID in the .meta.
+    auto* entity = createAnimatedTestEntity("VAT_E2E_UnityGuid");
+    ASSERT_NE(entity, nullptr);
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+
+    auto extractGuid = [](const QString& path) -> QString {
+        QFile f(path);
+        if (!f.open(QIODevice::ReadOnly)) return {};
+        const QByteArray body = f.readAll();
+        const int idx = body.indexOf("guid: ");
+        if (idx < 0) return {};
+        const int eol = body.indexOf('\n', idx + 6);
+        return QString::fromUtf8(body.mid(idx + 6, eol - (idx + 6)));
+    };
+
+    VATBaker::Options opts;
+    opts.animationName = QStringLiteral("TestAnim");
+    opts.fps = 10.0;
+    opts.outputDir = tmp.path();
+    opts.target = VATBaker::Target::Unity;
+
+    opts.basename = QStringLiteral("A");
+    auto r1 = VATBaker::bake(entity, opts);
+    ASSERT_TRUE(r1.ok);
+    opts.basename = QStringLiteral("B");
+    auto r2 = VATBaker::bake(entity, opts);
+    ASSERT_TRUE(r2.ok);
+
+    const QString g1 = extractGuid(r1.unityMetaPath);
+    const QString g2 = extractGuid(r2.unityMetaPath);
+    EXPECT_FALSE(g1.isEmpty());
+    EXPECT_EQ(g1.size(), 32) << "Unity GUID must be 32 hex chars";
+    EXPECT_NE(g1, g2);
 }
 
 TEST_F(VATBakerEndToEndTest, GodotTargetWritesShaderTemplate) {


### PR DESCRIPTION
Closes more of #371. Slice 3 of 4. VAT now knows about per-engine axis / UV / sidecar conventions so a baked output drops straight into the target engine without tooling.

## Targets

| target   | swizzle             | UV-V flip | extra sidecar          |
|----------|---------------------|-----------|------------------------|
| agnostic | none                | no        | —                      |
| unity    | none (Y-up like Ogre)| **yes** (pre-flip rows at write time) | \`<base>_pos.png.meta\` |
| unreal   | \`(x,y,z) → (x,z,y)\` | no        | —                      |
| godot    | none (Y-up like Ogre)| no        | \`<base>.gdshader\` template |

The Unity row-pre-flip means the runtime shader uses plain \`row / frameCount\` indexing on every target. The Unreal swizzle puts Ogre's Y-up axis onto Unreal's Z-up; bounds + normals follow.

## Files emitted

\`\`\`
out/
  Walk_pos.png        # position texture (all targets)
  Walk.json           # sidecar (all targets)
  Walk_pos.png.meta   # only target=unity
  Walk.gdshader       # only target=godot
\`\`\`

Sidecar JSON gains a \`target\` field; \`BakeResult\` carries \`unityMetaPath\` + \`godotShaderPath\` paths (empty when not applicable). CLI \`--json\` output exposes them.

## CLI

\`--target agnostic|unity|unreal|godot\` (default \`agnostic\`). Sentry breadcrumb in \`file.export\` records the target alongside encoding + normals flag.

## Tests (6 new)

- \`SidecarTargetFieldReflectsOption\` — sidecar carries the right name for all four enum values.
- \`UnityTargetWritesPngMetaSidecar\` — \`.meta\` exists with expected YAML keys.
- \`GodotTargetWritesShaderTemplate\` — \`.gdshader\` exists, contains \`shader_type spatial\`, vertex entry, substituted uniforms.
- \`UnrealTargetSwizzlesPositionsXZY\` — quantitative: bounds Y↔Z swap versus the agnostic bake on the same entity.
- \`UnityRowsAreVerticallyFlipped\` — pixel-level: Unity row 0 == agnostic last-row.

## Manual smoke (all 4 targets)

\`\`\`
$ qtmesh vat robot.mesh --anim Idle --target unity  -o /tmp/un   # → pos, json, .meta
$ qtmesh vat robot.mesh --anim Idle --target unreal -o /tmp/ue   # bounds Y↔Z swap visible
$ qtmesh vat robot.mesh --anim Idle --target godot  -o /tmp/gd   # → pos, json, .gdshader
\`\`\`

## Test plan
- [ ] CI Linux/Xvfb: all 25 standalone + e2e tests pass.
- [ ] CI macOS/Windows: build clean.
- [ ] Manual: drop a Godot-target bake into a Godot 4 \`MeshInstance3D\`, attach a Shader Material with the generated \`.gdshader\`, animate \`current_frame\` — animation plays. (Out of scope for this PR; covered in slice 4 once Inspector wiring exists.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--target` option to VAT command supporting agnostic, Unity, Unreal, and Godot targets.
  * Multi-engine output now generates target-specific sidecar files (Unity `.meta`, Godot shader templates).
  * Updated JSON and text output to display selected target and associated metadata paths.

* **Tests**
  * Added validation tests for target-specific baking behavior and sidecar file generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->