### PR TITLE
feat(morph): sub-slice A5 — controller API for dope-sheet morph rows

### DIFF
--- a/qml/AnimationDopeSheet.qml
+++ b/qml/AnimationDopeSheet.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import AnimationControl 1.0
+import PropertiesPanel 1.0  // MorphAnimationManager (slice A5)
 
 // Multi-bone dope sheet with multi-select, bulk move, and copy/paste.
 // One row per animated bone with diamond markers at each keyframe time.
@@ -20,6 +21,12 @@ Rectangle {
 
     // Cached row data refreshed from the controller.
     property var rows: AnimationControlController.allBoneRows()
+
+    // Slice A5: morph-target rows for the selected entity. Each
+    // entry is `{ name, keyTimes }`. Renders below the bone rows
+    // as a read-only band — full selection/move/copy interaction
+    // for morph tracks is a follow-up slice.
+    property var morphRows: AnimationControlController.allMorphRows()
 
     // Per-bone expansion state for per-channel rows. Keys are bone names,
     // values are bool. Reset when a new clip is selected (different bones).
@@ -145,11 +152,25 @@ Rectangle {
         // signal, and dropping selection there breaks bulk drag mid-gesture.
         function onSelectionChanged() {
             root.rows = AnimationControlController.allBoneRows()
+            root.morphRows = AnimationControlController.allMorphRows()
             root.clearSelection()
             root.expandedBones = {}
         }
         function onBoneRowsChanged()       { root.rows = AnimationControlController.allBoneRows() }
         function onKeyframeTicksChanged()  { root.rows = AnimationControlController.allBoneRows() }
+    }
+
+    // Refresh the morph band whenever the morph manager's data changes
+    // (selection moved to a different entity, or a weight was set
+    // through any path — Inspector slider, MCP, future authoring).
+    Connections {
+        target: MorphAnimationManager
+        function onMorphTargetsChanged() {
+            root.morphRows = AnimationControlController.allMorphRows()
+        }
+        function onMorphWeightChanged(entity, name, weight) {
+            root.morphRows = AnimationControlController.allMorphRows()
+        }
     }
 
     // Cross-platform "primary" modifier — Ctrl on Win/Linux, Cmd (Meta) on macOS.
@@ -540,6 +561,87 @@ Rectangle {
                                             rowDelegate.boneName, originalTime, target)
                                     }
                                 }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ── Morph-target rows (slice A5) ─────────────────────────────────────────
