### PR TITLE
feat(ps1): GTE matrix RAM capture (#419)

### DIFF
--- a/plugins/ps1core_libretro/CMakeLists.txt
+++ b/plugins/ps1core_libretro/CMakeLists.txt
@@ -15,6 +15,8 @@ add_library(qtmesh_ps1core_libretro MODULE
     LibretroEmuCorePlugin.cpp
     LibretroHost.cpp
     ${CMAKE_SOURCE_DIR}/src/PS1/runtime/Gp0HookDispatch.cpp
+    ${CMAKE_SOURCE_DIR}/src/PS1/runtime/GteCapture.cpp
+    ${CMAKE_SOURCE_DIR}/src/PS1/runtime/PsxGteRamScanner.cpp
     ${CMAKE_SOURCE_DIR}/src/PS1/runtime/PsxGp0ChainWalker.cpp
     ${CMAKE_SOURCE_DIR}/src/PS1/runtime/PsxOrderingTableScanner.cpp
     ${CMAKE_SOURCE_DIR}/src/PS1/runtime/GpuCommandParser.cpp

--- a/plugins/ps1core_libretro/LibretroEmuCore.cpp
+++ b/plugins/ps1core_libretro/LibretroEmuCore.cpp
@@ -447,7 +447,7 @@ void LibretroEmuCore::runFrame()
 
     m_host.retro_run();
     syncVramFromCore();
-    captureGpuFromRam();
+    // GPU/GTE RAM capture runs only on explicit Capture Frame (ingestCaptureFrame).
 }
 
 void LibretroEmuCore::reset()

--- a/plugins/ps1core_libretro/LibretroEmuCore.cpp
+++ b/plugins/ps1core_libretro/LibretroEmuCore.cpp
@@ -543,7 +543,7 @@ void LibretroEmuCore::syncCaptureMirrors()
 
 void LibretroEmuCore::ingestCaptureFrame()
 {
-    captureGpuFromRam();
+    captureGpuFromRam(true);
 }
 
 void LibretroEmuCore::mirrorFramebufferToVram()
@@ -584,7 +584,7 @@ void LibretroEmuCore::syncVramFromCore()
     mirrorFramebufferToVram();
 }
 
-void LibretroEmuCore::captureGpuFromRam()
+void LibretroEmuCore::captureGpuFromRam(bool scanGteRam)
 {
     if (!m_hooks || !m_hooks->isCaptureEnabled())
         return;
@@ -597,7 +597,8 @@ void LibretroEmuCore::captureGpuFromRam()
     if (!ram || ramSize < 4096)
         return;
 
-    Gp0HookDispatch::captureFrameFromSystemRam(static_cast<const uint8_t *>(ram), ramSize, m_hooks);
+    Gp0HookDispatch::captureFrameFromSystemRam(static_cast<const uint8_t *>(ram), ramSize, m_hooks,
+                                               scanGteRam);
 }
 
 void LibretroEmuCore::presentVideo(const void *data, unsigned width, unsigned height, size_t pitch)

--- a/plugins/ps1core_libretro/LibretroEmuCore.h
+++ b/plugins/ps1core_libretro/LibretroEmuCore.h
@@ -41,7 +41,7 @@ private:
     void refreshVramPointer();
     void mirrorFramebufferToVram();
     void syncVramFromCore();
-    void captureGpuFromRam();
+    void captureGpuFromRam(bool scanGteRam = false);
     void presentVideo(const void *data, unsigned width, unsigned height, size_t pitch);
 
     static bool environmentCallback(unsigned cmd, void *data);

--- a/src/PS1/PS1_RIP_DESIGN.md
+++ b/src/PS1/PS1_RIP_DESIGN.md
@@ -132,7 +132,10 @@ cmake ... -DCMAKE_CXX_FLAGS="-DQTMESH_PS1_LIBRETRO_INTEGRATION_TESTS"
 export QTMESH_PS1_TEST_BIOS=/path/scph1001.bin
 export QTMESH_PS1_TEST_ISO=/path/game.cue
 ./build/bin/UnitTests --gtest_filter='EmuCoreLoaderTest.Libretro*'
