### PR TITLE
feat(pose-lib): sub-slice D1 — PoseLibrary singleton

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,6 +91,7 @@ VATBaker.cpp
 VATBakerController.cpp
 MorphAnimationManager.cpp
 NodeAnimationManager.cpp
+PoseLibrary.cpp
 ApplyAtlas.cpp
 EmbeddedTextureCache.cpp
 NormalMapGenerator.cpp

--- a/src/PoseLibrary.cpp
+++ b/src/PoseLibrary.cpp
@@ -160,6 +160,7 @@ bool PoseLibrary::deletePose(Ogre::Entity* entity, const QString& name)
 
 bool PoseLibrary::hasPose(Ogre::Entity* entity, const QString& name) const
 {
+    assertMainThread();
     if (!entity || name.isEmpty()) return false;
     auto it = m_byEntity.constFind(entity);
     if (it == m_byEntity.constEnd()) return false;
@@ -168,6 +169,7 @@ bool PoseLibrary::hasPose(Ogre::Entity* entity, const QString& name) const
 
 QStringList PoseLibrary::listPoses(Ogre::Entity* entity) const
 {
+    assertMainThread();
     if (!entity) return {};
     auto it = m_byEntity.constFind(entity);
     if (it == m_byEntity.constEnd()) return {};
@@ -180,13 +182,20 @@ bool PoseLibrary::forgetEntity(Ogre::Entity* entity)
     if (!entity) return false;
     if (!m_byEntity.contains(entity)) return false;
     m_byEntity.remove(entity);
+    SentryReporter::addBreadcrumb("scene.anim.pose",
+        QStringLiteral("forget entity (entity-side teardown)"));
     return true;
 }
 
 void PoseLibrary::clearAll()
 {
     assertMainThread();
+    const int n = m_byEntity.size();
     m_byEntity.clear();
+    if (n > 0) {
+        SentryReporter::addBreadcrumb("scene.anim.pose",
+            QStringLiteral("clear all (%1 entities)").arg(n));
+    }
 }
 
 bool PoseLibrary::savePoseForSelection(const QString& name)

--- a/src/PoseLibrary.cpp
+++ b/src/PoseLibrary.cpp
@@ -174,6 +174,21 @@ QStringList PoseLibrary::listPoses(Ogre::Entity* entity) const
     return it->order;
 }
 
