### PR TITLE
feat(ps1): Phase 3 VRAM dump and texture decode (#420, #421)

### DIFF
--- a/plugins/ps1core_stub/StubCaptureSynth.cpp
+++ b/plugins/ps1core_stub/StubCaptureSynth.cpp
@@ -2,6 +2,10 @@
 
 #include "CaptureTypes.h"
 #include "EmuHooks.h"
+#include "PsxVramColor.h"
+
+#include <QVector>
+#include <QtGlobal>
 
 void stubEmitCaptureSample(EmuHooks *hooks)
 {
@@ -60,4 +64,51 @@ void stubEmitCaptureSample(EmuHooks *hooks)
     hooks->onDrawMode(mode);
 
     hooks->onFrameEnd();
+}
+
+void stubFillVramPattern(EmuHooks *hooks, std::uint64_t frameIndex)
+{
+    if (!hooks)
+        return;
+
+    QVector<uint16_t> clutRow(16);
+    for (int i = 0; i < 16; ++i) {
+        const uint8_t v = static_cast<uint8_t>((i * 16 + static_cast<int>(frameIndex % 16)) & 0xFF);
+        clutRow[i] = PsxVramColor::rgbaToBgr555(v, static_cast<uint8_t>(255 - v), 128, 255);
+    }
+    hooks->onVramWrite(0, 480, 16, 1, clutRow.constData());
+
+    QVector<uint16_t> block4(64 * 32);
+    for (int y = 0; y < 32; ++y) {
+        for (int x = 0; x < 64; ++x) {
+            uint16_t word = 0;
+            for (int nibble = 0; nibble < 4; ++nibble) {
+                const int idx = (x * 4 + nibble + y + static_cast<int>(frameIndex)) % 16;
+                word |= static_cast<uint16_t>(idx << (nibble * 4));
+            }
+            block4[y * 64 + x] = word;
+        }
+    }
+    hooks->onVramWrite(0, 0, 64, 32, block4.constData());
+
+    QVector<uint16_t> block8(128 * 32);
+    for (int y = 0; y < 32; ++y) {
+        for (int x = 0; x < 128; ++x) {
+            const uint8_t lo = static_cast<uint8_t>((x + y + static_cast<int>(frameIndex)) & 0xFF);
+            const uint8_t hi = static_cast<uint8_t>((x * 2 + y + static_cast<int>(frameIndex)) & 0xFF);
+            block8[y * 128 + x] = static_cast<uint16_t>(lo | (static_cast<uint16_t>(hi) << 8));
+        }
+    }
+    hooks->onVramWrite(64, 0, 128, 32, block8.constData());
+
+    QVector<uint16_t> block15(64 * 32);
+    for (int y = 0; y < 32; ++y) {
+        for (int x = 0; x < 64; ++x) {
+            const uint8_t r = static_cast<uint8_t>((x * 4 + y) & 0xFF);
+            const uint8_t g = static_cast<uint8_t>((32 + y + static_cast<int>(frameIndex)) & 0xFF);
+            const uint8_t b = static_cast<uint8_t>((x * 2 + y) & 0xFF);
+            block15[y * 64 + x] = PsxVramColor::rgbaToBgr555(r, g, b, (x & 1) ? 128 : 255);
+        }
+    }
+    hooks->onVramWrite(0, 256, 64, 32, block15.constData());
 }

--- a/plugins/ps1core_stub/StubCaptureSynth.h
+++ b/plugins/ps1core_stub/StubCaptureSynth.h
@@ -1,9 +1,14 @@
 #ifndef STUBCAPTURESYNTH_H
 #define STUBCAPTURESYNTH_H
 
+#include <cstdint>
+
 class EmuHooks;
 
 /** Emits one primitive of each GP0 flavor for capture regression tests (#418). */
 void stubEmitCaptureSample(EmuHooks *hooks);
+
+/** Fills VRAM with CLUT + 4/8/15 bpp test regions via onVramWrite (#420). */
+void stubFillVramPattern(EmuHooks *hooks, std::uint64_t frameIndex);
 
 #endif // STUBCAPTURESYNTH_H

--- a/plugins/ps1core_stub/StubEmuCore.cpp
+++ b/plugins/ps1core_stub/StubEmuCore.cpp
@@ -44,6 +44,7 @@ void StubEmuCore::runFrame()
     EmuFramebuffer &buf = m_buffers[static_cast<size_t>(m_writeIndex)];
     buf.frameIndex = ++m_frameIndex;
     fillTestPattern(buf);
+    stubFillVramPattern(m_hooks, buf.frameIndex);
     stubEmitCaptureSample(m_hooks);
 
     m_readIndex = m_writeIndex;

--- a/src/PS1/CMakeLists.txt
+++ b/src/PS1/CMakeLists.txt
@@ -32,6 +32,9 @@ if(ENABLE_PS1_RIP)
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipSessionWindow.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipWorker.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/RipperHooks.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/TextureDecoder.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/VramSnapshot.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/VramViewerWidget.cpp
     )
     list(APPEND HEADER_FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/CaptureBuffer.h
@@ -46,6 +49,10 @@ if(ENABLE_PS1_RIP)
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipManager.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipSessionWindow.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipWorker.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxVramColor.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/TextureDecoder.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/VramSnapshot.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/VramViewerWidget.h
     )
 endif()
 

--- a/src/PS1/PS1_RIP_DESIGN.md
+++ b/src/PS1/PS1_RIP_DESIGN.md
@@ -68,6 +68,14 @@ See epic #412 for phased issues (#413–#431).
 - Stub core emits seven primitive flavors per frame when capture is armed.
 - `armCapture` / `captureFrame` wire capture to the worker thread; CSV dump to temp for verification.
 
+## Phase 3 status (#420 / #421)
+
+- `VramSnapshot` — full 1024×512×16-bit VRAM buffer, view modes (RGB555, 4bpp index, 8bpp index, CLUT preview), PNG export.
+- `RipperHooks::onVramWrite` mirrors GPU uploads into the worker-owned snapshot.
+- `TextureDecoder` — CLUT-aware 4/8/15 bpp tile decode with `TileKey` cache and STP/alpha via `PsxVramColor`.
+- `dumpVRAM()` saves `<AppData>/ps1_rip/captures/<id>_vram.png` and feeds `VramViewerWidget` in the session window.
+- Stub core fills CLUT + 4/8/15 bpp test regions each frame via `stubFillVramPattern`.
+
 ## Open questions
 
 - mednafen-psx plugin build/integration (replace stub for real emulation).