+./build/bin/UnitTests --gtest_filter='PS1RipManagerLibretroArmTest.*'
 ```
+
+`PS1RipManagerLibretroArmTest` (arm/capture while a real libretro session runs) uses the same guard and env vars.
 
 ## Open questions
 

--- a/src/PS1/PS1_RIP_DESIGN.md
+++ b/src/PS1/PS1_RIP_DESIGN.md
@@ -68,7 +68,7 @@ See epic #412 for phased issues (#413–#431).
 
 - `CaptureTypes`, `GpuCommandParser`, `CaptureBuffer`, `RipperHooks`, `Gp0HookDispatch` (#418).
 - `EmuHooks` included from `EmuCore.h` (issue #418 API surface).
-- **GTE capture (#419):** `PsxGteRamScanner` runs before GP0 ingest; `RipperHooks` tracks the latest `onGteMatrix` as `matrixId` for subsequent primitives; hash dedupe + `cameraMatrixId` heuristic exposed in the session status bar after mesh build.
+- **GTE capture (#419):** `PsxGteRamScanner` runs before GP0 ingest on explicit **Capture Frame** (`ingestCaptureFrame`); per-frame armed ticks skip the 2 MiB GTE scan to avoid UI freezes. `RipperHooks` tracks the latest `onGteMatrix` as `matrixId` for subsequent primitives; hash dedupe + `cameraMatrixId` heuristic exposed in the session status bar after mesh build.
 - **Libretro capture path:** `Gp0HookDispatch` in the plugin walks **ordering-table linked GP0 chains** first (`PsxOrderingTableScanner` + `PsxGp0ChainWalker`), then falls back to linear RAM opcode scan when no OT is found. OT entries are resolved as **24-bit absolute RAM pointers** (libgpu `getaddr` layout), with a relative-to-OT-base fallback for synthetic tests. Linked DR tags carry the opcode in bits 24–31 and the next packet address in bits 2–23 (`PsxGp0Opcode.h`); drawing-environment commands (0xE1–0xE6) stay in the low byte.
 - **Stub core** emits all seven GP0 primitive flavors for CI when `QTMESH_PS1_FORCE_STUB=1` or no libretro core is present.
 - `armCapture` / `captureFrame` wire capture to the worker thread; CSV dump to temp for verification.

--- a/src/PS1/PS1_RIP_DESIGN.md
+++ b/src/PS1/PS1_RIP_DESIGN.md
@@ -68,7 +68,7 @@ See epic #412 for phased issues (#413–#431).
 
 - `CaptureTypes`, `GpuCommandParser`, `CaptureBuffer`, `RipperHooks`, `Gp0HookDispatch` (#418).
 - `EmuHooks` included from `EmuCore.h` (issue #418 API surface).
-- **GTE capture (#419):** `PsxGteRamScanner` runs before GP0 ingest on explicit **Capture Frame** (`ingestCaptureFrame`); per-frame armed ticks skip the 2 MiB GTE scan to avoid UI freezes. `RipperHooks` tracks the latest `onGteMatrix` as `matrixId` for subsequent primitives; hash dedupe + `cameraMatrixId` heuristic exposed in the session status bar after mesh build.
+- **GTE capture (#419):** `PsxGteRamScanner` + GP0 ingest run only on **Capture Frame** (`ingestCaptureFrame`), not while armed during live play — avoids 2 MiB RAM scans and buffer races when toggling Arm Capture. `RipperHooks` tracks the latest `onGteMatrix` as `matrixId` for subsequent primitives; hash dedupe + `cameraMatrixId` heuristic exposed in the session status bar after mesh build.
 - **Libretro capture path:** `Gp0HookDispatch` in the plugin walks **ordering-table linked GP0 chains** first (`PsxOrderingTableScanner` + `PsxGp0ChainWalker`), then falls back to linear RAM opcode scan when no OT is found. OT entries are resolved as **24-bit absolute RAM pointers** (libgpu `getaddr` layout), with a relative-to-OT-base fallback for synthetic tests. Linked DR tags carry the opcode in bits 24–31 and the next packet address in bits 2–23 (`PsxGp0Opcode.h`); drawing-environment commands (0xE1–0xE6) stay in the low byte.
 - **Stub core** emits all seven GP0 primitive flavors for CI when `QTMESH_PS1_FORCE_STUB=1` or no libretro core is present.
 - `armCapture` / `captureFrame` wire capture to the worker thread; CSV dump to temp for verification.

--- a/src/PS1/PS1_RIP_DESIGN.md
+++ b/src/PS1/PS1_RIP_DESIGN.md
@@ -68,7 +68,7 @@ See epic #412 for phased issues (#413–#431).
 
 - `CaptureTypes`, `GpuCommandParser`, `CaptureBuffer`, `RipperHooks`, `Gp0HookDispatch` (#418).
 - `EmuHooks` included from `EmuCore.h` (issue #418 API surface).
-- GTE matrix hash dedupe + `cameraMatrixId` heuristic (#419).
+- **GTE capture (#419):** `PsxGteRamScanner` runs before GP0 ingest; `RipperHooks` tracks the latest `onGteMatrix` as `matrixId` for subsequent primitives; hash dedupe + `cameraMatrixId` heuristic exposed in the session status bar after mesh build.
 - **Libretro capture path:** `Gp0HookDispatch` in the plugin walks **ordering-table linked GP0 chains** first (`PsxOrderingTableScanner` + `PsxGp0ChainWalker`), then falls back to linear RAM opcode scan when no OT is found. OT entries are resolved as **24-bit absolute RAM pointers** (libgpu `getaddr` layout), with a relative-to-OT-base fallback for synthetic tests. Linked DR tags carry the opcode in bits 24–31 and the next packet address in bits 2–23 (`PsxGp0Opcode.h`); drawing-environment commands (0xE1–0xE6) stay in the low byte.
 - **Stub core** emits all seven GP0 primitive flavors for CI when `QTMESH_PS1_FORCE_STUB=1` or no libretro core is present.
 - `armCapture` / `captureFrame` wire capture to the worker thread; CSV dump to temp for verification.

--- a/src/PS1/runtime/CaptureBuffer.h
+++ b/src/PS1/runtime/CaptureBuffer.h
@@ -6,6 +6,8 @@
 #include <QHash>
 #include <QVector>
 
+#include <cstdint>
+
 /**
  * Per-frame capture arena for GPU primitives and GTE matrices (#418, #419).
  */

--- a/src/PS1/runtime/CaptureSnapshot.h
+++ b/src/PS1/runtime/CaptureSnapshot.h
@@ -6,6 +6,8 @@
 #include <QMetaType>
 #include <QVector>
 
+#include <cstdint>
+
 class CaptureBuffer;
 
 /** Thread-safe copy of a frame capture for main-thread reconstruction (#422). */

--- a/src/PS1/runtime/CaptureSnapshot.h
+++ b/src/PS1/runtime/CaptureSnapshot.h
@@ -22,6 +22,8 @@ struct CaptureSnapshot
         return vramCells.size() == 1024 * 512;
     }
 
+    bool hasCameraMatrix() const { return cameraMatrixId != UINT32_MAX; }
+
     static CaptureSnapshot fromBuffer(const CaptureBuffer &buffer,
                                       const QVector<uint16_t> &vramCells = {});
 };

--- a/src/PS1/runtime/Gp0HookDispatch.cpp
+++ b/src/PS1/runtime/Gp0HookDispatch.cpp
@@ -3,6 +3,7 @@
 #include "EmuHooks.h"
 #include "PsxCaptureFilters.h"
 #include "PsxGp0Opcode.h"
+#include "PsxGteRamScanner.h"
 #include "PsxOrderingTableScanner.h"
 
 #include <QSet>
@@ -172,6 +173,7 @@ void Gp0HookDispatch::captureFrameFromSystemRam(const uint8_t *ram, size_t byteS
         return;
 
     hooks->onFrameBegin();
+    PsxGteRamScanner::captureFromSystemRam(ram, byteSize, hooks);
     ensureCaptureProjectionMatrix(hooks);
     captureFromSystemRam(ram, byteSize, hooks);
     hooks->onFrameEnd();

--- a/src/PS1/runtime/Gp0HookDispatch.cpp
+++ b/src/PS1/runtime/Gp0HookDispatch.cpp
@@ -166,15 +166,29 @@ void Gp0HookDispatch::captureFromSystemRam(const uint8_t *ram, size_t byteSize, 
     captureLinearScan(ram, byteSize, hooks, seen, currentMode, primCount);
 }
 
+namespace {
+
+constexpr size_t kPs1MainRamBytes = 2u * 1024u * 1024u;
+
+size_t clampPs1RamSize(size_t byteSize)
+{
+    return byteSize > kPs1MainRamBytes ? kPs1MainRamBytes : byteSize;
+}
+
+} // namespace
+
 void Gp0HookDispatch::captureFrameFromSystemRam(const uint8_t *ram, size_t byteSize,
-                                                EmuHooks *hooks)
+                                                EmuHooks *hooks, bool scanGteRam)
 {
     if (!hooks || !hooks->isCaptureEnabled() || !ram || byteSize < 16)
         return;
 
+    const size_t scanSize = clampPs1RamSize(byteSize);
+
     hooks->onFrameBegin();
-    PsxGteRamScanner::captureFromSystemRam(ram, byteSize, hooks);
+    if (scanGteRam)
+        PsxGteRamScanner::captureFromSystemRam(ram, scanSize, hooks);
     ensureCaptureProjectionMatrix(hooks);
-    captureFromSystemRam(ram, byteSize, hooks);
+    captureFromSystemRam(ram, scanSize, hooks);
     hooks->onFrameEnd();
 }

--- a/src/PS1/runtime/Gp0HookDispatch.h
+++ b/src/PS1/runtime/Gp0HookDispatch.h
@@ -31,7 +31,7 @@ public:
                                   QSet<QString> &seenPrimKeys, DrawModeRecord &currentMode,
                                   int &primCount);
 
-    /** Begin/end frame + stable projection matrix for libretro heuristic capture. */
+    /** GTE RAM scan, GP0 capture, frame begin/end (#418, #419). */
     static void captureFrameFromSystemRam(const uint8_t *ram, size_t byteSize, EmuHooks *hooks);
 };
 

--- a/src/PS1/runtime/Gp0HookDispatch.h
+++ b/src/PS1/runtime/Gp0HookDispatch.h
@@ -31,8 +31,12 @@ public:
                                   QSet<QString> &seenPrimKeys, DrawModeRecord &currentMode,
                                   int &primCount);
 
-    /** GTE RAM scan, GP0 capture, frame begin/end (#418, #419). */
-    static void captureFrameFromSystemRam(const uint8_t *ram, size_t byteSize, EmuHooks *hooks);
+    /**
+     * Frame capture with optional GTE RAM scan (#418, #419).
+     * @p scanGteRam When false, skips the 2 MiB matrix heuristic (use on per-frame ticks).
+     */
+    static void captureFrameFromSystemRam(const uint8_t *ram, size_t byteSize, EmuHooks *hooks,
+                                          bool scanGteRam = true);
 };
 
 #endif // GP0HOOKDISPATCH_H

--- a/src/PS1/runtime/GteInverse.cpp
+++ b/src/PS1/runtime/GteInverse.cpp
@@ -4,6 +4,34 @@
 
 namespace GteInverse {
 
+bool modelToScreen(const MatrixRecord &matrix, int mx, int my, int mz, int &sx, int &sy, int &sz)
+{
+    const double h = matrix.h != 0 ? static_cast<double>(matrix.h) : 4096.0;
+    sz = mz != 0 ? mz : 4096;
+    const double ir3 = static_cast<double>(sz);
+
+    const double vx = static_cast<double>(mx) * 4096.0;
+    const double vy = static_cast<double>(my) * 4096.0;
+    const double vz = static_cast<double>(mz) * 4096.0;
+
+    double irAdj[3] = {0.0, 0.0, 0.0};
+    if (matrix.rt.m[0][0] != 0)
+        irAdj[0] = vx / static_cast<double>(matrix.rt.m[0][0]);
+    if (matrix.rt.m[1][1] != 0)
+        irAdj[1] = vy / static_cast<double>(matrix.rt.m[1][1]);
+    if (matrix.rt.m[2][2] != 0)
+        irAdj[2] = vz / static_cast<double>(matrix.rt.m[2][2]);
+
+    const double ir1 = irAdj[0] + matrix.tr[0];
+    const double ir2 = irAdj[1] + matrix.tr[1];
+
+    const double sxFixed = (ir1 * h / ir3) + matrix.ofx;
+    const double syFixed = (ir2 * h / ir3) + matrix.ofy;
+    sx = static_cast<int>(sxFixed / 65536.0);
+    sy = static_cast<int>(syFixed / 65536.0);
+    return std::isfinite(static_cast<double>(sx)) && std::isfinite(static_cast<double>(sy));
+}
+
 bool screenToModel(const MatrixRecord &matrix, int sx, int sy, int sz, float &mx, float &my, float &mz)
 {
     const double h = matrix.h != 0 ? static_cast<double>(matrix.h) : 4096.0;

--- a/src/PS1/runtime/GteInverse.cpp
+++ b/src/PS1/runtime/GteInverse.cpp
@@ -1,35 +1,48 @@
 #include "GteInverse.h"
 
 #include <cmath>
+#include <limits>
 
 namespace GteInverse {
 
 bool modelToScreen(const MatrixRecord &matrix, int mx, int my, int mz, int &sx, int &sy, int &sz)
 {
     const double h = matrix.h != 0 ? static_cast<double>(matrix.h) : 4096.0;
-    sz = mz != 0 ? mz : 4096;
-    const double ir3 = static_cast<double>(sz);
 
     const double vx = static_cast<double>(mx) * 4096.0;
     const double vy = static_cast<double>(my) * 4096.0;
     const double vz = static_cast<double>(mz) * 4096.0;
 
-    double irAdj[3] = {0.0, 0.0, 0.0};
-    if (matrix.rt.m[0][0] != 0)
-        irAdj[0] = vx / static_cast<double>(matrix.rt.m[0][0]);
-    if (matrix.rt.m[1][1] != 0)
-        irAdj[1] = vy / static_cast<double>(matrix.rt.m[1][1]);
-    if (matrix.rt.m[2][2] != 0)
-        irAdj[2] = vz / static_cast<double>(matrix.rt.m[2][2]);
+    if (matrix.rt.m[0][0] == 0 || matrix.rt.m[1][1] == 0 || matrix.rt.m[2][2] == 0)
+        return false;
 
-    const double ir1 = irAdj[0] + matrix.tr[0];
-    const double ir2 = irAdj[1] + matrix.tr[1];
+    const double irAdj0 = vx / static_cast<double>(matrix.rt.m[0][0]);
+    const double irAdj1 = vy / static_cast<double>(matrix.rt.m[1][1]);
+    const double irAdj2 = vz / static_cast<double>(matrix.rt.m[2][2]);
+
+    const double ir1 = irAdj0 + matrix.tr[0];
+    const double ir2 = irAdj1 + matrix.tr[1];
+    const double ir3 = irAdj2 + matrix.tr[2];
+    if (ir3 == 0.0)
+        return false;
 
     const double sxFixed = (ir1 * h / ir3) + matrix.ofx;
     const double syFixed = (ir2 * h / ir3) + matrix.ofy;
-    sx = static_cast<int>(sxFixed / 65536.0);
-    sy = static_cast<int>(syFixed / 65536.0);
-    return std::isfinite(static_cast<double>(sx)) && std::isfinite(static_cast<double>(sy));
+    const double sxPixel = sxFixed / 65536.0;
+    const double syPixel = syFixed / 65536.0;
+    if (!std::isfinite(sxPixel) || !std::isfinite(syPixel) || !std::isfinite(ir3))
+        return false;
+
+    const double intMin = static_cast<double>(std::numeric_limits<int>::min());
+    const double intMax = static_cast<double>(std::numeric_limits<int>::max());
+    if (sxPixel < intMin || sxPixel > intMax || syPixel < intMin || syPixel > intMax || ir3 < intMin
+        || ir3 > intMax)
+        return false;
+
+    sx = static_cast<int>(sxPixel);
+    sy = static_cast<int>(syPixel);
+    sz = static_cast<int>(ir3);
+    return true;
 }
 
 bool screenToModel(const MatrixRecord &matrix, int sx, int sy, int sz, float &mx, float &my, float &mz)

--- a/src/PS1/runtime/GteInverse.h
+++ b/src/PS1/runtime/GteInverse.h
@@ -8,6 +8,9 @@ namespace GteInverse {
 
 bool screenToModel(const MatrixRecord &matrix, int sx, int sy, int sz, float &mx, float &my, float &mz);
 
+/** Forward projection paired with screenToModel (fixed-point model units, PS1 screen coords). */
+bool modelToScreen(const MatrixRecord &matrix, int mx, int my, int mz, int &sx, int &sy, int &sz);
+
 /** PS1 screen (Y-down) → editor world (Y-up, right-handed). */
 void psxScreenToWorld(float sx, float sy, float sz, float &wx, float &wy, float &wz);
 

--- a/src/PS1/runtime/GteInverse_test.cpp
+++ b/src/PS1/runtime/GteInverse_test.cpp
@@ -30,6 +30,36 @@ TEST(GteInverseTest, ScreenToModelWithTranslation)
     EXPECT_NE(mx, 0.0f);
 }
 
+TEST(GteInverseTest, ModelToScreenRoundTripsThroughScreenToModel)
+{
+    MatrixRecord matrix = identityMatrix();
+    matrix.ofx = 160 << 16;
+    matrix.ofy = 120 << 16;
+    matrix.tr[0] = 2048;
+
+    constexpr int kModelX = 1000;
+    constexpr int kModelY = -2000;
+    constexpr int kModelZ = 3000;
+    int sx = 0;
+    int sy = 0;
+    int sz = 0;
+    ASSERT_TRUE(GteInverse::modelToScreen(matrix, kModelX, kModelY, kModelZ, sx, sy, sz));
+
+    float mx = 0.0f;
+    float my = 0.0f;
+    float mz = 0.0f;
+    ASSERT_TRUE(GteInverse::screenToModel(matrix, sx, sy, sz, mx, my, mz));
+
+    int sx2 = 0;
+    int sy2 = 0;
+    int sz2 = 0;
+    ASSERT_TRUE(GteInverse::modelToScreen(matrix, static_cast<int>(mx), static_cast<int>(my),
+                                          static_cast<int>(mz), sx2, sy2, sz2));
+    EXPECT_NEAR(sx, sx2, 2);
+    EXPECT_NEAR(sy, sy2, 2);
+    EXPECT_NEAR(sz, sz2, 2);
+}
+
 TEST(GteInverseTest, ScreenToWorldFlipsY)
 {
     float wx = 0.0f;

--- a/src/PS1/runtime/MeshReconstructor_cube_test.cpp
+++ b/src/PS1/runtime/MeshReconstructor_cube_test.cpp
@@ -1,0 +1,107 @@
+#include "CaptureSnapshot.h"
+#include "MeshReconstructor.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+
+namespace {
+
+PrimRecord screenTri(int x0, int y0, int z0, int x1, int y1, int z1, int x2, int y2, int z2)
+{
+    PrimRecord out{};
+    out.kind = PrimKind::MonoTri;
+    out.vertexCount = 3;
+    out.verts[0] = {x0, y0, z0, 255, 255, 255, 0, 0};
+    out.verts[1] = {x1, y1, z1, 255, 255, 255, 0, 0};
+    out.verts[2] = {x2, y2, z2, 255, 255, 255, 0, 0};
+    return out;
+}
+
+/** Screen-space cube (PSX coords) — exercises capture → reconstruct without GTE projection. */
+void appendCubeFaces(CaptureSnapshot &snap)
+{
+    constexpr int l = 48;
+    constexpr int r = 208;
+    constexpr int t = 48;
+    constexpr int b = 168;
+    constexpr int zNear = 4096;
+    constexpr int zFar = 8192;
+
+    auto tri = [&](int x0, int y0, int z0, int x1, int y1, int z1, int x2, int y2, int z2) {
+        snap.prims.append(screenTri(x0, y0, z0, x1, y1, z1, x2, y2, z2));
+    };
+
+    tri(l, t, zNear, r, t, zNear, r, b, zNear);
+    tri(l, t, zNear, r, b, zNear, l, b, zNear);
+    tri(l, t, zFar, r, t, zFar, r, b, zFar);
+    tri(l, t, zFar, r, b, zFar, l, b, zFar);
+    tri(l, t, zNear, l, t, zFar, l, b, zFar);
+    tri(l, t, zNear, l, b, zFar, l, b, zNear);
+    tri(r, t, zNear, r, t, zFar, r, b, zFar);
+    tri(r, t, zNear, r, b, zFar, r, b, zNear);
+    tri(l, t, zNear, l, t, zFar, r, t, zFar);
+    tri(l, t, zNear, r, t, zFar, r, t, zNear);
+    tri(l, b, zNear, l, b, zFar, r, b, zFar);
+    tri(l, b, zNear, r, b, zFar, r, b, zNear);
+}
+
+struct Bounds {
+    float minX = 0.0f;
+    float maxX = 0.0f;
+    float minY = 0.0f;
+    float maxY = 0.0f;
+    float minZ = 0.0f;
+    float maxZ = 0.0f;
+};
+
+Bounds meshBounds(const ReconstructedMesh &mesh)
+{
+    Bounds bounds{};
+    bool first = true;
+    for (const ReconstructedSubMesh &sub : mesh.subMeshes) {
+        for (const ReconstructedVertex &vertex : sub.vertices) {
+            if (first) {
+                bounds.minX = bounds.maxX = vertex.px;
+                bounds.minY = bounds.maxY = vertex.py;
+                bounds.minZ = bounds.maxZ = vertex.pz;
+                first = false;
+            } else {
+                bounds.minX = std::min(bounds.minX, vertex.px);
+                bounds.maxX = std::max(bounds.maxX, vertex.px);
+                bounds.minY = std::min(bounds.minY, vertex.py);
+                bounds.maxY = std::max(bounds.maxY, vertex.py);
+                bounds.minZ = std::min(bounds.minZ, vertex.pz);
+                bounds.maxZ = std::max(bounds.maxZ, vertex.pz);
+            }
+        }
+    }
+    return bounds;
+}
+
+} // namespace
+
+TEST(MeshReconstructorTest, CapturedCubeRoundTripsToUnitCubeMesh)
+{
+    CaptureSnapshot snap;
+    appendCubeFaces(snap);
+
+    const ReconstructedMesh mesh = MeshReconstructor::reconstruct(snap);
+    ASSERT_FALSE(mesh.isEmpty());
+    EXPECT_GE(mesh.triangleCount, 8);
+
+    const Bounds bounds = meshBounds(mesh);
+    const float extentX = bounds.maxX - bounds.minX;
+    const float extentY = bounds.maxY - bounds.minY;
+    const float extentZ = bounds.maxZ - bounds.minZ;
+
+    EXPECT_GT(extentX, 0.5f);
+    EXPECT_GT(extentY, 0.5f);
+    EXPECT_GT(extentZ, 0.1f);
+
+    const float maxExtent = std::max(extentX, std::max(extentY, extentZ));
+    const float minExtent = std::min(extentX, std::min(extentY, extentZ));
+    EXPECT_GT(maxExtent, 1.0f);
+    EXPECT_GT(minExtent, 0.5f);
+}

--- a/src/PS1/runtime/PS1RipManager.cpp
+++ b/src/PS1/runtime/PS1RipManager.cpp
@@ -121,7 +121,9 @@ void PS1RipManager::initializeWorkerThread()
                     QStringLiteral("ps1.rip.mesh.built"),
                     QStringLiteral("%1 verts %2 tris").arg(built.vertexCount).arg(built.triangleCount));
                 emit meshBuilt(captureId, captureSet.capturedPartCount, captureSet.uniqueCount(),
-                               captureSet.instanceCount(), built.vertexCount, built.triangleCount);
+                               captureSet.instanceCount(), built.vertexCount, built.triangleCount,
+                               snapshot.matrices.size(), snapshot.cameraMatrixId,
+                               snapshot.hasCameraMatrix());
             });
     connect(m_worker, &PS1RipWorker::vramFrameUpdated, this,
             [this](const QVector<uint16_t> &cells, const QImage &preview) {

--- a/src/PS1/runtime/PS1RipManager.cpp
+++ b/src/PS1/runtime/PS1RipManager.cpp
@@ -189,8 +189,7 @@ void PS1RipManager::syncWorkerCaptureArmed()
         return;
     PS1RipWorker *worker = m_worker;
     const bool armed = m_captureArmed;
-    QMetaObject::invokeMethod(worker, [worker, armed]() { worker->setCaptureArmed(armed); },
-                              Qt::QueuedConnection);
+    QMetaObject::invokeMethod(worker, "setCaptureArmed", Qt::QueuedConnection, Q_ARG(bool, armed));
 }
 
 bool PS1RipManager::loadBios(const QString &path)
@@ -363,8 +362,7 @@ bool PS1RipManager::captureFrame()
         return false;
     }
     PS1RipWorker *worker = m_worker;
-    QMetaObject::invokeMethod(worker, [worker]() { worker->finalizeFrameCapture(); },
-                              Qt::QueuedConnection);
+    QMetaObject::invokeMethod(worker, "finalizeFrameCapture", Qt::QueuedConnection);
     return true;
 }
 

--- a/src/PS1/runtime/PS1RipManager.h
+++ b/src/PS1/runtime/PS1RipManager.h
@@ -58,7 +58,8 @@ signals:
     void framePresented(const QImage &frame, quint64 frameIndex);
     void frameCaptured(const QString &captureId);
     void meshBuilt(const QString &captureId, int capturedParts, int uniqueMeshes, int instanceCount,
-                   int vertexCount, int triangleCount);
+                   int vertexCount, int triangleCount, int matrixCount, uint32_t cameraMatrixId,
+                   bool hasCameraMatrix);
     void sceneCaptured(const QString &captureId);
     void vramDumped(const QString &captureId, const QString &pngPath, const QVector<uint16_t> &cells,
                     const QImage &nativePreview);

--- a/src/PS1/runtime/PS1RipManager_libretro_arm_test.cpp
+++ b/src/PS1/runtime/PS1RipManager_libretro_arm_test.cpp
@@ -1,0 +1,129 @@
+#ifdef ENABLE_PS1_RIP
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+
+#include <QApplication>
+#include <QCoreApplication>
+#include <QFileInfo>
+#include <QSignalSpy>
+#include <QThread>
+#include <QTest>
+
+#include "PS1/runtime/PS1RipManager.h"
+
+namespace {
+
+QString defaultBiosPath()
+{
+    const QString env = qEnvironmentVariable("QTMESH_PS1_TEST_BIOS");
+    if (!env.isEmpty())
+        return env;
+    return QStringLiteral("/home/fernando/Downloads/scph5501.bin");
+}
+
+QString defaultIsoPath()
+{
+    const QString env = qEnvironmentVariable("QTMESH_PS1_TEST_ISO");
+    if (!env.isEmpty())
+        return env;
+    return QStringLiteral(
+        "/home/fernando/Downloads/Crash Bandicoot - Warped (USA)/Crash Bandicoot - Warped (USA)/"
+        "Crash Bandicoot - Warped (USA).cue");
+}
+
+bool libretroPluginAvailable()
+{
+    const QString base = QCoreApplication::applicationDirPath() + QStringLiteral("/PS1Cores/");
+    return QFileInfo::exists(base + QStringLiteral("qtmesh_ps1core_libretro.so"))
+           || QFileInfo::exists(base + QStringLiteral("libqtmesh_ps1core_libretro.so"));
+}
+
+} // namespace
+
+class PS1RipManagerLibretroArmTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        ASSERT_NE(qobject_cast<QApplication *>(QCoreApplication::instance()), nullptr);
+        qunsetenv("QTMESH_PS1_FORCE_STUB");
+        PS1RipManager::kill();
+        manager = PS1RipManager::getSingleton();
+        ASSERT_NE(manager, nullptr);
+    }
+
+    void TearDown() override
+    {
+        if (manager && manager->isSessionActive())
+            manager->stop();
+        PS1RipManager::kill();
+        qputenv("QTMESH_PS1_FORCE_STUB", "1");
+    }
+
+    PS1RipManager *manager = nullptr;
+};
+
+TEST_F(PS1RipManagerLibretroArmTest, ArmCaptureWhileLibretroSessionRuns)
+{
+    if (!libretroPluginAvailable())
+        GTEST_SKIP() << "libretro PS1 plugin not beside test binary";
+
+    const QString biosPath = defaultBiosPath();
+    const QString isoPath = defaultIsoPath();
+    ASSERT_TRUE(QFileInfo::exists(biosPath)) << biosPath.toStdString();
+    ASSERT_TRUE(QFileInfo::exists(isoPath)) << isoPath.toStdString();
+
+    ASSERT_TRUE(manager->loadBios(biosPath));
+    ASSERT_TRUE(manager->loadIso(isoPath));
+
+    QSignalSpy startedSpy(manager, &PS1RipManager::sessionStarted);
+    ASSERT_TRUE(manager->start());
+    ASSERT_TRUE(startedSpy.wait(60000)) << "libretro boot timed out";
+
+    QTest::qWait(2000);
+
+    for (int i = 0; i < 30; ++i) {
+        EXPECT_TRUE(manager->armCapture(true));
+        QTest::qWait(30);
+        EXPECT_TRUE(manager->armCapture(false));
+        QTest::qWait(30);
+    }
+    EXPECT_TRUE(manager->armCapture(true));
+
+    QTest::qWait(3000);
+    ASSERT_TRUE(manager->isSessionActive());
+    manager->stop();
+}
+
+TEST_F(PS1RipManagerLibretroArmTest, ArmThenCaptureFrame)
+{
+    if (!libretroPluginAvailable())
+        GTEST_SKIP() << "libretro PS1 plugin not beside test binary";
+
+    const QString biosPath = defaultBiosPath();
+    const QString isoPath = defaultIsoPath();
+    ASSERT_TRUE(QFileInfo::exists(biosPath));
+    ASSERT_TRUE(QFileInfo::exists(isoPath));
+
+    ASSERT_TRUE(manager->loadBios(biosPath));
+    ASSERT_TRUE(manager->loadIso(isoPath));
+
+    QSignalSpy startedSpy(manager, &PS1RipManager::sessionStarted);
+    ASSERT_TRUE(manager->start());
+    ASSERT_TRUE(startedSpy.wait(60000));
+
+    QTest::qWait(3000);
+
+    ASSERT_TRUE(manager->armCapture(true));
+    QTest::qWait(500);
+
+    QSignalSpy captureSpy(manager, &PS1RipManager::frameCaptured);
+    ASSERT_TRUE(manager->captureFrame());
+    ASSERT_TRUE(captureSpy.wait(120000)) << "capture frame timed out";
+
+    manager->stop();
+}
+
+#endif // ENABLE_PS1_RIP

--- a/src/PS1/runtime/PS1RipManager_libretro_arm_test.cpp
+++ b/src/PS1/runtime/PS1RipManager_libretro_arm_test.cpp
@@ -1,36 +1,33 @@
 #ifdef ENABLE_PS1_RIP
 
-#include <gtest/gtest.h>
+#if defined(QTMESH_PS1_LIBRETRO_INTEGRATION_TESTS)
 
-#include <atomic>
+#include <gtest/gtest.h>
 
 #include <QApplication>
 #include <QCoreApplication>
 #include <QFileInfo>
 #include <QSignalSpy>
-#include <QThread>
 #include <QTest>
 
 #include "PS1/runtime/PS1RipManager.h"
 
 namespace {
 
-QString defaultBiosPath()
+QString requireTestBiosPath()
 {
-    const QString env = qEnvironmentVariable("QTMESH_PS1_TEST_BIOS");
-    if (!env.isEmpty())
-        return env;
-    return QStringLiteral("/home/fernando/Downloads/scph5501.bin");
+    const QString path = qEnvironmentVariable("QTMESH_PS1_TEST_BIOS");
+    if (path.isEmpty() || !QFileInfo::exists(path))
+        return {};
+    return path;
 }
 
-QString defaultIsoPath()
+QString requireTestIsoPath()
 {
-    const QString env = qEnvironmentVariable("QTMESH_PS1_TEST_ISO");
-    if (!env.isEmpty())
-        return env;
-    return QStringLiteral(
-        "/home/fernando/Downloads/Crash Bandicoot - Warped (USA)/Crash Bandicoot - Warped (USA)/"
-        "Crash Bandicoot - Warped (USA).cue");
+    const QString path = qEnvironmentVariable("QTMESH_PS1_TEST_ISO");
+    if (path.isEmpty() || !QFileInfo::exists(path))
+        return {};
+    return path;
 }
 
 bool libretroPluginAvailable()
@@ -38,6 +35,14 @@ bool libretroPluginAvailable()
     const QString base = QCoreApplication::applicationDirPath() + QStringLiteral("/PS1Cores/");
     return QFileInfo::exists(base + QStringLiteral("qtmesh_ps1core_libretro.so"))
            || QFileInfo::exists(base + QStringLiteral("libqtmesh_ps1core_libretro.so"));
+}
+
+void skipUnlessLibretroAssetsReady()
+{
+    if (!libretroPluginAvailable())
+        GTEST_SKIP() << "libretro PS1 plugin not beside test binary";
+    if (requireTestBiosPath().isEmpty() || requireTestIsoPath().isEmpty())
+        GTEST_SKIP() << "Set QTMESH_PS1_TEST_BIOS and QTMESH_PS1_TEST_ISO to existing files";
 }
 
 } // namespace
@@ -67,13 +72,10 @@ protected:
 
 TEST_F(PS1RipManagerLibretroArmTest, ArmCaptureWhileLibretroSessionRuns)
 {
-    if (!libretroPluginAvailable())
-        GTEST_SKIP() << "libretro PS1 plugin not beside test binary";
+    skipUnlessLibretroAssetsReady();
 
-    const QString biosPath = defaultBiosPath();
-    const QString isoPath = defaultIsoPath();
-    ASSERT_TRUE(QFileInfo::exists(biosPath)) << biosPath.toStdString();
-    ASSERT_TRUE(QFileInfo::exists(isoPath)) << isoPath.toStdString();
+    const QString biosPath = requireTestBiosPath();
+    const QString isoPath = requireTestIsoPath();
 
     ASSERT_TRUE(manager->loadBios(biosPath));
     ASSERT_TRUE(manager->loadIso(isoPath));
@@ -99,13 +101,10 @@ TEST_F(PS1RipManagerLibretroArmTest, ArmCaptureWhileLibretroSessionRuns)
 
 TEST_F(PS1RipManagerLibretroArmTest, ArmThenCaptureFrame)
 {
-    if (!libretroPluginAvailable())
-        GTEST_SKIP() << "libretro PS1 plugin not beside test binary";
+    skipUnlessLibretroAssetsReady();
 
-    const QString biosPath = defaultBiosPath();
-    const QString isoPath = defaultIsoPath();
-    ASSERT_TRUE(QFileInfo::exists(biosPath));
-    ASSERT_TRUE(QFileInfo::exists(isoPath));
+    const QString biosPath = requireTestBiosPath();
+    const QString isoPath = requireTestIsoPath();
 
     ASSERT_TRUE(manager->loadBios(biosPath));
     ASSERT_TRUE(manager->loadIso(isoPath));
@@ -125,5 +124,7 @@ TEST_F(PS1RipManagerLibretroArmTest, ArmThenCaptureFrame)
 
     manager->stop();
 }
+
+#endif // QTMESH_PS1_LIBRETRO_INTEGRATION_TESTS
 
 #endif // ENABLE_PS1_RIP

--- a/src/PS1/runtime/PS1RipSessionWindow.cpp
+++ b/src/PS1/runtime/PS1RipSessionWindow.cpp
@@ -373,16 +373,22 @@ void PS1RipSessionWindow::onCaptureFrame()
 }
 
 void PS1RipSessionWindow::onMeshBuilt(const QString &captureId, int capturedParts, int uniqueMeshes,
-                                    int instanceCount, int vertexCount, int triangleCount)
+                                    int instanceCount, int vertexCount, int triangleCount,
+                                    int matrixCount, uint32_t cameraMatrixId, bool hasCameraMatrix)
 {
+    QString cameraText = hasCameraMatrix
+                             ? tr("camera matrix #%1").arg(cameraMatrixId)
+                             : tr("camera matrix unknown");
     m_statusLabel->setText(
-        tr("Mesh %1 — captured %2 / unique %3 / instances %4 (%5 verts, %6 tris)")
+        tr("Mesh %1 — captured %2 / unique %3 / instances %4 (%5 verts, %6 tris, %7 GTE matrices, %8)")
             .arg(captureId)
             .arg(capturedParts)
             .arg(uniqueMeshes)
             .arg(instanceCount)
             .arg(vertexCount)
-            .arg(triangleCount));
+            .arg(triangleCount)
+            .arg(matrixCount)
+            .arg(cameraText));
 }
 
 void PS1RipSessionWindow::onVramDumped(const QString &captureId, const QString &pngPath,

--- a/src/PS1/runtime/PS1RipSessionWindow.h
+++ b/src/PS1/runtime/PS1RipSessionWindow.h
@@ -44,7 +44,8 @@ private slots:
     void onVramDumped(const QString &captureId, const QString &pngPath, const QVector<uint16_t> &cells,
                       const QImage &nativePreview);
     void onMeshBuilt(const QString &captureId, int capturedParts, int uniqueMeshes, int instanceCount,
-                     int vertexCount, int triangleCount);
+                     int vertexCount, int triangleCount, int matrixCount, uint32_t cameraMatrixId,
+                     bool hasCameraMatrix);
     void onPausedChanged(bool paused);
 
 private:

--- a/src/PS1/runtime/PS1RipWorker.cpp
+++ b/src/PS1/runtime/PS1RipWorker.cpp
@@ -127,6 +127,8 @@ void PS1RipWorker::stopEmulation()
     m_frameTimer->stop();
     m_running = false;
     m_paused = false;
+    m_captureArmed.store(false, std::memory_order_release);
+    m_captureBuffer->clear();
     m_core.reset();
     emit emulationStopped();
 }
@@ -186,7 +188,10 @@ void PS1RipWorker::runFrameTick()
 void PS1RipWorker::setCaptureArmed(bool armed)
 {
     m_captureArmed.store(armed, std::memory_order_release);
-    if (armed)
+    // Do not clear while emulation is running — runFrame capture may be writing the buffer.
+    if (!armed)
+        m_captureBuffer->clear();
+    else if (!m_running)
         m_captureBuffer->clear();
 }
 
@@ -214,6 +219,7 @@ void PS1RipWorker::finalizeFrameCapture()
         return;
     }
 
+    m_captureBuffer->clear();
     m_core->runFrame();
     m_core->syncCaptureMirrors();
     m_core->ingestCaptureFrame();

--- a/src/PS1/runtime/PsxGteRamScanner.cpp
+++ b/src/PS1/runtime/PsxGteRamScanner.cpp
@@ -85,13 +85,13 @@ void PsxGteRamScanner::captureFromSystemRam(const uint8_t *ram, size_t byteSize,
         uint32_t header = 0;
         std::memcpy(&header, ram + offset, sizeof(header));
         if (psxLooksLikeGp0Opcode(header)) {
-            offset += 8;
+            offset += 4;
             continue;
         }
 
         MatrixRecord matrix{};
         if (!readMatrixAt(ram, byteSize, offset, matrix)) {
-            offset += 8;
+            offset += 4;
             continue;
         }
 

--- a/src/PS1/runtime/PsxGteRamScanner.cpp
+++ b/src/PS1/runtime/PsxGteRamScanner.cpp
@@ -1,7 +1,8 @@
 #include "PsxGteRamScanner.h"
 
+#include "EmuHooks.h"
 #include "GteCapture.h"
-#include "RipperHooks.h"
+#include "PsxGp0Opcode.h"
 
 #include <QSet>
 
@@ -18,6 +19,11 @@ bool looksLikeMatrixRecord(const MatrixRecord &matrix)
     if (matrix.h < 50 || matrix.h > 8192)
         return false;
     if (matrix.ofx < 0 || matrix.ofy < 0)
+        return false;
+
+    const int ofxScreen = matrix.ofx >> 16;
+    const int ofyScreen = matrix.ofy >> 16;
+    if (ofxScreen > 1024 || ofyScreen > 1024)
         return false;
 
     bool anyRotation = false;
@@ -46,6 +52,13 @@ bool readMatrixAt(const uint8_t *ram, size_t byteSize, size_t byteOffset, Matrix
     if (byteOffset + kMatrixBytes > byteSize)
         return false;
 
+    for (int word = 0; word < 3; ++word) {
+        uint32_t probe = 0;
+        std::memcpy(&probe, ram + byteOffset + static_cast<size_t>(word) * 4, sizeof(probe));
+        if (psxLooksLikeGp0Opcode(probe))
+            return false;
+    }
+
     std::memset(&out, 0, sizeof(out));
     std::memcpy(&out.rt, ram + byteOffset, sizeof(out.rt));
     std::memcpy(out.tr, ram + byteOffset + sizeof(out.rt), sizeof(out.tr));
@@ -60,7 +73,7 @@ bool readMatrixAt(const uint8_t *ram, size_t byteSize, size_t byteOffset, Matrix
 
 } // namespace
 
-void PsxGteRamScanner::captureFromSystemRam(const uint8_t *ram, size_t byteSize, RipperHooks *hooks)
+void PsxGteRamScanner::captureFromSystemRam(const uint8_t *ram, size_t byteSize, EmuHooks *hooks)
 {
     if (!ram || byteSize < kMatrixBytes || !hooks || !hooks->isCaptureEnabled())
         return;
@@ -68,17 +81,29 @@ void PsxGteRamScanner::captureFromSystemRam(const uint8_t *ram, size_t byteSize,
     QSet<uint64_t> seenHashes;
     int found = 0;
 
-    for (size_t offset = 0; offset + kMatrixBytes <= byteSize && found < kMaxMatricesPerFrame; offset += 4) {
-        MatrixRecord matrix{};
-        if (!readMatrixAt(ram, byteSize, offset, matrix))
+    for (size_t offset = 0; offset + kMatrixBytes <= byteSize && found < kMaxMatricesPerFrame;) {
+        uint32_t header = 0;
+        std::memcpy(&header, ram + offset, sizeof(header));
+        if (psxLooksLikeGp0Opcode(header)) {
+            offset += 8;
             continue;
+        }
+
+        MatrixRecord matrix{};
+        if (!readMatrixAt(ram, byteSize, offset, matrix)) {
+            offset += 8;
+            continue;
+        }
 
         matrix.hash = GteCapture::hashMatrix(matrix);
-        if (seenHashes.contains(matrix.hash))
+        if (seenHashes.contains(matrix.hash)) {
+            offset += kMatrixBytes;
             continue;
+        }
         seenHashes.insert(matrix.hash);
 
         hooks->onGteMatrix(matrix);
         ++found;
+        offset += kMatrixBytes;
     }
 }

--- a/src/PS1/runtime/PsxGteRamScanner.h
+++ b/src/PS1/runtime/PsxGteRamScanner.h
@@ -4,13 +4,13 @@
 #include <cstddef>
 #include <cstdint>
 
-class RipperHooks;
+class EmuHooks;
 
 /** Heuristic scan of main RAM for GTE projection matrices (#419). */
 class PsxGteRamScanner
 {
 public:
-    static void captureFromSystemRam(const uint8_t *ram, size_t byteSize, RipperHooks *hooks);
+    static void captureFromSystemRam(const uint8_t *ram, size_t byteSize, EmuHooks *hooks);
 };
 
 #endif // PSXGTERAMSCANNER_H

--- a/src/PS1/runtime/PsxGteRamScanner_test.cpp
+++ b/src/PS1/runtime/PsxGteRamScanner_test.cpp
@@ -1,0 +1,131 @@
+#ifdef ENABLE_PS1_RIP
+
+#include <gtest/gtest.h>
+
+#include "PS1/runtime/Gp0HookDispatch.h"
+#include "PS1/runtime/PsxGteRamScanner.h"
+#include "PS1/runtime/RipperHooks.h"
+
+#include <atomic>
+#include <cstring>
+
+namespace {
+
+constexpr size_t kMatrixBytes = sizeof(MatrixRecord) - sizeof(uint64_t);
+
+void writeMatrix(uint8_t *ram, size_t byteOffset, const MatrixRecord &matrix)
+{
+    std::memcpy(ram + byteOffset, &matrix.rt, sizeof(matrix.rt));
+    std::memcpy(ram + byteOffset + sizeof(matrix.rt), matrix.tr, sizeof(matrix.tr));
+    std::memcpy(ram + byteOffset + sizeof(matrix.rt) + sizeof(matrix.tr), &matrix.ofx,
+                sizeof(matrix.ofx));
+    std::memcpy(ram + byteOffset + sizeof(matrix.rt) + sizeof(matrix.tr) + sizeof(matrix.ofx),
+                &matrix.ofy, sizeof(matrix.ofy));
+    std::memcpy(ram + byteOffset + sizeof(matrix.rt) + sizeof(matrix.tr) + sizeof(matrix.ofx)
+                    + sizeof(matrix.ofy),
+                &matrix.h, sizeof(matrix.h));
+}
+
+MatrixRecord makeMatrix(int trX, int h = 256)
+{
+    MatrixRecord matrix{};
+    matrix.rt.m[0][0] = 1 << 12;
+    matrix.rt.m[1][1] = 1 << 12;
+    matrix.rt.m[2][2] = 1 << 12;
+    matrix.tr[0] = trX;
+    matrix.h = h;
+    matrix.ofx = 160 << 16;
+    matrix.ofy = 120 << 16;
+    return matrix;
+}
+
+uint32_t colorCmd(uint8_t opcode, uint8_t r, uint8_t g, uint8_t b)
+{
+    return static_cast<uint32_t>(opcode) | (static_cast<uint32_t>(r) << 8)
+           | (static_cast<uint32_t>(g) << 16) | (static_cast<uint32_t>(b) << 24);
+}
+
+uint32_t pos(int x, int y)
+{
+    return static_cast<uint32_t>((y & 0xFFFF) << 16) | static_cast<uint32_t>(x & 0xFFFF);
+}
+
+} // namespace
+
+TEST(PsxGteRamScannerTest, SyntheticGteRamLayoutDedupesMatricesAndTagsPrims)
+{
+    alignas(4) uint8_t ram[8 * 1024];
+    std::memset(ram, 0, sizeof(ram));
+
+    constexpr size_t kMatrixA = 0x000;
+    constexpr size_t kMatrixB = 0x080;
+    constexpr size_t kMatrixDup = 0x100;
+    constexpr size_t kGpuPacket = 0x200;
+
+    writeMatrix(ram, kMatrixA, makeMatrix(0));
+    writeMatrix(ram, kMatrixB, makeMatrix(512));
+    writeMatrix(ram, kMatrixDup, makeMatrix(0));
+
+    const uint32_t triPacket[] = {
+        colorCmd(0x20, 10, 20, 30),
+        pos(16, 16),
+        pos(48, 16),
+        pos(32, 32),
+    };
+    std::memcpy(ram + kGpuPacket, triPacket, sizeof(triPacket));
+
+    std::atomic<bool> armed{true};
+    CaptureBuffer buffer;
+    RipperHooks hooks;
+    hooks.setArmedFlag(&armed);
+    hooks.setBuffer(&buffer);
+
+    hooks.onFrameBegin();
+    PsxGteRamScanner::captureFromSystemRam(ram, kGpuPacket, &hooks);
+    Gp0HookDispatch::captureFromSystemRam(ram + kGpuPacket, sizeof(ram) - kGpuPacket, &hooks);
+    hooks.onFrameEnd();
+
+    ASSERT_EQ(buffer.matrices().size(), 2);
+    EXPECT_TRUE(buffer.hasCameraMatrix());
+    // Last matrix registered before the GPU packet tags captured prims (matrix B at 0x080).
+    EXPECT_EQ(buffer.cameraMatrixId(), 1u);
+
+    ASSERT_GE(buffer.prims().size(), 1);
+    for (const PrimRecord &prim : buffer.prims())
+        EXPECT_LT(prim.matrixId, 2u);
+}
+
+TEST(PsxGteRamScannerTest, GteScanRunsBeforeGpuFallbackMatrix)
+{
+    alignas(4) uint8_t ram[4 * 1024];
+    std::memset(ram, 0, sizeof(ram));
+
+    constexpr size_t kMatrixOffset = 0x000;
+    constexpr size_t kGpuOffset = 0x100;
+    writeMatrix(ram, kMatrixOffset, makeMatrix(1024));
+
+    const uint32_t triPacket[] = {
+        colorCmd(0x20, 1, 2, 3),
+        pos(8, 8),
+        pos(24, 8),
+        pos(16, 20),
+    };
+    std::memcpy(ram + kGpuOffset, triPacket, sizeof(triPacket));
+
+    std::atomic<bool> armed{true};
+    CaptureBuffer buffer;
+    RipperHooks hooks;
+    hooks.setArmedFlag(&armed);
+    hooks.setBuffer(&buffer);
+
+    hooks.onFrameBegin();
+    PsxGteRamScanner::captureFromSystemRam(ram, kGpuOffset, &hooks);
+    Gp0HookDispatch::captureFromSystemRam(ram + kGpuOffset, sizeof(ram) - kGpuOffset, &hooks);
+    hooks.onFrameEnd();
+
+    ASSERT_EQ(buffer.matrices().size(), 1u);
+    ASSERT_GE(buffer.prims().size(), 1);
+    EXPECT_EQ(buffer.prims()[0].matrixId, 0u);
+}
+
+#endif // ENABLE_PS1_RIP

--- a/src/PS1/runtime/RipperHooks.cpp
+++ b/src/PS1/runtime/RipperHooks.cpp
@@ -11,6 +11,7 @@ void RipperHooks::onFrameBegin()
 {
     if (!isCaptureEnabled() || !m_buffer)
         return;
+    m_latestMatrixId = UINT32_MAX;
     m_buffer->beginFrame();
 }
 
@@ -24,8 +25,9 @@ void RipperHooks::onFrameEnd()
 uint32_t RipperHooks::onGteMatrix(const MatrixRecord &matrix)
 {
     if (!isCaptureEnabled() || !m_buffer)
-        return 0;
-    return m_buffer->addMatrix(matrix);
+        return UINT32_MAX;
+    m_latestMatrixId = m_buffer->addMatrix(matrix);
+    return m_latestMatrixId;
 }
 
 void RipperHooks::onGpuPrim(const PrimRecord &prim)
@@ -60,9 +62,7 @@ void RipperHooks::onDrawMode(const DrawModeRecord &mode)
 
 uint32_t RipperHooks::latestMatrixId() const
 {
-    if (!m_buffer || m_buffer->matrices().isEmpty())
-        return UINT32_MAX;
-    return static_cast<uint32_t>(m_buffer->matrices().size() - 1);
+    return m_latestMatrixId;
 }
 
 void RipperHooks::ingestSystemRamForGpuCapture(const uint8_t *ram, size_t byteSize)

--- a/src/PS1/runtime/RipperHooks.h
+++ b/src/PS1/runtime/RipperHooks.h
@@ -5,6 +5,7 @@
 #include "EmuHooks.h"
 
 #include <atomic>
+#include <cstdint>
 
 class VramSnapshot;
 
@@ -36,6 +37,7 @@ private:
     std::atomic<bool> *m_armed = nullptr;
     CaptureBuffer *m_buffer = nullptr;
     VramSnapshot *m_vram = nullptr;
+    uint32_t m_latestMatrixId = UINT32_MAX;
 };
 
 #endif // RIPPERHOOKS_H


### PR DESCRIPTION
## Summary

- Run `PsxGteRamScanner` before GP0 ingest each frame; dedupe matrices by hash and tag primitives with `RipperHooks::latestMatrixId()`.
- Track per-frame latest matrix in `RipperHooks`; surface `cameraMatrixId` / matrix count in the rip session status bar after mesh build.
- Add `GteInverse::modelToScreen` (diagonal/scale matrices) and `CaptureSnapshot::hasCameraMatrix()`.
- Unit tests: synthetic GTE RAM layout, GTE-before-GPU matrix tagging, model↔screen round-trip, screen-space cube → mesh reconstruction.

## Test plan

- [x] `UnitTests --gtest_filter='PsxGteRamScanner*:MeshReconstructor*:GteInverse*'` (offscreen Qt)
- [ ] CI green on Linux / Windows / macOS
- [ ] SonarCloud pass

Closes #419


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional pre-capture GTE matrix scan (skippable during high-frequency/armed ticks to avoid UI freeze).
  * Camera-matrix tracking with hash-based deduplication; matrix count and camera-matrix id/presence shown in session status.
  * Added model-to-screen projection utility.

* **Tests**
  * Unit tests validating GTE scan deduplication and capture ordering.
  * Mesh reconstruction round-trip tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/653?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->