### PR TITLE
review(morph): morph Flickable non-interactive, proxy wheel scroll

### DIFF
--- a/qml/AnimationDopeSheet.qml
+++ b/qml/AnimationDopeSheet.qml
@@ -690,9 +690,22 @@ Rectangle {
     // QQuickWidget inside QDockWidget can swallow wheel events on macOS;
     // routing them through here guarantees the rows scroll regardless.
     function scrollByPixels(dy) {
-        if (dy === 0 || !rowsView.visible) return
-        var maxY = Math.max(0, rowsView.contentHeight - rowsView.height)
-        rowsView.contentY = Math.max(0, Math.min(maxY, rowsView.contentY - dy))
+        if (dy === 0) return
+        // Scroll the bone list as before; ListView handles its own
+        // clamping in contentY assignments below.
+        if (rowsView.visible) {
+            var maxY = Math.max(0, rowsView.contentHeight - rowsView.height)
+            rowsView.contentY = Math.max(0, Math.min(maxY, rowsView.contentY - dy))
+        }
+        // Also scroll the morph band when it has overflowing content.
+        // We disable Flickable.interactive (so drag-marquee passes
+        // through to timelineArea) which removes Flickable's own wheel
+        // handling — proxy it here. Same dy as the bone list so a single
+        // wheel notch advances both views consistently.
+        if (morphBand.visible && morphList.contentHeight > morphList.height) {
+            var maxMY = morphList.contentHeight - morphList.height
+            morphList.contentY = Math.max(0, Math.min(maxMY, morphList.contentY - dy))
+        }
     }
 
     WheelHandler {
@@ -773,6 +786,13 @@ Rectangle {
             clip: true
             contentHeight: morphCol.height
             boundsBehavior: Flickable.StopAtBounds
+            // Match `rowsView` and disable left-drag flicking — the
+            // root timelineArea owns marquee selection over empty
+            // pixels and Flickable would otherwise grab those drags.
+            // Wheel scrolling still works because the root WheelHandler
+            // is routed through `scrollByPixels` rather than relying on
+            // Flickable's own wheel handling.
+            interactive: false
 
             Column {
                 id: morphCol


### PR DESCRIPTION
Codex follow-up on PR #582 (merged):

The new `Flickable` in the morph band defaulted to `interactive: true`, which consumed left-button drags in that region. `timelineArea` (the root marquee-selection MouseArea) expects empty-row drags to fall through to it — and they did before the Flickable was added. Starting a marquee drag over morph lanes was therefore silently dropped.

Fix: match `rowsView`'s `interactive: false` so left-drags pass through. Wheel scrolling still works because `scrollByPixels` (invoked by the root `WheelHandler`) now also drives the morph list's `contentY` when its content overflows — same `dy` as the bone list so one wheel notch advances both consistently.

## Test plan
- [ ] CI green
- [ ] Manual: drag left-click over morph lanes → marquee selection on bone keys still activates.
- [ ] Manual: high-blendshape character → wheel scrolls the morph list when it overflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed wheel scrolling in the dope sheet to properly scroll both the bone row list and morph-target band (when visible and overflowing).
  * Improved interaction handling for morph-target selections to ensure smooth mouse drag operations within the animation timeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->