--- a/src/PS1/runtime/PS1RipManager.cpp
+++ b/src/PS1/runtime/PS1RipManager.cpp
@@ -4,6 +4,7 @@
 
 #include <QFileInfo>
 #include <QMetaObject>
+#include <QMetaType>
 
 PS1RipManager *PS1RipManager::s_instance = nullptr;
 
@@ -38,6 +39,8 @@ PS1RipManager::~PS1RipManager()
 
 void PS1RipManager::initializeWorkerThread()
 {
+    qRegisterMetaType<QVector<uint16_t>>("QVector<uint16_t>");
+
     m_workerThread = new QThread(this);
     m_worker = new PS1RipWorker();
     m_worker->moveToThread(m_workerThread);
@@ -66,6 +69,13 @@ void PS1RipManager::initializeWorkerThread()
                                       QStringLiteral("ps1_rip_frame:%1").arg(captureId));
         emit frameCaptured(captureId);
     });
+    connect(m_worker, &PS1RipWorker::vramDumpReady, this,
+            [this](const QString &captureId, const QString &pngPath, const QVector<uint16_t> &cells,
+                   const QImage &preview) {
+                SentryReporter::addBreadcrumb(QStringLiteral("ps1.rip.vram.dump"),
+                                            QStringLiteral("%1:%2").arg(captureId, pngPath));
+                emit vramDumped(captureId, pngPath, cells, preview);
+            });
 
     connect(m_workerThread, &QThread::finished, m_worker, &QObject::deleteLater);
 
@@ -257,6 +267,7 @@ bool PS1RipManager::dumpVRAM()
         reportError(tr("No active PS1 session"));
         return false;
     }
-    reportError(tr("VRAM dump not implemented yet"));
-    return false;
+    PS1RipWorker *worker = m_worker;
+    QMetaObject::invokeMethod(worker, &PS1RipWorker::dumpVram, Qt::QueuedConnection);
+    return true;
 }

--- a/src/PS1/runtime/PS1RipManager.h
+++ b/src/PS1/runtime/PS1RipManager.h
@@ -5,6 +5,7 @@
 #include <QObject>
 #include <QString>
 #include <QThread>
+#include <QVector>
 
 class PS1RipWorker;
 
@@ -48,7 +49,8 @@ signals:
     void framePresented(const QImage &frame, quint64 frameIndex);
     void frameCaptured(const QString &captureId);
     void sceneCaptured(const QString &captureId);
-    void vramDumped(const QString &captureId);
+    void vramDumped(const QString &captureId, const QString &pngPath, const QVector<uint16_t> &cells,
+                    const QImage &nativePreview);
     void error(const QString &message);
     void pausedChanged(bool paused);
 

--- a/src/PS1/runtime/PS1RipSessionWindow.cpp
+++ b/src/PS1/runtime/PS1RipSessionWindow.cpp
@@ -3,11 +3,13 @@
 #include "PS1RipLegalityDialog.h"
 #include "PS1RipManager.h"
 #include "SentryReporter.h"
+#include "VramViewerWidget.h"
 
 #include <QAction>
 #include <QApplication>
 #include <QCloseEvent>
 #include <QDateTime>
+#include <QDockWidget>
 #include <QFileDialog>
 #include <QTimer>
 #include <QLabel>
@@ -50,6 +52,15 @@ PS1RipSessionWindow::PS1RipSessionWindow(QWidget *parent)
     connect(stepAct, &QAction::triggered, this, &PS1RipSessionWindow::onStep);
     auto *resetAct = toolbar->addAction(tr("Reset"));
     connect(resetAct, &QAction::triggered, this, &PS1RipSessionWindow::onReset);
+    toolbar->addSeparator();
+    auto *dumpVramAct = toolbar->addAction(tr("Dump VRAM"));
+    connect(dumpVramAct, &QAction::triggered, this, &PS1RipSessionWindow::onDumpVram);
+
+    m_vramViewer = new VramViewerWidget(this);
+    auto *vramDock = new QDockWidget(tr("VRAM"), this);
+    vramDock->setWidget(m_vramViewer);
+    vramDock->setMinimumHeight(220);
+    addDockWidget(Qt::BottomDockWidgetArea, vramDock);
 
     m_statusLabel = new QLabel(this);
     statusBar()->addPermanentWidget(m_statusLabel);
@@ -61,6 +72,7 @@ PS1RipSessionWindow::PS1RipSessionWindow(QWidget *parent)
     connect(m_manager, &PS1RipManager::sessionStopped, this,
             [this]() { m_statusLabel->setText(tr("Stopped")); });
     connect(m_manager, &PS1RipManager::error, this, &PS1RipSessionWindow::onError);
+    connect(m_manager, &PS1RipManager::vramDumped, this, &PS1RipSessionWindow::onVramDumped);
 
     const QString savedBios = QSettings().value(QString::fromLatin1(kSettingsGroup) + QLatin1Char('/')
                                                   + QString::fromLatin1(kBiosKey))
@@ -179,6 +191,20 @@ void PS1RipSessionWindow::onFrame(const QImage &frame, quint64 frameIndex)
 void PS1RipSessionWindow::onError(const QString &message)
 {
     QMessageBox::warning(this, tr("PS1 Runtime Ripper"), message);
+}
+
+void PS1RipSessionWindow::onDumpVram()
+{
+    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"), QStringLiteral("ps1_rip_dump_vram"));
+    m_manager->dumpVRAM();
+}
+
+void PS1RipSessionWindow::onVramDumped(const QString &captureId, const QString &pngPath,
+                                       const QVector<uint16_t> &cells, const QImage &nativePreview)
+{
+    if (m_vramViewer)
+        m_vramViewer->setVramData(cells, nativePreview);
+    m_statusLabel->setText(tr("VRAM dumped: %1 → %2").arg(captureId, pngPath));
 }
 
 void PS1RipSessionWindow::updateFps(quint64 frameIndex)

--- a/src/PS1/runtime/PS1RipSessionWindow.h
+++ b/src/PS1/runtime/PS1RipSessionWindow.h
@@ -1,11 +1,14 @@
 #ifndef PS1RIPSESSIONWINDOW_H
 #define PS1RIPSESSIONWINDOW_H
 
+#include <QImage>
 #include <QMainWindow>
+#include <QVector>
 
 class EmuViewport;
 class QLabel;
 class PS1RipManager;
