### PR TITLE
review(mcp): clarify mirror_pose dst-overwrite contract

### DIFF
--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -5912,7 +5912,7 @@ QJsonArray MCPServer::buildToolsList()
     {
         QJsonObject props;
         props["src"] = QJsonObject{{"type", "string"}, {"description", "Existing pose name to mirror (use list_poses to enumerate)."}};
-        props["dst"] = QJsonObject{{"type", "string"}, {"description", "Output pose name. Overwrites in place if same as `src`."}};
+        props["dst"] = QJsonObject{{"type", "string"}, {"description", "Output pose name. **Overwrites any existing pose at this name**, including poses unrelated to `src` — pick a unique name (or list_poses first) to avoid silent clobber."}};
         QJsonArray required;
         required.append("src");
         required.append("dst");


### PR DESCRIPTION
Codex P2 on PR #599 (merged): the schema description for `dst` implied "overwrites in place if same as `src`", but `PoseLibrary::mirrorPose` actually does an unconditional `byName.insert(dst, ...)` — any existing pose at `dst` is silently clobbered regardless of `src`.

## Fix
Update the schema description so agents know `dst` is an unconditional overwrite and should be chosen carefully (or `list_poses` called first to avoid stomping unrelated poses).

Code behaviour unchanged; this is a doc-only fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)