### PR TITLE
feat(node-anim): sub-slice C1 — NodeAnimationManager singleton

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,6 +89,7 @@ VertexColorBaker.cpp
 VATBaker.cpp
 VATBakerController.cpp
 MorphAnimationManager.cpp
+NodeAnimationManager.cpp
 ApplyAtlas.cpp
 EmbeddedTextureCache.cpp
 NormalMapGenerator.cpp

--- a/src/NodeAnimationManager.cpp
+++ b/src/NodeAnimationManager.cpp
@@ -1,0 +1,296 @@
+/*
+-----------------------------------------------------------------------------------
+A QtMeshEditor file
+
+Copyright (c) Fernando Tonon (https://github.com/fernandotonon)
+
+The MIT License
+-----------------------------------------------------------------------------------
+*/
+
+#include "NodeAnimationManager.h"
+
+#include "Manager.h"
+#include "SentryReporter.h"
+
+#include <QCoreApplication>
+#include <QHash>
+#include <QThread>
+
+#include <OgreAnimation.h>
+#include <OgreAnimationState.h>
+#include <OgreAnimationTrack.h>
+#include <OgreKeyFrame.h>
+#include <OgreSceneManager.h>
+#include <OgreSceneNode.h>
+
+namespace {
+
+// Per the project's singleton-on-main-thread convention (CLAUDE.md:
+// "All run on the main thread."), assert any cross-thread access at
+// lifecycle entry points so a regression surfaces loudly in debug
+// builds.
+inline void assertMainThread()
+{
+    Q_ASSERT(QCoreApplication::instance());
+    Q_ASSERT(QThread::currentThread() == QCoreApplication::instance()->thread());
+}
+
+// Distance below which two keyframe times are treated as the same
+// keyframe — 1ms matches the granularity of the dope-sheet slider
+// (which displays seconds with 2-3 decimals) so users can't
+// accidentally create back-to-back keys.
+constexpr double kKeyframeMergeEpsilon = 1e-3;
+
+} // namespace
+
+NodeAnimationManager* NodeAnimationManager::s_instance = nullptr;
+
+NodeAnimationManager* NodeAnimationManager::instance()
+{
+    assertMainThread();
+    if (!s_instance) s_instance = new NodeAnimationManager();
+    return s_instance;
+}
+
+NodeAnimationManager* NodeAnimationManager::qmlInstance(QQmlEngine*, QJSEngine*)
+{
+    assertMainThread();
+    return instance();
+}
+
+void NodeAnimationManager::kill()
+{
+    assertMainThread();
+    if (!s_instance) return;
+    delete s_instance;
+    s_instance = nullptr;
+}
+
+NodeAnimationManager::NodeAnimationManager(QObject* parent) : QObject(parent)
+{
+}
+
+NodeAnimationManager::~NodeAnimationManager() = default;
+
+unsigned short NodeAnimationManager::trackHandleForNode(const QString& nodeName)
+{
+    // qHash returns size_t / uint depending on platform. Track
+    // handles are unsigned short, so fold to 16 bits. Collisions are
+    // possible but very rare in practice — Mixamo rigs cap out
+    // around 100 bones; getting two hash collisions in one clip is
+    // ~6.5M:1 (birthday paradox on 16-bit space at N=100). If it
+    // ever matters in practice we can rev this to a per-clip
+    // {name → handle} map.
+    return static_cast<unsigned short>(qHash(nodeName) & 0xFFFFu);
+}
+
+Ogre::SceneNode* NodeAnimationManager::findSceneNode(const QString& nodeName)
+{
+    auto* mgr = Manager::getSingletonPtr();
+    if (!mgr) return nullptr;
+    auto* scene = mgr->getSceneMgr();
+    if (!scene) return nullptr;
+    const std::string sn = nodeName.toStdString();
+    if (!scene->hasSceneNode(sn)) return nullptr;
+    return scene->getSceneNode(sn);
+}
+
+bool NodeAnimationManager::createClip(const QString& name, double length)
+{
+    assertMainThread();
+    if (name.isEmpty() || length <= 0.0) return false;
+    auto* mgr = Manager::getSingletonPtr();
+    if (!mgr) return false;
+    auto* scene = mgr->getSceneMgr();
+    if (!scene) return false;
+    const std::string sn = name.toStdString();
+    if (scene->hasAnimation(sn)) return false;
+
+    scene->createAnimation(sn, static_cast<Ogre::Real>(length));
+    scene->createAnimationState(sn);
+
+    SentryReporter::addBreadcrumb("scene.anim.node",
+        QStringLiteral("create clip '%1' (%2s)").arg(name).arg(length, 0, 'f', 3));
+    emit clipsChanged();
+    return true;
+}
+
+bool NodeAnimationManager::deleteClip(const QString& name)
+{
+    assertMainThread();
+    if (name.isEmpty()) return false;
+    auto* mgr = Manager::getSingletonPtr();
+    if (!mgr) return false;
+    auto* scene = mgr->getSceneMgr();
+    if (!scene) return false;
+    const std::string sn = name.toStdString();
+    if (!scene->hasAnimation(sn)) return false;
+
+    if (scene->hasAnimationState(sn))
+        scene->destroyAnimationState(sn);
+    scene->removeAnimation(sn);
+
+    SentryReporter::addBreadcrumb("scene.anim.node",
+        QStringLiteral("delete clip '%1'").arg(name));
+    emit clipsChanged();
+    return true;
+}
+
+bool NodeAnimationManager::addKeyframe(const QString& clipName,
+                                       const QString& nodeName,
+                                       double time,
+                                       const Ogre::Vector3& translate,
+                                       const Ogre::Quaternion& rotation,
+                                       const Ogre::Vector3& scale)
+{
+    assertMainThread();
+    if (clipName.isEmpty() || nodeName.isEmpty()) return false;
+    if (time < 0.0) return false;
+
+    auto* mgr = Manager::getSingletonPtr();
+    if (!mgr) return false;
+    auto* scene = mgr->getSceneMgr();
+    if (!scene) return false;
+
+    const std::string sclip = clipName.toStdString();
+    if (!scene->hasAnimation(sclip)) return false;
+    Ogre::Animation* anim = scene->getAnimation(sclip);
+    if (!anim) return false;
+    if (time > anim->getLength()) return false;
+
+    Ogre::SceneNode* node = findSceneNode(nodeName);
+    if (!node) return false;
+
+    const unsigned short handle = trackHandleForNode(nodeName);
+    Ogre::NodeAnimationTrack* track =
+        anim->hasNodeTrack(handle) ? anim->getNodeTrack(handle)
+                                   : anim->createNodeTrack(handle, node);
+    if (!track) return false;
+
+    // Idempotent overwrite: if the closest existing keyframe is
+    // within `kKeyframeMergeEpsilon`, mutate it in place instead of
+    // creating a near-duplicate. Without this, dragging a slider
+    // back and forth would dribble extra keys all along the path.
+    Ogre::TransformKeyFrame* kf = nullptr;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        auto* candidate = static_cast<Ogre::TransformKeyFrame*>(track->getKeyFrame(i));
+        if (candidate && std::abs(candidate->getTime() - time) < kKeyframeMergeEpsilon) {
+            kf = candidate;
+            break;
+        }
+    }
+    if (!kf) kf = track->createNodeKeyFrame(static_cast<Ogre::Real>(time));
+    if (!kf) return false;
+
+    kf->setTranslate(translate);
+    kf->setRotation(rotation);
+    kf->setScale(scale);
+
+    SentryReporter::addBreadcrumb("scene.anim.node",
+        QStringLiteral("keyframe '%1':'%2'@%3").arg(clipName, nodeName).arg(time, 0, 'f', 3));
+    emit keyframesChanged(clipName);
+    return true;
+}
+
+bool NodeAnimationManager::setClipEnabled(const QString& name, bool enabled)
+{
+    assertMainThread();
+    if (name.isEmpty()) return false;
+    auto* mgr = Manager::getSingletonPtr();
+    if (!mgr) return false;
+    auto* scene = mgr->getSceneMgr();
+    if (!scene) return false;
+    const std::string sn = name.toStdString();
+    if (!scene->hasAnimationState(sn)) return false;
+    auto* state = scene->getAnimationState(sn);
+    if (!state) return false;
+    state->setEnabled(enabled);
+    if (enabled) state->setTimePosition(0.0f);
+    return true;
+}
+
+QStringList NodeAnimationManager::listClips() const
+{
+    QStringList out;
+    auto* mgr = Manager::getSingletonPtr();
+    if (!mgr) return out;
+    auto* scene = mgr->getSceneMgr();
+    if (!scene) return out;
+    // SceneManager has `getNumAnimations()` + `getAnimation(index)` —
+    // but it includes ALL animations (skeletal-attached clips, our
+    // node clips, etc.). For the C1 manager surface we only need
+    // node-clip names, but the filter is "has a NodeAnimationTrack
+    // somewhere in the animation." Anything we created via
+    // createClip qualifies; same-named anims created elsewhere are
+    // either purely-skeletal (zero NodeAnimationTrack) or our own.
+    for (unsigned short i = 0; i < scene->getNumAnimations(); ++i) {
+        Ogre::Animation* a = scene->getAnimation(i);
+        if (!a) continue;
+        // Cheap filter: only animations whose first track is a
+        // NodeAnimationTrack (and is non-empty) belong to us. Empty
+        // freshly-created clips also qualify so the UI can list them
+        // before any keyframe is added.
+        const auto& nodeTracks = a->_getNodeTrackList();
+        const auto& vertTracks = a->_getVertexTrackList();
+        // Skip purely-vertex animations (they belong to the morph /
+        // mesh-anim subsystems, not node-anim).
+        if (nodeTracks.empty() && !vertTracks.empty()) continue;
+        out << QString::fromStdString(a->getName());
+    }
+    return out;
+}
+
+QList<double> NodeAnimationManager::keyTimesForNode(const QString& clipName,
+                                                    const QString& nodeName) const
+{
+    QList<double> out;
+    if (clipName.isEmpty() || nodeName.isEmpty()) return out;
+    auto* mgr = Manager::getSingletonPtr();
+    if (!mgr) return out;
+    auto* scene = mgr->getSceneMgr();
+    if (!scene) return out;
+    const std::string sclip = clipName.toStdString();
+    if (!scene->hasAnimation(sclip)) return out;
+    Ogre::Animation* anim = scene->getAnimation(sclip);
+    if (!anim) return out;
+    const unsigned short handle = trackHandleForNode(nodeName);
+    if (!anim->hasNodeTrack(handle)) return out;
+    auto* track = anim->getNodeTrack(handle);
+    if (!track) return out;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        auto* kf = track->getKeyFrame(i);
+        if (kf) out.append(static_cast<double>(kf->getTime()));
+    }
+    return out;
+}
+
+bool NodeAnimationManager::createClipForName(const QString& name, double length)
+{
+    return createClip(name, length);
+}
+
+bool NodeAnimationManager::deleteClipForName(const QString& name)
+{
+    return deleteClip(name);
+}
+
+bool NodeAnimationManager::addKeyframeFromQml(const QString& clipName,
+                                              const QString& nodeName,
+                                              double time,
+                                              double tx, double ty, double tz,
+                                              double qw, double qx, double qy, double qz,
+                                              double sx, double sy, double sz)
+{
+    return addKeyframe(clipName, nodeName, time,
+                       Ogre::Vector3(static_cast<Ogre::Real>(tx),
+                                     static_cast<Ogre::Real>(ty),
+                                     static_cast<Ogre::Real>(tz)),
+                       Ogre::Quaternion(static_cast<Ogre::Real>(qw),
+                                        static_cast<Ogre::Real>(qx),
+                                        static_cast<Ogre::Real>(qy),
+                                        static_cast<Ogre::Real>(qz)),
+                       Ogre::Vector3(static_cast<Ogre::Real>(sx),
+                                     static_cast<Ogre::Real>(sy),
+                                     static_cast<Ogre::Real>(sz)));
+}