+class VramViewerWidget;
 
 /** Temporary host for emulator viewport + transport (#416 / #417). */
 class PS1RipSessionWindow : public QMainWindow
@@ -31,12 +34,16 @@ private slots:
     void onReset();
     void onFrame(const QImage &frame, quint64 frameIndex);
     void onError(const QString &message);
+    void onDumpVram();
+    void onVramDumped(const QString &captureId, const QString &pngPath, const QVector<uint16_t> &cells,
+                      const QImage &nativePreview);
 
 private:
     void updateFps(quint64 frameIndex);
     void addRecentIso(const QString &path);
 
     EmuViewport *m_viewport = nullptr;
+    VramViewerWidget *m_vramViewer = nullptr;
     QLabel *m_statusLabel = nullptr;
     PS1RipManager *m_manager = nullptr;
     qint64 m_lastFrameMs = 0;

--- a/src/PS1/runtime/PS1RipWorker.cpp
+++ b/src/PS1/runtime/PS1RipWorker.cpp
@@ -5,10 +5,12 @@
 #include "EmuFramebuffer.h"
 #include "GpuCommandParser.h"
 #include "RipperHooks.h"
+#include "VramSnapshot.h"
 
 #include <QDateTime>
 #include <QDir>
 #include <QFile>
+#include <QStandardPaths>
 #include <QTimer>
 
 #include <cstring>
@@ -17,9 +19,11 @@ PS1RipWorker::PS1RipWorker(QObject *parent)
     : QObject(parent)
     , m_captureBuffer(std::make_unique<CaptureBuffer>())
     , m_ripperHooks(std::make_unique<RipperHooks>())
+    , m_vram(std::make_unique<VramSnapshot>())
 {
     m_ripperHooks->setArmedFlag(&m_captureArmed);
     m_ripperHooks->setBuffer(m_captureBuffer.get());
+    m_ripperHooks->setVram(m_vram.get());
 
     m_frameTimer = new QTimer(this);
     m_frameTimer->setTimerType(Qt::PreciseTimer);
@@ -182,6 +186,32 @@ void PS1RipWorker::finalizeFrameCapture()
     file.close();
 
     emit frameCaptureReady(captureId, prims.size());
+}
+
+void PS1RipWorker::dumpVram()
+{
+    if (!m_running) {
+        emit emulationError(tr("No active emulation session"));
+        return;
+    }
+
+    const QString captureId = QString::number(QDateTime::currentMSecsSinceEpoch());
+    const QString baseDir =
+        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + QStringLiteral("/ps1_rip/captures");
+    if (!QDir().mkpath(baseDir)) {
+        emit emulationError(tr("Failed to create capture directory: %1").arg(baseDir));
+        return;
+    }
+
+    const QString pngPath = baseDir + QLatin1Char('/') + captureId + QStringLiteral("_vram.png");
+    if (!m_vram->savePng(pngPath)) {
+        emit emulationError(tr("Failed to write VRAM PNG: %1").arg(pngPath));
+        return;
+    }
+
+    const QVector<uint16_t> cells = m_vram->mutablePixels();
+    const QImage preview = m_vram->toImage(VramSnapshot::ViewMode::Native16);
+    emit vramDumpReady(captureId, pngPath, cells, preview);
 }
 
 QImage PS1RipWorker::framebufferToImage(const EmuFramebuffer &fb)

--- a/src/PS1/runtime/PS1RipWorker.h
+++ b/src/PS1/runtime/PS1RipWorker.h
@@ -4,12 +4,14 @@
 #include <QImage>
 #include <QObject>
 #include <QString>
+#include <QVector>
 #include <QtGlobal>
 
 #include <atomic>
 #include <memory>
 
 class CaptureBuffer;
+class VramSnapshot;
 class EmuCore;
 class QTimer;
 class RipperHooks;
@@ -39,6 +41,7 @@ public slots:
     void stepFrame();
     void setCaptureArmed(bool armed);
     void finalizeFrameCapture();
+    void dumpVram();
 
 signals:
     void emulationStarted();
@@ -46,6 +49,8 @@ signals:
     void framePresented(const QImage &frame, quint64 frameIndex);
     void emulationError(const QString &message);
     void frameCaptureReady(const QString &captureId, int primCount);
+    void vramDumpReady(const QString &captureId, const QString &pngPath, const QVector<uint16_t> &cells,
+                       const QImage &nativePreview);
 
 private slots:
     void runFrameTick();
@@ -65,6 +70,7 @@ private:
 
     std::unique_ptr<CaptureBuffer> m_captureBuffer;
     std::unique_ptr<RipperHooks> m_ripperHooks;
+    std::unique_ptr<VramSnapshot> m_vram;
 };
 
 #endif // PS1RIPWORKER_H

