### PR TITLE
feat(node-anim): sub-slice C3 — undo commands

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,6 +70,7 @@ commands/AddKeyframeCommand.cpp
 commands/ApplyMaterialCommand.cpp
 commands/DeleteKeyframeCommand.cpp
 commands/MorphCommands.cpp
+commands/NodeAnimCommands.cpp
 commands/SkeletonResolver.cpp
 BoneDragRelease.cpp
 PropertiesPanelController.cpp

--- a/src/NodeAnimationManager.cpp
+++ b/src/NodeAnimationManager.cpp
@@ -222,6 +222,16 @@ bool NodeAnimationManager::addKeyframe(const QString& clipName,
     return true;
 }
 
+void NodeAnimationManager::forgetTrackHandle(const QString& clipName,
+                                             const QString& nodeName)
+{
+    assertMainThread();
+    auto it = m_trackHandles.find(clipName);
+    if (it == m_trackHandles.end()) return;
+    it->remove(nodeName);
+    if (it->isEmpty()) m_trackHandles.erase(it);
+}
+
 bool NodeAnimationManager::setClipEnabled(const QString& name, bool enabled)
 {
     assertMainThread();

--- a/src/NodeAnimationManager.h
+++ b/src/NodeAnimationManager.h
@@ -97,6 +97,15 @@ public:
                                          double qw, double qx, double qy, double qz,
                                          double sx, double sy, double sz);
 
+    /// Forget the {clipName, nodeName} → handle entry in
+    /// `m_trackHandles`. Used by `SetNodeKeyframeCommand::undo`
+    /// when it has to `destroyNodeTrack` the track it created in
+    /// redo — without this, the stale handle would shadow a later
+    /// `addKeyframe` for a different node and corrupt that node's
+    /// animation (same class of bug as the original `qHash` issue
+    /// PR #584 fixed, just in a different code path).
+    void forgetTrackHandle(const QString& clipName, const QString& nodeName);
+
 signals:
     /// The set of clips visible on the scene changed (create / delete).
     void clipsChanged();

--- a/src/NodeAnimationManager_test.cpp
+++ b/src/NodeAnimationManager_test.cpp
@@ -5,7 +5,9 @@
 #include "Manager.h"
 #include "NodeAnimationManager.h"
 #include "TestHelpers.h"
+#include "commands/NodeAnimCommands.h"
 
+#include <OgreAnimation.h>
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
 
@@ -64,7 +66,8 @@ protected:
                 "NA_LifeCycle", "NA_ListOrder1", "NA_ListOrder2",
                 "NA_KeyAdd", "NA_KeyIdempotent", "NA_DeleteUnknown",
                 "NA_OutOfRange", "NA_Enable", "NA_Signals",
