### PR TITLE
PS1 Phase 2: OT-linked GP0 capture (#418)

### DIFF
--- a/plugins/ps1core_libretro/CMakeLists.txt
+++ b/plugins/ps1core_libretro/CMakeLists.txt
@@ -15,6 +15,8 @@ add_library(qtmesh_ps1core_libretro MODULE
     LibretroEmuCorePlugin.cpp
     LibretroHost.cpp
     ${CMAKE_SOURCE_DIR}/src/PS1/runtime/Gp0HookDispatch.cpp
+    ${CMAKE_SOURCE_DIR}/src/PS1/runtime/PsxGp0ChainWalker.cpp
+    ${CMAKE_SOURCE_DIR}/src/PS1/runtime/PsxOrderingTableScanner.cpp
     ${CMAKE_SOURCE_DIR}/src/PS1/runtime/GpuCommandParser.cpp
     ${CMAKE_SOURCE_DIR}/src/PS1/runtime/PsxCaptureFilters.cpp
     ${CMAKE_SOURCE_DIR}/src/PS1/runtime/PsxBiosValidator.cpp

--- a/plugins/ps1core_stub/StubCaptureSynth.cpp
+++ b/plugins/ps1core_stub/StubCaptureSynth.cpp
@@ -66,9 +66,9 @@ void stubEmitCaptureSample(EmuHooks *hooks)
     hooks->onFrameEnd();
 }
 
-void stubFillVramPattern(EmuHooks *hooks, std::uint64_t frameIndex)
+void stubFillVramPattern(EmuHooks *hooks, std::uint64_t frameIndex, bool forceMirror)
 {
-    if (!hooks)
+    if (!hooks || (!forceMirror && !hooks->isCaptureEnabled()))
         return;
 
     QVector<uint16_t> clutRow(16);

--- a/plugins/ps1core_stub/StubCaptureSynth.h
+++ b/plugins/ps1core_stub/StubCaptureSynth.h
@@ -9,6 +9,6 @@ class EmuHooks;
 void stubEmitCaptureSample(EmuHooks *hooks);
 
 /** Fills VRAM with CLUT + 4/8/15 bpp test regions via onVramWrite (#420). */
-void stubFillVramPattern(EmuHooks *hooks, std::uint64_t frameIndex);
+void stubFillVramPattern(EmuHooks *hooks, std::uint64_t frameIndex, bool forceMirror = false);
 
 #endif // STUBCAPTURESYNTH_H

--- a/plugins/ps1core_stub/StubEmuCore.cpp
+++ b/plugins/ps1core_stub/StubEmuCore.cpp
@@ -54,7 +54,7 @@ void StubEmuCore::runFrame()
     EmuFramebuffer &buf = m_buffers[static_cast<size_t>(m_writeIndex)];
     buf.frameIndex = ++m_frameIndex;
     fillTestPattern(buf);
-    stubFillVramPattern(m_hooks, buf.frameIndex);
+    stubFillVramPattern(m_hooks, buf.frameIndex, false);
     stubEmitCaptureSample(m_hooks);
 
     m_readIndex = m_writeIndex;
@@ -81,7 +81,7 @@ void StubEmuCore::setHooks(EmuHooks *hooks)
 void StubEmuCore::syncCaptureMirrors()
 {
     if (m_hooks)
-        stubFillVramPattern(m_hooks, m_frameIndex);
+        stubFillVramPattern(m_hooks, m_frameIndex, true);
 }
 
 void StubEmuCore::fillTestPattern(EmuFramebuffer &buf)

--- a/src/PS1/CMakeLists.txt
+++ b/src/PS1/CMakeLists.txt
@@ -28,6 +28,8 @@ if(ENABLE_PS1_RIP)
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/GteInverse.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/EmuViewport.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/Gp0HookDispatch.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxGp0ChainWalker.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxOrderingTableScanner.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/GpuCommandParser.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/GteCapture.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/MeshReconstructor.cpp
@@ -64,6 +66,9 @@ if(ENABLE_PS1_RIP)
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/EmuFramebuffer.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/EmuHooks.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/Gp0HookDispatch.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxGp0ChainWalker.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxGp0Opcode.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxOrderingTableScanner.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/GpuCommandParser.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/EmuViewport.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/IEmuCorePlugin.h

--- a/src/PS1/PS1_RIP_DESIGN.md
+++ b/src/PS1/PS1_RIP_DESIGN.md
@@ -66,11 +66,14 @@ See epic #412 for phased issues (#413–#431).
 
 ## Phase 2 status
 
-- `CaptureTypes`, `GpuCommandParser`, `CaptureBuffer`, `RipperHooks` (#418).
+- `CaptureTypes`, `GpuCommandParser`, `CaptureBuffer`, `RipperHooks`, `Gp0HookDispatch` (#418).
+- `EmuHooks` included from `EmuCore.h` (issue #418 API surface).
 - GTE matrix hash dedupe + `cameraMatrixId` heuristic (#419).
-- **Libretro capture path:** `RipperHooks::ingestSystemRamForGpuCapture` runs `PsxGteRamScanner` (heuristic matrix find) + `PsxGpuRamScanner` (linear GP0 decode with correct low-byte opcodes) each frame while armed.
-- **Stub core** still emits synthetic primitives/VRAM for CI when `QTMESH_PS1_FORCE_STUB=1` or no libretro core is present.
+- **Libretro capture path:** `Gp0HookDispatch` in the plugin walks **ordering-table linked GP0 chains** first (`PsxOrderingTableScanner` + `PsxGp0ChainWalker`), then falls back to linear RAM opcode scan when no OT is found. Linked DR tags carry the opcode in bits 24–31 (`PsxGp0Opcode.h`); drawing-environment commands (0xE1–0xE6) stay in the low byte.
+- **Stub core** emits all seven GP0 primitive flavors for CI when `QTMESH_PS1_FORCE_STUB=1` or no libretro core is present.
 - `armCapture` / `captureFrame` wire capture to the worker thread; CSV dump to temp for verification.
+- Sentry breadcrumb `ps1.rip.capture.frame_armed` via `ui.action`.
+- Tests: synthetic OT/homebrew RAM layout, seven-flavor CSV round-trip, disarmed capture &lt;1% `runFrame` overhead (stub + optional libretro integration).
 
 ## Phase 3 status (#420 / #421)
 
@@ -118,7 +121,7 @@ The **stub** core is active (`coreId=stub`). It draws a test pattern and synthet
 
 ### Capture mesh is a triangle “blob” (normal size, wrong shape)
 
-Capture is **not** a true GPU hook — it heuristically scans main RAM for GP0 command packets. Expect coarse triangle soup, not level geometry. Filters drop off-screen coordinates and cap at 2048 primitives per ingest pass to reduce noise. Quality improvements need ordering-table / DMA hooks (future work).
+Capture reads GP0 packets from **ordering-table chains** when present (typical homebrew/commercial frame setup), otherwise falls back to a linear RAM opcode scan. Expect coarse geometry on titles that stream primitives outside OT/DMA-visible RAM. Filters drop off-screen coordinates and cap at 2048 primitives per ingest pass. True in-core mednafen FIFO hooks remain future work.
 
 ### Libretro integration tests (local only)
 

--- a/src/PS1/PS1_RIP_DESIGN.md
+++ b/src/PS1/PS1_RIP_DESIGN.md
@@ -69,7 +69,7 @@ See epic #412 for phased issues (#413–#431).
 - `CaptureTypes`, `GpuCommandParser`, `CaptureBuffer`, `RipperHooks`, `Gp0HookDispatch` (#418).
 - `EmuHooks` included from `EmuCore.h` (issue #418 API surface).
 - GTE matrix hash dedupe + `cameraMatrixId` heuristic (#419).
-- **Libretro capture path:** `Gp0HookDispatch` in the plugin walks **ordering-table linked GP0 chains** first (`PsxOrderingTableScanner` + `PsxGp0ChainWalker`), then falls back to linear RAM opcode scan when no OT is found. Linked DR tags carry the opcode in bits 24–31 (`PsxGp0Opcode.h`); drawing-environment commands (0xE1–0xE6) stay in the low byte.
+- **Libretro capture path:** `Gp0HookDispatch` in the plugin walks **ordering-table linked GP0 chains** first (`PsxOrderingTableScanner` + `PsxGp0ChainWalker`), then falls back to linear RAM opcode scan when no OT is found. OT entries are resolved as **24-bit absolute RAM pointers** (libgpu `getaddr` layout), with a relative-to-OT-base fallback for synthetic tests. Linked DR tags carry the opcode in bits 24–31 and the next packet address in bits 2–23 (`PsxGp0Opcode.h`); drawing-environment commands (0xE1–0xE6) stay in the low byte.
 - **Stub core** emits all seven GP0 primitive flavors for CI when `QTMESH_PS1_FORCE_STUB=1` or no libretro core is present.
 - `armCapture` / `captureFrame` wire capture to the worker thread; CSV dump to temp for verification.
 - Sentry breadcrumb `ps1.rip.capture.frame_armed` via `ui.action`.

--- a/src/PS1/PS1_RIP_DESIGN.md
+++ b/src/PS1/PS1_RIP_DESIGN.md
@@ -82,7 +82,7 @@ See epic #412 for phased issues (#413–#431).
 - `TextureDecoder` — CLUT-aware 4/8/15 bpp tile decode with `TileKey` cache and STP/alpha via `PsxVramColor`.
 - `dumpVRAM()` saves `<AppData>/ps1_rip/captures/<id>_vram.png` and feeds `VramViewerWidget` in the session window.
 - **Libretro:** `syncVramFromCore()` mirrors live core VRAM every frame; capture snapshots include a VRAM cell copy for textured mesh export.
-- Stub core fills CLUT + 4/8/15 bpp test regions each frame via `stubFillVramPattern` (CI only).
+- Stub core fills CLUT + 4/8/15 bpp test regions via `stubFillVramPattern` when capture is armed or on `syncCaptureMirrors` (CI only).
 
 ## Phase 4 status (#422 / #423)
 

--- a/src/PS1/runtime/EmuCoreLoader_test.cpp
+++ b/src/PS1/runtime/EmuCoreLoader_test.cpp
@@ -6,10 +6,13 @@
 #include <QFileInfo>
 #include <QTemporaryFile>
 
+#include "PS1/runtime/CaptureBuffer.h"
 #include "PS1/runtime/EmuCore.h"
 #include "PS1/runtime/EmuCoreLoader.h"
 #include "PS1/runtime/RipperHooks.h"
 #include "PS1/runtime/VramSnapshot.h"
+
+#include <QElapsedTimer>
 
 class EmuCoreLoaderTest : public ::testing::Test
 {
@@ -146,6 +149,92 @@ TEST_F(EmuCoreLoaderTest, StubMirrorsVramAfterSync)
     EXPECT_TRUE(vram.hasVisibleContent(8)) << "Stub VRAM pattern should mirror after syncCaptureMirrors";
 }
 
+TEST_F(EmuCoreLoaderTest, StubDisarmedHooksAddLessThanOnePercentOverhead)
+{
+    ASSERT_TRUE(stubCorePluginBesideBinary());
+
+    QString err;
+    std::unique_ptr<EmuCore> core = EmuCoreLoader::loadCore(&err);
+    ASSERT_TRUE(core) << err.toStdString();
+
+    QTemporaryFile bios(QDir::tempPath() + "/qtmesh_bios_XXXXXX.bin");
+    QTemporaryFile iso(QDir::tempPath() + "/qtmesh_iso_XXXXXX.bin");
+    ASSERT_TRUE(bios.open());
+    ASSERT_TRUE(iso.open());
+    bios.write(QByteArray(512 * 1024, '\0'));
+    iso.write("iso");
+    bios.close();
+    iso.close();
+    ASSERT_TRUE(core->loadBios(bios.fileName()));
+    ASSERT_TRUE(core->loadIso(iso.fileName()));
+    QString bootErr;
+    ASSERT_TRUE(core->boot(&bootErr)) << bootErr.toStdString();
+
+    constexpr int kFrames = 120;
+    for (int i = 0; i < 10; ++i)
+        core->runFrame();
+
+    QElapsedTimer timer;
+    core->setHooks(nullptr);
+    timer.start();
+    for (int i = 0; i < kFrames; ++i)
+        core->runFrame();
+    const qint64 baselineNs = timer.nsecsElapsed();
+
+    std::atomic<bool> armed{false};
+    CaptureBuffer buffer;
+    RipperHooks hooks;
+    hooks.setArmedFlag(&armed);
+    hooks.setBuffer(&buffer);
+    core->setHooks(&hooks);
+
+    timer.restart();
+    for (int i = 0; i < kFrames; ++i)
+        core->runFrame();
+    const qint64 withHooksNs = timer.nsecsElapsed();
+
+    ASSERT_GT(baselineNs, 1000000);
+    if (withHooksNs > baselineNs + baselineNs / 100 + 3000000) {
+        GTEST_SKIP() << "Timing variance on this runner (baseline=" << baselineNs
+                     << "ns disarmed-hooks=" << withHooksNs << "ns)";
+    }
+}
+
+TEST_F(EmuCoreLoaderTest, StubArmedCaptureProducesPrimitives)
+{
+    ASSERT_TRUE(stubCorePluginBesideBinary());
+
+    QString err;
+    std::unique_ptr<EmuCore> core = EmuCoreLoader::loadCore(&err);
+    ASSERT_TRUE(core) << err.toStdString();
+
+    std::atomic<bool> armed{true};
+    CaptureBuffer buffer;
+    RipperHooks hooks;
+    hooks.setArmedFlag(&armed);
+    hooks.setBuffer(&buffer);
+    core->setHooks(&hooks);
+
+    QTemporaryFile bios(QDir::tempPath() + "/qtmesh_bios_XXXXXX.bin");
+    QTemporaryFile iso(QDir::tempPath() + "/qtmesh_iso_XXXXXX.bin");
+    ASSERT_TRUE(bios.open());
+    ASSERT_TRUE(iso.open());
+    bios.write(QByteArray(512 * 1024, '\0'));
+    iso.write("iso");
+    bios.close();
+    iso.close();
+    ASSERT_TRUE(core->loadBios(bios.fileName()));
+    ASSERT_TRUE(core->loadIso(iso.fileName()));
+    QString bootErr;
+    ASSERT_TRUE(core->boot(&bootErr)) << bootErr.toStdString();
+
+    for (int i = 0; i < 3; ++i)
+        core->runFrame();
+
+    EXPECT_GE(buffer.prims().size(), 7)
+        << "Stub core should emit all seven GP0 primitive flavors when armed";
+}
+
 #if defined(QTMESH_PS1_LIBRETRO_INTEGRATION_TESTS)
 TEST_F(EmuCoreLoaderTest, LibretroBootsDiscWhenTestPathsSet)
 {
@@ -230,6 +319,98 @@ TEST_F(EmuCoreLoaderTest, LibretroMirrorsVramAfterGameplay)
 
     EXPECT_TRUE(vram.hasVisibleContent(8))
         << "VRAM mirror empty after 180 frames — core may not expose RETRO_MEMORY_VIDEO_RAM";
+
+    qputenv("QTMESH_PS1_FORCE_STUB", "1");
+}
+
+TEST_F(EmuCoreLoaderTest, LibretroDisarmedHooksAddLessThanOnePercentOverhead)
+{
+    const QDir coresDir(QCoreApplication::applicationDirPath() + QStringLiteral("/PS1Cores"));
+#if defined(Q_OS_WIN)
+    if (!QFileInfo::exists(coresDir.filePath(QStringLiteral("mednafen_psx_libretro.dll"))))
+        GTEST_SKIP() << "mednafen_psx_libretro not installed";
+#else
+    if (!QFileInfo::exists(coresDir.filePath(QStringLiteral("mednafen_psx_libretro.so"))))
+        GTEST_SKIP() << "mednafen_psx_libretro not installed";
+#endif
+
+    const QString biosPath = qEnvironmentVariable("QTMESH_PS1_TEST_BIOS");
+    const QString isoPath = qEnvironmentVariable("QTMESH_PS1_TEST_ISO");
+    ASSERT_FALSE(biosPath.isEmpty()) << "Set QTMESH_PS1_TEST_BIOS";
+    ASSERT_FALSE(isoPath.isEmpty()) << "Set QTMESH_PS1_TEST_ISO";
+
+    qunsetenv("QTMESH_PS1_FORCE_STUB");
+
+    QString err;
+    std::unique_ptr<EmuCore> core = EmuCoreLoader::loadCore(&err);
+    ASSERT_TRUE(core) << err.toStdString();
+    ASSERT_EQ(core->coreId(), QStringLiteral("libretro"));
+    ASSERT_TRUE(core->loadBios(biosPath));
+    ASSERT_TRUE(core->loadIso(isoPath));
+    QString bootErr;
+    ASSERT_TRUE(core->boot(&bootErr)) << bootErr.toStdString();
+
+    constexpr int kFrames = 60;
+    QElapsedTimer timer;
+    timer.start();
+    for (int i = 0; i < kFrames; ++i)
+        core->runFrame();
+    const qint64 baselineNs = timer.nsecsElapsed();
+
+    std::atomic<bool> armed{false};
+    CaptureBuffer buffer;
+    RipperHooks hooks;
+    hooks.setArmedFlag(&armed);
+    hooks.setBuffer(&buffer);
+    core->setHooks(&hooks);
+
+    timer.restart();
+    for (int i = 0; i < kFrames; ++i)
+        core->runFrame();
+    const qint64 withHooksNs = timer.nsecsElapsed();
+
+    ASSERT_GT(baselineNs, 1000000);
+    EXPECT_LE(withHooksNs, baselineNs + baselineNs / 100 + 5000000)
+        << "baseline=" << baselineNs << "ns hooks=" << withHooksNs << "ns";
+
+    qputenv("QTMESH_PS1_FORCE_STUB", "1");
+}
+
+TEST_F(EmuCoreLoaderTest, LibretroArmedCaptureMayProducePrimitives)
+{
+    const QString biosPath = qEnvironmentVariable("QTMESH_PS1_TEST_BIOS");
+    const QString isoPath = qEnvironmentVariable("QTMESH_PS1_TEST_ISO");
+    ASSERT_FALSE(biosPath.isEmpty()) << "Set QTMESH_PS1_TEST_BIOS";
+    ASSERT_FALSE(isoPath.isEmpty()) << "Set QTMESH_PS1_TEST_ISO";
+
+    qunsetenv("QTMESH_PS1_FORCE_STUB");
+
+    QString err;
+    std::unique_ptr<EmuCore> core = EmuCoreLoader::loadCore(&err);
+    ASSERT_TRUE(core) << err.toStdString();
+    ASSERT_EQ(core->coreId(), QStringLiteral("libretro"));
+
+    std::atomic<bool> armed{true};
+    CaptureBuffer buffer;
+    RipperHooks hooks;
+    hooks.setArmedFlag(&armed);
+    hooks.setBuffer(&buffer);
+    core->setHooks(&hooks);
+
+    ASSERT_TRUE(core->loadBios(biosPath));
+    ASSERT_TRUE(core->loadIso(isoPath));
+    QString bootErr;
+    ASSERT_TRUE(core->boot(&bootErr)) << bootErr.toStdString();
+
+    for (int i = 0; i < 240; ++i) {
+        core->runFrame();
+        if ((i % 30) == 29)
+            core->ingestCaptureFrame();
+    }
+    core->ingestCaptureFrame();
+
+    EXPECT_GT(buffer.prims().size(), 0)
+        << "Armed libretro capture should find GP0 packets (OT or linear scan) during gameplay";
 
     qputenv("QTMESH_PS1_FORCE_STUB", "1");
 }

--- a/src/PS1/runtime/EmuCoreLoader_test.cpp
+++ b/src/PS1/runtime/EmuCoreLoader_test.cpp
@@ -194,10 +194,49 @@ TEST_F(EmuCoreLoaderTest, StubDisarmedHooksAddLessThanOnePercentOverhead)
     const qint64 withHooksNs = timer.nsecsElapsed();
 
     ASSERT_GT(baselineNs, 1000000);
-    if (withHooksNs > baselineNs + baselineNs / 100 + 3000000) {
-        GTEST_SKIP() << "Timing variance on this runner (baseline=" << baselineNs
-                     << "ns disarmed-hooks=" << withHooksNs << "ns)";
-    }
+    EXPECT_LE(withHooksNs, baselineNs + baselineNs / 100 + 5000000)
+        << "baseline=" << baselineNs << "ns disarmed-hooks=" << withHooksNs << "ns";
+}
+
+TEST_F(EmuCoreLoaderTest, StubDisarmedHooksDoNotCaptureOrMirrorVramPerFrame)
+{
+    ASSERT_TRUE(stubCorePluginBesideBinary());
+
+    QString err;
+    std::unique_ptr<EmuCore> core = EmuCoreLoader::loadCore(&err);
+    ASSERT_TRUE(core) << err.toStdString();
+
+    std::atomic<bool> armed{false};
+    CaptureBuffer buffer;
+    RipperHooks hooks;
+    hooks.setArmedFlag(&armed);
+    hooks.setBuffer(&buffer);
+    VramSnapshot vram;
+    hooks.setVram(&vram);
+    core->setHooks(&hooks);
+
+    QTemporaryFile bios(QDir::tempPath() + "/qtmesh_bios_XXXXXX.bin");
+    QTemporaryFile iso(QDir::tempPath() + "/qtmesh_iso_XXXXXX.bin");
+    ASSERT_TRUE(bios.open());
+    ASSERT_TRUE(iso.open());
+    bios.write(QByteArray(512 * 1024, '\0'));
+    iso.write("iso");
+    bios.close();
+    iso.close();
+    ASSERT_TRUE(core->loadBios(bios.fileName()));
+    ASSERT_TRUE(core->loadIso(iso.fileName()));
+    QString bootErr;
+    ASSERT_TRUE(core->boot(&bootErr)) << bootErr.toStdString();
+
+    for (int i = 0; i < 5; ++i)
+        core->runFrame();
+
+    EXPECT_TRUE(buffer.prims().isEmpty());
+    EXPECT_FALSE(vram.hasVisibleContent(8))
+        << "Disarmed runFrame must not mirror VRAM; use syncCaptureMirrors explicitly";
+
+    core->syncCaptureMirrors();
+    EXPECT_TRUE(vram.hasVisibleContent(8));
 }
 
 TEST_F(EmuCoreLoaderTest, StubArmedCaptureProducesPrimitives)

--- a/src/PS1/runtime/Gp0HookDispatch.cpp
+++ b/src/PS1/runtime/Gp0HookDispatch.cpp
@@ -2,6 +2,8 @@
 
 #include "EmuHooks.h"
 #include "PsxCaptureFilters.h"
+#include "PsxGp0Opcode.h"
+#include "PsxOrderingTableScanner.h"
 
 #include <QSet>
 #include <QString>
@@ -27,7 +29,7 @@ void ensureCaptureProjectionMatrix(EmuHooks *hooks)
 
 bool looksLikeGp0Opcode(uint32_t word)
 {
-    const uint8_t cmd = static_cast<uint8_t>(word & 0xFF);
+    const uint8_t cmd = psxGp0OpcodeByte(word);
     if (cmd >= 0x20 && cmd <= 0x3F)
         return true;
     if (cmd >= 0x60 && cmd <= 0x7F)
@@ -104,15 +106,13 @@ void Gp0HookDispatch::dispatchStep(const GpuCommandParser::Gp0Step &step, EmuHoo
     ++primCount;
 }
 
-void Gp0HookDispatch::captureFromSystemRam(const uint8_t *ram, size_t byteSize, EmuHooks *hooks)
+void Gp0HookDispatch::captureLinearScan(const uint8_t *ram, size_t byteSize, EmuHooks *hooks,
+                                      QSet<QString> &seen, DrawModeRecord &currentMode, int &primCount)
 {
-    if (!ram || byteSize < 16 || !hooks || !hooks->isCaptureEnabled())
+    if (!ram || byteSize < 16 || !hooks)
         return;
 
     const size_t wordCount = byteSize / 4;
-    QSet<QString> seen;
-    DrawModeRecord currentMode{};
-    int primCount = 0;
 
     for (size_t offset = 0; offset < wordCount;) {
         if (primCount >= kMaxPrimsPerFrame)
@@ -161,6 +161,22 @@ void Gp0HookDispatch::captureFromSystemRam(const uint8_t *ram, size_t byteSize, 
         dispatchStep(step, hooks, currentMode, primCount);
         offset += step.wordsConsumed;
     }
+}
+
+void Gp0HookDispatch::captureFromSystemRam(const uint8_t *ram, size_t byteSize, EmuHooks *hooks)
+{
+    if (!ram || byteSize < 16 || !hooks || !hooks->isCaptureEnabled())
+        return;
+
+    QSet<QString> seen;
+    DrawModeRecord currentMode{};
+    int primCount = 0;
+
+    const int otPrims = PsxOrderingTableScanner::captureFromOrderingTables(ram, byteSize, hooks);
+    if (otPrims > 0)
+        return;
+
+    captureLinearScan(ram, byteSize, hooks, seen, currentMode, primCount);
 }
 
 void Gp0HookDispatch::captureFrameFromSystemRam(const uint8_t *ram, size_t byteSize,

--- a/src/PS1/runtime/Gp0HookDispatch.cpp
+++ b/src/PS1/runtime/Gp0HookDispatch.cpp
@@ -27,20 +27,6 @@ void ensureCaptureProjectionMatrix(EmuHooks *hooks)
     hooks->onGteMatrix(matrix);
 }
 
-bool looksLikeGp0Opcode(uint32_t word)
-{
-    const uint8_t cmd = psxGp0OpcodeByte(word);
-    if (cmd >= 0x20 && cmd <= 0x3F)
-        return true;
-    if (cmd >= 0x60 && cmd <= 0x7F)
-        return true;
-    if (cmd >= 0xE1 && cmd <= 0xE6)
-        return true;
-    if (cmd == 0xA0 || cmd == 0xC0)
-        return true;
-    return false;
-}
-
 void applyDrawMode(PrimRecord &prim, const DrawModeRecord &mode)
 {
     if (prim.drawModeBits == 0 && mode.drawModeBits != 0)
@@ -120,7 +106,7 @@ void Gp0HookDispatch::captureLinearScan(const uint8_t *ram, size_t byteSize, Emu
 
         uint32_t word = 0;
         std::memcpy(&word, ram + offset * 4, sizeof(word));
-        if (!looksLikeGp0Opcode(word)) {
+        if (!psxLooksLikeGp0Opcode(word)) {
             ++offset;
             continue;
         }

--- a/src/PS1/runtime/Gp0HookDispatch.h
+++ b/src/PS1/runtime/Gp0HookDispatch.h
@@ -3,6 +3,8 @@
 
 #include "GpuCommandParser.h"
 
+#include <QSet>
+
 #include <cstddef>
 #include <cstdint>
 
@@ -20,10 +22,14 @@ public:
                              DrawModeRecord &currentMode, int &primCount);
 
     /**
-     * Linear scan of emulated main RAM for GP0 packets while capture is armed.
-     * Used by the libretro plugin when true in-core GPU hooks are unavailable.
+     * OT-first capture from main RAM, then linear GP0 opcode scan as fallback (#418).
      */
     static void captureFromSystemRam(const uint8_t *ram, size_t byteSize, EmuHooks *hooks);
+
+    /** Fallback linear scan when no ordering table is found. */
+    static void captureLinearScan(const uint8_t *ram, size_t byteSize, EmuHooks *hooks,
+                                  QSet<QString> &seenPrimKeys, DrawModeRecord &currentMode,
+                                  int &primCount);
 
     /** Begin/end frame + stable projection matrix for libretro heuristic capture. */
     static void captureFrameFromSystemRam(const uint8_t *ram, size_t byteSize, EmuHooks *hooks);

--- a/src/PS1/runtime/GpuCommandParser.cpp
+++ b/src/PS1/runtime/GpuCommandParser.cpp
@@ -1,5 +1,7 @@
 #include "GpuCommandParser.h"
 
+#include "PsxGp0Opcode.h"
+
 #include <QTextStream>
 
 namespace {
@@ -318,7 +320,7 @@ GpuCommandParser::Gp0Step GpuCommandParser::stepGp0(const uint32_t *words, size_
 
     size_t index = 0;
     const size_t startIndex = 0;
-    const uint8_t cmd = static_cast<uint8_t>(words[index] & 0xFF);
+    const uint8_t cmd = psxGp0OpcodeByte(words[index]);
 
     if (cmd >= 0xE1 && cmd <= 0xE6) {
         if (!parseDrawingEnv(words, wordCount, index, step.drawMode, step.error))

--- a/src/PS1/runtime/PsxGp0ChainWalker.cpp
+++ b/src/PS1/runtime/PsxGp0ChainWalker.cpp
@@ -11,20 +11,6 @@ namespace {
 
 constexpr int kMaxChainPackets = 512;
 
-bool looksLikeGp0Opcode(uint32_t word)
-{
-    const uint8_t cmd = psxGp0OpcodeByte(word);
-    if (cmd >= 0x20 && cmd <= 0x3F)
-        return true;
-    if (cmd >= 0x60 && cmd <= 0x7F)
-        return true;
-    if (cmd >= 0xE1 && cmd <= 0xE6)
-        return true;
-    if (cmd == 0xA0 || cmd == 0xC0)
-        return true;
-    return false;
-}
-
 QString primDedupeKey(const PrimRecord &prim)
 {
     QString key = QStringLiteral("%1|%2").arg(static_cast<int>(prim.kind)).arg(prim.vertexCount);
@@ -59,7 +45,7 @@ PsxGp0ChainWalker::WalkResult PsxGp0ChainWalker::walkChain(const uint8_t *ram, s
         if (remainingWords == 0)
             break;
 
-        if (!looksLikeGp0Opcode(words[0]))
+        if (!psxLooksLikeGp0Opcode(words[0]))
             break;
 
         const GpuCommandParser::Gp0Step step = GpuCommandParser::stepGp0(words, remainingWords);

--- a/src/PS1/runtime/PsxGp0ChainWalker.cpp
+++ b/src/PS1/runtime/PsxGp0ChainWalker.cpp
@@ -1,0 +1,100 @@
+#include "PsxGp0ChainWalker.h"
+
+#include "EmuHooks.h"
+#include "Gp0HookDispatch.h"
+#include "PsxCaptureFilters.h"
+#include "PsxGp0Opcode.h"
+
+#include <cstring>
+
+namespace {
+
+constexpr int kMaxChainPackets = 512;
+
+bool looksLikeGp0Opcode(uint32_t word)
+{
+    const uint8_t cmd = psxGp0OpcodeByte(word);
+    if (cmd >= 0x20 && cmd <= 0x3F)
+        return true;
+    if (cmd >= 0x60 && cmd <= 0x7F)
+        return true;
+    if (cmd >= 0xE1 && cmd <= 0xE6)
+        return true;
+    if (cmd == 0xA0 || cmd == 0xC0)
+        return true;
+    return false;
+}
+
+QString primDedupeKey(const PrimRecord &prim)
+{
+    QString key = QStringLiteral("%1|%2").arg(static_cast<int>(prim.kind)).arg(prim.vertexCount);
+    for (int v = 0; v < 4; ++v)
+        key += QStringLiteral("|%1,%2").arg(prim.verts[v].x).arg(prim.verts[v].y);
+    key += QStringLiteral("|%1,%2|%3|%4")
+               .arg(prim.tpage)
+               .arg(prim.clut)
+               .arg(prim.semiTrans)
+               .arg(prim.matrixId);
+    return key;
+}
+
+} // namespace
+
+PsxGp0ChainWalker::WalkResult PsxGp0ChainWalker::walkChain(const uint8_t *ram, size_t byteSize,
+                                                           uint32_t chainBaseByte, EmuHooks *hooks,
+                                                           DrawModeRecord &currentMode,
+                                                           int &primCount, QSet<QString> &seenPrimKeys)
+{
+    WalkResult result;
+    if (!ram || !hooks || !hooks->isCaptureEnabled() || byteSize < 8)
+        return result;
+
+    uint32_t addr = chainBaseByte;
+    for (int guard = 0; guard < kMaxChainPackets; ++guard) {
+        if (addr + 4 > byteSize || (addr % 4) != 0)
+            break;
+
+        const uint32_t *words = reinterpret_cast<const uint32_t *>(ram + addr);
+        const size_t remainingWords = (byteSize - addr) / 4;
+        if (remainingWords == 0)
+            break;
+
+        if (!looksLikeGp0Opcode(words[0]))
+            break;
+
+        const GpuCommandParser::Gp0Step step = GpuCommandParser::stepGp0(words, remainingWords);
+        if (step.wordsConsumed == 0 || !step.error.isEmpty())
+            break;
+
+        ++result.packetsParsed;
+
+        if (step.hasPrim) {
+            PrimRecord prim = step.prim;
+            if (PsxCaptureFilters::isOnScreenPrim(prim)) {
+                const uint32_t matrixId = hooks->latestMatrixId();
+                if (matrixId != UINT32_MAX)
+                    prim.matrixId = matrixId;
+                const QString key = primDedupeKey(prim);
+                if (!seenPrimKeys.contains(key)) {
+                    seenPrimKeys.insert(key);
+                    Gp0HookDispatch::dispatchStep(step, hooks, currentMode, primCount);
+                    ++result.primsDispatched;
+                }
+            }
+        } else {
+            Gp0HookDispatch::dispatchStep(step, hooks, currentMode, primCount);
+        }
+
+        const uint32_t header = words[0];
+        if ((header & 1u) == 0)
+            break;
+
+        const uint32_t offsetWords = (header >> 2) & 0x3FFFFFu;
+        const uint32_t nextAddr = chainBaseByte + offsetWords * 4u;
+        if (nextAddr == addr || nextAddr + 4 > byteSize)
+            break;
+        addr = nextAddr;
+    }
+
+    return result;
+}

--- a/src/PS1/runtime/PsxGp0ChainWalker.cpp
+++ b/src/PS1/runtime/PsxGp0ChainWalker.cpp
@@ -89,9 +89,8 @@ PsxGp0ChainWalker::WalkResult PsxGp0ChainWalker::walkChain(const uint8_t *ram, s
         if ((header & 1u) == 0)
             break;
 
-        const uint32_t offsetWords = (header >> 2) & 0x3FFFFFu;
-        const uint32_t nextAddr = chainBaseByte + offsetWords * 4u;
-        if (nextAddr == addr || nextAddr + 4 > byteSize)
+        const uint32_t nextAddr = psxGp0TagNextByteAddr(header);
+        if (nextAddr == addr || nextAddr + 4 > byteSize || (nextAddr % 4) != 0)
             break;
         addr = nextAddr;
     }

--- a/src/PS1/runtime/PsxGp0ChainWalker.h
+++ b/src/PS1/runtime/PsxGp0ChainWalker.h
@@ -1,0 +1,30 @@
+#ifndef PSXGP0CHAINWALKER_H
+#define PSXGP0CHAINWALKER_H
+
+#include "GpuCommandParser.h"
+
+#include <QSet>
+#include <QString>
+#include <cstddef>
+#include <cstdint>
+
+class EmuHooks;
+
+/**
+ * Walks PSX GPU packet linked lists (nocash psx-spx: bit0 of header links to next packet).
+ */
+class PsxGp0ChainWalker
+{
+public:
+    struct WalkResult {
+        int packetsParsed = 0;
+        int primsDispatched = 0;
+    };
+
+    /** Follow one OT / DMA chain starting at @p chainBaseByte (byte address in main RAM). */
+    static WalkResult walkChain(const uint8_t *ram, size_t byteSize, uint32_t chainBaseByte,
+                                EmuHooks *hooks, DrawModeRecord &currentMode, int &primCount,
+                                QSet<QString> &seenPrimKeys);
+};
+
+#endif // PSXGP0CHAINWALKER_H

--- a/src/PS1/runtime/PsxGp0Opcode.h
+++ b/src/PS1/runtime/PsxGp0Opcode.h
@@ -1,0 +1,29 @@
+#ifndef PSXGP0OPCODE_H
+#define PSXGP0OPCODE_H
+
+#include <cstdint>
+
+/**
+ * Decodes the GP0 command byte from a RAM packet header.
+ * Linked OT/DMA tags (bit0 set) carry the opcode in bits 24-31; drawing-environment
+ * commands keep the opcode in the low byte (0xE1 already has bit0 set).
+ */
+inline uint8_t psxGp0OpcodeByte(uint32_t word)
+{
+    const uint8_t low = static_cast<uint8_t>(word & 0xFF);
+    if (low >= 0xE1 && low <= 0xE6)
+        return low;
+
+    const uint8_t tagOpcode = static_cast<uint8_t>((word >> 24) & 0xFF);
+    if ((word & 1u) != 0u && tagOpcode >= 0x20 && tagOpcode <= 0x7F)
+        return tagOpcode;
+
+    if ((word & 1u) != 0u) {
+        const uint8_t high = static_cast<uint8_t>((word >> 8) & 0xFF);
+        if (high >= 0x20 && high <= 0x7F)
+            return high;
+    }
+    return low;
+}
+
+#endif // PSXGP0OPCODE_H

--- a/src/PS1/runtime/PsxGp0Opcode.h
+++ b/src/PS1/runtime/PsxGp0Opcode.h
@@ -26,4 +26,10 @@ inline uint8_t psxGp0OpcodeByte(uint32_t word)
     return low;
 }
 
+/** libgpu getaddr(): byte address of the next DR tag from bits 2–23 (addr >> 2). */
+inline uint32_t psxGp0TagNextByteAddr(uint32_t tag)
+{
+    return ((tag >> 2) & 0x3FFFFFu) << 2;
+}
+
 #endif // PSXGP0OPCODE_H

--- a/src/PS1/runtime/PsxGp0Opcode.h
+++ b/src/PS1/runtime/PsxGp0Opcode.h
@@ -32,4 +32,18 @@ inline uint32_t psxGp0TagNextByteAddr(uint32_t tag)
     return ((tag >> 2) & 0x3FFFFFu) << 2;
 }
 
+inline bool psxLooksLikeGp0Opcode(uint32_t word)
+{
+    const uint8_t cmd = psxGp0OpcodeByte(word);
+    if (cmd >= 0x20 && cmd <= 0x3F)
+        return true;
+    if (cmd >= 0x60 && cmd <= 0x7F)
+        return true;
+    if (cmd >= 0xE1 && cmd <= 0xE6)
+        return true;
+    if (cmd == 0xA0 || cmd == 0xC0)
+        return true;
+    return false;
+}
+
 #endif // PSXGP0OPCODE_H

--- a/src/PS1/runtime/PsxOrderingTableScanner.cpp
+++ b/src/PS1/runtime/PsxOrderingTableScanner.cpp
@@ -1,0 +1,152 @@
+#include "PsxOrderingTableScanner.h"
+
+#include "EmuHooks.h"
+#include "PsxGp0ChainWalker.h"
+#include "PsxGp0Opcode.h"
+
+#include <QSet>
+#include <QString>
+#include <QVector>
+
+#include <algorithm>
+#include <cstring>
+
+namespace {
+
+constexpr int kMaxPrimsPerFrame = 2048;
+constexpr int kMaxOtCandidates = 12;
+constexpr int kMaxChainsPerTable = 384;
+
+bool looksLikeGp0Opcode(uint32_t word)
+{
+    const uint8_t cmd = psxGp0OpcodeByte(word);
+    if (cmd >= 0x20 && cmd <= 0x3F)
+        return true;
+    if (cmd >= 0x60 && cmd <= 0x7F)
+        return true;
+    if (cmd >= 0xE1 && cmd <= 0xE6)
+        return true;
+    if (cmd == 0xA0 || cmd == 0xC0)
+        return true;
+    return false;
+}
+
+struct OtCandidate {
+    uint32_t baseByte = 0;
+    int entryCount = 0;
+    int score = 0;
+};
+
+int scoreOrderingTable(const uint8_t *ram, size_t byteSize, uint32_t baseByte, int entryCount)
+{
+    if (baseByte + static_cast<size_t>(entryCount) * 4 > byteSize)
+        return 0;
+
+    int nonZero = 0;
+    int validChains = 0;
+    for (int i = 0; i < entryCount; ++i) {
+        uint32_t offset = 0;
+        std::memcpy(&offset, ram + baseByte + static_cast<size_t>(i) * 4, sizeof(offset));
+        if (offset == 0)
+            continue;
+        ++nonZero;
+        if (offset < 4 || offset >= static_cast<uint32_t>(entryCount) * 4 || (offset % 4) != 0)
+            continue;
+        const uint32_t chainAddr = baseByte + offset;
+        if (chainAddr + 4 > byteSize)
+            continue;
+        uint32_t header = 0;
+        std::memcpy(&header, ram + chainAddr, sizeof(header));
+        if (looksLikeGp0Opcode(header))
+            ++validChains;
+    }
+
+    if (nonZero < 1 || validChains < 1)
+        return 0;
+    return validChains * 4 + nonZero;
+}
+
+QVector<OtCandidate> findOrderingTableCandidates(const uint8_t *ram, size_t byteSize)
+{
+    static const int kOtEntryCounts[] = {256, 512, 128, 1024, 64, 2048};
+    QVector<OtCandidate> candidates;
+
+    const size_t scanEnd = byteSize > 4096 ? byteSize - 4096 : 0;
+    for (size_t base = 0; base < scanEnd; base += 256) {
+        for (int entryCount : kOtEntryCounts) {
+            const int score = scoreOrderingTable(ram, byteSize, static_cast<uint32_t>(base),
+                                                 entryCount);
+            if (score < 6)
+                continue;
+
+            OtCandidate candidate{};
+            candidate.baseByte = static_cast<uint32_t>(base);
+            candidate.entryCount = entryCount;
+            candidate.score = score;
+            candidates.append(candidate);
+        }
+    }
+
+    std::sort(candidates.begin(), candidates.end(),
+              [](const OtCandidate &a, const OtCandidate &b) { return a.score > b.score; });
+
+    QVector<OtCandidate> unique;
+    for (const OtCandidate &candidate : candidates) {
+        bool overlaps = false;
+        for (const OtCandidate &picked : unique) {
+            const uint32_t delta = candidate.baseByte > picked.baseByte
+                                       ? candidate.baseByte - picked.baseByte
+                                       : picked.baseByte - candidate.baseByte;
+            if (delta < static_cast<uint32_t>(picked.entryCount) * 4) {
+                overlaps = true;
+                break;
+            }
+        }
+        if (!overlaps)
+            unique.append(candidate);
+        if (unique.size() >= kMaxOtCandidates)
+            break;
+    }
+
+    return unique;
+}
+
+} // namespace
+
+int PsxOrderingTableScanner::captureFromOrderingTables(const uint8_t *ram, size_t byteSize,
+                                                       EmuHooks *hooks)
+{
+    if (!ram || byteSize < 256 || !hooks || !hooks->isCaptureEnabled())
+        return 0;
+
+    const QVector<OtCandidate> tables = findOrderingTableCandidates(ram, byteSize);
+    if (tables.isEmpty())
+        return 0;
+
+    QSet<QString> seenPrimKeys;
+    DrawModeRecord currentMode{};
+    int primCount = 0;
+    int chainsWalked = 0;
+
+    for (const OtCandidate &table : tables) {
+        for (int i = 0; i < table.entryCount; ++i) {
+            if (primCount >= kMaxPrimsPerFrame || chainsWalked >= kMaxChainsPerTable)
+                break;
+
+            uint32_t offset = 0;
+            std::memcpy(&offset, ram + table.baseByte + static_cast<size_t>(i) * 4, sizeof(offset));
+            if (offset < 4 || offset >= static_cast<uint32_t>(table.entryCount) * 4
+                || (offset % 4) != 0)
+                continue;
+
+            const uint32_t chainAddr = table.baseByte + offset;
+            const PsxGp0ChainWalker::WalkResult walked =
+                PsxGp0ChainWalker::walkChain(ram, byteSize, chainAddr, hooks, currentMode,
+                                             primCount, seenPrimKeys);
+            if (walked.packetsParsed > 0)
+                ++chainsWalked;
+        }
+    }
+
+    return primCount;
+}

--- a/src/PS1/runtime/PsxOrderingTableScanner.cpp
+++ b/src/PS1/runtime/PsxOrderingTableScanner.cpp
@@ -9,6 +9,7 @@
 #include <QVector>
 
 #include <algorithm>
+#include <cstdint>
 #include <cstring>
 
 namespace {
@@ -37,6 +38,35 @@ struct OtCandidate {
     int score = 0;
 };
 
+/** DrawOTag entries are 24-bit RAM pointers; tests may use offsets from the OT base. */
+uint32_t resolveOtEntryChainAddr(const uint8_t *ram, size_t byteSize, uint32_t otBase,
+                                 uint32_t entry, int entryCount)
+{
+    if (entry == 0)
+        return UINT32_MAX;
+
+    const uint32_t absAddr = psxGp0TagNextByteAddr(entry);
+    if (absAddr >= 4 && absAddr + 4 <= byteSize && (absAddr % 4) == 0) {
+        uint32_t header = 0;
+        std::memcpy(&header, ram + absAddr, sizeof(header));
+        if (looksLikeGp0Opcode(header))
+            return absAddr;
+    }
+
+    const uint32_t rel = entry & 0x3FFFFCu;
+    if (rel >= 4 && rel < static_cast<uint32_t>(entryCount) * 4 && (rel % 4) == 0) {
+        const uint32_t relAddr = otBase + rel;
+        if (relAddr + 4 <= byteSize) {
+            uint32_t header = 0;
+            std::memcpy(&header, ram + relAddr, sizeof(header));
+            if (looksLikeGp0Opcode(header))
+                return relAddr;
+        }
+    }
+
+    return UINT32_MAX;
+}
+
 int scoreOrderingTable(const uint8_t *ram, size_t byteSize, uint32_t baseByte, int entryCount)
 {
     if (baseByte + static_cast<size_t>(entryCount) * 4 > byteSize)
@@ -45,19 +75,12 @@ int scoreOrderingTable(const uint8_t *ram, size_t byteSize, uint32_t baseByte, i
     int nonZero = 0;
     int validChains = 0;
     for (int i = 0; i < entryCount; ++i) {
-        uint32_t offset = 0;
-        std::memcpy(&offset, ram + baseByte + static_cast<size_t>(i) * 4, sizeof(offset));
-        if (offset == 0)
+        uint32_t entry = 0;
+        std::memcpy(&entry, ram + baseByte + static_cast<size_t>(i) * 4, sizeof(entry));
+        if (entry == 0)
             continue;
         ++nonZero;
-        if (offset < 4 || offset >= static_cast<uint32_t>(entryCount) * 4 || (offset % 4) != 0)
-            continue;
-        const uint32_t chainAddr = baseByte + offset;
-        if (chainAddr + 4 > byteSize)
-            continue;
-        uint32_t header = 0;
-        std::memcpy(&header, ram + chainAddr, sizeof(header));
-        if (looksLikeGp0Opcode(header))
+        if (resolveOtEntryChainAddr(ram, byteSize, baseByte, entry, entryCount) != UINT32_MAX)
             ++validChains;
     }
 
@@ -133,13 +156,12 @@ int PsxOrderingTableScanner::captureFromOrderingTables(const uint8_t *ram, size_
             if (primCount >= kMaxPrimsPerFrame || chainsWalked >= kMaxChainsPerTable)
                 break;
 
-            uint32_t offset = 0;
-            std::memcpy(&offset, ram + table.baseByte + static_cast<size_t>(i) * 4, sizeof(offset));
-            if (offset < 4 || offset >= static_cast<uint32_t>(table.entryCount) * 4
-                || (offset % 4) != 0)
+            uint32_t entry = 0;
+            std::memcpy(&entry, ram + table.baseByte + static_cast<size_t>(i) * 4, sizeof(entry));
+            const uint32_t chainAddr =
+                resolveOtEntryChainAddr(ram, byteSize, table.baseByte, entry, table.entryCount);
+            if (chainAddr == UINT32_MAX)
                 continue;
-
-            const uint32_t chainAddr = table.baseByte + offset;
             const PsxGp0ChainWalker::WalkResult walked =
                 PsxGp0ChainWalker::walkChain(ram, byteSize, chainAddr, hooks, currentMode,
                                              primCount, seenPrimKeys);

--- a/src/PS1/runtime/PsxOrderingTableScanner.cpp
+++ b/src/PS1/runtime/PsxOrderingTableScanner.cpp
@@ -18,20 +18,6 @@ constexpr int kMaxPrimsPerFrame = 2048;
 constexpr int kMaxOtCandidates = 12;
 constexpr int kMaxChainsPerTable = 384;
 
-bool looksLikeGp0Opcode(uint32_t word)
-{
-    const uint8_t cmd = psxGp0OpcodeByte(word);
-    if (cmd >= 0x20 && cmd <= 0x3F)
-        return true;
-    if (cmd >= 0x60 && cmd <= 0x7F)
-        return true;
-    if (cmd >= 0xE1 && cmd <= 0xE6)
-        return true;
-    if (cmd == 0xA0 || cmd == 0xC0)
-        return true;
-    return false;
-}
-
 struct OtCandidate {
     uint32_t baseByte = 0;
     int entryCount = 0;
@@ -49,7 +35,7 @@ uint32_t resolveOtEntryChainAddr(const uint8_t *ram, size_t byteSize, uint32_t o
     if (absAddr >= 4 && absAddr + 4 <= byteSize && (absAddr % 4) == 0) {
         uint32_t header = 0;
         std::memcpy(&header, ram + absAddr, sizeof(header));
-        if (looksLikeGp0Opcode(header))
+        if (psxLooksLikeGp0Opcode(header))
             return absAddr;
     }
 
@@ -59,7 +45,7 @@ uint32_t resolveOtEntryChainAddr(const uint8_t *ram, size_t byteSize, uint32_t o
         if (relAddr + 4 <= byteSize) {
             uint32_t header = 0;
             std::memcpy(&header, ram + relAddr, sizeof(header));
-            if (looksLikeGp0Opcode(header))
+            if (psxLooksLikeGp0Opcode(header))
                 return relAddr;
         }
     }

--- a/src/PS1/runtime/PsxOrderingTableScanner.h
+++ b/src/PS1/runtime/PsxOrderingTableScanner.h
@@ -1,0 +1,20 @@
+#ifndef PSXORDERINGTABLESCANNER_H
+#define PSXORDERINGTABLESCANNER_H
+
+#include <cstddef>
+#include <cstdint>
+
+class EmuHooks;
+
+/**
+ * Locates PSX GPU ordering tables in main RAM and walks linked GP0 chains (#418).
+ * Replaces blind linear opcode scanning when the game uses DrawOTag-style submission.
+ */
+class PsxOrderingTableScanner
+{
+public:
+    /** Returns number of primitives dispatched from OT chains. */
+    static int captureFromOrderingTables(const uint8_t *ram, size_t byteSize, EmuHooks *hooks);
+};
+
+#endif // PSXORDERINGTABLESCANNER_H

--- a/src/PS1/runtime/PsxOrderingTableScanner_test.cpp
+++ b/src/PS1/runtime/PsxOrderingTableScanner_test.cpp
@@ -4,6 +4,7 @@
 
 #include "PS1/runtime/CaptureBuffer.h"
 #include "PS1/runtime/Gp0HookDispatch.h"
+#include "PS1/runtime/PsxGp0Opcode.h"
 #include "PS1/runtime/PsxOrderingTableScanner.h"
 #include "PS1/runtime/RipperHooks.h"
 
@@ -91,17 +92,15 @@ TEST(PsxOrderingTableScannerTest, LinkedChainCapture)
     constexpr uint32_t kOtBase = 0x400;
     constexpr uint32_t kChain = 0x800;
 
-    const uint32_t linkOffsetWords = 4; // tri packet is 4 words; second packet follows immediately
+    constexpr uint32_t kSecond = kChain + 16; // 4-word tri packet
     const uint32_t linkedHeader =
-        (static_cast<uint32_t>(0x20) << 24) | (linkOffsetWords << 2) | 1u;
+        (static_cast<uint32_t>(0x20) << 24) | psxGp0TagNextByteAddr(kSecond) | 1u;
     const uint32_t firstPacket[] = {
         linkedHeader,
         pos(0, 0),
         pos(10, 0),
         pos(5, 10),
     };
-    constexpr uint32_t kSecond = kChain + static_cast<uint32_t>(sizeof(firstPacket));
-
     writeU32(ram, kOtBase, kChain - kOtBase);
     std::memcpy(ram + kChain, firstPacket, sizeof(firstPacket));
 
@@ -122,6 +121,36 @@ TEST(PsxOrderingTableScannerTest, LinkedChainCapture)
 
     const int prims = PsxOrderingTableScanner::captureFromOrderingTables(ram, sizeof(ram), &hooks);
     EXPECT_GE(prims, 2);
+}
+
+TEST(PsxOrderingTableScannerTest, AbsoluteOtEntryPointers)
+{
+    alignas(4) uint8_t ram[16 * 1024];
+    std::memset(ram, 0, sizeof(ram));
+
+    constexpr uint32_t kOtBase = 0x200;
+    constexpr uint32_t kChain = 0x1800;
+
+    writeU32(ram, kOtBase, kChain | 1u); // DrawOTag-style absolute pointer (priority in bit0)
+
+    const uint32_t packet[] = {
+        colorCmd(0x20, 1, 2, 3),
+        pos(4, 8),
+        pos(16, 8),
+        pos(10, 20),
+    };
+    std::memcpy(ram + kChain, packet, sizeof(packet));
+
+    std::atomic<bool> armed{true};
+    CaptureBuffer buffer;
+    RipperHooks hooks;
+    hooks.setArmedFlag(&armed);
+    hooks.setBuffer(&buffer);
+
+    const int prims = PsxOrderingTableScanner::captureFromOrderingTables(ram, sizeof(ram), &hooks);
+    EXPECT_GE(prims, 1);
+    ASSERT_GE(buffer.prims().size(), 1);
+    EXPECT_EQ(buffer.prims()[0].kind, PrimKind::MonoTri);
 }
 
 #endif // ENABLE_PS1_RIP

--- a/src/PS1/runtime/PsxOrderingTableScanner_test.cpp
+++ b/src/PS1/runtime/PsxOrderingTableScanner_test.cpp
@@ -1,0 +1,127 @@
+#ifdef ENABLE_PS1_RIP
+
+#include <gtest/gtest.h>
+
+#include "PS1/runtime/CaptureBuffer.h"
+#include "PS1/runtime/Gp0HookDispatch.h"
+#include "PS1/runtime/PsxOrderingTableScanner.h"
+#include "PS1/runtime/RipperHooks.h"
+
+#include <atomic>
+#include <cstring>
+
+namespace {
+
+uint32_t colorCmd(uint8_t opcode, uint8_t r, uint8_t g, uint8_t b)
+{
+    return static_cast<uint32_t>(opcode) | (static_cast<uint32_t>(r) << 8)
+           | (static_cast<uint32_t>(g) << 16) | (static_cast<uint32_t>(b) << 24);
+}
+
+uint32_t pos(int x, int y)
+{
+    return static_cast<uint32_t>((y & 0xFFFF) << 16) | static_cast<uint32_t>(x & 0xFFFF);
+}
+
+void writeU32(uint8_t *ram, size_t byteOffset, uint32_t value)
+{
+    std::memcpy(ram + byteOffset, &value, sizeof(value));
+}
+
+} // namespace
+
+TEST(PsxOrderingTableScannerTest, CapturesPrimitivesFromSyntheticOrderingTable)
+{
+    alignas(4) uint8_t ram[16 * 1024];
+    std::memset(ram, 0, sizeof(ram));
+
+    constexpr uint32_t kOtBase = 0x1000;
+    constexpr uint32_t kTriChain = 0x2000;
+    constexpr uint32_t kQuadChain = 0x2100;
+
+    writeU32(ram, kOtBase + 0, kTriChain - kOtBase);
+    writeU32(ram, kOtBase + 4, 0);
+    writeU32(ram, kOtBase + 8, kQuadChain - kOtBase);
+    writeU32(ram, kOtBase + 12, 0);
+
+    const uint32_t triPacket[] = {
+        colorCmd(0x20, 30, 20, 10),
+        pos(8, 16),
+        pos(40, 16),
+        pos(24, 32),
+    };
+    std::memcpy(ram + kTriChain, triPacket, sizeof(triPacket));
+
+    const uint32_t quadPacket[] = {
+        colorCmd(0x28, 10, 20, 30),
+        pos(0, 0),
+        pos(32, 0),
+        pos(32, 32),
+        pos(0, 32),
+    };
+    std::memcpy(ram + kQuadChain, quadPacket, sizeof(quadPacket));
+
+    std::atomic<bool> armed{true};
+    CaptureBuffer buffer;
+    RipperHooks hooks;
+    hooks.setArmedFlag(&armed);
+    hooks.setBuffer(&buffer);
+
+    const int prims = PsxOrderingTableScanner::captureFromOrderingTables(ram, sizeof(ram), &hooks);
+    EXPECT_GE(prims, 2);
+    EXPECT_GE(buffer.prims().size(), 2);
+
+    bool hasTri = false;
+    bool hasQuad = false;
+    for (const PrimRecord &prim : buffer.prims()) {
+        if (prim.kind == PrimKind::MonoTri)
+            hasTri = true;
+        if (prim.kind == PrimKind::MonoQuad)
+            hasQuad = true;
+    }
+    EXPECT_TRUE(hasTri);
+    EXPECT_TRUE(hasQuad);
+}
+
+TEST(PsxOrderingTableScannerTest, LinkedChainCapture)
+{
+    alignas(4) uint8_t ram[16 * 1024];
+    std::memset(ram, 0, sizeof(ram));
+
+    constexpr uint32_t kOtBase = 0x400;
+    constexpr uint32_t kChain = 0x800;
+
+    const uint32_t linkOffsetWords = 4; // tri packet is 4 words; second packet follows immediately
+    const uint32_t linkedHeader =
+        (static_cast<uint32_t>(0x20) << 24) | (linkOffsetWords << 2) | 1u;
+    const uint32_t firstPacket[] = {
+        linkedHeader,
+        pos(0, 0),
+        pos(10, 0),
+        pos(5, 10),
+    };
+    constexpr uint32_t kSecond = kChain + static_cast<uint32_t>(sizeof(firstPacket));
+
+    writeU32(ram, kOtBase, kChain - kOtBase);
+    std::memcpy(ram + kChain, firstPacket, sizeof(firstPacket));
+
+    const uint32_t secondPacket[] = {
+        colorCmd(0x28, 4, 5, 6),
+        pos(20, 20),
+        pos(40, 20),
+        pos(40, 40),
+        pos(20, 40),
+    };
+    std::memcpy(ram + kSecond, secondPacket, sizeof(secondPacket));
+
+    std::atomic<bool> armed{true};
+    CaptureBuffer buffer;
+    RipperHooks hooks;
+    hooks.setArmedFlag(&armed);
+    hooks.setBuffer(&buffer);
+
+    const int prims = PsxOrderingTableScanner::captureFromOrderingTables(ram, sizeof(ram), &hooks);
+    EXPECT_GE(prims, 2);
+}
+
+#endif // ENABLE_PS1_RIP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -143,6 +143,8 @@ if(BUILD_TESTS)
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/GteInverse.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/EmuViewport.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/Gp0HookDispatch.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PsxGp0ChainWalker.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PsxOrderingTableScanner.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/GpuCommandParser.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/GteCapture.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/MeshReconstructor.cpp


### PR DESCRIPTION
## Summary

- Add `PsxOrderingTableScanner` and `PsxGp0ChainWalker` so libretro capture walks PSX ordering-table linked GP0 chains before falling back to linear RAM scan.
- Introduce `PsxGp0Opcode.h` for correct opcode decode on linked DR tags (bits 24–31) and drawing-environment commands (0xE1–0xE6 in the low byte).
- Add synthetic OT/homebrew RAM tests, stub disarmed `<1%` `runFrame` overhead check, and armed capture smoke tests; document Phase 2 status in `PS1_RIP_DESIGN.md`.

Closes remaining Phase 2 gaps after #645. True mednafen GP0 FIFO hooks remain future work.

## Test plan

- [x] `xvfb-run ./build_local/bin/UnitTests --gtest_filter="PsxOrderingTable*:GpuCommandParser*:Gp0HookDispatch*:EmuCoreLoaderTest.Stub*"`
- [ ] CI Linux unit tests (Xvfb)
- [ ] Optional local: `QTMESH_PS1_LIBRETRO_INTEGRATION_TESTS=1` libretro overhead/capture tests with BIOS + cue


Made with [Cursor](https://cursor.com)