--- a/src/PS1/runtime/PsxVramColor.h
+++ b/src/PS1/runtime/PsxVramColor.h
@@ -1,0 +1,38 @@
+#ifndef PSXVRAMCOLOR_H
+#define PSXVRAMCOLOR_H
+
+#include <cstdint>
+
+/** PS1 VRAM 16-bit BGR555 (+ STP in bit 15) helpers shared by rip + TIM paths. */
+namespace PsxVramColor {
+
+inline void bgr555ToRgba(uint16_t c, uint8_t &r, uint8_t &g, uint8_t &b, uint8_t &a,
+                         bool treatZeroAsTransparent = true)
+{
+    const uint8_t rr = static_cast<uint8_t>(c & 0x1F);
+    const uint8_t gg = static_cast<uint8_t>((c >> 5) & 0x1F);
+    const uint8_t bb = static_cast<uint8_t>((c >> 10) & 0x1F);
+    r = static_cast<uint8_t>((rr * 255 + 15) / 31);
+    g = static_cast<uint8_t>((gg * 255 + 15) / 31);
+    b = static_cast<uint8_t>((bb * 255 + 15) / 31);
+    const bool stp = (c & 0x8000) != 0;
+    if (treatZeroAsTransparent && c == 0)
+        a = 0;
+    else if (stp)
+        a = 128;
+    else
+        a = 255;
+}
+
+inline uint16_t rgbaToBgr555(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+{
+    const uint16_t r5 = static_cast<uint16_t>(r >> 3);
+    const uint16_t g5 = static_cast<uint16_t>(g >> 3);
+    const uint16_t b5 = static_cast<uint16_t>(b >> 3);
+    const uint16_t stp = (a < 128) ? 1u : 0u;
+    return static_cast<uint16_t>((stp << 15) | (b5 << 10) | (g5 << 5) | r5);
+}
+
+} // namespace PsxVramColor
+
+#endif // PSXVRAMCOLOR_H

--- a/src/PS1/runtime/RipperHooks.cpp
+++ b/src/PS1/runtime/RipperHooks.cpp
@@ -1,4 +1,5 @@
 #include "RipperHooks.h"
+#include "VramSnapshot.h"
 
 bool RipperHooks::isCaptureEnabled() const
 {
@@ -35,11 +36,9 @@ void RipperHooks::onGpuPrim(const PrimRecord &prim)
 
 void RipperHooks::onVramWrite(uint16_t x, uint16_t y, uint16_t w, uint16_t h, const uint16_t *pixels)
 {
-    (void)x;
-    (void)y;
-    (void)w;
-    (void)h;
-    (void)pixels;
+    if (!m_vram || !pixels)
+        return;
+    m_vram->writeRect(x, y, w, h, pixels);
 }
 
 void RipperHooks::onVramRead(uint16_t x, uint16_t y, uint16_t w, uint16_t h)

--- a/src/PS1/runtime/RipperHooks.h
+++ b/src/PS1/runtime/RipperHooks.h
@@ -6,6 +6,8 @@
 
 #include <atomic>
 
+class VramSnapshot;
+
 /**
  * Concrete EmuHooks that records into CaptureBuffer when capture is armed (#418).
  */
@@ -14,6 +16,7 @@ class RipperHooks final : public EmuHooks
 public:
     void setArmedFlag(std::atomic<bool> *armed) { m_armed = armed; }
     void setBuffer(CaptureBuffer *buffer) { m_buffer = buffer; }
+    void setVram(VramSnapshot *vram) { m_vram = vram; }
 
     bool isCaptureEnabled() const override;
 
@@ -30,6 +33,7 @@ public:
 private:
     std::atomic<bool> *m_armed = nullptr;
     CaptureBuffer *m_buffer = nullptr;
+    VramSnapshot *m_vram = nullptr;
 };
 
 #endif // RIPPERHOOKS_H

--- a/src/PS1/runtime/TextureDecoder.cpp
+++ b/src/PS1/runtime/TextureDecoder.cpp
@@ -8,14 +8,15 @@
 bool TextureDecoder::TileKey::operator==(const TileKey &other) const
 {
     return tpage == other.tpage && clutX == other.clutX && clutY == other.clutY
-           && bitDepth == other.bitDepth;
+           && bitDepth == other.bitDepth && regionOnPage == other.regionOnPage;
 }
 
 size_t qHash(const TextureDecoder::TileKey &key, size_t seed)
 {
     return qHash(static_cast<uint>(key.tpage), seed) ^ qHash(static_cast<uint>(key.clutX), seed << 1)
            ^ qHash(static_cast<uint>(key.clutY), seed << 2)
-           ^ qHash(static_cast<int>(key.bitDepth), seed << 3);
+           ^ qHash(static_cast<int>(key.bitDepth), seed << 3)
+           ^ qHash(key.regionOnPage, seed << 4);
 }
 
 void TextureDecoder::clearCache()
@@ -32,13 +33,6 @@ QImage TextureDecoder::cachedTile(const TileKey &key) const
 QImage TextureDecoder::decodeTile(const VramSnapshot &vram, const TileKey &key,
                                   const QRect &regionOnPage, QString *errorOut)
 {
-    if (m_cache.contains(key)) {
-        ++m_stats.cacheHits;
-        return m_cache.value(key);
-    }
-
-    ++m_stats.cacheMisses;
-
     const QRect page = VramSnapshot::tpageRect(key.tpage);
     QRect region = regionOnPage.isValid() ? regionOnPage : QRect(0, 0, 256, 256);
     region = region.intersected(QRect(0, 0, 256, 256));
@@ -47,6 +41,15 @@ QImage TextureDecoder::decodeTile(const VramSnapshot &vram, const TileKey &key,
             *errorOut = QStringLiteral("Texture region is empty");
         return {};
     }
+
+    TileKey cacheKey = key;
+    cacheKey.regionOnPage = region;
+    if (m_cache.contains(cacheKey)) {
+        ++m_stats.cacheHits;
+        return m_cache.value(cacheKey);
+    }
+
+    ++m_stats.cacheMisses;
 
     QImage img(region.width(), region.height(), QImage::Format_ARGB32);
     img.fill(Qt::transparent);
@@ -102,7 +105,7 @@ QImage TextureDecoder::decodeTile(const VramSnapshot &vram, const TileKey &key,
         }
     }
 
-    m_cache.insert(key, img);
+    m_cache.insert(cacheKey, img);
     ++m_stats.decodedTiles;
     m_stats.rgbaBytes += img.sizeInBytes();
     return img;

--- a/src/PS1/runtime/TextureDecoder.cpp
+++ b/src/PS1/runtime/TextureDecoder.cpp
@@ -1,0 +1,109 @@
+#include "TextureDecoder.h"
+
+#include "PsxVramColor.h"
+#include "VramSnapshot.h"
+
+#include <QRgb>
+
+bool TextureDecoder::TileKey::operator==(const TileKey &other) const
+{
+    return tpage == other.tpage && clutX == other.clutX && clutY == other.clutY
+           && bitDepth == other.bitDepth;
+}
+
+size_t qHash(const TextureDecoder::TileKey &key, size_t seed)
+{
+    return qHash(static_cast<uint>(key.tpage), seed) ^ qHash(static_cast<uint>(key.clutX), seed << 1)
+           ^ qHash(static_cast<uint>(key.clutY), seed << 2)
+           ^ qHash(static_cast<int>(key.bitDepth), seed << 3);
+}
+
+void TextureDecoder::clearCache()
+{
+    m_cache.clear();
+    m_stats = {};
+}
+
+QImage TextureDecoder::cachedTile(const TileKey &key) const
+{
+    return m_cache.value(key);
+}
+
+QImage TextureDecoder::decodeTile(const VramSnapshot &vram, const TileKey &key,
+                                  const QRect &regionOnPage, QString *errorOut)
+{
+    if (m_cache.contains(key)) {
+        ++m_stats.cacheHits;
+        return m_cache.value(key);
+    }
+
+    ++m_stats.cacheMisses;
+
+    const QRect page = VramSnapshot::tpageRect(key.tpage);
+    QRect region = regionOnPage.isValid() ? regionOnPage : QRect(0, 0, 256, 256);
+    region = region.intersected(QRect(0, 0, 256, 256));
+    if (!region.isValid() || region.isEmpty()) {
+        if (errorOut)
+            *errorOut = QStringLiteral("Texture region is empty");
+        return {};
+    }
+
+    QImage img(region.width(), region.height(), QImage::Format_ARGB32);
+    img.fill(Qt::transparent);
+
+    const int clutX = static_cast<int>(key.clutX);
+    const int clutY = static_cast<int>(key.clutY);
+
+    if (key.bitDepth == BitDepth::Bpp15) {
+        for (int y = 0; y < region.height(); ++y) {
+            auto *scan = reinterpret_cast<QRgb *>(img.scanLine(y));
+            for (int x = 0; x < region.width(); ++x) {
+                const int vramX = page.x() + region.x() + x;
+                const int vramY = page.y() + region.y() + y;
+                const uint16_t c = vram.pixel(vramX, vramY);
+                uint8_t r, g, b, a;
+                PsxVramColor::bgr555ToRgba(c, r, g, b, a, true);
+                scan[x] = qRgba(r, g, b, a);
+            }
+        }
+    } else if (key.bitDepth == BitDepth::Bpp8) {
+        for (int y = 0; y < region.height(); ++y) {
+            auto *scan = reinterpret_cast<QRgb *>(img.scanLine(y));
+            for (int x = 0; x < region.width(); ++x) {
+                const int texX = region.x() + x;
+                const int texY = region.y() + y;
+                const int wordX = page.x() + (texX / 2);
+                const int vramY = page.y() + texY;
+                const uint16_t word = vram.pixel(wordX, vramY);
+                const uint8_t idx = (texX & 1) ? static_cast<uint8_t>((word >> 8) & 0xFF)
+                                                : static_cast<uint8_t>(word & 0xFF);
+                const uint16_t c = vram.pixel(clutX + idx, clutY);
+                uint8_t r, g, b, a;
+                PsxVramColor::bgr555ToRgba(c, r, g, b, a, true);
+                scan[x] = qRgba(r, g, b, a);
+            }
+        }
+    } else {
+        for (int y = 0; y < region.height(); ++y) {
+            auto *scan = reinterpret_cast<QRgb *>(img.scanLine(y));
+            for (int x = 0; x < region.width(); ++x) {
+                const int texX = region.x() + x;
+                const int texY = region.y() + y;
+                const int wordX = page.x() + (texX / 4);
+                const int vramY = page.y() + texY;
+                const uint16_t word = vram.pixel(wordX, vramY);
+                const int shift = (texX & 3) * 4;
+                const uint8_t idx = static_cast<uint8_t>((word >> shift) & 0xF);
+                const uint16_t c = vram.pixel(clutX + idx, clutY);
+                uint8_t r, g, b, a;
+                PsxVramColor::bgr555ToRgba(c, r, g, b, a, true);
+                scan[x] = qRgba(r, g, b, a);
+            }
+        }
+    }
+
+    m_cache.insert(key, img);
+    ++m_stats.decodedTiles;
+    m_stats.rgbaBytes += img.sizeInBytes();
+    return img;
+}

--- a/src/PS1/runtime/TextureDecoder.h
+++ b/src/PS1/runtime/TextureDecoder.h
@@ -25,6 +25,7 @@ public:
         uint16_t clutX = 0;
         uint16_t clutY = 0;
         BitDepth bitDepth = BitDepth::Bpp15;
+        QRect regionOnPage;
 
         bool operator==(const TileKey &other) const;
     };
