### PR TITLE
feat(ps1): Phase 4 mesh reconstruction from capture (#422)

### DIFF
--- a/src/PS1/CMakeLists.txt
+++ b/src/PS1/CMakeLists.txt
@@ -23,10 +23,14 @@ ${CMAKE_CURRENT_SOURCE_DIR}/PS1TIM.h
 if(ENABLE_PS1_RIP)
     list(APPEND SRC_FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/CaptureBuffer.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/CaptureSnapshot.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/EmuCoreLoader.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/GteInverse.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/EmuViewport.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/GpuCommandParser.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/GteCapture.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/MeshReconstructor.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipMeshBuilder.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipLegalityDialog.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipManager.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipSessionWindow.cpp
@@ -38,7 +42,11 @@ if(ENABLE_PS1_RIP)
     )
     list(APPEND HEADER_FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/CaptureBuffer.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/CaptureSnapshot.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/CaptureTypes.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/GteInverse.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/MeshReconstructor.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipMeshBuilder.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/EmuCore.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/EmuCoreLoader.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/EmuFramebuffer.h

--- a/src/PS1/PS1_RIP_DESIGN.md
+++ b/src/PS1/PS1_RIP_DESIGN.md
@@ -76,6 +76,15 @@ See epic #412 for phased issues (#413–#431).
 - `dumpVRAM()` saves `<AppData>/ps1_rip/captures/<id>_vram.png` and feeds `VramViewerWidget` in the session window.
 - Stub core fills CLUT + 4/8/15 bpp test regions each frame via `stubFillVramPattern`.
 
+## Phase 4 status (#422)
+
+- `CaptureSnapshot` copies worker `CaptureBuffer` to the main thread for reconstruction.
+- `GteInverse` approximates GTE screen→model un-projection; PS1 Y-down → editor Y-up.
+- `MeshReconstructor` groups primitives by `matrixId` + texture key, triangulates quads, emits vertex color + UV.
+- `PS1RipMeshBuilder` creates Ogre mesh/submeshes and attaches `PS1Capture_<id>` to the live scene via `Manager`.
+- `captureFrame` builds mesh automatically; session toolbar adds **Arm Capture** / **Capture Frame**.
+- Sentry breadcrumb `ps1.rip.mesh.built` with vertex/triangle counts.
+
 ## Open questions
 
 - mednafen-psx plugin build/integration (replace stub for real emulation).

--- a/src/PS1/runtime/CaptureSnapshot.cpp
+++ b/src/PS1/runtime/CaptureSnapshot.cpp
@@ -1,0 +1,11 @@
+#include "CaptureSnapshot.h"
+#include "CaptureBuffer.h"
+
+CaptureSnapshot CaptureSnapshot::fromBuffer(const CaptureBuffer &buffer)
+{
+    CaptureSnapshot snap;
+    snap.prims = buffer.prims();
+    snap.matrices = buffer.matrices();
+    snap.cameraMatrixId = buffer.cameraMatrixId();
+    return snap;
+}

--- a/src/PS1/runtime/CaptureSnapshot.h
+++ b/src/PS1/runtime/CaptureSnapshot.h
@@ -1,0 +1,23 @@
+#ifndef CAPTURESNAPSHOT_H
+#define CAPTURESNAPSHOT_H
+
+#include "CaptureTypes.h"
+
+#include <QMetaType>
+#include <QVector>
+
+class CaptureBuffer;
+
+/** Thread-safe copy of a frame capture for main-thread reconstruction (#422). */
+struct CaptureSnapshot
+{
+    QVector<PrimRecord> prims;
+    QVector<MatrixRecord> matrices;
+    uint32_t cameraMatrixId = UINT32_MAX;
+
+    static CaptureSnapshot fromBuffer(const CaptureBuffer &buffer);
+};
+
+Q_DECLARE_METATYPE(CaptureSnapshot)
+
+#endif // CAPTURESNAPSHOT_H

--- a/src/PS1/runtime/GteInverse.cpp
+++ b/src/PS1/runtime/GteInverse.cpp
@@ -1,0 +1,41 @@
+#include "GteInverse.h"
+
+#include <cmath>
+
+namespace GteInverse {
+
+bool screenToModel(const MatrixRecord &matrix, int sx, int sy, int sz, float &mx, float &my, float &mz)
+{
+    const double h = matrix.h != 0 ? static_cast<double>(matrix.h) : 4096.0;
+    const double ir3 = sz != 0 ? static_cast<double>(sz) : 4096.0;
+    const double ir1 = ((static_cast<double>(sx) * 65536.0) - matrix.ofx) * ir3 / h;
+    const double ir2 = ((static_cast<double>(sy) * 65536.0) - matrix.ofy) * ir3 / h;
+
+    const double ir[3] = {ir1, ir2, ir3};
+    double vx = 0.0;
+    double vy = 0.0;
+    double vz = 0.0;
+    for (int c = 0; c < 3; ++c) {
+        vx += static_cast<double>(matrix.rt.m[c][0]) * ir[c];
+        vy += static_cast<double>(matrix.rt.m[c][1]) * ir[c];
+        vz += static_cast<double>(matrix.rt.m[c][2]) * ir[c];
+    }
+
+    constexpr double kFixedScale = 1.0 / 4096.0;
+    mx = static_cast<float>(vx * kFixedScale);
+    my = static_cast<float>(vy * kFixedScale);
+    mz = static_cast<float>(vz * kFixedScale);
+    return std::isfinite(mx) && std::isfinite(my) && std::isfinite(mz);
+}
+
+void psxScreenToWorld(float sx, float sy, float sz, float &wx, float &wy, float &wz)
+{
+    constexpr float kCenterX = 160.0f;
+    constexpr float kCenterY = 120.0f;
+    constexpr float kScale = 0.01f;
+    wx = (sx - kCenterX) * kScale;
+    wy = -(sy - kCenterY) * kScale;
+    wz = sz * kScale;
+}
+
+} // namespace GteInverse

--- a/src/PS1/runtime/GteInverse.cpp
+++ b/src/PS1/runtime/GteInverse.cpp
@@ -11,14 +11,14 @@ bool screenToModel(const MatrixRecord &matrix, int sx, int sy, int sz, float &mx
     const double ir1 = ((static_cast<double>(sx) * 65536.0) - matrix.ofx) * ir3 / h;
     const double ir2 = ((static_cast<double>(sy) * 65536.0) - matrix.ofy) * ir3 / h;
 
-    const double ir[3] = {ir1, ir2, ir3};
+    const double irAdj[3] = {ir1 - matrix.tr[0], ir2 - matrix.tr[1], ir3 - matrix.tr[2]};
     double vx = 0.0;
     double vy = 0.0;
     double vz = 0.0;
     for (int c = 0; c < 3; ++c) {
-        vx += static_cast<double>(matrix.rt.m[c][0]) * ir[c];
-        vy += static_cast<double>(matrix.rt.m[c][1]) * ir[c];
-        vz += static_cast<double>(matrix.rt.m[c][2]) * ir[c];
+        vx += static_cast<double>(matrix.rt.m[c][0]) * irAdj[c];
+        vy += static_cast<double>(matrix.rt.m[c][1]) * irAdj[c];
+        vz += static_cast<double>(matrix.rt.m[c][2]) * irAdj[c];
     }
 
     constexpr double kFixedScale = 1.0 / 4096.0;
@@ -36,6 +36,14 @@ void psxScreenToWorld(float sx, float sy, float sz, float &wx, float &wy, float 
     wx = (sx - kCenterX) * kScale;
     wy = -(sy - kCenterY) * kScale;
     wz = sz * kScale;
+}
+
+void modelToEditor(float mx, float my, float mz, float &wx, float &wy, float &wz)
+{
+    constexpr float kScale = 0.01f;
+    wx = mx * kScale;
+    wy = -my * kScale;
+    wz = -mz * kScale;
 }
 
 } // namespace GteInverse

--- a/src/PS1/runtime/GteInverse.h
+++ b/src/PS1/runtime/GteInverse.h
@@ -11,6 +11,9 @@ bool screenToModel(const MatrixRecord &matrix, int sx, int sy, int sz, float &mx
 /** PS1 screen (Y-down) → editor world (Y-up, right-handed). */
 void psxScreenToWorld(float sx, float sy, float sz, float &wx, float &wy, float &wz);
 
+/** GTE model space → editor world (handedness flip only, no screen re-centering). */
+void modelToEditor(float mx, float my, float mz, float &wx, float &wy, float &wz);
+
 } // namespace GteInverse
 
 #endif // GTEINVERSE_H

--- a/src/PS1/runtime/GteInverse.h
+++ b/src/PS1/runtime/GteInverse.h
@@ -1,0 +1,16 @@
+#ifndef GTEINVERSE_H
+#define GTEINVERSE_H
+
+#include "CaptureTypes.h"
+
+/** Approximate inverse of PS1 GTE screen projection (#422). */
+namespace GteInverse {
+
+bool screenToModel(const MatrixRecord &matrix, int sx, int sy, int sz, float &mx, float &my, float &mz);
+
+/** PS1 screen (Y-down) → editor world (Y-up, right-handed). */
+void psxScreenToWorld(float sx, float sy, float sz, float &wx, float &wy, float &wz);
+
+} // namespace GteInverse
+
+#endif // GTEINVERSE_H

--- a/src/PS1/runtime/GteInverse_test.cpp
+++ b/src/PS1/runtime/GteInverse_test.cpp
@@ -1,0 +1,15 @@
+#include "GteInverse.h"
+
+#include <gtest/gtest.h>
+
+TEST(GteInverseTest, ScreenToWorldFlipsY)
+{
+    float wx = 0.0f;
+    float wy = 0.0f;
+    float wz = 0.0f;
+    GteInverse::psxScreenToWorld(160.0f, 120.0f, 0.0f, wx, wy, wz);
+    EXPECT_NEAR(wx, 0.0f, 1e-4f);
+    EXPECT_NEAR(wy, 0.0f, 1e-4f);
+    GteInverse::psxScreenToWorld(160.0f, 140.0f, 0.0f, wx, wy, wz);
+    EXPECT_LT(wy, 0.0f);
+}

--- a/src/PS1/runtime/GteInverse_test.cpp
+++ b/src/PS1/runtime/GteInverse_test.cpp
@@ -1,6 +1,34 @@
 #include "GteInverse.h"
 
+#include <cmath>
 #include <gtest/gtest.h>
+
+static MatrixRecord identityMatrix()
+{
+    MatrixRecord m{};
+    m.rt.m[0][0] = 1 << 12;
+    m.rt.m[1][1] = 1 << 12;
+    m.rt.m[2][2] = 1 << 12;
+    m.h = 256;
+    return m;
+}
+
+TEST(GteInverseTest, ScreenToModelWithTranslation)
+{
+    MatrixRecord matrix = identityMatrix();
+    matrix.tr[0] = 4096;
+    matrix.tr[1] = 0;
+    matrix.tr[2] = 0;
+
+    float mx = 0.0f;
+    float my = 0.0f;
+    float mz = 0.0f;
+    ASSERT_TRUE(GteInverse::screenToModel(matrix, 160, 120, 4096, mx, my, mz));
+    EXPECT_TRUE(std::isfinite(mx));
+    EXPECT_TRUE(std::isfinite(my));
+    EXPECT_TRUE(std::isfinite(mz));
+    EXPECT_NE(mx, 0.0f);
+}
 
 TEST(GteInverseTest, ScreenToWorldFlipsY)
 {

--- a/src/PS1/runtime/MeshReconstructor.cpp
+++ b/src/PS1/runtime/MeshReconstructor.cpp
@@ -51,12 +51,11 @@ ReconstructedVertex vertexFromPsx(const PsxVertex &v, const MatrixRecord *matrix
     float mx = 0.0f;
     float my = 0.0f;
     float mz = 0.0f;
-    if (matrix && GteInverse::screenToModel(*matrix, v.x, v.y, v.z, mx, my, mz)) {
-        GteInverse::psxScreenToWorld(mx, my, mz, out.px, out.py, out.pz);
-    } else {
+    if (matrix && GteInverse::screenToModel(*matrix, v.x, v.y, v.z, mx, my, mz))
+        GteInverse::modelToEditor(mx, my, mz, out.px, out.py, out.pz);
+    else
         GteInverse::psxScreenToWorld(static_cast<float>(v.x), static_cast<float>(v.y),
                                      static_cast<float>(v.z), out.px, out.py, out.pz);
-    }
 
     if (textured) {
         out.u = static_cast<float>(v.u) / 256.0f;

--- a/src/PS1/runtime/MeshReconstructor.cpp
+++ b/src/PS1/runtime/MeshReconstructor.cpp
@@ -1,0 +1,145 @@
+#include "MeshReconstructor.h"
+
+#include "GteInverse.h"
+
+#include <OgreColourValue.h>
+
+#include <QHash>
+
+namespace {
+
+uint32_t packDiffuse(uint8_t r, uint8_t g, uint8_t b)
+{
+    const Ogre::ColourValue cv(r / 255.0f, g / 255.0f, b / 255.0f, 1.0f);
+    return cv.getAsBYTE();
+}
+
+QString textureMaterialName(uint16_t tpage, uint16_t clut)
+{
+    return QStringLiteral("PS1Rip/tpage_%1_clut_%2")
+        .arg(tpage, 4, 16, QChar('0'))
+        .arg(clut, 4, 16, QChar('0'));
+}
+
+quint64 textureGroupKey(uint16_t tpage, uint16_t clut)
+{
+    return (static_cast<quint64>(tpage) << 32) | clut;
+}
+
+struct SubMeshAccumulator {
+    QString materialName;
+    QVector<ReconstructedVertex> vertices;
+    QVector<uint32_t> indices;
+
+    void addTriangle(const ReconstructedVertex &a, const ReconstructedVertex &b, const ReconstructedVertex &c)
+    {
+        const uint32_t base = static_cast<uint32_t>(vertices.size());
+        vertices.append(a);
+        vertices.append(b);
+        vertices.append(c);
+        indices.append(base);
+        indices.append(base + 1);
+        indices.append(base + 2);
+    }
+};
+
+ReconstructedVertex vertexFromPsx(const PsxVertex &v, const MatrixRecord *matrix, bool textured)
+{
+    ReconstructedVertex out;
+    out.diffuseArgb = packDiffuse(v.r, v.g, v.b);
+
+    float mx = 0.0f;
+    float my = 0.0f;
+    float mz = 0.0f;
+    if (matrix && GteInverse::screenToModel(*matrix, v.x, v.y, v.z, mx, my, mz)) {
+        GteInverse::psxScreenToWorld(mx, my, mz, out.px, out.py, out.pz);
+    } else {
+        GteInverse::psxScreenToWorld(static_cast<float>(v.x), static_cast<float>(v.y),
+                                     static_cast<float>(v.z), out.px, out.py, out.pz);
+    }
+
+    if (textured) {
+        out.u = static_cast<float>(v.u) / 256.0f;
+        out.v = static_cast<float>(v.v) / 256.0f;
+    }
+    return out;
+}
+
+void emitPrimitive(const PrimRecord &prim, const MatrixRecord *matrix, SubMeshAccumulator &acc)
+{
+    const bool textured = prim.kind == PrimKind::TexturedTri || prim.kind == PrimKind::TexturedQuad
+                          || prim.kind == PrimKind::Sprite;
+
+    auto vtx = [&](int i) { return vertexFromPsx(prim.verts[i], matrix, textured); };
+
+    if (prim.kind == PrimKind::MonoTri || prim.kind == PrimKind::ShadedTri
+        || prim.kind == PrimKind::TexturedTri) {
+        if (prim.vertexCount >= 3)
+            acc.addTriangle(vtx(0), vtx(1), vtx(2));
+        return;
+    }
+
+    if (prim.kind == PrimKind::MonoQuad || prim.kind == PrimKind::ShadedQuad
+        || prim.kind == PrimKind::TexturedQuad) {
+        if (prim.vertexCount >= 4) {
+            acc.addTriangle(vtx(0), vtx(1), vtx(2));
+            acc.addTriangle(vtx(0), vtx(2), vtx(3));
+        }
+        return;
+    }
+
+    if (prim.kind == PrimKind::Sprite && prim.vertexCount >= 2) {
+        ReconstructedVertex a = vtx(0);
+        ReconstructedVertex b = vtx(1);
+        ReconstructedVertex c = b;
+        ReconstructedVertex d = a;
+        c.py = b.py + 0.05f;
+        d.py = a.py + 0.05f;
+        acc.addTriangle(a, b, c);
+        acc.addTriangle(a, c, d);
+    }
+}
+
+} // namespace
+
+ReconstructedMesh MeshReconstructor::reconstruct(const CaptureSnapshot &snapshot)
+{
+    ReconstructedMesh result;
+    if (snapshot.prims.isEmpty())
+        return result;
+
+    QHash<uint32_t, QHash<quint64, SubMeshAccumulator>> groupsByMatrix;
+
+    for (const PrimRecord &prim : snapshot.prims) {
+        const MatrixRecord *matrix = nullptr;
+        if (prim.matrixId < static_cast<uint32_t>(snapshot.matrices.size()))
+            matrix = &snapshot.matrices[static_cast<int>(prim.matrixId)];
+
+        const quint64 texKey = textureGroupKey(prim.tpage, prim.clut);
+        SubMeshAccumulator &acc = groupsByMatrix[prim.matrixId][texKey];
+        if (acc.materialName.isEmpty())
+            acc.materialName = textureMaterialName(prim.tpage, prim.clut);
+        emitPrimitive(prim, matrix, acc);
+    }
+
+    int subIndex = 0;
+    for (auto matIt = groupsByMatrix.constBegin(); matIt != groupsByMatrix.constEnd(); ++matIt) {
+        for (auto texIt = matIt.value().constBegin(); texIt != matIt.value().constEnd(); ++texIt) {
+            const SubMeshAccumulator &acc = texIt.value();
+            if (acc.vertices.isEmpty() || acc.indices.size() < 3)
+                continue;
+
+            ReconstructedSubMesh sub;
+            sub.materialName = acc.materialName;
+            sub.vertices = acc.vertices;
+            sub.indices = acc.indices;
+            result.subMeshes.append(sub);
+            result.vertexCount += acc.vertices.size();
+            result.triangleCount += acc.indices.size() / 3;
+            ++subIndex;
+        }
+    }
+
+    result.meshName = QStringLiteral("ps1_capture");
+    return result;
+}

--- a/src/PS1/runtime/MeshReconstructor.h
+++ b/src/PS1/runtime/MeshReconstructor.h
@@ -1,0 +1,44 @@
+#ifndef MESHRECONSTRUCTOR_H
+#define MESHRECONSTRUCTOR_H
+
+#include "CaptureSnapshot.h"
+
+#include <QString>
+#include <QVector>
+
+/** One vertex in reconstructed editor space (#422). */
+struct ReconstructedVertex {
+    float px = 0.0f;
+    float py = 0.0f;
+    float pz = 0.0f;
+    float nx = 0.0f;
+    float ny = 1.0f;
+    float nz = 0.0f;
+    float u = 0.0f;
+    float v = 0.0f;
+    uint32_t diffuseArgb = 0xFFFFFFFFu;
+};
+
+struct ReconstructedSubMesh {
+    QString materialName;
+    QVector<ReconstructedVertex> vertices;
+    QVector<uint32_t> indices;
+};
+
+struct ReconstructedMesh {
+    QString meshName;
+    QVector<ReconstructedSubMesh> subMeshes;
+    int vertexCount = 0;
+    int triangleCount = 0;
+
+    bool isEmpty() const { return subMeshes.isEmpty(); }
+};
+
+/** Builds editor-space meshes from a captured primitive stream (#422). */
+class MeshReconstructor
+{
+public:
+    static ReconstructedMesh reconstruct(const CaptureSnapshot &snapshot);
+};
+
+#endif // MESHRECONSTRUCTOR_H

--- a/src/PS1/runtime/MeshReconstructor.h
+++ b/src/PS1/runtime/MeshReconstructor.h
@@ -12,7 +12,7 @@ struct ReconstructedVertex {
     float py = 0.0f;
     float pz = 0.0f;
     float nx = 0.0f;
-    float ny = 1.0f;
+    float ny = 0.0f;
     float nz = 0.0f;
     float u = 0.0f;
     float v = 0.0f;

--- a/src/PS1/runtime/MeshReconstructor_test.cpp
+++ b/src/PS1/runtime/MeshReconstructor_test.cpp
@@ -1,0 +1,75 @@
+#include "CaptureSnapshot.h"
+#include "MeshReconstructor.h"
+
+#include <gtest/gtest.h>
+
+static MatrixRecord identityMatrix()
+{
+    MatrixRecord m{};
+    m.rt.m[0][0] = 1 << 12;
+    m.rt.m[1][1] = 1 << 12;
+    m.rt.m[2][2] = 1 << 12;
+    m.h = 256;
+    return m;
+}
+
+static PrimRecord coloredTri(int x0, int y0, uint32_t matrixId)
+{
+    PrimRecord prim{};
+    prim.kind = PrimKind::MonoTri;
+    prim.vertexCount = 3;
+    prim.matrixId = matrixId;
+    prim.tpage = 0x100;
+    prim.clut = 0x200;
+    prim.verts[0] = {x0, y0, 0, 255, 0, 0, 0, 0};
+    prim.verts[1] = {x0 + 32, y0, 0, 0, 255, 0, 0, 0};
+    prim.verts[2] = {x0 + 16, y0 + 24, 0, 0, 0, 255, 0, 0};
+    return prim;
+}
+
+TEST(MeshReconstructorTest, GroupsByMatrixAndTexture)
+{
+    CaptureSnapshot snap;
+    snap.matrices.append(identityMatrix());
+    MatrixRecord other = identityMatrix();
+    other.tr[0] = 1024;
+    snap.matrices.append(other);
+
+    snap.prims.append(coloredTri(16, 16, 0));
+    snap.prims.append(coloredTri(80, 16, 1));
+
+    const ReconstructedMesh mesh = MeshReconstructor::reconstruct(snap);
+    EXPECT_FALSE(mesh.isEmpty());
+    EXPECT_EQ(mesh.subMeshes.size(), 2);
+    EXPECT_GE(mesh.vertexCount, 6);
+    EXPECT_GE(mesh.triangleCount, 2);
+}
+
+TEST(MeshReconstructorTest, TriangulatesQuad)
+{
+    CaptureSnapshot snap;
+    snap.matrices.append(identityMatrix());
+
+    PrimRecord quad{};
+    quad.kind = PrimKind::MonoQuad;
+    quad.vertexCount = 4;
+    quad.matrixId = 0;
+    quad.tpage = 0;
+    quad.clut = 0;
+    quad.verts[0] = {10, 10, 0, 255, 255, 255, 0, 0};
+    quad.verts[1] = {40, 10, 0, 255, 255, 255, 0, 0};
+    quad.verts[2] = {40, 40, 0, 255, 255, 255, 0, 0};
+    quad.verts[3] = {10, 40, 0, 255, 255, 255, 0, 0};
+    snap.prims.append(quad);
+
+    const ReconstructedMesh mesh = MeshReconstructor::reconstruct(snap);
+    ASSERT_EQ(mesh.subMeshes.size(), 1);
+    EXPECT_EQ(mesh.subMeshes[0].indices.size(), 6u);
+    EXPECT_EQ(mesh.triangleCount, 2);
+}
+
+TEST(MeshReconstructorTest, EmptySnapshotReturnsEmpty)
+{
+    const ReconstructedMesh mesh = MeshReconstructor::reconstruct(CaptureSnapshot{});
+    EXPECT_TRUE(mesh.isEmpty());
+}

--- a/src/PS1/runtime/PS1RipManager.cpp
+++ b/src/PS1/runtime/PS1RipManager.cpp
@@ -1,4 +1,7 @@
 #include "PS1RipManager.h"
+#include "CaptureSnapshot.h"
+#include "MeshReconstructor.h"
+#include "PS1RipMeshBuilder.h"
 #include "PS1RipWorker.h"
 #include "SentryReporter.h"
 
@@ -40,6 +43,7 @@ PS1RipManager::~PS1RipManager()
 void PS1RipManager::initializeWorkerThread()
 {
     qRegisterMetaType<QVector<uint16_t>>("QVector<uint16_t>");
+    qRegisterMetaType<CaptureSnapshot>("CaptureSnapshot");
 
     m_workerThread = new QThread(this);
     m_worker = new PS1RipWorker();
@@ -64,11 +68,31 @@ void PS1RipManager::initializeWorkerThread()
         reportError(msg);
     });
     connect(m_worker, &PS1RipWorker::framePresented, this, &PS1RipManager::framePresented);
-    connect(m_worker, &PS1RipWorker::frameCaptureReady, this, [this](const QString &captureId, int) {
-        SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
-                                      QStringLiteral("ps1_rip_frame:%1").arg(captureId));
-        emit frameCaptured(captureId);
-    });
+    connect(m_worker, &PS1RipWorker::frameCaptureReady, this,
+            [this](const QString &captureId, const CaptureSnapshot &snapshot, int) {
+                SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
+                                              QStringLiteral("ps1_rip_frame:%1").arg(captureId));
+
+                emit frameCaptured(captureId);
+
+                const ReconstructedMesh mesh = MeshReconstructor::reconstruct(snapshot);
+                if (mesh.isEmpty()) {
+                    reportError(tr("Capture produced no reconstructable geometry"));
+                    return;
+                }
+
+                PS1RipMeshBuilder::BuildResult built;
+                QString buildErr;
+                if (!PS1RipMeshBuilder::attachToScene(mesh, captureId, &built, &buildErr)) {
+                    reportError(buildErr);
+                    return;
+                }
+
+                SentryReporter::addBreadcrumb(
+                    QStringLiteral("ps1.rip.mesh.built"),
+                    QStringLiteral("%1 verts %2 tris").arg(built.vertexCount).arg(built.triangleCount));
+                emit meshBuilt(captureId, built.vertexCount, built.triangleCount);
+            });
     connect(m_worker, &PS1RipWorker::vramDumpReady, this,
             [this](const QString &captureId, const QString &pngPath, const QVector<uint16_t> &cells,
                    const QImage &preview) {

--- a/src/PS1/runtime/PS1RipManager.h
+++ b/src/PS1/runtime/PS1RipManager.h
@@ -48,6 +48,7 @@ signals:
     void sessionStopped();
     void framePresented(const QImage &frame, quint64 frameIndex);
     void frameCaptured(const QString &captureId);
+    void meshBuilt(const QString &captureId, int vertexCount, int triangleCount);
     void sceneCaptured(const QString &captureId);
     void vramDumped(const QString &captureId, const QString &pngPath, const QVector<uint16_t> &cells,
                     const QImage &nativePreview);

--- a/src/PS1/runtime/PS1RipMeshBuilder.cpp
+++ b/src/PS1/runtime/PS1RipMeshBuilder.cpp
@@ -1,0 +1,152 @@
+#include "PS1RipMeshBuilder.h"
+
+#include "Manager.h"
+
+#include <QVector>
+#include <vector>
+
+#include <OgreEntity.h>
+#include <OgreResourceGroupManager.h>
+#include <OgreHardwareBufferManager.h>
+#include <OgreMaterialManager.h>
+#include <OgreMesh.h>
+#include <OgreMeshManager.h>
+#include <OgrePass.h>
+#include <OgreSceneNode.h>
+#include <OgreSubMesh.h>
+#include <OgreTechnique.h>
+
+namespace {
+
+Ogre::MaterialPtr ensureMaterial(const QString &name)
+{
+    const std::string matName = name.toStdString();
+    if (Ogre::MaterialManager::getSingleton().resourceExists(matName))
+        return Ogre::MaterialManager::getSingleton().getByName(matName);
+
+    Ogre::MaterialPtr mat = Ogre::MaterialManager::getSingleton().create(
+        matName, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+    Ogre::Pass *pass = mat->getTechnique(0)->getPass(0);
+    pass->setLightingEnabled(true);
+    pass->setVertexColourTracking(Ogre::TVC_DIFFUSE);
+    pass->setDiffuse(Ogre::ColourValue::White);
+    return mat;
+}
+
+void writeSubMesh(const ReconstructedSubMesh &sub, Ogre::SubMesh *ogreSub)
+{
+    ogreSub->useSharedVertices = false;
+    ogreSub->vertexData = new Ogre::VertexData();
+    ogreSub->vertexData->vertexCount = static_cast<uint32_t>(sub.vertices.size());
+
+    Ogre::VertexDeclaration *decl = ogreSub->vertexData->vertexDeclaration;
+    Ogre::VertexBufferBinding *binding = ogreSub->vertexData->vertexBufferBinding;
+
+    size_t offset = 0;
+    decl->addElement(0, offset, Ogre::VET_FLOAT3, Ogre::VES_POSITION);
+    offset += Ogre::VertexElement::getTypeSize(Ogre::VET_FLOAT3);
+    decl->addElement(0, offset, Ogre::VET_FLOAT3, Ogre::VES_NORMAL);
+    offset += Ogre::VertexElement::getTypeSize(Ogre::VET_FLOAT3);
+    decl->addElement(0, offset, Ogre::VET_FLOAT2, Ogre::VES_TEXTURE_COORDINATES);
+    offset += Ogre::VertexElement::getTypeSize(Ogre::VET_FLOAT2);
+    decl->addElement(1, 0, Ogre::VET_COLOUR, Ogre::VES_DIFFUSE);
+
+    const size_t stride0 = decl->getVertexSize(0);
+    Ogre::HardwareVertexBufferSharedPtr vbuf0 =
+        Ogre::HardwareBufferManager::getSingleton().createVertexBuffer(
+            stride0, sub.vertices.size(), Ogre::HardwareBuffer::HBU_STATIC_WRITE_ONLY);
+
+    std::vector<float> buf0(stride0 * sub.vertices.size() / sizeof(float), 0.0f);
+    for (size_t i = 0; i < sub.vertices.size(); ++i) {
+        const ReconstructedVertex &v = sub.vertices[static_cast<int>(i)];
+        float *base = buf0.data() + (i * stride0) / sizeof(float);
+        base[0] = v.px;
+        base[1] = v.py;
+        base[2] = v.pz;
+        base[3] = v.nx;
+        base[4] = v.ny;
+        base[5] = v.nz;
+        base[6] = v.u;
+        base[7] = v.v;
+    }
+    vbuf0->writeData(0, stride0 * sub.vertices.size(), buf0.data());
+    binding->setBinding(0, vbuf0);
+
+    Ogre::HardwareVertexBufferSharedPtr vbuf1 =
+        Ogre::HardwareBufferManager::getSingleton().createVertexBuffer(
+            Ogre::VertexElement::getTypeSize(Ogre::VET_COLOUR), sub.vertices.size(),
+            Ogre::HardwareBuffer::HBU_STATIC_WRITE_ONLY);
+    QVector<uint32_t> colors;
+    colors.reserve(sub.vertices.size());
+    for (const ReconstructedVertex &v : sub.vertices)
+        colors.append(v.diffuseArgb);
+    vbuf1->writeData(0, colors.size() * sizeof(uint32_t), colors.constData());
+    binding->setBinding(1, vbuf1);
+
+    ogreSub->indexData->indexCount = sub.indices.size();
+    Ogre::HardwareIndexBufferSharedPtr ibuf =
+        Ogre::HardwareBufferManager::getSingleton().createIndexBuffer(
+            Ogre::HardwareIndexBuffer::IT_32BIT, sub.indices.size(),
+            Ogre::HardwareBuffer::HBU_STATIC_WRITE_ONLY);
+    ibuf->writeData(0, sub.indices.size() * sizeof(uint32_t), sub.indices.constData());
+    ogreSub->indexData->indexBuffer = ibuf;
+}
+
+} // namespace
+
+bool PS1RipMeshBuilder::attachToScene(const ReconstructedMesh &mesh, const QString &captureId,
+                                        BuildResult *resultOut, QString *errorOut)
+{
+    if (mesh.isEmpty()) {
+        if (errorOut)
+            *errorOut = QStringLiteral("Reconstructed mesh is empty");
+        return false;
+    }
+
+    Manager *mgr = Manager::getSingletonPtr();
+    if (!mgr) {
+        if (errorOut)
+            *errorOut = QStringLiteral("Editor scene is not available");
+        return false;
+    }
+
+    const QString meshName = mesh.meshName + QLatin1Char('_') + captureId;
+    const std::string ogreMeshName = meshName.toStdString();
+
+    if (Ogre::MeshManager::getSingleton().resourceExists(ogreMeshName))
+        Ogre::MeshManager::getSingleton().remove(ogreMeshName);
+
+    Ogre::MeshPtr ogreMesh = Ogre::MeshManager::getSingleton().createManual(
+        ogreMeshName, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+
+    Ogre::AxisAlignedBox bounds;
+    bounds.setNull();
+
+    for (const ReconstructedSubMesh &sub : mesh.subMeshes) {
+        Ogre::SubMesh *ogreSub = ogreMesh->createSubMesh();
+        ogreSub->setMaterialName(ensureMaterial(sub.materialName)->getName());
+        writeSubMesh(sub, ogreSub);
+
+        for (const ReconstructedVertex &v : sub.vertices)
+            bounds.merge(Ogre::Vector3(v.px, v.py, v.pz));
+    }
+
+    if (bounds.isNull())
+        bounds = Ogre::AxisAlignedBox(-0.5f, -0.5f, -0.5f, 0.5f, 0.5f, 0.5f);
+
+    ogreMesh->_setBounds(bounds);
+    ogreMesh->_setBoundingSphereRadius(bounds.getHalfSize().length());
+    ogreMesh->load();
+
+    const QString nodeName = QStringLiteral("PS1Capture_%1").arg(captureId);
+    Ogre::SceneNode *node = mgr->addSceneNode(nodeName);
+    Ogre::Entity *entity = mgr->createEntity(node, ogreMesh);
+
+    if (resultOut) {
+        resultOut->sceneNode = node;
+        resultOut->entity = entity;
+        resultOut->vertexCount = mesh.vertexCount;
+        resultOut->triangleCount = mesh.triangleCount;
+    }
+    return entity != nullptr;
+}

--- a/src/PS1/runtime/PS1RipMeshBuilder.cpp
+++ b/src/PS1/runtime/PS1RipMeshBuilder.cpp
@@ -27,7 +27,7 @@ Ogre::MaterialPtr ensureMaterial(const QString &name)
     Ogre::MaterialPtr mat = Ogre::MaterialManager::getSingleton().create(
         matName, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
     Ogre::Pass *pass = mat->getTechnique(0)->getPass(0);
-    pass->setLightingEnabled(true);
+    pass->setLightingEnabled(false);
     pass->setVertexColourTracking(Ogre::TVC_DIFFUSE);
     pass->setDiffuse(Ogre::ColourValue::White);
     return mat;
@@ -142,11 +142,17 @@ bool PS1RipMeshBuilder::attachToScene(const ReconstructedMesh &mesh, const QStri
     Ogre::SceneNode *node = mgr->addSceneNode(nodeName);
     Ogre::Entity *entity = mgr->createEntity(node, ogreMesh);
 
+    if (!entity) {
+        if (errorOut)
+            *errorOut = QStringLiteral("Failed to create Ogre entity for reconstructed mesh");
+        return false;
+    }
+
     if (resultOut) {
         resultOut->sceneNode = node;
         resultOut->entity = entity;
         resultOut->vertexCount = mesh.vertexCount;
         resultOut->triangleCount = mesh.triangleCount;
     }
-    return entity != nullptr;
+    return true;
 }

--- a/src/PS1/runtime/PS1RipMeshBuilder.h
+++ b/src/PS1/runtime/PS1RipMeshBuilder.h
@@ -1,0 +1,28 @@
+#ifndef PS1RIPMESHBUILDER_H
+#define PS1RIPMESHBUILDER_H
+
+#include "MeshReconstructor.h"
+
+#include <QString>
+
+namespace Ogre {
+class Entity;
+class SceneNode;
+}
+
+/** Attaches reconstructed capture meshes to the live Ogre scene (#422). */
+class PS1RipMeshBuilder
+{
+public:
+    struct BuildResult {
+        Ogre::SceneNode *sceneNode = nullptr;
+        Ogre::Entity *entity = nullptr;
+        int vertexCount = 0;
+        int triangleCount = 0;
+    };
+
+    static bool attachToScene(const ReconstructedMesh &mesh, const QString &captureId,
+                              BuildResult *resultOut, QString *errorOut = nullptr);
+};
+
+#endif // PS1RIPMESHBUILDER_H

--- a/src/PS1/runtime/PS1RipSessionWindow.cpp
+++ b/src/PS1/runtime/PS1RipSessionWindow.cpp
@@ -6,6 +6,7 @@
 #include "VramViewerWidget.h"
 
 #include <QAction>
+#include <QSignalBlocker>
 #include <QApplication>
 #include <QCloseEvent>
 #include <QDateTime>
@@ -56,6 +57,10 @@ PS1RipSessionWindow::PS1RipSessionWindow(QWidget *parent)
     auto *armCapAct = toolbar->addAction(tr("Arm Capture"));
     armCapAct->setCheckable(true);
     connect(armCapAct, &QAction::toggled, this, [this](bool on) { m_manager->armCapture(on); });
+    connect(m_manager, &PS1RipManager::sessionStopped, this, [armCapAct]() {
+        QSignalBlocker blocker(armCapAct);
+        armCapAct->setChecked(false);
+    });
     auto *captureAct = toolbar->addAction(tr("Capture Frame"));
     connect(captureAct, &QAction::triggered, this, &PS1RipSessionWindow::onCaptureFrame);
     auto *dumpVramAct = toolbar->addAction(tr("Dump VRAM"));

--- a/src/PS1/runtime/PS1RipSessionWindow.cpp
+++ b/src/PS1/runtime/PS1RipSessionWindow.cpp
@@ -53,6 +53,11 @@ PS1RipSessionWindow::PS1RipSessionWindow(QWidget *parent)
     auto *resetAct = toolbar->addAction(tr("Reset"));
     connect(resetAct, &QAction::triggered, this, &PS1RipSessionWindow::onReset);
     toolbar->addSeparator();
+    auto *armCapAct = toolbar->addAction(tr("Arm Capture"));
+    armCapAct->setCheckable(true);
+    connect(armCapAct, &QAction::toggled, this, [this](bool on) { m_manager->armCapture(on); });
+    auto *captureAct = toolbar->addAction(tr("Capture Frame"));
+    connect(captureAct, &QAction::triggered, this, &PS1RipSessionWindow::onCaptureFrame);
     auto *dumpVramAct = toolbar->addAction(tr("Dump VRAM"));
     connect(dumpVramAct, &QAction::triggered, this, &PS1RipSessionWindow::onDumpVram);
 
@@ -73,6 +78,7 @@ PS1RipSessionWindow::PS1RipSessionWindow(QWidget *parent)
             [this]() { m_statusLabel->setText(tr("Stopped")); });
     connect(m_manager, &PS1RipManager::error, this, &PS1RipSessionWindow::onError);
     connect(m_manager, &PS1RipManager::vramDumped, this, &PS1RipSessionWindow::onVramDumped);
+    connect(m_manager, &PS1RipManager::meshBuilt, this, &PS1RipSessionWindow::onMeshBuilt);
 
     const QString savedBios = QSettings().value(QString::fromLatin1(kSettingsGroup) + QLatin1Char('/')
                                                   + QString::fromLatin1(kBiosKey))
@@ -197,6 +203,20 @@ void PS1RipSessionWindow::onDumpVram()
 {
     SentryReporter::addBreadcrumb(QStringLiteral("ui.action"), QStringLiteral("ps1_rip_dump_vram"));
     m_manager->dumpVRAM();
+}
+
+void PS1RipSessionWindow::onCaptureFrame()
+{
+    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"), QStringLiteral("ps1_rip_capture_frame"));
+    m_manager->captureFrame();
+}
+
+void PS1RipSessionWindow::onMeshBuilt(const QString &captureId, int vertexCount, int triangleCount)
+{
+    m_statusLabel->setText(tr("Mesh built: %1 (%2 verts, %3 tris) — see main scene")
+                               .arg(captureId)
+                               .arg(vertexCount)
+                               .arg(triangleCount));
 }
 
 void PS1RipSessionWindow::onVramDumped(const QString &captureId, const QString &pngPath,

--- a/src/PS1/runtime/PS1RipSessionWindow.h
+++ b/src/PS1/runtime/PS1RipSessionWindow.h
@@ -35,8 +35,10 @@ private slots:
     void onFrame(const QImage &frame, quint64 frameIndex);
     void onError(const QString &message);
     void onDumpVram();
+    void onCaptureFrame();
     void onVramDumped(const QString &captureId, const QString &pngPath, const QVector<uint16_t> &cells,
                       const QImage &nativePreview);
+    void onMeshBuilt(const QString &captureId, int vertexCount, int triangleCount);
 
 private:
     void updateFps(quint64 frameIndex);

--- a/src/PS1/runtime/PS1RipWorker.cpp
+++ b/src/PS1/runtime/PS1RipWorker.cpp
@@ -7,6 +7,7 @@
 #include "EmuFramebuffer.h"
 #include "GpuCommandParser.h"
 #include "RipperHooks.h"
+#include "SentryReporter.h"
 #include "VramSnapshot.h"
 
 #include <QDateTime>
@@ -187,6 +188,8 @@ void PS1RipWorker::finalizeFrameCapture()
     }
     file.close();
 
+    SentryReporter::addBreadcrumb(QStringLiteral("ps1.rip.capture"),
+                                QStringLiteral("%1 prims:%2").arg(captureId).arg(prims.size()));
     emit frameCaptureReady(captureId, CaptureSnapshot::fromBuffer(*m_captureBuffer), prims.size());
 }
 

--- a/src/PS1/runtime/PS1RipWorker.cpp
+++ b/src/PS1/runtime/PS1RipWorker.cpp
@@ -1,5 +1,7 @@
 #include "PS1RipWorker.h"
 #include "CaptureBuffer.h"
+#include "CaptureSnapshot.h"
+#include "CaptureSnapshot.h"
 #include "EmuCore.h"
 #include "EmuCoreLoader.h"
 #include "EmuFramebuffer.h"
@@ -185,7 +187,7 @@ void PS1RipWorker::finalizeFrameCapture()
     }
     file.close();
 
-    emit frameCaptureReady(captureId, prims.size());
+    emit frameCaptureReady(captureId, CaptureSnapshot::fromBuffer(*m_captureBuffer), prims.size());
 }
 
 void PS1RipWorker::dumpVram()

--- a/src/PS1/runtime/PS1RipWorker.h
+++ b/src/PS1/runtime/PS1RipWorker.h
@@ -1,6 +1,8 @@
 #ifndef PS1RIPWORKER_H
 #define PS1RIPWORKER_H
 
+#include "CaptureSnapshot.h"
+
 #include <QImage>
 #include <QObject>
 #include <QString>
@@ -48,7 +50,7 @@ signals:
     void emulationStopped();
     void framePresented(const QImage &frame, quint64 frameIndex);
     void emulationError(const QString &message);
-    void frameCaptureReady(const QString &captureId, int primCount);
+    void frameCaptureReady(const QString &captureId, const CaptureSnapshot &snapshot, int primCount);
     void vramDumpReady(const QString &captureId, const QString &pngPath, const QVector<uint16_t> &cells,
                        const QImage &nativePreview);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -138,10 +138,14 @@ if(BUILD_TESTS)
     if(ENABLE_PS1_RIP)
         list(APPEND TEST_SRC_FILES
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/CaptureBuffer.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/CaptureSnapshot.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/EmuCoreLoader.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/GteInverse.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/EmuViewport.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/GpuCommandParser.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/GteCapture.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/MeshReconstructor.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PS1RipMeshBuilder.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PS1RipLegalityDialog.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PS1RipManager.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PS1RipSessionWindow.cpp


### PR DESCRIPTION
## Summary
- Add `CaptureSnapshot`, `GteInverse`, `MeshReconstructor`, and `PS1RipMeshBuilder` to turn captured primitives into Ogre meshes
- Group by `matrixId` + texture key; triangulate quads; vertex color + UV; PS1 Y-down → editor Y-up
- `captureFrame` imports `PS1Capture_<id>` into the main scene when the editor is open
- Session toolbar: **Arm Capture** + **Capture Frame**; Sentry `ps1.rip.mesh.built`

## Test plan
- [x] `UnitTests --gtest_filter="MeshReconstructorTest.*:GteInverseTest.*"`
- [x] `PS1RipManagerTest.ArmedCaptureAccumulatesPrimitives`
- [ ] CI Linux with `ENABLE_PS1_RIP=ON`
- [ ] Manual: main editor open → PS1 Ripper → Arm Capture → Capture Frame → `PS1Capture_*` node in scene tree

Closes #422 (epic #412 Phase 4).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic mesh reconstruction from PS1 captures, with geometry now displayed in the scene
  * Added "Arm Capture" and "Capture Frame" toolbar actions to the capture session window
  * Added real-time status updates showing mesh build results with vertex and triangle counts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/601?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->