### PR TITLE
feat(morph): A3b — Inspector add / rename / delete for morph targets

### DIFF
--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -4363,7 +4363,37 @@ Rectangle {
                             font.bold: true
                             anchors.verticalCenter: parent.verticalCenter
                         }
-                        Item { width: parent.width - 260; height: 1 }
+                        Item { width: parent.width - 320; height: 1 }
+                        // Add from current edit — captures the user's current
+                        // edit-mode geometry minus the bind-pose baseline as
+                        // a new morph target. Greyed out + tooltip when
+                        // outside edit mode (since EditableSubMesh::
+                        // originalPositions is only populated then).
+                        Rectangle {
+                            id: addBtn
+                            width: 56; height: 20; radius: 3
+                            color: addMa.containsMouse
+                                   ? Qt.lighter(PropertiesPanelController.headerColor, 1.3)
+                                   : PropertiesPanelController.controlBgColor
+                            border.color: PropertiesPanelController.borderColor
+                            anchors.verticalCenter: parent.verticalCenter
+                            Text {
+                                anchors.centerIn: parent
+                                text: "+ Add…"
+                                color: PropertiesPanelController.textColor
+                                font.pixelSize: 9
+                            }
+                            MouseArea {
+                                id: addMa
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: {
+                                    addNameField.text = ""
+                                    addNamePopup.open()
+                                }
+                            }
+                        }
                         // Reset all: walks every target and sets weight to 0.
                         Rectangle {
                             width: 60; height: 20; radius: 3
@@ -4391,6 +4421,72 @@ Rectangle {
                         }
                     }
 
+                    // Inline name-entry popup for "Add from edit…". Kept
+                    // simple (no styled component) so a misbehaving custom
+                    // dialog can't break the rest of the panel — Popup is
+                    // a built-in Qt Quick Controls primitive with no
+                    // singleton dependencies.
+                    Popup {
+                        id: addNamePopup
+                        modal: true
+                        focus: true
+                        width: 240
+                        contentItem: Column {
+                            spacing: 6
+                            Text {
+                                text: "New morph target name:"
+                                color: PropertiesPanelController.textColor
+                                font.pixelSize: 11
+                            }
+                            TextField {
+                                id: addNameField
+                                width: 220
+                                font.pixelSize: 11
+                                onAccepted: addConfirmMa.confirm()
+                                Component.onCompleted: forceActiveFocus()
+                            }
+                            Row {
+                                spacing: 6
+                                Rectangle {
+                                    width: 60; height: 20; radius: 3
+                                    color: addConfirmMa.containsMouse
+                                           ? Qt.lighter(PropertiesPanelController.headerColor, 1.3)
+                                           : PropertiesPanelController.controlBgColor
+                                    border.color: PropertiesPanelController.borderColor
+                                    Text { anchors.centerIn: parent; text: "Save"; color: PropertiesPanelController.textColor; font.pixelSize: 10 }
+                                    MouseArea {
+                                        id: addConfirmMa
+                                        anchors.fill: parent
+                                        hoverEnabled: true
+                                        cursorShape: Qt.PointingHandCursor
+                                        function confirm() {
+                                            var n = addNameField.text.trim()
+                                            if (n.length === 0) return
+                                            MorphAnimationManager.addMorphTargetFromCurrentEdit(n)
+                                            addNamePopup.close()
+                                        }
+                                        onClicked: confirm()
+                                    }
+                                }
+                                Rectangle {
+                                    width: 60; height: 20; radius: 3
+                                    color: addCancelMa.containsMouse
+                                           ? Qt.lighter(PropertiesPanelController.headerColor, 1.3)
+                                           : PropertiesPanelController.controlBgColor
+                                    border.color: PropertiesPanelController.borderColor
+                                    Text { anchors.centerIn: parent; text: "Cancel"; color: PropertiesPanelController.textColor; font.pixelSize: 10 }
+                                    MouseArea {
+                                        id: addCancelMa
+                                        anchors.fill: parent
+                                        hoverEnabled: true
+                                        cursorShape: Qt.PointingHandCursor
+                                        onClicked: addNamePopup.close()
+                                    }
+                                }
+                            }
+                        }
+                    }
+
                     // Filter / search — characters often have 50+ blend
                     // shapes, scanning a flat list is hopeless without
                     // a typeahead box.
