### PR TITLE
feat(ps1): complete emulator viewport (#416)

### DIFF
--- a/src/PS1/PS1_RIP_DESIGN.md
+++ b/src/PS1/PS1_RIP_DESIGN.md
@@ -60,7 +60,8 @@ See epic #412 for phased issues (#413–#431).
 - `EmuCore` + `IEmuCorePlugin` + `EmuCoreLoader` landed (#415).
 - **Libretro host** `plugins/ps1core_libretro/` loads `mednafen_psx_libretro` / `beetle_psx_*` from `PS1Cores/`, system paths, or `QTMESH_PS1_LIBRETRO_CORE`. Runs a real ISO when BIOS + disc image are set.
 - Stub plugin `plugins/ps1core_stub/` remains for CI (test pattern + synthetic capture).
-- `PS1RipSessionWindow` + `EmuViewport` + legality dialog (#416–#417) — keyboard/gamepad input still TODO.
+- `PS1RipSessionWindow` + `EmuViewport` (#416): software framebuffer via `QPainter`, integer-scale and bilinear toggles (View menu), 4:3 NTSC/PAL letterbox mode, FPS overlay, frame pacing tied to `runFrame()` completion (~16 ms target). Hosted in a temporary session window from *Tools → Experimental → PS1 Runtime Ripper…* until #425 dock lands.
+- Legality dialog + BIOS/ISO + keyboard/gamepad (#417) — controller mapping beyond keyboard/mouse still TODO.
 - Install helper: `scripts/install-ps1-libretro-core.sh` copies a distro libretro core into `build/bin/PS1Cores/`.
 
 ## Phase 2 status

--- a/src/PS1/runtime/EmuViewport.cpp
+++ b/src/PS1/runtime/EmuViewport.cpp
@@ -12,6 +12,28 @@ namespace {
 
 constexpr unsigned kPort = 0;
 
+QRect aspectContentArea(const QSize &widgetSize, EmuViewport::AspectMode aspect)
+{
+    if (widgetSize.width() < 1 || widgetSize.height() < 1)
+        return {};
+
+    QRect area(0, 0, widgetSize.width(), widgetSize.height());
+    if (aspect != EmuViewport::AspectMode::Display43)
+        return area;
+
+    constexpr qreal kDisplayAspect = 4.0 / 3.0;
+    const qreal widgetAspect =
+        static_cast<qreal>(widgetSize.width()) / static_cast<qreal>(widgetSize.height());
+    if (widgetAspect > kDisplayAspect) {
+        const int w = static_cast<int>(widgetSize.height() * kDisplayAspect);
+        area = QRect((widgetSize.width() - w) / 2, 0, w, widgetSize.height());
+    } else if (widgetAspect < kDisplayAspect) {
+        const int h = static_cast<int>(widgetSize.width() / kDisplayAspect);
+        area = QRect(0, (widgetSize.height() - h) / 2, widgetSize.width(), h);
+    }
+    return area;
+}
+
 void setButton(unsigned id, bool pressed)
 {
     PsxJoypadState::setPressed(kPort, id, pressed);
@@ -100,6 +122,37 @@ bool mapMouse(Qt::MouseButton button, unsigned *buttonOut)
 
 } // namespace
 
+EmuViewport::FrameLayout EmuViewport::computeFrameLayout(const QSize &widgetSize,
+                                                       const QSize &frameSize, bool integerScale,
+                                                       bool smoothFiltering, AspectMode aspect)
+{
+    FrameLayout layout;
+    if (widgetSize.width() < 1 || widgetSize.height() < 1 || frameSize.width() < 1
+        || frameSize.height() < 1)
+        return layout;
+
+    const QRect content = aspectContentArea(widgetSize, aspect);
+    if (content.isEmpty())
+        return layout;
+
+    QSize dst = frameSize;
+    if (integerScale) {
+        const int scaleX = qMax(1, content.width() / frameSize.width());
+        const int scaleY = qMax(1, content.height() / frameSize.height());
+        const int scale = qMin(scaleX, scaleY);
+        dst = QSize(frameSize.width() * scale, frameSize.height() * scale);
+        layout.smoothFiltering = false;
+    } else {
+        dst = frameSize.scaled(content.size(), Qt::KeepAspectRatio);
+        layout.smoothFiltering = smoothFiltering;
+    }
+
+    const int x = content.x() + (content.width() - dst.width()) / 2;
+    const int y = content.y() + (content.height() - dst.height()) / 2;
+    layout.target = QRect(x, y, dst.width(), dst.height());
+    return layout;
+}
+
 EmuViewport::EmuViewport(QWidget *parent)
     : QWidget(parent)
 {
@@ -120,6 +173,18 @@ void EmuViewport::setFrame(const QImage &frame)
 void EmuViewport::setIntegerScale(bool enabled)
 {
     m_integerScale = enabled;
+    update();
+}
+
+void EmuViewport::setSmoothFiltering(bool enabled)
+{
+    m_smoothFiltering = enabled;
+    update();
+}
+
+void EmuViewport::setAspectMode(AspectMode mode)
+{
+    m_aspectMode = mode;
     update();
 }
 
@@ -203,6 +268,12 @@ void EmuViewport::paintEvent(QPaintEvent *event)
     QPainter painter(this);
     painter.fillRect(rect(), QColor(16, 16, 16));
 
+    if (m_aspectMode == AspectMode::Display43) {
+        const QRect content = aspectContentArea(size(), m_aspectMode);
+        if (!content.isEmpty())
+            painter.fillRect(content, QColor(8, 8, 8));
+    }
+
     if (m_frame.isNull()) {
         painter.setPen(QColor(160, 160, 160));
         painter.drawText(rect(), Qt::AlignCenter,
@@ -210,23 +281,13 @@ void EmuViewport::paintEvent(QPaintEvent *event)
         return;
     }
 
-    const QSize src = m_frame.size();
-    QSize dst = src;
-    if (m_integerScale && src.width() > 0 && src.height() > 0) {
-        const int scaleX = qMax(1, width() / src.width());
-        const int scaleY = qMax(1, height() / src.height());
-        const int scale = qMin(scaleX, scaleY);
-        dst = QSize(src.width() * scale, src.height() * scale);
-    } else {
-        dst = src.scaled(size(), Qt::KeepAspectRatio);
-    }
+    const FrameLayout layout =
+        computeFrameLayout(size(), m_frame.size(), m_integerScale, m_smoothFiltering, m_aspectMode);
+    if (layout.target.isEmpty())
+        return;
 
-    const int x = (width() - dst.width()) / 2;
-    const int y = (height() - dst.height()) / 2;
-    const QRect target(x, y, dst.width(), dst.height());
-
-    painter.setRenderHint(QPainter::SmoothPixmapTransform, !m_integerScale);
-    painter.drawImage(target, m_frame);
+    painter.setRenderHint(QPainter::SmoothPixmapTransform, layout.smoothFiltering);
+    painter.drawImage(layout.target, m_frame);
 
     painter.setPen(QColor(220, 220, 220));
     painter.drawText(8, 20, tr("FPS: %1").arg(m_fps, 0, 'f', 1));

--- a/src/PS1/runtime/EmuViewport.h
+++ b/src/PS1/runtime/EmuViewport.h
@@ -2,6 +2,8 @@
 #define EMUVIEWPORT_H
 
 #include <QImage>
+#include <QRect>
+#include <QSize>
 #include <QWidget>
 
 /**
@@ -13,13 +15,32 @@ class EmuViewport : public QWidget
     Q_OBJECT
 
 public:
+    /** How the widget fits the PS1 picture into the window. */
+    enum class AspectMode {
+        Native,   ///< Use the core framebuffer aspect only.
+        Display43 ///< Letterbox/pillarbox to 4:3 (NTSC/PAL display aspect).
+    };
+
+    struct FrameLayout {
+        QRect target;
+        bool smoothFiltering = false;
+    };
+
     explicit EmuViewport(QWidget *parent = nullptr);
 
     void setFrame(const QImage &frame);
     void setIntegerScale(bool enabled);
     bool integerScale() const { return m_integerScale; }
+    void setSmoothFiltering(bool enabled);
+    bool smoothFiltering() const { return m_smoothFiltering; }
+    void setAspectMode(AspectMode mode);
+    AspectMode aspectMode() const { return m_aspectMode; }
     void setFps(double fps);
     void setShowInputHelp(bool show);
+
+    /** Pure layout math for unit tests (#416). */
+    static FrameLayout computeFrameLayout(const QSize &widgetSize, const QSize &frameSize,
+                                        bool integerScale, bool smoothFiltering, AspectMode aspect);
 
 protected:
     void paintEvent(QPaintEvent *event) override;
@@ -37,6 +58,8 @@ private:
 
     QImage m_frame;
     bool m_integerScale = true;
+    bool m_smoothFiltering = false;
+    AspectMode m_aspectMode = AspectMode::Display43;
     bool m_showInputHelp = true;
     double m_fps = 0.0;
 };

--- a/src/PS1/runtime/EmuViewport_test.cpp
+++ b/src/PS1/runtime/EmuViewport_test.cpp
@@ -1,0 +1,49 @@
+#ifdef ENABLE_PS1_RIP
+
+#include "EmuViewport.h"
+
+#include <gtest/gtest.h>
+#include <QApplication>
+
+class EmuViewportTest : public ::testing::Test
+{
+protected:
+    void SetUp() override { ASSERT_NE(QCoreApplication::instance(), nullptr); }
+};
+
+TEST_F(EmuViewportTest, IntegerScaleUsesWholePixelSteps)
+{
+    const QSize frame(320, 240);
+    const EmuViewport::FrameLayout layout = EmuViewport::computeFrameLayout(
+        QSize(960, 720), frame, true, false, EmuViewport::AspectMode::Native);
+
+    ASSERT_FALSE(layout.target.isEmpty());
+    EXPECT_FALSE(layout.smoothFiltering);
+    EXPECT_EQ(layout.target.width() % frame.width(), 0);
+    EXPECT_EQ(layout.target.height() % frame.height(), 0);
+    EXPECT_GE(layout.target.width(), frame.width());
+    EXPECT_GE(layout.target.height(), frame.height());
+}
+
+TEST_F(EmuViewportTest, SmoothFilteringWhenNotIntegerScaled)
+{
+    const EmuViewport::FrameLayout layout = EmuViewport::computeFrameLayout(
+        QSize(400, 300), QSize(320, 240), false, true, EmuViewport::AspectMode::Native);
+
+    ASSERT_FALSE(layout.target.isEmpty());
+    EXPECT_TRUE(layout.smoothFiltering);
+}
+
+TEST_F(EmuViewportTest, Display43LetterboxesWideWidget)
+{
+    const EmuViewport::FrameLayout layout = EmuViewport::computeFrameLayout(
+        QSize(1000, 600), QSize(320, 240), true, false, EmuViewport::AspectMode::Display43);
+
+    ASSERT_FALSE(layout.target.isEmpty());
+    const qreal layoutAspect =
+        static_cast<qreal>(layout.target.width()) / static_cast<qreal>(layout.target.height());
+    EXPECT_NEAR(layoutAspect, 4.0 / 3.0, 0.02);
+    EXPECT_LT(layout.target.width(), 1000);
+}
+
+#endif // ENABLE_PS1_RIP

--- a/src/PS1/runtime/PS1RipSessionWindow.cpp
+++ b/src/PS1/runtime/PS1RipSessionWindow.cpp
@@ -19,6 +19,7 @@
 #include <QSettings>
 #include <QStatusBar>
 #include <QCheckBox>
+#include <QMenuBar>
 #include <QToolBar>
 
 namespace {
@@ -26,6 +27,14 @@ constexpr auto kSettingsGroup = "ps1Rip";
 constexpr auto kBiosKey = "biosPath";
 constexpr auto kRecentIsoKey = "recentIsos";
 constexpr auto kDedupeStrictKey = "dedupeStrict";
+constexpr auto kViewportIntegerScaleKey = "viewportIntegerScale";
+constexpr auto kViewportSmoothFilterKey = "viewportSmoothFilter";
+constexpr auto kViewportAspect43Key = "viewportAspect43";
+
+QString ps1SettingsKey(const char *name)
+{
+    return QString::fromLatin1(kSettingsGroup) + QLatin1Char('/') + QString::fromLatin1(name);
+}
 } // namespace
 
 PS1RipSessionWindow::PS1RipSessionWindow(QWidget *parent)
@@ -37,6 +46,53 @@ PS1RipSessionWindow::PS1RipSessionWindow(QWidget *parent)
 
     m_viewport = new EmuViewport(this);
     setCentralWidget(m_viewport);
+
+    QSettings settings;
+    m_viewport->setIntegerScale(
+        settings.value(ps1SettingsKey(kViewportIntegerScaleKey), true).toBool());
+    m_viewport->setSmoothFiltering(
+        settings.value(ps1SettingsKey(kViewportSmoothFilterKey), false).toBool());
+    m_viewport->setAspectMode(
+        settings.value(ps1SettingsKey(kViewportAspect43Key), true).toBool()
+            ? EmuViewport::AspectMode::Display43
+            : EmuViewport::AspectMode::Native);
+
+    auto *viewMenu = menuBar()->addMenu(tr("View"));
+    auto *integerScaleAct = viewMenu->addAction(tr("Integer scale"));
+    integerScaleAct->setCheckable(true);
+    integerScaleAct->setChecked(m_viewport->integerScale());
+    integerScaleAct->setToolTip(tr("Nearest-neighbor upscale in whole-pixel steps"));
+    connect(integerScaleAct, &QAction::toggled, this, [this](bool on) {
+        m_viewport->setIntegerScale(on);
+        QSettings().setValue(ps1SettingsKey(kViewportIntegerScaleKey), on);
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                    on ? QStringLiteral("ps1_rip_viewport_integer_scale_on")
+                                       : QStringLiteral("ps1_rip_viewport_integer_scale_off"));
+    });
+
+    auto *smoothFilterAct = viewMenu->addAction(tr("Bilinear filtering"));
+    smoothFilterAct->setCheckable(true);
+    smoothFilterAct->setChecked(m_viewport->smoothFiltering());
+    smoothFilterAct->setToolTip(tr("Smooth scaling when integer scale is off"));
+    connect(smoothFilterAct, &QAction::toggled, this, [this](bool on) {
+        m_viewport->setSmoothFiltering(on);
+        QSettings().setValue(ps1SettingsKey(kViewportSmoothFilterKey), on);
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                    on ? QStringLiteral("ps1_rip_viewport_bilinear_on")
+                                       : QStringLiteral("ps1_rip_viewport_bilinear_off"));
+    });
+
+    auto *aspect43Act = viewMenu->addAction(tr("4:3 display aspect (NTSC/PAL)"));
+    aspect43Act->setCheckable(true);
+    aspect43Act->setChecked(m_viewport->aspectMode() == EmuViewport::AspectMode::Display43);
+    connect(aspect43Act, &QAction::toggled, this, [this](bool on) {
+        m_viewport->setAspectMode(on ? EmuViewport::AspectMode::Display43
+                                     : EmuViewport::AspectMode::Native);
+        QSettings().setValue(ps1SettingsKey(kViewportAspect43Key), on);
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                    on ? QStringLiteral("ps1_rip_viewport_aspect_43_on")
+                                       : QStringLiteral("ps1_rip_viewport_aspect_43_off"));
+    });
 
     auto *toolbar = addToolBar(tr("Transport"));
     toolbar->setMovable(false);
@@ -68,10 +124,7 @@ PS1RipSessionWindow::PS1RipSessionWindow(QWidget *parent)
     connect(captureAct, &QAction::triggered, this, &PS1RipSessionWindow::onCaptureFrame);
     auto *strictDedupe = new QCheckBox(tr("Strict dedupe"), this);
     strictDedupe->setToolTip(tr("Bit-exact topology hash (off = 0.01 position snap)"));
-    strictDedupe->setChecked(
-        QSettings().value(QString::fromLatin1(kSettingsGroup) + QLatin1Char('/')
-                              + QString::fromLatin1(kDedupeStrictKey), false)
-            .toBool());
+    strictDedupe->setChecked(settings.value(ps1SettingsKey(kDedupeStrictKey), false).toBool());
     m_manager->setDedupeStrict(strictDedupe->isChecked());
     connect(strictDedupe, &QCheckBox::toggled, this, [this](bool on) {
         m_manager->setDedupeStrict(on);
@@ -79,9 +132,7 @@ PS1RipSessionWindow::PS1RipSessionWindow(QWidget *parent)
             QStringLiteral("ui.action"),
             on ? QStringLiteral("ps1_rip_strict_dedupe_on")
                : QStringLiteral("ps1_rip_strict_dedupe_off"));
-        QSettings().setValue(QString::fromLatin1(kSettingsGroup) + QLatin1Char('/')
-                                 + QString::fromLatin1(kDedupeStrictKey),
-                             on);
+        QSettings().setValue(ps1SettingsKey(kDedupeStrictKey), on);
     });
     toolbar->addWidget(strictDedupe);
     auto *dumpVramAct = toolbar->addAction(tr("Dump VRAM"));

--- a/src/PS1/runtime/PS1RipWorker.cpp
+++ b/src/PS1/runtime/PS1RipWorker.cpp
@@ -13,6 +13,7 @@
 #include <QDir>
 #include <QFile>
 #include <QStandardPaths>
+#include <QElapsedTimer>
 #include <QTimer>
 
 #include <cstring>
@@ -28,8 +29,8 @@ PS1RipWorker::PS1RipWorker(QObject *parent)
     m_ripperHooks->setVram(m_vram.get());
 
     m_frameTimer = new QTimer(this);
+    m_frameTimer->setSingleShot(true);
     m_frameTimer->setTimerType(Qt::PreciseTimer);
-    m_frameTimer->setInterval(16);
     connect(m_frameTimer, &QTimer::timeout, this, &PS1RipWorker::runFrameTick);
 }
 
@@ -112,7 +113,7 @@ void PS1RipWorker::startEmulation()
 
     m_running = true;
     m_paused = false;
-    m_frameTimer->start();
+    scheduleNextFrame(0);
     emit emulationStarted(m_core ? m_core->coreId() : QString());
 }
 
@@ -135,10 +136,11 @@ void PS1RipWorker::pauseEmulation()
     if (!m_running)
         return;
     m_paused = !m_paused;
-    if (m_paused)
+    if (m_paused) {
         m_frameTimer->stop();
-    else
-        m_frameTimer->start();
+    } else {
+        scheduleNextFrame(0);
+    }
 }
 
 void PS1RipWorker::stepFrame()
