### PR TITLE
review(cli): nodeanim — exit non-zero when import fails

### DIFF
--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -5093,6 +5093,23 @@ int CLIPipeline::cmdNodeAnim(int argc, char* argv[])
 
     MeshImporterExporter::importer({fi.absoluteFilePath()});
 
+    // Verify the import actually produced anything. A corrupt or
+    // unsupported-but-existing file would otherwise produce
+    // "No node animations found" with exit code 0 — masking real
+    // load failures in CI/audit workflows. Same guard cmdMorph uses.
+    auto& movables = Manager::getSingleton()->getEntities();
+    bool hasAnyEntity = false;
+    for (auto* obj : movables) {
+        if (obj && obj->getMovableType() == "Entity") {
+            hasAnyEntity = true;
+            break;
+        }
+    }
+    if (!hasAnyEntity) {
+        err() << "Error: Failed to load file: " << filePath << Qt::endl;
+        return 1;
+    }
+
     // The NodeAnimationManager reads from the SceneManager's animation
     // table, which is what `importer()` populated. Round-trip the
     // listClips() Q_INVOKABLE so the CLI output matches whatever an


### PR DESCRIPTION
Codex P1 on PR #589 (merged): `qtmesh nodeanim` ran `MeshImporterExporter::importer` and went straight to listing, without verifying anything actually loaded. A corrupt / unsupported-but-existing file silently returned exit 0 with the "No node animations found" message, masking real import failures in CI/audit workflows.

## Fix
Walk `Manager::getSceneMgr()` post-import looking for at least one `Entity`. None → emit `Error: Failed to load file: <path>` to stderr and return 1. Same guard `cmdMorph` already uses.

## Manual check
`qtmesh nodeanim CLAUDE.md --list` now exits 1 with the expected error message instead of 0 with a vacuous result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)