@@ -4413,18 +4509,56 @@ Rectangle {
                                   || modelData.toLowerCase().indexOf(morphCol.filter.toLowerCase()) >= 0
                             height: visible ? 22 : 0
 
+                            // Name — double-click to rename in place,
+                            // matching the per-animation rename UX above.
                             Text {
+                                id: morphNameText
+                                visible: !morphNameEdit.visible
                                 text: modelData
                                 color: PropertiesPanelController.textColor
                                 font.pixelSize: 10
                                 width: 120
                                 elide: Text.ElideRight
                                 anchors.verticalCenter: parent.verticalCenter
+                                MouseArea {
+                                    anchors.fill: parent
+                                    onDoubleClicked: {
+                                        morphNameEdit.text = modelData
+                                        morphNameEdit.visible = true
+                                        morphNameEdit.forceActiveFocus()
+                                        morphNameEdit.selectAll()
+                                    }
+                                }
+                            }
+                            TextInput {
+                                id: morphNameEdit
+                                visible: false
+                                width: 120
+                                color: PropertiesPanelController.textColor
+                                font.pixelSize: 10
+                                anchors.verticalCenter: parent.verticalCenter
+                                selectByMouse: true
+                                Rectangle {
+                                    anchors.fill: parent
+                                    anchors.margins: -2
+                                    z: -1
+                                    color: PropertiesPanelController.inputColor
+                                    border.color: PropertiesPanelController.highlightColor
+                                    border.width: 1
+                                    radius: 2
+                                }
+                                onEditingFinished: {
+                                    var trimmed = text.trim()
+                                    if (trimmed.length > 0 && trimmed !== modelData)
+                                        MorphAnimationManager.renameMorphTarget(modelData, trimmed)
+                                    visible = false
+                                }
+                                Keys.onEscapePressed: visible = false
                             }
                             Slider {
                                 id: weightSlider
                                 from: 0; to: 1; stepSize: 0.01
-                                width: parent.width - 200
+                                width: parent.width - 222
                                 // Bind to `weightTick` so changes that
                                 // bypass user drag (Reset all, MCP, future
                                 // dope-sheet scrubs) refresh the readout.
@@ -4439,6 +4573,30 @@ Rectangle {
                                 font.pixelSize: 10
                                 width: 36
                                 anchors.verticalCenter: parent.verticalCenter
+                            }
+                            // Delete (×) — drops the pose + animation
+                            // through DeleteMorphTargetCommand so Ctrl+Z
+                            // restores it.
+                            Rectangle {
+                                width: 18; height: 18; radius: 3
+                                anchors.verticalCenter: parent.verticalCenter
+                                color: morphDelMa.containsMouse
+                                       ? Qt.lighter(PropertiesPanelController.headerColor, 1.3)
+                                       : "transparent"
+                                Text {
+                                    anchors.centerIn: parent
+                                    text: "×"
+                                    color: PropertiesPanelController.textColor
+                                    font.pixelSize: 12
+                                    font.bold: true
+                                }
+                                MouseArea {
+                                    id: morphDelMa
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                    cursorShape: Qt.PointingHandCursor
+                                    onClicked: MorphAnimationManager.deleteMorphTarget(modelData)
+                                }
                             }
                         }
                     }

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -4366,13 +4366,17 @@ Rectangle {
                         Item { width: parent.width - 320; height: 1 }
                         // Add from current edit — captures the user's current
                         // edit-mode geometry minus the bind-pose baseline as
-                        // a new morph target. Greyed out + tooltip when
-                        // outside edit mode (since EditableSubMesh::
-                        // originalPositions is only populated then).
+                        // a new morph target. Disabled (greyed out, forbidden
+                        // cursor) when outside edit mode because
+                        // EditableSubMesh::originalPositions is only
+                        // populated by EditModeController and the C++ method
+                        // would return false anyway.
                         Rectangle {
                             id: addBtn
+                            property bool canAddFromEdit: EditModeController.editModeActive
                             width: 56; height: 20; radius: 3
-                            color: addMa.containsMouse
+                            opacity: canAddFromEdit ? 1.0 : 0.45
+                            color: addMa.containsMouse && canAddFromEdit
                                    ? Qt.lighter(PropertiesPanelController.headerColor, 1.3)
                                    : PropertiesPanelController.controlBgColor
                             border.color: PropertiesPanelController.borderColor
@@ -4387,11 +4391,15 @@ Rectangle {
                                 id: addMa
                                 anchors.fill: parent
                                 hoverEnabled: true
-                                cursorShape: Qt.PointingHandCursor
+                                enabled: addBtn.canAddFromEdit
+                                cursorShape: enabled ? Qt.PointingHandCursor : Qt.ForbiddenCursor
                                 onClicked: {
                                     addNameField.text = ""
+                                    addError.text = ""
                                     addNamePopup.open()
                                 }
+                                ToolTip.visible: containsMouse && !enabled
+                                ToolTip.text: "Enter Edit Mode (Tab) to add morph targets from current edit."
                             }
                         }
                         // Reset all: walks every target and sets weight to 0.
@@ -4443,7 +4451,22 @@ Rectangle {
                                 width: 220
                                 font.pixelSize: 11
                                 onAccepted: addConfirmMa.confirm()
+                                onTextChanged: addError.text = ""
                                 Component.onCompleted: forceActiveFocus()
+                            }
+                            // Inline error: shown when the C++ side rejects
+                            // the request (duplicate name, no vertex moved,
+                            // not in edit mode, …). We deliberately keep the
+                            // popup open so the user can fix the input
+                            // without retyping.
+                            Text {
+                                id: addError
+                                text: ""
+                                visible: text.length > 0
+                                color: "#d65d5d"
+                                font.pixelSize: 10
+                                width: 220
+                                wrapMode: Text.Wrap
                             }
                             Row {
                                 spacing: 6
@@ -4461,9 +4484,22 @@ Rectangle {
                                         cursorShape: Qt.PointingHandCursor
                                         function confirm() {
                                             var n = addNameField.text.trim()
-                                            if (n.length === 0) return
-                                            MorphAnimationManager.addMorphTargetFromCurrentEdit(n)
-                                            addNamePopup.close()
+                                            if (n.length === 0) {
+                                                addError.text = "Name cannot be empty."
+                                                return
+                                            }
+                                            if (!EditModeController.editModeActive) {
+                                                addError.text = "Enter Edit Mode (Tab) before saving."
+                                                return
+                                            }
+                                            var ok = MorphAnimationManager.addMorphTargetFromCurrentEdit(n)
+                                            if (ok) {
+                                                addNamePopup.close()
+                                            } else {
+                                                // C++ rejected — likely name collision or
+                                                // no vertex moved vs the bind baseline.
+                                                addError.text = "Couldn't save: name already in use, or no vertex was edited."
+                                            }
                                         }
                                         onClicked: confirm()
                                     }
@@ -4538,6 +4574,12 @@ Rectangle {
                                 font.pixelSize: 10
                                 anchors.verticalCenter: parent.verticalCenter
                                 selectByMouse: true
+                                // Set by `Keys.onEscapePressed`; checked in
+                                // `onEditingFinished` so that hiding the
+                                // input on Escape (which causes focus loss
+                                // and fires `editingFinished`) doesn't
+                                // accidentally commit the rename.
+                                property bool cancelled: false
                                 Rectangle {
                                     anchors.fill: parent
                                     anchors.margins: -2
@@ -4548,12 +4590,13 @@ Rectangle {
                                     radius: 2
                                 }
                                 onEditingFinished: {
+                                    if (cancelled) { cancelled = false; visible = false; return }
                                     var trimmed = text.trim()
                                     if (trimmed.length > 0 && trimmed !== modelData)
                                         MorphAnimationManager.renameMorphTarget(modelData, trimmed)
                                     visible = false
                                 }
-                                Keys.onEscapePressed: visible = false
+                                Keys.onEscapePressed: { cancelled = true; visible = false }
                             }
                             Slider {
                                 id: weightSlider


### PR DESCRIPTION
Follow-up to #578. Surfaces the C++ authoring API from morph slice A3 in the existing Morph Targets subgroup in `qml/PropertiesPanel.qml`. After this PR the morph epic (#518) is end-to-end: import → list → set weight → save current edit as new target → rename → delete → export, all with undo.

## What ships

### "+ Add…" button (top row, next to "Reset all")
Opens a built-in Qt Quick Controls `Popup` with a name field, calls `MorphAnimationManager.addMorphTargetFromCurrentEdit`. Deliberately uses primitives — no custom dialog component, no new imports — because A5's QML changes hit cross-engine initialization issues we never fully isolated and I want to keep this slice's blast radius minimal.

### Inline rename (double-click name)
Mirrors the per-animation rename UX a few sections above. Double-click → hidden `TextInput` becomes visible → `onEditingFinished` calls `renameMorphTarget`. Empty / whitespace-only / unchanged names are filtered client-side before the call. Server-side collision rejection still applies (no shadowing).

### Per-row "×" delete
Pushes `DeleteMorphTargetCommand` through the shared `UndoManager`, so Ctrl+Z restores the pose + animation.

## Why this is small and safe
- No new QML imports — `MorphAnimationManager` was already imported by the existing subgroup.
- No new `Connections` blocks — the existing one already refreshes target list and weight readouts on `morphTargetsChanged` / `morphWeightChanged`, so add / rename / delete flow back into the UI without new wiring.
- All three new buttons are pure pass-throughs to existing `Q_INVOKABLE` methods on `MorphAnimationManager`. The C++ surface was already covered by the 16 tests merged in #578.

## #518 status

| Sub-slice | Status |
|-|-|
| A1 — Importer + manager + CLI list | shipped (#569) |
| A2 — Inspector subgroup | shipped (#570) |
| A3 — Authoring data layer | shipped (#578) |
| A3b — Inspector authoring UI | **this PR** |
| A4a — glTF export | shipped (#573) |
| A4b — FBX export | shipped (#575) |
| A5 — Controller API | shipped (#576) |
| A5b — Dope-sheet UI | follow-up |
| A6 — MCP tools | shipped (#571) |

Once A3b lands the epic is feature-complete except for the dope-sheet morph band (the deferred UI from A5).

## Test plan
- [ ] CI green (unit-tests-linux + all platforms)
- [ ] Manual: import an FBX with blend shapes → enter edit-mode → translate a vertex → click "+ Add…" → name "Test" → confirm new entry appears with slider → double-click name to rename → click × to delete → Ctrl+Z restores it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Add" button to create new morph targets/blend shapes in the Animations panel
  * Morph target names now support direct editing via double-click-to-rename functionality
  * Added delete control to remove morph targets from the panel

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/579?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->