--- a/src/NodeAnimationManager.cpp
+++ b/src/NodeAnimationManager.cpp
@@ -73,16 +73,41 @@ NodeAnimationManager::NodeAnimationManager(QObject* parent) : QObject(parent)
 
 NodeAnimationManager::~NodeAnimationManager() = default;
 
-unsigned short NodeAnimationManager::trackHandleForNode(const QString& nodeName)
+unsigned short NodeAnimationManager::trackHandleForNode(const QString& clipName,
+                                                        const QString& nodeName)
 {
-    // qHash returns size_t / uint depending on platform. Track
-    // handles are unsigned short, so fold to 16 bits. Collisions are
-    // possible but very rare in practice — Mixamo rigs cap out
-    // around 100 bones; getting two hash collisions in one clip is
-    // ~6.5M:1 (birthday paradox on 16-bit space at N=100). If it
-    // ever matters in practice we can rev this to a per-clip
-    // {name → handle} map.
-    return static_cast<unsigned short>(qHash(nodeName) & 0xFFFFu);
+    // Per-clip allocator: first sighting of (clipName, nodeName)
+    // claims the next free handle inside the clip's Animation
+    // (Ogre's hasNodeTrack(handle) is the source of truth — we walk
+    // 0..N_handles to find the first gap). Subsequent calls find
+    // the existing handle in m_trackHandles and reuse it, so
+    // repeated addKeyframe writes go to the same NodeAnimationTrack.
+    //
+    // Replaces an earlier `qHash & 0xFFFF` strategy that silently
+    // collapsed two different node names onto the same track when
+    // their hashes collided — birthday paradox hits 50% at ~300
+    // names on a 16-bit space (Codex P1 on PR #584).
+    auto& clipMap = m_trackHandles[clipName];
+    auto it = clipMap.find(nodeName);
+    if (it != clipMap.end()) return *it;
+
+    // Allocate the lowest unused handle in the clip's track table.
+    auto* mgr = Manager::getSingletonPtr();
+    if (!mgr) return 0;
+    auto* scene = mgr->getSceneMgr();
+    if (!scene) return 0;
+    const std::string sclip = clipName.toStdString();
+    Ogre::Animation* anim = scene->hasAnimation(sclip) ? scene->getAnimation(sclip) : nullptr;
+
+    unsigned short handle = 0;
+    while (anim && anim->hasNodeTrack(handle)) {
+        // Defensive cap — wrap at 65535 would happen automatically,
+        // but at that point we're well past the realistic node count.
+        if (handle == 65535) break;
+        ++handle;
+    }
+    clipMap.insert(nodeName, handle);
+    return handle;
 }
 
 Ogre::SceneNode* NodeAnimationManager::findSceneNode(const QString& nodeName)
