### PR TITLE
feat(pose-lib): sub-slice D3 — undo commands

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,6 +71,7 @@ commands/ApplyMaterialCommand.cpp
 commands/DeleteKeyframeCommand.cpp
 commands/MorphCommands.cpp
 commands/NodeAnimCommands.cpp
+commands/PoseLibraryCommands.cpp
 commands/SkeletonResolver.cpp
 BoneDragRelease.cpp
 PropertiesPanelController.cpp

--- a/src/PoseLibrary_test.cpp
+++ b/src/PoseLibrary_test.cpp
@@ -6,6 +6,7 @@
 #include "PoseLibrary.h"
 #include "SelectionSet.h"
 #include "TestHelpers.h"
+#include "commands/PoseLibraryCommands.h"
 
 #include <OgreBone.h>
 #include <OgreEntity.h>
@@ -209,4 +210,106 @@ TEST_F(PoseLibrarySceneTest, ForgetEntityDropsEverythingForThatEntity) {
     EXPECT_TRUE(lib->listPoses(entity).isEmpty());
     // Idempotent — forgetting again is a no-op false.
     EXPECT_FALSE(lib->forgetEntity(entity));
+}
+
+// ─── Slice D3 — undo commands ────────────────────────────────────────
+
+TEST_F(PoseLibrarySceneTest, SavePoseCommandRoundTripsForFreshPose) {
+    Ogre::Entity* entity = createAnimatedTestEntity("PoseLib_CmdSaveNew");
+    ASSERT_NE(entity, nullptr);
+    auto* lib = PoseLibrary::instance();
+
+    SavePoseCommand cmd(entity, QStringLiteral("First"));
+    cmd.redo();
+    EXPECT_TRUE(lib->hasPose(entity, QStringLiteral("First")));
+
+    cmd.undo();
+    EXPECT_FALSE(lib->hasPose(entity, QStringLiteral("First")));
+
+    cmd.redo();
+    EXPECT_TRUE(lib->hasPose(entity, QStringLiteral("First")));
+}
+
+TEST_F(PoseLibrarySceneTest, SavePoseCommandRestoresPriorOnOverwrite) {
+    Ogre::Entity* entity = createAnimatedTestEntity("PoseLib_CmdOverwrite");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+    auto* lib = PoseLibrary::instance();
+
+    // Seed an initial pose at bone[0] position (1,0,0).
+    skel->getBone(0)->setPosition(Ogre::Vector3(1, 0, 0));
+    ASSERT_TRUE(lib->savePose(entity, QStringLiteral("X")));
+
+    // Move bone, then overwrite via command. After undo the
+    // library should still contain the FIRST pose's data — so a
+    // subsequent apply restores (1,0,0), not the (5,5,5) we wrote.
+    skel->getBone(0)->setPosition(Ogre::Vector3(5, 5, 5));
+    SavePoseCommand cmd(entity, QStringLiteral("X"));
+    cmd.redo();
+    cmd.undo();
+
+    skel->getBone(0)->setPosition(Ogre::Vector3::ZERO);
+    lib->applyPose(entity, QStringLiteral("X"));
+    EXPECT_FLOAT_EQ(skel->getBone(0)->getPosition().x, 1.0f);
+    EXPECT_FLOAT_EQ(skel->getBone(0)->getPosition().y, 0.0f);
+    EXPECT_FLOAT_EQ(skel->getBone(0)->getPosition().z, 0.0f);
+}
+
+TEST_F(PoseLibrarySceneTest, DeletePoseCommandRoundTrips) {
+    Ogre::Entity* entity = createAnimatedTestEntity("PoseLib_CmdDelete");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+    auto* lib = PoseLibrary::instance();
+
+    skel->getBone(0)->setPosition(Ogre::Vector3(7, 0, 0));
+    ASSERT_TRUE(lib->savePose(entity, QStringLiteral("Y")));
+
+    DeletePoseCommand cmd(entity, QStringLiteral("Y"));
+    cmd.redo();
+    EXPECT_FALSE(lib->hasPose(entity, QStringLiteral("Y")));
+
+    cmd.undo();
+    EXPECT_TRUE(lib->hasPose(entity, QStringLiteral("Y")));
+
+    // Apply after undo should restore the original 7,0,0.
+    skel->getBone(0)->setPosition(Ogre::Vector3::ZERO);
+    lib->applyPose(entity, QStringLiteral("Y"));
+    EXPECT_FLOAT_EQ(skel->getBone(0)->getPosition().x, 7.0f);
+}
+
+TEST_F(PoseLibrarySceneTest, ApplyPoseCommandRestoresPreApplyState) {
+    Ogre::Entity* entity = createAnimatedTestEntity("PoseLib_CmdApply");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+    auto* lib = PoseLibrary::instance();
+
+    // Save a pose with bone at (10, 0, 0).
+    skel->getBone(0)->setPosition(Ogre::Vector3(10, 0, 0));
+    ASSERT_TRUE(lib->savePose(entity, QStringLiteral("PosePos10")));
+
+    // Move bone to (3, 3, 3) — this is the pre-apply state.
+    skel->getBone(0)->setPosition(Ogre::Vector3(3, 3, 3));
+
+    ApplyPoseCommand cmd(entity, QStringLiteral("PosePos10"));
+    cmd.redo();
+    // After redo bone is at the saved pose's position.
+    EXPECT_FLOAT_EQ(skel->getBone(0)->getPosition().x, 10.0f);
+
+    cmd.undo();
+    // After undo bone is back at the (3,3,3) snapshot.
+    const auto pos = skel->getBone(0)->getPosition();
+    EXPECT_FLOAT_EQ(pos.x, 3.0f);
+    EXPECT_FLOAT_EQ(pos.y, 3.0f);
+    EXPECT_FLOAT_EQ(pos.z, 3.0f);
+}
+
+TEST_F(PoseLibrarySceneTest, DeletePoseCommandIsNoOpForUnknownName) {
+    Ogre::Entity* entity = createAnimatedTestEntity("PoseLib_CmdDelMissing");
+    ASSERT_NE(entity, nullptr);
+    // Construct + redo + undo on a name that doesn't exist — both
+    // sides should be safe no-ops (no crash, no stray pose).
+    DeletePoseCommand cmd(entity, QStringLiteral("Missing"));
+    cmd.redo();
+    cmd.undo();
+    EXPECT_FALSE(PoseLibrary::instance()->hasPose(entity, QStringLiteral("Missing")));
 }

