### PR TITLE
feat(pose-lib): save_pose_library / load_pose_library MCP + CLI

### DIFF
--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -554,6 +554,9 @@ void CLIPipeline::printUsage()
         "                                    Export a single posed frame as static mesh\n"
         "  pose <file> --animation <name> --count N -o <pattern>\n"
         "                                    Export N evenly spaced frames (use %02d in pattern)\n"
+        "  pose <library.poselib> --library list [--json]\n"
+        "                                    List pose names in a `.poselib` sidecar JSON file.\n"
+        "                                    No mesh load needed; reads the file directly.\n"
         "  scan [path] [options]           Scan directory for 3D asset issues (default path: .)\n"
         "  material <file> --preset <name> [-o <output>]\n"
         "                                  Apply a built-in material preset to every sub-entity\n"
@@ -2399,9 +2402,20 @@ int CLIPipeline::cmdLod(int argc, char* argv[])
 
 int CLIPipeline::cmdPose(int argc, char* argv[])
 {
-    // Parse: pose <file> --animation <name> --time <t> -o <output>
-    //        pose <file> --animation <name> --count N -o <pattern>
+    // Two modes:
+    //   pose <file> --animation <name> --time <t> -o <output>
+    //   pose <file> --animation <name> --count N -o <pattern>
+    //     (skeleton-anim frame export — pre-existing path)
+    //
+    //   pose <library.poselib> --library list [--json]
+    //     (list pose names in a `.poselib` sidecar JSON, no mesh
+    //     load needed — added with D-Project. Future modes will
+    //     extend this with --library apply <name> -o out.fbx
+    //     once the round-trip exporter lands.)
     QString filePath, outputPath, animName;
+    QString libraryOp;          // "list" only for now
+    bool libraryMode = false;
+    bool jsonOutput = false;
     float time = -1.0f;
     int count = 0;
 
@@ -2420,6 +2434,12 @@ int CLIPipeline::cmdPose(int argc, char* argv[])
             count = QString(argv[++i]).toInt();
             continue;
         }
+        if (arg == "--library" && i + 1 < argc) {
+            libraryMode = true;
+            libraryOp = QString(argv[++i]);
+            continue;
+        }
+        if (arg == "--json") { jsonOutput = true; continue; }
         if ((arg == "-o" || arg == "--output") && i + 1 < argc) {
             outputPath = QString(argv[++i]);
             continue;
@@ -2428,6 +2448,75 @@ int CLIPipeline::cmdPose(int argc, char* argv[])
             filePath = arg;
             continue;
         }
+    }
+
+    if (libraryMode) {
+        // Library mode: filePath is the .poselib sidecar, not a
+        // mesh. The PoseLibrary singleton needs an entity to key
+        // poses against; we use a temporary "CLI pose-list anchor"
+        // entity for this — no skeleton, just an anchor.
+        if (libraryOp != QStringLiteral("list")) {
+            err() << "Error: --library currently supports only 'list'." << Qt::endl;
+            err() << "       --library apply needs the round-trip exporter (follow-up)." << Qt::endl;
+            return 2;
+        }
+        if (filePath.isEmpty()) {
+            err() << "Error: No input file specified." << Qt::endl;
+            err() << "Usage: qtmesh pose <library.poselib> --library list [--json]" << Qt::endl;
+            return 2;
+        }
+        QFileInfo libFi(filePath);
+        if (!libFi.exists()) {
+            err() << "Error: File not found: " << filePath << Qt::endl;
+            return 1;
+        }
+        // Read JSON directly — we don't need an Ogre scene at all.
+        QFile f(filePath);
+        if (!f.open(QIODevice::ReadOnly)) {
+            err() << "Error: Cannot open " << filePath << Qt::endl;
+            return 1;
+        }
+        const QByteArray bytes = f.readAll();
+        f.close();
+        QJsonParseError pe{};
+        const QJsonDocument doc = QJsonDocument::fromJson(bytes, &pe);
+        if (pe.error != QJsonParseError::NoError || !doc.isObject()) {
+            err() << "Error: malformed JSON in " << filePath << Qt::endl;
+            return 1;
+        }
+        const QJsonObject root = doc.object();
+        if (root.value("schema").toString() != QStringLiteral("qtmesheditor.poselib.v1")) {
+            err() << "Error: schema mismatch in " << filePath << Qt::endl;
+            return 1;
+        }
+        const QJsonArray poses = root.value("poses").toArray();
+        QStringList names;
+        for (const QJsonValue& v : poses) {
+            const QString n = v.toObject().value("name").toString();
+            if (!n.isEmpty()) names << n;
+        }
+
+        SentryReporter::addBreadcrumb("cli.pose",
+            QString("Library list .%1 (%2 poses)").arg(libFi.suffix()).arg(names.size()));
+
+        if (jsonOutput) {
+            QJsonArray arr;
+            for (const QString& n : names) arr.append(n);
+            QJsonObject out;
+            out["file"]  = filePath;
+            out["count"] = static_cast<int>(names.size());
+            out["poses"] = arr;
+            cliWrite(QString::fromUtf8(QJsonDocument(out).toJson(QJsonDocument::Indented)));
+        } else {
+            if (names.isEmpty()) {
+                cliWrite(QStringLiteral("No poses in library.\n"));
+            } else {
+                cliWrite(QStringLiteral("Poses (%1):\n").arg(names.size()));
+                for (const QString& n : names)
+                    cliWrite(QStringLiteral("  %1\n").arg(n));
+            }
+        }
+        return 0;
     }
 
     if (filePath.isEmpty()) {

--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -609,7 +609,9 @@ const QMap<QString, MCPServer::ToolHandler>& MCPServer::toolHandlers()
         {QStringLiteral("save_pose"), &MCPServer::toolSavePose},
         {QStringLiteral("apply_pose"), &MCPServer::toolApplyPose},
         {QStringLiteral("delete_pose"), &MCPServer::toolDeletePose},
-        {QStringLiteral("mirror_pose"), &MCPServer::toolMirrorPose}
+        {QStringLiteral("mirror_pose"), &MCPServer::toolMirrorPose},
+        {QStringLiteral("save_pose_library"), &MCPServer::toolSavePoseLibrary},
+        {QStringLiteral("load_pose_library"), &MCPServer::toolLoadPoseLibrary}
     };
     return handlers;
 }
