### PR TITLE
feat(pose-lib): sub-slice D-MCP — MCP tools for pose library

### DIFF
--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -10,6 +10,7 @@
 #include "VATBaker.h"
 #include "MorphAnimationManager.h"
 #include "NodeAnimationManager.h"
+#include "PoseLibrary.h"
 #include "PrimitiveObject.h"
 #include "SelectionSet.h"
 #include "TransformOperator.h"
@@ -603,7 +604,11 @@ const QMap<QString, MCPServer::ToolHandler>& MCPServer::toolHandlers()
         {QStringLiteral("set_morph_weight"), &MCPServer::toolSetMorphWeight},
         {QStringLiteral("list_node_animations"), &MCPServer::toolListNodeAnimations},
         {QStringLiteral("add_node_animation_clip"), &MCPServer::toolAddNodeAnimationClip},
-        {QStringLiteral("set_node_keyframe"), &MCPServer::toolSetNodeKeyframe}
+        {QStringLiteral("set_node_keyframe"), &MCPServer::toolSetNodeKeyframe},
+        {QStringLiteral("list_poses"), &MCPServer::toolListPoses},
+        {QStringLiteral("save_pose"), &MCPServer::toolSavePose},
+        {QStringLiteral("apply_pose"), &MCPServer::toolApplyPose},
+        {QStringLiteral("delete_pose"), &MCPServer::toolDeletePose}
     };
     return handlers;
 }
@@ -4541,6 +4546,90 @@ QJsonObject MCPServer::toolSetNodeKeyframe(const QJsonObject &args)
         QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Indented)));
 }
 