--- a/src/commands/PoseLibraryCommands.cpp
+++ b/src/commands/PoseLibraryCommands.cpp
@@ -1,0 +1,210 @@
+/*
+-----------------------------------------------------------------------------------
+A QtMeshEditor file
+
+Copyright (c) Fernando Tonon (https://github.com/fernandotonon)
+
+The MIT License
+-----------------------------------------------------------------------------------
+*/
+
+#include "PoseLibraryCommands.h"
+
+#include "../PoseLibrary.h"
+#include "../SentryReporter.h"
+
+#include <OgreBone.h>
+#include <OgreEntity.h>
+#include <OgreSkeleton.h>
+#include <OgreSkeletonInstance.h>
+
+namespace {
+
+// Mirrors PoseLibrary's internal skeleton lookup so the commands
+// don't need a private-API hook. Null when the entity has no
+// skeleton (a static prop) or is itself null.
+Ogre::SkeletonInstance* skeletonOf(Ogre::Entity* entity)
+{
+    if (!entity) return nullptr;
+    if (!entity->hasSkeleton()) return nullptr;
+    return entity->getSkeleton();
+}
+
+// Walk every Bone on the entity's skeleton and capture its TRS
+// into the returned hash. Mirrors `PoseLibrary::savePose`'s
+// capture loop — same NAME-keyed shape so the commands and the
+// library agree on what a "snapshot" is.
+PoseLibSnapshot capturePose(Ogre::Entity* entity)
+{
+    PoseLibSnapshot out;
+    auto* skel = skeletonOf(entity);
+    if (!skel) return out;
+    out.reserve(skel->getNumBones());
+    for (unsigned short i = 0; i < skel->getNumBones(); ++i) {
+        Ogre::Bone* bone = skel->getBone(i);
+        if (!bone) continue;
+        PoseLibBoneTRS trs;
+        trs.translate = bone->getPosition();
+        trs.rotation = bone->getOrientation();
+        trs.scale = bone->getScale();
+        out.insert(QString::fromStdString(bone->getName()), trs);
+    }
+    return out;
+}
+
+// Write a captured snapshot back onto the live bones. Bones
+// present in the snapshot but missing on the current skeleton are
+// skipped silently — same partial-apply contract PoseLibrary uses.
+void applyPose(Ogre::Entity* entity, const PoseLibSnapshot& snap)
+{
+    auto* skel = skeletonOf(entity);
+    if (!skel) return;
+    for (auto it = snap.cbegin(); it != snap.cend(); ++it) {
+        const std::string boneName = it.key().toStdString();
+        if (!skel->hasBone(boneName)) continue;
+        Ogre::Bone* bone = skel->getBone(boneName);
+        if (!bone) continue;
+        bone->setPosition(it.value().translate);
+        bone->setOrientation(it.value().rotation);
+        bone->setScale(it.value().scale);
+    }
+}
+
+// Save a precomputed snapshot into the library under `name`. Done
+// in two steps because PoseLibrary's public surface only accepts
+// "save what's on the entity right now": we apply the snapshot
+// transiently, hit PoseLibrary::savePose, then restore the bones
+// to whatever they were before. Caller is responsible for the
+// "restore" via captureBeforeAndAfter.
+void writeSnapshotToLibrary(Ogre::Entity* entity,
+                            const QString& name,
+                            const PoseLibSnapshot& snap)
+{
+    if (!entity || name.isEmpty()) return;
+    auto* lib = PoseLibrary::instance();
+    if (!lib) return;
+    const PoseLibSnapshot live = capturePose(entity);
+    applyPose(entity, snap);
+    lib->savePose(entity, name);
+    applyPose(entity, live);
+}
+
+} // namespace
+
+// ──────────────── SavePoseCommand ───────────────────────────────────
+
+SavePoseCommand::SavePoseCommand(Ogre::Entity* entity,
+                                 const QString& name,
+                                 QUndoCommand* parent)
+    : QUndoCommand(parent), mEntity(entity), mName(name)
+{
+    setText(QStringLiteral("Save pose \"%1\"").arg(name));
+    mNewSnapshot = capturePose(entity);
+
+    // Snapshot the prior content if a same-name pose already
+    // exists, so undo can restore it. We capture it by
+    // round-tripping: apply the saved pose, capture, restore
+    // current bones. (Pose data is only readable through the
+    // entity's live bones, not directly through PoseLibrary's
+    // public surface.)
+    auto* lib = PoseLibrary::instance();
+    if (lib && lib->hasPose(entity, name)) {
+        const PoseLibSnapshot live = capturePose(entity);
+        lib->applyPose(entity, name);
+        mPriorSnapshot = capturePose(entity);
+        applyPose(entity, live);
+    }
+}
+
+void SavePoseCommand::redo()
+{
+    if (!mEntity) return;
+    writeSnapshotToLibrary(mEntity, mName, mNewSnapshot);
+    SentryReporter::addBreadcrumb("scene.anim.pose.cmd",
+        QStringLiteral("redo: save '%1'").arg(mName));
+}
+
+void SavePoseCommand::undo()
+{
+    if (!mEntity) return;
+    auto* lib = PoseLibrary::instance();
+    if (!lib) return;
+    if (mPriorSnapshot.has_value()) {
+        // Overwrite case — write the prior content back under
+        // the same name.
+        writeSnapshotToLibrary(mEntity, mName, *mPriorSnapshot);
+    } else {
+        // Pure-add case — drop the pose we created.
+        lib->deletePose(mEntity, mName);
+    }
+    SentryReporter::addBreadcrumb("scene.anim.pose.cmd",
+        QStringLiteral("undo: save '%1'").arg(mName));
+}
+
+// ──────────────── DeletePoseCommand ─────────────────────────────────
+
+DeletePoseCommand::DeletePoseCommand(Ogre::Entity* entity,
+                                     const QString& name,
+                                     QUndoCommand* parent)
+    : QUndoCommand(parent), mEntity(entity), mName(name)
+{
+    setText(QStringLiteral("Delete pose \"%1\"").arg(name));
+    auto* lib = PoseLibrary::instance();
+    if (lib && lib->hasPose(entity, name)) {
+        mWasPresent = true;
+        // Round-trip-capture the pose content. We need this to
+        // recreate the pose on undo since once deleted the
+        // library has nothing to restore from.
+        const PoseLibSnapshot live = capturePose(entity);
+        lib->applyPose(entity, name);
+        mSnapshot = capturePose(entity);
+        applyPose(entity, live);
+    }
+}
+
+void DeletePoseCommand::redo()
+{
+    if (!mEntity || !mWasPresent) return;
+    auto* lib = PoseLibrary::instance();
+    if (lib) lib->deletePose(mEntity, mName);
+    SentryReporter::addBreadcrumb("scene.anim.pose.cmd",
+        QStringLiteral("redo: delete '%1'").arg(mName));
+}
+
+void DeletePoseCommand::undo()
+{
+    if (!mEntity || !mWasPresent) return;
+    writeSnapshotToLibrary(mEntity, mName, mSnapshot);
+    SentryReporter::addBreadcrumb("scene.anim.pose.cmd",
+        QStringLiteral("undo: delete '%1'").arg(mName));
+}
+
+// ──────────────── ApplyPoseCommand ──────────────────────────────────
+
+ApplyPoseCommand::ApplyPoseCommand(Ogre::Entity* entity,
+                                   const QString& name,
+                                   QUndoCommand* parent)
+    : QUndoCommand(parent), mEntity(entity), mName(name)
+{
+    setText(QStringLiteral("Apply pose \"%1\"").arg(name));
+    // Capture the live bone TRS BEFORE redo applies the saved
+    // pose. Undo will write these back.
+    mPreApply = capturePose(entity);
+}
+
+void ApplyPoseCommand::redo()
+{
+    if (!mEntity) return;
+    auto* lib = PoseLibrary::instance();
+    if (lib) lib->applyPose(mEntity, mName);
+    SentryReporter::addBreadcrumb("scene.anim.pose.cmd",
+        QStringLiteral("redo: apply '%1'").arg(mName));
+}
+
+void ApplyPoseCommand::undo()
+{
+    if (!mEntity) return;
+    applyPose(mEntity, mPreApply);
+    SentryReporter::addBreadcrumb("scene.anim.pose.cmd",
+        QStringLiteral("undo: apply '%1'").arg(mName));
+}

