### PR TITLE
feat(pose-lib): sub-slice D4 — mirror pose (_l ↔ _r heuristic)

### DIFF
--- a/src/PoseLibrary.cpp
+++ b/src/PoseLibrary.cpp
@@ -176,6 +176,161 @@ QStringList PoseLibrary::listPoses(Ogre::Entity* entity) const
     return it->order;
 }
 
+QString PoseLibrary::flipBoneName(const QString& boneName)
+{
+    // Mixamo / generic _l ↔ _r suffix. Case-preserving on the
+    // suffix letter so "BoneL" stays uppercase, "bone_l" stays
+    // lowercase, etc.
+    if (boneName.endsWith(QStringLiteral("_l"))) {
+        return boneName.left(boneName.size() - 2) + QStringLiteral("_r");
+    }
+    if (boneName.endsWith(QStringLiteral("_r"))) {
+        return boneName.left(boneName.size() - 2) + QStringLiteral("_l");
+    }
+    if (boneName.endsWith(QStringLiteral("_L"))) {
+        return boneName.left(boneName.size() - 2) + QStringLiteral("_R");
+    }
+    if (boneName.endsWith(QStringLiteral("_R"))) {
+        return boneName.left(boneName.size() - 2) + QStringLiteral("_L");
+    }
+    // Blender .L / .R convention.
+    if (boneName.endsWith(QStringLiteral(".L"))) {
+        return boneName.left(boneName.size() - 2) + QStringLiteral(".R");
+    }
+    if (boneName.endsWith(QStringLiteral(".R"))) {
+        return boneName.left(boneName.size() - 2) + QStringLiteral(".L");
+    }
+    // Maya Left / Right prefix. We require the prefix to be
+    // followed by an uppercase letter so "Lefty" isn't flipped
+    // to "Righty"; the convention is "LeftHand", "RightArm" etc.
+    auto hasPrefixWord = [&](const QString& prefix) {
+        if (!boneName.startsWith(prefix)) return false;
+        if (boneName.size() == prefix.size()) return true;
+        const QChar next = boneName.at(prefix.size());
+        return next.isUpper() || next == QLatin1Char('_');
+    };
+    if (hasPrefixWord(QStringLiteral("Left"))) {
+        return QStringLiteral("Right") + boneName.mid(4);
+    }
+    if (hasPrefixWord(QStringLiteral("Right"))) {
+        return QStringLiteral("Left") + boneName.mid(5);
+    }
+    return boneName;
+}
+
+bool PoseLibrary::mirrorPose(Ogre::Entity* entity,
+                             const QString& srcName,
+                             const QString& dstName)
+{
+    assertMainThread();
+    if (!entity || srcName.isEmpty() || dstName.isEmpty()) return false;
+    if (!hasPose(entity, srcName)) return false;
+    auto* skel = skeletonOf(entity);
+    if (!skel) return false;
+
+    // Capture the source pose into a snapshot via round-trip-apply
+    // — same idiom the command path uses, for the same reason:
+    // PoseLibrary's public API doesn't expose direct pose
+    // contents.
+    PoseSnapshot src;
+    {
+        // Save the live state, apply src, capture, restore.
+        PoseSnapshot live;
+        live.reserve(skel->getNumBones());
+        for (unsigned short i = 0; i < skel->getNumBones(); ++i) {
+            Ogre::Bone* bone = skel->getBone(i);
+            if (!bone) continue;
+            BonePoseSnapshot bs;
+            bs.translate = bone->getPosition();
+            bs.rotation = bone->getOrientation();
+            bs.scale = bone->getScale();
+            live.insert(QString::fromStdString(bone->getName()), bs);
+        }
+        applyPose(entity, srcName);
+        for (unsigned short i = 0; i < skel->getNumBones(); ++i) {
+            Ogre::Bone* bone = skel->getBone(i);
+            if (!bone) continue;
+            BonePoseSnapshot bs;
+            bs.translate = bone->getPosition();
+            bs.rotation = bone->getOrientation();
+            bs.scale = bone->getScale();
+            src.insert(QString::fromStdString(bone->getName()), bs);
+        }
+        // Restore the live state.
+        for (auto it = live.cbegin(); it != live.cend(); ++it) {
+            const std::string n = it.key().toStdString();
+            if (!skel->hasBone(n)) continue;
+            Ogre::Bone* b = skel->getBone(n);
+            b->setPosition(it.value().translate);
+            b->setOrientation(it.value().rotation);
+            b->setScale(it.value().scale);
+        }
+    }
+
+    // Build the mirrored snapshot: for each source bone, look up
+    // its mirrored counterpart's name and write the X-flipped TRS
+    // under that key. Bones whose flipped name is the same as the
+    // original (centre-line: Spine, Hips, Head, etc.) get the
+    // reflected TRS in place.
+    PoseSnapshot mirrored;
+    mirrored.reserve(src.size());
+    for (auto it = src.cbegin(); it != src.cend(); ++it) {
+        const QString flipped = flipBoneName(it.key());
+        BonePoseSnapshot bs;
+        const auto& s = it.value();
+        bs.translate = Ogre::Vector3(-s.translate.x, s.translate.y, s.translate.z);
+        // X-symmetric reflection of a quaternion: keep w, x; flip y, z.
+        // Equivalent to conjugating by the reflection-X transform.
+        bs.rotation = Ogre::Quaternion(s.rotation.w, s.rotation.x,
+                                       -s.rotation.y, -s.rotation.z);
+        // Negative scale.x is the standard mirror trick — preserves
+        // volume and produces the correct mirrored orientation when
+        // the renderer applies the bone transform.
+        bs.scale = Ogre::Vector3(-s.scale.x, s.scale.y, s.scale.z);
+        mirrored.insert(flipped, bs);
+    }
+
+    // Apply the mirrored snapshot to the live skeleton and call
+    // savePose under dstName — same write-pattern the commands use
+    // so the per-entity order list stays consistent.
+    PoseSnapshot liveBeforeWrite;
+    liveBeforeWrite.reserve(skel->getNumBones());
+    for (unsigned short i = 0; i < skel->getNumBones(); ++i) {
+        Ogre::Bone* bone = skel->getBone(i);
+        if (!bone) continue;
+        BonePoseSnapshot bs;
+        bs.translate = bone->getPosition();
+        bs.rotation = bone->getOrientation();
+        bs.scale = bone->getScale();
+        liveBeforeWrite.insert(QString::fromStdString(bone->getName()), bs);
+    }
+    // Write the mirrored TRS to the live skeleton.
+    for (auto it = mirrored.cbegin(); it != mirrored.cend(); ++it) {
+        const std::string n = it.key().toStdString();
+        if (!skel->hasBone(n)) continue;
+        Ogre::Bone* b = skel->getBone(n);
+        b->setPosition(it.value().translate);
+        b->setOrientation(it.value().rotation);
+        b->setScale(it.value().scale);
+    }
+    const bool ok = savePose(entity, dstName);
+    // Restore the live state.
+    for (auto it = liveBeforeWrite.cbegin(); it != liveBeforeWrite.cend(); ++it) {
+        const std::string n = it.key().toStdString();
+        if (!skel->hasBone(n)) continue;
+        Ogre::Bone* b = skel->getBone(n);
+        b->setPosition(it.value().translate);
+        b->setOrientation(it.value().rotation);
+        b->setScale(it.value().scale);
+    }
+
+    if (ok) {
+        SentryReporter::addBreadcrumb("scene.anim.pose",
+            QStringLiteral("mirror '%1' -> '%2'").arg(srcName, dstName));
+    }
+    return ok;
+}
+
 bool PoseLibrary::forgetEntity(Ogre::Entity* entity)
 {
     assertMainThread();

--- a/src/PoseLibrary.h
+++ b/src/PoseLibrary.h
@@ -85,6 +85,42 @@ public:
     /// All pose names on `entity` in save-order.
     QStringList listPoses(Ogre::Entity* entity) const;
 
+    /// Mirror a saved pose across the YZ plane (X = symmetry axis,
+    /// the convention every common rig follows). Reads `srcName`
+    /// from the library on `entity`, flips each bone's TRS by:
+    ///   - mapping the bone name via the `_l`/`_r`, `.L`/`.R`,
+    ///     `Left`/`Right` heuristic (so a left-hand keyframe lands
+    ///     on the right hand, and vice-versa);
+    ///   - reflecting the position's X component (pos.x → -pos.x);
+    ///   - flipping the Y/Z parts of the rotation quaternion
+    ///     (w,x,y,z → w,x,-y,-z), which is the X-axis-symmetric
+    ///     reflection of an orientation;
+    ///   - negating scale.x so the volume stays right and the
+    ///     mirrored bone aligns with the mirrored axis.
+    ///
+    /// Bones whose names don't match the heuristic (centre-line
+    /// bones like Spine, Hips) keep their TRS reflected in place.
+    ///
+    /// Writes the result under `dstName`. Returns false if `entity`
+    /// is null, has no skeleton, `srcName` doesn't exist, or
+    /// `dstName` is empty. `srcName == dstName` is allowed and
+    /// overwrites the source.
+    bool mirrorPose(Ogre::Entity* entity,
+                    const QString& srcName,
+                    const QString& dstName);
+
+    /// Heuristic name flip for mirror-pose. Recognises three
+    /// common rig conventions:
+    ///   - suffix `_l` ↔ `_r` (`Mixamo_Hand_l` ↔ `Mixamo_Hand_r`)
+    ///   - suffix `.L` ↔ `.R` (Blender convention, case-preserved)
+    ///   - prefix `Left` ↔ `Right` (Maya convention, case-preserved)
+    /// Returns the original name unchanged when no rule matches —
+    /// centre-line bones (`Spine`, `Hips`, `Head`) flow through
+    /// untouched and just have their TRS reflected in place.
+    /// Pure function with no Ogre dependency — exposed publicly
+    /// for tests and so future apply-with-mask code can reuse it.
+    static QString flipBoneName(const QString& boneName);
+
     /// Drop every entry on `entity` (called when an entity is
     /// destroyed or a scene closes). No-op if `entity` was never
     /// saved. Returns `true` when something was actually erased so

--- a/src/PoseLibrary_test.cpp
+++ b/src/PoseLibrary_test.cpp
@@ -212,6 +212,89 @@ TEST_F(PoseLibrarySceneTest, ForgetEntityDropsEverythingForThatEntity) {
     EXPECT_FALSE(lib->forgetEntity(entity));
 }
 
+// ─── Slice D4 — bone name flip + mirror pose ─────────────────────────
+
+TEST(PoseLibraryStandalone, FlipBoneName_MixamoLowercaseSuffix) {
+    EXPECT_EQ(PoseLibrary::flipBoneName(QStringLiteral("Hand_l")),
+              QStringLiteral("Hand_r"));
+    EXPECT_EQ(PoseLibrary::flipBoneName(QStringLiteral("Hand_r")),
+              QStringLiteral("Hand_l"));
+    EXPECT_EQ(PoseLibrary::flipBoneName(QStringLiteral("mixamorig_LeftUpLeg_l")),
+              QStringLiteral("mixamorig_LeftUpLeg_r"));
+}
+
+TEST(PoseLibraryStandalone, FlipBoneName_UppercaseSuffix) {
+    EXPECT_EQ(PoseLibrary::flipBoneName(QStringLiteral("Hand_L")),
+              QStringLiteral("Hand_R"));
+    EXPECT_EQ(PoseLibrary::flipBoneName(QStringLiteral("Hand.R")),
+              QStringLiteral("Hand.L"));
+}
+
+TEST(PoseLibraryStandalone, FlipBoneName_LeftRightPrefix) {
+    EXPECT_EQ(PoseLibrary::flipBoneName(QStringLiteral("LeftHand")),
+              QStringLiteral("RightHand"));
+    EXPECT_EQ(PoseLibrary::flipBoneName(QStringLiteral("RightArm")),
+              QStringLiteral("LeftArm"));
+    // Edge case: prefix MUST be followed by uppercase / underscore /
+    // end. "Lefty" should NOT flip to "Righty".
+    EXPECT_EQ(PoseLibrary::flipBoneName(QStringLiteral("Lefty")),
+              QStringLiteral("Lefty"));
+}
+
+TEST(PoseLibraryStandalone, FlipBoneName_CentreLineUntouched) {
+    EXPECT_EQ(PoseLibrary::flipBoneName(QStringLiteral("Spine")),
+              QStringLiteral("Spine"));
+    EXPECT_EQ(PoseLibrary::flipBoneName(QStringLiteral("Hips")),
+              QStringLiteral("Hips"));
+    EXPECT_EQ(PoseLibrary::flipBoneName(QStringLiteral("Head_End")),
+              QStringLiteral("Head_End"));
+}
+
+TEST_F(PoseLibrarySceneTest, MirrorPoseProducesXFlippedSnapshot) {
+    Ogre::Entity* entity = createAnimatedTestEntity("PoseLib_Mirror");
+    ASSERT_NE(entity, nullptr);
+    auto* skel = entity->getSkeleton();
+    auto* lib = PoseLibrary::instance();
+
+    // Set bone[0] to a non-symmetric pose; capture as "src".
+    skel->getBone(0)->setPosition(Ogre::Vector3(2, 3, 4));
+    skel->getBone(0)->setOrientation(Ogre::Quaternion(0.5, 0.5, 0.5, 0.5));
+    ASSERT_TRUE(lib->savePose(entity, QStringLiteral("src")));
+
+    EXPECT_TRUE(lib->mirrorPose(entity,
+                                 QStringLiteral("src"),
+                                 QStringLiteral("dst")));
+    EXPECT_TRUE(lib->hasPose(entity, QStringLiteral("dst")));
+
+    // Reset bone, apply mirrored — should see X-flipped values.
+    skel->getBone(0)->setPosition(Ogre::Vector3::ZERO);
+    skel->getBone(0)->setOrientation(Ogre::Quaternion::IDENTITY);
+    lib->applyPose(entity, QStringLiteral("dst"));
+    const auto pos = skel->getBone(0)->getPosition();
+    const auto rot = skel->getBone(0)->getOrientation();
+    EXPECT_FLOAT_EQ(pos.x, -2.0f);
+    EXPECT_FLOAT_EQ(pos.y, 3.0f);
+    EXPECT_FLOAT_EQ(pos.z, 4.0f);
+    // Quaternion: keep w + x, flip y + z.
+    EXPECT_FLOAT_EQ(rot.w, 0.5f);
+    EXPECT_FLOAT_EQ(rot.x, 0.5f);
+    EXPECT_FLOAT_EQ(rot.y, -0.5f);
+    EXPECT_FLOAT_EQ(rot.z, -0.5f);
+}
+
+TEST_F(PoseLibrarySceneTest, MirrorPoseRejectsMissingSourceAndEmptyDst) {
+    Ogre::Entity* entity = createAnimatedTestEntity("PoseLib_MirrorReject");
+    ASSERT_NE(entity, nullptr);
+    auto* lib = PoseLibrary::instance();
+
+    EXPECT_FALSE(lib->mirrorPose(entity, QStringLiteral("NoSuchSrc"),
+                                  QStringLiteral("dst")));
+    ASSERT_TRUE(lib->savePose(entity, QStringLiteral("ok")));
+    EXPECT_FALSE(lib->mirrorPose(entity, QStringLiteral("ok"), QString()));
+    EXPECT_FALSE(lib->mirrorPose(nullptr, QStringLiteral("ok"),
+                                  QStringLiteral("dst")));
+}
+
 // ─── Slice D3 — undo commands ────────────────────────────────────────
 
 TEST_F(PoseLibrarySceneTest, SavePoseCommandRoundTripsForFreshPose) {


### PR DESCRIPTION
Fourth sub-slice of #521 (named-pose library). Adds the "mirror this asymmetric pose to the other side" operation every DCC tool ships — turn a left-side facial expression into its right-side counterpart with one click.

## What ships

### `PoseLibrary::flipBoneName(name)` static helper

Pure function (no Ogre dependency) mapping bone names across three common rig conventions:
- **`_l` ↔ `_r`** and **`_L` ↔ `_R`** (Mixamo / generic)
- **`.L` ↔ `.R`** (Blender)
- **`Left*` ↔ `Right*`** (Maya prefix), where the prefix must be followed by uppercase / underscore / end-of-string so "Lefty" doesn't flip to "Righty"

Bones that don't match any rule (centre-line: Spine, Hips, Head) pass through unchanged. Exposed publicly so future apply-with-mask code can reuse it.

### `PoseLibrary::mirrorPose(entity, srcName, dstName)`

Reads `srcName`, applies the X-symmetric reflection to every bone, saves as `dstName`. TRS flip:
- `pos.x → -pos.x`
- rotation: `(w, x, y, z) → (w, x, -y, -z)` (X-symmetric reflection of an orientation)
- `scale.x → -scale.x` (negative scale preserves volume and produces correct orientation)

For each source bone, the resulting TRS is written under the mirrored bone name from `flipBoneName`. Centre-line bones get the X-flipped TRS in place (they ARE on the axis of symmetry).

## 6 new tests

- 4 `FlipBoneName_*` standalone tests covering each suffix/prefix pattern + the "Lefty" non-flip edge case.
- `MirrorPoseProducesXFlippedSnapshot` — apply mirrored pose and verify pos/rot are X-flipped.
- `MirrorPoseRejectsMissingSourceAndEmptyDst`.

## #521 status

| Sub-slice | Status |
|-|-|
| D1 — Singleton data layer | shipped (#592) |
| D-MCP — MCP tools | shipped (#593) |
| D3 — Undo commands | shipped (#595) |
| D4 — Mirror pose | **this PR** |
| D2 — Inspector subgroup | follow-up |
| D5 — Apply-with-mask | follow-up |
| D6 — Time-blended apply | follow-up |
| D-Project — `.poselib` sidecar | follow-up |
| D-Thumbnail | follow-up |
| D-CLI | follow-up |

🤖 Generated with [Claude Code](https://claude.com/claude-code)