### PR TITLE
review(cli): pose --library list — reject non-array poses field

### DIFF
--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -2489,7 +2489,17 @@ int CLIPipeline::cmdPose(int argc, char* argv[])
             err() << "Error: schema mismatch in " << filePath << Qt::endl;
             return 1;
         }
-        const QJsonArray poses = root.value("poses").toArray();
+        // Validate `poses` is actually an array — a schema-matching
+        // file with `poses` missing or non-array would otherwise
+        // silently report "No poses in library" with exit 0,
+        // masking corruption (Codex P2 on PR #604, same bug class
+        // as the loadPoseLibrary fix in #603).
+        const QJsonValue posesV = root.value("poses");
+        if (!posesV.isArray()) {
+            err() << "Error: malformed 'poses' field in " << filePath << Qt::endl;
+            return 1;
+        }
+        const QJsonArray poses = posesV.toArray();
         QStringList names;
         for (const QJsonValue& v : poses) {
             const QString n = v.toObject().value("name").toString();


### PR DESCRIPTION
Codex P2 on PR #604 (merged). The CLI's `--library list` path checked the `schema` string but then did `root.value("poses").toArray()` unconditionally — same silent-empty-on-bad-type bug class as `loadPoseLibrary` had on PR #602 (fixed in #603), just in the duplicated parse path inside `cmdPose`.

A schema-matching `.poselib` file with `poses` missing or non-array reported "No poses in library" with exit 0 instead of surfacing the corruption. CI/audit workflows relying on non-zero exit would miss the failure.

## Fix
Explicit `isArray()` check after the schema match. Emit `Error: malformed 'poses' field in <path>` to stderr and return 1.

## Manual verification
A `{"schema": "qtmesheditor.poselib.v1", "poses": "oops"}` file now exits 1 with the expected message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)