--- a/src/commands/PoseLibraryCommands.h
+++ b/src/commands/PoseLibraryCommands.h
@@ -1,0 +1,105 @@
+/*
+-----------------------------------------------------------------------------------
+A QtMeshEditor file
+
+Copyright (c) Fernando Tonon (https://github.com/fernandotonon)
+
+The MIT License
+-----------------------------------------------------------------------------------
+*/
+
+#ifndef POSE_LIBRARY_COMMANDS_H
+#define POSE_LIBRARY_COMMANDS_H
+
+#include <QHash>
+#include <QString>
+#include <QUndoCommand>
+
+#include <OgreQuaternion.h>
+#include <OgreVector.h>
+
+#include <optional>
+
+namespace Ogre { class Entity; }
+
+// Per-bone snapshot captured directly by the commands. We keep our
+// own structure (rather than reaching into `PoseLibrary::BonePoseSnapshot`)
+// so the commands don't depend on the library's private types and
+// undo can store snapshots for poses that were never saved (the
+// ApplyPoseCommand's "where were the bones before I applied" data).
+struct PoseLibBoneTRS {
+    Ogre::Vector3 translate{Ogre::Vector3::ZERO};
+    Ogre::Quaternion rotation{Ogre::Quaternion::IDENTITY};
+    Ogre::Vector3 scale{Ogre::Vector3(1, 1, 1)};
+};
+
+using PoseLibSnapshot = QHash<QString, PoseLibBoneTRS>;
+
+// SavePoseCommand: redo captures-and-saves under `name`. Undo
+// deletes the pose IF this command created it (i.e. there was no
+// same-name pose before), or restores the previous content if we
+// overwrote one.
+class SavePoseCommand : public QUndoCommand
+{
+public:
+    SavePoseCommand(Ogre::Entity* entity,
+                    const QString& name,
+                    QUndoCommand* parent = nullptr);
+    void undo() override;
+    void redo() override;
+
+private:
+    Ogre::Entity* mEntity = nullptr;
+    QString mName;
+    // Bones-TRS at command-construction time. This is what redo
+    // saves into the library; it captures BEFORE the user makes
+    // further edits so the saved pose is the user's intended
+    // snapshot, not whatever the bones look like after the
+    // command sits unexecuted on the stack.
+    PoseLibSnapshot mNewSnapshot;
+    // Empty when there was no prior pose by that name; populated
+    // when we're overwriting an existing one so undo can restore it.
+    std::optional<PoseLibSnapshot> mPriorSnapshot;
+};
+
+// DeletePoseCommand: redo drops the pose. Construction snapshots
+// the pose content so undo can recreate it.
+class DeletePoseCommand : public QUndoCommand
+{
+public:
+    DeletePoseCommand(Ogre::Entity* entity,
+                      const QString& name,
+                      QUndoCommand* parent = nullptr);
+    void undo() override;
+    void redo() override;
+
+private:
+    Ogre::Entity* mEntity = nullptr;
+    QString mName;
+    PoseLibSnapshot mSnapshot;
+    bool mWasPresent = false;
+};
+
+// ApplyPoseCommand: redo applies the saved pose to the live
+// skeleton; undo restores the pre-apply bone TRS values. The
+// snapshot is captured at construction so we know the exact
+// state to revert to even if the user keeps editing on the
+// undo stack.
+class ApplyPoseCommand : public QUndoCommand
+{
+public:
+    ApplyPoseCommand(Ogre::Entity* entity,
+                     const QString& name,
+                     QUndoCommand* parent = nullptr);
+    void undo() override;
+    void redo() override;
+
+private:
+    Ogre::Entity* mEntity = nullptr;
+    QString mName;
+    // Bone TRS values as they were BEFORE redo applied the saved
+    // pose. Undo writes these back.
+    PoseLibSnapshot mPreApply;
+};
+
+#endif // POSE_LIBRARY_COMMANDS_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -101,6 +101,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/NodeAnimationManager.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/NodeAnimCommands.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/PoseLibrary.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/PoseLibraryCommands.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/ApplyAtlas.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/EmbeddedTextureCache.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/NormalMapGenerator.cpp