@@ -40,6 +41,7 @@ public:
                       QString *errorOut = nullptr);
     QImage cachedTile(const TileKey &key) const;
     DecodeStats stats() const { return m_stats; }
+    /** Call when VRAM content changes; cached tiles are keyed by region + tpage/clut. */
     void clearCache();
 
 private:

--- a/src/PS1/runtime/TextureDecoder.h
+++ b/src/PS1/runtime/TextureDecoder.h
@@ -1,0 +1,52 @@
+#ifndef TEXTUREDECODER_H
+#define TEXTUREDECODER_H
+
+#include <QHash>
+#include <QImage>
+#include <QRect>
+#include <QString>
+
+#include <cstdint>
+
+class VramSnapshot;
+
+/** Decodes PS1 texture pages from a VRAM snapshot (#421). */
+class TextureDecoder
+{
+public:
+    enum class BitDepth : uint8_t {
+        Bpp4 = 0,
+        Bpp8 = 1,
+        Bpp15 = 2,
+    };
+
+    struct TileKey {
+        uint16_t tpage = 0;
+        uint16_t clutX = 0;
+        uint16_t clutY = 0;
+        BitDepth bitDepth = BitDepth::Bpp15;
+
+        bool operator==(const TileKey &other) const;
+    };
+
+    struct DecodeStats {
+        int cacheHits = 0;
+        int cacheMisses = 0;
+        int decodedTiles = 0;
+        qint64 rgbaBytes = 0;
+    };
+
+    QImage decodeTile(const VramSnapshot &vram, const TileKey &key, const QRect &regionOnPage,
+                      QString *errorOut = nullptr);
+    QImage cachedTile(const TileKey &key) const;
+    DecodeStats stats() const { return m_stats; }
+    void clearCache();
+
+private:
+    QHash<TileKey, QImage> m_cache;
+    DecodeStats m_stats;
+};
+
+size_t qHash(const TextureDecoder::TileKey &key, size_t seed = 0);
+
+#endif // TEXTUREDECODER_H

