### PR TITLE
feat(ps1): mesh deduplication and instances (#423)

### DIFF
--- a/src/PS1/CMakeLists.txt
+++ b/src/PS1/CMakeLists.txt
@@ -30,6 +30,7 @@ if(ENABLE_PS1_RIP)
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/GpuCommandParser.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/GteCapture.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/MeshReconstructor.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/MeshTopologyHash.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipMeshBuilder.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipLegalityDialog.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipManager.cpp
@@ -52,6 +53,7 @@ if(ENABLE_PS1_RIP)
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/CaptureTypes.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/GteInverse.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/MeshReconstructor.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/MeshTopologyHash.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipMeshBuilder.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/EmuCore.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/EmuCoreLoader.h

--- a/src/PS1/PS1_RIP_DESIGN.md
+++ b/src/PS1/PS1_RIP_DESIGN.md
@@ -80,14 +80,15 @@ See epic #412 for phased issues (#413–#431).
 - **Libretro:** `syncVramFromCore()` mirrors live core VRAM every frame; capture snapshots include a VRAM cell copy for textured mesh export.
 - Stub core fills CLUT + 4/8/15 bpp test regions each frame via `stubFillVramPattern` (CI only).
 
-## Phase 4 status (#422)
+## Phase 4 status (#422 / #423)
 
 - `CaptureSnapshot` copies worker `CaptureBuffer` + VRAM cells to the main thread for reconstruction.
 - `GteInverse` approximates GTE screen→model un-projection; PS1 Y-down → editor Y-up.
 - `MeshReconstructor` groups primitives by `matrixId` + texture key, triangulates quads, emits vertex color + UV.
-- `PS1RipMeshBuilder` creates Ogre mesh/submeshes, binds decoded TPAGE/CLUT textures when VRAM is present, and attaches `PS1Capture_<id>` to the live scene via `Manager`.
-- `captureFrame` builds mesh automatically; session toolbar adds **Arm Capture** / **Capture Frame**.
-- Sentry breadcrumb `ps1.rip.mesh.built` with vertex/triangle counts.
+- `MeshTopologyHash` + `reconstructDeduped()` collapse identical topology (loose 0.01 snap vs strict bit-exact) into unique meshes with instance centroids (#423).
+- `PS1RipMeshBuilder::attachCaptureSetToScene` places one `PS1Capture_<id>_instN` SceneNode per instance at the captured world position.
+- Session toolbar **Strict dedupe** toggle (persisted in QSettings); status shows captured / unique / instance counts.
+- Sentry breadcrumbs `ps1.rip.mesh.built` and `ps1.rip.dedupe.summary`.
 
 ## Troubleshooting
 

--- a/src/PS1/runtime/MeshReconstructor.cpp
+++ b/src/PS1/runtime/MeshReconstructor.cpp
@@ -1,6 +1,7 @@
 #include "MeshReconstructor.h"
 
 #include "GteInverse.h"
+#include "MeshTopologyHash.h"
 #include "PsxCaptureFilters.h"
 
 #include <OgreColourValue.h>
@@ -117,14 +118,8 @@ void emitPrimitive(const PrimRecord &prim, const MatrixRecord *matrix, SubMeshAc
     }
 }
 
-} // namespace
-
-ReconstructedMesh MeshReconstructor::reconstruct(const CaptureSnapshot &snapshot)
+QHash<uint32_t, QHash<quint64, SubMeshAccumulator>> buildMatrixGroups(const CaptureSnapshot &snapshot)
 {
-    ReconstructedMesh result;
-    if (snapshot.prims.isEmpty())
-        return result;
-
     QHash<uint32_t, QHash<quint64, SubMeshAccumulator>> groupsByMatrix;
 
     for (const PrimRecord &prim : snapshot.prims) {
@@ -141,25 +136,99 @@ ReconstructedMesh MeshReconstructor::reconstruct(const CaptureSnapshot &snapshot
             acc.materialName = textureMaterialName(prim.tpage, prim.clut);
         emitPrimitive(prim, matrix, acc);
     }
+    return groupsByMatrix;
+}
 
-    int subIndex = 0;
+ReconstructedMesh meshFromMatrixGroup(uint32_t matrixId,
+                                      const QHash<quint64, SubMeshAccumulator> &texGroups)
+{
+    ReconstructedMesh result;
+    result.meshName = QStringLiteral("ps1_part_%1").arg(matrixId);
+
+    for (auto texIt = texGroups.constBegin(); texIt != texGroups.constEnd(); ++texIt) {
+        const SubMeshAccumulator &acc = texIt.value();
+        if (acc.vertices.isEmpty() || acc.indices.size() < 3)
+            continue;
+
+        ReconstructedSubMesh sub;
+        sub.materialName = acc.materialName;
+        sub.vertices = acc.vertices;
+        sub.indices = acc.indices;
+        result.subMeshes.append(sub);
+        result.vertexCount += acc.vertices.size();
+        result.triangleCount += acc.indices.size() / 3;
+    }
+    return result;
+}
+
+QVector<ReconstructedMesh> buildParts(const CaptureSnapshot &snapshot)
+{
+    QVector<ReconstructedMesh> parts;
+    const QHash<uint32_t, QHash<quint64, SubMeshAccumulator>> groupsByMatrix =
+        buildMatrixGroups(snapshot);
+
     for (auto matIt = groupsByMatrix.constBegin(); matIt != groupsByMatrix.constEnd(); ++matIt) {
-        for (auto texIt = matIt.value().constBegin(); texIt != matIt.value().constEnd(); ++texIt) {
-            const SubMeshAccumulator &acc = texIt.value();
-            if (acc.vertices.isEmpty() || acc.indices.size() < 3)
-                continue;
+        ReconstructedMesh part = meshFromMatrixGroup(matIt.key(), matIt.value());
+        if (!part.isEmpty())
+            parts.append(part);
+    }
+    return parts;
+}
 
-            ReconstructedSubMesh sub;
-            sub.materialName = acc.materialName;
-            sub.vertices = acc.vertices;
-            sub.indices = acc.indices;
-            result.subMeshes.append(sub);
-            result.vertexCount += acc.vertices.size();
-            result.triangleCount += acc.indices.size() / 3;
-            ++subIndex;
+ReconstructedMesh flattenParts(const QVector<ReconstructedMesh> &parts)
+{
+    ReconstructedMesh merged;
+    merged.meshName = QStringLiteral("ps1_capture");
+    for (const ReconstructedMesh &part : parts) {
+        for (const ReconstructedSubMesh &sub : part.subMeshes)
+            merged.subMeshes.append(sub);
+        merged.vertexCount += part.vertexCount;
+        merged.triangleCount += part.triangleCount;
+    }
+    return merged;
+}
+
+} // namespace
+
+ReconstructedMesh MeshReconstructor::reconstruct(const CaptureSnapshot &snapshot)
+{
+    return flattenParts(buildParts(snapshot));
+}
+
+ReconstructedCaptureSet MeshReconstructor::reconstructDeduped(const CaptureSnapshot &snapshot,
+                                                            MeshDedupeMode dedupeMode)
+{
+    ReconstructedCaptureSet result;
+    const QVector<ReconstructedMesh> parts = buildParts(snapshot);
+    result.capturedPartCount = parts.size();
+    if (parts.isEmpty())
+        return result;
+
+    QHash<quint64, int> hashToUnique;
+
+    for (const ReconstructedMesh &part : parts) {
+        float cx = 0.0f;
+        float cy = 0.0f;
+        float cz = 0.0f;
+        const ReconstructedMesh local = MeshTopologyHash::centered(part, cx, cy, cz);
+        const quint64 h = MeshTopologyHash::hashMesh(local, dedupeMode);
+
+        int uniqueIndex = hashToUnique.value(h, -1);
+        if (uniqueIndex < 0) {
+            uniqueIndex = result.uniqueMeshes.size();
+            hashToUnique.insert(h, uniqueIndex);
+            ReconstructedMesh unique = local;
+            unique.meshName = QStringLiteral("ps1_unique_%1").arg(uniqueIndex);
+            result.uniqueMeshes.append(unique);
         }
+
+        ReconstructedInstance inst;
+        inst.uniqueMeshIndex = uniqueIndex;
+        inst.px = cx;
+        inst.py = cy;
+        inst.pz = cz;
+        result.instances.append(inst);
     }
 
-    result.meshName = QStringLiteral("ps1_capture");
     return result;
 }

--- a/src/PS1/runtime/MeshReconstructor.h
+++ b/src/PS1/runtime/MeshReconstructor.h
@@ -6,6 +6,8 @@
 #include <QString>
 #include <QVector>
 
+enum class MeshDedupeMode;
+
 /** One vertex in reconstructed editor space (#422). */
 struct ReconstructedVertex {
     float px = 0.0f;
@@ -34,11 +36,32 @@ struct ReconstructedMesh {
     bool isEmpty() const { return subMeshes.isEmpty(); }
 };
 
-/** Builds editor-space meshes from a captured primitive stream (#422). */
+/** One placed copy of a deduplicated mesh (#423). */
+struct ReconstructedInstance {
+    int uniqueMeshIndex = 0;
+    float px = 0.0f;
+    float py = 0.0f;
+    float pz = 0.0f;
+};
+
+/** Deduplicated capture output: unique meshes + instance transforms (#423). */
+struct ReconstructedCaptureSet {
+    QVector<ReconstructedMesh> uniqueMeshes;
+    QVector<ReconstructedInstance> instances;
+    int capturedPartCount = 0;
+
+    bool isEmpty() const { return uniqueMeshes.isEmpty(); }
+    int uniqueCount() const { return uniqueMeshes.size(); }
+    int instanceCount() const { return instances.size(); }
+};
+
+/** Builds editor-space meshes from a captured primitive stream (#422, #423). */
 class MeshReconstructor
 {
 public:
     static ReconstructedMesh reconstruct(const CaptureSnapshot &snapshot);
+    static ReconstructedCaptureSet reconstructDeduped(const CaptureSnapshot &snapshot,
+                                                      MeshDedupeMode dedupeMode);
 };
 
 #endif // MESHRECONSTRUCTOR_H

--- a/src/PS1/runtime/MeshReconstructor_test.cpp
+++ b/src/PS1/runtime/MeshReconstructor_test.cpp
@@ -1,5 +1,6 @@
 #include "CaptureSnapshot.h"
 #include "MeshReconstructor.h"
+#include "MeshTopologyHash.h"
 #include "PsxCaptureFilters.h"
 
 #include <gtest/gtest.h>
@@ -91,6 +92,31 @@ TEST(MeshReconstructorTest, IgnoresOffscreenPrimitives)
     const ReconstructedMesh mesh = MeshReconstructor::reconstruct(snap);
     ASSERT_FALSE(mesh.isEmpty());
     EXPECT_EQ(mesh.triangleCount, 1);
+}
+
+TEST(MeshReconstructorTest, DedupesIdenticalInstances)
+{
+    CaptureSnapshot snap;
+    snap.matrices.append(identityMatrix());
+    MatrixRecord shifted = identityMatrix();
+    shifted.tr[0] = 512;
+    snap.matrices.append(shifted);
+    MatrixRecord shifted2 = identityMatrix();
+    shifted2.tr[0] = 1024;
+    snap.matrices.append(shifted2);
+
+    snap.prims.append(coloredTri(16, 16, 0));
+    snap.prims.append(coloredTri(80, 16, 1));
+    snap.prims.append(coloredTri(144, 16, 2));
+
+    const ReconstructedCaptureSet loose =
+        MeshReconstructor::reconstructDeduped(snap, MeshDedupeMode::Loose);
+    EXPECT_EQ(loose.capturedPartCount, 3);
+    EXPECT_EQ(loose.uniqueCount(), 1);
+    EXPECT_EQ(loose.instanceCount(), 3);
+    EXPECT_EQ(loose.instances[0].uniqueMeshIndex, 0);
+    EXPECT_EQ(loose.instances[1].uniqueMeshIndex, 0);
+    EXPECT_EQ(loose.instances[2].uniqueMeshIndex, 0);
 }
 
 TEST(MeshReconstructorTest, KeepsPartiallyOnScreenPrimitives)

--- a/src/PS1/runtime/MeshTopologyHash.cpp
+++ b/src/PS1/runtime/MeshTopologyHash.cpp
@@ -1,7 +1,10 @@
 #include "MeshTopologyHash.h"
 
-#include <cstring>
+#include <QVector>
+
+#include <algorithm>
 #include <cmath>
+#include <cstring>
 
 namespace {
 
@@ -37,7 +40,19 @@ quint64 MeshTopologyHash::hashMesh(const ReconstructedMesh &mesh, MeshDedupeMode
     quint64 h = 0xcbf29ce484222325ULL;
     mixHash(h, static_cast<quint64>(mesh.subMeshes.size()));
 
-    for (const ReconstructedSubMesh &sub : mesh.subMeshes) {
+    QVector<const ReconstructedSubMesh *> ordered;
+    ordered.reserve(mesh.subMeshes.size());
+    for (const ReconstructedSubMesh &sub : mesh.subMeshes)
+        ordered.append(&sub);
+    std::sort(ordered.begin(), ordered.end(),
+              [](const ReconstructedSubMesh *a, const ReconstructedSubMesh *b) {
+                  return a->materialName < b->materialName;
+              });
+
+    for (const ReconstructedSubMesh *subPtr : ordered) {
+        const ReconstructedSubMesh &sub = *subPtr;
+        for (QChar ch : sub.materialName)
+            mixHash(h, static_cast<quint64>(ch.unicode()));
         mixHash(h, static_cast<quint64>(sub.vertices.size()));
         mixHash(h, static_cast<quint64>(sub.indices.size()));
 

--- a/src/PS1/runtime/MeshTopologyHash.cpp
+++ b/src/PS1/runtime/MeshTopologyHash.cpp
@@ -33,6 +33,27 @@ void mixFloat(quint64 &h, float v, MeshDedupeMode mode)
     }
 }
 
+quint64 submeshContentKey(const ReconstructedSubMesh &sub, MeshDedupeMode mode)
+{
+    quint64 h = 0xcbf29ce484222325ULL;
+    mixHash(h, static_cast<quint64>(sub.vertices.size()));
+    mixHash(h, static_cast<quint64>(sub.indices.size()));
+
+    for (uint32_t idx : sub.indices) {
+        mixHash(h, idx);
+        if (idx >= static_cast<uint32_t>(sub.vertices.size()))
+            continue;
+        const ReconstructedVertex &v = sub.vertices[static_cast<int>(idx)];
+        mixFloat(h, quantize(v.px, mode), mode);
+        mixFloat(h, quantize(v.py, mode), mode);
+        mixFloat(h, quantize(v.pz, mode), mode);
+        mixFloat(h, quantize(v.u, mode), mode);
+        mixFloat(h, quantize(v.v, mode), mode);
+        mixHash(h, v.diffuseArgb);
+    }
+    return h;
+}
+
 } // namespace
 
 quint64 MeshTopologyHash::hashMesh(const ReconstructedMesh &mesh, MeshDedupeMode mode)
@@ -45,8 +66,14 @@ quint64 MeshTopologyHash::hashMesh(const ReconstructedMesh &mesh, MeshDedupeMode
     for (const ReconstructedSubMesh &sub : mesh.subMeshes)
         ordered.append(&sub);
     std::sort(ordered.begin(), ordered.end(),
-              [](const ReconstructedSubMesh *a, const ReconstructedSubMesh *b) {
-                  return a->materialName < b->materialName;
+              [mode](const ReconstructedSubMesh *a, const ReconstructedSubMesh *b) {
+                  if (a->materialName != b->materialName)
+                      return a->materialName < b->materialName;
+                  const quint64 keyA = submeshContentKey(*a, mode);
+                  const quint64 keyB = submeshContentKey(*b, mode);
+                  if (keyA != keyB)
+                      return keyA < keyB;
+                  return a < b;
               });
 
     for (const ReconstructedSubMesh *subPtr : ordered) {

--- a/src/PS1/runtime/MeshTopologyHash.cpp
+++ b/src/PS1/runtime/MeshTopologyHash.cpp
@@ -1,0 +1,89 @@
+#include "MeshTopologyHash.h"
+
+#include <cstring>
+#include <cmath>
+
+namespace {
+
+float quantize(float v, MeshDedupeMode mode)
+{
+    if (mode == MeshDedupeMode::Loose)
+        return std::round(v * 100.0f) * 0.01f;
+    return v;
+}
+
+void mixHash(quint64 &h, quint64 v)
+{
+    h ^= v + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+}
+
+void mixFloat(quint64 &h, float v, MeshDedupeMode mode)
+{
+    if (mode == MeshDedupeMode::Strict) {
+        quint32 bits = 0;
+        static_assert(sizeof(float) == sizeof(quint32));
+        std::memcpy(&bits, &v, sizeof(bits));
+        mixHash(h, bits);
+    } else {
+        const qint32 q = static_cast<qint32>(std::lround(v * 100.0f));
+        mixHash(h, static_cast<quint64>(static_cast<quint32>(q)));
+    }
+}
+
+} // namespace
+
+quint64 MeshTopologyHash::hashMesh(const ReconstructedMesh &mesh, MeshDedupeMode mode)
+{
+    quint64 h = 0xcbf29ce484222325ULL;
+    mixHash(h, static_cast<quint64>(mesh.subMeshes.size()));
+
+    for (const ReconstructedSubMesh &sub : mesh.subMeshes) {
+        mixHash(h, static_cast<quint64>(sub.vertices.size()));
+        mixHash(h, static_cast<quint64>(sub.indices.size()));
+
+        for (uint32_t idx : sub.indices) {
+            mixHash(h, idx);
+            if (idx >= static_cast<uint32_t>(sub.vertices.size()))
+                continue;
+            const ReconstructedVertex &v = sub.vertices[static_cast<int>(idx)];
+            mixFloat(h, quantize(v.px, mode), mode);
+            mixFloat(h, quantize(v.py, mode), mode);
+            mixFloat(h, quantize(v.pz, mode), mode);
+            mixFloat(h, quantize(v.u, mode), mode);
+            mixFloat(h, quantize(v.v, mode), mode);
+            mixHash(h, v.diffuseArgb);
+        }
+    }
+    return h;
+}
+
+ReconstructedMesh MeshTopologyHash::centered(const ReconstructedMesh &mesh, float &cxOut, float &cyOut,
+                                               float &czOut)
+{
+    ReconstructedMesh out = mesh;
+    cxOut = cyOut = czOut = 0.0f;
+    int count = 0;
+    for (const ReconstructedSubMesh &sub : mesh.subMeshes) {
+        for (const ReconstructedVertex &v : sub.vertices) {
+            cxOut += v.px;
+            cyOut += v.py;
+            czOut += v.pz;
+            ++count;
+        }
+    }
+    if (count == 0)
+        return out;
+
+    cxOut /= static_cast<float>(count);
+    cyOut /= static_cast<float>(count);
+    czOut /= static_cast<float>(count);
+
+    for (ReconstructedSubMesh &sub : out.subMeshes) {
+        for (ReconstructedVertex &v : sub.vertices) {
+            v.px -= cxOut;
+            v.py -= cyOut;
+            v.pz -= czOut;
+        }
+    }
+    return out;
+}

--- a/src/PS1/runtime/MeshTopologyHash.h
+++ b/src/PS1/runtime/MeshTopologyHash.h
@@ -1,0 +1,21 @@
+#ifndef MESHTOPOLOGYHASH_H
+#define MESHTOPOLOGYHASH_H
+
+#include "MeshReconstructor.h"
+
+#include <QtGlobal>
+
+/** Loose rounds positions to 0.01; strict uses bit-exact floats (#423). */
+enum class MeshDedupeMode { Loose, Strict };
+
+/** Topology fingerprint for mesh deduplication (#423). */
+class MeshTopologyHash
+{
+public:
+    static quint64 hashMesh(const ReconstructedMesh &mesh, MeshDedupeMode mode);
+
+    /** Subtract mesh centroid; writes centroid to out params. */
+    static ReconstructedMesh centered(const ReconstructedMesh &mesh, float &cxOut, float &cyOut, float &czOut);
+};
+
+#endif // MESHTOPOLOGYHASH_H

--- a/src/PS1/runtime/MeshTopologyHash_test.cpp
+++ b/src/PS1/runtime/MeshTopologyHash_test.cpp
@@ -78,6 +78,39 @@ TEST(MeshTopologyHashTest, SubmeshOrderIsInvariant)
               MeshTopologyHash::hashMesh(centeredPermuted, MeshDedupeMode::Loose));
 }
 
+TEST(MeshTopologyHashTest, SameMaterialSubmeshOrderIsInvariant)
+{
+    const QString sharedMat = QStringLiteral("PS1Rip/tpage_0001_clut_0000");
+
+    ReconstructedSubMesh triA;
+    triA.materialName = sharedMat;
+    triA.vertices = {{0, 0, 0, 0, 0, 1, 0, 0, 0xFFFFFFFFu},
+                     {1, 0, 0, 0, 0, 1, 0, 0, 0xFFFFFFFFu},
+                     {0, 1, 0, 0, 0, 1, 0, 0, 0xFFFFFFFFu}};
+    triA.indices = {0, 1, 2};
+
+    ReconstructedSubMesh triB;
+    triB.materialName = sharedMat;
+    triB.vertices = {{2, 0, 0, 0, 0, 1, 0, 0, 0xFFFFFFFFu},
+                     {3, 0, 0, 0, 0, 1, 0, 0, 0xFFFFFFFFu},
+                     {2, 1, 0, 0, 0, 1, 0, 0, 0xFFFFFFFFu}};
+    triB.indices = {0, 1, 2};
+
+    ReconstructedMesh ordered;
+    ordered.subMeshes = {triA, triB};
+    ReconstructedMesh permuted;
+    permuted.subMeshes = {triB, triA};
+
+    float cx = 0.0f;
+    float cy = 0.0f;
+    float cz = 0.0f;
+    const ReconstructedMesh centeredOrdered = MeshTopologyHash::centered(ordered, cx, cy, cz);
+    const ReconstructedMesh centeredPermuted = MeshTopologyHash::centered(permuted, cx, cy, cz);
+
+    EXPECT_EQ(MeshTopologyHash::hashMesh(centeredOrdered, MeshDedupeMode::Loose),
+              MeshTopologyHash::hashMesh(centeredPermuted, MeshDedupeMode::Loose));
+}
+
 TEST(MeshTopologyHashTest, StrictModeSeparatesSmallTranslation)
 {
     const ReconstructedMesh a = unitTriangleAt(0.0f, 0.0f, 0.0f);

--- a/src/PS1/runtime/MeshTopologyHash_test.cpp
+++ b/src/PS1/runtime/MeshTopologyHash_test.cpp
@@ -1,0 +1,51 @@
+#include "MeshReconstructor.h"
+#include "MeshTopologyHash.h"
+
+#include <gtest/gtest.h>
+
+static ReconstructedMesh unitTriangleAt(float ox, float oy, float oz)
+{
+    ReconstructedMesh mesh;
+    ReconstructedSubMesh sub;
+    sub.materialName = QStringLiteral("PS1Rip/tpage_0000_clut_0000");
+    sub.vertices = {
+        {ox, oy, oz, 0, 0, 1, 0, 0, 0xFFFFFFFFu},
+        {ox + 1.0f, oy, oz, 0, 0, 1, 0, 0, 0xFFFFFFFFu},
+        {ox, oy + 1.0f, oz, 0, 0, 1, 0, 0, 0xFFFFFFFFu},
+    };
+    sub.indices = {0, 1, 2};
+    mesh.subMeshes.append(sub);
+    mesh.vertexCount = 3;
+    mesh.triangleCount = 1;
+    return mesh;
+}
+
+TEST(MeshTopologyHashTest, LooseModeIgnoresSmallTranslation)
+{
+    const ReconstructedMesh a = unitTriangleAt(0.0f, 0.0f, 0.0f);
+    const ReconstructedMesh b = unitTriangleAt(0.005f, 0.005f, 0.0f);
+
+    float cx = 0.0f;
+    float cy = 0.0f;
+    float cz = 0.0f;
+    const ReconstructedMesh ca = MeshTopologyHash::centered(a, cx, cy, cz);
+    const ReconstructedMesh cb = MeshTopologyHash::centered(b, cx, cy, cz);
+
+    EXPECT_EQ(MeshTopologyHash::hashMesh(ca, MeshDedupeMode::Loose),
+              MeshTopologyHash::hashMesh(cb, MeshDedupeMode::Loose));
+}
+
+TEST(MeshTopologyHashTest, StrictModeSeparatesSmallTranslation)
+{
+    const ReconstructedMesh a = unitTriangleAt(0.0f, 0.0f, 0.0f);
+    const ReconstructedMesh b = unitTriangleAt(0.05f, 0.0f, 0.0f);
+
+    float cx = 0.0f;
+    float cy = 0.0f;
+    float cz = 0.0f;
+    const ReconstructedMesh ca = MeshTopologyHash::centered(a, cx, cy, cz);
+    const ReconstructedMesh cb = MeshTopologyHash::centered(b, cx, cy, cz);
+
+    EXPECT_NE(MeshTopologyHash::hashMesh(ca, MeshDedupeMode::Strict),
+              MeshTopologyHash::hashMesh(cb, MeshDedupeMode::Strict));
+}

--- a/src/PS1/runtime/MeshTopologyHash_test.cpp
+++ b/src/PS1/runtime/MeshTopologyHash_test.cpp
@@ -35,6 +35,49 @@ TEST(MeshTopologyHashTest, LooseModeIgnoresSmallTranslation)
               MeshTopologyHash::hashMesh(cb, MeshDedupeMode::Loose));
 }
 
+TEST(MeshTopologyHashTest, DifferentMaterialSeparatesHash)
+{
+    ReconstructedMesh a = unitTriangleAt(0.0f, 0.0f, 0.0f);
+    a.subMeshes[0].materialName = QStringLiteral("PS1Rip/tpage_0001_clut_0000");
+    ReconstructedMesh b = a;
+    b.subMeshes[0].materialName = QStringLiteral("PS1Rip/tpage_0002_clut_0000");
+
+    float cx = 0.0f;
+    float cy = 0.0f;
+    float cz = 0.0f;
+    const ReconstructedMesh ca = MeshTopologyHash::centered(a, cx, cy, cz);
+    const ReconstructedMesh cb = MeshTopologyHash::centered(b, cx, cy, cz);
+
+    EXPECT_NE(MeshTopologyHash::hashMesh(ca, MeshDedupeMode::Loose),
+              MeshTopologyHash::hashMesh(cb, MeshDedupeMode::Loose));
+}
+
+TEST(MeshTopologyHashTest, SubmeshOrderIsInvariant)
+{
+    ReconstructedMesh ordered;
+    ReconstructedSubMesh subA;
+    subA.materialName = QStringLiteral("PS1Rip/tpage_0001_clut_0000");
+    subA.vertices = {{0, 0, 0, 0, 0, 1, 0, 0, 0xFFFFFFFFu},
+                     {1, 0, 0, 0, 0, 1, 0, 0, 0xFFFFFFFFu},
+                     {0, 1, 0, 0, 0, 1, 0, 0, 0xFFFFFFFFu}};
+    subA.indices = {0, 1, 2};
+    ReconstructedSubMesh subB = subA;
+    subB.materialName = QStringLiteral("PS1Rip/tpage_0002_clut_0000");
+    ordered.subMeshes = {subA, subB};
+
+    ReconstructedMesh permuted;
+    permuted.subMeshes = {subB, subA};
+
+    float cx = 0.0f;
+    float cy = 0.0f;
+    float cz = 0.0f;
+    const ReconstructedMesh centeredOrdered = MeshTopologyHash::centered(ordered, cx, cy, cz);
+    const ReconstructedMesh centeredPermuted = MeshTopologyHash::centered(permuted, cx, cy, cz);
+
+    EXPECT_EQ(MeshTopologyHash::hashMesh(centeredOrdered, MeshDedupeMode::Loose),
+              MeshTopologyHash::hashMesh(centeredPermuted, MeshDedupeMode::Loose));
+}
+
 TEST(MeshTopologyHashTest, StrictModeSeparatesSmallTranslation)
 {
     const ReconstructedMesh a = unitTriangleAt(0.0f, 0.0f, 0.0f);

--- a/src/PS1/runtime/PS1RipManager.cpp
+++ b/src/PS1/runtime/PS1RipManager.cpp
@@ -1,6 +1,7 @@
 #include "PS1RipManager.h"
 #include "CaptureSnapshot.h"
 #include "MeshReconstructor.h"
+#include "MeshTopologyHash.h"
 #include "PS1RipMeshBuilder.h"
 #include "PS1RipWorker.h"
 #include "PsxDiscResolver.h"
@@ -85,8 +86,11 @@ void PS1RipManager::initializeWorkerThread()
 
                 emit frameCaptured(captureId);
 
-                const ReconstructedMesh mesh = MeshReconstructor::reconstruct(snapshot);
-                if (mesh.isEmpty()) {
+                const MeshDedupeMode dedupeMode =
+                    m_dedupeStrict ? MeshDedupeMode::Strict : MeshDedupeMode::Loose;
+                const ReconstructedCaptureSet captureSet =
+                    MeshReconstructor::reconstructDeduped(snapshot, dedupeMode);
+                if (captureSet.isEmpty()) {
                     reportError(tr("Capture produced no reconstructable geometry"));
                     return;
                 }
@@ -94,7 +98,8 @@ void PS1RipManager::initializeWorkerThread()
                 PS1RipMeshBuilder::BuildResult built;
                 QString buildErr;
                 try {
-                    if (!PS1RipMeshBuilder::attachToScene(mesh, captureId, &snapshot, &built, &buildErr)) {
+                    if (!PS1RipMeshBuilder::attachCaptureSetToScene(captureSet, captureId, &snapshot,
+                                                                    &built, &buildErr)) {
                         reportError(buildErr.isEmpty() ? tr("Failed to build capture mesh")
                                                      : buildErr);
                         return;
@@ -105,9 +110,17 @@ void PS1RipManager::initializeWorkerThread()
                 }
 
                 SentryReporter::addBreadcrumb(
+                    QStringLiteral("ps1.rip.dedupe.summary"),
+                    QStringLiteral("captured=%1 unique=%2 instances=%3 mode=%4")
+                        .arg(captureSet.capturedPartCount)
+                        .arg(captureSet.uniqueCount())
+                        .arg(captureSet.instanceCount())
+                        .arg(m_dedupeStrict ? QStringLiteral("strict") : QStringLiteral("loose")));
+                SentryReporter::addBreadcrumb(
                     QStringLiteral("ps1.rip.mesh.built"),
                     QStringLiteral("%1 verts %2 tris").arg(built.vertexCount).arg(built.triangleCount));
-                emit meshBuilt(captureId, built.vertexCount, built.triangleCount);
+                emit meshBuilt(captureId, captureSet.capturedPartCount, captureSet.uniqueCount(),
+                               captureSet.instanceCount(), built.vertexCount, built.triangleCount);
             });
     connect(m_worker, &PS1RipWorker::vramFrameUpdated, this,
             [this](const QVector<uint16_t> &cells, const QImage &preview) {

--- a/src/PS1/runtime/PS1RipManager.h
+++ b/src/PS1/runtime/PS1RipManager.h
@@ -42,6 +42,9 @@ public:
     bool captureScene(int seconds);
     bool dumpVRAM();
 
+    bool dedupeStrict() const { return m_dedupeStrict; }
+    void setDedupeStrict(bool strict) { m_dedupeStrict = strict; }
+
     void setJoypadPressed(unsigned port, unsigned buttonId, bool pressed);
     void resetJoypad(unsigned port = 0);
 
@@ -53,7 +56,8 @@ signals:
     void sessionStopped();
     void framePresented(const QImage &frame, quint64 frameIndex);
     void frameCaptured(const QString &captureId);
-    void meshBuilt(const QString &captureId, int vertexCount, int triangleCount);
+    void meshBuilt(const QString &captureId, int capturedParts, int uniqueMeshes, int instanceCount,
+                   int vertexCount, int triangleCount);
     void sceneCaptured(const QString &captureId);
     void vramDumped(const QString &captureId, const QString &pngPath, const QVector<uint16_t> &cells,
                     const QImage &nativePreview);
@@ -79,6 +83,7 @@ private:
     bool m_startPending = false;
     bool m_paused = false;
     bool m_captureArmed = false;
+    bool m_dedupeStrict = false;
 
     QThread *m_workerThread = nullptr;
     PS1RipWorker *m_worker = nullptr;

--- a/src/PS1/runtime/PS1RipMeshBuilder.cpp
+++ b/src/PS1/runtime/PS1RipMeshBuilder.cpp
@@ -339,3 +339,113 @@ bool PS1RipMeshBuilder::attachToScene(const ReconstructedMesh &mesh, const QStri
     }
     return true;
 }
+
+bool PS1RipMeshBuilder::attachCaptureSetToScene(const ReconstructedCaptureSet &captureSet,
+                                                const QString &captureId,
+                                                const CaptureSnapshot *textureSource,
+                                                BuildResult *resultOut, QString *errorOut)
+{
+    if (captureSet.isEmpty()) {
+        if (errorOut)
+            *errorOut = QStringLiteral("Reconstructed capture set is empty");
+        return false;
+    }
+
+    Manager *mgr = Manager::getSingletonPtr();
+    if (!mgr) {
+        if (errorOut)
+            *errorOut = QStringLiteral("Editor scene is not available");
+        return false;
+    }
+
+    removePriorCaptureNodes(mgr);
+
+    Ogre::AxisAlignedBox combinedBounds;
+    combinedBounds.setNull();
+    for (const ReconstructedMesh &mesh : captureSet.uniqueMeshes) {
+        const Ogre::AxisAlignedBox b = meshBounds(mesh);
+        if (!b.isNull())
+            combinedBounds.merge(b);
+    }
+    if (combinedBounds.isNull())
+        combinedBounds = Ogre::AxisAlignedBox(-0.5f, -0.5f, -0.5f, 0.5f, 0.5f, 0.5f);
+
+    const Ogre::Vector3 size = combinedBounds.getSize();
+    const float maxExtent = std::max(size.x, std::max(size.y, size.z));
+    float placementScale = 1.0f;
+    if (maxExtent > 1e-6f) {
+        placementScale = kTargetMaxExtent / maxExtent;
+        if (maxExtent < 0.01f)
+            placementScale = 3.0f / maxExtent;
+    }
+
+    TextureDecoder textureDecoder;
+    int totalVerts = 0;
+    int totalTris = 0;
+    Ogre::SceneNode *firstNode = nullptr;
+    Ogre::Entity *firstEntity = nullptr;
+
+    int instanceOrdinal = 0;
+    for (int meshIndex = 0; meshIndex < captureSet.uniqueMeshes.size(); ++meshIndex) {
+        const ReconstructedMesh &mesh = captureSet.uniqueMeshes[meshIndex];
+        const QString meshName = QStringLiteral("ps1_capture_%1_u%2").arg(captureId).arg(meshIndex);
+        const std::string ogreMeshName = meshName.toStdString();
+
+        if (Ogre::MeshManager::getSingleton().resourceExists(ogreMeshName))
+            Ogre::MeshManager::getSingleton().remove(ogreMeshName);
+
+        const Ogre::AxisAlignedBox localBounds = meshBounds(mesh);
+        Ogre::AxisAlignedBox bounds = localBounds;
+        if (bounds.isNull())
+            bounds = Ogre::AxisAlignedBox(-0.5f, -0.5f, -0.5f, 0.5f, 0.5f, 0.5f);
+
+        Ogre::MeshPtr ogreMesh = Ogre::MeshManager::getSingleton().createManual(
+            ogreMeshName, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+
+        for (const ReconstructedSubMesh &sub : mesh.subMeshes) {
+            Ogre::SubMesh *ogreSub = ogreMesh->createSubMesh();
+            ogreSub->setMaterialName(
+                ensureMaterial(sub.materialName, textureSource, captureId, &textureDecoder)
+                    ->getName());
+            writeSubMesh(sub, ogreSub);
+        }
+
+        ogreMesh->_setBounds(bounds);
+        ogreMesh->_setBoundingSphereRadius(bounds.getHalfSize().length());
+        ogreMesh->load();
+
+        totalVerts += mesh.vertexCount;
+        totalTris += mesh.triangleCount;
+
+        for (const ReconstructedInstance &inst : captureSet.instances) {
+            if (inst.uniqueMeshIndex != meshIndex)
+                continue;
+
+            const QString nodeName =
+                QStringLiteral("PS1Capture_%1_inst%2").arg(captureId).arg(instanceOrdinal++);
+            Ogre::SceneNode *node = mgr->addSceneNode(nodeName);
+            node->setPosition(inst.px * placementScale, inst.py * placementScale,
+                              inst.pz * placementScale);
+            node->setScale(placementScale, placementScale, placementScale);
+
+            Ogre::Entity *entity = mgr->createEntity(node, ogreMesh);
+            if (!entity) {
+                if (errorOut)
+                    *errorOut = QStringLiteral("Failed to create Ogre entity for instance");
+                return false;
+            }
+            if (!firstNode) {
+                firstNode = node;
+                firstEntity = entity;
+            }
+        }
+    }
+
+    if (resultOut) {
+        resultOut->sceneNode = firstNode;
+        resultOut->entity = firstEntity;
+        resultOut->vertexCount = totalVerts;
+        resultOut->triangleCount = totalTris;
+    }
+    return true;
+}

--- a/src/PS1/runtime/PS1RipMeshBuilder.cpp
+++ b/src/PS1/runtime/PS1RipMeshBuilder.cpp
@@ -360,12 +360,27 @@ bool PS1RipMeshBuilder::attachCaptureSetToScene(const ReconstructedCaptureSet &c
 
     removePriorCaptureNodes(mgr);
 
+    QVector<Ogre::AxisAlignedBox> localBoundsByMesh(captureSet.uniqueMeshes.size());
+    for (int i = 0; i < captureSet.uniqueMeshes.size(); ++i)
+        localBoundsByMesh[i] = meshBounds(captureSet.uniqueMeshes[i]);
+
     Ogre::AxisAlignedBox combinedBounds;
     combinedBounds.setNull();
-    for (const ReconstructedMesh &mesh : captureSet.uniqueMeshes) {
-        const Ogre::AxisAlignedBox b = meshBounds(mesh);
-        if (!b.isNull())
-            combinedBounds.merge(b);
+    for (const ReconstructedInstance &inst : captureSet.instances) {
+        if (inst.uniqueMeshIndex < 0 || inst.uniqueMeshIndex >= localBoundsByMesh.size())
+            continue;
+        const Ogre::AxisAlignedBox &local = localBoundsByMesh[inst.uniqueMeshIndex];
+        if (local.isNull())
+            continue;
+        const Ogre::Vector3 t(inst.px, inst.py, inst.pz);
+        combinedBounds.merge(local.getMinimum() + t);
+        combinedBounds.merge(local.getMaximum() + t);
+    }
+    if (combinedBounds.isNull()) {
+        for (const Ogre::AxisAlignedBox &local : localBoundsByMesh) {
+            if (!local.isNull())
+                combinedBounds.merge(local);
+        }
     }
     if (combinedBounds.isNull())
         combinedBounds = Ogre::AxisAlignedBox(-0.5f, -0.5f, -0.5f, 0.5f, 0.5f, 0.5f);
@@ -385,6 +400,7 @@ bool PS1RipMeshBuilder::attachCaptureSetToScene(const ReconstructedCaptureSet &c
     Ogre::SceneNode *firstNode = nullptr;
     Ogre::Entity *firstEntity = nullptr;
 
+    QStringList createdNodeNames;
     int instanceOrdinal = 0;
     for (int meshIndex = 0; meshIndex < captureSet.uniqueMeshes.size(); ++meshIndex) {
         const ReconstructedMesh &mesh = captureSet.uniqueMeshes[meshIndex];
@@ -424,12 +440,15 @@ bool PS1RipMeshBuilder::attachCaptureSetToScene(const ReconstructedCaptureSet &c
             const QString nodeName =
                 QStringLiteral("PS1Capture_%1_inst%2").arg(captureId).arg(instanceOrdinal++);
             Ogre::SceneNode *node = mgr->addSceneNode(nodeName);
+            createdNodeNames.append(nodeName);
             node->setPosition(inst.px * placementScale, inst.py * placementScale,
                               inst.pz * placementScale);
             node->setScale(placementScale, placementScale, placementScale);
 
             Ogre::Entity *entity = mgr->createEntity(node, ogreMesh);
             if (!entity) {
+                for (const QString &createdName : createdNodeNames)
+                    mgr->destroySceneNode(createdName);
                 if (errorOut)
                     *errorOut = QStringLiteral("Failed to create Ogre entity for instance");
                 return false;

--- a/src/PS1/runtime/PS1RipMeshBuilder.h
+++ b/src/PS1/runtime/PS1RipMeshBuilder.h
@@ -25,6 +25,12 @@ public:
     static bool attachToScene(const ReconstructedMesh &mesh, const QString &captureId,
                               const CaptureSnapshot *textureSource, BuildResult *resultOut,
                               QString *errorOut = nullptr);
+
+    /** Places deduplicated meshes with one SceneNode per instance (#423). */
+    static bool attachCaptureSetToScene(const ReconstructedCaptureSet &captureSet,
+                                        const QString &captureId,
+                                        const CaptureSnapshot *textureSource, BuildResult *resultOut,
+                                        QString *errorOut = nullptr);
 };
 
 #endif // PS1RIPMESHBUILDER_H

--- a/src/PS1/runtime/PS1RipSessionWindow.cpp
+++ b/src/PS1/runtime/PS1RipSessionWindow.cpp
@@ -75,6 +75,10 @@ PS1RipSessionWindow::PS1RipSessionWindow(QWidget *parent)
     m_manager->setDedupeStrict(strictDedupe->isChecked());
     connect(strictDedupe, &QCheckBox::toggled, this, [this](bool on) {
         m_manager->setDedupeStrict(on);
+        SentryReporter::addBreadcrumb(
+            QStringLiteral("ui.action"),
+            on ? QStringLiteral("ps1_rip_strict_dedupe_on")
+               : QStringLiteral("ps1_rip_strict_dedupe_off"));
         QSettings().setValue(QString::fromLatin1(kSettingsGroup) + QLatin1Char('/')
                                  + QString::fromLatin1(kDedupeStrictKey),
                              on);

--- a/src/PS1/runtime/PS1RipSessionWindow.cpp
+++ b/src/PS1/runtime/PS1RipSessionWindow.cpp
@@ -18,12 +18,14 @@
 #include <QMessageBox>
 #include <QSettings>
 #include <QStatusBar>
+#include <QCheckBox>
 #include <QToolBar>
 
 namespace {
 constexpr auto kSettingsGroup = "ps1Rip";
 constexpr auto kBiosKey = "biosPath";
 constexpr auto kRecentIsoKey = "recentIsos";
+constexpr auto kDedupeStrictKey = "dedupeStrict";
 } // namespace
 
 PS1RipSessionWindow::PS1RipSessionWindow(QWidget *parent)
@@ -64,6 +66,20 @@ PS1RipSessionWindow::PS1RipSessionWindow(QWidget *parent)
     });
     auto *captureAct = toolbar->addAction(tr("Capture Frame"));
     connect(captureAct, &QAction::triggered, this, &PS1RipSessionWindow::onCaptureFrame);
+    auto *strictDedupe = new QCheckBox(tr("Strict dedupe"), this);
+    strictDedupe->setToolTip(tr("Bit-exact topology hash (off = 0.01 position snap)"));
+    strictDedupe->setChecked(
+        QSettings().value(QString::fromLatin1(kSettingsGroup) + QLatin1Char('/')
+                              + QString::fromLatin1(kDedupeStrictKey), false)
+            .toBool());
+    m_manager->setDedupeStrict(strictDedupe->isChecked());
+    connect(strictDedupe, &QCheckBox::toggled, this, [this](bool on) {
+        m_manager->setDedupeStrict(on);
+        QSettings().setValue(QString::fromLatin1(kSettingsGroup) + QLatin1Char('/')
+                                 + QString::fromLatin1(kDedupeStrictKey),
+                             on);
+    });
+    toolbar->addWidget(strictDedupe);
     auto *dumpVramAct = toolbar->addAction(tr("Dump VRAM"));
     connect(dumpVramAct, &QAction::triggered, this, &PS1RipSessionWindow::onDumpVram);
 
@@ -238,12 +254,17 @@ void PS1RipSessionWindow::onCaptureFrame()
     m_manager->captureFrame();
 }
 
-void PS1RipSessionWindow::onMeshBuilt(const QString &captureId, int vertexCount, int triangleCount)
+void PS1RipSessionWindow::onMeshBuilt(const QString &captureId, int capturedParts, int uniqueMeshes,
+                                    int instanceCount, int vertexCount, int triangleCount)
 {
-    m_statusLabel->setText(tr("Mesh built: %1 (%2 verts, %3 tris) — see main scene")
-                               .arg(captureId)
-                               .arg(vertexCount)
-                               .arg(triangleCount));
+    m_statusLabel->setText(
+        tr("Mesh %1 — captured %2 / unique %3 / instances %4 (%5 verts, %6 tris)")
+            .arg(captureId)
+            .arg(capturedParts)
+            .arg(uniqueMeshes)
+            .arg(instanceCount)
+            .arg(vertexCount)
+            .arg(triangleCount));
 }
 
 void PS1RipSessionWindow::onVramDumped(const QString &captureId, const QString &pngPath,

--- a/src/PS1/runtime/PS1RipSessionWindow.h
+++ b/src/PS1/runtime/PS1RipSessionWindow.h
@@ -38,7 +38,8 @@ private slots:
     void onCaptureFrame();
     void onVramDumped(const QString &captureId, const QString &pngPath, const QVector<uint16_t> &cells,
                       const QImage &nativePreview);
-    void onMeshBuilt(const QString &captureId, int vertexCount, int triangleCount);
+    void onMeshBuilt(const QString &captureId, int capturedParts, int uniqueMeshes, int instanceCount,
+                     int vertexCount, int triangleCount);
 
 private:
     void updateFps(quint64 frameIndex);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -145,6 +145,7 @@ if(BUILD_TESTS)
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/GpuCommandParser.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/GteCapture.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/MeshReconstructor.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/MeshTopologyHash.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PS1RipMeshBuilder.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PS1RipLegalityDialog.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PS1RipManager.cpp


### PR DESCRIPTION
## Summary
- Adds topology hashing (`MeshTopologyHash`) with loose (0.01) and strict modes to collapse identical per-matrix capture parts into unique meshes.
- Places one `PS1Capture_<id>_instN` SceneNode per instance at the captured centroid; session toolbar shows **Strict dedupe** and status counts (captured / unique / instances).
- Sentry breadcrumb `ps1.rip.dedupe.summary` plus unit tests for hash modes and a 3-instance synthetic scene.

## Test plan
- [x] `UnitTests --gtest_filter='MeshReconstructor*:MeshTopologyHash*'` (8/8 pass, offscreen)
- [ ] CI `unit-tests-linux` with `ENABLE_PS1_RIP=ON`
- [ ] Manual: arm capture on libretro session, capture repeated props, verify one mesh + multiple instances in main scene

Closes #423


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mesh deduplication with Loose and Strict modes; captures unique meshes and instances, and attaches deduped capture sets to the scene
  * Added "Strict dedupe" toolbar toggle (persisted) and richer mesh-built notifications with captured parts, unique meshes, instance, vertex and triangle counts

* **Documentation**
  * Updated Phase 4 design to describe the reconstruction and dedupe pipeline

* **Tests**
  * Added unit tests validating deduplication and topology hashing behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/639?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->