+    // Read-only band anchored to the bottom of the dope sheet. Shows
+    // one row per Ogre::Pose on the selected entity, with diamond
+    // markers at each keyframe time. Selection / move / copy
+    // interaction is a follow-up — A5 ships visibility only.
+    Rectangle {
+        id: morphBand
+        anchors.left: parent.left; anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        height: visible ? (morphHeader.height + morphRowsCol.implicitHeight) : 0
+        color: AnimationControlController.panelColor
+        border.color: AnimationControlController.borderColor
+        visible: root.morphRows.length > 0
+
+        Rectangle {
+            id: morphHeader
+            anchors.left: parent.left; anchors.right: parent.right
+            anchors.top: parent.top
+            height: 18
+            color: AnimationControlController.headerColor
+            border.color: AnimationControlController.borderColor
+            Text {
+                anchors.left: parent.left; anchors.leftMargin: 6
+                anchors.verticalCenter: parent.verticalCenter
+                text: "Morph Targets (" + root.morphRows.length + ")"
+                color: AnimationControlController.textColor
+                font.pixelSize: 10; font.bold: true
+            }
+        }
+
+        Column {
+            id: morphRowsCol
+            anchors.left: parent.left; anchors.right: parent.right
+            anchors.top: morphHeader.bottom
+            spacing: 1
+
+            Repeater {
+                model: root.morphRows
+                delegate: Item {
+                    width: morphRowsCol.width
+                    height: root.rowHeight
+
+                    // Name strip
+                    Rectangle {
+                        width: root.leftStripWidth; height: parent.height
+                        color: AnimationControlController.panelColor
+                        border.color: AnimationControlController.borderColor; border.width: 1
+                        Text {
+                            anchors.fill: parent
+                            anchors.leftMargin: 6
+                            verticalAlignment: Text.AlignVCenter
+                            text: modelData.name
+                            color: AnimationControlController.textColor
+                            elide: Text.ElideRight
+                            font.pixelSize: 11
+                        }
+                    }
+
+                    // Track strip with diamonds at each keyframe.
+                    Item {
+                        anchors.left: parent.left; anchors.leftMargin: root.leftStripWidth
+                        anchors.right: parent.right
+                        height: parent.height
+                        Repeater {
+                            model: modelData.keyTimes
+                            delegate: Rectangle {
+                                property real keyTime: modelData
+                                width: 8; height: 8; radius: 1
+                                rotation: 45
+                                color: "#c08040"
+                                border.color: AnimationControlController.borderColor
+                                anchors.verticalCenter: parent.verticalCenter
+                                x: (keyTime - root.viewStart) * root.pxPerSec - width / 2
                             }
                         }
                     }

--- a/qml/AnimationDopeSheet.qml
+++ b/qml/AnimationDopeSheet.qml
@@ -2,7 +2,6 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import AnimationControl 1.0
-import PropertiesPanel 1.0  // MorphAnimationManager (slice A5)
 
 // Multi-bone dope sheet with multi-select, bulk move, and copy/paste.
 // One row per animated bone with diamond markers at each keyframe time.
@@ -21,12 +20,6 @@ Rectangle {
 
     // Cached row data refreshed from the controller.
     property var rows: AnimationControlController.allBoneRows()
-
-    // Slice A5: morph-target rows for the selected entity. Each
-    // entry is `{ name, keyTimes }`. Renders below the bone rows
-    // as a read-only band — full selection/move/copy interaction
-    // for morph tracks is a follow-up slice.
-    property var morphRows: AnimationControlController.allMorphRows()
 
     // Per-bone expansion state for per-channel rows. Keys are bone names,
     // values are bool. Reset when a new clip is selected (different bones).
@@ -152,27 +145,11 @@ Rectangle {
         // signal, and dropping selection there breaks bulk drag mid-gesture.
         function onSelectionChanged() {
             root.rows = AnimationControlController.allBoneRows()
-            root.morphRows = AnimationControlController.allMorphRows()
             root.clearSelection()
             root.expandedBones = {}
         }
         function onBoneRowsChanged()       { root.rows = AnimationControlController.allBoneRows() }
         function onKeyframeTicksChanged()  { root.rows = AnimationControlController.allBoneRows() }
-    }
-
-    // Refresh the morph band when the manager's target list changes
-    // (selection moved to a different entity). We deliberately don't
-    // listen to `morphWeightChanged` here — its payload includes an
-    // `Ogre::Entity*` raw pointer which Qt 6 can't safely marshal to
-    // JS, and binding the slot crashed the QML engine on some Linux/
-    // Xvfb CI runners. The dope sheet's per-row keyTimes are
-    // structural, not weight-driven, so we don't lose anything by
-    // skipping per-weight notifications.
-    Connections {
-        target: MorphAnimationManager
-        function onMorphTargetsChanged() {
-            root.morphRows = AnimationControlController.allMorphRows()
-        }
     }
 
     // Cross-platform "primary" modifier — Ctrl on Win/Linux, Cmd (Meta) on macOS.
@@ -279,13 +256,7 @@ Rectangle {
         id: rowsView
         anchors.left: parent.left; anchors.right: parent.right
         anchors.top: header.visible ? header.bottom : parent.top
-        // Reserve space at the bottom for the morph band when it's
-        // visible. Anchoring both to `parent.bottom` would have them
-        // overlap and (under some layout pressures) hit a QML
-        // assertion when both layouts run during a redraw — drove
-        // the SIGSEGV crashes on MCPServerTest + MainWindowTest
-        // visibility-toggle tests in CI.
-        anchors.bottom: morphBand.visible ? morphBand.top : parent.bottom
+        anchors.bottom: parent.bottom
         clip: true
         model: root.rows
         spacing: 1
@@ -569,87 +540,6 @@ Rectangle {
                                             rowDelegate.boneName, originalTime, target)
                                     }
                                 }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    // ── Morph-target rows (slice A5) ─────────────────────────────────────────
-    // Read-only band anchored to the bottom of the dope sheet. Shows
-    // one row per Ogre::Pose on the selected entity, with diamond
-    // markers at each keyframe time. Selection / move / copy
-    // interaction is a follow-up — A5 ships visibility only.
-    Rectangle {
-        id: morphBand
-        anchors.left: parent.left; anchors.right: parent.right
-        anchors.bottom: parent.bottom
-        height: visible ? (morphHeader.height + morphRowsCol.implicitHeight) : 0
-        color: AnimationControlController.panelColor
-        border.color: AnimationControlController.borderColor
-        visible: root.morphRows.length > 0
-
-        Rectangle {
-            id: morphHeader
-            anchors.left: parent.left; anchors.right: parent.right
-            anchors.top: parent.top
-            height: 18
-            color: AnimationControlController.headerColor
-            border.color: AnimationControlController.borderColor
-            Text {
-                anchors.left: parent.left; anchors.leftMargin: 6
-                anchors.verticalCenter: parent.verticalCenter
-                text: "Morph Targets (" + root.morphRows.length + ")"
-                color: AnimationControlController.textColor
-                font.pixelSize: 10; font.bold: true
-            }
-        }
-
-        Column {
-            id: morphRowsCol
-            anchors.left: parent.left; anchors.right: parent.right
-            anchors.top: morphHeader.bottom
-            spacing: 1
-
-            Repeater {
-                model: root.morphRows
-                delegate: Item {
-                    width: morphRowsCol.width
-                    height: root.rowHeight
-
-                    // Name strip
-                    Rectangle {
-                        width: root.leftStripWidth; height: parent.height
-                        color: AnimationControlController.panelColor
-                        border.color: AnimationControlController.borderColor; border.width: 1
-                        Text {
-                            anchors.fill: parent
-                            anchors.leftMargin: 6
-                            verticalAlignment: Text.AlignVCenter
-                            text: modelData.name
-                            color: AnimationControlController.textColor
-                            elide: Text.ElideRight
-                            font.pixelSize: 11
-                        }
-                    }
-
-                    // Track strip with diamonds at each keyframe.
-                    Item {
-                        anchors.left: parent.left; anchors.leftMargin: root.leftStripWidth
-                        anchors.right: parent.right
-                        height: parent.height
-                        Repeater {
-                            model: modelData.keyTimes
-                            delegate: Rectangle {
-                                property real keyTime: modelData
-                                width: 8; height: 8; radius: 1
-                                rotation: 45
-                                color: "#c08040"
-                                border.color: AnimationControlController.borderColor
-                                anchors.verticalCenter: parent.verticalCenter
-                                x: (keyTime - root.viewStart) * root.pxPerSec - width / 2
                             }
                         }
                     }

--- a/qml/AnimationDopeSheet.qml
+++ b/qml/AnimationDopeSheet.qml
@@ -277,7 +277,13 @@ Rectangle {
         id: rowsView
         anchors.left: parent.left; anchors.right: parent.right
         anchors.top: header.visible ? header.bottom : parent.top
-        anchors.bottom: parent.bottom
+        // Reserve space at the bottom for the morph band when it's
+        // visible. Anchoring both to `parent.bottom` would have them
+        // overlap and (under some layout pressures) hit a QML
+        // assertion when both layouts run during a redraw — drove
+        // the SIGSEGV crashes on MCPServerTest + MainWindowTest
+        // visibility-toggle tests in CI.
+        anchors.bottom: morphBand.visible ? morphBand.top : parent.bottom
         clip: true
         model: root.rows
         spacing: 1

--- a/qml/AnimationDopeSheet.qml
+++ b/qml/AnimationDopeSheet.qml
@@ -160,15 +160,17 @@ Rectangle {
         function onKeyframeTicksChanged()  { root.rows = AnimationControlController.allBoneRows() }
     }
 
-    // Refresh the morph band whenever the morph manager's data changes
-    // (selection moved to a different entity, or a weight was set
-    // through any path — Inspector slider, MCP, future authoring).
+    // Refresh the morph band when the manager's target list changes
+    // (selection moved to a different entity). We deliberately don't
+    // listen to `morphWeightChanged` here — its payload includes an
+    // `Ogre::Entity*` raw pointer which Qt 6 can't safely marshal to
+    // JS, and binding the slot crashed the QML engine on some Linux/
+    // Xvfb CI runners. The dope sheet's per-row keyTimes are
+    // structural, not weight-driven, so we don't lose anything by
+    // skipping per-weight notifications.
     Connections {
         target: MorphAnimationManager
         function onMorphTargetsChanged() {
-            root.morphRows = AnimationControlController.allMorphRows()
-        }
-        function onMorphWeightChanged(entity, name, weight) {
             root.morphRows = AnimationControlController.allMorphRows()
         }
     }

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -924,12 +924,20 @@ QVariantList AnimationControlController::allMorphRows() const
 
         QVariantList keyTimes;
         if (mesh->hasAnimation(poseName)) {
+            // The importer (MeshProcessor) groups same-named poses
+            // across submeshes into a single Animation with one
+            // VAT_POSE track per submesh. Pull only the track
+            // matching this pose's target handle — otherwise a
+            // shape that appears on body + head would show its
+            // diamonds twice in the dope sheet.
             Ogre::Animation* anim = mesh->getAnimation(poseName);
-            const auto& vtracks = anim->_getVertexTrackList();
-            for (const auto& [handle, track] : vtracks) {
-                if (!track) continue;
-                for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i)
-                    keyTimes.append(static_cast<double>(track->getKeyFrame(i)->getTime()));
+            const unsigned short handle = pose->getTarget();
+            if (anim->hasVertexTrack(handle)) {
+                Ogre::VertexAnimationTrack* track = anim->getVertexTrack(handle);
+                if (track && track->getAnimationType() == Ogre::VAT_POSE) {
+                    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i)
+                        keyTimes.append(static_cast<double>(track->getKeyFrame(i)->getTime()));
+                }
             }
         }
 

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -899,6 +899,48 @@ QVariantList AnimationControlController::allBoneRows() const
     return rows;
 }
 
+QVariantList AnimationControlController::allMorphRows() const
+{
+    QVariantList rows;
+    auto* sel = SelectionSet::getSingleton();
+    if (!sel) return rows;
+    const auto entities = sel->getResolvedEntities();
+    if (entities.isEmpty() || !entities.first()) return rows;
+    Ogre::Entity* entity = entities.first();
+    if (!entity) return rows;
+    Ogre::MeshPtr mesh = entity->getMesh();
+    if (!mesh) return rows;
+    const Ogre::PoseList& poseList = mesh->getPoseList();
+    if (poseList.empty()) return rows;
+
+    // Each pose has a matching `Ogre::Animation` (see MeshProcessor:
+    // import-time one-animation-per-pose pattern). Read the keyframe
+    // times off the animation's VAT_POSE track; in A1 every animation
+    // carries a single t=0 keyframe, but future slices may add more.
+    for (const Ogre::Pose* pose : poseList) {
+        if (!pose) continue;
+        const Ogre::String poseName = pose->getName();
+        if (poseName.empty()) continue;
+
+        QVariantList keyTimes;
+        if (mesh->hasAnimation(poseName)) {
+            Ogre::Animation* anim = mesh->getAnimation(poseName);
+            const auto& vtracks = anim->_getVertexTrackList();
+            for (const auto& [handle, track] : vtracks) {
+                if (!track) continue;
+                for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i)
+                    keyTimes.append(static_cast<double>(track->getKeyFrame(i)->getTime()));
+            }
+        }
+
+        QVariantMap row;
+        row[QStringLiteral("name")]     = QString::fromStdString(poseName);
+        row[QStringLiteral("keyTimes")] = keyTimes;
+        rows.append(row);
+    }
+    return rows;
+}
+
 bool AnimationControlController::moveKeyframe(const QString& boneName,
                                               double oldTime, double newTime)
 {

--- a/src/AnimationControlController.h
+++ b/src/AnimationControlController.h
@@ -196,6 +196,15 @@ public:
     /// Returns an empty list when no animation is selected.
     Q_INVOKABLE QVariantList allBoneRows() const;
 
+    /// Slice A5: enumerate morph-target tracks for the selected
+    /// entity so the dope sheet can render them alongside bone
+    /// tracks. Each entry: `{ name: QString, keyTimes: [double] }`.
+    /// In A1's importer-emitted Animations, every pose's track has
+    /// a single keyframe at t=0; future slices may add per-time
+    /// keys when authoring lands. Returns empty when there's no
+    /// selection or the entity has no morph targets.
+    Q_INVOKABLE QVariantList allMorphRows() const;
+
     /// Move a keyframe on `boneName`'s track from `oldTime` to `newTime`
     /// (both seconds). Match tolerance is 1 ms — same as the existing
     /// keyframe-tick comparison. Refuses the move if `newTime` collides

--- a/src/AnimationControlController_test.cpp
+++ b/src/AnimationControlController_test.cpp
@@ -15,6 +15,13 @@
 #include <OgreAnimation.h>
 #include <OgreAnimationState.h>
 #include <OgreKeyFrame.h>
+#include <OgreMesh.h>
+#include <OgreMeshManager.h>
+#include <OgrePose.h>
+#include <OgreSceneManager.h>
+#include <OgreSceneNode.h>
+#include <OgreSubMesh.h>
+#include <OgreEntity.h>
 
 class AnimationControlControllerTest : public ::testing::Test {
 protected:
@@ -1763,3 +1770,70 @@ TEST_F(AnimationControlControllerTest, DeleteKeyframeIsUndoableViaQUndoStack) {
     app->processEvents();
     EXPECT_EQ(track->getNumKeyFrames(), countBefore - 1);
 }
+
+// ── Slice A5: allMorphRows for dope sheet ─────────────────────────────────
+
+TEST_F(AnimationControlControllerTest, AllMorphRowsEmptyWhenNoSelection) {
+    SelectionSet::getSingleton()->clear();
+    auto* ctrl = AnimationControlController::instance();
+    EXPECT_TRUE(ctrl->allMorphRows().isEmpty());
+}
+
+TEST_F(AnimationControlControllerTest, AllMorphRowsEmptyForMeshWithoutPoses) {
+    // createAnimatedTestEntity has bones but no morph targets;
+    // allMorphRows must return an empty list (not crash).
+    ASSERT_TRUE(canLoadMeshFiles());
+    Ogre::Entity* entity = setupAnimatedEntity("Morph_NoPoses");
+    ASSERT_NE(entity, nullptr);
+    auto* ctrl = AnimationControlController::instance();
+    EXPECT_TRUE(ctrl->allMorphRows().isEmpty());
+}
+
+TEST_F(AnimationControlControllerTest, AllMorphRowsListsPoseNamesAndKeyTimes) {
+    ASSERT_TRUE(canLoadMeshFiles());
+
+    // Build a fresh mesh + entity with two named poses + matching
+    // VAT_POSE animations — mirrors what MeshProcessor produces from
+    // an FBX blend shape. Pose targets handle 0 (shared-vertex
+    // submesh) to match createInMemoryTriangleMesh's layout.
+    auto mesh = createInMemoryTriangleMesh("Morph_AllRows");
+    ASSERT_NE(mesh, nullptr);
+    {
+        Ogre::Pose* p = mesh->createPose(0, "JawOpen");
+        p->addVertex(0, Ogre::Vector3(0, -0.1f, 0));
+    }
+    {
+        Ogre::Pose* p = mesh->createPose(0, "Smile");
+        p->addVertex(1, Ogre::Vector3(0.05f, 0.02f, 0));
+    }
+    const auto& poseList = mesh->getPoseList();
+    for (unsigned short pi = 0; pi < poseList.size(); ++pi) {
+        Ogre::Animation* a = mesh->createAnimation(poseList[pi]->getName(), 0.0f);
+        auto* track = a->createVertexTrack(poseList[pi]->getTarget(), Ogre::VAT_POSE);
+        auto* kf = track->createVertexPoseKeyFrame(0.0f);
+        kf->addPoseReference(pi, 1.0f);
+    }
+
+    auto* node = Manager::getSingleton()->addSceneNode("Morph_AllRows_Node");
+    auto* entity = Manager::getSingleton()->getSceneMgr()->createEntity(node->getName(), mesh->getName());
+    node->attachObject(entity);
+    SelectionSet::getSingleton()->selectOne(node);
+    app->processEvents();
+
+    auto* ctrl = AnimationControlController::instance();
+    QVariantList rows = ctrl->allMorphRows();
+    ASSERT_EQ(rows.size(), 2);
+    QSet<QString> names;
+    for (const QVariant& v : rows) {
+        const QVariantMap row = v.toMap();
+        names.insert(row["name"].toString());
+        // Each pose's Animation has a single keyframe at t=0.
+        const QVariantList times = row["keyTimes"].toList();
+        ASSERT_EQ(times.size(), 1);
+        EXPECT_NEAR(times.first().toDouble(), 0.0, 1e-6);
+    }
+    EXPECT_TRUE(names.contains(QStringLiteral("JawOpen")));
+    EXPECT_TRUE(names.contains(QStringLiteral("Smile")));
+}
+
+


### PR DESCRIPTION
## Summary
- Add `AnimationControlController::allMorphRows()` — Q_INVOKABLE that returns a `QVariantList` of `{ name, keyTimes }` rows for poses on the selected entity's mesh.
- Filter morph keyframe times by `pose->getTarget()` handle so importer-grouped same-name animations don't collapse into one track (Codex P2 fix).
- 3 new GTest cases:
  - `AllMorphRowsEmptyWhenNoSelection` — returns `[]` cleanly.
  - `AllMorphRowsEmptyForMeshWithoutPoses` — bone-only entity returns `[]`.
  - `AllMorphRowsListsPoseNamesAndKeyTimes` — two named poses each with t=0 keyframe.

## Why scope was narrowed
The original PR also integrated a morph band into the QML dope sheet, but the QML changes consistently triggered SIGSEGV in unrelated test suites (`MCPServerTest.ToggleNormals_WithMainWindowTogglesVisibility` and `MainWindowTest.ViewMenuConsoleToggleUpdatesDockVisibilityAndSettings`) across 4 CI re-runs. The 3 new controller tests pass; only the QML integration is blocking. Shipping the data API alone unblocks the rest of the morph epic — the dope-sheet UI lands in a follow-up PR where the crash can be isolated without holding back the backend work that other slices depend on.

## #518 status after this slice

| Sub-slice | Status |
|-|-|
| A1 — Importer + manager + CLI list | shipped (#569) |
| A2 — Inspector subgroup | shipped (#570) |
| A4a — glTF export | shipped (#573) |
| A4b — FBX export | shipped (#575) |
| A5 — Controller API (data) | **this PR** |
| A5b — Dope-sheet UI band | follow-up |
| A6 — MCP tools | shipped (#571) |
| A3 — Authoring | still pending |

## Test plan
- [ ] CI green (unit-tests-linux + all platforms)
- [ ] No new code-review comments to address
- [ ] 3 new `AnimationControlControllerTest` cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)