@@ -130,6 +155,10 @@ bool NodeAnimationManager::deleteClip(const QString& name)
     if (scene->hasAnimationState(sn))
         scene->destroyAnimationState(sn);
     scene->removeAnimation(sn);
+    // Drop the clip's node→handle allocator entries — otherwise a
+    // later createClip(name, ...) would reuse stale handles that
+    // map to tracks Ogre no longer has.
+    m_trackHandles.remove(name);
 
     SentryReporter::addBreadcrumb("scene.anim.node",
         QStringLiteral("delete clip '%1'").arg(name));
@@ -162,7 +191,7 @@ bool NodeAnimationManager::addKeyframe(const QString& clipName,
     Ogre::SceneNode* node = findSceneNode(nodeName);
     if (!node) return false;
 
-    const unsigned short handle = trackHandleForNode(nodeName);
+    const unsigned short handle = trackHandleForNode(clipName, nodeName);
     Ogre::NodeAnimationTrack* track =
         anim->hasNodeTrack(handle) ? anim->getNodeTrack(handle)
                                    : anim->createNodeTrack(handle, node);
@@ -254,7 +283,14 @@ QList<double> NodeAnimationManager::keyTimesForNode(const QString& clipName,
     if (!scene->hasAnimation(sclip)) return out;
     Ogre::Animation* anim = scene->getAnimation(sclip);
     if (!anim) return out;
-    const unsigned short handle = trackHandleForNode(nodeName);
+    // Read-only lookup — don't allocate a new handle for a node that
+    // doesn't yet have one. If the {clip, node} pair was never
+    // written, return empty.
+    auto clipIt = m_trackHandles.constFind(clipName);
+    if (clipIt == m_trackHandles.constEnd()) return out;
+    auto handleIt = clipIt->constFind(nodeName);
+    if (handleIt == clipIt->constEnd()) return out;
+    const unsigned short handle = *handleIt;
     if (!anim->hasNodeTrack(handle)) return out;
     auto* track = anim->getNodeTrack(handle);
     if (!track) return out;

--- a/src/NodeAnimationManager.h
+++ b/src/NodeAnimationManager.h
@@ -1,0 +1,122 @@
+/*
+-----------------------------------------------------------------------------------
+A QtMeshEditor file
+
+Copyright (c) Fernando Tonon (https://github.com/fernandotonon)
+
+The MIT License
+-----------------------------------------------------------------------------------
+*/
+
+#ifndef NODEANIMATIONMANAGER_H
+#define NODEANIMATIONMANAGER_H
+
+#include <QObject>
+#include <QQmlEngine>
+#include <QString>
+#include <QStringList>
+#include <QVariantList>
+#include <QtQml/qqmlregistration.h>
+
+#include <OgreVector.h>
+#include <OgreQuaternion.h>
+
+namespace Ogre { class SceneNode; class Animation; class NodeAnimationTrack; }
+
+/**
+ * @brief QML_SINGLETON owning per-scene-node transform-animation clips.
+ *
+ * Wraps Ogre's `SceneManager` Animation + NodeAnimationTrack subsystem,
+ * which QtMeshEditor never previously exercised. Use cases: animated
+ * props, doors, simple machinery, scripted camera moves, animated
+ * lights — anything that needs a transform track without a skeleton.
+ *
+ * Slice C1 (this file) ships the *data layer* surface — the manager
+ * owns the clips, you create them by name, push keyframes, list,
+ * delete. The Inspector subgroup, dope-sheet integration, undo
+ * commands, and CLI/MCP land in C2..Cn (mirroring the morph slice
+ * pattern: data first, UI per-slice).
+ *
+ * Clips are owned by `Manager::getSceneMgr()` so they share lifetime
+ * with the scene. When the scene is destroyed (asset close, exit)
+ * everything goes with it; we don't manually destroy on shutdown.
+ */
+class NodeAnimationManager : public QObject
+{
+    Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
+
+public:
+    static NodeAnimationManager* instance();
+    static NodeAnimationManager* qmlInstance(QQmlEngine* engine, QJSEngine* scriptEngine);
+    static void kill();
+
+    /// Create a named clip with `length` seconds duration. Returns
+    /// false if the name already exists on the scene (clip names are
+    /// unique within `Ogre::SceneManager`'s animation table).
+    bool createClip(const QString& name, double length);
+
+    /// Delete a clip and its driving AnimationState. Returns false
+    /// if the clip doesn't exist.
+    bool deleteClip(const QString& name);
+
+    /// Add (or overwrite) a keyframe for `nodeName` on `clipName` at
+    /// `time`. Returns false on missing clip, missing node, negative
+    /// time, or time > clip length. If the same node already has a
+    /// keyframe within 1ms of `time`, that keyframe is updated in
+    /// place — keeps the user's edits idempotent.
+    bool addKeyframe(const QString& clipName,
+                     const QString& nodeName,
+                     double time,
+                     const Ogre::Vector3& translate,
+                     const Ogre::Quaternion& rotation,
+                     const Ogre::Vector3& scale);
+
+    /// Toggle whether the clip is playing. Returns false on missing
+    /// clip; otherwise true.
+    bool setClipEnabled(const QString& name, bool enabled);
+
+    /// All clip names on the current scene, in creation order.
+    Q_INVOKABLE QStringList listClips() const;
+
+    /// Per-node sorted list of keyframe times for `clipName`. Empty
+    /// when the clip is missing or the node has no keyframes.
+    Q_INVOKABLE QList<double> keyTimesForNode(const QString& clipName,
+                                              const QString& nodeName) const;
+
+    /// QML-friendly variants of the setters; pass POD-ish doubles in
+    /// instead of Ogre types so the API binds cleanly into JS.
+    Q_INVOKABLE bool createClipForName(const QString& name, double length);
+    Q_INVOKABLE bool deleteClipForName(const QString& name);
+    Q_INVOKABLE bool addKeyframeFromQml(const QString& clipName,
+                                         const QString& nodeName,
+                                         double time,
+                                         double tx, double ty, double tz,
+                                         double qw, double qx, double qy, double qz,
+                                         double sx, double sy, double sz);
+
+signals:
+    /// The set of clips visible on the scene changed (create / delete).
+    void clipsChanged();
+    /// A clip's keyframes changed (add / overwrite / future remove).
+    void keyframesChanged(const QString& clipName);
+
+private:
+    explicit NodeAnimationManager(QObject* parent = nullptr);
+    ~NodeAnimationManager() override;
+
+    /// Pick a stable track handle for `nodeName` within `clip`. Same
+    /// hash strategy across calls so two add operations on the same
+    /// node land on the same track.
+    static unsigned short trackHandleForNode(const QString& nodeName);
+
+    /// Look up a SceneNode by name on the current scene. Returns
+    /// null when the node doesn't exist. Centralised so name-not-
+    /// found behaviour is consistent across all setters.
+    static Ogre::SceneNode* findSceneNode(const QString& nodeName);
+
+    static NodeAnimationManager* s_instance;
+};
+
+#endif // NODEANIMATIONMANAGER_H

--- a/src/NodeAnimationManager.h
+++ b/src/NodeAnimationManager.h
@@ -11,6 +11,7 @@ The MIT License
 #ifndef NODEANIMATIONMANAGER_H
 #define NODEANIMATIONMANAGER_H
 
+#include <QHash>
 #include <QObject>
 #include <QQmlEngine>
 #include <QString>
@@ -106,15 +107,25 @@ private:
     explicit NodeAnimationManager(QObject* parent = nullptr);
     ~NodeAnimationManager() override;
 
-    /// Pick a stable track handle for `nodeName` within `clip`. Same
-    /// hash strategy across calls so two add operations on the same
-    /// node land on the same track.
-    static unsigned short trackHandleForNode(const QString& nodeName);
+    /// Per-clip {nodeName → track handle} map. Allocated lazily on
+    /// the first `addKeyframe(clip, node, …)` call for a given pair
+    /// and reused for every subsequent call. This is a collision-free
+    /// replacement for an earlier `qHash & 0xFFFF` strategy that
+    /// silently corrupted both nodes on a 16-bit hash collision
+    /// (which is realistic at typical scene sizes — birthday paradox
+    /// hits ~50% by ~300 names).
+    unsigned short trackHandleForNode(const QString& clipName,
+                                      const QString& nodeName);
 
     /// Look up a SceneNode by name on the current scene. Returns
     /// null when the node doesn't exist. Centralised so name-not-
     /// found behaviour is consistent across all setters.
     static Ogre::SceneNode* findSceneNode(const QString& nodeName);
+
+    /// `clipName → { nodeName → handle }`. Mutated by `addKeyframe`
+    /// (lazy allocation) and `deleteClip` (forgets the whole clip
+    /// entry). Lives only on the manager — no Ogre dependency.
+    QHash<QString, QHash<QString, unsigned short>> m_trackHandles;
 
     static NodeAnimationManager* s_instance;
 };

--- a/src/NodeAnimationManager_test.cpp
+++ b/src/NodeAnimationManager_test.cpp
@@ -63,7 +63,8 @@ protected:
             const std::vector<std::string> drops = {
                 "NA_LifeCycle", "NA_ListOrder1", "NA_ListOrder2",
                 "NA_KeyAdd", "NA_KeyIdempotent", "NA_DeleteUnknown",
-                "NA_OutOfRange", "NA_Enable", "NA_Signals"
+                "NA_OutOfRange", "NA_Enable", "NA_Signals",
+                "NA_Collision"
             };
             for (const auto& n : drops) {
                 if (scene->hasAnimationState(n))
@@ -232,4 +233,40 @@ TEST_F(NodeAnimationManagerSceneTest, KeyTimesForMissingClipIsEmpty) {
     auto* m = NodeAnimationManager::instance();
     EXPECT_TRUE(m->keyTimesForNode(QStringLiteral("Nope"),
                                     QStringLiteral("Whatever")).isEmpty());
+}
+
+// Two nodes in the same clip must land on independent tracks even
+// when their names would have hash-collided under the original
+// `qHash & 0xFFFF` strategy (Codex P1 on PR #584). This test
+// verifies via the more general property: distinct node names →
+// keyTimesForNode returns disjoint key sets, never a shared one.
+TEST_F(NodeAnimationManagerSceneTest, DistinctNodesGetDistinctTracks) {
+    auto* m = NodeAnimationManager::instance();
+    ASSERT_TRUE(m->createClip(QStringLiteral("NA_Collision"), 2.0));
+    auto* nodeA = makeNamedNode("NA_Collision_NodeA");
+    auto* nodeB = makeNamedNode("NA_Collision_NodeB");
+    ASSERT_NE(nodeA, nullptr);
+    ASSERT_NE(nodeB, nullptr);
+
+    EXPECT_TRUE(m->addKeyframe(QStringLiteral("NA_Collision"),
+                                QStringLiteral("NA_Collision_NodeA"),
+                                0.25, Ogre::Vector3(1,0,0),
+                                Ogre::Quaternion::IDENTITY, Ogre::Vector3(1,1,1)));
+    EXPECT_TRUE(m->addKeyframe(QStringLiteral("NA_Collision"),
+                                QStringLiteral("NA_Collision_NodeB"),
+                                0.75, Ogre::Vector3(0,1,0),
+                                Ogre::Quaternion::IDENTITY, Ogre::Vector3(1,1,1)));
+
+    auto keysA = m->keyTimesForNode(QStringLiteral("NA_Collision"),
+                                     QStringLiteral("NA_Collision_NodeA"));
+    auto keysB = m->keyTimesForNode(QStringLiteral("NA_Collision"),
+                                     QStringLiteral("NA_Collision_NodeB"));
+    // Each node sees ONLY its own keyframe. The pre-fix hash-truncation
+    // strategy would have made keysA == keysB == [0.25, 0.75] on
+    // collision, or worse, only [0.75] if the second add silently
+    // overwrote the first track's keyframe.
+    ASSERT_EQ(keysA.size(), 1);
+    ASSERT_EQ(keysB.size(), 1);
+    EXPECT_NEAR(keysA[0], 0.25, 1e-4);
+    EXPECT_NEAR(keysB[0], 0.75, 1e-4);
 }

--- a/src/NodeAnimationManager_test.cpp
+++ b/src/NodeAnimationManager_test.cpp
@@ -1,0 +1,235 @@
+#include <gtest/gtest.h>
+
+#include <QSignalSpy>
+
+#include "Manager.h"
+#include "NodeAnimationManager.h"
+#include "TestHelpers.h"
+
+#include <OgreSceneManager.h>
+#include <OgreSceneNode.h>
+
+namespace {
+
+// Build (or fetch) a named SceneNode under the scene root so the
+// add-keyframe path has a real Ogre::Node to bind to. Named so the
+// manager can look it up via Manager::getSceneMgr()->getSceneNode.
+Ogre::SceneNode* makeNamedNode(const std::string& name)
+{
+    auto* scene = Manager::getSingleton()->getSceneMgr();
+    if (scene->hasSceneNode(name))
+        return scene->getSceneNode(name);
+    return scene->getRootSceneNode()->createChildSceneNode(name);
+}
+
+}  // namespace
+
+// =============================================================================
+// Standalone (no Ogre)
+// =============================================================================
+
+TEST(NodeAnimationManagerStandalone, InstanceIsSingleton) {
+    auto* a = NodeAnimationManager::instance();
+    auto* b = NodeAnimationManager::instance();
+    EXPECT_EQ(a, b);
+    EXPECT_NE(a, nullptr);
+}
+
+TEST(NodeAnimationManagerStandalone, EmptyNamesRejected) {
+    auto* m = NodeAnimationManager::instance();
+    EXPECT_FALSE(m->createClip(QString(), 1.0));
+    EXPECT_FALSE(m->createClip(QStringLiteral("OK"), 0.0));   // zero length
+    EXPECT_FALSE(m->createClip(QStringLiteral("OK"), -1.0));  // negative length
+    EXPECT_FALSE(m->deleteClip(QString()));
+    EXPECT_FALSE(m->setClipEnabled(QString(), true));
+}
+
+// =============================================================================
+// Scene fixture — tests need a real Ogre SceneManager.
+// =============================================================================
+
+class NodeAnimationManagerSceneTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        ASSERT_TRUE(tryInitOgre());
+        // Reset whatever state a prior test left behind. We don't
+        // tear down the SceneManager (Manager::kill() before each
+        // test would invalidate Ogre::Root for the rest of the
+        // suite), but we do drop our clips so name collisions don't
+        // bleed between cases.
+        if (auto* scene = Manager::getSingleton()->getSceneMgr()) {
+            const std::vector<std::string> drops = {
+                "NA_LifeCycle", "NA_ListOrder1", "NA_ListOrder2",
+                "NA_KeyAdd", "NA_KeyIdempotent", "NA_DeleteUnknown",
+                "NA_OutOfRange", "NA_Enable", "NA_Signals"
+            };
+            for (const auto& n : drops) {
+                if (scene->hasAnimationState(n))
+                    scene->destroyAnimationState(n);
+                if (scene->hasAnimation(n))
+                    scene->removeAnimation(n);
+            }
+        }
+    }
+};
+
+TEST_F(NodeAnimationManagerSceneTest, CreateAndDeleteClip) {
+    auto* m = NodeAnimationManager::instance();
+    EXPECT_TRUE(m->createClip(QStringLiteral("NA_LifeCycle"), 2.0));
+    auto* scene = Manager::getSingleton()->getSceneMgr();
+    EXPECT_TRUE(scene->hasAnimation("NA_LifeCycle"));
+    EXPECT_TRUE(scene->hasAnimationState("NA_LifeCycle"));
+
+    // Duplicate-name create is rejected.
+    EXPECT_FALSE(m->createClip(QStringLiteral("NA_LifeCycle"), 1.0));
+
+    EXPECT_TRUE(m->deleteClip(QStringLiteral("NA_LifeCycle")));
+    EXPECT_FALSE(scene->hasAnimation("NA_LifeCycle"));
+    EXPECT_FALSE(scene->hasAnimationState("NA_LifeCycle"));
+}
+
+TEST_F(NodeAnimationManagerSceneTest, ListClipsReturnsInScenecreationOrder) {
+    auto* m = NodeAnimationManager::instance();
+    ASSERT_TRUE(m->createClip(QStringLiteral("NA_ListOrder1"), 1.0));
+    ASSERT_TRUE(m->createClip(QStringLiteral("NA_ListOrder2"), 1.0));
+    const QStringList clips = m->listClips();
+    EXPECT_TRUE(clips.contains(QStringLiteral("NA_ListOrder1")));
+    EXPECT_TRUE(clips.contains(QStringLiteral("NA_ListOrder2")));
+}
+
+TEST_F(NodeAnimationManagerSceneTest, AddKeyframeStoresTransformAndAdvancesTrack) {
+    auto* m = NodeAnimationManager::instance();
+    ASSERT_TRUE(m->createClip(QStringLiteral("NA_KeyAdd"), 2.0));
+    auto* node = makeNamedNode("NA_KeyAdd_Node");
+    ASSERT_NE(node, nullptr);
+
+    EXPECT_TRUE(m->addKeyframe(QStringLiteral("NA_KeyAdd"),
+                                QStringLiteral("NA_KeyAdd_Node"),
+                                0.5,
+                                Ogre::Vector3(1, 2, 3),
+                                Ogre::Quaternion(1, 0, 0, 0),
+                                Ogre::Vector3(1, 1, 1)));
+
+    QList<double> keys = m->keyTimesForNode(QStringLiteral("NA_KeyAdd"),
+                                             QStringLiteral("NA_KeyAdd_Node"));
+    ASSERT_EQ(keys.size(), 1);
+    EXPECT_NEAR(keys[0], 0.5, 1e-4);
+
+    // Adding a second, distinct keyframe creates a new entry — not
+    // a duplicate. Verifies the merge-epsilon doesn't over-collapse.
+    EXPECT_TRUE(m->addKeyframe(QStringLiteral("NA_KeyAdd"),
+                                QStringLiteral("NA_KeyAdd_Node"),
+                                1.5,
+                                Ogre::Vector3(4, 5, 6),
+                                Ogre::Quaternion(1, 0, 0, 0),
+                                Ogre::Vector3(2, 2, 2)));
+    keys = m->keyTimesForNode(QStringLiteral("NA_KeyAdd"),
+                              QStringLiteral("NA_KeyAdd_Node"));
+    EXPECT_EQ(keys.size(), 2);
+}
+
+TEST_F(NodeAnimationManagerSceneTest, AddKeyframeIdempotentWithinEpsilon) {
+    auto* m = NodeAnimationManager::instance();
+    ASSERT_TRUE(m->createClip(QStringLiteral("NA_KeyIdempotent"), 2.0));
+    auto* node = makeNamedNode("NA_KeyIdempotent_Node");
+    ASSERT_NE(node, nullptr);
+
+    // Two keyframes < 1ms apart → second one updates the first in place.
+    EXPECT_TRUE(m->addKeyframe(QStringLiteral("NA_KeyIdempotent"),
+                                QStringLiteral("NA_KeyIdempotent_Node"),
+                                0.500,
+                                Ogre::Vector3(1, 0, 0),
+                                Ogre::Quaternion(1, 0, 0, 0),
+                                Ogre::Vector3(1, 1, 1)));
+    EXPECT_TRUE(m->addKeyframe(QStringLiteral("NA_KeyIdempotent"),
+                                QStringLiteral("NA_KeyIdempotent_Node"),
+                                0.5005,
+                                Ogre::Vector3(9, 9, 9),
+                                Ogre::Quaternion(1, 0, 0, 0),
+                                Ogre::Vector3(2, 2, 2)));
+    QList<double> keys = m->keyTimesForNode(QStringLiteral("NA_KeyIdempotent"),
+                                             QStringLiteral("NA_KeyIdempotent_Node"));
+    EXPECT_EQ(keys.size(), 1);  // collapsed
+}
+
+TEST_F(NodeAnimationManagerSceneTest, KeyframeRejectedForUnknownNodeOrClip) {
+    auto* m = NodeAnimationManager::instance();
+    ASSERT_TRUE(m->createClip(QStringLiteral("NA_DeleteUnknown"), 1.0));
+    EXPECT_FALSE(m->addKeyframe(QStringLiteral("NA_DeleteUnknown"),
+                                 QStringLiteral("DoesNotExist"),
+                                 0.5,
+                                 Ogre::Vector3::ZERO,
+                                 Ogre::Quaternion::IDENTITY,
+                                 Ogre::Vector3(1,1,1)));
+    EXPECT_FALSE(m->addKeyframe(QStringLiteral("ClipDoesNotExist"),
+                                 QStringLiteral("Anything"),
+                                 0.5,
+                                 Ogre::Vector3::ZERO,
+                                 Ogre::Quaternion::IDENTITY,
+                                 Ogre::Vector3(1,1,1)));
+}
+
+TEST_F(NodeAnimationManagerSceneTest, KeyframeOutOfRangeRejected) {
+    auto* m = NodeAnimationManager::instance();
+    ASSERT_TRUE(m->createClip(QStringLiteral("NA_OutOfRange"), 1.0));
+    makeNamedNode("NA_OutOfRange_Node");
+
+    // Negative time
+    EXPECT_FALSE(m->addKeyframe(QStringLiteral("NA_OutOfRange"),
+                                 QStringLiteral("NA_OutOfRange_Node"),
+                                 -0.1,
+                                 Ogre::Vector3::ZERO,
+                                 Ogre::Quaternion::IDENTITY,
+                                 Ogre::Vector3(1,1,1)));
+    // Past clip length
+    EXPECT_FALSE(m->addKeyframe(QStringLiteral("NA_OutOfRange"),
+                                 QStringLiteral("NA_OutOfRange_Node"),
+                                 2.0,
+                                 Ogre::Vector3::ZERO,
+                                 Ogre::Quaternion::IDENTITY,
+                                 Ogre::Vector3(1,1,1)));
+    // At length boundary (inclusive) is fine
+    EXPECT_TRUE(m->addKeyframe(QStringLiteral("NA_OutOfRange"),
+                                QStringLiteral("NA_OutOfRange_Node"),
+                                1.0,
+                                Ogre::Vector3::ZERO,
+                                Ogre::Quaternion::IDENTITY,
+                                Ogre::Vector3(1,1,1)));
+}
+
+TEST_F(NodeAnimationManagerSceneTest, SetClipEnabledTogglesState) {
+    auto* m = NodeAnimationManager::instance();
+    ASSERT_TRUE(m->createClip(QStringLiteral("NA_Enable"), 1.0));
+
+    auto* scene = Manager::getSingleton()->getSceneMgr();
+    auto* state = scene->getAnimationState("NA_Enable");
+    ASSERT_NE(state, nullptr);
+
+    EXPECT_FALSE(state->getEnabled());  // newly created is disabled by default
+    EXPECT_TRUE(m->setClipEnabled(QStringLiteral("NA_Enable"), true));
+    EXPECT_TRUE(state->getEnabled());
+    EXPECT_TRUE(m->setClipEnabled(QStringLiteral("NA_Enable"), false));
+    EXPECT_FALSE(state->getEnabled());
+
+    EXPECT_FALSE(m->setClipEnabled(QStringLiteral("UnknownClip"), true));
+}
+
+TEST_F(NodeAnimationManagerSceneTest, ClipsChangedSignalFiresOnCreateAndDelete) {
+    auto* m = NodeAnimationManager::instance();
+    QSignalSpy spy(m, &NodeAnimationManager::clipsChanged);
+
+    ASSERT_TRUE(m->createClip(QStringLiteral("NA_Signals"), 1.0));
+    EXPECT_GE(spy.count(), 1);
+
+    const int afterCreate = spy.count();
+    ASSERT_TRUE(m->deleteClip(QStringLiteral("NA_Signals")));
+    EXPECT_GT(spy.count(), afterCreate);
+}
+
+TEST_F(NodeAnimationManagerSceneTest, KeyTimesForMissingClipIsEmpty) {
+    auto* m = NodeAnimationManager::instance();
+    EXPECT_TRUE(m->keyTimesForNode(QStringLiteral("Nope"),
+                                    QStringLiteral("Whatever")).isEmpty());
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -98,6 +98,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/VATBakerController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MorphAnimationManager.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/MorphCommands.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/NodeAnimationManager.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/ApplyAtlas.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/EmbeddedTextureCache.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/NormalMapGenerator.cpp


### PR DESCRIPTION
First sub-slice of #520. Adds the data layer for animating non-skinned scene-node transforms over time — wraps Ogre's `SceneManager` + `Animation` + `NodeAnimationTrack` subsystem that QtMeshEditor never previously exercised. Use cases per the epic spec: animated props, doors, simple machinery, cameras, and animated lights (#482) — anything that doesn't need bones.

## What ships

### `NodeAnimationManager` singleton (QML_SINGLETON)
- `createClip(name, length)` — creates a scene-level `Animation` + `AnimationState` pair. Rejects empty names, non-positive lengths, and duplicate names.
- `deleteClip(name)` — removes the Animation and its driving AnimationState. Rejects unknown clips.
- `addKeyframe(clip, node, time, T, R, S)` — finds-or-creates the per-node track inside the clip, writes a `TransformKeyFrame`. **Idempotent within 1ms** of an existing keyframe so dragging a slider doesn't dribble dozens of near-duplicate keys.
- `setClipEnabled(name, enabled)` — toggle the AnimationState. C2 (Inspector) and a future tick-loop hookup drive playback.
- `listClips()` / `keyTimesForNode(clip, node)` — read-side helpers for the dope-sheet and Inspector to come.
- `Q_INVOKABLE` QML-friendly variants (`addKeyframeFromQml`, etc.) taking doubles instead of `Vector3` / `Quaternion`.
- Signals: `clipsChanged`, `keyframesChanged(clipName)` for the Inspector / dope-sheet to bind to.

## What's deferred to future sub-slices

| Sub-slice | Scope |
|-|-|
| C2 | Inspector "Node Animation" subgroup (Set keyframe / Auto-key / clip switcher) |
| C3 | Undo coverage — `AddKeyframe/CreateClip/Delete` commands (mirror morph A3 pattern) |
| C4 | Dope-sheet integration — node TRS rows alongside bone rows |
| C5 | glTF + FBX node-animation round-trip in the exporters |
| C6 | CLI `qtmesh nodeanim` + MCP `add_node_animation_clip` / `set_node_keyframe` |

## 11 new tests

- Singleton lifecycle.
- Empty / non-positive-length / duplicate-name rejection.
- Create + delete round-trip; AnimationState destroyed alongside.
- `listClips` returns created clips.
- Add keyframe stores transform; subsequent distinct-time add appends rather than replaces.
- Add keyframe **within 1ms** of existing collapses to in-place update.
- Unknown node / unknown clip rejected.
- Negative time + past-length time rejected; time == length accepted.
- `setClipEnabled` toggles `AnimationState::enabled`; unknown name rejected.
- `clipsChanged` signal fires on create and delete.
- `keyTimesForNode` on missing clip returns empty list.

## Test plan
- [ ] CI green (unit-tests-linux + all platforms)
- [ ] 11 new `NodeAnimationManager*Test` cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)