--- a/src/PS1/runtime/TextureDecoder_test.cpp
+++ b/src/PS1/runtime/TextureDecoder_test.cpp
@@ -1,0 +1,49 @@
+#include "TextureDecoder.h"
+#include "PsxVramColor.h"
+#include "VramSnapshot.h"
+
+#include <gtest/gtest.h>
+
+static void writeClut(VramSnapshot &vram, int clutX, int clutY)
+{
+    for (int i = 0; i < 16; ++i) {
+        const uint8_t v = static_cast<uint8_t>(i * 16);
+        vram.setPixel(clutX + i, clutY, PsxVramColor::rgbaToBgr555(v, v, v, 255));
+    }
+}
+
+TEST(TextureDecoderTest, Decodes15bppTile)
+{
+    VramSnapshot vram;
+    vram.setPixel(0, 0, PsxVramColor::rgbaToBgr555(0, 0, 255, 255));
+    TextureDecoder decoder;
+    TextureDecoder::TileKey key{};
+    key.tpage = 0;
+    key.bitDepth = TextureDecoder::BitDepth::Bpp15;
+    const QImage tile = decoder.decodeTile(vram, key, QRect(0, 0, 1, 1));
+    ASSERT_FALSE(tile.isNull());
+    EXPECT_EQ(qAlpha(tile.pixel(0, 0)), 255);
+    EXPECT_EQ(decoder.stats().decodedTiles, 1);
+    EXPECT_EQ(decoder.stats().cacheHits, 0);
+    EXPECT_FALSE(decoder.cachedTile(key).isNull());
+    const QImage cached = decoder.decodeTile(vram, key, QRect(0, 0, 1, 1));
+    EXPECT_FALSE(cached.isNull());
+    EXPECT_EQ(decoder.stats().cacheHits, 1);
+}
+
+TEST(TextureDecoderTest, Decodes4bppWithClut)
+{
+    VramSnapshot vram;
+    writeClut(vram, 0, 480);
+    vram.setPixel(0, 0, 0x000F); // index 15 in low nibble
+    TextureDecoder decoder;
+    TextureDecoder::TileKey key{};
+    key.tpage = 0;
+    key.clutX = 0;
+    key.clutY = 480;
+    key.bitDepth = TextureDecoder::BitDepth::Bpp4;
+    const QImage tile = decoder.decodeTile(vram, key, QRect(0, 0, 1, 1));
+    ASSERT_FALSE(tile.isNull());
+    const QRgb px = tile.pixel(0, 0);
+    EXPECT_GT(qRed(px), 200);
+}

--- a/src/PS1/runtime/TextureDecoder_test.cpp
+++ b/src/PS1/runtime/TextureDecoder_test.cpp
@@ -20,13 +20,16 @@ TEST(TextureDecoderTest, Decodes15bppTile)
     TextureDecoder::TileKey key{};
     key.tpage = 0;
     key.bitDepth = TextureDecoder::BitDepth::Bpp15;
-    const QImage tile = decoder.decodeTile(vram, key, QRect(0, 0, 1, 1));
+    const QRect region(0, 0, 1, 1);
+    const QImage tile = decoder.decodeTile(vram, key, region);
     ASSERT_FALSE(tile.isNull());
     EXPECT_EQ(qAlpha(tile.pixel(0, 0)), 255);
     EXPECT_EQ(decoder.stats().decodedTiles, 1);
     EXPECT_EQ(decoder.stats().cacheHits, 0);
+
+    key.regionOnPage = region;
     EXPECT_FALSE(decoder.cachedTile(key).isNull());
-    const QImage cached = decoder.decodeTile(vram, key, QRect(0, 0, 1, 1));
+    const QImage cached = decoder.decodeTile(vram, key, region);
     EXPECT_FALSE(cached.isNull());
     EXPECT_EQ(decoder.stats().cacheHits, 1);
 }
@@ -46,4 +49,22 @@ TEST(TextureDecoderTest, Decodes4bppWithClut)
     ASSERT_FALSE(tile.isNull());
     const QRgb px = tile.pixel(0, 0);
     EXPECT_GT(qRed(px), 200);
+}
+
+TEST(TextureDecoderTest, CacheKeyIncludesRegion)
+{
+    VramSnapshot vram;
+    vram.setPixel(0, 0, PsxVramColor::rgbaToBgr555(255, 0, 0, 255));
+    vram.setPixel(1, 0, PsxVramColor::rgbaToBgr555(0, 255, 0, 255));
+    TextureDecoder decoder;
+    TextureDecoder::TileKey key{};
+    key.tpage = 0;
+    key.bitDepth = TextureDecoder::BitDepth::Bpp15;
+
+    const QImage a = decoder.decodeTile(vram, key, QRect(0, 0, 1, 1));
+    const QImage b = decoder.decodeTile(vram, key, QRect(1, 0, 1, 1));
+    ASSERT_FALSE(a.isNull());
+    ASSERT_FALSE(b.isNull());
+    EXPECT_NE(a.pixel(0, 0), b.pixel(0, 0));
+    EXPECT_EQ(decoder.stats().decodedTiles, 2);
 }

--- a/src/PS1/runtime/VramSnapshot.cpp
+++ b/src/PS1/runtime/VramSnapshot.cpp
@@ -1,0 +1,100 @@
+#include "VramSnapshot.h"
+
+#include "PsxVramColor.h"
+
+#include <QRgb>
+
+VramSnapshot::VramSnapshot()
+{
+    m_pixels.resize(kWidth * kHeight);
+    clear();
+}
+
+void VramSnapshot::clear(uint16_t fill)
+{
+    m_pixels.fill(fill);
+}
+
+bool VramSnapshot::isEmpty() const
+{
+    for (uint16_t v : m_pixels) {
+        if (v != 0)
+            return false;
+    }
+    return true;
+}
+
+void VramSnapshot::writeRect(uint16_t x, uint16_t y, uint16_t w, uint16_t h, const uint16_t *pixels)
+{
+    if (!pixels || w == 0 || h == 0)
+        return;
+
+    for (uint16_t row = 0; row < h; ++row) {
+        const int dstY = static_cast<int>(y) + row;
+        if (dstY < 0 || dstY >= kHeight)
+            continue;
+        for (uint16_t col = 0; col < w; ++col) {
+            const int dstX = static_cast<int>(x) + col;
+            if (dstX < 0 || dstX >= kWidth)
+                continue;
+            m_pixels[dstY * kWidth + dstX] = pixels[row * w + col];
+        }
+    }
+}
+
+uint16_t VramSnapshot::pixel(int x, int y) const
+{
+    if (x < 0 || y < 0 || x >= kWidth || y >= kHeight)
+        return 0;
+    return m_pixels[y * kWidth + x];
+}
+
+void VramSnapshot::setPixel(int x, int y, uint16_t value)
+{
+    if (x < 0 || y < 0 || x >= kWidth || y >= kHeight)
+        return;
+    m_pixels[y * kWidth + x] = value;
+}
+
+QRect VramSnapshot::tpageRect(uint16_t tpage)
+{
+    const int pageX = ((tpage >> 0) & 0xF) * 64;
+    const int pageY = ((tpage >> 4) & 0x1) * 256;
+    return QRect(pageX, pageY, 256, 256);
+}
+
+QImage VramSnapshot::toImage(ViewMode mode, int clutX, int clutY) const
+{
+    QImage img(kWidth, kHeight, QImage::Format_ARGB32);
+    img.fill(Qt::black);
+
+    for (int y = 0; y < kHeight; ++y) {
+        auto *scan = reinterpret_cast<QRgb *>(img.scanLine(y));
+        for (int x = 0; x < kWidth; ++x) {
+            const uint16_t cell = pixel(x, y);
+            if (mode == ViewMode::Native16) {
+                uint8_t r, g, b, a;
+                PsxVramColor::bgr555ToRgba(cell, r, g, b, a, false);
+                scan[x] = qRgba(r, g, b, a);
+            } else if (mode == ViewMode::As4bpp) {
+                const int idx = cell & 0xF;
+                scan[x] = qRgb(idx * 17, idx * 17, idx * 17);
+            } else if (mode == ViewMode::As8bpp) {
+                const int idx = cell & 0xFF;
+                scan[x] = qRgb(idx, idx, idx);
+            } else {
+                const int idx = (cell & 0xF);
+                const uint16_t clutColor = pixel(clutX + idx, clutY);
+                uint8_t r, g, b, a;
+                PsxVramColor::bgr555ToRgba(clutColor, r, g, b, a, false);
+                scan[x] = qRgba(r, g, b, a);
+            }
+        }
+    }
+    return img;
+}
+
+bool VramSnapshot::savePng(const QString &path) const
+{
+    return toImage(ViewMode::Native16).save(path, "PNG");
+}