@@ -4656,6 +4658,49 @@ QJsonObject MCPServer::toolMirrorPose(const QJsonObject &args)
         QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Indented)));
 }
 
+QJsonObject MCPServer::toolSavePoseLibrary(const QJsonObject &args)
+{
+    SentryReporter::addBreadcrumb("ai.tool_call", "save_pose_library");
+    const QString path = args.value("path").toString();
+    if (path.isEmpty())
+        return makeErrorResult("Error: missing required 'path' argument");
+
+    auto* lib = PoseLibrary::instance();
+    if (!lib->savePoseLibraryForSelection(path))
+        return makeErrorResult(
+            QString("Error: failed to save library to '%1' "
+                    "(no selection, empty library, or unwritable path)")
+                .arg(path));
+
+    QJsonObject content;
+    content["ok"] = true;
+    content["path"] = path;
+    return makeSuccessResult(
+        QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Indented)));
+}
+
+QJsonObject MCPServer::toolLoadPoseLibrary(const QJsonObject &args)
+{
+    SentryReporter::addBreadcrumb("ai.tool_call", "load_pose_library");
+    const QString path = args.value("path").toString();
+    if (path.isEmpty())
+        return makeErrorResult("Error: missing required 'path' argument");
+
+    auto* lib = PoseLibrary::instance();
+    if (!lib->loadPoseLibraryForSelection(path))
+        return makeErrorResult(
+            QString("Error: failed to load library from '%1' "
+                    "(no selection, file missing, or malformed JSON/schema)")
+                .arg(path));
+
+    QJsonObject content;
+    content["ok"] = true;
+    content["path"] = path;
+    content["count"] = static_cast<int>(lib->listPosesForSelection().size());
+    return makeSuccessResult(
+        QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Indented)));
+}
+
 QJsonArray MCPServer::buildToolsList()
 {
     QJsonArray tools;
@@ -5923,6 +5968,41 @@ QJsonArray MCPServer::buildToolsList()
             "naming. TRS flip: pos.x → -pos.x, rotation (w,x,y,z) → (w,x,-y,-z), "
             "scale.x → -scale.x. Centre-line bones (Spine, Hips, Head) get "
             "the X-flipped TRS in place. Writes the result under `dst`.",
+            props,
+            required
+        );
+    }
+
+    // save_pose_library
+    {
+        QJsonObject props;
+        props["path"] = QJsonObject{{"type", "string"}, {"description", "Destination `.poselib` file path. Written atomically via QSaveFile. Side-by-side with the asset is the recommended location."}};
+        QJsonArray required;
+        required.append("path");
+        appendTool(
+            "save_pose_library",
+            "Persist the first selected entity's pose library to a "
+            "`.poselib` sidecar JSON (schema `qtmesheditor.poselib.v1`). "
+            "Returns error when there's no selection, the library is "
+            "empty, or the path is unwritable.",
+            props,
+            required
+        );
+    }
+
+    // load_pose_library
+    {
+        QJsonObject props;
+        props["path"] = QJsonObject{{"type", "string"}, {"description", "Source `.poselib` file path. Schema-validated; malformed files don't disturb in-memory library."}};
+        QJsonArray required;
+        required.append("path");
+        appendTool(
+            "load_pose_library",
+            "Load a `.poselib` sidecar JSON into the first selected "
+            "entity's library, **replacing** the in-memory contents. "
+            "Returns error when there's no selection, the file is "
+            "missing, or the JSON / schema is malformed (in-memory "
+            "library is preserved on parse failure).",
             props,
             required
         );

--- a/src/MCPServer.h
+++ b/src/MCPServer.h
@@ -252,6 +252,15 @@ private:
     /// Args: `src` (existing pose), `dst` (output pose name).
     QJsonObject toolMirrorPose(const QJsonObject &args);
 
+    /// Pose-lib D-Project: write the first-selected entity's pose
+    /// library to a `.poselib` sidecar JSON file. Args: `path`.
+    QJsonObject toolSavePoseLibrary(const QJsonObject &args);
+
+    /// Pose-lib D-Project: load a `.poselib` sidecar into the
+    /// first-selected entity's library, replacing whatever was
+    /// in memory. Args: `path`.
+    QJsonObject toolLoadPoseLibrary(const QJsonObject &args);
+
     // Animation
     struct NodeAnimation {
         Ogre::SceneNode* node;

--- a/src/MCPServer_test.cpp
+++ b/src/MCPServer_test.cpp
@@ -7310,3 +7310,27 @@ TEST_F(MCPServerTest, MirrorPose_UnknownSrcRejected)
     QJsonObject r = server->callTool("mirror_pose", args);
     EXPECT_TRUE(isError(r));
 }
+
+TEST_F(MCPServerTest, SavePoseLibrary_MissingPathRejected)
+{
+    QJsonObject empty;
+    QJsonObject r = server->callTool("save_pose_library", empty);
+    EXPECT_TRUE(isError(r));
+    EXPECT_TRUE(getResultText(r).contains("path"));
+}
+
+TEST_F(MCPServerTest, LoadPoseLibrary_MissingPathRejected)
+{
+    QJsonObject empty;
+    QJsonObject r = server->callTool("load_pose_library", empty);
+    EXPECT_TRUE(isError(r));
+    EXPECT_TRUE(getResultText(r).contains("path"));
+}
+
+TEST_F(MCPServerTest, LoadPoseLibrary_MissingFileRejected)
+{
+    QJsonObject args;
+    args["path"] = "/nonexistent/path/no.poselib";
+    QJsonObject r = server->callTool("load_pose_library", args);
+    EXPECT_TRUE(isError(r));
+}


### PR DESCRIPTION
Closes the GUI / MCP / CLI triad for the pose library now that D-Project (#602) provides the `.poselib` sidecar format.

## What ships

### MCP tools (2 new)

- **`save_pose_library`** — required `path`. Wraps `PoseLibrary::savePoseLibraryForSelection`. Returns `ok` + `path` on success; error on no selection / empty library / unwritable path.
- **`load_pose_library`** — required `path`. Wraps `loadPoseLibraryForSelection`. Returns `ok` + `path` + `count` on success; error on no selection / missing file / malformed JSON or schema (in-memory library is preserved on parse failure thanks to the D-Project staging fix).

### CLI mode (new branch in `cmdPose`)

`qtmesh pose <library.poselib> --library list [--json]` — reads the sidecar JSON directly (no mesh load needed) and prints the pose names. JSON shape mirrors the other CLI tools: `{ file, count, poses: [name…] }`.

Doesn't go through `PoseLibrary` itself — there's no entity to key against in a standalone CLI invocation; we just parse the JSON. This intentionally bypasses the strict schema-replacement semantics that `loadPoseLibrary` enforces on a live entity; for read-only listing, schema-checking the file is enough.

`--library apply <name> -o out.fbx` is deliberately not in this PR — it needs the round-trip exporter to write pose-driven bone states back into the mesh.

## 3 new MCP tests + manual CLI verification

- `SavePoseLibrary_MissingPathRejected`
- `LoadPoseLibrary_MissingPathRejected`
- `LoadPoseLibrary_MissingFileRejected`

Manual:
- `qtmesh pose test.poselib --library list` → `"Poses (N):  …"`
- `qtmesh pose test.poselib --library list --json` → JSON shape
- `qtmesh pose /nonexistent.poselib --library list` → exit 1

## #521 status

| Sub-slice | Status |
|-|-|
| D1 — Singleton data layer | shipped (#592) |
| D-MCP — 7 tools (list/save/apply/delete/mirror/save_lib/load_lib) | shipped (#593, #599, **this PR**) |
| D3 — Undo commands | shipped (#595) |
| D4 — Mirror pose | shipped (#597) |
| D-Project — .poselib sidecar | shipped (#602) |
| D-CLI — `qtmesh pose --library list` | shipped (**this PR**) |
| D2 — Inspector subgroup | follow-up |
| D5 — Apply-with-mask | follow-up |
| D6 — Time-blended apply | follow-up |
| D-Thumbnail | follow-up |
| D-CLI apply mode | follow-up (needs exporter round-trip) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)