### PR TITLE
review(mcp): reject non-finite TRS components in node-anim helper

### DIFF
--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -4463,7 +4463,16 @@ static bool readNumericArray(const QJsonObject& args, const char* key,
                       .arg(key).arg(i);
             return false;
         }
-        out[i] = a[i].toDouble();
+        const double v = a[i].toDouble();
+        // Extremely large literals (e.g. `1e400`) JSON-parse as Doubles
+        // but produce Inf, which would silently propagate into the
+        // keyframe. Reject NaN / Inf the same way time / length do.
+        if (!std::isfinite(v)) {
+            err = QStringLiteral("Error: '%1'[%2] must be a finite number")
+                      .arg(key).arg(i);
+            return false;
+        }
+        out[i] = v;
     }
     return true;
 }

--- a/src/MCPServer_test.cpp
+++ b/src/MCPServer_test.cpp
@@ -7215,3 +7215,26 @@ TEST_F(MCPServerTest, AddNodeAnimationClip_RejectsNonNumericLength)
     EXPECT_TRUE(getResultText(r).contains("length"));
     EXPECT_TRUE(getResultText(r).contains("number"));
 }
+
+// CodeRabbit nit on PR #587 — reject NaN / Inf TRS components.
+// Extremely large literals (1e400) JSON-parse as Doubles but produce
+// Inf, which would silently propagate into the keyframe. Round-trips
+// through Ogre and exporters would then NaN-cascade.
+TEST_F(MCPServerTest, SetNodeKeyframe_RejectsNonFiniteTRSComponent)
+{
+    QJsonObject create;
+    create["name"] = "MCP_C6_FiniteTRS";
+    create["length"] = 1.0;
+    server->callTool("add_node_animation_clip", create);
+
+    QJsonObject args;
+    args["clip"] = "MCP_C6_FiniteTRS";
+    args["node"] = "SomeNode";
+    args["time"] = 0.0;
+    // 1e400 → Inf at JSON parse time.
+    args["translate"] = QJsonArray{1e400, 0.0, 0.0};
+    QJsonObject r = server->callTool("set_node_keyframe", args);
+    EXPECT_TRUE(isError(r));
+    EXPECT_TRUE(getResultText(r).contains("translate"));
+    EXPECT_TRUE(getResultText(r).contains("finite"));
+}


### PR DESCRIPTION
CodeRabbit nit on PR #587 (merged) — `readNumericArray` accepted any JSON Double, but extremely large literals (e.g. `1e400`) parse as `Inf` and would propagate silently into the keyframe + downstream exporters. Round-trip through glTF would then NaN-cascade.

## Fix
- `std::isfinite()` check on each component before storing.
- Rejection message mentions "finite" so callers can distinguish from the type-mismatch path.

## 1 new test
- `SetNodeKeyframe_RejectsNonFiniteTRSComponent` exercises `1e400` in a translate slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)