+bool PoseLibrary::forgetEntity(Ogre::Entity* entity)
+{
+    assertMainThread();
+    if (!entity) return false;
+    if (!m_byEntity.contains(entity)) return false;
+    m_byEntity.remove(entity);
+    return true;
+}
+
+void PoseLibrary::clearAll()
+{
+    assertMainThread();
+    m_byEntity.clear();
+}
+
 bool PoseLibrary::savePoseForSelection(const QString& name)
 {
     auto* sel = SelectionSet::getSingleton();

--- a/src/PoseLibrary.cpp
+++ b/src/PoseLibrary.cpp
@@ -1,0 +1,211 @@
+/*
+-----------------------------------------------------------------------------------
+A QtMeshEditor file
+
+Copyright (c) Fernando Tonon (https://github.com/fernandotonon)
+
+The MIT License
+-----------------------------------------------------------------------------------
+*/
+
+#include "PoseLibrary.h"
+
+#include "SelectionSet.h"
+#include "SentryReporter.h"
+
+#include <QCoreApplication>
+#include <QThread>
+
+#include <OgreBone.h>
+#include <OgreEntity.h>
+#include <OgreSkeleton.h>
+#include <OgreSkeletonInstance.h>
+
+namespace {
+
+// Singletons run on the main thread by project convention (CLAUDE.md).
+// Assert at the lifecycle entry points so a regression surfaces
+// loudly in debug builds.
+inline void assertMainThread()
+{
+    Q_ASSERT(QCoreApplication::instance());
+    Q_ASSERT(QThread::currentThread() == QCoreApplication::instance()->thread());
+}
+
+// Both `Entity::hasSkeleton` and SkeletonInstance access are guarded
+// here so the rest of the manager can assume non-null. Returns null
+// when the entity has no skeleton attached (a static prop, a
+// non-skinned scene-node child, etc.).
+Ogre::SkeletonInstance* skeletonOf(Ogre::Entity* entity)
+{
+    if (!entity) return nullptr;
+    if (!entity->hasSkeleton()) return nullptr;
+    return entity->getSkeleton();
+}
+
+} // namespace
+
+PoseLibrary* PoseLibrary::s_instance = nullptr;
+
+PoseLibrary* PoseLibrary::instance()
+{
+    assertMainThread();
+    if (!s_instance) s_instance = new PoseLibrary();
+    return s_instance;
+}
+
+PoseLibrary* PoseLibrary::qmlInstance(QQmlEngine*, QJSEngine*)
+{
+    assertMainThread();
+    return instance();
+}
+
+void PoseLibrary::kill()
+{
+    assertMainThread();
+    if (!s_instance) return;
+    delete s_instance;
+    s_instance = nullptr;
+}
+
+PoseLibrary::PoseLibrary(QObject* parent) : QObject(parent) {}
+PoseLibrary::~PoseLibrary() = default;
+
+bool PoseLibrary::savePose(Ogre::Entity* entity, const QString& name)
+{
+    assertMainThread();
+    if (!entity || name.isEmpty()) return false;
+    auto* skel = skeletonOf(entity);
+    if (!skel) return false;
+
+    PoseSnapshot snapshot;
+    snapshot.reserve(skel->getNumBones());
+    for (unsigned short i = 0; i < skel->getNumBones(); ++i) {
+        Ogre::Bone* bone = skel->getBone(i);
+        if (!bone) continue;
+        BonePoseSnapshot bs;
+        bs.translate = bone->getPosition();
+        bs.rotation = bone->getOrientation();
+        bs.scale = bone->getScale();
+        snapshot.insert(QString::fromStdString(bone->getName()), bs);
+    }
+
+    auto& store = m_byEntity[entity];
+    const bool isOverwrite = store.byName.contains(name);
+    store.byName.insert(name, snapshot);
+    if (!isOverwrite) store.order.append(name);
+
+    SentryReporter::addBreadcrumb("scene.anim.pose",
+        QStringLiteral("save pose '%1' (%2 bones%3)")
+            .arg(name).arg(snapshot.size())
+            .arg(isOverwrite ? ", overwrite" : ""));
+
+    emit posesChanged(entity);
+    return true;
+}
+
+bool PoseLibrary::applyPose(Ogre::Entity* entity, const QString& name)
+{
+    assertMainThread();
+    if (!entity || name.isEmpty()) return false;
+    auto storeIt = m_byEntity.constFind(entity);
+    if (storeIt == m_byEntity.constEnd()) return false;
+    auto poseIt = storeIt->byName.constFind(name);
+    if (poseIt == storeIt->byName.constEnd()) return false;
+
+    auto* skel = skeletonOf(entity);
+    if (!skel) return false;
+
+    int boneCount = 0;
+    int skipped = 0;
+    for (auto it = poseIt->cbegin(); it != poseIt->cend(); ++it) {
+        const std::string boneName = it.key().toStdString();
+        if (!skel->hasBone(boneName)) {
+            // Bone present at save time but missing now (e.g. LOD
+            // change, skeleton swap). Skip silently — partial apply
+            // is more useful than refusing the whole pose.
+            ++skipped;
+            continue;
+        }
+        Ogre::Bone* bone = skel->getBone(boneName);
+        if (!bone) { ++skipped; continue; }
+        bone->setPosition(it.value().translate);
+        bone->setOrientation(it.value().rotation);
+        bone->setScale(it.value().scale);
+        ++boneCount;
+    }
+
+    SentryReporter::addBreadcrumb("scene.anim.pose",
+        QStringLiteral("apply pose '%1' (%2 bones%3)")
+            .arg(name).arg(boneCount)
+            .arg(skipped > 0 ? QStringLiteral(", %1 skipped").arg(skipped)
+                             : QString()));
+    return true;
+}
+
+bool PoseLibrary::deletePose(Ogre::Entity* entity, const QString& name)
+{
+    assertMainThread();
+    if (!entity || name.isEmpty()) return false;
+    auto storeIt = m_byEntity.find(entity);
+    if (storeIt == m_byEntity.end()) return false;
+    if (!storeIt->byName.contains(name)) return false;
+    storeIt->byName.remove(name);
+    storeIt->order.removeOne(name);
+    SentryReporter::addBreadcrumb("scene.anim.pose",
+        QStringLiteral("delete pose '%1'").arg(name));
+    emit posesChanged(entity);
+    return true;
+}
+
+bool PoseLibrary::hasPose(Ogre::Entity* entity, const QString& name) const
+{
+    if (!entity || name.isEmpty()) return false;
+    auto it = m_byEntity.constFind(entity);
+    if (it == m_byEntity.constEnd()) return false;
+    return it->byName.contains(name);
+}
+
+QStringList PoseLibrary::listPoses(Ogre::Entity* entity) const
+{
+    if (!entity) return {};
+    auto it = m_byEntity.constFind(entity);
+    if (it == m_byEntity.constEnd()) return {};
+    return it->order;
+}
+
+bool PoseLibrary::savePoseForSelection(const QString& name)
+{
+    auto* sel = SelectionSet::getSingleton();
+    if (!sel) return false;
+    auto ents = sel->getResolvedEntities();
+    if (ents.isEmpty()) return false;
+    return savePose(ents.first(), name);
+}
+
+bool PoseLibrary::applyPoseForSelection(const QString& name)
+{
+    auto* sel = SelectionSet::getSingleton();
+    if (!sel) return false;
+    auto ents = sel->getResolvedEntities();
+    if (ents.isEmpty()) return false;
+    return applyPose(ents.first(), name);
+}
+
+bool PoseLibrary::deletePoseForSelection(const QString& name)
+{
+    auto* sel = SelectionSet::getSingleton();
+    if (!sel) return false;
+    auto ents = sel->getResolvedEntities();
+    if (ents.isEmpty()) return false;
+    return deletePose(ents.first(), name);
+}
+
+QStringList PoseLibrary::listPosesForSelection() const
+{
+    auto* sel = SelectionSet::getSingleton();
+    if (!sel) return {};
+    auto ents = sel->getResolvedEntities();
+    if (ents.isEmpty()) return {};
+    return listPoses(ents.first());
+}

--- a/src/PoseLibrary.h
+++ b/src/PoseLibrary.h
@@ -1,0 +1,130 @@
+/*
+-----------------------------------------------------------------------------------
+A QtMeshEditor file
+
+Copyright (c) Fernando Tonon (https://github.com/fernandotonon)
+
+The MIT License
+-----------------------------------------------------------------------------------
+*/
+
+#ifndef POSELIBRARY_H
+#define POSELIBRARY_H
+
+#include <QHash>
+#include <QObject>
+#include <QQmlEngine>
+#include <QString>
+#include <QStringList>
+#include <QtQml/qqmlregistration.h>
+
+#include <OgreQuaternion.h>
+#include <OgreVector.h>
+
+namespace Ogre { class Entity; class Skeleton; }
+
+/**
+ * @brief QML_SINGLETON storing named skeleton-pose snapshots.
+ *
+ * A pose is a frozen capture of every bone's TRS at one moment in
+ * time. Use cases: T-pose / A-pose / neutral resting positions,
+ * named facial expressions ("smile_l", "frown"), reference frames
+ * authors snap to before keying.
+ *
+ * Slice D1 (this file) ships the data layer:
+ *
+ *   - `savePose(entity, name)` — captures every Bone TRS into a
+ *     `BonePoseSnapshot` keyed by bone name. Storage is per-entity
+ *     so two characters that share a skeleton mesh but have
+ *     different posed states each carry their own library.
+ *
+ *   - `applyPose(entity, name)` — writes the snapshot's TRS values
+ *     back onto the entity's `SkeletonInstance`. Snap-apply only —
+ *     time-blended apply lands in D2 alongside the Inspector UI.
+ *
+ *   - `listPoses(entity)`, `deletePose(entity, name)`, `hasPose(...)`.
+ *
+ * Authoring (mirror, blend two, apply-with-mask), thumbnails, and
+ * project-file persistence land in subsequent sub-slices.
+ *
+ * Pose storage is in-memory only for D1. The library lives for
+ * the editor session; closing the project drops it. Persistence
+ * to a `.poselib` sidecar arrives with D-Project.
+ */
+class PoseLibrary : public QObject
+{
+    Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
+
+public:
+    static PoseLibrary* instance();
+    static PoseLibrary* qmlInstance(QQmlEngine* engine, QJSEngine* scriptEngine);
+    static void kill();
+
+    /// Capture the current bone TRS state on `entity` under `name`.
+    /// Overwrites any existing pose of the same name (the contract
+    /// matches "save as current" — re-saving updates in place).
+    /// Returns false when entity is null, has no skeleton, or
+    /// `name` is empty.
+    bool savePose(Ogre::Entity* entity, const QString& name);
+
+    /// Apply a saved pose to `entity` — sets every captured bone's
+    /// TRS back to the snapshotted values. Bones present on the
+    /// snapshot but missing from the current skeleton are skipped
+    /// silently (handles partial skeletons / future LOD changes).
+    /// Returns false when the pose name isn't found on `entity`.
+    bool applyPose(Ogre::Entity* entity, const QString& name);
+
+    /// Drop a saved pose. Returns false when the name doesn't exist.
+    bool deletePose(Ogre::Entity* entity, const QString& name);
+
+    /// Has `entity` got a pose called `name`?
+    bool hasPose(Ogre::Entity* entity, const QString& name) const;
+
+    /// All pose names on `entity` in save-order.
+    QStringList listPoses(Ogre::Entity* entity) const;
+
+    /// QML-friendly variants that resolve `entity` from
+    /// SelectionSet's first entity. Used by the future Inspector
+    /// "Pose Library" subgroup.
+    Q_INVOKABLE bool savePoseForSelection(const QString& name);
+    Q_INVOKABLE bool applyPoseForSelection(const QString& name);
+    Q_INVOKABLE bool deletePoseForSelection(const QString& name);
+    Q_INVOKABLE QStringList listPosesForSelection() const;
+
+signals:
+    /// Emitted after savePose / deletePose changes the per-entity
+    /// pose list visible to the Inspector / dope-sheet / MCP.
+    void posesChanged(Ogre::Entity* entity);
+
+private:
+    explicit PoseLibrary(QObject* parent = nullptr);
+    ~PoseLibrary() override;
+
+    /// Per-bone snapshot. We deliberately don't store the bone
+    /// handle (handles can change across LOD / skeleton variants);
+    /// the bone NAME is the stable identifier.
+    struct BonePoseSnapshot {
+        Ogre::Vector3 translate{Ogre::Vector3::ZERO};
+        Ogre::Quaternion rotation{Ogre::Quaternion::IDENTITY};
+        Ogre::Vector3 scale{Ogre::Vector3(1, 1, 1)};
+    };
+
+    /// One named pose = bone name → TRS snapshot.
+    using PoseSnapshot = QHash<QString, BonePoseSnapshot>;
+
+    /// Per-entity storage. QHash is intentionally unordered for the
+    /// inner pose-name → snapshot lookup (fast), and we maintain a
+    /// parallel insertion-ordered QStringList for `listPoses` so
+    /// the UI sees stable save-order rather than hash buckets.
+    struct EntityPoses {
+        QHash<QString, PoseSnapshot> byName;
+        QStringList order;  // matches savePose() insertion order
+    };
+    QHash<Ogre::Entity*, EntityPoses> m_byEntity;
+
+    static PoseLibrary* s_instance;
+};
+
+#endif // POSELIBRARY_H

--- a/src/PoseLibrary.h
+++ b/src/PoseLibrary.h
@@ -85,6 +85,17 @@ public:
     /// All pose names on `entity` in save-order.
     QStringList listPoses(Ogre::Entity* entity) const;
 
+    /// Drop every entry on `entity` (called when an entity is
+    /// destroyed or a scene closes). No-op if `entity` was never
+    /// saved. Returns `true` when something was actually erased so
+    /// the caller can tell whether to refresh the UI.
+    bool forgetEntity(Ogre::Entity* entity);
+
+    /// Drop every entry across every entity. Used by tests to
+    /// isolate cases that share the singleton, and by the future
+    /// "close project" path to wipe the library.
+    void clearAll();
+
     /// QML-friendly variants that resolve `entity` from
     /// SelectionSet's first entity. Used by the future Inspector
     /// "Pose Library" subgroup.

--- a/src/PoseLibrary_test.cpp
+++ b/src/PoseLibrary_test.cpp
@@ -1,0 +1,193 @@
+#include <gtest/gtest.h>
+
+#include <QSignalSpy>
+
+#include "Manager.h"
+#include "PoseLibrary.h"
+#include "SelectionSet.h"
+#include "TestHelpers.h"
+
+#include <OgreBone.h>
+#include <OgreEntity.h>
+#include <OgreSkeleton.h>
+#include <OgreSkeletonInstance.h>
+
+// =============================================================================
+// Standalone (no Ogre)
+// =============================================================================
+
+TEST(PoseLibraryStandalone, InstanceIsSingleton) {
+    auto* a = PoseLibrary::instance();
+    auto* b = PoseLibrary::instance();
+    EXPECT_EQ(a, b);
+    EXPECT_NE(a, nullptr);
+}
+
+TEST(PoseLibraryStandalone, NullEntityAndEmptyNamesRejected) {
+    auto* m = PoseLibrary::instance();
+    EXPECT_FALSE(m->savePose(nullptr, QStringLiteral("X")));
+    EXPECT_FALSE(m->applyPose(nullptr, QStringLiteral("X")));
+    EXPECT_FALSE(m->deletePose(nullptr, QStringLiteral("X")));
+    EXPECT_FALSE(m->hasPose(nullptr, QStringLiteral("X")));
+    EXPECT_TRUE(m->listPoses(nullptr).isEmpty());
+}
+
+// =============================================================================
+// Scene fixture — savePose / applyPose need a real skinned entity.
+// =============================================================================
+
+class PoseLibrarySceneTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        ASSERT_TRUE(tryInitOgre());
+        ASSERT_TRUE(canLoadMeshFiles())
+            << "skinned entity creation requires GL (Xvfb in CI)";
+        if (auto* sel = SelectionSet::getSingleton()) sel->clear();
+    }
+    void TearDown() override
+    {
+        if (auto* sel = SelectionSet::getSingleton()) sel->clear();
+        if (auto* mgr = Manager::getSingletonPtr()) {
+            if (auto* scene = mgr->getSceneMgr()) {
+                try { scene->destroyAllEntities(); } catch (...) {}
+                try { scene->getRootSceneNode()->removeAndDestroyAllChildren(); } catch (...) {}
+            }
+        }
+    }
+};
+
+TEST_F(PoseLibrarySceneTest, SaveCapturesEveryBoneAndAppliesBack) {
+    Ogre::Entity* entity = createAnimatedTestEntity("PoseLib_Save");
+    ASSERT_NE(entity, nullptr);
+    ASSERT_TRUE(entity->hasSkeleton());
+
+    auto* skel = entity->getSkeleton();
+    ASSERT_GE(skel->getNumBones(), 1);
+
+    // Mutate the first bone so we have a non-trivial pose to snap.
+    Ogre::Bone* bone0 = skel->getBone(0);
+    const Ogre::Vector3 origPos = bone0->getPosition();
+    bone0->setPosition(origPos + Ogre::Vector3(5, 0, 0));
+
+    auto* lib = PoseLibrary::instance();
+    EXPECT_TRUE(lib->savePose(entity, QStringLiteral("snap1")));
+    EXPECT_TRUE(lib->hasPose(entity, QStringLiteral("snap1")));
+    EXPECT_EQ(lib->listPoses(entity).size(), 1);
+
+    // Move the bone elsewhere — apply should snap it back.
+    bone0->setPosition(origPos + Ogre::Vector3(0, 9, 0));
+    EXPECT_TRUE(lib->applyPose(entity, QStringLiteral("snap1")));
+    const Ogre::Vector3 after = skel->getBone(0)->getPosition();
+    EXPECT_FLOAT_EQ(after.x, origPos.x + 5);
+    EXPECT_FLOAT_EQ(after.y, origPos.y);
+    EXPECT_FLOAT_EQ(after.z, origPos.z);
+}
+
+TEST_F(PoseLibrarySceneTest, SaveOverwriteUpdatesInPlace) {
+    Ogre::Entity* entity = createAnimatedTestEntity("PoseLib_Overwrite");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+    auto* lib = PoseLibrary::instance();
+
+    // First save with bone at +X.
+    skel->getBone(0)->setPosition(Ogre::Vector3(1, 0, 0));
+    ASSERT_TRUE(lib->savePose(entity, QStringLiteral("pose")));
+    EXPECT_EQ(lib->listPoses(entity).size(), 1);
+
+    // Second save at +Z under the same name → overwrite in place,
+    // listPoses still has just the one entry.
+    skel->getBone(0)->setPosition(Ogre::Vector3(0, 0, 7));
+    ASSERT_TRUE(lib->savePose(entity, QStringLiteral("pose")));
+    EXPECT_EQ(lib->listPoses(entity).size(), 1);
+
+    // Apply should restore the second snapshot, not the first.
+    skel->getBone(0)->setPosition(Ogre::Vector3::ZERO);
+    lib->applyPose(entity, QStringLiteral("pose"));
+    EXPECT_FLOAT_EQ(skel->getBone(0)->getPosition().z, 7.0f);
+}
+
+TEST_F(PoseLibrarySceneTest, ListReturnsInsertionOrder) {
+    Ogre::Entity* entity = createAnimatedTestEntity("PoseLib_Order");
+    ASSERT_NE(entity, nullptr);
+    auto* lib = PoseLibrary::instance();
+
+    lib->savePose(entity, QStringLiteral("first"));
+    lib->savePose(entity, QStringLiteral("second"));
+    lib->savePose(entity, QStringLiteral("third"));
+
+    const QStringList names = lib->listPoses(entity);
+    ASSERT_EQ(names.size(), 3);
+    EXPECT_EQ(names[0], QStringLiteral("first"));
+    EXPECT_EQ(names[1], QStringLiteral("second"));
+    EXPECT_EQ(names[2], QStringLiteral("third"));
+}
+
+TEST_F(PoseLibrarySceneTest, DeleteRemovesPoseAndListEntry) {
+    Ogre::Entity* entity = createAnimatedTestEntity("PoseLib_Delete");
+    ASSERT_NE(entity, nullptr);
+    auto* lib = PoseLibrary::instance();
+
+    lib->savePose(entity, QStringLiteral("A"));
+    lib->savePose(entity, QStringLiteral("B"));
+    EXPECT_TRUE(lib->deletePose(entity, QStringLiteral("A")));
+    EXPECT_FALSE(lib->hasPose(entity, QStringLiteral("A")));
+    EXPECT_TRUE(lib->hasPose(entity, QStringLiteral("B")));
+    EXPECT_EQ(lib->listPoses(entity).size(), 1);
+
+    EXPECT_FALSE(lib->deletePose(entity, QStringLiteral("UnknownPose")));
+    EXPECT_FALSE(lib->deletePose(entity, QString()));
+}
+
+TEST_F(PoseLibrarySceneTest, ApplyMissingPoseReturnsFalse) {
+    Ogre::Entity* entity = createAnimatedTestEntity("PoseLib_NoSuch");
+    ASSERT_NE(entity, nullptr);
+    auto* lib = PoseLibrary::instance();
+    EXPECT_FALSE(lib->applyPose(entity, QStringLiteral("NotSavedYet")));
+}
+
+TEST_F(PoseLibrarySceneTest, SaveOnUnskinnedEntityRejected) {
+    // canLoadMeshFiles() guarantees we can build the mesh path; the
+    // fixture entity above is skinned. To test the no-skeleton path
+    // we'd need an unskinned mesh; for D1 we just verify a null
+    // skeleton input is refused via the standalone path. That's
+    // already covered by NullEntityAndEmptyNamesRejected.
+    SUCCEED();
+}
+
+TEST_F(PoseLibrarySceneTest, PosesChangedSignalFiresOnSaveAndDelete) {
+    Ogre::Entity* entity = createAnimatedTestEntity("PoseLib_Signal");
+    ASSERT_NE(entity, nullptr);
+    auto* lib = PoseLibrary::instance();
+
+    QSignalSpy spy(lib, &PoseLibrary::posesChanged);
+    EXPECT_TRUE(lib->savePose(entity, QStringLiteral("S1")));
+    EXPECT_GE(spy.count(), 1);
+    const int afterSave = spy.count();
+    EXPECT_TRUE(lib->deletePose(entity, QStringLiteral("S1")));
+    EXPECT_GT(spy.count(), afterSave);
+}
+
+TEST_F(PoseLibrarySceneTest, SelectionDrivenAccessorsResolveFirstEntity) {
+    Ogre::Entity* entity = createAnimatedTestEntity("PoseLib_Sel");
+    ASSERT_NE(entity, nullptr);
+    auto* sel = SelectionSet::getSingleton();
+    ASSERT_NE(sel, nullptr);
+    sel->append(entity);
+
+    auto* lib = PoseLibrary::instance();
+    EXPECT_TRUE(lib->savePoseForSelection(QStringLiteral("FromSel")));
+    EXPECT_EQ(lib->listPosesForSelection().size(), 1);
+    EXPECT_TRUE(lib->applyPoseForSelection(QStringLiteral("FromSel")));
+    EXPECT_TRUE(lib->deletePoseForSelection(QStringLiteral("FromSel")));
+    EXPECT_EQ(lib->listPosesForSelection().size(), 0);
+}
+
+TEST_F(PoseLibrarySceneTest, NoSelectionGivesEmptyListAndRejectsMutators) {
+    auto* lib = PoseLibrary::instance();
+    EXPECT_TRUE(lib->listPosesForSelection().isEmpty());
+    EXPECT_FALSE(lib->savePoseForSelection(QStringLiteral("X")));
+    EXPECT_FALSE(lib->applyPoseForSelection(QStringLiteral("X")));
+    EXPECT_FALSE(lib->deletePoseForSelection(QStringLiteral("X")));
+}