@@ -149,10 +151,20 @@ void PS1RipWorker::stepFrame()
     emit framePresented(framebufferToImage(m_core->framebuffer()), m_core->framebuffer().frameIndex);
 }
 
+void PS1RipWorker::scheduleNextFrame(int delayMs)
+{
+    if (!m_running || m_paused || !m_core || !m_frameTimer)
+        return;
+    m_frameTimer->start(qMax(0, delayMs));
+}
+
 void PS1RipWorker::runFrameTick()
 {
     if (!m_running || m_paused || !m_core)
         return;
+
+    QElapsedTimer frameClock;
+    frameClock.start();
 
     m_core->runFrame();
     const EmuFramebuffer &fb = m_core->framebuffer();
@@ -162,6 +174,13 @@ void PS1RipWorker::runFrameTick()
         const QVector<uint16_t> cells = m_vram->mutablePixels();
         emit vramFrameUpdated(cells, m_vram->toImage(VramSnapshot::ViewMode::Native16));
     }
+
+    if (!m_running || m_paused || !m_core)
+        return;
+
+    constexpr int kTargetFrameMs = 16;
+    const int delayMs = qMax(0, kTargetFrameMs - static_cast<int>(frameClock.elapsed()));
+    scheduleNextFrame(delayMs);
 }
 
 void PS1RipWorker::setCaptureArmed(bool armed)