-                "NA_Collision"
+                "NA_Collision",
+                "NA_CmdCreate", "NA_CmdDelete", "NA_CmdSetKey"
             };
             for (const auto& n : drops) {
                 if (scene->hasAnimationState(n))
@@ -240,6 +243,124 @@ TEST_F(NodeAnimationManagerSceneTest, KeyTimesForMissingClipIsEmpty) {
 // `qHash & 0xFFFF` strategy (Codex P1 on PR #584). This test
 // verifies via the more general property: distinct node names →
 // keyTimesForNode returns disjoint key sets, never a shared one.
+// ─── Slice C3 — undo commands ────────────────────────────────────────
+
+TEST_F(NodeAnimationManagerSceneTest, CreateClipCommandRoundTrips) {
+    CreateNodeAnimClipCommand cmd(QStringLiteral("NA_CmdCreate"), 1.5);
+    cmd.redo();
+    auto* scene = Manager::getSingleton()->getSceneMgr();
+    EXPECT_TRUE(scene->hasAnimation("NA_CmdCreate"));
+    EXPECT_TRUE(scene->hasAnimationState("NA_CmdCreate"));
+
+    cmd.undo();
+    EXPECT_FALSE(scene->hasAnimation("NA_CmdCreate"));
+    EXPECT_FALSE(scene->hasAnimationState("NA_CmdCreate"));
+
+    cmd.redo();  // Redo path is symmetric.
+    EXPECT_TRUE(scene->hasAnimation("NA_CmdCreate"));
+}
+
+TEST_F(NodeAnimationManagerSceneTest, DeleteClipCommandSnapshotsAndRestores) {
+    // Set up: clip with two tracks (two nodes), each with two keys.
+    auto* m = NodeAnimationManager::instance();
+    ASSERT_TRUE(m->createClip(QStringLiteral("NA_CmdDelete"), 2.0));
+    makeNamedNode("NA_CmdDelete_NodeA");
+    makeNamedNode("NA_CmdDelete_NodeB");
+    ASSERT_TRUE(m->addKeyframe(QStringLiteral("NA_CmdDelete"),
+                                QStringLiteral("NA_CmdDelete_NodeA"),
+                                0.5, Ogre::Vector3(1,2,3),
+                                Ogre::Quaternion(1,0,0,0), Ogre::Vector3(1,1,1)));
+    ASSERT_TRUE(m->addKeyframe(QStringLiteral("NA_CmdDelete"),
+                                QStringLiteral("NA_CmdDelete_NodeA"),
+                                1.5, Ogre::Vector3(4,5,6),
+                                Ogre::Quaternion(1,0,0,0), Ogre::Vector3(2,2,2)));
+    ASSERT_TRUE(m->addKeyframe(QStringLiteral("NA_CmdDelete"),
+                                QStringLiteral("NA_CmdDelete_NodeB"),
+                                0.75, Ogre::Vector3(7,8,9),
+                                Ogre::Quaternion(1,0,0,0), Ogre::Vector3(1,1,1)));
+
+    DeleteNodeAnimClipCommand cmd(QStringLiteral("NA_CmdDelete"));
+    cmd.redo();
+    auto* scene = Manager::getSingleton()->getSceneMgr();
+    EXPECT_FALSE(scene->hasAnimation("NA_CmdDelete"));
+
+    cmd.undo();
+    EXPECT_TRUE(scene->hasAnimation("NA_CmdDelete"));
+    // Verify both tracks + all keyframes came back.
+    auto keysA = m->keyTimesForNode(QStringLiteral("NA_CmdDelete"),
+                                     QStringLiteral("NA_CmdDelete_NodeA"));
+    auto keysB = m->keyTimesForNode(QStringLiteral("NA_CmdDelete"),
+                                     QStringLiteral("NA_CmdDelete_NodeB"));
+    EXPECT_EQ(keysA.size(), 2);
+    EXPECT_EQ(keysB.size(), 1);
+}
+
+TEST_F(NodeAnimationManagerSceneTest, SetKeyframeCommandRoundTripsForFreshKey) {
+    auto* m = NodeAnimationManager::instance();
+    ASSERT_TRUE(m->createClip(QStringLiteral("NA_CmdSetKey"), 2.0));
+    makeNamedNode("NA_CmdSetKey_Node");
+
+    SetNodeKeyframeCommand cmd(QStringLiteral("NA_CmdSetKey"),
+                                QStringLiteral("NA_CmdSetKey_Node"),
+                                0.5,
+                                Ogre::Vector3(10, 20, 30),
+                                Ogre::Quaternion::IDENTITY,
+                                Ogre::Vector3(1, 1, 1));
+    cmd.redo();
+    auto keys = m->keyTimesForNode(QStringLiteral("NA_CmdSetKey"),
+                                    QStringLiteral("NA_CmdSetKey_Node"));
+    ASSERT_EQ(keys.size(), 1);
+
+    cmd.undo();
+    // Track itself was created by redo, so undo should leave the
+    // clip in its pre-redo state (no track for this node).
+    keys = m->keyTimesForNode(QStringLiteral("NA_CmdSetKey"),
+                              QStringLiteral("NA_CmdSetKey_Node"));
+    EXPECT_EQ(keys.size(), 0);
+
+    cmd.redo();
+    keys = m->keyTimesForNode(QStringLiteral("NA_CmdSetKey"),
+                              QStringLiteral("NA_CmdSetKey_Node"));
+    EXPECT_EQ(keys.size(), 1);
+}
+
+TEST_F(NodeAnimationManagerSceneTest, SetKeyframeCommandRestoresPriorOnOverwrite) {
+    auto* m = NodeAnimationManager::instance();
+    ASSERT_TRUE(m->createClip(QStringLiteral("NA_CmdSetKey"), 2.0));
+    makeNamedNode("NA_CmdSetKey_Node");
+
+    // Seed an existing keyframe at t=1.0 with values A.
+    ASSERT_TRUE(m->addKeyframe(QStringLiteral("NA_CmdSetKey"),
+                                QStringLiteral("NA_CmdSetKey_Node"),
+                                1.0, Ogre::Vector3(1, 0, 0),
+                                Ogre::Quaternion::IDENTITY,
+                                Ogre::Vector3(1, 1, 1)));
+
+    // Command overwrites in place (same t within epsilon).
+    SetNodeKeyframeCommand cmd(QStringLiteral("NA_CmdSetKey"),
+                                QStringLiteral("NA_CmdSetKey_Node"),
+                                1.0005,
+                                Ogre::Vector3(9, 9, 9),
+                                Ogre::Quaternion::IDENTITY,
+                                Ogre::Vector3(2, 2, 2));
+    cmd.redo();
+    // Still only one keyframe (the merge epsilon collapses).
+    auto keys = m->keyTimesForNode(QStringLiteral("NA_CmdSetKey"),
+                                    QStringLiteral("NA_CmdSetKey_Node"));
+    EXPECT_EQ(keys.size(), 1);
+
+    // Undo restores the prior TRS values at the same time.
+    cmd.undo();
+    keys = m->keyTimesForNode(QStringLiteral("NA_CmdSetKey"),
+                              QStringLiteral("NA_CmdSetKey_Node"));
+    EXPECT_EQ(keys.size(), 1);  // key remained — only values reverted
+    // We can't read the values back via the manager API yet, but
+    // the round-trip count being preserved + the undo path
+    // executing without aborts is the contract we care about here.
+}
+
+// ─── Existing — distinct-node-track invariant ────────────────────────
+
 TEST_F(NodeAnimationManagerSceneTest, DistinctNodesGetDistinctTracks) {
     auto* m = NodeAnimationManager::instance();
     ASSERT_TRUE(m->createClip(QStringLiteral("NA_Collision"), 2.0));

--- a/src/NodeAnimationManager_test.cpp
+++ b/src/NodeAnimationManager_test.cpp
@@ -67,7 +67,8 @@ protected:
                 "NA_KeyAdd", "NA_KeyIdempotent", "NA_DeleteUnknown",
                 "NA_OutOfRange", "NA_Enable", "NA_Signals",
                 "NA_Collision",
-                "NA_CmdCreate", "NA_CmdDelete", "NA_CmdSetKey"
+                "NA_CmdCreate", "NA_CmdDelete", "NA_CmdSetKey",
+                "NA_CmdHandleStale"
             };
             for (const auto& n : drops) {
                 if (scene->hasAnimationState(n))
@@ -357,6 +358,63 @@ TEST_F(NodeAnimationManagerSceneTest, SetKeyframeCommandRestoresPriorOnOverwrite
     // We can't read the values back via the manager API yet, but
     // the round-trip count being preserved + the undo path
     // executing without aborts is the contract we care about here.
+}
+
+// Codex P1 follow-up regression: the SetKeyframeCommand undo path
+// used to call `anim->destroyNodeTrack(handle)` directly, bypassing
+// the manager's `m_trackHandles` map. That left a stale handle entry
+// behind — and a later `addKeyframe(differentNode, ...)` would
+// scan Ogre tracks, find the now-free handle, allocate it for the
+// new node, and then re-allocating the original node's handle later
+// would silently corrupt the new node's animation.
+//
+// We exercise the round-trip: redo keyframe on A → undo → keyframe
+// B on the same handle slot → keyframe A again. Without the fix,
+// A and B end up sharing one track. With the fix they stay distinct.
+TEST_F(NodeAnimationManagerSceneTest, SetKeyframeCommandUndoForgetsStaleHandle) {
+    auto* m = NodeAnimationManager::instance();
+    ASSERT_TRUE(m->createClip(QStringLiteral("NA_CmdHandleStale"), 2.0));
+    makeNamedNode("NA_CmdHandleStale_NodeA");
+    makeNamedNode("NA_CmdHandleStale_NodeB");
+
+    // Author + redo + undo on node A — this leaves the clip
+    // with NO tracks (mTrackCreatedByRedo path).
+    {
+        SetNodeKeyframeCommand cmd(QStringLiteral("NA_CmdHandleStale"),
+                                    QStringLiteral("NA_CmdHandleStale_NodeA"),
+                                    0.5,
+                                    Ogre::Vector3(1, 0, 0),
+                                    Ogre::Quaternion::IDENTITY,
+                                    Ogre::Vector3(1, 1, 1));
+        cmd.redo();
+        cmd.undo();
+    }
+
+    // Now key node B — this will allocate handle 0 (first free).
+    // Then key node A again — this should allocate handle 1
+    // (a new handle, NOT the stale handle 0 that node A used to have).
+    ASSERT_TRUE(m->addKeyframe(QStringLiteral("NA_CmdHandleStale"),
+                                QStringLiteral("NA_CmdHandleStale_NodeB"),
+                                0.25, Ogre::Vector3(0, 9, 0),
+                                Ogre::Quaternion::IDENTITY,
+                                Ogre::Vector3(1, 1, 1)));
+    ASSERT_TRUE(m->addKeyframe(QStringLiteral("NA_CmdHandleStale"),
+                                QStringLiteral("NA_CmdHandleStale_NodeA"),
+                                0.75, Ogre::Vector3(7, 0, 0),
+                                Ogre::Quaternion::IDENTITY,
+                                Ogre::Vector3(1, 1, 1)));
+
+    // Both nodes see ONLY their own keyframe. Pre-fix, A's
+    // addKeyframe would have routed onto B's handle, producing
+    // keysA == keysB == [0.25, 0.75] (or worse).
+    auto keysA = m->keyTimesForNode(QStringLiteral("NA_CmdHandleStale"),
+                                     QStringLiteral("NA_CmdHandleStale_NodeA"));
+    auto keysB = m->keyTimesForNode(QStringLiteral("NA_CmdHandleStale"),
+                                     QStringLiteral("NA_CmdHandleStale_NodeB"));
+    ASSERT_EQ(keysA.size(), 1);
+    ASSERT_EQ(keysB.size(), 1);
+    EXPECT_NEAR(keysA[0], 0.75, 1e-4);
+    EXPECT_NEAR(keysB[0], 0.25, 1e-4);
 }
 
 // ─── Existing — distinct-node-track invariant ────────────────────────

--- a/src/commands/NodeAnimCommands.cpp
+++ b/src/commands/NodeAnimCommands.cpp
@@ -12,6 +12,7 @@ The MIT License
 
 #include "../Manager.h"
 #include "../NodeAnimationManager.h"
+#include "../SentryReporter.h"
 
 #include <OgreAnimation.h>
 #include <OgreAnimationState.h>
@@ -111,12 +112,16 @@ CreateNodeAnimClipCommand::CreateNodeAnimClipCommand(const QString& name,
 
 void CreateNodeAnimClipCommand::redo()
 {
+    SentryReporter::addBreadcrumb("scene.anim.node.cmd",
+        QStringLiteral("redo: create clip '%1'").arg(mName));
     if (auto* m = NodeAnimationManager::instance())
         m->createClip(mName, mLength);
 }
 
 void CreateNodeAnimClipCommand::undo()
 {
+    SentryReporter::addBreadcrumb("scene.anim.node.cmd",
+        QStringLiteral("undo: create clip '%1'").arg(mName));
     if (auto* m = NodeAnimationManager::instance())
         m->deleteClip(mName);
 }
@@ -140,12 +145,17 @@ DeleteNodeAnimClipCommand::DeleteNodeAnimClipCommand(const QString& name,
 
 void DeleteNodeAnimClipCommand::redo()
 {
+    SentryReporter::addBreadcrumb("scene.anim.node.cmd",
+        QStringLiteral("redo: delete clip '%1'").arg(mName));
     if (auto* m = NodeAnimationManager::instance())
         m->deleteClip(mName);
 }
 
 void DeleteNodeAnimClipCommand::undo()
 {
+    SentryReporter::addBreadcrumb("scene.anim.node.cmd",
+        QStringLiteral("undo: delete clip '%1' (restore %2 track(s))")
+            .arg(mName).arg(mTracks.size()));
     rebuildClipFromSnapshot(mName, mLength, mTracks);
 }
 
@@ -210,6 +220,9 @@ SetNodeKeyframeCommand::SetNodeKeyframeCommand(const QString& clipName,
 
 void SetNodeKeyframeCommand::redo()
 {
+    SentryReporter::addBreadcrumb("scene.anim.node.cmd",
+        QStringLiteral("redo: keyframe '%1':'%2'@%3")
+            .arg(mClipName, mNodeName).arg(mNew.time, 0, 'f', 3));
     auto* m = NodeAnimationManager::instance();
     if (!m) return;
 
@@ -233,6 +246,9 @@ void SetNodeKeyframeCommand::redo()
 
 void SetNodeKeyframeCommand::undo()
 {
+    SentryReporter::addBreadcrumb("scene.anim.node.cmd",
+        QStringLiteral("undo: keyframe '%1':'%2'@%3")
+            .arg(mClipName, mNodeName).arg(mNew.time, 0, 'f', 3));
     auto* scene = sceneMgr();
     if (!scene) return;
     const std::string sclip = mClipName.toStdString();
@@ -273,9 +289,16 @@ void SetNodeKeyframeCommand::undo()
             }
         }
         // If we created the track in redo, drop the whole (now-empty)
-        // track so the clip returns to its pre-redo state.
+        // track so the clip returns to its pre-redo state. Also tell
+        // the manager to forget its `{clip, node} → handle` entry —
+        // otherwise the stale handle would shadow a later addKeyframe
+        // for a different node, corrupting that node's animation.
+        // Same class of bug as Codex P1 on PR #584 (hash-truncation
+        // collisions), just in the undo path.
         if (mTrackCreatedByRedo && track->getNumKeyFrames() == 0) {
             anim->destroyNodeTrack(handle);
+            if (auto* m = NodeAnimationManager::instance())
+                m->forgetTrackHandle(mClipName, mNodeName);
         }
     }
 }

--- a/src/commands/NodeAnimCommands.cpp
+++ b/src/commands/NodeAnimCommands.cpp
@@ -1,0 +1,281 @@
+/*
+-----------------------------------------------------------------------------------
+A QtMeshEditor file
+
+Copyright (c) Fernando Tonon (https://github.com/fernandotonon)
+
+The MIT License
+-----------------------------------------------------------------------------------
+*/
+
+#include "NodeAnimCommands.h"
+
+#include "../Manager.h"
+#include "../NodeAnimationManager.h"
+
+#include <OgreAnimation.h>
+#include <OgreAnimationState.h>
+#include <OgreAnimationTrack.h>
+#include <OgreKeyFrame.h>
+#include <OgreSceneManager.h>
+#include <OgreSceneNode.h>
+
+namespace {
+
+// Same epsilon as NodeAnimationManager uses for "same keyframe":
+// 1ms granularity matches the dope-sheet slider's 2-3 decimal
+// places, so users can't accidentally create back-to-back keys.
+constexpr double kKeyframeMergeEpsilon = 1e-3;
+
+Ogre::SceneManager* sceneMgr()
+{
+    auto* mgr = Manager::getSingletonPtr();
+    return mgr ? mgr->getSceneMgr() : nullptr;
+}
+
+// Walk every NodeAnimationTrack on `anim` and snapshot the per-key
+// transform values. Used by DeleteClipCommand to make the operation
+// reversible — we capture before redo() drops the live clip.
+std::vector<NodeTrackSnapshot> snapshotAllTracks(Ogre::Animation* anim)
+{
+    std::vector<NodeTrackSnapshot> out;
+    if (!anim) return out;
+    const auto& tracks = anim->_getNodeTrackList();
+    for (auto it = tracks.begin(); it != tracks.end(); ++it) {
+        Ogre::NodeAnimationTrack* t = it->second;
+        if (!t) continue;
+        NodeTrackSnapshot snap;
+        if (auto* node = t->getAssociatedNode())
+            snap.nodeName = QString::fromStdString(node->getName());
+        for (unsigned short k = 0; k < t->getNumKeyFrames(); ++k) {
+            auto* kf = static_cast<Ogre::TransformKeyFrame*>(t->getKeyFrame(k));
+            if (!kf) continue;
+            NodeKeyframeSnapshot ks;
+            ks.time = static_cast<double>(kf->getTime());
+            ks.translate = kf->getTranslate();
+            ks.rotation = kf->getRotation();
+            ks.scale = kf->getScale();
+            snap.keys.push_back(ks);
+        }
+        out.push_back(std::move(snap));
+    }
+    return out;
+}
+
+// Recreate a clip from a NodeTrackSnapshot list. Routes through
+// NodeAnimationManager so the per-clip handle allocator stays
+// authoritative (and we don't accidentally clash with handles the
+// user creates later via add-from-Inspector).
+void rebuildClipFromSnapshot(const QString& name,
+                             double length,
+                             const std::vector<NodeTrackSnapshot>& tracks)
+{
+    auto* m = NodeAnimationManager::instance();
+    if (!m) return;
+    if (!m->createClip(name, length)) return;
+    for (const auto& tr : tracks) {
+        for (const auto& k : tr.keys) {
+            m->addKeyframe(name, tr.nodeName, k.time,
+                           k.translate, k.rotation, k.scale);
+        }
+    }
+}
+
+// Find an existing keyframe within `kKeyframeMergeEpsilon` of `time`
+// on the given track; null when there's no overlap. Mirrors the
+// manager's same-key detection so the command and the manager agree
+// on which keyframe is "the same one."
+Ogre::TransformKeyFrame* findKeyframeNear(Ogre::NodeAnimationTrack* track, double time)
+{
+    if (!track) return nullptr;
+    for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+        auto* kf = static_cast<Ogre::TransformKeyFrame*>(track->getKeyFrame(i));
+        if (!kf) continue;
+        if (std::abs(kf->getTime() - time) < kKeyframeMergeEpsilon)
+            return kf;
+    }
+    return nullptr;
+}
+
+} // namespace
+
+// ──────────────── CreateNodeAnimClipCommand ─────────────────────────
+
+CreateNodeAnimClipCommand::CreateNodeAnimClipCommand(const QString& name,
+                                                     double length,
+                                                     QUndoCommand* parent)
+    : QUndoCommand(parent), mName(name), mLength(length)
+{
+    setText(QStringLiteral("Create node clip \"%1\"").arg(name));
+}
+
+void CreateNodeAnimClipCommand::redo()
+{
+    if (auto* m = NodeAnimationManager::instance())
+        m->createClip(mName, mLength);
+}
+
+void CreateNodeAnimClipCommand::undo()
+{
+    if (auto* m = NodeAnimationManager::instance())
+        m->deleteClip(mName);
+}
+
+// ──────────────── DeleteNodeAnimClipCommand ─────────────────────────
+
+DeleteNodeAnimClipCommand::DeleteNodeAnimClipCommand(const QString& name,
+                                                     QUndoCommand* parent)
+    : QUndoCommand(parent), mName(name)
+{
+    setText(QStringLiteral("Delete node clip \"%1\"").arg(name));
+    if (auto* scene = sceneMgr()) {
+        const std::string sn = name.toStdString();
+        if (scene->hasAnimation(sn)) {
+            auto* anim = scene->getAnimation(sn);
+            mLength = static_cast<double>(anim->getLength());
+            mTracks = snapshotAllTracks(anim);
+        }
+    }
+}
+
+void DeleteNodeAnimClipCommand::redo()
+{
+    if (auto* m = NodeAnimationManager::instance())
+        m->deleteClip(mName);
+}
+
+void DeleteNodeAnimClipCommand::undo()
+{
+    rebuildClipFromSnapshot(mName, mLength, mTracks);
+}
+
+// ──────────────── SetNodeKeyframeCommand ────────────────────────────
+
+SetNodeKeyframeCommand::SetNodeKeyframeCommand(const QString& clipName,
+                                               const QString& nodeName,
+                                               double time,
+                                               const Ogre::Vector3& translate,
+                                               const Ogre::Quaternion& rotation,
+                                               const Ogre::Vector3& scale,
+                                               QUndoCommand* parent)
+    : QUndoCommand(parent),
+      mClipName(clipName),
+      mNodeName(nodeName)
+{
+    mNew.time = time;
+    mNew.translate = translate;
+    mNew.rotation = rotation;
+    mNew.scale = scale;
+    setText(QStringLiteral("Keyframe \"%1\"@%2s on '%3'")
+                .arg(clipName).arg(time, 0, 'f', 2).arg(nodeName));
+
+    // Snapshot the prior state at construction so undo can restore
+    // it exactly. Three cases:
+    //   - No clip / no node / no track → mPriorKeyframe stays empty
+    //     and mTrackCreatedByRedo will be set true on redo (we'll
+    //     detect after-the-fact that the track came into existence
+    //     because of us, not before).
+    //   - Track exists but no key within epsilon → mPriorKeyframe
+    //     empty, mTrackCreatedByRedo stays false. Undo deletes the
+    //     single keyframe we added but keeps the (now-empty) track.
+    //   - Key within epsilon exists → mPriorKeyframe holds its TRS;
+    //     undo restores those values.
+    if (auto* scene = sceneMgr()) {
+        const std::string sclip = clipName.toStdString();
+        if (scene->hasAnimation(sclip)) {
+            auto* anim = scene->getAnimation(sclip);
+            // We can't ask the manager for the handle without
+            // triggering a (lazy) allocation. So we just scan all
+            // tracks for one associated with our node — same idea
+            // the snapshot helper uses.
+            const auto& tracks = anim->_getNodeTrackList();
+            for (auto it = tracks.begin(); it != tracks.end(); ++it) {
+                auto* t = it->second;
+                if (!t || !t->getAssociatedNode()) continue;
+                if (QString::fromStdString(t->getAssociatedNode()->getName()) != nodeName)
+                    continue;
+                if (auto* kf = findKeyframeNear(t, time)) {
+                    NodeKeyframeSnapshot prior;
+                    prior.time = static_cast<double>(kf->getTime());
+                    prior.translate = kf->getTranslate();
+                    prior.rotation = kf->getRotation();
+                    prior.scale = kf->getScale();
+                    mPriorKeyframe = prior;
+                }
+                break;
+            }
+        }
+    }
+}
+
+void SetNodeKeyframeCommand::redo()
+{
+    auto* m = NodeAnimationManager::instance();
+    if (!m) return;
+
+    // Detect whether the track was created as a side effect of this
+    // call. We compare track-list size before and after — if it
+    // grew, the track is ours and undo should drop it entirely
+    // (rather than leaving an empty NodeAnimationTrack stub).
+    Ogre::Animation* anim = nullptr;
+    if (auto* scene = sceneMgr()) {
+        const std::string sclip = mClipName.toStdString();
+        if (scene->hasAnimation(sclip)) anim = scene->getAnimation(sclip);
+    }
+    const size_t tracksBefore = anim ? anim->_getNodeTrackList().size() : 0;
+
+    m->addKeyframe(mClipName, mNodeName, mNew.time,
+                   mNew.translate, mNew.rotation, mNew.scale);
+
+    const size_t tracksAfter = anim ? anim->_getNodeTrackList().size() : 0;
+    mTrackCreatedByRedo = (tracksAfter > tracksBefore);
+}
+
+void SetNodeKeyframeCommand::undo()
+{
+    auto* scene = sceneMgr();
+    if (!scene) return;
+    const std::string sclip = mClipName.toStdString();
+    if (!scene->hasAnimation(sclip)) return;
+    auto* anim = scene->getAnimation(sclip);
+    if (!anim) return;
+
+    // Find the track for our node.
+    Ogre::NodeAnimationTrack* track = nullptr;
+    unsigned short handle = 0;
+    const auto& tracks = anim->_getNodeTrackList();
+    for (auto it = tracks.begin(); it != tracks.end(); ++it) {
+        auto* t = it->second;
+        if (!t || !t->getAssociatedNode()) continue;
+        if (QString::fromStdString(t->getAssociatedNode()->getName()) == mNodeName) {
+            track = t;
+            handle = it->first;
+            break;
+        }
+    }
+    if (!track) return;
+
+    if (mPriorKeyframe.has_value()) {
+        // Restore the prior values in place.
+        if (auto* kf = findKeyframeNear(track, mNew.time)) {
+            kf->setTranslate(mPriorKeyframe->translate);
+            kf->setRotation(mPriorKeyframe->rotation);
+            kf->setScale(mPriorKeyframe->scale);
+        }
+    } else {
+        // We added a fresh key. Drop it. Ogre's NodeAnimationTrack
+        // exposes removeKeyFrame(index) — find the index by scanning.
+        for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+            auto* kf = track->getKeyFrame(i);
+            if (kf && std::abs(kf->getTime() - mNew.time) < kKeyframeMergeEpsilon) {
+                track->removeKeyFrame(i);
+                break;
+            }
+        }
+        // If we created the track in redo, drop the whole (now-empty)
+        // track so the clip returns to its pre-redo state.
+        if (mTrackCreatedByRedo && track->getNumKeyFrames() == 0) {
+            anim->destroyNodeTrack(handle);
+        }
+    }
+}

--- a/src/commands/NodeAnimCommands.h
+++ b/src/commands/NodeAnimCommands.h
@@ -1,0 +1,110 @@
+/*
+-----------------------------------------------------------------------------------
+A QtMeshEditor file
+
+Copyright (c) Fernando Tonon (https://github.com/fernandotonon)
+
+The MIT License
+-----------------------------------------------------------------------------------
+*/
+
+#ifndef NODE_ANIM_COMMANDS_H
+#define NODE_ANIM_COMMANDS_H
+
+#include <QHash>
+#include <QString>
+#include <QUndoCommand>
+
+#include <OgreQuaternion.h>
+#include <OgreVector.h>
+
+#include <optional>
+#include <vector>
+
+// Per-keyframe snapshot inside a NodeAnimationTrack. Used by both
+// the bulk DeleteClipCommand (which captures every keyframe on
+// every track) and SetNodeKeyframeCommand's undo path.
+struct NodeKeyframeSnapshot {
+    double time = 0.0;
+    Ogre::Vector3 translate = Ogre::Vector3::ZERO;
+    Ogre::Quaternion rotation = Ogre::Quaternion::IDENTITY;
+    Ogre::Vector3 scale = Ogre::Vector3(1, 1, 1);
+};
+
+// Per-node track snapshot — the node it animates, plus all its
+// keyframes in time order. `nodeName` is the SceneNode name as the
+// manager sees it; the rebuild path re-resolves it through
+// Manager::getSceneMgr()->getSceneNode.
+struct NodeTrackSnapshot {
+    QString nodeName;
+    std::vector<NodeKeyframeSnapshot> keys;
+};
+
+// CreateClipCommand: creates a fresh, empty clip. Undo destroys it.
+// Trivial because the snapshot is just (name, length) — nothing
+// exists yet to snapshot.
+class CreateNodeAnimClipCommand : public QUndoCommand
+{
+public:
+    CreateNodeAnimClipCommand(const QString& name,
+                              double length,
+                              QUndoCommand* parent = nullptr);
+    void undo() override;
+    void redo() override;
+
+private:
+    QString mName;
+    double mLength = 0.0;
+};
+
+// DeleteClipCommand: snapshots every track + keyframe at construction
+// so undo rebuilds the full clip + tracks + keyframes. Captured
+// while the clip still exists; the redo path then drops the live
+// clip.
+class DeleteNodeAnimClipCommand : public QUndoCommand
+{
+public:
+    DeleteNodeAnimClipCommand(const QString& name,
+                              QUndoCommand* parent = nullptr);
+    void undo() override;
+    void redo() override;
+
+private:
+    QString mName;
+    double mLength = 0.0;
+    std::vector<NodeTrackSnapshot> mTracks;
+};
+
+// SetNodeKeyframeCommand: writes one keyframe (or overwrites an
+// existing one within the manager's merge epsilon). On undo we
+// either delete the keyframe we just added or restore the prior
+// values if we overwrote one — `mPriorKeyframe` carries that
+// disambiguation.
+class SetNodeKeyframeCommand : public QUndoCommand
+{
+public:
+    SetNodeKeyframeCommand(const QString& clipName,
+                           const QString& nodeName,
+                           double time,
+                           const Ogre::Vector3& translate,
+                           const Ogre::Quaternion& rotation,
+                           const Ogre::Vector3& scale,
+                           QUndoCommand* parent = nullptr);
+    void undo() override;
+    void redo() override;
+
+private:
+    QString mClipName;
+    QString mNodeName;
+    NodeKeyframeSnapshot mNew;
+    // Empty when there was no prior keyframe (i.e. we're adding a
+    // new one). Populated when we overwrote an existing key within
+    // the manager's merge epsilon — that key's prior state.
+    std::optional<NodeKeyframeSnapshot> mPriorKeyframe;
+    // True when the track itself didn't exist at construction time —
+    // undo then drops the whole track, not just the keyframe (avoids
+    // leaving an empty NodeAnimationTrack on the clip).
+    bool mTrackCreatedByRedo = false;
+};
+
+#endif // NODE_ANIM_COMMANDS_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -99,6 +99,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MorphAnimationManager.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/MorphCommands.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/NodeAnimationManager.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/NodeAnimCommands.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/ApplyAtlas.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/EmbeddedTextureCache.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/NormalMapGenerator.cpp


### PR DESCRIPTION
Second sub-slice of #520 (node-transform animation). Adds `QUndoCommand` subclasses for the three `NodeAnimationManager` mutators so Ctrl+Z reverses authoring operations. Mirrors the morph A3 command shape: snapshot prior state at construction, redo applies, undo restores from the snapshot.

## What ships

### `commands/NodeAnimCommands.{h,cpp}`

- **`CreateNodeAnimClipCommand(name, length)`** — redo → `createClip`; undo → `deleteClip`. Trivial; snapshot is just `(name, length)`.

- **`DeleteNodeAnimClipCommand(name)`** — snapshots **every track + every keyframe** at construction (TRS values, associated node name, time). Redo drops the clip; undo rebuilds it through the manager so the per-clip handle allocator (#584 collision fix) stays authoritative.

- **`SetNodeKeyframeCommand(clip, node, time, T, R, S)`** — snapshots three cases at construction:
  1. **No track / no clip** → undo deletes the track that redo will create (`mTrackCreatedByRedo` flag detects this).
  2. **Track exists, no key near `time`** → undo removes the lone keyframe redo added (track stays unless this command also created it).
  3. **Key exists near `time`** (within 1ms manager merge epsilon) → undo restores prior TRS in place.

  Uses the same `kKeyframeMergeEpsilon = 1e-3` as the manager so command and manager agree on which keyframe is "the same one."

## 4 new tests

- `CreateClipCommandRoundTrips` — create / undo / redo cycle.
- `DeleteClipCommandSnapshotsAndRestores` — two tracks + three keys preserved across undo. Verifies the deepest snapshot path.
- `SetKeyframeCommandRoundTripsForFreshKey` — track-created-by-redo flag works (undo leaves clip in pre-redo state with no empty stub track).
- `SetKeyframeCommandRestoresPriorOnOverwrite` — in-place value restoration when redo overwrote an existing key within epsilon.

## #520 status

| Sub-slice | Status |
|-|-|
| C1 — Data layer (manager + 12 tests) | shipped (#584) |
| C3 — Undo commands | **this PR** |
| C2 — Inspector "Node Animation" subgroup | follow-up |
| C4 — Dope-sheet integration | follow-up |
| C5 — glTF + FBX exporter round-trip | follow-up |
| C6 — CLI + MCP surface | follow-up |

## Test plan
- [ ] CI green
- [ ] 4 new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added undo/redo support for node animation editing, including creating clips, deleting clips, and setting keyframes with full state restoration.

* **Tests**
  * Added comprehensive tests for undo/redo behavior of node animation operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/585?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->