--- a/src/PS1/runtime/VramSnapshot.h
+++ b/src/PS1/runtime/VramSnapshot.h
@@ -1,0 +1,49 @@
+#ifndef VRAMSNAPSHOT_H
+#define VRAMSNAPSHOT_H
+
+#include <QImage>
+#include <QRect>
+#include <QString>
+#include <QVector>
+
+#include <cstdint>
+
+/**
+ * Full PS1 VRAM buffer (1024×512×16-bit cells) for dump + texture decode (#420).
+ */
+class VramSnapshot
+{
+public:
+    static constexpr int kWidth = 1024;
+    static constexpr int kHeight = 512;
+
+    enum class ViewMode {
+        Native16,
+        As4bpp,
+        As8bpp,
+        ClutPreview,
+    };
+
+    VramSnapshot();
+
+    void clear(uint16_t fill = 0);
+    bool isEmpty() const;
+
+    void writeRect(uint16_t x, uint16_t y, uint16_t w, uint16_t h, const uint16_t *pixels);
+    uint16_t pixel(int x, int y) const;
+    void setPixel(int x, int y, uint16_t value);
+
+    const uint16_t *data() const { return m_pixels.constData(); }
+    QVector<uint16_t> &mutablePixels() { return m_pixels; }
+
+    QImage toImage(ViewMode mode, int clutX = 0, int clutY = 0) const;
+    bool savePng(const QString &path) const;
+
+    /** TPAGE top-left in VRAM texel coordinates (256×256 page). */
+    static QRect tpageRect(uint16_t tpage);
+
+private:
+    QVector<uint16_t> m_pixels;
+};
+
+#endif // VRAMSNAPSHOT_H

--- a/src/PS1/runtime/VramSnapshot_test.cpp
+++ b/src/PS1/runtime/VramSnapshot_test.cpp
@@ -1,0 +1,35 @@
+#include "VramSnapshot.h"
+#include "PsxVramColor.h"
+
+#include <QFileInfo>
+#include <QTemporaryDir>
+#include <gtest/gtest.h>
+
+TEST(VramSnapshotTest, WriteRectAndPixel)
+{
+    VramSnapshot vram;
+    const uint16_t cells[] = {0x7C00, 0x03E0, 0x001F};
+    vram.writeRect(10, 20, 3, 1, cells);
+    EXPECT_EQ(vram.pixel(10, 20), 0x7C00u);
+    EXPECT_EQ(vram.pixel(12, 20), 0x001Fu);
+}
+
+TEST(VramSnapshotTest, TpageRectDecodesPageOrigin)
+{
+    const QRect page = VramSnapshot::tpageRect(0x0001);
+    EXPECT_EQ(page.x(), 64);
+    EXPECT_EQ(page.y(), 0);
+    EXPECT_EQ(page.width(), 256);
+    EXPECT_EQ(page.height(), 256);
+}
+
+TEST(VramSnapshotTest, SavePngRoundTrip)
+{
+    VramSnapshot vram;
+    vram.setPixel(0, 0, PsxVramColor::rgbaToBgr555(255, 0, 0, 255));
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString path = dir.filePath(QStringLiteral("vram.png"));
+    ASSERT_TRUE(vram.savePng(path));
+    EXPECT_TRUE(QFileInfo::exists(path));
+}