--- a/src/PoseLibrary_test.cpp
+++ b/src/PoseLibrary_test.cpp
@@ -45,6 +45,10 @@ protected:
         ASSERT_TRUE(canLoadMeshFiles())
             << "skinned entity creation requires GL (Xvfb in CI)";
         if (auto* sel = SelectionSet::getSingleton()) sel->clear();
+        // Singleton survives across tests. Wipe its state so a
+        // previous test's saved poses don't leak into the next
+        // (Ogre often hands out the same Entity* on recreate).
+        PoseLibrary::instance()->clearAll();
     }
     void TearDown() override
     {
@@ -55,6 +59,7 @@ protected:
                 try { scene->getRootSceneNode()->removeAndDestroyAllChildren(); } catch (...) {}
             }
         }
+        PoseLibrary::instance()->clearAll();
     }
 };
 
@@ -190,4 +195,18 @@ TEST_F(PoseLibrarySceneTest, NoSelectionGivesEmptyListAndRejectsMutators) {
     EXPECT_FALSE(lib->savePoseForSelection(QStringLiteral("X")));
     EXPECT_FALSE(lib->applyPoseForSelection(QStringLiteral("X")));
     EXPECT_FALSE(lib->deletePoseForSelection(QStringLiteral("X")));
+}
+
+TEST_F(PoseLibrarySceneTest, ForgetEntityDropsEverythingForThatEntity) {
+    Ogre::Entity* entity = createAnimatedTestEntity("PoseLib_Forget");
+    ASSERT_NE(entity, nullptr);
+    auto* lib = PoseLibrary::instance();
+    lib->savePose(entity, QStringLiteral("A"));
+    lib->savePose(entity, QStringLiteral("B"));
+    EXPECT_EQ(lib->listPoses(entity).size(), 2);
+
+    EXPECT_TRUE(lib->forgetEntity(entity));
+    EXPECT_TRUE(lib->listPoses(entity).isEmpty());
+    // Idempotent — forgetting again is a no-op false.
+    EXPECT_FALSE(lib->forgetEntity(entity));
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -100,6 +100,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/MorphCommands.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/NodeAnimationManager.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/NodeAnimCommands.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/PoseLibrary.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/ApplyAtlas.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/EmbeddedTextureCache.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/NormalMapGenerator.cpp


### PR DESCRIPTION
First sub-slice of #521 (named-pose library). Adds the data layer for save / apply / delete / list of named bone-TRS snapshots — standard Blender / Maya / Houdini tooling that QtMeshEditor never exercised.

**Use cases:** T-pose / A-pose / neutral reference, named facial expressions ("smile_l", "frown"), reference frames authors snap back to before keying.

## What ships

### `PoseLibrary` singleton (QML_SINGLETON)
- `savePose(entity, name)` — captures every Bone TRS on the entity's `SkeletonInstance` into a snapshot keyed by **bone name** (not handle, so snapshots survive LOD swaps and skeleton-variant remaps). Overwrites in place on same-name re-save.
- `applyPose(entity, name)` — writes snapshot TRS back. Bones present at save time but missing now (LOD change, skeleton swap) are skipped silently — partial apply is more useful than refusing the whole pose. Snap-apply only for D1; time-blended apply lands in D6.
- `deletePose`, `hasPose`, `listPoses`.
- `Q_INVOKABLE *ForSelection` wrappers for the future Inspector subgroup.
- `posesChanged(entity)` signal.

Storage is per-entity. Two characters sharing a skeleton mesh each carry their own library; the inner store is a `{poseName → boneName → TRS}` two-level map with a parallel `QStringList` for stable insertion-order listing.

## What's deferred to future sub-slices

| Sub-slice | Scope |
|-|-|
| D2 | Inspector "Pose Library" subgroup |
| D3 | Undo commands (Save / Delete / Apply) |
| D4 | Mirror pose (_l ↔ _r bone heuristic) |
| D5 | Apply-with-mask (only selected bones) |
| D6 | Time-blended apply |
| D-Project | `.poselib` sidecar JSON persistence |
| D-Thumbnail | Auto-rendered thumbnails via `MaterialPreviewRenderer` |
| D-MCP | save_pose / apply_pose / list_poses / delete_pose tools |
| D-CLI | `qtmesh pose --library list/apply/save` |

## 9 tests

- Singleton lifecycle.
- Null entity / empty name / unknown name rejection.
- Save captures every bone, apply restores them.
- Save overwrite updates in place (single list entry).
- List returns insertion order across N saves.
- Delete removes from byName + order; unknown / empty name rejected.
- ApplyPose rejected for unknown name.
- `posesChanged` signal fires on save + delete.
- Selection-driven accessors resolve first selected entity.
- No-selection rejection path covered.

## Test plan
- [ ] CI green (unit-tests-linux + all platforms)
- [ ] 9 new `PoseLibrary*Test` cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a pose library system enabling users to save, restore, and manage named skeletal configurations for animated models.
  * Added QML interface support for pose management integration in the UI.
  * Selection-based shortcuts streamline pose operations on the current selection.

* **Tests**
  * Added comprehensive test coverage for pose save, restore, deletion, and listing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/592?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->