### PR TITLE
feat(ps1): Phase 2 GPU/GTE capture hooks (#418, #419)

### DIFF
--- a/plugins/ps1core_stub/CMakeLists.txt
+++ b/plugins/ps1core_stub/CMakeLists.txt
@@ -5,6 +5,7 @@ endif()
 set(PS1_RUNTIME_INCLUDE "${CMAKE_SOURCE_DIR}/src/PS1/runtime")
 
 add_library(qtmesh_ps1core_stub MODULE
+    StubCaptureSynth.cpp
     StubEmuCore.cpp
     StubEmuCorePlugin.cpp
 )

--- a/plugins/ps1core_stub/StubCaptureSynth.cpp
+++ b/plugins/ps1core_stub/StubCaptureSynth.cpp
@@ -1,0 +1,63 @@
+#include "StubCaptureSynth.h"
+
+#include "CaptureTypes.h"
+#include "EmuHooks.h"
+
+void stubEmitCaptureSample(EmuHooks *hooks)
+{
+    if (!hooks || !hooks->isCaptureEnabled())
+        return;
+
+    hooks->onFrameBegin();
+
+    MatrixRecord matrix{};
+    matrix.rt.m[0][0] = 1 << 12;
+    matrix.rt.m[1][1] = 1 << 12;
+    matrix.rt.m[2][2] = 1 << 12;
+    matrix.h = 256;
+    const uint32_t matrixId = hooks->onGteMatrix(matrix);
+
+    auto emitPrim = [&](PrimKind kind, uint8_t count, int x0, int y0) {
+        PrimRecord prim{};
+        prim.kind = kind;
+        prim.vertexCount = count;
+        prim.matrixId = matrixId;
+        prim.tpage = 0x100;
+        prim.clut = 0x200;
+        prim.verts[0].x = x0;
+        prim.verts[0].y = y0;
+        prim.verts[0].r = 200;
+        prim.verts[0].g = 40;
+        prim.verts[0].b = 40;
+        prim.verts[0].u = 8;
+        prim.verts[0].v = 8;
+        if (count >= 2) {
+            prim.verts[1].x = x0 + 32;
+            prim.verts[1].y = y0;
+        }
+        if (count >= 3) {
+            prim.verts[2].x = x0 + 16;
+            prim.verts[2].y = y0 + 24;
+        }
+        if (count >= 4) {
+            prim.verts[3].x = x0 + 32;
+            prim.verts[3].y = y0 + 24;
+        }
+        hooks->onGpuPrim(prim);
+    };
+
+    emitPrim(PrimKind::MonoTri, 3, 16, 16);
+    emitPrim(PrimKind::ShadedTri, 3, 64, 16);
+    emitPrim(PrimKind::TexturedTri, 3, 112, 16);
+    emitPrim(PrimKind::MonoQuad, 4, 16, 64);
+    emitPrim(PrimKind::ShadedQuad, 4, 64, 64);
+    emitPrim(PrimKind::TexturedQuad, 4, 112, 64);
+    emitPrim(PrimKind::Sprite, 2, 160, 64);
+
+    DrawModeRecord mode{};
+    mode.drawModeBits = 0x1234;
+    mode.tpage = 0x100;
+    hooks->onDrawMode(mode);
+
+    hooks->onFrameEnd();
+}

--- a/plugins/ps1core_stub/StubCaptureSynth.h
+++ b/plugins/ps1core_stub/StubCaptureSynth.h
@@ -1,0 +1,9 @@
+#ifndef STUBCAPTURESYNTH_H
+#define STUBCAPTURESYNTH_H
+
+class EmuHooks;
+
+/** Emits one primitive of each GP0 flavor for capture regression tests (#418). */
+void stubEmitCaptureSample(EmuHooks *hooks);
+
+#endif // STUBCAPTURESYNTH_H

--- a/plugins/ps1core_stub/StubEmuCore.cpp
+++ b/plugins/ps1core_stub/StubEmuCore.cpp
@@ -1,4 +1,5 @@
 #include "StubEmuCore.h"
+#include "StubCaptureSynth.h"
 
 #include <QFileInfo>
 
@@ -43,6 +44,7 @@ void StubEmuCore::runFrame()
     EmuFramebuffer &buf = m_buffers[static_cast<size_t>(m_writeIndex)];
     buf.frameIndex = ++m_frameIndex;
     fillTestPattern(buf);
+    stubEmitCaptureSample(m_hooks);
 
     m_readIndex = m_writeIndex;
     m_writeIndex = (m_writeIndex + 1) % 3;

--- a/src/PS1/CMakeLists.txt
+++ b/src/PS1/CMakeLists.txt
@@ -22,14 +22,20 @@ ${CMAKE_CURRENT_SOURCE_DIR}/PS1TIM.h
 
 if(ENABLE_PS1_RIP)
     list(APPEND SRC_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/CaptureBuffer.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/EmuCoreLoader.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/EmuViewport.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/GpuCommandParser.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/GteCapture.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipLegalityDialog.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipManager.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipSessionWindow.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipWorker.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/RipperHooks.cpp
     )
     list(APPEND HEADER_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/CaptureBuffer.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/CaptureTypes.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/EmuCore.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/EmuCoreLoader.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/EmuFramebuffer.h

--- a/src/PS1/PS1_RIP_DESIGN.md
+++ b/src/PS1/PS1_RIP_DESIGN.md
@@ -61,6 +61,13 @@ See epic #412 for phased issues (#413–#431).
 - Stub plugin `plugins/ps1core_stub/` renders a 320×240 test pattern when BIOS+ISO paths validate.
 - `PS1RipSessionWindow` + `EmuViewport` + legality dialog (#416–#417) — keyboard/gamepad input still TODO.
 
+## Phase 2 status
+
+- `CaptureTypes`, `GpuCommandParser`, `CaptureBuffer`, `RipperHooks` (#418).
+- GTE matrix hash dedupe + `cameraMatrixId` heuristic (#419).
+- Stub core emits seven primitive flavors per frame when capture is armed.
+- `armCapture` / `captureFrame` wire capture to the worker thread; CSV dump to temp for verification.
+
 ## Open questions
 
 - mednafen-psx plugin build/integration (replace stub for real emulation).

--- a/src/PS1/runtime/CaptureBuffer.cpp
+++ b/src/PS1/runtime/CaptureBuffer.cpp
@@ -1,0 +1,59 @@
+#include "CaptureBuffer.h"
+
+#include "GteCapture.h"
+
+void CaptureBuffer::beginFrame()
+{
+    m_prims.clear();
+    m_drawModes.clear();
+    m_matrixUseCount.clear();
+    m_cameraMatrixId = UINT32_MAX;
+}
+
+void CaptureBuffer::endFrame()
+{
+    int bestCount = 0;
+    uint32_t bestId = UINT32_MAX;
+    for (auto it = m_matrixUseCount.constBegin(); it != m_matrixUseCount.constEnd(); ++it) {
+        if (it.value() > bestCount) {
+            bestCount = it.value();
+            bestId = it.key();
+        }
+    }
+    m_cameraMatrixId = bestId;
+}
+
+uint32_t CaptureBuffer::addMatrix(MatrixRecord matrix)
+{
+    matrix.hash = GteCapture::hashMatrix(matrix);
+    const auto found = m_matrixIndexByHash.constFind(matrix.hash);
+    if (found != m_matrixIndexByHash.constEnd())
+        return found.value();
+
+    const uint32_t id = static_cast<uint32_t>(m_matrices.size());
+    m_matrices.append(matrix);
+    m_matrixIndexByHash.insert(matrix.hash, id);
+    return id;
+}
+
+void CaptureBuffer::addPrim(PrimRecord prim)
+{
+    if (prim.matrixId < static_cast<uint32_t>(m_matrices.size()))
+        m_matrixUseCount[prim.matrixId] = m_matrixUseCount.value(prim.matrixId, 0) + 1;
+    m_prims.append(prim);
+}
+
+void CaptureBuffer::addDrawMode(const DrawModeRecord &mode)
+{
+    m_drawModes.append(mode);
+}
+
+void CaptureBuffer::clear()
+{
+    m_prims.clear();
+    m_matrices.clear();
+    m_drawModes.clear();
+    m_matrixIndexByHash.clear();
+    m_matrixUseCount.clear();
+    m_cameraMatrixId = UINT32_MAX;
+}

--- a/src/PS1/runtime/CaptureBuffer.cpp
+++ b/src/PS1/runtime/CaptureBuffer.cpp
@@ -27,8 +27,12 @@ uint32_t CaptureBuffer::addMatrix(MatrixRecord matrix)
 {
     matrix.hash = GteCapture::hashMatrix(matrix);
     const auto found = m_matrixIndexByHash.constFind(matrix.hash);
-    if (found != m_matrixIndexByHash.constEnd())
-        return found.value();
+    if (found != m_matrixIndexByHash.constEnd()) {
+        const uint32_t existingId = found.value();
+        if (existingId < static_cast<uint32_t>(m_matrices.size())
+            && GteCapture::matricesEqual(m_matrices[static_cast<int>(existingId)], matrix))
+            return existingId;
+    }
 
     const uint32_t id = static_cast<uint32_t>(m_matrices.size());
     m_matrices.append(matrix);

--- a/src/PS1/runtime/CaptureBuffer.h
+++ b/src/PS1/runtime/CaptureBuffer.h
@@ -1,0 +1,40 @@
+#ifndef CAPTUREBUFFER_H
+#define CAPTUREBUFFER_H
+
+#include "CaptureTypes.h"
+
+#include <QHash>
+#include <QVector>
+
+/**
+ * Per-frame capture arena for GPU primitives and GTE matrices (#418, #419).
+ */
+class CaptureBuffer
+{
+public:
+    void beginFrame();
+    void endFrame();
+
+    uint32_t addMatrix(MatrixRecord matrix);
+    void addPrim(PrimRecord prim);
+    void addDrawMode(const DrawModeRecord &mode);
+
+    const QVector<PrimRecord> &prims() const { return m_prims; }
+    const QVector<MatrixRecord> &matrices() const { return m_matrices; }
+    const QVector<DrawModeRecord> &drawModes() const { return m_drawModes; }
+
+    uint32_t cameraMatrixId() const { return m_cameraMatrixId; }
+    bool hasCameraMatrix() const { return m_cameraMatrixId != UINT32_MAX; }
+
+    void clear();
+
+private:
+    QVector<PrimRecord> m_prims;
+    QVector<MatrixRecord> m_matrices;
+    QVector<DrawModeRecord> m_drawModes;
+    QHash<uint64_t, uint32_t> m_matrixIndexByHash;
+    QHash<uint32_t, int> m_matrixUseCount;
+    uint32_t m_cameraMatrixId = UINT32_MAX;
+};
+
+#endif // CAPTUREBUFFER_H

--- a/src/PS1/runtime/CaptureBuffer_test.cpp
+++ b/src/PS1/runtime/CaptureBuffer_test.cpp
@@ -1,0 +1,53 @@
+#ifdef ENABLE_PS1_RIP
+
+#include <gtest/gtest.h>
+
+#include "PS1/runtime/CaptureBuffer.h"
+#include "PS1/runtime/GteCapture.h"
+
+TEST(CaptureBufferTest, MatrixDedupeByHash)
+{
+    CaptureBuffer buffer;
+    buffer.beginFrame();
+
+    MatrixRecord a{};
+    a.rt.m[0][0] = 4096;
+    a.tr[0] = 10;
+    a.h = 256;
+
+    MatrixRecord b = a;
+    b.tr[0] = 99;
+
+    const uint32_t id0 = buffer.addMatrix(a);
+    const uint32_t id1 = buffer.addMatrix(a);
+    const uint32_t id2 = buffer.addMatrix(b);
+
+    EXPECT_EQ(id0, id1);
+    EXPECT_NE(id0, id2);
+    EXPECT_EQ(buffer.matrices().size(), 2);
+
+    PrimRecord prim{};
+    prim.matrixId = id0;
+    buffer.addPrim(prim);
+    prim.matrixId = id0;
+    buffer.addPrim(prim);
+    prim.matrixId = id2;
+    buffer.addPrim(prim);
+
+    buffer.endFrame();
+    EXPECT_TRUE(buffer.hasCameraMatrix());
+    EXPECT_EQ(buffer.cameraMatrixId(), id0);
+}
+
+TEST(GteCaptureTest, HashStableForIdenticalMatrices)
+{
+    MatrixRecord m{};
+    m.rt.m[1][1] = 2048;
+    m.ofx = 160;
+    m.ofy = 120;
+    m.h = 512;
+    EXPECT_EQ(GteCapture::hashMatrix(m), GteCapture::hashMatrix(m));
+    EXPECT_TRUE(GteCapture::matricesEqual(m, m));
+}
+
+#endif // ENABLE_PS1_RIP

--- a/src/PS1/runtime/CaptureTypes.h
+++ b/src/PS1/runtime/CaptureTypes.h
@@ -1,0 +1,63 @@
+#ifndef CAPTURETYPES_H
+#define CAPTURETYPES_H
+
+#include <cstdint>
+
+/** PS1 GPU primitive kinds decoded from GP0 (#418). */
+enum class PrimKind : uint8_t {
+    MonoTri = 0,
+    ShadedTri,
+    TexturedTri,
+    MonoQuad,
+    ShadedQuad,
+    TexturedQuad,
+    Sprite,
+};
+
+struct PsxVertex {
+    int32_t x = 0;
+    int32_t y = 0;
+    int32_t z = 0;
+    uint8_t r = 0;
+    uint8_t g = 0;
+    uint8_t b = 0;
+    int16_t u = 0;
+    int16_t v = 0;
+};
+
+/** One draw call lifted from the GPU command stream. */
+struct PrimRecord {
+    PrimKind kind = PrimKind::MonoTri;
+    uint8_t vertexCount = 0;
+    PsxVertex verts[4]{};
+    uint16_t tpage = 0;
+    uint16_t clut = 0;
+    uint8_t semiTrans = 0;
+    uint32_t drawModeBits = 0;
+    uint32_t matrixId = 0;
+};
+
+/** GP0 0xE1–0xE6 drawing environment snapshot. */
+struct DrawModeRecord {
+    uint32_t drawModeBits = 0;
+    uint16_t tpage = 0;
+    uint16_t clut = 0;
+    uint8_t textureWindow = 0;
+    uint8_t maskSetting = 0;
+};
+
+/** 3×3 fixed-point rotation + translation from the GTE (#419). */
+struct Matrix3 {
+    int32_t m[3][3]{};
+};
+
+struct MatrixRecord {
+    Matrix3 rt{};
+    int32_t tr[3]{};
+    int32_t ofx = 0;
+    int32_t ofy = 0;
+    int32_t h = 0;
+    uint64_t hash = 0;
+};
+
+#endif // CAPTURETYPES_H

--- a/src/PS1/runtime/EmuHooks.h
+++ b/src/PS1/runtime/EmuHooks.h
@@ -1,14 +1,36 @@
 #ifndef EMUHOOKS_H
 #define EMUHOOKS_H
 
+#include "CaptureTypes.h"
+
+#include <cstdint>
+
 /**
- * GPU/GTE interception callbacks (Phase 2 — #418).
- * Stub cores leave hooks null; real cores invoke these from the worker thread.
+ * GPU/GTE interception callbacks (Phase 2 — #418, #419).
+ * Implemented by RipperHooks in the app; invoked from the emulator plugin worker thread.
  */
 class EmuHooks
 {
 public:
     virtual ~EmuHooks() = default;
+
+    virtual bool isCaptureEnabled() const { return false; }
+
+    virtual void onFrameBegin() {}
+    virtual void onFrameEnd() {}
+
+    virtual uint32_t onGteMatrix(const MatrixRecord &matrix) { (void)matrix; return 0; }
+    virtual void onGpuPrim(const PrimRecord &prim) { (void)prim; }
+    virtual void onVramWrite(uint16_t x, uint16_t y, uint16_t w, uint16_t h, const uint16_t *pixels)
+    {
+        (void)x;
+        (void)y;
+        (void)w;
+        (void)h;
+        (void)pixels;
+    }
+    virtual void onVramRead(uint16_t x, uint16_t y, uint16_t w, uint16_t h) { (void)x; (void)y; (void)w; (void)h; }
+    virtual void onDrawMode(const DrawModeRecord &mode) { (void)mode; }
 };
 
 #endif // EMUHOOKS_H

--- a/src/PS1/runtime/GpuCommandParser.cpp
+++ b/src/PS1/runtime/GpuCommandParser.cpp
@@ -29,8 +29,9 @@ void decodeUvTpageClut(uint32_t word, int16_t &u, int16_t &v, uint16_t &clut, ui
 {
     u = static_cast<int16_t>(word & 0xFF);
     v = static_cast<int16_t>((word >> 8) & 0xFF);
-    clut = static_cast<uint16_t>((word >> 16) & 0xFFFF);
-    (void)tpage;
+    const uint16_t upper = static_cast<uint16_t>((word >> 16) & 0xFFFF);
+    clut = upper;
+    tpage = upper;
 }
 
 PrimKind kindFromOpcode(uint8_t cmd, uint8_t &vertexCount)
@@ -139,10 +140,36 @@ bool parseGouraudTri(const uint32_t *words, size_t wordCount, size_t &index, Pri
     return true;
 }
 
+bool parseTexturedGouraudTri(const uint32_t *words, size_t wordCount, size_t &index, PrimRecord &out,
+                             QString &error)
+{
+    if (index + 9 > wordCount) {
+        error = QStringLiteral("textured gouraud triangle: packet too short");
+        return false;
+    }
+
+    const uint32_t cmdWord = words[index++];
+    out.semiTrans = static_cast<uint8_t>((cmdWord >> 24) & 0x3);
+    decodeColor24(cmdWord >> 8, out.verts[0].r, out.verts[0].g, out.verts[0].b);
+    decodeScreenPos(words[index++], out.verts[0].x, out.verts[0].y);
+    decodeUvTpageClut(words[index++], out.verts[0].u, out.verts[0].v, out.clut, out.tpage);
+
+    for (int v = 1; v < 3; ++v) {
+        const uint32_t colorWord = words[index++];
+        decodeColor24(colorWord, out.verts[v].r, out.verts[v].g, out.verts[v].b);
+        decodeScreenPos(words[index++], out.verts[v].x, out.verts[v].y);
+        decodeUvTpageClut(words[index++], out.verts[v].u, out.verts[v].v, out.clut, out.tpage);
+    }
+
+    out.kind = PrimKind::TexturedTri;
+    out.vertexCount = 3;
+    return true;
+}
+
 bool parseTexturedQuad(const uint32_t *words, size_t wordCount, size_t &index, PrimRecord &out,
                        QString &error)
 {
-    if (index + 13 > wordCount) {
+    if (index + 9 > wordCount) {
         error = QStringLiteral("textured quad: packet too short");
         return false;
     }
@@ -265,11 +292,11 @@ size_t packetWordCount(uint8_t cmd)
     if (cmd >= 0x28 && cmd <= 0x2B)
         return 5;
     if (cmd >= 0x2C && cmd <= 0x2F)
-        return 13;
+        return 9;
     if (cmd >= 0x30 && cmd <= 0x33)
         return 6;
     if (cmd >= 0x34 && cmd <= 0x37)
-        return 13;
+        return 9;
     if (cmd >= 0x38 && cmd <= 0x3B)
         return 8;
     if (cmd >= 0x60 && cmd <= 0x7F)
@@ -323,6 +350,8 @@ GpuCommandParser::ParseResult GpuCommandParser::parseGp0(const uint32_t *words, 
             ok = parseTexturedQuad(words, wordCount, index, prim, result.error);
         else if (cmd >= 0x30 && cmd <= 0x33)
             ok = parseGouraudTri(words, wordCount, index, prim, result.error);
+        else if (cmd >= 0x34 && cmd <= 0x37)
+            ok = parseTexturedGouraudTri(words, wordCount, index, prim, result.error);
         else if (cmd >= 0x38 && cmd <= 0x3B)
             ok = parseGouraudQuad(words, wordCount, index, prim, result.error);
         else if (cmd >= 0x60 && cmd <= 0x7F)

--- a/src/PS1/runtime/GpuCommandParser.cpp
+++ b/src/PS1/runtime/GpuCommandParser.cpp
@@ -1,0 +1,358 @@
+#include "GpuCommandParser.h"
+
+#include <QTextStream>
+
+namespace {
+
+int16_t signExtend11(uint32_t v)
+{
+    v &= 0x7FF;
+    if (v & 0x400)
+        v |= ~0x7FFu;
+    return static_cast<int16_t>(v);
+}
+
+void decodeScreenPos(uint32_t word, int32_t &x, int32_t &y)
+{
+    x = signExtend11(word & 0xFFFF);
+    y = signExtend11((word >> 16) & 0xFFFF);
+}
+
+void decodeColor24(uint32_t word, uint8_t &r, uint8_t &g, uint8_t &b)
+{
+    r = (word >> 0) & 0xFF;
+    g = (word >> 8) & 0xFF;
+    b = (word >> 16) & 0xFF;
+}
+
+void decodeUvTpageClut(uint32_t word, int16_t &u, int16_t &v, uint16_t &clut, uint16_t &tpage)
+{
+    u = static_cast<int16_t>(word & 0xFF);
+    v = static_cast<int16_t>((word >> 8) & 0xFF);
+    clut = static_cast<uint16_t>((word >> 16) & 0xFFFF);
+    (void)tpage;
+}
+
+PrimKind kindFromOpcode(uint8_t cmd, uint8_t &vertexCount)
+{
+    if (cmd >= 0x20 && cmd <= 0x27) {
+        vertexCount = 3;
+        if (cmd >= 0x24)
+            return PrimKind::TexturedTri;
+        return PrimKind::MonoTri;
+    }
+    if (cmd >= 0x28 && cmd <= 0x2F) {
+        vertexCount = 4;
+        if (cmd >= 0x2C)
+            return PrimKind::TexturedQuad;
+        return PrimKind::MonoQuad;
+    }
+    if (cmd >= 0x30 && cmd <= 0x3F) {
+        vertexCount = 3;
+        if (cmd >= 0x34)
+            return PrimKind::TexturedTri;
+        return PrimKind::ShadedTri;
+    }
+    if (cmd >= 0x60 && cmd <= 0x7F) {
+        vertexCount = 2;
+        return PrimKind::Sprite;
+    }
+    vertexCount = 0;
+    return PrimKind::MonoTri;
+}
+
+bool parseMonoTri(const uint32_t *words, size_t wordCount, size_t &index, PrimRecord &out, QString &error)
+{
+    if (index + 4 > wordCount) {
+        error = QStringLiteral("monochrome triangle: packet too short");
+        return false;
+    }
+
+    const uint32_t cmdWord = words[index++];
+    decodeColor24(cmdWord >> 8, out.verts[0].r, out.verts[0].g, out.verts[0].b);
+    out.semiTrans = static_cast<uint8_t>((cmdWord >> 24) & 0x3);
+
+    for (int v = 0; v < 3; ++v) {
+        decodeScreenPos(words[index++], out.verts[v].x, out.verts[v].y);
+        if (v > 0) {
+            out.verts[v].r = out.verts[0].r;
+            out.verts[v].g = out.verts[0].g;
+            out.verts[v].b = out.verts[0].b;
+        }
+    }
+
+    out.kind = PrimKind::MonoTri;
+    out.vertexCount = 3;
+    return true;
+}
+
+bool parseTexturedTri(const uint32_t *words, size_t wordCount, size_t &index, PrimRecord &out,
+                      QString &error)
+{
+    if (index + 7 > wordCount) {
+        error = QStringLiteral("textured triangle: packet too short");
+        return false;
+    }
+
+    const uint32_t cmdWord = words[index++];
+    decodeColor24(cmdWord >> 8, out.verts[0].r, out.verts[0].g, out.verts[0].b);
+    out.semiTrans = static_cast<uint8_t>((cmdWord >> 24) & 0x3);
+
+    for (int v = 0; v < 3; ++v) {
+        decodeScreenPos(words[index++], out.verts[v].x, out.verts[v].y);
+        uint32_t uvWord = words[index++];
+        decodeUvTpageClut(uvWord, out.verts[v].u, out.verts[v].v, out.clut, out.tpage);
+        if (v > 0) {
+            out.verts[v].r = out.verts[0].r;
+            out.verts[v].g = out.verts[0].g;
+            out.verts[v].b = out.verts[0].b;
+        }
+    }
+
+    out.kind = PrimKind::TexturedTri;
+    out.vertexCount = 3;
+    return true;
+}
+
+bool parseGouraudTri(const uint32_t *words, size_t wordCount, size_t &index, PrimRecord &out,
+                     QString &error)
+{
+    if (index + 7 > wordCount) {
+        error = QStringLiteral("gouraud triangle: packet too short");
+        return false;
+    }
+
+    const uint32_t cmdWord = words[index++];
+    out.semiTrans = static_cast<uint8_t>((cmdWord >> 24) & 0x3);
+
+    for (int v = 0; v < 3; ++v) {
+        const uint32_t colorWord = words[index++];
+        decodeColor24(colorWord, out.verts[v].r, out.verts[v].g, out.verts[v].b);
+        decodeScreenPos(words[index++], out.verts[v].x, out.verts[v].y);
+    }
+
+    out.kind = PrimKind::ShadedTri;
+    out.vertexCount = 3;
+    return true;
+}
+
+bool parseTexturedQuad(const uint32_t *words, size_t wordCount, size_t &index, PrimRecord &out,
+                       QString &error)
+{
+    if (index + 13 > wordCount) {
+        error = QStringLiteral("textured quad: packet too short");
+        return false;
+    }
+
+    const uint32_t cmdWord = words[index++];
+    decodeColor24(cmdWord >> 8, out.verts[0].r, out.verts[0].g, out.verts[0].b);
+    out.semiTrans = static_cast<uint8_t>((cmdWord >> 24) & 0x3);
+
+    for (int v = 0; v < 4; ++v) {
+        decodeScreenPos(words[index++], out.verts[v].x, out.verts[v].y);
+        const uint32_t uvWord = words[index++];
+        decodeUvTpageClut(uvWord, out.verts[v].u, out.verts[v].v, out.clut, out.tpage);
+        if (v > 0) {
+            out.verts[v].r = out.verts[0].r;
+            out.verts[v].g = out.verts[0].g;
+            out.verts[v].b = out.verts[0].b;
+        }
+    }
+
+    out.kind = PrimKind::TexturedQuad;
+    out.vertexCount = 4;
+    return true;
+}
+
+bool parseMonoQuad(const uint32_t *words, size_t wordCount, size_t &index, PrimRecord &out,
+                   QString &error)
+{
+    if (index + 5 > wordCount) {
+        error = QStringLiteral("monochrome quad: packet too short");
+        return false;
+    }
+
+    const uint32_t cmdWord = words[index++];
+    decodeColor24(cmdWord >> 8, out.verts[0].r, out.verts[0].g, out.verts[0].b);
+    out.semiTrans = static_cast<uint8_t>((cmdWord >> 24) & 0x3);
+
+    for (int v = 0; v < 4; ++v) {
+        decodeScreenPos(words[index++], out.verts[v].x, out.verts[v].y);
+        if (v > 0) {
+            out.verts[v].r = out.verts[0].r;
+            out.verts[v].g = out.verts[0].g;
+            out.verts[v].b = out.verts[0].b;
+        }
+    }
+
+    out.kind = PrimKind::MonoQuad;
+    out.vertexCount = 4;
+    return true;
+}
+
+bool parseGouraudQuad(const uint32_t *words, size_t wordCount, size_t &index, PrimRecord &out,
+                      QString &error)
+{
+    if (index + 9 > wordCount) {
+        error = QStringLiteral("gouraud quad: packet too short");
+        return false;
+    }
+
+    const uint32_t cmdWord = words[index++];
+    out.semiTrans = static_cast<uint8_t>((cmdWord >> 24) & 0x3);
+
+    for (int v = 0; v < 4; ++v) {
+        const uint32_t colorWord = words[index++];
+        decodeColor24(colorWord, out.verts[v].r, out.verts[v].g, out.verts[v].b);
+        decodeScreenPos(words[index++], out.verts[v].x, out.verts[v].y);
+    }
+
+    out.kind = PrimKind::ShadedQuad;
+    out.vertexCount = 4;
+    return true;
+}
+
+bool parseSprite(const uint32_t *words, size_t wordCount, size_t &index, PrimRecord &out,
+                 QString &error)
+{
+    if (index + 4 > wordCount) {
+        error = QStringLiteral("sprite: packet too short");
+        return false;
+    }
+
+    const uint32_t cmdWord = words[index++];
+    decodeColor24(cmdWord >> 8, out.verts[0].r, out.verts[0].g, out.verts[0].b);
+    out.semiTrans = static_cast<uint8_t>((cmdWord >> 24) & 0x3);
+
+    decodeScreenPos(words[index++], out.verts[0].x, out.verts[0].y);
+    decodeScreenPos(words[index++], out.verts[1].x, out.verts[1].y);
+    const uint32_t uvWord = words[index++];
+    decodeUvTpageClut(uvWord, out.verts[0].u, out.verts[0].v, out.clut, out.tpage);
+    out.verts[1].u = out.verts[0].u;
+    out.verts[1].v = out.verts[0].v;
+
+    out.kind = PrimKind::Sprite;
+    out.vertexCount = 2;
+    return true;
+}
+
+bool parseDrawMode(const uint32_t *words, size_t wordCount, size_t &index, DrawModeRecord &out,
+                   QString &error)
+{
+    if (index + 2 > wordCount) {
+        error = QStringLiteral("draw mode: packet too short");
+        return false;
+    }
+
+    const uint32_t cmdWord = words[index++];
+    out.drawModeBits = words[index++];
+    out.tpage = static_cast<uint16_t>((cmdWord >> 16) & 0xFFFF);
+    out.clut = static_cast<uint16_t>(out.drawModeBits & 0xFFFF);
+    return true;
+}
+
+size_t packetWordCount(uint8_t cmd)
+{
+    if (cmd >= 0x20 && cmd <= 0x23)
+        return 4;
+    if (cmd >= 0x24 && cmd <= 0x27)
+        return 10;
+    if (cmd >= 0x28 && cmd <= 0x2B)
+        return 5;
+    if (cmd >= 0x2C && cmd <= 0x2F)
+        return 13;
+    if (cmd >= 0x30 && cmd <= 0x33)
+        return 7;
+    if (cmd >= 0x34 && cmd <= 0x37)
+        return 13;
+    if (cmd >= 0x38 && cmd <= 0x3B)
+        return 9;
+    if (cmd >= 0x60 && cmd <= 0x7F)
+        return 4;
+    if (cmd == 0xE1)
+        return 2;
+    if (cmd == 0xA0)
+        return 3; // minimum; variable in hardware — tests use fixed uploads
+    return 0;
+}
+
+} // namespace
+
+GpuCommandParser::ParseResult GpuCommandParser::parseGp0(const uint32_t *words, size_t wordCount)
+{
+    ParseResult result;
+    if (!words || wordCount == 0)
+        return result;
+
+    size_t index = 0;
+    while (index < wordCount) {
+        const uint8_t cmd = static_cast<uint8_t>(words[index] & 0xFF);
+
+        if (cmd >= 0xE1 && cmd <= 0xE6) {
+            DrawModeRecord mode{};
+            if (!parseDrawMode(words, wordCount, index, mode, result.error))
+                break;
+            result.drawModes.append(mode);
+            continue;
+        }
+
+        if (cmd == 0xA0 || cmd == 0xC0) {
+            const size_t skip = packetWordCount(cmd);
+            if (skip == 0 || index + skip > wordCount) {
+                result.error = QStringLiteral("VRAM copy packet truncated");
+                break;
+            }
+            index += skip;
+            continue;
+        }
+
+        PrimRecord prim{};
+        bool ok = false;
+        if (cmd >= 0x20 && cmd <= 0x23)
+            ok = parseMonoTri(words, wordCount, index, prim, result.error);
+        else if (cmd >= 0x24 && cmd <= 0x27)
+            ok = parseTexturedTri(words, wordCount, index, prim, result.error);
+        else if (cmd >= 0x28 && cmd <= 0x2B)
+            ok = parseMonoQuad(words, wordCount, index, prim, result.error);
+        else if (cmd >= 0x2C && cmd <= 0x2F)
+            ok = parseTexturedQuad(words, wordCount, index, prim, result.error);
+        else if (cmd >= 0x30 && cmd <= 0x33)
+            ok = parseGouraudTri(words, wordCount, index, prim, result.error);
+        else if (cmd >= 0x38 && cmd <= 0x3B)
+            ok = parseGouraudQuad(words, wordCount, index, prim, result.error);
+        else if (cmd >= 0x60 && cmd <= 0x7F)
+            ok = parseSprite(words, wordCount, index, prim, result.error);
+        else {
+            const size_t skip = packetWordCount(cmd);
+            if (skip == 0) {
+                result.error = QStringLiteral("unknown GP0 opcode 0x%1").arg(cmd, 2, 16, QChar('0'));
+                break;
+            }
+            if (index + skip > wordCount) {
+                result.error = QStringLiteral("packet truncated for opcode 0x%1").arg(cmd, 2, 16, QChar('0'));
+                break;
+            }
+            index += skip;
+            continue;
+        }
+
+        if (!ok)
+            break;
+        result.prims.append(prim);
+    }
+
+    return result;
+}
+
+QString GpuCommandParser::primsToCsv(const QVector<PrimRecord> &prims)
+{
+    QString out;
+    QTextStream stream(&out);
+    stream << "kind,vertexCount,matrixId,tpage,clut,x0,y0,u0,v0\n";
+    for (const PrimRecord &p : prims) {
+        stream << static_cast<int>(p.kind) << ',' << static_cast<int>(p.vertexCount) << ','
+               << p.matrixId << ',' << p.tpage << ',' << p.clut << ',' << p.verts[0].x << ','
+               << p.verts[0].y << ',' << p.verts[0].u << ',' << p.verts[0].v << '\n';
+    }
+    return out;
+}

--- a/src/PS1/runtime/GpuCommandParser.cpp
+++ b/src/PS1/runtime/GpuCommandParser.cpp
@@ -117,15 +117,18 @@ bool parseTexturedTri(const uint32_t *words, size_t wordCount, size_t &index, Pr
 bool parseGouraudTri(const uint32_t *words, size_t wordCount, size_t &index, PrimRecord &out,
                      QString &error)
 {
-    if (index + 7 > wordCount) {
+    // psx-spx: cmd carries vertex-0 color; then (x,y) for v0; color+(x,y) for v1 and v2.
+    if (index + 6 > wordCount) {
         error = QStringLiteral("gouraud triangle: packet too short");
         return false;
     }
 
     const uint32_t cmdWord = words[index++];
     out.semiTrans = static_cast<uint8_t>((cmdWord >> 24) & 0x3);
+    decodeColor24(cmdWord >> 8, out.verts[0].r, out.verts[0].g, out.verts[0].b);
+    decodeScreenPos(words[index++], out.verts[0].x, out.verts[0].y);
 
-    for (int v = 0; v < 3; ++v) {
+    for (int v = 1; v < 3; ++v) {
         const uint32_t colorWord = words[index++];
         decodeColor24(colorWord, out.verts[v].r, out.verts[v].g, out.verts[v].b);
         decodeScreenPos(words[index++], out.verts[v].x, out.verts[v].y);
@@ -193,15 +196,17 @@ bool parseMonoQuad(const uint32_t *words, size_t wordCount, size_t &index, PrimR
 bool parseGouraudQuad(const uint32_t *words, size_t wordCount, size_t &index, PrimRecord &out,
                       QString &error)
 {
-    if (index + 9 > wordCount) {
+    if (index + 8 > wordCount) {
         error = QStringLiteral("gouraud quad: packet too short");
         return false;
     }
 
     const uint32_t cmdWord = words[index++];
     out.semiTrans = static_cast<uint8_t>((cmdWord >> 24) & 0x3);
+    decodeColor24(cmdWord >> 8, out.verts[0].r, out.verts[0].g, out.verts[0].b);
+    decodeScreenPos(words[index++], out.verts[0].x, out.verts[0].y);
 
-    for (int v = 0; v < 4; ++v) {
+    for (int v = 1; v < 4; ++v) {
         const uint32_t colorWord = words[index++];
         decodeColor24(colorWord, out.verts[v].r, out.verts[v].g, out.verts[v].b);
         decodeScreenPos(words[index++], out.verts[v].x, out.verts[v].y);
@@ -236,18 +241,18 @@ bool parseSprite(const uint32_t *words, size_t wordCount, size_t &index, PrimRec
     return true;
 }
 
-bool parseDrawMode(const uint32_t *words, size_t wordCount, size_t &index, DrawModeRecord &out,
-                   QString &error)
+bool parseDrawingEnv(const uint32_t *words, size_t wordCount, size_t &index, DrawModeRecord &out,
+                     QString &error)
 {
-    if (index + 2 > wordCount) {
-        error = QStringLiteral("draw mode: packet too short");
+    if (index + 1 > wordCount) {
+        error = QStringLiteral("drawing environment: packet too short");
         return false;
     }
 
     const uint32_t cmdWord = words[index++];
-    out.drawModeBits = words[index++];
+    out.drawModeBits = cmdWord;
     out.tpage = static_cast<uint16_t>((cmdWord >> 16) & 0xFFFF);
-    out.clut = static_cast<uint16_t>(out.drawModeBits & 0xFFFF);
+    out.clut = static_cast<uint16_t>((cmdWord >> 16) & 0xFFFF);
     return true;
 }
 
@@ -262,17 +267,17 @@ size_t packetWordCount(uint8_t cmd)
     if (cmd >= 0x2C && cmd <= 0x2F)
         return 13;
     if (cmd >= 0x30 && cmd <= 0x33)
-        return 7;
+        return 6;
     if (cmd >= 0x34 && cmd <= 0x37)
         return 13;
     if (cmd >= 0x38 && cmd <= 0x3B)
-        return 9;
+        return 8;
     if (cmd >= 0x60 && cmd <= 0x7F)
         return 4;
-    if (cmd == 0xE1)
-        return 2;
-    if (cmd == 0xA0)
-        return 3; // minimum; variable in hardware — tests use fixed uploads
+    if (cmd >= 0xE1 && cmd <= 0xE6)
+        return 1;
+    if (cmd == 0xA0 || cmd == 0xC0)
+        return 3; // minimum header; variable in hardware — tests use fixed uploads
     return 0;
 }
 
@@ -290,7 +295,7 @@ GpuCommandParser::ParseResult GpuCommandParser::parseGp0(const uint32_t *words, 
 
         if (cmd >= 0xE1 && cmd <= 0xE6) {
             DrawModeRecord mode{};
-            if (!parseDrawMode(words, wordCount, index, mode, result.error))
+            if (!parseDrawingEnv(words, wordCount, index, mode, result.error))
                 break;
             result.drawModes.append(mode);
             continue;

--- a/src/PS1/runtime/GpuCommandParser.h
+++ b/src/PS1/runtime/GpuCommandParser.h
@@ -1,0 +1,30 @@
+#ifndef GPUCOMMANDPARSER_H
+#define GPUCOMMANDPARSER_H
+
+#include "CaptureTypes.h"
+
+#include <QVector>
+#include <QString>
+#include <cstddef>
+#include <cstdint>
+
+/**
+ * Decodes PS1 GP0 command streams into PrimRecord / DrawModeRecord (#418).
+ * Reference: nocash psx-spx — GPU Rendering Polygon Commands.
+ */
+class GpuCommandParser
+{
+public:
+    struct ParseResult {
+        QVector<PrimRecord> prims;
+        QVector<DrawModeRecord> drawModes;
+        QString error;
+    };
+
+    static ParseResult parseGp0(const uint32_t *words, size_t wordCount);
+
+    /** Serialize primitives to CSV for regression dumps (tests / debug). */
+    static QString primsToCsv(const QVector<PrimRecord> &prims);
+};
+
+#endif // GPUCOMMANDPARSER_H

--- a/src/PS1/runtime/GpuCommandParser_test.cpp
+++ b/src/PS1/runtime/GpuCommandParser_test.cpp
@@ -53,10 +53,11 @@ TEST(GpuCommandParserTest, ParsesDrawModeAndSprite)
     ASSERT_EQ(result.prims.size(), 1);
     EXPECT_EQ(result.prims[0].kind, PrimKind::Sprite);
 
-    const uint32_t modeWords[] = {0x000000E1u, 0x00001234u};
-    const auto modeResult = GpuCommandParser::parseGp0(modeWords, 2);
+    const uint32_t modeWords[] = {0xE1u | (0x1234u << 8)};
+    const auto modeResult = GpuCommandParser::parseGp0(modeWords, 1);
     ASSERT_TRUE(modeResult.error.isEmpty()) << modeResult.error.toStdString();
     EXPECT_EQ(modeResult.drawModes.size(), 1);
+    EXPECT_EQ(modeResult.drawModes[0].drawModeBits, modeWords[0]);
 
     const QString csv = GpuCommandParser::primsToCsv(result.prims);
     EXPECT_TRUE(csv.contains(QStringLiteral("kind,vertexCount")));
@@ -79,6 +80,43 @@ TEST(GpuCommandParserTest, ParsesTexturedTriangle)
     ASSERT_EQ(result.prims.size(), 1);
     EXPECT_EQ(result.prims[0].kind, PrimKind::TexturedTri);
     EXPECT_EQ(result.prims[0].clut, 0x0810u);
+}
+
+TEST(GpuCommandParserTest, ParsesGouraudTriangle)
+{
+    const uint32_t words[] = {
+        colorCmd(0x30, 255, 0, 0),
+        pos(10, 20),
+        0x0000FF00u,
+        pos(30, 20),
+        0x00FF0000u,
+        pos(20, 40),
+    };
+
+    const auto result = GpuCommandParser::parseGp0(words, 6);
+    ASSERT_TRUE(result.error.isEmpty()) << result.error.toStdString();
+    ASSERT_EQ(result.prims.size(), 1);
+    EXPECT_EQ(result.prims[0].kind, PrimKind::ShadedTri);
+    EXPECT_EQ(result.prims[0].verts[0].r, 255);
+    EXPECT_EQ(result.prims[0].verts[1].g, 255);
+    EXPECT_EQ(result.prims[0].verts[2].b, 255);
+}
+
+TEST(GpuCommandParserTest, SkipsVramCopyCommands)
+{
+    const uint32_t words[] = {
+        colorCmd(0x20, 1, 2, 3),
+        pos(0, 0),
+        pos(10, 0),
+        pos(5, 10),
+        0x000000C0u,
+        0x00000000u,
+        0x00000000u,
+    };
+
+    const auto result = GpuCommandParser::parseGp0(words, 7);
+    ASSERT_TRUE(result.error.isEmpty()) << result.error.toStdString();
+    ASSERT_EQ(result.prims.size(), 1);
 }
 
 #endif // ENABLE_PS1_RIP

--- a/src/PS1/runtime/GpuCommandParser_test.cpp
+++ b/src/PS1/runtime/GpuCommandParser_test.cpp
@@ -1,0 +1,84 @@
+#ifdef ENABLE_PS1_RIP
+
+#include <gtest/gtest.h>
+
+#include "PS1/runtime/GpuCommandParser.h"
+
+namespace {
+
+uint32_t colorCmd(uint8_t opcode, uint8_t r, uint8_t g, uint8_t b)
+{
+    return static_cast<uint32_t>(opcode) | (static_cast<uint32_t>(r) << 8)
+           | (static_cast<uint32_t>(g) << 16) | (static_cast<uint32_t>(b) << 24);
+}
+
+uint32_t pos(int x, int y)
+{
+    return static_cast<uint32_t>((y & 0xFFFF) << 16) | static_cast<uint32_t>(x & 0xFFFF);
+}
+
+} // namespace
+
+TEST(GpuCommandParserTest, ParsesMonochromeTriangle)
+{
+    const uint32_t words[] = {
+        colorCmd(0x20, 30, 20, 10),
+        pos(8, 16),
+        pos(40, 16),
+        pos(24, 32),
+    };
+
+    const auto result = GpuCommandParser::parseGp0(words, 4);
+    ASSERT_TRUE(result.error.isEmpty()) << result.error.toStdString();
+    ASSERT_EQ(result.prims.size(), 1);
+    EXPECT_EQ(result.prims[0].kind, PrimKind::MonoTri);
+    EXPECT_EQ(result.prims[0].vertexCount, 3);
+    EXPECT_EQ(result.prims[0].verts[0].r, 30);
+    EXPECT_EQ(result.prims[0].verts[0].g, 20);
+    EXPECT_EQ(result.prims[0].verts[0].b, 10);
+    EXPECT_EQ(result.prims[0].verts[1].x, 40);
+}
+
+TEST(GpuCommandParserTest, ParsesDrawModeAndSprite)
+{
+    const uint32_t words[] = {
+        colorCmd(0x60, 0, 0, 0),
+        pos(8, 8),
+        pos(32, 32),
+        0x00080810u,
+    };
+
+    const auto result = GpuCommandParser::parseGp0(words, 4);
+    ASSERT_TRUE(result.error.isEmpty()) << result.error.toStdString();
+    ASSERT_EQ(result.prims.size(), 1);
+    EXPECT_EQ(result.prims[0].kind, PrimKind::Sprite);
+
+    const uint32_t modeWords[] = {0x000000E1u, 0x00001234u};
+    const auto modeResult = GpuCommandParser::parseGp0(modeWords, 2);
+    ASSERT_TRUE(modeResult.error.isEmpty()) << modeResult.error.toStdString();
+    EXPECT_EQ(modeResult.drawModes.size(), 1);
+
+    const QString csv = GpuCommandParser::primsToCsv(result.prims);
+    EXPECT_TRUE(csv.contains(QStringLiteral("kind,vertexCount")));
+}
+
+TEST(GpuCommandParserTest, ParsesTexturedTriangle)
+{
+    const uint32_t words[] = {
+        colorCmd(0x24, 0, 0, 0),
+        pos(8, 16),
+        0x08100808u,
+        pos(40, 16),
+        0x08100808u,
+        pos(24, 32),
+        0x08100808u,
+    };
+
+    const auto result = GpuCommandParser::parseGp0(words, 7);
+    ASSERT_TRUE(result.error.isEmpty()) << result.error.toStdString();
+    ASSERT_EQ(result.prims.size(), 1);
+    EXPECT_EQ(result.prims[0].kind, PrimKind::TexturedTri);
+    EXPECT_EQ(result.prims[0].clut, 0x0810u);
+}
+
+#endif // ENABLE_PS1_RIP

--- a/src/PS1/runtime/GpuCommandParser_test.cpp
+++ b/src/PS1/runtime/GpuCommandParser_test.cpp
@@ -80,6 +80,7 @@ TEST(GpuCommandParserTest, ParsesTexturedTriangle)
     ASSERT_EQ(result.prims.size(), 1);
     EXPECT_EQ(result.prims[0].kind, PrimKind::TexturedTri);
     EXPECT_EQ(result.prims[0].clut, 0x0810u);
+    EXPECT_EQ(result.prims[0].tpage, 0x0810u);
 }
 
 TEST(GpuCommandParserTest, ParsesGouraudTriangle)
@@ -100,6 +101,48 @@ TEST(GpuCommandParserTest, ParsesGouraudTriangle)
     EXPECT_EQ(result.prims[0].verts[0].r, 255);
     EXPECT_EQ(result.prims[0].verts[1].g, 255);
     EXPECT_EQ(result.prims[0].verts[2].b, 255);
+}
+
+TEST(GpuCommandParserTest, ParsesTexturedGouraudTriangle)
+{
+    const uint32_t words[] = {
+        colorCmd(0x34, 255, 0, 0),
+        pos(10, 20),
+        0x08100808u,
+        0x0000FF00u,
+        pos(30, 20),
+        0x08100808u,
+        0x00FF0000u,
+        pos(20, 40),
+        0x08100808u,
+    };
+
+    const auto result = GpuCommandParser::parseGp0(words, 9);
+    ASSERT_TRUE(result.error.isEmpty()) << result.error.toStdString();
+    ASSERT_EQ(result.prims.size(), 1);
+    EXPECT_EQ(result.prims[0].kind, PrimKind::TexturedTri);
+    EXPECT_EQ(result.prims[0].verts[2].b, 255);
+}
+
+TEST(GpuCommandParserTest, ParsesTexturedQuad)
+{
+    const uint32_t words[] = {
+        colorCmd(0x2C, 10, 20, 30),
+        pos(0, 0),
+        0x08100808u,
+        pos(32, 0),
+        0x08100808u,
+        pos(32, 32),
+        0x08100808u,
+        pos(0, 32),
+        0x08100808u,
+    };
+
+    const auto result = GpuCommandParser::parseGp0(words, 9);
+    ASSERT_TRUE(result.error.isEmpty()) << result.error.toStdString();
+    ASSERT_EQ(result.prims.size(), 1);
+    EXPECT_EQ(result.prims[0].kind, PrimKind::TexturedQuad);
+    EXPECT_EQ(result.prims[0].vertexCount, 4);
 }
 
 TEST(GpuCommandParserTest, SkipsVramCopyCommands)

--- a/src/PS1/runtime/GteCapture.cpp
+++ b/src/PS1/runtime/GteCapture.cpp
@@ -1,0 +1,36 @@
+#include "GteCapture.h"
+
+#include <cstring>
+
+namespace GteCapture {
+
+uint64_t hashMatrix(const MatrixRecord &matrix)
+{
+    uint64_t h = 1469598103934665603ULL;
+    auto mix = [&h](uint64_t v) {
+        h ^= v;
+        h *= 1099511628211ULL;
+    };
+
+    mix(static_cast<uint64_t>(matrix.ofx));
+    mix(static_cast<uint64_t>(matrix.ofy));
+    mix(static_cast<uint64_t>(matrix.h));
+    for (int i = 0; i < 3; ++i)
+        mix(static_cast<uint64_t>(static_cast<uint32_t>(matrix.tr[i])));
+    for (int r = 0; r < 3; ++r) {
+        for (int c = 0; c < 3; ++c)
+            mix(static_cast<uint64_t>(static_cast<uint32_t>(matrix.rt.m[r][c])));
+    }
+    return h;
+}
+
+bool matricesEqual(const MatrixRecord &a, const MatrixRecord &b)
+{
+    if (a.ofx != b.ofx || a.ofy != b.ofy || a.h != b.h)
+        return false;
+    if (std::memcmp(a.tr, b.tr, sizeof(a.tr)) != 0)
+        return false;
+    return std::memcmp(a.rt.m, b.rt.m, sizeof(a.rt.m)) == 0;
+}
+
+} // namespace GteCapture

--- a/src/PS1/runtime/GteCapture.h
+++ b/src/PS1/runtime/GteCapture.h
@@ -1,0 +1,16 @@
+#ifndef GTECAPTURE_H
+#define GTECAPTURE_H
+
+#include "CaptureTypes.h"
+
+#include <cstdint>
+
+/** Hashing and deduplication for GTE matrix records (#419). */
+namespace GteCapture {
+
+uint64_t hashMatrix(const MatrixRecord &matrix);
+bool matricesEqual(const MatrixRecord &a, const MatrixRecord &b);
+
+} // namespace GteCapture
+
+#endif // GTECAPTURE_H

--- a/src/PS1/runtime/PS1RipManager.cpp
+++ b/src/PS1/runtime/PS1RipManager.cpp
@@ -53,6 +53,7 @@ void PS1RipManager::initializeWorkerThread()
         m_sessionActive = false;
         m_paused = false;
         m_captureArmed = false;
+        syncWorkerCaptureArmed();
         emit sessionStopped();
     });
     connect(m_worker, &PS1RipWorker::emulationError, this, [this](const QString &msg) {
@@ -61,8 +62,8 @@ void PS1RipManager::initializeWorkerThread()
     });
     connect(m_worker, &PS1RipWorker::framePresented, this, &PS1RipManager::framePresented);
     connect(m_worker, &PS1RipWorker::frameCaptureReady, this, [this](const QString &captureId, int) {
-        SentryReporter::addBreadcrumb(QStringLiteral("ps1.rip.capture"),
-                                      QStringLiteral("frame_saved:%1").arg(captureId));
+        SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
+                                      QStringLiteral("ps1_rip_frame:%1").arg(captureId));
         emit frameCaptured(captureId);
     });
 
@@ -95,6 +96,16 @@ void PS1RipManager::syncWorkerSession()
         return;
     QMetaObject::invokeMethod(m_worker, "configureSession", Qt::QueuedConnection,
                               Q_ARG(QString, m_biosPath), Q_ARG(QString, m_isoPath));
+}
+
+void PS1RipManager::syncWorkerCaptureArmed()
+{
+    if (!m_worker)
+        return;
+    PS1RipWorker *worker = m_worker;
+    const bool armed = m_captureArmed;
+    QMetaObject::invokeMethod(worker, [worker, armed]() { worker->setCaptureArmed(armed); },
+                              Qt::QueuedConnection);
 }
 
 bool PS1RipManager::loadBios(const QString &path)
@@ -158,6 +169,7 @@ bool PS1RipManager::stop()
         return false;
 
     m_captureArmed = false;
+    syncWorkerCaptureArmed();
     SentryReporter::addBreadcrumb(QStringLiteral("ps1.rip"), QStringLiteral("stop"));
 
     if (m_startPending && !m_sessionActive) {
@@ -198,17 +210,14 @@ bool PS1RipManager::armCapture(bool armed)
 {
     m_captureArmed = armed;
     if (armed) {
-        SentryReporter::addBreadcrumb(QStringLiteral("ps1.rip.capture"),
-                                      QStringLiteral("frame_armed"));
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("ps1_rip_arm_capture"));
     } else {
-        SentryReporter::addBreadcrumb(QStringLiteral("ps1.rip"),
-                                      QStringLiteral("disarmCapture"));
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("ps1_rip_disarm_capture"));
     }
 
-    if (m_worker) {
-        QMetaObject::invokeMethod(
-            m_worker, [this, armed]() { m_worker->setCaptureArmed(armed); }, Qt::QueuedConnection);
-    }
+    syncWorkerCaptureArmed();
     return true;
 }
 
@@ -222,7 +231,8 @@ bool PS1RipManager::captureFrame()
         reportError(tr("No active PS1 session"));
         return false;
     }
-    QMetaObject::invokeMethod(m_worker, [this]() { m_worker->finalizeFrameCapture(); },
+    PS1RipWorker *worker = m_worker;
+    QMetaObject::invokeMethod(worker, [worker]() { worker->finalizeFrameCapture(); },
                               Qt::QueuedConnection);
     return true;
 }

--- a/src/PS1/runtime/PS1RipManager.cpp
+++ b/src/PS1/runtime/PS1RipManager.cpp
@@ -60,6 +60,11 @@ void PS1RipManager::initializeWorkerThread()
         reportError(msg);
     });
     connect(m_worker, &PS1RipWorker::framePresented, this, &PS1RipManager::framePresented);
+    connect(m_worker, &PS1RipWorker::frameCaptureReady, this, [this](const QString &captureId, int) {
+        SentryReporter::addBreadcrumb(QStringLiteral("ps1.rip.capture"),
+                                      QStringLiteral("frame_saved:%1").arg(captureId));
+        emit frameCaptured(captureId);
+    });
 
     connect(m_workerThread, &QThread::finished, m_worker, &QObject::deleteLater);
 
@@ -192,8 +197,18 @@ bool PS1RipManager::step()
 bool PS1RipManager::armCapture(bool armed)
 {
     m_captureArmed = armed;
-    SentryReporter::addBreadcrumb(QStringLiteral("ps1.rip"),
-                                  armed ? QStringLiteral("armCapture") : QStringLiteral("disarmCapture"));
+    if (armed) {
+        SentryReporter::addBreadcrumb(QStringLiteral("ps1.rip.capture"),
+                                      QStringLiteral("frame_armed"));
+    } else {
+        SentryReporter::addBreadcrumb(QStringLiteral("ps1.rip"),
+                                      QStringLiteral("disarmCapture"));
+    }
+
+    if (m_worker) {
+        QMetaObject::invokeMethod(
+            m_worker, [this, armed]() { m_worker->setCaptureArmed(armed); }, Qt::QueuedConnection);
+    }
     return true;
 }
 
@@ -203,8 +218,13 @@ bool PS1RipManager::captureFrame()
         reportError(tr("Capture is not armed"));
         return false;
     }
-    reportError(tr("Capture pipeline not implemented yet"));
-    return false;
+    if (!m_sessionActive) {
+        reportError(tr("No active PS1 session"));
+        return false;
+    }
+    QMetaObject::invokeMethod(m_worker, [this]() { m_worker->finalizeFrameCapture(); },
+                              Qt::QueuedConnection);
+    return true;
 }
 
 bool PS1RipManager::captureScene(int seconds)

--- a/src/PS1/runtime/PS1RipManager.h
+++ b/src/PS1/runtime/PS1RipManager.h
@@ -60,6 +60,7 @@ private:
     void shutdownWorkerThread();
     void reportError(const QString &message);
     void syncWorkerSession();
+    void syncWorkerCaptureArmed();
 
     static PS1RipManager *s_instance;
 

--- a/src/PS1/runtime/PS1RipManager_test.cpp
+++ b/src/PS1/runtime/PS1RipManager_test.cpp
@@ -7,6 +7,7 @@
 #include <QFileInfo>
 #include <QSignalSpy>
 #include <QTemporaryFile>
+#include <QTest>
 
 #include "PS1/runtime/PS1RipManager.h"
 
@@ -145,6 +146,38 @@ TEST_F(PS1RipManagerTest, StopCancelsPendingStart)
 
     ASSERT_FALSE(startedSpy.wait(500));
     EXPECT_TRUE(startedSpy.empty());
+}
+
+TEST_F(PS1RipManagerTest, ArmedCaptureAccumulatesPrimitives)
+{
+    if (!stubPluginAvailable())
+        GTEST_SKIP() << "PS1 stub core plugin not beside test binary";
+
+    QTemporaryFile bios(QDir::tempPath() + "/qtmesh_bios_cap_XXXXXX.bin");
+    QTemporaryFile iso(QDir::tempPath() + "/qtmesh_iso_cap_XXXXXX.bin");
+    ASSERT_TRUE(bios.open());
+    ASSERT_TRUE(iso.open());
+    bios.write("bios");
+    iso.write("iso");
+    bios.close();
+    iso.close();
+
+    ASSERT_TRUE(manager->loadBios(bios.fileName()));
+    ASSERT_TRUE(manager->loadIso(iso.fileName()));
+    ASSERT_TRUE(manager->armCapture(true));
+
+    QSignalSpy startedSpy(manager, &PS1RipManager::sessionStarted);
+    ASSERT_TRUE(manager->start());
+    ASSERT_TRUE(startedSpy.wait(3000));
+
+    QTest::qWait(100);
+
+    QSignalSpy captureSpy(manager, &PS1RipManager::frameCaptured);
+    ASSERT_TRUE(manager->captureFrame());
+    ASSERT_TRUE(captureSpy.wait(3000));
+    EXPECT_FALSE(captureSpy.empty());
+
+    manager->stop();
 }
 
 #endif // ENABLE_PS1_RIP

--- a/src/PS1/runtime/PS1RipWorker.cpp
+++ b/src/PS1/runtime/PS1RipWorker.cpp
@@ -162,13 +162,24 @@ void PS1RipWorker::finalizeFrameCapture()
 
     const QString captureId = QString::number(QDateTime::currentMSecsSinceEpoch());
     const QString dir = QDir::temp().filePath(QStringLiteral("qtmesh_ps1_capture"));
-    QDir().mkpath(dir);
+    if (!QDir().mkpath(dir)) {
+        emit emulationError(tr("Failed to create capture directory: %1").arg(dir));
+        return;
+    }
+
     const QString csvPath = dir + QLatin1Char('/') + captureId + QStringLiteral(".csv");
     QFile file(csvPath);
-    if (file.open(QIODevice::WriteOnly | QIODevice::Text)) {
-        file.write(GpuCommandParser::primsToCsv(prims).toUtf8());
-        file.close();
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        emit emulationError(tr("Failed to write capture file: %1").arg(csvPath));
+        return;
     }
+
+    const QByteArray csv = GpuCommandParser::primsToCsv(prims).toUtf8();
+    if (file.write(csv) != csv.size()) {
+        emit emulationError(tr("Failed to write capture data: %1").arg(csvPath));
+        return;
+    }
+    file.close();
 
     emit frameCaptureReady(captureId, prims.size());
 }

--- a/src/PS1/runtime/PS1RipWorker.cpp
+++ b/src/PS1/runtime/PS1RipWorker.cpp
@@ -1,15 +1,26 @@
 #include "PS1RipWorker.h"
+#include "CaptureBuffer.h"
 #include "EmuCore.h"
 #include "EmuCoreLoader.h"
 #include "EmuFramebuffer.h"
+#include "GpuCommandParser.h"
+#include "RipperHooks.h"
 
+#include <QDateTime>
+#include <QDir>
+#include <QFile>
 #include <QTimer>
 
 #include <cstring>
 
 PS1RipWorker::PS1RipWorker(QObject *parent)
     : QObject(parent)
+    , m_captureBuffer(std::make_unique<CaptureBuffer>())
+    , m_ripperHooks(std::make_unique<RipperHooks>())
 {
+    m_ripperHooks->setArmedFlag(&m_captureArmed);
+    m_ripperHooks->setBuffer(m_captureBuffer.get());
+
     m_frameTimer = new QTimer(this);
     m_frameTimer->setTimerType(Qt::PreciseTimer);
     m_frameTimer->setInterval(16);
@@ -75,6 +86,7 @@ void PS1RipWorker::startEmulation()
         return;
     }
 
+    m_core->setHooks(m_ripperHooks.get());
     m_core->reset();
 
     if (m_startSuperseded.load(std::memory_order_acquire)) {
@@ -128,6 +140,37 @@ void PS1RipWorker::runFrameTick()
     m_core->runFrame();
     const EmuFramebuffer &fb = m_core->framebuffer();
     emit framePresented(framebufferToImage(fb), fb.frameIndex);
+}
+
+void PS1RipWorker::setCaptureArmed(bool armed)
+{
+    m_captureArmed.store(armed, std::memory_order_release);
+}
+
+void PS1RipWorker::finalizeFrameCapture()
+{
+    if (!m_captureArmed.load(std::memory_order_acquire)) {
+        emit emulationError(tr("Capture is not armed"));
+        return;
+    }
+
+    const QVector<PrimRecord> &prims = m_captureBuffer->prims();
+    if (prims.isEmpty()) {
+        emit emulationError(tr("No primitives captured in the current frame"));
+        return;
+    }
+
+    const QString captureId = QString::number(QDateTime::currentMSecsSinceEpoch());
+    const QString dir = QDir::temp().filePath(QStringLiteral("qtmesh_ps1_capture"));
+    QDir().mkpath(dir);
+    const QString csvPath = dir + QLatin1Char('/') + captureId + QStringLiteral(".csv");
+    QFile file(csvPath);
+    if (file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        file.write(GpuCommandParser::primsToCsv(prims).toUtf8());
+        file.close();
+    }
+
+    emit frameCaptureReady(captureId, prims.size());
 }
 
 QImage PS1RipWorker::framebufferToImage(const EmuFramebuffer &fb)

--- a/src/PS1/runtime/PS1RipWorker.h
+++ b/src/PS1/runtime/PS1RipWorker.h
@@ -9,8 +9,10 @@
 #include <atomic>
 #include <memory>
 
+class CaptureBuffer;
 class EmuCore;
 class QTimer;
+class RipperHooks;
 
 /**
  * Runs EmuCore on a dedicated QThread owned by PS1RipManager (#415).
@@ -26,6 +28,8 @@ public:
     void clearStartCancel() { m_startSuperseded.store(false, std::memory_order_release); }
     void requestCancelStart() { m_startSuperseded.store(true, std::memory_order_release); }
 
+    const CaptureBuffer *captureBuffer() const { return m_captureBuffer.get(); }
+
 public slots:
     void configureSession(const QString &biosPath, const QString &isoPath);
     void startEmulation();
@@ -33,12 +37,15 @@ public slots:
     void stopEmulation();
     void pauseEmulation();
     void stepFrame();
+    void setCaptureArmed(bool armed);
+    void finalizeFrameCapture();
 
 signals:
     void emulationStarted();
     void emulationStopped();
     void framePresented(const QImage &frame, quint64 frameIndex);
     void emulationError(const QString &message);
+    void frameCaptureReady(const QString &captureId, int primCount);
 
 private slots:
     void runFrameTick();
@@ -54,6 +61,10 @@ private:
     bool m_running = false;
     bool m_paused = false;
     std::atomic<bool> m_startSuperseded{false};
+    std::atomic<bool> m_captureArmed{false};
+
+    std::unique_ptr<CaptureBuffer> m_captureBuffer;
+    std::unique_ptr<RipperHooks> m_ripperHooks;
 };
 
 #endif // PS1RIPWORKER_H

--- a/src/PS1/runtime/RipperHooks.cpp
+++ b/src/PS1/runtime/RipperHooks.cpp
@@ -1,0 +1,58 @@
+#include "RipperHooks.h"
+
+bool RipperHooks::isCaptureEnabled() const
+{
+    return m_armed && m_armed->load(std::memory_order_acquire);
+}
+
+void RipperHooks::onFrameBegin()
+{
+    if (!isCaptureEnabled() || !m_buffer)
+        return;
+    m_buffer->beginFrame();
+}
+
+void RipperHooks::onFrameEnd()
+{
+    if (!isCaptureEnabled() || !m_buffer)
+        return;
+    m_buffer->endFrame();
+}
+
+uint32_t RipperHooks::onGteMatrix(const MatrixRecord &matrix)
+{
+    if (!isCaptureEnabled() || !m_buffer)
+        return 0;
+    return m_buffer->addMatrix(matrix);
+}
+
+void RipperHooks::onGpuPrim(const PrimRecord &prim)
+{
+    if (!isCaptureEnabled() || !m_buffer)
+        return;
+    m_buffer->addPrim(prim);
+}
+
+void RipperHooks::onVramWrite(uint16_t x, uint16_t y, uint16_t w, uint16_t h, const uint16_t *pixels)
+{
+    (void)x;
+    (void)y;
+    (void)w;
+    (void)h;
+    (void)pixels;
+}
+
+void RipperHooks::onVramRead(uint16_t x, uint16_t y, uint16_t w, uint16_t h)
+{
+    (void)x;
+    (void)y;
+    (void)w;
+    (void)h;
+}
+
+void RipperHooks::onDrawMode(const DrawModeRecord &mode)
+{
+    if (!isCaptureEnabled() || !m_buffer)
+        return;
+    m_buffer->addDrawMode(mode);
+}

--- a/src/PS1/runtime/RipperHooks.h
+++ b/src/PS1/runtime/RipperHooks.h
@@ -1,0 +1,35 @@
+#ifndef RIPPERHOOKS_H
+#define RIPPERHOOKS_H
+
+#include "CaptureBuffer.h"
+#include "EmuHooks.h"
+
+#include <atomic>
+
+/**
+ * Concrete EmuHooks that records into CaptureBuffer when capture is armed (#418).
+ */
+class RipperHooks final : public EmuHooks
+{
+public:
+    void setArmedFlag(std::atomic<bool> *armed) { m_armed = armed; }
+    void setBuffer(CaptureBuffer *buffer) { m_buffer = buffer; }
+
+    bool isCaptureEnabled() const override;
+
+    void onFrameBegin() override;
+    void onFrameEnd() override;
+
+    uint32_t onGteMatrix(const MatrixRecord &matrix) override;
+    void onGpuPrim(const PrimRecord &prim) override;
+    void onVramWrite(uint16_t x, uint16_t y, uint16_t w, uint16_t h,
+                     const uint16_t *pixels) override;
+    void onVramRead(uint16_t x, uint16_t y, uint16_t w, uint16_t h) override;
+    void onDrawMode(const DrawModeRecord &mode) override;
+
+private:
+    std::atomic<bool> *m_armed = nullptr;
+    CaptureBuffer *m_buffer = nullptr;
+};
+
+#endif // RIPPERHOOKS_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -132,12 +132,16 @@ if(BUILD_TESTS)
 
     if(ENABLE_PS1_RIP)
         list(APPEND TEST_SRC_FILES
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/CaptureBuffer.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/EmuCoreLoader.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/EmuViewport.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/GpuCommandParser.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/GteCapture.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PS1RipLegalityDialog.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PS1RipManager.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PS1RipSessionWindow.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PS1RipWorker.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/RipperHooks.cpp
         )
     endif()
 


### PR DESCRIPTION
## Summary

- Implements `CaptureTypes`, `GpuCommandParser`, `CaptureBuffer`, and `RipperHooks` for GP0 primitive and GTE matrix capture (#418, #419).
- Wires `armCapture` / `captureFrame` to the worker thread with an atomic armed flag; disarmed hooks are no-ops.
- Stub core emits all seven primitive flavors per frame when capture is armed for CI regression.
- Unit tests cover GP0 decoding, matrix hash dedupe, camera-matrix heuristic, and end-to-end capture via `captureFrame`.

## Test plan

- [x] `UnitTests --gtest_filter="GpuCommandParser*:CaptureBuffer*:GteCapture*:PS1RipManager*"` (Linux, offscreen)
- [ ] CI `unit-tests-linux` with `ENABLE_PS1_RIP=ON`

Closes #418, #419.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced PS1 geometry capture pipeline for runtime frame analysis
  * Added GPU command parser for decoding PS1 primitive graphics commands
  * Implemented matrix deduplication using hash-based caching to optimize storage
  * Captured frame data exportable as CSV for verification and debugging

* **Tests**
  * Added comprehensive test coverage for capture infrastructure, buffer operations, GPU command parsing, and matrix operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/581?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->