--- a/src/PS1/runtime/VramViewerWidget.cpp
+++ b/src/PS1/runtime/VramViewerWidget.cpp
@@ -1,0 +1,110 @@
+#include "VramViewerWidget.h"
+
+#include "PsxVramColor.h"
+
+#include <QComboBox>
+#include <QHBoxLayout>
+#include <QMouseEvent>
+#include <QVBoxLayout>
+
+VramViewerWidget::VramViewerWidget(QWidget *parent)
+    : QWidget(parent)
+{
+    auto *layout = new QVBoxLayout(this);
+
+    auto *toolbar = new QHBoxLayout();
+    m_modeCombo = new QComboBox(this);
+    m_modeCombo->addItem(tr("16-bit (RGB555)"), static_cast<int>(VramSnapshot::ViewMode::Native16));
+    m_modeCombo->addItem(tr("4bpp index"), static_cast<int>(VramSnapshot::ViewMode::As4bpp));
+    m_modeCombo->addItem(tr("8bpp index"), static_cast<int>(VramSnapshot::ViewMode::As8bpp));
+    m_modeCombo->addItem(tr("CLUT preview"), static_cast<int>(VramSnapshot::ViewMode::ClutPreview));
+    connect(m_modeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            &VramViewerWidget::onViewModeChanged);
+    toolbar->addWidget(new QLabel(tr("View:"), this));
+    toolbar->addWidget(m_modeCombo, 1);
+    layout->addLayout(toolbar);
+
+    m_scroll = new QScrollArea(this);
+    m_scroll->setWidgetResizable(true);
+    m_imageLabel = new QLabel(m_scroll);
+    m_imageLabel->setAlignment(Qt::AlignCenter);
+    m_imageLabel->setMinimumSize(256, 128);
+    m_imageLabel->setMouseTracking(true);
+    m_imageLabel->installEventFilter(this);
+    m_scroll->setWidget(m_imageLabel);
+    layout->addWidget(m_scroll, 1);
+
+    m_hoverLabel = new QLabel(this);
+    m_hoverLabel->setText(tr("Hover over VRAM to inspect pixels"));
+    layout->addWidget(m_hoverLabel);
+}
+
+void VramViewerWidget::setVramData(const QVector<uint16_t> &cells, const QImage &nativePreview)
+{
+    m_vramCells = cells;
+    m_nativeImage = nativePreview;
+    refreshDisplay();
+}
+
+void VramViewerWidget::setViewMode(VramSnapshot::ViewMode mode)
+{
+    m_mode = mode;
+    const int idx = m_modeCombo->findData(static_cast<int>(mode));
+    if (idx >= 0)
+        m_modeCombo->setCurrentIndex(idx);
+    refreshDisplay();
+}
+
+void VramViewerWidget::onViewModeChanged(int index)
+{
+    m_mode = static_cast<VramSnapshot::ViewMode>(m_modeCombo->itemData(index).toInt());
+    refreshDisplay();
+}
+
+void VramViewerWidget::refreshDisplay()
+{
+    if (m_vramCells.size() != VramSnapshot::kWidth * VramSnapshot::kHeight) {
+        m_imageLabel->clear();
+        return;
+    }
+
+    VramSnapshot snap;
+    snap.mutablePixels() = m_vramCells;
+    const QImage shown = snap.toImage(m_mode, 0, 0);
+    m_imageLabel->setPixmap(
+        QPixmap::fromImage(shown.scaled(shown.size() * 2, Qt::KeepAspectRatio, Qt::FastTransformation)));
+}
+
+bool VramViewerWidget::eventFilter(QObject *watched, QEvent *event)
+{
+    if (watched == m_imageLabel && event->type() == QEvent::MouseMove) {
+        const auto *me = static_cast<QMouseEvent *>(event);
+        const QPixmap pix = m_imageLabel->pixmap(Qt::ReturnByValue);
+        if (!pix.isNull() && m_vramCells.size() == VramSnapshot::kWidth * VramSnapshot::kHeight) {
+            const QPoint labelPos = me->pos();
+            const int x = (labelPos.x() * VramSnapshot::kWidth) / qMax(1, pix.width());
+            const int y = (labelPos.y() * VramSnapshot::kHeight) / qMax(1, pix.height());
+            updateHover(QPoint(x, y));
+        }
+    }
+    return QWidget::eventFilter(watched, event);
+}
+
+void VramViewerWidget::updateHover(const QPoint &pos)
+{
+    if (m_vramCells.size() != VramSnapshot::kWidth * VramSnapshot::kHeight
+        || !QRect(0, 0, VramSnapshot::kWidth, VramSnapshot::kHeight).contains(pos)) {
+        m_hoverLabel->setText(tr("Hover over VRAM to inspect pixels"));
+        return;
+    }
+
+    const uint16_t cell = m_vramCells[pos.y() * VramSnapshot::kWidth + pos.x()];
+    const int tpageX = (pos.x() / 64) * 64;
+    const int tpageY = (pos.y() / 256) * 256;
+    m_hoverLabel->setText(tr("VRAM (%1,%2) TPAGE≈(%3,%4) RGB555=0x%5")
+                              .arg(pos.x())
+                              .arg(pos.y())
+                              .arg(tpageX)
+                              .arg(tpageY)
+                              .arg(cell, 4, 16, QChar('0')));
+}

--- a/src/PS1/runtime/VramViewerWidget.h
+++ b/src/PS1/runtime/VramViewerWidget.h
@@ -1,0 +1,44 @@
+#ifndef VRAMVIEWERWIDGET_H
+#define VRAMVIEWERWIDGET_H
+
+#include "VramSnapshot.h"
+
+#include <QImage>
+#include <QLabel>
+#include <QVector>
+#include <QScrollArea>
+#include <QWidget>
+
+class QComboBox;
+
+/** Interactive 1024×512 VRAM view for the PS1 rip session (#420). */
+class VramViewerWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit VramViewerWidget(QWidget *parent = nullptr);
+
+    void setVramData(const QVector<uint16_t> &cells, const QImage &nativePreview);
+    void setViewMode(VramSnapshot::ViewMode mode);
+
+public slots:
+    void onViewModeChanged(int index);
+
+protected:
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
+private:
+    void refreshDisplay();
+    void updateHover(const QPoint &pos);
+
+    QVector<uint16_t> m_vramCells;
+    QImage m_nativeImage;
+    VramSnapshot::ViewMode m_mode = VramSnapshot::ViewMode::Native16;
+    QComboBox *m_modeCombo = nullptr;
+    QLabel *m_imageLabel = nullptr;
+    QLabel *m_hoverLabel = nullptr;
+    QScrollArea *m_scroll = nullptr;
+};
+
+#endif // VRAMVIEWERWIDGET_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -145,6 +145,9 @@ if(BUILD_TESTS)
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PS1RipSessionWindow.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PS1RipWorker.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/RipperHooks.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/TextureDecoder.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/VramSnapshot.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/VramViewerWidget.cpp
         )
     endif()
 


### PR DESCRIPTION
## Summary
- Add `VramSnapshot` (1024×512×16), view modes, PNG export, and `RipperHooks::onVramWrite` mirroring
- Add `TextureDecoder` for CLUT-aware 4/8/15 bpp tile decode with `TileKey` cache and STP/alpha via `PsxVramColor`
- Wire `dumpVRAM()` → `<AppData>/ps1_rip/captures/<id>_vram.png`, session dock `VramViewerWidget`, stub VRAM test pattern

## Test plan
- [x] `UnitTests --gtest_filter="VramSnapshotTest.*:TextureDecoderTest.*"` (offscreen Qt)
- [ ] CI Linux `UnitTests` with `ENABLE_PS1_RIP=ON`
- [ ] Manual: load BIOS+ISO, Start, Dump VRAM — dock shows 2× VRAM + view modes; PNG on disk

Closes #420, #421 (epic #412 Phase 3).

Made with [Cursor](https://cursor.com)