### PR TITLE
fix(windows): ship OgreMeshLodGenerator.dll

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -352,6 +352,28 @@ jobs:
         rm -f "${{github.workspace}}/bin/QtMeshEditor.debug.exe"
       shell: bash
 
+    - name: Verify OgreMeshLodGenerator.dll is packaged
+      run: |
+            $dest = "${{github.workspace}}/bin/OgreMeshLodGenerator.dll"
+            if (-not (Test-Path $dest)) {
+                $candidates = @(
+                    "${{github.workspace}}/ogre-build/SDK/bin/OgreMeshLodGenerator.dll",
+                    "${{github.workspace}}/ogre-build/SDK/bin/Release/OgreMeshLodGenerator.dll"
+                )
+                foreach ($src in $candidates) {
+                    if (Test-Path $src) {
+                        Copy-Item $src $dest -Force
+                        Write-Host "Copied OgreMeshLodGenerator.dll from $src"
+                        break
+                    }
+                }
+            }
+            if (-not (Test-Path $dest)) {
+                Write-Error "OgreMeshLodGenerator.dll is missing from the Windows package (LOD/decimate requires this DLL)."
+                exit 1
+            }
+      shell: powershell
+
     - name: Copy assimp dll to the binary folder
       run: |
             Write-Host "Checking available DLL files:"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -352,28 +352,6 @@ jobs:
         rm -f "${{github.workspace}}/bin/QtMeshEditor.debug.exe"
       shell: bash
 
-    - name: Verify OgreMeshLodGenerator.dll is packaged
-      run: |
-            $dest = "${{github.workspace}}/bin/OgreMeshLodGenerator.dll"
-            if (-not (Test-Path $dest)) {
-                $candidates = @(
-                    "${{github.workspace}}/ogre-build/SDK/bin/OgreMeshLodGenerator.dll",
-                    "${{github.workspace}}/ogre-build/SDK/bin/Release/OgreMeshLodGenerator.dll"
-                )
-                foreach ($src in $candidates) {
-                    if (Test-Path $src) {
-                        Copy-Item $src $dest -Force
-                        Write-Host "Copied OgreMeshLodGenerator.dll from $src"
-                        break
-                    }
-                }
-            }
-            if (-not (Test-Path $dest)) {
-                Write-Error "OgreMeshLodGenerator.dll is missing from the Windows package (LOD/decimate requires this DLL)."
-                exit 1
-            }
-      shell: powershell
-
     - name: Copy assimp dll to the binary folder
       run: |
             Write-Host "Checking available DLL files:"
@@ -435,6 +413,21 @@ jobs:
                     Write-Host "Copied $lib.dll"
                 }
             }
+      shell: powershell
+
+    - name: Verify Windows package DLL dependencies
+      run: |
+            $mingw = "D:/a/QtMeshEditor/Qt/Tools/mingw1310_64/bin"
+            $objdump = "$mingw/objdump.exe"
+            $ogreSdk = "${{github.workspace}}/ogre-build/SDK/bin"
+            if (-not (Test-Path $ogreSdk)) {
+              $ogreSdk = "${{github.workspace}}/ogre-build/SDK/bin/Release"
+            }
+            pwsh -File "${{github.workspace}}/scripts/verify-windows-package-dlls.ps1" `
+              -BinDir "${{github.workspace}}/bin" `
+              -Objdump $objdump `
+              -OgreSdkBin $ogreSdk `
+              -CopyMissingOgreDlls
       shell: powershell
 
     - name: Remove test-only dance models from package