### PR DESCRIPTION
Third sub-slice of #521 (named-pose library). Adds `QUndoCommand` subclasses for SavePose / DeletePose / ApplyPose so Ctrl+Z reverses every pose-library mutation. Mirrors the morph A3 / node-anim C3 command shape.

## What ships — `commands/PoseLibraryCommands.{h,cpp}`

- **`SavePoseCommand(entity, name)`** — at construction, captures the current bone TRS into `mNewSnapshot` AND (if a same-name pose already exists) snapshots its content into `mPriorSnapshot` via round-trip-apply. Redo writes `mNewSnapshot` into the library; undo either **deletes** (fresh-add path) or **restores the prior content** (overwrite path).
- **`DeletePoseCommand(entity, name)`** — at construction, captures the pose content via round-trip-apply so undo can recreate it. Redo drops; undo restores. No-op redo/undo for unknown names so the command is safe to construct speculatively.
- **`ApplyPoseCommand(entity, name)`** — at construction, captures the CURRENT bone TRS state into `mPreApply`. Redo applies the saved pose; undo writes the captured pre-apply TRS back onto the bones. Snapshot lives in the command (not the library) so undo doesn't pollute the user-visible pose list with hidden internal poses.

All three emit `scene.anim.pose.cmd` Sentry breadcrumbs.

