### PR TITLE
feat(pose-lib): mirror_pose MCP tool

### DIFF
--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -608,7 +608,8 @@ const QMap<QString, MCPServer::ToolHandler>& MCPServer::toolHandlers()
         {QStringLiteral("list_poses"), &MCPServer::toolListPoses},
         {QStringLiteral("save_pose"), &MCPServer::toolSavePose},
         {QStringLiteral("apply_pose"), &MCPServer::toolApplyPose},
-        {QStringLiteral("delete_pose"), &MCPServer::toolDeletePose}
+        {QStringLiteral("delete_pose"), &MCPServer::toolDeletePose},
+        {QStringLiteral("mirror_pose"), &MCPServer::toolMirrorPose}
     };
     return handlers;
 }
@@ -4630,6 +4631,31 @@ QJsonObject MCPServer::toolDeletePose(const QJsonObject &args)
         QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Indented)));
 }
 
+QJsonObject MCPServer::toolMirrorPose(const QJsonObject &args)
+{
+    SentryReporter::addBreadcrumb("ai.tool_call", "mirror_pose");
+    const QString src = args.value("src").toString();
+    const QString dst = args.value("dst").toString();
+    if (src.isEmpty())
+        return makeErrorResult("Error: missing required 'src' argument");
+    if (dst.isEmpty())
+        return makeErrorResult("Error: missing required 'dst' argument");
+
+    auto* lib = PoseLibrary::instance();
+    if (!lib->mirrorPoseForSelection(src, dst))
+        return makeErrorResult(
+            QString("Error: failed to mirror pose '%1' → '%2' "
+                    "(no selection, no skeleton, or src not found)")
+                .arg(src, dst));
+
+    QJsonObject content;
+    content["ok"] = true;
+    content["src"] = src;
+    content["dst"] = dst;
+    return makeSuccessResult(
+        QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Indented)));
+}
+
 QJsonArray MCPServer::buildToolsList()
 {
     QJsonArray tools;
@@ -5877,6 +5903,26 @@ QJsonArray MCPServer::buildToolsList()
             "delete_pose",
             "Drop a saved pose from the first selected entity's library. "
             "Returns error when the pose name isn't found.",
+            props,
+            required
+        );
+    }
+
+    // mirror_pose
+    {
+        QJsonObject props;
+        props["src"] = QJsonObject{{"type", "string"}, {"description", "Existing pose name to mirror (use list_poses to enumerate)."}};
+        props["dst"] = QJsonObject{{"type", "string"}, {"description", "Output pose name. Overwrites in place if same as `src`."}};
+        QJsonArray required;
+        required.append("src");
+        required.append("dst");
+        appendTool(
+            "mirror_pose",
+            "Mirror a saved pose across the YZ plane using the bone-name "
+            "heuristic. Recognises `_l`/`_r`, `.L`/`.R`, and `Left*`/`Right*` "
+            "naming. TRS flip: pos.x → -pos.x, rotation (w,x,y,z) → (w,x,-y,-z), "
+            "scale.x → -scale.x. Centre-line bones (Spine, Hips, Head) get "
+            "the X-flipped TRS in place. Writes the result under `dst`.",
             props,
             required
         );

--- a/src/MCPServer.h
+++ b/src/MCPServer.h
@@ -247,6 +247,11 @@ private:
     /// Pose-lib D-MCP: drop a saved pose by name. Args: `name`.
     QJsonObject toolDeletePose(const QJsonObject &args);
 
+    /// Pose-lib D-MCP: mirror a saved pose across the YZ plane
+    /// using the _l/_r/.L/.R/Left/Right bone-name heuristic.
+    /// Args: `src` (existing pose), `dst` (output pose name).
+    QJsonObject toolMirrorPose(const QJsonObject &args);
+
     // Animation
     struct NodeAnimation {
         Ogre::SceneNode* node;

--- a/src/MCPServer_test.cpp
+++ b/src/MCPServer_test.cpp
@@ -7283,3 +7283,30 @@ TEST_F(MCPServerTest, SavePose_NoSelectionRejected)
     QJsonObject r = server->callTool("save_pose", args);
     EXPECT_TRUE(isError(r));
 }
+
+TEST_F(MCPServerTest, MirrorPose_MissingSrcRejected)
+{
+    QJsonObject args;
+    args["dst"] = "MCP_MirrorDst";
+    QJsonObject r = server->callTool("mirror_pose", args);
+    EXPECT_TRUE(isError(r));
+    EXPECT_TRUE(getResultText(r).contains("src"));
+}
+
+TEST_F(MCPServerTest, MirrorPose_MissingDstRejected)
+{
+    QJsonObject args;
+    args["src"] = "MCP_MirrorSrc";
+    QJsonObject r = server->callTool("mirror_pose", args);
+    EXPECT_TRUE(isError(r));
+    EXPECT_TRUE(getResultText(r).contains("dst"));
+}
+
+TEST_F(MCPServerTest, MirrorPose_UnknownSrcRejected)
+{
+    QJsonObject args;
+    args["src"] = "MCP_NoSuchPose";
+    args["dst"] = "MCP_AnyDst";
+    QJsonObject r = server->callTool("mirror_pose", args);
+    EXPECT_TRUE(isError(r));
+}

--- a/src/PoseLibrary.cpp
+++ b/src/PoseLibrary.cpp
@@ -331,6 +331,16 @@ bool PoseLibrary::deletePoseForSelection(const QString& name)
     return deletePose(ents.first(), name);
 }
 
+bool PoseLibrary::mirrorPoseForSelection(const QString& srcName,
+                                          const QString& dstName)
+{
+    auto* sel = SelectionSet::getSingleton();
+    if (!sel) return false;
+    auto ents = sel->getResolvedEntities();
+    if (ents.isEmpty()) return false;
+    return mirrorPose(ents.first(), srcName, dstName);
+}
+
 QStringList PoseLibrary::listPosesForSelection() const
 {
     auto* sel = SelectionSet::getSingleton();

--- a/src/PoseLibrary.h
+++ b/src/PoseLibrary.h
@@ -138,6 +138,8 @@ public:
     Q_INVOKABLE bool savePoseForSelection(const QString& name);
     Q_INVOKABLE bool applyPoseForSelection(const QString& name);
     Q_INVOKABLE bool deletePoseForSelection(const QString& name);
+    Q_INVOKABLE bool mirrorPoseForSelection(const QString& srcName,
+                                             const QString& dstName);
     Q_INVOKABLE QStringList listPosesForSelection() const;
 
 signals:


### PR DESCRIPTION
Tiny follow-up exposing D4's mirror feature through MCP so an agent can call "make a right-side variant of this left-side facial pose" in one tool call.

## What ships
- `PoseLibrary::mirrorPoseForSelection(src, dst)` `Q_INVOKABLE` wrapper resolving the entity from `SelectionSet`'s first.
- `mirror_pose` MCP tool with required `src` + `dst`.
- 3 dispatcher tests: missing src, missing dst, unknown src.

🤖 Generated with [Claude Code](https://claude.com/claude-code)