--- a/scripts/verify-windows-package-dlls.ps1
+++ b/scripts/verify-windows-package-dlls.ps1
@@ -1,0 +1,134 @@
+# Verify that every non-system DLL imported by QtMeshEditor / qtmesh (and bundled
+# DLLs in bin/) is present in the package directory. Mirrors the Linux Docker
+# "ldd | grep not found" check in deploy.yml.
+#
+# Usage (CI):
+#   pwsh scripts/verify-windows-package-dlls.ps1 `
+#     -BinDir "$env:GITHUB_WORKSPACE/bin" `
+#     -Objdump "D:/a/QtMeshEditor/Qt/Tools/mingw1310_64/bin/objdump.exe" `
+#     -OgreSdkBin "$env:GITHUB_WORKSPACE/ogre-build/SDK/bin"
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$BinDir,
+    [string]$Objdump = "objdump",
+    [string]$OgreSdkBin = "",
+    [switch]$CopyMissingOgreDlls
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path $BinDir)) {
+    Write-Error "BinDir does not exist: $BinDir"
+    exit 1
+}
+
+$BinDir = (Resolve-Path $BinDir).Path
+
+# Windows loader / MinGW runtimes that are expected from System32 or need not be bundled.
+$SystemDllPattern = '^(?i)(api-ms-.*|ext-ms-.*|kernel32|kernelbase|user32|gdi32|advapi32|shell32|ole32|comdlg32|ws2_32|winmm|imm32|oleaut32|setupapi|version|msvcrt|ucrtbase|vcruntime.*|dbghelp|crypt32|secur32|bcrypt|ntdll|msvcp.*|d3d.*|dxgi|opengl32|glu32|wtsapi32|userenv|netapi32|iphlpapi|shlwapi|comctl32|uxtheme|dwmapi|propsys|windowscodecs|hid|setupapi|winspool|mpr|powrprof|cfgmgr32|devobj|wintrust|imagehlp|mswsock|dnsapi|rsaenh|bcryptprimitives|profapi)\.dll$'
+
+function Test-IsSystemDll([string]$Name) {
+    return $Name -match $SystemDllPattern
+}
+
+function Get-PeImports([string]$Path) {
+    if (-not (Test-Path $Path)) { return @() }
+    $imports = [System.Collections.Generic.List[string]]::new()
+    $output = & $Objdump -p $Path 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "objdump failed for $Path (exit $LASTEXITCODE)"
+        return @()
+    }
+    foreach ($line in $output) {
+        if ($line -match '^\s*DLL Name:\s*(.+)\s*$') {
+            $imports.Add($Matches[1].Trim())
+        }
+    }
+    return $imports
+}
+
+function Resolve-DllPath([string]$Name, [string]$SearchDir) {
+    $local = Join-Path $SearchDir $Name
+    if (Test-Path $local) { return $local }
+    $sys32 = Join-Path $env:SystemRoot "System32\$Name"
+    if (Test-Path $sys32) { return $sys32 }
+    $syswow = Join-Path $env:SystemRoot "SysWOW64\$Name"
+    if (Test-Path $syswow) { return $syswow }
+    return $null
+}
+
+function Copy-OgreSdkDlls([string]$SdkBin, [string]$DestBin) {
+    if (-not (Test-Path $SdkBin)) {
+        Write-Host "Ogre SDK bin not found ($SdkBin); skipping Ogre DLL copy pass"
+        return
+    }
+    $patterns = @("Ogre*.dll", "Plugin_*.dll", "Codec_*.dll", "RenderSystem_*.dll", "cg.dll")
+    foreach ($pattern in $patterns) {
+        Get-ChildItem -Path $SdkBin -Filter $pattern -ErrorAction SilentlyContinue | ForEach-Object {
+            $dest = Join-Path $DestBin $_.Name
+            if (-not (Test-Path $dest)) {
+                Copy-Item $_.FullName $dest -Force
+                Write-Host "Copied missing Ogre runtime: $($_.Name)"
+            }
+        }
+    }
+}
+
+if ($CopyMissingOgreDlls -and $OgreSdkBin) {
+    Copy-OgreSdkDlls -SdkBin $OgreSdkBin -DestBin $BinDir
+}
+
+$roots = @()
+Get-ChildItem -Path $BinDir -Filter "*.exe" -File | ForEach-Object { $roots += $_.FullName }
+if ($roots.Count -eq 0) {
+    Write-Error "No .exe files found in $BinDir"
+    exit 1
+}
+
+$queue = [System.Collections.Generic.Queue[string]]::new()
+$processed = @{}
+foreach ($r in $roots) { $queue.Enqueue($r) }
+
+$missing = [System.Collections.Generic.List[object]]::new()
+
+while ($queue.Count -gt 0) {
+    $path = $queue.Dequeue()
+    if ($processed.ContainsKey($path)) { continue }
+    $processed[$path] = $true
+
+    $imports = Get-PeImports -Path $path
+    foreach ($dll in $imports) {
+        if (Test-IsSystemDll $dll) { continue }
+
+        $resolved = Resolve-DllPath -Name $dll -SearchDir $BinDir
+        if (-not $resolved) {
+            $missing.Add([PSCustomObject]@{
+                    RequiredBy = Split-Path $path -Leaf
+                    Dll        = $dll
+                })
+            continue
+        }
+
+        # Walk transitive deps for DLLs shipped in the package.
+        if ($resolved.StartsWith($BinDir, [System.StringComparison]::OrdinalIgnoreCase) `
+            -and $resolved -match '\.dll$' `
+            -and -not $processed.ContainsKey($resolved)) {
+            $queue.Enqueue($resolved)
+        }
+    }
+}
+
+Write-Host "=== Windows DLL dependency check: $BinDir ==="
+Write-Host "Scanned $($processed.Count) PE file(s) (exe + bundled dll chain)"
+
+if ($missing.Count -gt 0) {
+    Write-Host ""
+    Write-Host "Missing DLL(s) (not in bin/ or System32):"
+    $missing | Sort-Object Dll, RequiredBy -Unique | Format-Table -AutoSize
+    Write-Error "$($missing.Count) missing DLL dependency(ies) in Windows package"
+    exit 1
+}
+
+Write-Host "All non-system DLL dependencies resolved."
+exit 0

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -619,7 +619,8 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
         OgreTerrain_d
         OgreRTShaderSystem_d
         OgreVolume_d
