### PR TITLE
feat(morph): sub-slice A2 — Inspector Morph Targets subgroup

### DIFF
--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -4306,6 +4306,126 @@ Rectangle {
                     }
                 }
             }
+
+            // ---- Morph Targets / Blend Shapes (slice A2) ----
+            // Per-pose weight sliders, sourced from MorphAnimationManager.
+            // Lives at the bottom of the Animations section, outside the
+            // per-entity repeater above — morph data is read from the
+            // SelectionSet's first entity to keep the surface focused.
+            // Authoring (add/rename/delete) lands in A3.
+            Rectangle {
+                width: parent.width - 16
+                visible: morphCol.targetCount > 0
+                height: morphCol.implicitHeight + 12
+                color: PropertiesPanelController.headerColor
+                border.color: PropertiesPanelController.borderColor
+                border.width: 1
+                radius: 3
+
+                Column {
+                    id: morphCol
+                    anchors.fill: parent
+                    anchors.margins: 6
+                    spacing: 4
+
+                    property var targets: MorphAnimationManager.morphTargetsForSelection()
+                    property int targetCount: targets.length
+                    property string filter: ""
+
+                    Connections {
+                        target: MorphAnimationManager
+                        function onMorphTargetsChanged() {
+                            morphCol.targets = MorphAnimationManager.morphTargetsForSelection()
+                        }
+                    }
+
+                    Row {
+                        spacing: 4
+                        width: parent.width
+                        Text {
+                            text: "Morph Targets (" + morphCol.targetCount + ")"
+                            color: PropertiesPanelController.textColor
+                            font.pixelSize: 11
+                            font.bold: true
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                        Item { width: parent.width - 260; height: 1 }
+                        // Reset all: walks every target and sets weight to 0.
+                        Rectangle {
+                            width: 60; height: 20; radius: 3
+                            color: resetMa.containsMouse
+                                   ? Qt.lighter(PropertiesPanelController.headerColor, 1.3)
+                                   : PropertiesPanelController.controlBgColor
+                            border.color: PropertiesPanelController.borderColor
+                            anchors.verticalCenter: parent.verticalCenter
+                            Text {
+                                anchors.centerIn: parent
+                                text: "Reset all"
+                                color: PropertiesPanelController.textColor
+                                font.pixelSize: 9
+                            }
+                            MouseArea {
+                                id: resetMa
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: {
+                                    for (var i = 0; i < morphCol.targets.length; ++i)
+                                        MorphAnimationManager.setWeightForSelection(morphCol.targets[i], 0)
+                                }
+                            }
+                        }
+                    }
+
+                    // Filter / search — characters often have 50+ blend
+                    // shapes, scanning a flat list is hopeless without
+                    // a typeahead box.
+                    TextField {
+                        id: filterField
+                        width: parent.width
+                        placeholderText: "Filter targets…"
+                        font.pixelSize: 10
+                        onTextChanged: morphCol.filter = text
+                        visible: morphCol.targetCount > 6
+                    }
+
+                    // One row per target. Hidden when filter doesn't match.
+                    Repeater {
+                        model: morphCol.targets
+                        Row {
+                            width: morphCol.width
+                            spacing: 4
+                            visible: morphCol.filter === ""
+                                  || modelData.toLowerCase().indexOf(morphCol.filter.toLowerCase()) >= 0
+                            height: visible ? 22 : 0
+
+                            Text {
+                                text: modelData
+                                color: PropertiesPanelController.textColor
+                                font.pixelSize: 10
+                                width: 120
+                                elide: Text.ElideRight
+                                anchors.verticalCenter: parent.verticalCenter
+                            }
+                            Slider {
+                                id: weightSlider
+                                from: 0; to: 1; stepSize: 0.01
+                                width: parent.width - 200
+                                value: MorphAnimationManager.weightForSelection(modelData)
+                                anchors.verticalCenter: parent.verticalCenter
+                                onMoved: MorphAnimationManager.setWeightForSelection(modelData, value)
+                            }
+                            Text {
+                                text: weightSlider.value.toFixed(2)
+                                color: PropertiesPanelController.textColor
+                                font.pixelSize: 10
+                                width: 36
+                                anchors.verticalCenter: parent.verticalCenter
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -4328,7 +4328,10 @@ Rectangle {
                     anchors.margins: 6
                     spacing: 4
 
-                    property var targets: MorphAnimationManager.morphTargetsForSelection()
+                    // Defensive `|| []` so an unexpected null return
+                    // doesn't crash the binding — the manager currently
+                    // always returns a QStringList, but contracts drift.
+                    property var targets: MorphAnimationManager.morphTargetsForSelection() || []
                     property int targetCount: targets.length
                     property string filter: ""
                     // Bumped on `morphWeightChanged`; sliders bind their
@@ -4342,7 +4345,7 @@ Rectangle {
                     Connections {
                         target: MorphAnimationManager
                         function onMorphTargetsChanged() {
-                            morphCol.targets = MorphAnimationManager.morphTargetsForSelection()
+                            morphCol.targets = MorphAnimationManager.morphTargetsForSelection() || []
                             morphCol.weightTick = morphCol.weightTick + 1
                         }
                         function onMorphWeightChanged(entity, name, weight) {

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -4331,11 +4331,22 @@ Rectangle {
                     property var targets: MorphAnimationManager.morphTargetsForSelection()
                     property int targetCount: targets.length
                     property string filter: ""
+                    // Bumped on `morphWeightChanged`; sliders bind their
+                    // `value` to a function call gated on this counter so
+                    // weight changes from any code path (Reset all,
+                    // dope-sheet scrubs in later slices, MCP, etc.) flow
+                    // back into the UI rather than going stale until the
+                    // delegate is recreated.
+                    property int weightTick: 0
 
                     Connections {
                         target: MorphAnimationManager
                         function onMorphTargetsChanged() {
                             morphCol.targets = MorphAnimationManager.morphTargetsForSelection()
+                            morphCol.weightTick = morphCol.weightTick + 1
+                        }
+                        function onMorphWeightChanged(entity, name, weight) {
+                            morphCol.weightTick = morphCol.weightTick + 1
                         }
                     }
 
@@ -4411,7 +4422,11 @@ Rectangle {
                                 id: weightSlider
                                 from: 0; to: 1; stepSize: 0.01
                                 width: parent.width - 200
-                                value: MorphAnimationManager.weightForSelection(modelData)
+                                // Bind to `weightTick` so changes that
+                                // bypass user drag (Reset all, MCP, future
+                                // dope-sheet scrubs) refresh the readout.
+                                value: (morphCol.weightTick,
+                                        MorphAnimationManager.weightForSelection(modelData))
                                 anchors.verticalCenter: parent.verticalCenter
                                 onMoved: MorphAnimationManager.setWeightForSelection(modelData, value)
                             }


### PR DESCRIPTION
Second sub-slice of #518. A1 (#569) shipped the data path — importer + `MorphAnimationManager` + `qtmesh morph --list`. A2 wires the QML Inspector surface authors will actually use.

## What ships

New **Morph Targets (N)** subgroup at the bottom of the Animations section in \`qml/PropertiesPanel.qml\`:
- Bound to \`MorphAnimationManager.morphTargetsForSelection()\` — refreshes via the \`morphTargetsChanged\` signal when selection moves.
- One row per target: name (elided), 0..1 slider (step 0.01), numeric readout. Slider \`onMoved\` writes back through \`setWeightForSelection\`, which drives the underlying Ogre \`AnimationState\` weight — the live-preview path A1 set up.
- **Reset all** button — walks every target and sets weight to 0.
- **Filter / search** text field, shown when target count > 6 (characters routinely ship 50+ shapes; flat list is hopeless).
- Whole subgroup is \`visible: targetCount > 0\` so meshes without blend shapes don't show an empty header.

## What's NOT in this PR (deferred to A3–A6)
- **A3 (authoring):** save edit-mode delta as new target, rename, delete, undo.
- **A4 (export):** FBX / glTF write morph targets so round-trips preserve them.
- **A5 (dope sheet):** morph-weight tracks appear alongside bone tracks.
- **A6 (MCP):** `list_morph_targets`, `set_morph_weight`, `add_morph_target`, `delete_morph_target`.

## Manual smoke
1. Open the app, select an entity with blend shapes (any DCC-authored FBX with a facial rig).
2. Expand the Animations section — a "Morph Targets (N)" panel appears at the bottom with one slider per shape.
3. Drag a slider — the mesh deforms in real time. The slider value also drives \`AnimationState.weight\` so playback timelines respect it.
4. Click **Reset all** — every slider snaps back to 0.

## Test plan
- [ ] CI: existing A1 tests on `MorphAnimationManager` still pass (this PR doesn't change the C++).
- [ ] Manual: live preview matches DCC reference for the same shape weights.
- [ ] Manual: filter narrows the slider list, "Reset all" clears every weight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Morph Targets / Blend Shapes subsection to the Animations panel, enabling precise control over morph animations
  * Adjust individual morph target weights using interactive sliders with real-time updates
  * "Reset all" button to instantly reset all morph targets to zero weight
  * Optional filter field to quickly search for and locate specific morph targets

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/570?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->