--- a/src/PS1/runtime/PS1RipWorker.h
+++ b/src/PS1/runtime/PS1RipWorker.h
@@ -64,6 +64,7 @@ private slots:
 
 private:
     bool ensureCore(QString *errorOut);
+    void scheduleNextFrame(int delayMs);
     static QImage framebufferToImage(const class EmuFramebuffer &fb);
 
     QString m_biosPath;


### PR DESCRIPTION
## Summary
- **View menu** in the PS1 session window: integer scale (nearest-neighbor), bilinear filtering, and 4:3 NTSC/PAL letterbox (persisted in QSettings).
- **`EmuViewport::computeFrameLayout`** — shared layout math with unit tests.
- **Frame pacing** — worker schedules the next frame after `runFrame()` completes, targeting ~60 Hz (16 ms minus elapsed time) instead of a blind repeating timer.
- Design doc updated; closes #416.

## Acceptance criteria (#416)
- [x] Software `EmuViewport` via `QPainter`, independent of Ogre
- [x] Integer scale toggle (View menu)
- [x] Bilinear toggle (View menu)
- [x] 4:3 display aspect (NTSC/PAL letterbox)
- [x] FPS readout
- [x] Sentry `ps1.rip.viewport.open` / `.close` (existing)
- [x] Clean shutdown on window close (existing)
- [x] Unit tests for viewport layout

## Test plan
- [x] `UnitTests --gtest_filter='EmuViewport*'` (3/3 pass, offscreen)
- [ ] Manual: open PS1 Runtime Ripper, toggle View options, confirm scaling/aspect/FPS

Closes #416


Made with [Cursor](https://cursor.com)