### PR TITLE
review(pose-lib): D3 — apply-failure undo no-op + constructor guards

### DIFF
--- a/src/PoseLibrary_test.cpp
+++ b/src/PoseLibrary_test.cpp
@@ -303,6 +303,33 @@ TEST_F(PoseLibrarySceneTest, ApplyPoseCommandRestoresPreApplyState) {
     EXPECT_FLOAT_EQ(pos.z, 3.0f);
 }
 
+// Codex P1 on PR #595 — when ApplyPoseCommand::redo fails (pose
+// name not found in the library), undo MUST also be a no-op.
+// Restoring `mPreApply` would clobber any bone edits the user made
+// after the failed apply with stale snapshot values.
+TEST_F(PoseLibrarySceneTest, ApplyPoseCommandUndoNoOpWhenRedoFailed) {
+    Ogre::Entity* entity = createAnimatedTestEntity("PoseLib_CmdApplyFail");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+
+    // Pre-apply bone position. The command will capture this as
+    // mPreApply at construction.
+    skel->getBone(0)->setPosition(Ogre::Vector3(2, 2, 2));
+    ApplyPoseCommand cmd(entity, QStringLiteral("PoseDoesNotExist"));
+
+    // Move the bone — these edits are what undo MUST preserve.
+    skel->getBone(0)->setPosition(Ogre::Vector3(9, 9, 9));
+
+    cmd.redo();  // No-op — pose doesn't exist.
+    // Bone still at user-edited position; redo didn't apply.
+    EXPECT_FLOAT_EQ(skel->getBone(0)->getPosition().x, 9.0f);
+
+    cmd.undo();  // Must NOT revert to (2,2,2) — that would clobber the user edit.
+    EXPECT_FLOAT_EQ(skel->getBone(0)->getPosition().x, 9.0f);
+    EXPECT_FLOAT_EQ(skel->getBone(0)->getPosition().y, 9.0f);
+    EXPECT_FLOAT_EQ(skel->getBone(0)->getPosition().z, 9.0f);
+}
+
 TEST_F(PoseLibrarySceneTest, DeletePoseCommandIsNoOpForUnknownName) {
     Ogre::Entity* entity = createAnimatedTestEntity("PoseLib_CmdDelMissing");
     ASSERT_NE(entity, nullptr);

--- a/src/commands/PoseLibraryCommands.cpp
+++ b/src/commands/PoseLibraryCommands.cpp
@@ -99,6 +99,11 @@ SavePoseCommand::SavePoseCommand(Ogre::Entity* entity,
     : QUndoCommand(parent), mEntity(entity), mName(name)
 {
     setText(QStringLiteral("Save pose \"%1\"").arg(name));
+    // Bail early on invalid inputs — match the redo/undo no-op
+    // guard so speculative-construction can't accidentally hit
+    // the PoseLibrary singleton with null/empty args. CodeRabbit
+    // major on PR #595.
+    if (!entity || name.isEmpty()) return;
     mNewSnapshot = capturePose(entity);
 
     // Snapshot the prior content if a same-name pose already
@@ -149,6 +154,7 @@ DeletePoseCommand::DeletePoseCommand(Ogre::Entity* entity,
     : QUndoCommand(parent), mEntity(entity), mName(name)
 {
     setText(QStringLiteral("Delete pose \"%1\"").arg(name));
+    if (!entity || name.isEmpty()) return;  // see SavePoseCommand
     auto* lib = PoseLibrary::instance();
     if (lib && lib->hasPose(entity, name)) {
         mWasPresent = true;
@@ -187,6 +193,7 @@ ApplyPoseCommand::ApplyPoseCommand(Ogre::Entity* entity,
     : QUndoCommand(parent), mEntity(entity), mName(name)
 {
     setText(QStringLiteral("Apply pose \"%1\"").arg(name));
+    if (!entity || name.isEmpty()) return;  // see SavePoseCommand
     // Capture the live bone TRS BEFORE redo applies the saved
     // pose. Undo will write these back.
     mPreApply = capturePose(entity);
@@ -194,16 +201,24 @@ ApplyPoseCommand::ApplyPoseCommand(Ogre::Entity* entity,
 
 void ApplyPoseCommand::redo()
 {
+    mRedoApplied = false;
     if (!mEntity) return;
     auto* lib = PoseLibrary::instance();
-    if (lib) lib->applyPose(mEntity, mName);
-    SentryReporter::addBreadcrumb("scene.anim.pose.cmd",
-        QStringLiteral("redo: apply '%1'").arg(mName));
+    if (lib && lib->applyPose(mEntity, mName)) {
+        mRedoApplied = true;
+        SentryReporter::addBreadcrumb("scene.anim.pose.cmd",
+            QStringLiteral("redo: apply '%1'").arg(mName));
+    }
 }
 
 void ApplyPoseCommand::undo()
 {
     if (!mEntity) return;
+    // No-op when redo didn't actually apply (stale / missing pose
+    // name). Restoring `mPreApply` in that case would clobber any
+    // bone edits the user made after the failed apply (Codex P1
+    // on PR #595).
+    if (!mRedoApplied) return;
     applyPose(mEntity, mPreApply);
     SentryReporter::addBreadcrumb("scene.anim.pose.cmd",
         QStringLiteral("undo: apply '%1'").arg(mName));

--- a/src/commands/PoseLibraryCommands.h
+++ b/src/commands/PoseLibraryCommands.h
@@ -100,6 +100,12 @@ private:
     // Bone TRS values as they were BEFORE redo applied the saved
     // pose. Undo writes these back.
     PoseLibSnapshot mPreApply;
+    // True only when the most recent redo() actually applied the
+    // pose. If the pose name was missing / library returned false,
+    // redo is a no-op and undo MUST also be a no-op — otherwise
+    // we'd clobber user edits made after the failed apply with the
+    // stale `mPreApply` snapshot (Codex P1 on PR #595).
+    bool mRedoApplied = false;
 };
 
 #endif // POSE_LIBRARY_COMMANDS_H


### PR DESCRIPTION
Two review findings on PR #595 (merged).

## Codex P1 — `ApplyPoseCommand::undo` clobbered user edits when redo failed

When `redo()` failed to apply (stale / missing pose name, library returned false), the command still kept its pre-apply snapshot — and `undo()` unconditionally wrote that snapshot back. So if the user made bone edits AFTER the failed apply attempt, undo would revert those edits using stale data from before redo ran.

**Fix:** track redo success in `mRedoApplied`, set on successful `PoseLibrary::applyPose`. Undo short-circuits when false.

Regression test `ApplyPoseCommandUndoNoOpWhenRedoFailed`:
- Bone at (2,2,2). Construct command for a pose name that doesn't exist.
- Move bone to (9,9,9) (user's edit).
- `redo` → no-op.
- `undo` → MUST leave bone at (9,9,9), not revert to (2,2,2).

## CodeRabbit Major — constructors hit PoseLibrary with invalid args

All three constructors queried / applied the PoseLibrary singleton during construction even on `entity == nullptr` or `name.isEmpty()`. `redo()/undo()` already short-circuit on invalid entity but the constructors didn't, leaving an unsafe ordering when commands are constructed speculatively.

**Fix:** early-return after `setText()` on invalid inputs in all three constructors.

## Test plan
- [ ] CI green
- [ ] New `ApplyPoseCommandUndoNoOpWhenRedoFailed` test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)