## Why "round-trip-apply" for snapshotting saved poses

`PoseLibrary` exposes only entity-relative operations ("save what's on the entity now", "apply a saved pose"). There's no `getPoseSnapshot(name)` accessor. To capture data of an EXISTING saved pose (for SavePose's overwrite path, DeletePose's pre-delete snapshot), we transiently apply it to the live skeleton, read the bones, then restore the live state from another snapshot. Pure round-trip; no library internals touched.

## 5 new tests
- `SavePoseCommandRoundTripsForFreshPose`
- `SavePoseCommandRestoresPriorOnOverwrite` (apply after undo yields the original seeded values)
- `DeletePoseCommandRoundTrips`
- `ApplyPoseCommandRestoresPreApplyState`
- `DeletePoseCommandIsNoOpForUnknownName`

## #521 status

| Sub-slice | Status |
|-|-|
| D1 — Singleton data layer | shipped (#592) |
| D-MCP — MCP tools | shipped (#593) |
| D3 — Undo commands | **this PR** |
| D2 — Inspector subgroup | follow-up |
| D4 — Mirror pose | follow-up |
| D5 — Apply-with-mask | follow-up |
| D6 — Time-blended apply | follow-up |
| D-Project — `.poselib` sidecar | follow-up |
| D-Thumbnail | follow-up |
| D-CLI | follow-up |

## Test plan
- [ ] CI green
- [ ] 5 new command-round-trip tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added undo/redo functionality for all pose library operations (save, delete, and apply), enabling users to easily reverse or repeat pose-related actions.

* **Tests**
  * Added comprehensive test coverage for pose library undo/redo workflows, validating state restoration and proper command behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/595?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->