-        OgreOverlay_d)
+        OgreOverlay_d
+        OgreMeshLodGenerator_d)
 
     FOREACH(ogrelib ${OGRELIBLIST})
         IF(WIN32)
@@ -647,12 +648,12 @@ else()
         OgreTerrain
         OgreRTShaderSystem
         OgreVolume
-        OgreOverlay)
+        OgreOverlay
+        OgreMeshLodGenerator)
     IF(APPLE) # this is just for test, it is not using OgreBites yet. TODO: remove
         SET(OGRELIBLIST ${OGRELIBLIST}
             OgreBites
             OgreBullet
-            OgreMeshLodGenerator
             RenderSystem_GL3Plus
         )
     ENDIF()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -627,6 +627,18 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
             INSTALL(FILES ${OGRE_PLUGIN_DIR_DBG}/${ogrelib}.dll DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
         ENDIF()
     ENDFOREACH(ogrelib)
+    IF(WIN32 AND OGRE_PLUGIN_DIR_DBG)
+        file(GLOB _OGRE_WIN_RUNTIME_DLLS_DBG
+            "${OGRE_PLUGIN_DIR_DBG}/Ogre*.dll"
+            "${OGRE_PLUGIN_DIR_DBG}/Plugin_*.dll"
+            "${OGRE_PLUGIN_DIR_DBG}/Codec_*.dll"
+            "${OGRE_PLUGIN_DIR_DBG}/RenderSystem_*.dll"
+            "${OGRE_PLUGIN_DIR_DBG}/cg.dll")
+        if(_OGRE_WIN_RUNTIME_DLLS_DBG)
+            install(FILES ${_OGRE_WIN_RUNTIME_DLLS_DBG}
+                    DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+        endif()
+    ENDIF()
 else()
     IF(OGRE_Plugin_CgProgramManager_INCLUDE_DIR)
         SET(OGRELIBLIST cg
@@ -687,6 +699,20 @@ else()
             ENDIF()
         ENDIF()
     ENDFOREACH(ogrelib)
+    # Windows: also install every Ogre runtime DLL beside the plugins dir so component
+    # libraries (e.g. OgreMeshLodGenerator.dll) cannot be omitted from OGRELIBLIST.
+    IF(WIN32 AND OGRE_PLUGIN_DIR)
+        file(GLOB _OGRE_WIN_RUNTIME_DLLS
+            "${OGRE_PLUGIN_DIR}/Ogre*.dll"
+            "${OGRE_PLUGIN_DIR}/Plugin_*.dll"
+            "${OGRE_PLUGIN_DIR}/Codec_*.dll"
+            "${OGRE_PLUGIN_DIR}/RenderSystem_*.dll"
+            "${OGRE_PLUGIN_DIR}/cg.dll")
+        if(_OGRE_WIN_RUNTIME_DLLS)
+            install(FILES ${_OGRE_WIN_RUNTIME_DLLS}
+                    DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+        endif()
+    ENDIF()
 endif()
 
 ##############################################################


### PR DESCRIPTION
## Summary

Windows users see a system error on launch: `OgreMeshLodGenerator.dll` was not found.

The app links Ogre's MeshLodGenerator component (LOD generation, decimation, `qtmesh lod` / `optimize`), but the Windows packaging step only copied plugin DLLs and core Ogre libs — `OgreMeshLodGenerator.dll` was listed for macOS installs only.

## Fix

- Add `OgreMeshLodGenerator` / `OgreMeshLodGenerator_d` to the Windows OGRE DLL install lists in `src/CMakeLists.txt`
- CI: verify the DLL exists in `bin/` after `make install`, with a fallback copy from the Ogre SDK if needed

## Test plan

- [x] Windows `build-windows` job packages `OgreMeshLodGenerator.dll`
- [ ] Manual: launch `QtMeshEditor.exe` from a clean install / release zip on Windows

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows package verification to ensure critical dependencies are properly included in builds.
  * Enhanced consistency of library installation across different build configurations and platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/622?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->