### PR TITLE
review(mcp): node-anim — strict JSON type validation

### DIFF
--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -4437,6 +4437,37 @@ QJsonObject MCPServer::toolAddNodeAnimationClip(const QJsonObject &args)
         QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Indented)));
 }
 
+// Parse an optional N-element numeric JSON array argument. Returns
+// `def` when the key is missing. Sets `ok = false` and populates
+// `err` on wrong arity or any non-numeric element. Pulled out of
+// `toolSetNodeKeyframe` so the dispatcher stays under SonarCloud's
+// cognitive-complexity threshold and the inner lambdas don't exceed
+// the 20-line cap.
+template <int N>
+static bool readNumericArray(const QJsonObject& args, const char* key,
+                             double out[N], bool& present, QString& err)
+{
+    present = false;
+    err.clear();
+    if (!args.contains(key)) return true;
+    present = true;
+    const QJsonArray a = args.value(key).toArray();
+    if (a.size() != N) {
+        err = QStringLiteral("Error: '%1' must be an array of %2 numbers")
+                  .arg(key).arg(N);
+        return false;
+    }
+    for (int i = 0; i < N; ++i) {
+        if (!a[i].isDouble()) {
+            err = QStringLiteral("Error: '%1'[%2] must be a number")
+                      .arg(key).arg(i);
+            return false;
+        }
+        out[i] = a[i].toDouble();
+    }
+    return true;
+}
+
 QJsonObject MCPServer::toolSetNodeKeyframe(const QJsonObject &args)
 {
     SentryReporter::addBreadcrumb("ai.tool_call", "set_node_keyframe");
@@ -4460,63 +4491,31 @@ QJsonObject MCPServer::toolSetNodeKeyframe(const QJsonObject &args)
     if (!std::isfinite(time) || time < 0.0)
         return makeErrorResult("Error: time must be a non-negative finite number");
 
-    // Translate / rotation / scale all default to identity if omitted,
-    // so the agent can author "snapshot the current pose at time T"
-    // by passing just the clip/node/time triple. Each is parsed
-    // strictly: malformed arrays AND non-numeric components return
-    // an error rather than silently falling back to defaults (which
-    // would mask agent bugs).
-    auto parseVec3 = [&](const char* key, const Ogre::Vector3& def,
-                         bool& ok, QString& err) -> Ogre::Vector3 {
-        ok = true;
-        if (!args.contains(key)) return def;
-        const QJsonArray a = args.value(key).toArray();
-        if (a.size() != 3) {
-            ok = false;
-            err = QStringLiteral("Error: '%1' must be an array of 3 numbers").arg(key);
-            return def;
-        }
-        for (int i = 0; i < 3; ++i) {
-            if (!a[i].isDouble()) {
-                ok = false;
-                err = QStringLiteral("Error: '%1'[%2] must be a number").arg(key).arg(i);
-                return def;
-            }
-        }
-        return Ogre::Vector3(static_cast<Ogre::Real>(a[0].toDouble()),
-                             static_cast<Ogre::Real>(a[1].toDouble()),
-                             static_cast<Ogre::Real>(a[2].toDouble()));
-    };
-    auto parseQuat = [&](const char* key, const Ogre::Quaternion& def,
-                         bool& ok, QString& err) -> Ogre::Quaternion {
-        ok = true;
-        if (!args.contains(key)) return def;
-        const QJsonArray a = args.value(key).toArray();
-        if (a.size() != 4) {
-            ok = false;
-            err = QStringLiteral("Error: '%1' must be an array of 4 numbers (w,x,y,z)").arg(key);
-            return def;
-        }
-        for (int i = 0; i < 4; ++i) {
-            if (!a[i].isDouble()) {
-                ok = false;
-                err = QStringLiteral("Error: '%1'[%2] must be a number").arg(key).arg(i);
-                return def;
-            }
-        }
-        return Ogre::Quaternion(static_cast<Ogre::Real>(a[0].toDouble()),
-                                static_cast<Ogre::Real>(a[1].toDouble()),
-                                static_cast<Ogre::Real>(a[2].toDouble()),
-                                static_cast<Ogre::Real>(a[3].toDouble()));
-    };
-
-    bool ok = true; QString err;
-    const Ogre::Vector3 translate = parseVec3("translate", Ogre::Vector3::ZERO, ok, err);
-    if (!ok) return makeErrorResult(err);
-    const Ogre::Quaternion rotation = parseQuat("rotation", Ogre::Quaternion::IDENTITY, ok, err);
-    if (!ok) return makeErrorResult(err);
-    const Ogre::Vector3 scale = parseVec3("scale", Ogre::Vector3(1, 1, 1), ok, err);
-    if (!ok) return makeErrorResult(err);
+    // Translate / rotation / scale all default to identity / one when
+    // omitted, so the agent can author "snapshot pose at time T" with
+    // just the clip/node/time triple. Each is parsed strictly:
+    // wrong-arity arrays AND non-numeric elements return an error.
+    QString err;
+    bool present = false;
+    double t[3] = {0, 0, 0};
+    double r[4] = {1, 0, 0, 0};
+    double s[3] = {1, 1, 1};
+    if (!readNumericArray<3>(args, "translate", t, present, err))
+        return makeErrorResult(err);
+    if (!readNumericArray<4>(args, "rotation", r, present, err))
+        return makeErrorResult(err);
+    if (!readNumericArray<3>(args, "scale", s, present, err))
+        return makeErrorResult(err);
+    const Ogre::Vector3 translate(static_cast<Ogre::Real>(t[0]),
+                                  static_cast<Ogre::Real>(t[1]),
+                                  static_cast<Ogre::Real>(t[2]));
+    const Ogre::Quaternion rotation(static_cast<Ogre::Real>(r[0]),
+                                    static_cast<Ogre::Real>(r[1]),
+                                    static_cast<Ogre::Real>(r[2]),
+                                    static_cast<Ogre::Real>(r[3]));
+    const Ogre::Vector3 scale(static_cast<Ogre::Real>(s[0]),
+                              static_cast<Ogre::Real>(s[1]),
+                              static_cast<Ogre::Real>(s[2]));
 
     auto* m = NodeAnimationManager::instance();
     if (!m->addKeyframe(clip, node, time, translate, rotation, scale))

--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -4416,7 +4416,11 @@ QJsonObject MCPServer::toolAddNodeAnimationClip(const QJsonObject &args)
         return makeErrorResult("Error: missing required 'name' argument");
     if (!args.contains("length"))
         return makeErrorResult("Error: missing required 'length' argument");
-    const double length = args.value("length").toDouble();
+    // Strict number check first — see set_node_keyframe rationale.
+    const QJsonValue lengthV = args.value("length");
+    if (!lengthV.isDouble())
+        return makeErrorResult("Error: 'length' must be a number");
+    const double length = lengthV.toDouble();
     if (!std::isfinite(length) || length <= 0.0)
         return makeErrorResult("Error: length must be a positive finite number");
 
@@ -4445,15 +4449,23 @@ QJsonObject MCPServer::toolSetNodeKeyframe(const QJsonObject &args)
         return makeErrorResult("Error: missing required 'node' argument");
     if (!args.contains("time"))
         return makeErrorResult("Error: missing required 'time' argument");
-    const double time = args.value("time").toDouble();
+    // Strict number check first: QJsonValue::toDouble() silently
+    // returns 0.0 on non-numeric inputs (string, bool, null), which
+    // would create a phantom keyframe at t=0 from a caller bug like
+    // `"time": "0.5"`. Reject any non-Double type up front.
+    const QJsonValue timeV = args.value("time");
+    if (!timeV.isDouble())
+        return makeErrorResult("Error: 'time' must be a number");
+    const double time = timeV.toDouble();
     if (!std::isfinite(time) || time < 0.0)
         return makeErrorResult("Error: time must be a non-negative finite number");
 
     // Translate / rotation / scale all default to identity if omitted,
     // so the agent can author "snapshot the current pose at time T"
     // by passing just the clip/node/time triple. Each is parsed
-    // strictly: malformed arrays return an error rather than silently
-    // falling back to defaults (which would mask agent bugs).
+    // strictly: malformed arrays AND non-numeric components return
+    // an error rather than silently falling back to defaults (which
+    // would mask agent bugs).
     auto parseVec3 = [&](const char* key, const Ogre::Vector3& def,
                          bool& ok, QString& err) -> Ogre::Vector3 {
         ok = true;
@@ -4463,6 +4475,13 @@ QJsonObject MCPServer::toolSetNodeKeyframe(const QJsonObject &args)
             ok = false;
             err = QStringLiteral("Error: '%1' must be an array of 3 numbers").arg(key);
             return def;
+        }
+        for (int i = 0; i < 3; ++i) {
+            if (!a[i].isDouble()) {
+                ok = false;
+                err = QStringLiteral("Error: '%1'[%2] must be a number").arg(key).arg(i);
+                return def;
+            }
         }
         return Ogre::Vector3(static_cast<Ogre::Real>(a[0].toDouble()),
                              static_cast<Ogre::Real>(a[1].toDouble()),
@@ -4477,6 +4496,13 @@ QJsonObject MCPServer::toolSetNodeKeyframe(const QJsonObject &args)
             ok = false;
             err = QStringLiteral("Error: '%1' must be an array of 4 numbers (w,x,y,z)").arg(key);
             return def;
+        }
+        for (int i = 0; i < 4; ++i) {
+            if (!a[i].isDouble()) {
+                ok = false;
+                err = QStringLiteral("Error: '%1'[%2] must be a number").arg(key).arg(i);
+                return def;
+            }
         }
         return Ogre::Quaternion(static_cast<Ogre::Real>(a[0].toDouble()),
                                 static_cast<Ogre::Real>(a[1].toDouble()),

--- a/src/MCPServer_test.cpp
+++ b/src/MCPServer_test.cpp
@@ -7163,3 +7163,55 @@ TEST_F(MCPServerTest, SetNodeKeyframe_RejectsMalformedTransformArray)
     EXPECT_TRUE(isError(r));
     EXPECT_TRUE(getResultText(r).contains("translate"));
 }
+
+// Codex P1 follow-ups on PR #586: QJsonValue::toDouble() silently
+// returns 0.0 on non-numeric input. Without explicit `isDouble()`
+// guards, callers passing `"time": "abc"` or
+// `"translate": ["x", 1, 2]` would create phantom keyframes at t=0
+// or with zeroed components — corrupting authored data without a
+// visible error. These tests lock the strict-validation contract.
+
+TEST_F(MCPServerTest, SetNodeKeyframe_RejectsNonNumericTime)
+{
+    QJsonObject create;
+    create["name"] = "MCP_C6_StrictTime";
+    create["length"] = 1.0;
+    server->callTool("add_node_animation_clip", create);
+
+    QJsonObject args;
+    args["clip"] = "MCP_C6_StrictTime";
+    args["node"] = "SomeNode";
+    args["time"] = "0.5";  // STRING instead of number
+    QJsonObject r = server->callTool("set_node_keyframe", args);
+    EXPECT_TRUE(isError(r));
+    EXPECT_TRUE(getResultText(r).contains("time"));
+    EXPECT_TRUE(getResultText(r).contains("number"));
+}
+
+TEST_F(MCPServerTest, SetNodeKeyframe_RejectsNonNumericTRSComponent)
+{
+    QJsonObject create;
+    create["name"] = "MCP_C6_StrictTRS";
+    create["length"] = 1.0;
+    server->callTool("add_node_animation_clip", create);
+
+    QJsonObject args;
+    args["clip"] = "MCP_C6_StrictTRS";
+    args["node"] = "SomeNode";
+    args["time"] = 0.0;
+    args["translate"] = QJsonArray{QString("x"), 1.0, 2.0};  // string in slot 0
+    QJsonObject r = server->callTool("set_node_keyframe", args);
+    EXPECT_TRUE(isError(r));
+    EXPECT_TRUE(getResultText(r).contains("translate"));
+}
+
+TEST_F(MCPServerTest, AddNodeAnimationClip_RejectsNonNumericLength)
+{
+    QJsonObject args;
+    args["name"] = "MCP_C6_StrictLen";
+    args["length"] = "1.5";  // STRING instead of number
+    QJsonObject r = server->callTool("add_node_animation_clip", args);
+    EXPECT_TRUE(isError(r));
+    EXPECT_TRUE(getResultText(r).contains("length"));
+    EXPECT_TRUE(getResultText(r).contains("number"));
+}


### PR DESCRIPTION
Codex P1 follow-up on PR #586 (merged):

## Bug — silent coercion to 0.0 on non-numeric JSON

`QJsonValue::toDouble()` returns 0.0 on any non-Double type — string, bool, null. So a caller bug like `"time": "0.5"` or `"translate": ["x", 1, 2]` would silently create a keyframe at t=0 with zeroed components instead of surfacing the problem. That contradicts the strict-parse contract documented in the tool descriptions and can quietly corrupt authored animation data.

## Fix
- **`set_node_keyframe`** — explicit `isDouble()` guard on `time` before `toDouble()`. Inner Vec3 / Quat parse helpers loop over every component and reject any non-numeric element with a descriptive error naming the failing index (e.g. `"Error: 'translate'[0] must be a number"`).
- **`add_node_animation_clip`** — same `isDouble()` guard on `length`.

## 3 new tests
- `SetNodeKeyframe_RejectsNonNumericTime` — `"time": "0.5"` → error mentions "time" + "number".
- `SetNodeKeyframe_RejectsNonNumericTRSComponent` — string in a translate slot → error names the field.
- `AddNodeAnimationClip_RejectsNonNumericLength` — string-typed length → error mentions "length" + "number".

## Test plan
- [ ] CI green
- [ ] 3 new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for node animation keyframe and clip inputs to properly reject non-numeric values (strings, booleans, null) instead of silently converting them, providing clearer error messages that identify the problematic field and expected type.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->