+// ---------------------------------------------------------------------------
+// Pose-lib D-MCP — named bone-TRS snapshots on the live scene.
+// ---------------------------------------------------------------------------
+// All four tools operate on the first selected entity, same surface as
+// `set_morph_weight` / `set_node_keyframe`. The agent is expected to
+// drive `load_mesh` / `save_scene` around them for persistence — the
+// `.poselib` sidecar arrives with D-Project.
+
+QJsonObject MCPServer::toolListPoses(const QJsonObject & /*args*/)
+{
+    SentryReporter::addBreadcrumb("ai.tool_call", "list_poses");
+    auto* lib = PoseLibrary::instance();
+    const QStringList poses = lib ? lib->listPosesForSelection() : QStringList();
+
+    QJsonArray arr;
+    for (const QString& n : poses) arr.append(n);
+    QJsonObject content;
+    content["count"] = static_cast<int>(poses.size());
+    content["poses"] = arr;
+    return makeSuccessResult(
+        QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Indented)));
+}
+
+QJsonObject MCPServer::toolSavePose(const QJsonObject &args)
+{
+    SentryReporter::addBreadcrumb("ai.tool_call", "save_pose");
+    const QString name = args.value("name").toString();
+    if (name.isEmpty())
+        return makeErrorResult("Error: missing required 'name' argument");
+
+    auto* lib = PoseLibrary::instance();
+    if (!lib->savePoseForSelection(name))
+        return makeErrorResult(
+            QString("Error: failed to save pose '%1' (no selection or unskinned entity)")
+                .arg(name));
+
+    QJsonObject content;
+    content["ok"] = true;
+    content["name"] = name;
+    return makeSuccessResult(
+        QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Indented)));
+}
+
+QJsonObject MCPServer::toolApplyPose(const QJsonObject &args)
+{
+    SentryReporter::addBreadcrumb("ai.tool_call", "apply_pose");
+    const QString name = args.value("name").toString();
+    if (name.isEmpty())
+        return makeErrorResult("Error: missing required 'name' argument");
+
+    auto* lib = PoseLibrary::instance();
+    if (!lib->applyPoseForSelection(name))
+        return makeErrorResult(
+            QString("Error: failed to apply pose '%1' (no selection, unskinned entity, "
+                    "or pose name not found in this entity's library)")
+                .arg(name));
+
+    QJsonObject content;
+    content["ok"] = true;
+    content["name"] = name;
+    return makeSuccessResult(
+        QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Indented)));
+}
+
+QJsonObject MCPServer::toolDeletePose(const QJsonObject &args)
+{
+    SentryReporter::addBreadcrumb("ai.tool_call", "delete_pose");
+    const QString name = args.value("name").toString();
+    if (name.isEmpty())
+        return makeErrorResult("Error: missing required 'name' argument");
+
+    auto* lib = PoseLibrary::instance();
+    if (!lib->deletePoseForSelection(name))
+        return makeErrorResult(
+            QString("Error: pose '%1' not found on the first selected entity")
+                .arg(name));
+
+    QJsonObject content;
+    content["ok"] = true;
+    content["name"] = name;
+    return makeSuccessResult(
+        QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Indented)));
+}
+
 QJsonArray MCPServer::buildToolsList()
 {
     QJsonArray tools;
@@ -5727,6 +5816,67 @@ QJsonArray MCPServer::buildToolsList()
             "1ms of `time` already exists, it's updated in place — same idempotency "
             "behaviour as the Inspector. Returns an error on missing clip / missing "
             "node / out-of-range time / malformed TRS arrays.",
+            props,
+            required
+        );
+    }
+
+    // list_poses
+    {
+        QJsonObject props;
+        appendTool(
+            "list_poses",
+            "List saved bone-TRS poses on the first selected entity. Returns "
+            "the names in insertion order. Use save_pose to capture and "
+            "apply_pose to snap back.",
+            props
+        );
+    }
+
+    // save_pose
+    {
+        QJsonObject props;
+        props["name"] = QJsonObject{{"type", "string"}, {"description", "Pose name. Overwrites any existing same-name pose in place."}};
+        QJsonArray required;
+        required.append("name");
+        appendTool(
+            "save_pose",
+            "Capture the current bone-TRS state of the first selected entity as "
+            "a named pose. Use cases: T-pose / A-pose / neutral reference frames, "
+            "named facial expressions. Returns error when no entity is selected "
+            "or the entity has no skeleton.",
+            props,
+            required
+        );
+    }
+
+    // apply_pose
+    {
+        QJsonObject props;
+        props["name"] = QJsonObject{{"type", "string"}, {"description", "Pose name (use list_poses to enumerate)."}};
+        QJsonArray required;
+        required.append("name");
+        appendTool(
+            "apply_pose",
+            "Snap the first selected entity back to a saved pose — writes every "
+            "captured bone TRS onto the skeleton instance. Bones present at save "
+            "time but missing now are skipped silently (handles LOD changes). "
+            "Snap-apply only; time-blended apply lands in D6.",
+            props,
+            required
+        );
+    }
+
+    // delete_pose
+    {
+        QJsonObject props;
+        props["name"] = QJsonObject{{"type", "string"}, {"description", "Pose name to remove."}};
+        QJsonArray required;
+        required.append("name");
+        appendTool(
+            "delete_pose",
+            "Drop a saved pose from the first selected entity's library. "
+            "Returns error when the pose name isn't found.",
             props,
             required
         );

--- a/src/MCPServer.h
+++ b/src/MCPServer.h
@@ -231,6 +231,22 @@ private:
     /// `rotation` ([w,x,y,z] quaternion), `scale` ([x,y,z]). Light.
     QJsonObject toolSetNodeKeyframe(const QJsonObject &args);
 
+    /// Pose-lib D-MCP: list saved pose names on the first selected
+    /// entity. Light read; returns `{ count, poses: [name…] }`.
+    QJsonObject toolListPoses(const QJsonObject &args);
+
+    /// Pose-lib D-MCP: capture current bone-TRS on the first
+    /// selected entity under `name`. Overwrites in place if the
+    /// name already exists. Args: `name`.
+    QJsonObject toolSavePose(const QJsonObject &args);
+
+    /// Pose-lib D-MCP: snap the first selected entity to a saved
+    /// pose. Args: `name`. Returns error when no such pose.
+    QJsonObject toolApplyPose(const QJsonObject &args);
+
+    /// Pose-lib D-MCP: drop a saved pose by name. Args: `name`.
+    QJsonObject toolDeletePose(const QJsonObject &args);
+
     // Animation
     struct NodeAnimation {
         Ogre::SceneNode* node;

--- a/src/MCPServer_test.cpp
+++ b/src/MCPServer_test.cpp
@@ -7238,3 +7238,48 @@ TEST_F(MCPServerTest, SetNodeKeyframe_RejectsNonFiniteTRSComponent)
     EXPECT_TRUE(getResultText(r).contains("translate"));
     EXPECT_TRUE(getResultText(r).contains("finite"));
 }
+
+// ==========================================================================
+// Pose-lib D-MCP — round-trips against the live PoseLibrary singleton
+// ==========================================================================
+
+TEST_F(MCPServerTest, ListPoses_EmptyWhenNoSelection)
+{
+    // No entity selected, no skinned entity to bind to — list should
+    // come back empty without throwing.
+    QJsonObject r = server->callTool("list_poses", QJsonObject{});
+    EXPECT_FALSE(isError(r));
+    EXPECT_TRUE(getResultText(r).contains("\"count\": 0"));
+}
+
+TEST_F(MCPServerTest, SavePose_MissingNameRejected)
+{
+    QJsonObject empty;
+    QJsonObject r = server->callTool("save_pose", empty);
+    EXPECT_TRUE(isError(r));
+    EXPECT_TRUE(getResultText(r).contains("name"));
+}
+
+TEST_F(MCPServerTest, ApplyPose_MissingNameRejected)
+{
+    QJsonObject r = server->callTool("apply_pose", QJsonObject{});
+    EXPECT_TRUE(isError(r));
+    EXPECT_TRUE(getResultText(r).contains("name"));
+}
+
+TEST_F(MCPServerTest, DeletePose_UnknownNameRejected)
+{
+    QJsonObject args;
+    args["name"] = "MCP_PoseDoesNotExist";
+    QJsonObject r = server->callTool("delete_pose", args);
+    EXPECT_TRUE(isError(r));
+}
+
+TEST_F(MCPServerTest, SavePose_NoSelectionRejected)
+{
+    // No selection set up — save should fail with a helpful error.
+    QJsonObject args;
+    args["name"] = "MCP_NoSelPose";
+    QJsonObject r = server->callTool("save_pose", args);
+    EXPECT_TRUE(isError(r));
+}


### PR DESCRIPTION
Second sub-slice of #521 (named-pose library). Surfaces D1's PoseLibrary singleton through four new MCP tools so an AI agent can author and apply named bone-TRS poses via JSON-RPC.

## What ships

### Four new MCP tools (all operate on the **first selected entity**)

- **`list_poses`** — no args. Returns `{ count, poses: [name…] }`. Light; reads `listPosesForSelection`.
- **`save_pose`** — required: `name`. Captures every bone TRS into a new (or overwrite-in-place) pose snapshot. Errors on missing selection / unskinned entity.
- **`apply_pose`** — required: `name`. Snaps every bone back to the saved values. Bones missing now (LOD change) are skipped silently. Errors on missing pose name.
- **`delete_pose`** — required: `name`. Drops the pose. Errors on unknown name.

All four route through the existing `*ForSelection` `Q_INVOKABLE` wrappers — the C++ side already handles selection resolution and error reporting; the MCP layer just adapts arg parsing and result formatting.

## 5 new tests

- `ListPoses_EmptyWhenNoSelection`
- `SavePose_MissingNameRejected`
- `ApplyPose_MissingNameRejected`
- `DeletePose_UnknownNameRejected`
- `SavePose_NoSelectionRejected`

## #521 status

| Sub-slice | Status |
|-|-|
| D1 — Singleton data layer | shipped (#592) |
| D-MCP — MCP tools | **this PR** |
| D2 — Inspector subgroup | follow-up |
| D3 — Undo commands | follow-up |
| D4 — Mirror pose | follow-up |
| D5 — Apply-with-mask | follow-up |
| D6 — Time-blended apply | follow-up |
| D-Project — `.poselib` sidecar | follow-up |
| D-Thumbnail — Auto-rendered thumbnails | follow-up |
| D-CLI — `qtmesh pose --library` | follow-up |

## Test plan
- [ ] CI green
- [ ] 5 new MCP tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)