### PR TITLE
feat(ps1): CLUT-aware texture decoding for capture meshes (#421)

### DIFF
--- a/src/MaterialEditorQML.cpp
+++ b/src/MaterialEditorQML.cpp
@@ -208,6 +208,9 @@ void MaterialEditorQML::loadMaterial(const QString &materialName)
     }
 
     if (isPs1RipMaterial(materialName)) {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("ps1_rip_material_edit_blocked:%1")
+                                          .arg(materialName));
         emit errorOccurred(tr("Material \"%1\" is a PS1 capture material (read-only). "
                               "Recapture or use a regular mesh material to edit in this window.")
                                .arg(materialName));

--- a/src/MaterialEditorQML.cpp
+++ b/src/MaterialEditorQML.cpp
@@ -45,6 +45,22 @@
 #include <QJsonObject>
 #include <QJsonArray>
 
+namespace {
+
+bool isPs1RipMaterial(const QString &name)
+{
+    return name.startsWith(QLatin1String("PS1Rip_")) || name.startsWith(QLatin1String("PS1Rip/"));
+}
+
+bool isPaintPipelineMaterial(const QString &name)
+{
+    return name.startsWith(QLatin1String("QMEPaintMaskOverlay_"))
+           || name.startsWith(QLatin1String("QMEPaint_"))
+           || name.startsWith(QLatin1String("TexturePaint/"));
+}
+
+} // namespace
+
 MaterialEditorQML::MaterialEditorQML(QObject *parent)
     : QObject(parent)
 {
@@ -188,6 +204,13 @@ void MaterialEditorQML::loadMaterial(const QString &materialName)
 {
     if (materialName.isEmpty()) {
         createNewMaterial();
+        return;
+    }
+
+    if (isPs1RipMaterial(materialName)) {
+        emit errorOccurred(tr("Material \"%1\" is a PS1 capture material (read-only). "
+                              "Recapture or use a regular mesh material to edit in this window.")
+                               .arg(materialName));
         return;
     }
 
@@ -3893,9 +3916,7 @@ QStringList MaterialEditorQML::getMaterialList() const
             // ring material) and EditModeController's session, so the
             // user never authored them and shouldn't be able to
             // accidentally select / edit / delete them.
-            if (name.startsWith(QLatin1String("QMEPaintMaskOverlay_"))
-             || name.startsWith(QLatin1String("QMEPaint_"))
-             || name.startsWith(QLatin1String("TexturePaint/"))) {
+            if (isPaintPipelineMaterial(name)) {
                 materialIterator.moveNext();
                 continue;
             }
@@ -3911,6 +3932,8 @@ QStringList MaterialEditorQML::getMaterialList() const
 
 QString MaterialEditorQML::materialPreview(const QString& materialName) const
 {
+    if (isPs1RipMaterial(materialName) || isPaintPipelineMaterial(materialName))
+        return QString();
     return MaterialPreviewRenderer::instance()->renderPreviewAsDataUri(materialName);
 }
 
@@ -3919,6 +3942,8 @@ QString MaterialEditorQML::interactiveMaterialPreview(const QString& materialNam
                                                        int shape,
                                                        double yawDegrees) const
 {
+    if (isPs1RipMaterial(materialName) || isPaintPipelineMaterial(materialName))
+        return QString();
     return MaterialPreviewRenderer::instance()
         ->renderInteractivePreview(materialName, size, shape, yawDegrees);
 }

--- a/src/PS1/PS1_RIP_DESIGN.md
+++ b/src/PS1/PS1_RIP_DESIGN.md
@@ -79,7 +79,8 @@ See epic #412 for phased issues (#413–#431).
 
 - `VramSnapshot` — full 1024×512×16-bit VRAM buffer, view modes (RGB555, 4bpp index, 8bpp index, CLUT preview), PNG export.
 - `RipperHooks::onVramWrite` mirrors GPU uploads into the worker-owned snapshot.
-- `TextureDecoder` — CLUT-aware 4/8/15 bpp tile decode with `TileKey` cache and STP/alpha via `PsxVramColor`.
+- `TextureDecoder` — CLUT-aware 4/8/15 bpp decode keyed by `(TPAGE, CLUT, bit depth, semiTrans, draw mode)` with UV-bounds cache merge and STP/alpha via `PsxVramColor`.
+- `PS1RipMeshBuilder` — pre-decodes capture textures, uploads to `PS1Rip_Session<N>` resource group, applies PS1 semi-transparency blend modes, Sentry `ps1.rip.texture.decoded`. Ogre material resources are scoped per capture (`PS1Rip_<captureId>_tpage_…`); prior capture meshes/materials/textures are purged before each rebuild. Runtime materials use the `PS1Rip_` prefix (listed in Material Editor, read-only; GPU thumbnails are skipped to avoid UI freezes).
 - `dumpVRAM()` saves `<AppData>/ps1_rip/captures/<id>_vram.png` and feeds `VramViewerWidget` in the session window.
 - **Libretro:** `syncVramFromCore()` mirrors live core VRAM every frame; capture snapshots include a VRAM cell copy for textured mesh export.
 - Stub core fills CLUT + 4/8/15 bpp test regions via `stubFillVramPattern` when capture is armed or on `syncCaptureMirrors` (CI only).

--- a/src/PS1/runtime/MeshReconstructor.cpp
+++ b/src/PS1/runtime/MeshReconstructor.cpp
@@ -20,20 +20,6 @@ uint32_t packDiffuse(uint8_t r, uint8_t g, uint8_t b)
     return cv.getAsBYTE();
 }
 
-QString textureMaterialName(uint16_t tpage, uint16_t clut, uint8_t semiTrans)
-{
-    return QStringLiteral("PS1Rip_tpage_%1_clut_%2_st%3")
-        .arg(tpage, 4, 16, QChar('0'))
-        .arg(clut, 4, 16, QChar('0'))
-        .arg(semiTrans & 3);
-}
-
-quint64 textureGroupKey(uint16_t tpage, uint16_t clut, uint8_t semiTrans)
-{
-    return (static_cast<quint64>(tpage) << 32) | clut
-           | (static_cast<quint64>(semiTrans & 3) << 48);
-}
-
 struct SubMeshAccumulator {
     QString materialName;
     QVector<ReconstructedVertex> vertices;
@@ -132,10 +118,12 @@ QHash<uint32_t, QHash<quint64, SubMeshAccumulator>> buildMatrixGroups(const Capt
         if (prim.matrixId < static_cast<uint32_t>(snapshot.matrices.size()))
             matrix = &snapshot.matrices[static_cast<int>(prim.matrixId)];
 
-        const quint64 texKey = textureGroupKey(prim.tpage, prim.clut, prim.semiTrans);
+        const quint64 texKey = MeshReconstructor::textureGroupKey(
+            prim.tpage, prim.clut, prim.semiTrans, prim.drawModeBits);
         SubMeshAccumulator &acc = groupsByMatrix[prim.matrixId][texKey];
         if (acc.materialName.isEmpty())
-            acc.materialName = textureMaterialName(prim.tpage, prim.clut, prim.semiTrans);
+            acc.materialName = MeshReconstructor::textureMaterialName(
+                prim.tpage, prim.clut, prim.semiTrans, prim.drawModeBits);
         emitPrimitive(prim, matrix, acc);
     }
     return groupsByMatrix;
@@ -191,6 +179,24 @@ ReconstructedMesh flattenParts(const QVector<ReconstructedMesh> &parts)
 }
 
 } // namespace
+
+QString MeshReconstructor::textureMaterialName(uint16_t tpage, uint16_t clut, uint8_t semiTrans,
+                                                 uint32_t drawModeBits)
+{
+    return QStringLiteral("PS1Rip_tpage_%1_clut_%2_st%3_dm%4")
+        .arg(tpage, 4, 16, QChar('0'))
+        .arg(clut, 4, 16, QChar('0'))
+        .arg(semiTrans & 3)
+        .arg((drawModeBits >> 11) & 1u);
+}
+
+quint64 MeshReconstructor::textureGroupKey(uint16_t tpage, uint16_t clut, uint8_t semiTrans,
+                                           uint32_t drawModeBits)
+{
+    return (static_cast<quint64>(tpage) << 32) | clut
+           | (static_cast<quint64>(semiTrans & 3) << 48)
+           | (static_cast<quint64>((drawModeBits >> 11) & 1u) << 52);
+}
 
 ReconstructedMesh MeshReconstructor::reconstruct(const CaptureSnapshot &snapshot)
 {

--- a/src/PS1/runtime/MeshReconstructor.cpp
+++ b/src/PS1/runtime/MeshReconstructor.cpp
@@ -20,16 +20,18 @@ uint32_t packDiffuse(uint8_t r, uint8_t g, uint8_t b)
     return cv.getAsBYTE();
 }
 
-QString textureMaterialName(uint16_t tpage, uint16_t clut)
+QString textureMaterialName(uint16_t tpage, uint16_t clut, uint8_t semiTrans)
 {
-    return QStringLiteral("PS1Rip/tpage_%1_clut_%2")
+    return QStringLiteral("PS1Rip_tpage_%1_clut_%2_st%3")
         .arg(tpage, 4, 16, QChar('0'))
-        .arg(clut, 4, 16, QChar('0'));
+        .arg(clut, 4, 16, QChar('0'))
+        .arg(semiTrans & 3);
 }
 
-quint64 textureGroupKey(uint16_t tpage, uint16_t clut)
+quint64 textureGroupKey(uint16_t tpage, uint16_t clut, uint8_t semiTrans)
 {
-    return (static_cast<quint64>(tpage) << 32) | clut;
+    return (static_cast<quint64>(tpage) << 32) | clut
+           | (static_cast<quint64>(semiTrans & 3) << 48);
 }
 
 struct SubMeshAccumulator {
@@ -130,10 +132,10 @@ QHash<uint32_t, QHash<quint64, SubMeshAccumulator>> buildMatrixGroups(const Capt
         if (prim.matrixId < static_cast<uint32_t>(snapshot.matrices.size()))
             matrix = &snapshot.matrices[static_cast<int>(prim.matrixId)];
 
-        const quint64 texKey = textureGroupKey(prim.tpage, prim.clut);
+        const quint64 texKey = textureGroupKey(prim.tpage, prim.clut, prim.semiTrans);
         SubMeshAccumulator &acc = groupsByMatrix[prim.matrixId][texKey];
         if (acc.materialName.isEmpty())
-            acc.materialName = textureMaterialName(prim.tpage, prim.clut);
+            acc.materialName = textureMaterialName(prim.tpage, prim.clut, prim.semiTrans);
         emitPrimitive(prim, matrix, acc);
     }
     return groupsByMatrix;

--- a/src/PS1/runtime/MeshReconstructor.h
+++ b/src/PS1/runtime/MeshReconstructor.h
@@ -59,6 +59,11 @@ struct ReconstructedCaptureSet {
 class MeshReconstructor
 {
 public:
+    static QString textureMaterialName(uint16_t tpage, uint16_t clut, uint8_t semiTrans,
+                                       uint32_t drawModeBits);
+    static quint64 textureGroupKey(uint16_t tpage, uint16_t clut, uint8_t semiTrans,
+                                  uint32_t drawModeBits);
+
     static ReconstructedMesh reconstruct(const CaptureSnapshot &snapshot);
     static ReconstructedCaptureSet reconstructDeduped(const CaptureSnapshot &snapshot,
                                                       MeshDedupeMode dedupeMode);

--- a/src/PS1/runtime/PS1RipMeshBuilder.cpp
+++ b/src/PS1/runtime/PS1RipMeshBuilder.cpp
@@ -36,10 +36,11 @@ namespace {
 constexpr float kTargetMaxExtent = 2.0f;
 constexpr int kPageTexels = 256;
 
+std::atomic<int> g_nextSessionId{0};
+
 int allocateSessionId()
 {
-    static std::atomic<int> nextId{0};
-    return ++nextId;
+    return ++g_nextSessionId;
 }
 
 QString sessionResourceGroup(int sessionId)
@@ -317,6 +318,21 @@ void removePriorCaptureNodes(Manager *mgr)
         mgr->destroySceneNode(name);
 }
 
+void purgeSessionResourceGroups()
+{
+    Ogre::ResourceGroupManager &rgm = Ogre::ResourceGroupManager::getSingleton();
+    const int lastSessionId = g_nextSessionId.load();
+    for (int id = 1; id <= lastSessionId; ++id) {
+        const std::string group = sessionResourceGroup(id).toStdString();
+        if (!rgm.resourceGroupExists(group))
+            continue;
+        try {
+            rgm.destroyResourceGroup(group);
+        } catch (...) {
+        }
+    }
+}
+
 void purgePriorCaptureGpuResources()
 {
     Ogre::MeshManager &meshMgr = Ogre::MeshManager::getSingleton();
@@ -367,6 +383,33 @@ void purgePriorCaptureGpuResources()
         } catch (...) {
         }
     }
+
+    purgeSessionResourceGroups();
+}
+
+void rollbackFailedAttach(Manager *mgr, const QStringList &nodeNames, const QString &reason)
+{
+    if (mgr) {
+        for (const QString &name : nodeNames)
+            mgr->destroySceneNode(name);
+    }
+    purgePriorCaptureGpuResources();
+    SentryReporter::addBreadcrumb(QStringLiteral("ps1.rip.attach"), reason, QStringLiteral("error"));
+}
+
+void beginCaptureAttach(Manager *mgr, const QString &captureId, const CaptureSnapshot *textureSource,
+                        TextureBuildContext *texCtx)
+{
+    SentryReporter::addBreadcrumb(QStringLiteral("ps1.rip.attach"), QStringLiteral("start"));
+    removePriorCaptureNodes(mgr);
+    SentryReporter::addBreadcrumb(QStringLiteral("ps1.rip.attach"), QStringLiteral("purge"));
+    purgePriorCaptureGpuResources();
+
+    texCtx->sessionId = allocateSessionId();
+    texCtx->resourceGroup = sessionResourceGroup(texCtx->sessionId);
+    texCtx->captureId = captureId;
+    ensureResourceGroup(texCtx->resourceGroup);
+    predecodeCaptureTextures(textureSource, texCtx);
 }
 
 Ogre::AxisAlignedBox meshBounds(const ReconstructedMesh &mesh)
@@ -507,15 +550,8 @@ bool PS1RipMeshBuilder::attachToScene(const ReconstructedMesh &mesh, const QStri
         return false;
     }
 
-    removePriorCaptureNodes(mgr);
-    purgePriorCaptureGpuResources();
-
     TextureBuildContext texCtx;
-    texCtx.sessionId = allocateSessionId();
-    texCtx.resourceGroup = sessionResourceGroup(texCtx.sessionId);
-    texCtx.captureId = captureId;
-    ensureResourceGroup(texCtx.resourceGroup);
-    predecodeCaptureTextures(textureSource, &texCtx);
+    beginCaptureAttach(mgr, captureId, textureSource, &texCtx);
 
     Ogre::MeshPtr ogreMesh;
     Ogre::AxisAlignedBox localBounds;
@@ -527,6 +563,8 @@ bool PS1RipMeshBuilder::attachToScene(const ReconstructedMesh &mesh, const QStri
     Ogre::Entity *entity = mgr->createEntity(node, ogreMesh);
 
     if (!entity) {
+        rollbackFailedAttach(mgr, {nodeName},
+                             QStringLiteral("createEntity failed capture=%1").arg(captureId));
         if (errorOut)
             *errorOut = QStringLiteral("Failed to create Ogre entity for reconstructed mesh");
         return false;
@@ -538,6 +576,12 @@ bool PS1RipMeshBuilder::attachToScene(const ReconstructedMesh &mesh, const QStri
         resultOut->vertexCount = mesh.vertexCount;
         resultOut->triangleCount = mesh.triangleCount;
     }
+    SentryReporter::addBreadcrumb(
+        QStringLiteral("ps1.rip.attach"),
+        QStringLiteral("success capture=%1 verts=%2 tris=%3")
+            .arg(captureId)
+            .arg(mesh.vertexCount)
+            .arg(mesh.triangleCount));
     return true;
 }
 
@@ -558,9 +602,6 @@ bool PS1RipMeshBuilder::attachCaptureSetToScene(const ReconstructedCaptureSet &c
             *errorOut = QStringLiteral("Editor scene is not available");
         return false;
     }
-
-    removePriorCaptureNodes(mgr);
-    purgePriorCaptureGpuResources();
 
     QVector<Ogre::AxisAlignedBox> localBoundsByMesh(captureSet.uniqueMeshes.size());
     for (int i = 0; i < captureSet.uniqueMeshes.size(); ++i)
@@ -597,11 +638,7 @@ bool PS1RipMeshBuilder::attachCaptureSetToScene(const ReconstructedCaptureSet &c
     }
 
     TextureBuildContext texCtx;
-    texCtx.sessionId = allocateSessionId();
-    texCtx.resourceGroup = sessionResourceGroup(texCtx.sessionId);
-    texCtx.captureId = captureId;
-    ensureResourceGroup(texCtx.resourceGroup);
-    predecodeCaptureTextures(textureSource, &texCtx);
+    beginCaptureAttach(mgr, captureId, textureSource, &texCtx);
 
     int totalVerts = 0;
     int totalTris = 0;
@@ -633,8 +670,11 @@ bool PS1RipMeshBuilder::attachCaptureSetToScene(const ReconstructedCaptureSet &c
 
             Ogre::Entity *entity = mgr->createEntity(node, ogreMesh);
             if (!entity) {
-                for (const QString &createdName : createdNodeNames)
-                    mgr->destroySceneNode(createdName);
+                rollbackFailedAttach(
+                    mgr, createdNodeNames,
+                    QStringLiteral("createEntity failed capture=%1 instance=%2")
+                        .arg(captureId)
+                        .arg(instanceOrdinal - 1));
                 if (errorOut)
                     *errorOut = QStringLiteral("Failed to create Ogre entity for instance");
                 return false;
@@ -652,5 +692,12 @@ bool PS1RipMeshBuilder::attachCaptureSetToScene(const ReconstructedCaptureSet &c
         resultOut->vertexCount = totalVerts;
         resultOut->triangleCount = totalTris;
     }
+    SentryReporter::addBreadcrumb(
+        QStringLiteral("ps1.rip.attach"),
+        QStringLiteral("success capture=%1 verts=%2 tris=%3 instances=%4")
+            .arg(captureId)
+            .arg(totalVerts)
+            .arg(totalTris)
+            .arg(captureSet.instances.size()));
     return true;
 }

--- a/src/PS1/runtime/PS1RipMeshBuilder.cpp
+++ b/src/PS1/runtime/PS1RipMeshBuilder.cpp
@@ -56,7 +56,7 @@ void ensureResourceGroup(const QString &groupName)
 }
 
 bool parseTpageClutMaterial(const QString &name, uint16_t &tpageOut, uint16_t &clutOut,
-                            uint8_t &semiTransOut)
+                            uint8_t &semiTransOut, uint8_t &drawModeBitOut)
 {
     static const QRegularExpression re(
         QStringLiteral("^PS1Rip_tpage_([0-9a-fA-F]+)_clut_([0-9a-fA-F]+)(?:_st([0-3]))?(?:_dm([01]))?$"));
@@ -67,7 +67,22 @@ bool parseTpageClutMaterial(const QString &name, uint16_t &tpageOut, uint16_t &c
     clutOut = static_cast<uint16_t>(match.captured(2).toUInt(nullptr, 16));
     semiTransOut = match.captured(3).isEmpty() ? 0
                                                : static_cast<uint8_t>(match.captured(3).toUInt());
+    drawModeBitOut = match.captured(4).isEmpty()
+                         ? 0
+                         : static_cast<uint8_t>(match.captured(4).toUInt());
     return true;
+}
+
+TextureDecoder::MaterialKey materialKeyFromParsedName(uint16_t tpage, uint16_t clutWord,
+                                                      uint8_t semiTrans, uint8_t drawModeBit)
+{
+    TextureDecoder::MaterialKey key{};
+    key.tpage = tpage;
+    TextureDecoder::clutCoordsFromClutWord(clutWord, key.clutX, key.clutY);
+    key.bitDepth = TextureDecoder::bitDepthFromTpage(tpage);
+    key.semiTrans = semiTrans;
+    key.drawModeBits = drawModeBit ? (1u << 11) : 0u;
+    return key;
 }
 
 void applySemiTransBlend(Ogre::Pass *pass, uint8_t semiTrans)
@@ -261,10 +276,16 @@ Ogre::MaterialPtr ensureMaterial(const QString &logicalName, TextureBuildContext
     uint16_t tpage = 0;
     uint16_t clut = 0;
     uint8_t semiTrans = 0;
-    if (parseTpageClutMaterial(logicalName, tpage, clut, semiTrans)) {
+    uint8_t drawModeBit = 0;
+    if (parseTpageClutMaterial(logicalName, tpage, clut, semiTrans, drawModeBit)) {
         applySemiTransBlend(pass, semiTrans);
 
-        const TextureDecoder::MaterialKey key = ctx->materialKeys.value(logicalName);
+        TextureDecoder::MaterialKey key = ctx->materialKeys.value(logicalName);
+        if (!ctx->materialKeys.contains(logicalName))
+            key = materialKeyFromParsedName(tpage, clut, semiTrans, drawModeBit);
+        else if (((key.drawModeBits >> 11) & 1u) != drawModeBit)
+            key.drawModeBits = drawModeBit ? (1u << 11) : 0u;
+
         const QImage tile = ctx->decoder.cachedMaterial(key);
         const QRect bounds = ctx->decoder.cachedBoundsOnPage(key);
         if (!tile.isNull()) {

--- a/src/PS1/runtime/PS1RipMeshBuilder.cpp
+++ b/src/PS1/runtime/PS1RipMeshBuilder.cpp
@@ -1,6 +1,7 @@
 #include "PS1RipMeshBuilder.h"
 
 #include "Manager.h"
+#include "MeshReconstructor.h"
 #include "SentryReporter.h"
 #include "TextureDecoder.h"
 #include "VramSnapshot.h"
@@ -58,7 +59,7 @@ bool parseTpageClutMaterial(const QString &name, uint16_t &tpageOut, uint16_t &c
                             uint8_t &semiTransOut)
 {
     static const QRegularExpression re(
-        QStringLiteral("^PS1Rip_tpage_([0-9a-fA-F]+)_clut_([0-9a-fA-F]+)(?:_st([0-3]))?$"));
+        QStringLiteral("^PS1Rip_tpage_([0-9a-fA-F]+)_clut_([0-9a-fA-F]+)(?:_st([0-3]))?(?:_dm([01]))?$"));
     const QRegularExpressionMatch match = re.match(name);
     if (!match.hasMatch())
         return false;
@@ -170,11 +171,19 @@ QImage pageImageFromCachedTile(const QImage &tile, const QRect &boundsOnPage)
     page.fill(Qt::transparent);
     if (tile.isNull() || !boundsOnPage.isValid())
         return page;
-    for (int y = 0; y < tile.height(); ++y) {
-        const QRgb *src = reinterpret_cast<const QRgb *>(tile.constScanLine(y));
-        QRgb *dst = reinterpret_cast<QRgb *>(page.scanLine(boundsOnPage.y() + y));
-        for (int x = 0; x < tile.width(); ++x)
-            dst[boundsOnPage.x() + x] = src[x];
+
+    const QRect pageRect(0, 0, kPageTexels, kPageTexels);
+    const QRect dstRect = boundsOnPage.intersected(pageRect);
+    if (dstRect.isEmpty())
+        return page;
+
+    const int srcX0 = dstRect.x() - boundsOnPage.x();
+    const int srcY0 = dstRect.y() - boundsOnPage.y();
+    for (int y = 0; y < dstRect.height(); ++y) {
+        const QRgb *src = reinterpret_cast<const QRgb *>(tile.constScanLine(srcY0 + y));
+        QRgb *dst = reinterpret_cast<QRgb *>(page.scanLine(dstRect.y() + y));
+        for (int x = 0; x < dstRect.width(); ++x)
+            dst[dstRect.x() + x] = src[srcX0 + x];
     }
     return page;
 }
@@ -204,11 +213,8 @@ void predecodeCaptureTextures(const CaptureSnapshot *textureSource, TextureBuild
         const TextureDecoder::MaterialKey key = TextureDecoder::materialKeyFromPrim(prim);
         TextureDecoder::accumulateUvBounds(prim, boundsByKey[key]);
 
-        const QString matName =
-            QStringLiteral("PS1Rip_tpage_%1_clut_%2_st%3")
-                .arg(prim.tpage, 4, 16, QChar('0'))
-                .arg(prim.clut, 4, 16, QChar('0'))
-                .arg(prim.semiTrans & 3);
+        const QString matName = MeshReconstructor::textureMaterialName(
+            prim.tpage, prim.clut, prim.semiTrans, prim.drawModeBits);
         ctx->materialKeys.insert(matName, key);
     }
 
@@ -297,7 +303,8 @@ void purgePriorCaptureGpuResources()
     Ogre::ResourceManager::ResourceMapIterator meshIt = meshMgr.getResourceIterator();
     while (meshIt.hasMoreElements()) {
         const std::string name = meshIt.peekNextValue()->getName();
-        if (name.rfind("ps1_capture_", 0) == 0 || name.rfind("ps1_part_", 0) == 0)
+        if (name.rfind("ps1_capture_", 0) == 0 || name.rfind("ps1_part_", 0) == 0
+            || name.rfind("ps1_unique_", 0) == 0)
             meshesToRemove.push_back(name);
         meshIt.moveNext();
     }

--- a/src/PS1/runtime/PS1RipMeshBuilder.cpp
+++ b/src/PS1/runtime/PS1RipMeshBuilder.cpp
@@ -1,12 +1,15 @@
 #include "PS1RipMeshBuilder.h"
 
 #include "Manager.h"
+#include "SentryReporter.h"
 #include "TextureDecoder.h"
 #include "VramSnapshot.h"
 
+#include <QHash>
 #include <QRegularExpression>
 #include <QVector>
 #include <algorithm>
+#include <atomic>
 #include <vector>
 
 #include <OgreAxisAlignedBox.h>
@@ -30,35 +33,69 @@
 namespace {
 
 constexpr float kTargetMaxExtent = 2.0f;
+constexpr int kPageTexels = 256;
 
-bool parseTpageClutMaterial(const QString &name, uint16_t &tpageOut, uint16_t &clutOut)
+int allocateSessionId()
+{
+    static std::atomic<int> nextId{0};
+    return ++nextId;
+}
+
+QString sessionResourceGroup(int sessionId)
+{
+    return QStringLiteral("PS1Rip_Session%1").arg(sessionId);
+}
+
+void ensureResourceGroup(const QString &groupName)
+{
+    Ogre::ResourceGroupManager &rgm = Ogre::ResourceGroupManager::getSingleton();
+    const std::string group = groupName.toStdString();
+    if (!rgm.resourceGroupExists(group))
+        rgm.createResourceGroup(group);
+}
+
+bool parseTpageClutMaterial(const QString &name, uint16_t &tpageOut, uint16_t &clutOut,
+                            uint8_t &semiTransOut)
 {
     static const QRegularExpression re(
-        QStringLiteral("^PS1Rip/tpage_([0-9a-fA-F]+)_clut_([0-9a-fA-F]+)$"));
+        QStringLiteral("^PS1Rip_tpage_([0-9a-fA-F]+)_clut_([0-9a-fA-F]+)(?:_st([0-3]))?$"));
     const QRegularExpressionMatch match = re.match(name);
     if (!match.hasMatch())
         return false;
     tpageOut = static_cast<uint16_t>(match.captured(1).toUInt(nullptr, 16));
     clutOut = static_cast<uint16_t>(match.captured(2).toUInt(nullptr, 16));
+    semiTransOut = match.captured(3).isEmpty() ? 0
+                                               : static_cast<uint8_t>(match.captured(3).toUInt());
     return true;
 }
 
-TextureDecoder::BitDepth bitDepthFromTpage(uint16_t tpage)
+void applySemiTransBlend(Ogre::Pass *pass, uint8_t semiTrans)
 {
-    switch ((tpage >> 7) & 3) {
-    case 0:
-        return TextureDecoder::BitDepth::Bpp4;
-    case 1:
-        return TextureDecoder::BitDepth::Bpp8;
-    default:
-        return TextureDecoder::BitDepth::Bpp15;
-    }
-}
+    if (!pass)
+        return;
 
-void clutCoordsFromClutWord(uint16_t clut, uint16_t &clutXOut, uint16_t &clutYOut)
-{
-    clutXOut = static_cast<uint16_t>((clut & 0x3F) << 4);
-    clutYOut = static_cast<uint16_t>((clut >> 6) & 0x3FF);
+    switch (semiTrans & 3) {
+    case 0:
+        pass->setSceneBlending(Ogre::SBF_DEST_COLOUR, Ogre::SBF_SOURCE_COLOUR);
+        pass->setSceneBlendingOperation(Ogre::SBO_ADD);
+        break;
+    case 1:
+        pass->setSceneBlending(Ogre::SBF_ONE, Ogre::SBF_ONE);
+        pass->setSceneBlendingOperation(Ogre::SBO_ADD);
+        break;
+    case 2:
+        pass->setSceneBlending(Ogre::SBF_ONE, Ogre::SBF_ONE);
+        pass->setSceneBlendingOperation(Ogre::SBO_SUBTRACT);
+        break;
+    case 3:
+        // PS1: B + F/4 — Ogre has no constant 0.25 factor; scale pass alpha as approximation.
+        pass->setSceneBlending(Ogre::SBF_ONE, Ogre::SBF_SOURCE_ALPHA);
+        pass->setDiffuse(Ogre::ColourValue(1.0f, 1.0f, 1.0f, 0.25f));
+        break;
+    default:
+        pass->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
+        break;
+    }
 }
 
 QString textureResourceName(const QString &captureId, const QString &materialName)
@@ -68,7 +105,13 @@ QString textureResourceName(const QString &captureId, const QString &materialNam
     return QStringLiteral("ps1rip_%1_%2").arg(captureId, safe);
 }
 
-bool uploadTextureToOgre(const QString &resourceName, const QImage &image, QString *errorOut)
+QString scopedMaterialResourceName(const QString &captureId, const QString &logicalName)
+{
+    return QStringLiteral("PS1Rip_%1_%2").arg(captureId, logicalName);
+}
+
+bool uploadTextureToOgre(const QString &resourceGroup, const QString &resourceName,
+                         const QImage &image, QString *errorOut)
 {
     if (image.isNull() || image.width() < 1 || image.height() < 1) {
         if (errorOut)
@@ -83,8 +126,6 @@ bool uploadTextureToOgre(const QString &resourceName, const QImage &image, QStri
         return false;
     }
 
-    // Ogre 14 loadDynamicImage(..., depth, format, autoDelete, numFaces, numMipMaps) — there is
-    // no row-pitch parameter. A QImage row stride (bytesPerLine) must not be passed as numFaces.
     const int tightStride = rgba.width() * 4;
     if (rgba.bytesPerLine() != tightStride)
         rgba = rgba.copy();
@@ -101,13 +142,13 @@ bool uploadTextureToOgre(const QString &resourceName, const QImage &image, QStri
     }
 
     const std::string texName = resourceName.toStdString();
+    const std::string group = resourceGroup.toStdString();
     if (Ogre::TextureManager::getSingleton().resourceExists(texName))
         Ogre::TextureManager::getSingleton().remove(texName);
 
     Ogre::TexturePtr texture = Ogre::TextureManager::getSingleton().createManual(
-        texName, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME, Ogre::TEX_TYPE_2D,
-        ogreImage.getWidth(), ogreImage.getHeight(), 0, ogreImage.getFormat(),
-        Ogre::TU_STATIC_WRITE_ONLY);
+        texName, group, Ogre::TEX_TYPE_2D, ogreImage.getWidth(), ogreImage.getHeight(), 0,
+        ogreImage.getFormat(), Ogre::TU_STATIC_WRITE_ONLY);
     if (!texture)
         return false;
 
@@ -123,51 +164,117 @@ bool uploadTextureToOgre(const QString &resourceName, const QImage &image, QStri
     return true;
 }
 
-Ogre::MaterialPtr ensureMaterial(const QString &name, const CaptureSnapshot *textureSource,
-                                   const QString &captureId, TextureDecoder *decoder)
+QImage pageImageFromCachedTile(const QImage &tile, const QRect &boundsOnPage)
 {
-    const std::string matName = name.toStdString();
-    if (Ogre::MaterialManager::getSingleton().resourceExists(matName))
-        return Ogre::MaterialManager::getSingleton().getByName(matName);
+    QImage page(kPageTexels, kPageTexels, QImage::Format_ARGB32);
+    page.fill(Qt::transparent);
+    if (tile.isNull() || !boundsOnPage.isValid())
+        return page;
+    for (int y = 0; y < tile.height(); ++y) {
+        const QRgb *src = reinterpret_cast<const QRgb *>(tile.constScanLine(y));
+        QRgb *dst = reinterpret_cast<QRgb *>(page.scanLine(boundsOnPage.y() + y));
+        for (int x = 0; x < tile.width(); ++x)
+            dst[boundsOnPage.x() + x] = src[x];
+    }
+    return page;
+}
 
-    Ogre::MaterialPtr mat = Ogre::MaterialManager::getSingleton().create(
-        matName, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    Ogre::Pass *pass = mat->getTechnique(0)->getPass(0);
+struct TextureBuildContext {
+    int sessionId = 0;
+    QString resourceGroup;
+    QString captureId;
+    TextureDecoder decoder;
+    VramSnapshot vram;
+    QHash<QString, TextureDecoder::MaterialKey> materialKeys;
+    QHash<QString, Ogre::MaterialPtr> materials;
+};
+
+void predecodeCaptureTextures(const CaptureSnapshot *textureSource, TextureBuildContext *ctx)
+{
+    if (!textureSource || !textureSource->hasVram() || !ctx)
+        return;
+
+    ctx->vram.mutablePixels() = textureSource->vramCells;
+
+    QHash<TextureDecoder::MaterialKey, QRect> boundsByKey;
+    for (const PrimRecord &prim : textureSource->prims) {
+        if (!TextureDecoder::isTexturedPrim(prim))
+            continue;
+
+        const TextureDecoder::MaterialKey key = TextureDecoder::materialKeyFromPrim(prim);
+        TextureDecoder::accumulateUvBounds(prim, boundsByKey[key]);
+
+        const QString matName =
+            QStringLiteral("PS1Rip_tpage_%1_clut_%2_st%3")
+                .arg(prim.tpage, 4, 16, QChar('0'))
+                .arg(prim.clut, 4, 16, QChar('0'))
+                .arg(prim.semiTrans & 3);
+        ctx->materialKeys.insert(matName, key);
+    }
+
+    for (auto it = boundsByKey.constBegin(); it != boundsByKey.constEnd(); ++it)
+        ctx->decoder.decodeMaterial(ctx->vram, it.key(), it.value());
+
+    const TextureDecoder::DecodeStats stats = ctx->decoder.stats();
+    SentryReporter::addBreadcrumb(
+        QStringLiteral("ps1.rip.texture.decoded"),
+        QStringLiteral("materials=%1 rgba_bytes=%2 warnings=%3")
+            .arg(stats.decodedMaterials)
+            .arg(stats.rgbaBytes)
+            .arg(ctx->decoder.warnings().size()));
+}
+
+Ogre::MaterialPtr ensureMaterial(const QString &logicalName, TextureBuildContext *ctx)
+{
+    if (!ctx)
+        return {};
+
+    if (ctx->materials.contains(logicalName))
+        return ctx->materials.value(logicalName);
+
+    const QString ogreName = scopedMaterialResourceName(ctx->captureId, logicalName);
+    const std::string matName = ogreName.toStdString();
+    Ogre::MaterialManager &matMgr = Ogre::MaterialManager::getSingleton();
+
+    Ogre::MaterialPtr mat;
+    if (matMgr.resourceExists(matName))
+        mat = matMgr.getByName(matName);
+    else
+        mat = matMgr.create(matName, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+
+    Ogre::Technique *technique = mat->getTechnique(0);
+    while (technique->getNumPasses() > 1)
+        technique->removePass(1);
+    Ogre::Pass *pass = technique->getPass(0);
+    pass->removeAllTextureUnitStates();
     pass->setLightingEnabled(false);
     pass->setVertexColourTracking(Ogre::TVC_DIFFUSE);
     pass->setDiffuse(Ogre::ColourValue::White);
-
-    if (!textureSource || !textureSource->hasVram() || !decoder)
-        return mat;
+    pass->setSceneBlending(Ogre::SBT_REPLACE);
 
     uint16_t tpage = 0;
     uint16_t clut = 0;
-    if (!parseTpageClutMaterial(name, tpage, clut))
-        return mat;
+    uint8_t semiTrans = 0;
+    if (parseTpageClutMaterial(logicalName, tpage, clut, semiTrans)) {
+        applySemiTransBlend(pass, semiTrans);
 
-    VramSnapshot vram;
-    vram.mutablePixels() = textureSource->vramCells;
+        const TextureDecoder::MaterialKey key = ctx->materialKeys.value(logicalName);
+        const QImage tile = ctx->decoder.cachedMaterial(key);
+        const QRect bounds = ctx->decoder.cachedBoundsOnPage(key);
+        if (!tile.isNull()) {
+            const QImage page = pageImageFromCachedTile(tile, bounds);
+            const QString texResource = textureResourceName(ctx->captureId, logicalName);
+            QString uploadErr;
+            if (uploadTextureToOgre(ctx->resourceGroup, texResource, page, &uploadErr)) {
+                pass->setVertexColourTracking(Ogre::TVC_AMBIENT | Ogre::TVC_DIFFUSE);
+                Ogre::TextureUnitState *tus = pass->createTextureUnitState(texResource.toStdString());
+                tus->setTextureFiltering(Ogre::TFO_NONE);
+                tus->setTextureAddressingMode(Ogre::TextureUnitState::TAM_CLAMP);
+            }
+        }
+    }
 
-    TextureDecoder::TileKey key{};
-    key.tpage = tpage;
-    clutCoordsFromClutWord(clut, key.clutX, key.clutY);
-    key.bitDepth = bitDepthFromTpage(tpage);
-    const QRect page = VramSnapshot::tpageRect(tpage);
-
-    QString decodeErr;
-    const QImage tile = decoder->decodeTile(vram, key, page, &decodeErr);
-    if (tile.isNull())
-        return mat;
-
-    const QString texResource = textureResourceName(captureId, name);
-    QString uploadErr;
-    if (!uploadTextureToOgre(texResource, tile, &uploadErr))
-        return mat;
-
-    pass->setVertexColourTracking(Ogre::TVC_AMBIENT | Ogre::TVC_DIFFUSE);
-    Ogre::TextureUnitState *tus = pass->createTextureUnitState(texResource.toStdString());
-    tus->setTextureFiltering(Ogre::TFO_NONE);
-    tus->setTextureAddressingMode(Ogre::TextureUnitState::TAM_CLAMP);
+    ctx->materials.insert(logicalName, mat);
     return mat;
 }
 
@@ -181,6 +288,57 @@ void removePriorCaptureNodes(Manager *mgr)
     }
     for (const QString &name : toRemove)
         mgr->destroySceneNode(name);
+}
+
+void purgePriorCaptureGpuResources()
+{
+    Ogre::MeshManager &meshMgr = Ogre::MeshManager::getSingleton();
+    std::vector<std::string> meshesToRemove;
+    Ogre::ResourceManager::ResourceMapIterator meshIt = meshMgr.getResourceIterator();
+    while (meshIt.hasMoreElements()) {
+        const std::string name = meshIt.peekNextValue()->getName();
+        if (name.rfind("ps1_capture_", 0) == 0 || name.rfind("ps1_part_", 0) == 0)
+            meshesToRemove.push_back(name);
+        meshIt.moveNext();
+    }
+    for (const std::string &name : meshesToRemove) {
+        try {
+            meshMgr.remove(name);
+        } catch (...) {
+        }
+    }
+
+    Ogre::MaterialManager &matMgr = Ogre::MaterialManager::getSingleton();
+    std::vector<std::string> materialsToRemove;
+    Ogre::ResourceManager::ResourceMapIterator matIt = matMgr.getResourceIterator();
+    while (matIt.hasMoreElements()) {
+        const std::string name = matIt.peekNextValue()->getName();
+        if (name.rfind("PS1Rip_", 0) == 0 || name.rfind("PS1Rip/", 0) == 0)
+            materialsToRemove.push_back(name);
+        matIt.moveNext();
+    }
+    for (const std::string &name : materialsToRemove) {
+        try {
+            matMgr.remove(name);
+        } catch (...) {
+        }
+    }
+
+    Ogre::TextureManager &texMgr = Ogre::TextureManager::getSingleton();
+    std::vector<std::string> texturesToRemove;
+    Ogre::ResourceManager::ResourceMapIterator texIt = texMgr.getResourceIterator();
+    while (texIt.hasMoreElements()) {
+        const std::string name = texIt.peekNextValue()->getName();
+        if (name.rfind("ps1rip_", 0) == 0)
+            texturesToRemove.push_back(name);
+        texIt.moveNext();
+    }
+    for (const std::string &name : texturesToRemove) {
+        try {
+            texMgr.remove(name);
+        } catch (...) {
+        }
+    }
 }
 
 Ogre::AxisAlignedBox meshBounds(const ReconstructedMesh &mesh)
@@ -272,6 +430,36 @@ void writeSubMesh(const ReconstructedSubMesh &sub, Ogre::SubMesh *ogreSub)
     ogreSub->indexData->indexBuffer = ibuf;
 }
 
+bool buildMeshResources(const ReconstructedMesh &mesh, const QString &captureId,
+                        const CaptureSnapshot *textureSource, TextureBuildContext *ctx,
+                        Ogre::MeshPtr &ogreMeshOut, Ogre::AxisAlignedBox &localBoundsOut)
+{
+    const QString meshName = mesh.meshName + QLatin1Char('_') + captureId;
+    const std::string ogreMeshName = meshName.toStdString();
+
+    if (Ogre::MeshManager::getSingleton().resourceExists(ogreMeshName))
+        Ogre::MeshManager::getSingleton().remove(ogreMeshName);
+
+    ogreMeshOut = Ogre::MeshManager::getSingleton().createManual(
+        ogreMeshName, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+
+    localBoundsOut = meshBounds(mesh);
+    Ogre::AxisAlignedBox bounds = localBoundsOut;
+    if (bounds.isNull())
+        bounds = Ogre::AxisAlignedBox(-0.5f, -0.5f, -0.5f, 0.5f, 0.5f, 0.5f);
+
+    for (const ReconstructedSubMesh &sub : mesh.subMeshes) {
+        Ogre::SubMesh *ogreSub = ogreMeshOut->createSubMesh();
+        ogreSub->setMaterialName(ensureMaterial(sub.materialName, ctx)->getName());
+        writeSubMesh(sub, ogreSub);
+    }
+
+    ogreMeshOut->_setBounds(bounds);
+    ogreMeshOut->_setBoundingSphereRadius(bounds.getHalfSize().length());
+    ogreMeshOut->load();
+    return true;
+}
+
 } // namespace
 
 bool PS1RipMeshBuilder::attachToScene(const ReconstructedMesh &mesh, const QString &captureId,
@@ -291,34 +479,19 @@ bool PS1RipMeshBuilder::attachToScene(const ReconstructedMesh &mesh, const QStri
         return false;
     }
 
-    const QString meshName = mesh.meshName + QLatin1Char('_') + captureId;
-    const std::string ogreMeshName = meshName.toStdString();
-
-    if (Ogre::MeshManager::getSingleton().resourceExists(ogreMeshName))
-        Ogre::MeshManager::getSingleton().remove(ogreMeshName);
-
-    Ogre::MeshPtr ogreMesh = Ogre::MeshManager::getSingleton().createManual(
-        ogreMeshName, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-
-    const Ogre::AxisAlignedBox localBounds = meshBounds(mesh);
-    Ogre::AxisAlignedBox bounds = localBounds;
-    if (bounds.isNull())
-        bounds = Ogre::AxisAlignedBox(-0.5f, -0.5f, -0.5f, 0.5f, 0.5f, 0.5f);
-
-    TextureDecoder textureDecoder;
-
-    for (const ReconstructedSubMesh &sub : mesh.subMeshes) {
-        Ogre::SubMesh *ogreSub = ogreMesh->createSubMesh();
-        ogreSub->setMaterialName(
-            ensureMaterial(sub.materialName, textureSource, captureId, &textureDecoder)->getName());
-        writeSubMesh(sub, ogreSub);
-    }
-
-    ogreMesh->_setBounds(bounds);
-    ogreMesh->_setBoundingSphereRadius(bounds.getHalfSize().length());
-    ogreMesh->load();
-
     removePriorCaptureNodes(mgr);
+    purgePriorCaptureGpuResources();
+
+    TextureBuildContext texCtx;
+    texCtx.sessionId = allocateSessionId();
+    texCtx.resourceGroup = sessionResourceGroup(texCtx.sessionId);
+    texCtx.captureId = captureId;
+    ensureResourceGroup(texCtx.resourceGroup);
+    predecodeCaptureTextures(textureSource, &texCtx);
+
+    Ogre::MeshPtr ogreMesh;
+    Ogre::AxisAlignedBox localBounds;
+    buildMeshResources(mesh, captureId, textureSource, &texCtx, ogreMesh, localBounds);
 
     const QString nodeName = QStringLiteral("PS1Capture_%1").arg(captureId);
     Ogre::SceneNode *node = mgr->addSceneNode(nodeName);
@@ -359,6 +532,7 @@ bool PS1RipMeshBuilder::attachCaptureSetToScene(const ReconstructedCaptureSet &c
     }
 
     removePriorCaptureNodes(mgr);
+    purgePriorCaptureGpuResources();
 
     QVector<Ogre::AxisAlignedBox> localBoundsByMesh(captureSet.uniqueMeshes.size());
     for (int i = 0; i < captureSet.uniqueMeshes.size(); ++i)
@@ -394,7 +568,13 @@ bool PS1RipMeshBuilder::attachCaptureSetToScene(const ReconstructedCaptureSet &c
             placementScale = 3.0f / maxExtent;
     }
 
-    TextureDecoder textureDecoder;
+    TextureBuildContext texCtx;
+    texCtx.sessionId = allocateSessionId();
+    texCtx.resourceGroup = sessionResourceGroup(texCtx.sessionId);
+    texCtx.captureId = captureId;
+    ensureResourceGroup(texCtx.resourceGroup);
+    predecodeCaptureTextures(textureSource, &texCtx);
+
     int totalVerts = 0;
     int totalTris = 0;
     Ogre::SceneNode *firstNode = nullptr;
@@ -404,31 +584,9 @@ bool PS1RipMeshBuilder::attachCaptureSetToScene(const ReconstructedCaptureSet &c
     int instanceOrdinal = 0;
     for (int meshIndex = 0; meshIndex < captureSet.uniqueMeshes.size(); ++meshIndex) {
         const ReconstructedMesh &mesh = captureSet.uniqueMeshes[meshIndex];
-        const QString meshName = QStringLiteral("ps1_capture_%1_u%2").arg(captureId).arg(meshIndex);
-        const std::string ogreMeshName = meshName.toStdString();
-
-        if (Ogre::MeshManager::getSingleton().resourceExists(ogreMeshName))
-            Ogre::MeshManager::getSingleton().remove(ogreMeshName);
-
-        const Ogre::AxisAlignedBox localBounds = meshBounds(mesh);
-        Ogre::AxisAlignedBox bounds = localBounds;
-        if (bounds.isNull())
-            bounds = Ogre::AxisAlignedBox(-0.5f, -0.5f, -0.5f, 0.5f, 0.5f, 0.5f);
-
-        Ogre::MeshPtr ogreMesh = Ogre::MeshManager::getSingleton().createManual(
-            ogreMeshName, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-
-        for (const ReconstructedSubMesh &sub : mesh.subMeshes) {
-            Ogre::SubMesh *ogreSub = ogreMesh->createSubMesh();
-            ogreSub->setMaterialName(
-                ensureMaterial(sub.materialName, textureSource, captureId, &textureDecoder)
-                    ->getName());
-            writeSubMesh(sub, ogreSub);
-        }
-
-        ogreMesh->_setBounds(bounds);
-        ogreMesh->_setBoundingSphereRadius(bounds.getHalfSize().length());
-        ogreMesh->load();
+        Ogre::MeshPtr ogreMesh;
+        Ogre::AxisAlignedBox localBounds;
+        buildMeshResources(mesh, captureId, textureSource, &texCtx, ogreMesh, localBounds);
 
         totalVerts += mesh.vertexCount;
         totalTris += mesh.triangleCount;

--- a/src/PS1/runtime/PsxVramColor.h
+++ b/src/PS1/runtime/PsxVramColor.h
@@ -6,6 +6,12 @@
 /** PS1 VRAM 16-bit BGR555 (+ STP in bit 15) helpers shared by rip + TIM paths. */
 namespace PsxVramColor {
 
+/** GP0 draw-mode bit 11: when clear, texel 0x0000 is transparent; when set, opaque black. */
+inline bool drawModeMasksZeroAsTransparent(uint32_t drawModeBits)
+{
+    return (drawModeBits & (1u << 11)) == 0;
+}
+
 inline void bgr555ToRgba(uint16_t c, uint8_t &r, uint8_t &g, uint8_t &b, uint8_t &a,
                          bool treatZeroAsTransparent = true)
 {

--- a/src/PS1/runtime/TextureDecoder.cpp
+++ b/src/PS1/runtime/TextureDecoder.cpp
@@ -4,19 +4,83 @@
 #include "VramSnapshot.h"
 
 #include <QRgb>
+#include <QtGlobal>
 
-bool TextureDecoder::TileKey::operator==(const TileKey &other) const
+#include <algorithm>
+
+namespace {
+
+constexpr int kPageSize = 256;
+
+bool treatZeroAsTransparent(const TextureDecoder::MaterialKey &key)
 {
-    return tpage == other.tpage && clutX == other.clutX && clutY == other.clutY
-           && bitDepth == other.bitDepth && regionOnPage == other.regionOnPage;
+    return PsxVramColor::drawModeMasksZeroAsTransparent(key.drawModeBits);
 }
 
-size_t qHash(const TextureDecoder::TileKey &key, size_t seed)
+} // namespace
+
+bool TextureDecoder::MaterialKey::operator==(const MaterialKey &other) const
+{
+    return tpage == other.tpage && clutX == other.clutX && clutY == other.clutY
+           && bitDepth == other.bitDepth && semiTrans == other.semiTrans
+           && drawModeBits == other.drawModeBits;
+}
+
+size_t qHash(const TextureDecoder::MaterialKey &key, size_t seed)
 {
     return qHash(static_cast<uint>(key.tpage), seed) ^ qHash(static_cast<uint>(key.clutX), seed << 1)
            ^ qHash(static_cast<uint>(key.clutY), seed << 2)
            ^ qHash(static_cast<int>(key.bitDepth), seed << 3)
-           ^ qHash(key.regionOnPage, seed << 4);
+           ^ qHash(static_cast<uint>(key.semiTrans), seed << 4)
+           ^ qHash(key.drawModeBits, seed << 5);
+}
+
+TextureDecoder::BitDepth TextureDecoder::bitDepthFromTpage(uint16_t tpage)
+{
+    switch ((tpage >> 7) & 3) {
+    case 0:
+        return BitDepth::Bpp4;
+    case 1:
+        return BitDepth::Bpp8;
+    default:
+        return BitDepth::Bpp15;
+    }
+}
+
+void TextureDecoder::clutCoordsFromClutWord(uint16_t clut, uint16_t &clutXOut, uint16_t &clutYOut)
+{
+    clutXOut = static_cast<uint16_t>((clut & 0x3F) << 4);
+    clutYOut = static_cast<uint16_t>((clut >> 6) & 0x3FF);
+}
+
+TextureDecoder::MaterialKey TextureDecoder::materialKeyFromPrim(const PrimRecord &prim)
+{
+    MaterialKey key{};
+    key.tpage = prim.tpage;
+    clutCoordsFromClutWord(prim.clut, key.clutX, key.clutY);
+    key.bitDepth = bitDepthFromTpage(prim.tpage);
+    key.semiTrans = prim.semiTrans;
+    key.drawModeBits = prim.drawModeBits;
+    return key;
+}
+
+bool TextureDecoder::isTexturedPrim(const PrimRecord &prim)
+{
+    return prim.kind == PrimKind::TexturedTri || prim.kind == PrimKind::TexturedQuad
+           || prim.kind == PrimKind::Sprite;
+}
+
+void TextureDecoder::accumulateUvBounds(const PrimRecord &prim, QRect &boundsOnPage)
+{
+    if (!isTexturedPrim(prim))
+        return;
+
+    for (int v = 0; v < prim.vertexCount && v < 4; ++v) {
+        const int u = static_cast<int>(static_cast<uint8_t>(prim.verts[v].u));
+        const int vv = static_cast<int>(static_cast<uint8_t>(prim.verts[v].v));
+        const QRect texel(u, vv, 1, 1);
+        boundsOnPage = boundsOnPage.isValid() ? boundsOnPage.united(texel) : texel;
+    }
 }
 
 void TextureDecoder::clearCache()
@@ -25,37 +89,42 @@ void TextureDecoder::clearCache()
     m_stats = {};
 }
 
-QImage TextureDecoder::cachedTile(const TileKey &key) const
+void TextureDecoder::clearWarnings()
 {
-    return m_cache.value(key);
+    m_warnings.clear();
 }
 
-QImage TextureDecoder::decodeTile(const VramSnapshot &vram, const TileKey &key,
-                                  const QRect &regionOnPage, QString *errorOut)
+void TextureDecoder::warnOutOfVram(const QString &message)
 {
-    const QRect page = VramSnapshot::tpageRect(key.tpage);
-    QRect region = regionOnPage.isValid() ? regionOnPage : QRect(0, 0, 256, 256);
-    region = region.intersected(QRect(0, 0, 256, 256));
-    if (!region.isValid() || region.isEmpty()) {
-        if (errorOut)
-            *errorOut = QStringLiteral("Texture region is empty");
-        return {};
+    if (!m_warnings.contains(message))
+        m_warnings.append(message);
+}
+
+uint16_t TextureDecoder::readVramPixel(const VramSnapshot &vram, int x, int y)
+{
+    if (x < 0 || y < 0 || x >= VramSnapshot::kWidth || y >= VramSnapshot::kHeight) {
+        warnOutOfVram(QStringLiteral("VRAM read out of range (%1,%2)").arg(x).arg(y));
+        return 0;
     }
+    return vram.pixel(x, y);
+}
 
-    TileKey cacheKey = key;
-    cacheKey.regionOnPage = region;
-    if (m_cache.contains(cacheKey)) {
-        ++m_stats.cacheHits;
-        return m_cache.value(cacheKey);
-    }
+uint16_t TextureDecoder::readClutColor(const VramSnapshot &vram, int clutX, int clutY, int index,
+                                       BitDepth bitDepth, const MaterialKey &key)
+{
+    const int maxIndex = bitDepth == BitDepth::Bpp4 ? 15 : 255;
+    const int clamped = std::clamp(index, 0, maxIndex);
+    return readVramPixel(vram, clutX + clamped, clutY);
+}
 
-    ++m_stats.cacheMisses;
-
+QImage TextureDecoder::decodeRegion(const VramSnapshot &vram, const MaterialKey &key,
+                                    const QRect &region)
+{
     QImage img(region.width(), region.height(), QImage::Format_ARGB32);
     img.fill(Qt::transparent);
 
-    const int clutX = static_cast<int>(key.clutX);
-    const int clutY = static_cast<int>(key.clutY);
+    const QRect page = VramSnapshot::tpageRect(key.tpage);
+    const bool zeroTransparent = treatZeroAsTransparent(key);
 
     if (key.bitDepth == BitDepth::Bpp15) {
         for (int y = 0; y < region.height(); ++y) {
@@ -63,13 +132,16 @@ QImage TextureDecoder::decodeTile(const VramSnapshot &vram, const TileKey &key,
             for (int x = 0; x < region.width(); ++x) {
                 const int vramX = page.x() + region.x() + x;
                 const int vramY = page.y() + region.y() + y;
-                const uint16_t c = vram.pixel(vramX, vramY);
+                const uint16_t c = readVramPixel(vram, vramX, vramY);
                 uint8_t r, g, b, a;
-                PsxVramColor::bgr555ToRgba(c, r, g, b, a, true);
+                PsxVramColor::bgr555ToRgba(c, r, g, b, a, zeroTransparent);
                 scan[x] = qRgba(r, g, b, a);
             }
         }
-    } else if (key.bitDepth == BitDepth::Bpp8) {
+        return img;
+    }
+
+    if (key.bitDepth == BitDepth::Bpp8) {
         for (int y = 0; y < region.height(); ++y) {
             auto *scan = reinterpret_cast<QRgb *>(img.scanLine(y));
             for (int x = 0; x < region.width(); ++x) {
@@ -77,36 +149,88 @@ QImage TextureDecoder::decodeTile(const VramSnapshot &vram, const TileKey &key,
                 const int texY = region.y() + y;
                 const int wordX = page.x() + (texX / 2);
                 const int vramY = page.y() + texY;
-                const uint16_t word = vram.pixel(wordX, vramY);
+                const uint16_t word = readVramPixel(vram, wordX, vramY);
                 const uint8_t idx = (texX & 1) ? static_cast<uint8_t>((word >> 8) & 0xFF)
-                                                : static_cast<uint8_t>(word & 0xFF);
-                const uint16_t c = vram.pixel(clutX + idx, clutY);
+                                               : static_cast<uint8_t>(word & 0xFF);
+                const uint16_t c =
+                    readClutColor(vram, key.clutX, key.clutY, idx, key.bitDepth, key);
                 uint8_t r, g, b, a;
-                PsxVramColor::bgr555ToRgba(c, r, g, b, a, true);
+                PsxVramColor::bgr555ToRgba(c, r, g, b, a, zeroTransparent);
                 scan[x] = qRgba(r, g, b, a);
             }
         }
-    } else {
-        for (int y = 0; y < region.height(); ++y) {
-            auto *scan = reinterpret_cast<QRgb *>(img.scanLine(y));
-            for (int x = 0; x < region.width(); ++x) {
-                const int texX = region.x() + x;
-                const int texY = region.y() + y;
-                const int wordX = page.x() + (texX / 4);
-                const int vramY = page.y() + texY;
-                const uint16_t word = vram.pixel(wordX, vramY);
-                const int shift = (texX & 3) * 4;
-                const uint8_t idx = static_cast<uint8_t>((word >> shift) & 0xF);
-                const uint16_t c = vram.pixel(clutX + idx, clutY);
-                uint8_t r, g, b, a;
-                PsxVramColor::bgr555ToRgba(c, r, g, b, a, true);
-                scan[x] = qRgba(r, g, b, a);
-            }
-        }
+        return img;
     }
 
-    m_cache.insert(cacheKey, img);
-    ++m_stats.decodedTiles;
+    for (int y = 0; y < region.height(); ++y) {
+        auto *scan = reinterpret_cast<QRgb *>(img.scanLine(y));
+        for (int x = 0; x < region.width(); ++x) {
+            const int texX = region.x() + x;
+            const int texY = region.y() + y;
+            const int wordX = page.x() + (texX / 4);
+            const int vramY = page.y() + texY;
+            const uint16_t word = readVramPixel(vram, wordX, vramY);
+            const int shift = (texX & 3) * 4;
+            const uint8_t idx = static_cast<uint8_t>((word >> shift) & 0xF);
+            const uint16_t c = readClutColor(vram, key.clutX, key.clutY, idx, key.bitDepth, key);
+            uint8_t r, g, b, a;
+            PsxVramColor::bgr555ToRgba(c, r, g, b, a, zeroTransparent);
+            scan[x] = qRgba(r, g, b, a);
+        }
+    }
+    return img;
+}
+
+QImage TextureDecoder::cachedMaterial(const MaterialKey &key) const
+{
+    return m_cache.value(key).image;
+}
+
+QRect TextureDecoder::cachedBoundsOnPage(const MaterialKey &key) const
+{
+    return m_cache.value(key).boundsOnPage;
+}
+
+QImage TextureDecoder::decodeMaterial(const VramSnapshot &vram, const MaterialKey &key,
+                                      const QRect &uvBoundsOnPage, QString *errorOut)
+{
+    QRect region = uvBoundsOnPage.isValid() ? uvBoundsOnPage : QRect(0, 0, kPageSize, kPageSize);
+    region = region.intersected(QRect(0, 0, kPageSize, kPageSize));
+    if (!region.isValid() || region.isEmpty()) {
+        if (errorOut)
+            *errorOut = QStringLiteral("Texture UV bounds are empty");
+        return {};
+    }
+
+    if (m_cache.contains(key)) {
+        const CachedMaterial &cached = m_cache.value(key);
+        if (cached.boundsOnPage.contains(region)) {
+            ++m_stats.cacheHits;
+            const QPoint offset = region.topLeft() - cached.boundsOnPage.topLeft();
+            return cached.image.copy(offset.x(), offset.y(), region.width(), region.height());
+        }
+
+        const QRect merged = cached.boundsOnPage.united(region);
+        QImage mergedImg = decodeRegion(vram, key, merged);
+        m_cache.insert(key, CachedMaterial{mergedImg, merged});
+        ++m_stats.cacheMisses;
+        ++m_stats.decodedMaterials;
+        m_stats.rgbaBytes += mergedImg.sizeInBytes();
+
+        const QPoint offset = region.topLeft() - merged.topLeft();
+        return mergedImg.copy(offset.x(), offset.y(), region.width(), region.height());
+    }
+
+    ++m_stats.cacheMisses;
+    QImage img = decodeRegion(vram, key, region);
+    if (img.isNull()) {
+        if (errorOut)
+            *errorOut = QStringLiteral("Texture decode failed");
+        return {};
+    }
+
+    m_cache.insert(key, CachedMaterial{img, region});
+    ++m_stats.decodedMaterials;
     m_stats.rgbaBytes += img.sizeInBytes();
     return img;
 }

--- a/src/PS1/runtime/TextureDecoder.cpp
+++ b/src/PS1/runtime/TextureDecoder.cpp
@@ -110,7 +110,7 @@ uint16_t TextureDecoder::readVramPixel(const VramSnapshot &vram, int x, int y)
 }
 
 uint16_t TextureDecoder::readClutColor(const VramSnapshot &vram, int clutX, int clutY, int index,
-                                       BitDepth bitDepth, const MaterialKey &key)
+                                       BitDepth bitDepth)
 {
     const int maxIndex = bitDepth == BitDepth::Bpp4 ? 15 : 255;
     const int clamped = std::clamp(index, 0, maxIndex);
@@ -152,8 +152,7 @@ QImage TextureDecoder::decodeRegion(const VramSnapshot &vram, const MaterialKey 
                 const uint16_t word = readVramPixel(vram, wordX, vramY);
                 const uint8_t idx = (texX & 1) ? static_cast<uint8_t>((word >> 8) & 0xFF)
                                                : static_cast<uint8_t>(word & 0xFF);
-                const uint16_t c =
-                    readClutColor(vram, key.clutX, key.clutY, idx, key.bitDepth, key);
+                const uint16_t c = readClutColor(vram, key.clutX, key.clutY, idx, key.bitDepth);
                 uint8_t r, g, b, a;
                 PsxVramColor::bgr555ToRgba(c, r, g, b, a, zeroTransparent);
                 scan[x] = qRgba(r, g, b, a);
@@ -172,7 +171,7 @@ QImage TextureDecoder::decodeRegion(const VramSnapshot &vram, const MaterialKey 
             const uint16_t word = readVramPixel(vram, wordX, vramY);
             const int shift = (texX & 3) * 4;
             const uint8_t idx = static_cast<uint8_t>((word >> shift) & 0xF);
-            const uint16_t c = readClutColor(vram, key.clutX, key.clutY, idx, key.bitDepth, key);
+            const uint16_t c = readClutColor(vram, key.clutX, key.clutY, idx, key.bitDepth);
             uint8_t r, g, b, a;
             PsxVramColor::bgr555ToRgba(c, r, g, b, a, zeroTransparent);
             scan[x] = qRgba(r, g, b, a);

--- a/src/PS1/runtime/TextureDecoder.h
+++ b/src/PS1/runtime/TextureDecoder.h
@@ -1,10 +1,13 @@
 #ifndef TEXTUREDECODER_H
 #define TEXTUREDECODER_H
 
+#include "CaptureTypes.h"
+
 #include <QHash>
 #include <QImage>
 #include <QRect>
 #include <QString>
+#include <QStringList>
 
 #include <cstdint>
 
@@ -20,35 +23,68 @@ public:
         Bpp15 = 2,
     };
 
-    struct TileKey {
+    /** Dedupe key: TPAGE + CLUT + bit depth + GP0 semi-transparency mode. */
+    struct MaterialKey {
         uint16_t tpage = 0;
         uint16_t clutX = 0;
         uint16_t clutY = 0;
         BitDepth bitDepth = BitDepth::Bpp15;
-        QRect regionOnPage;
+        uint8_t semiTrans = 0;
+        uint32_t drawModeBits = 0;
 
-        bool operator==(const TileKey &other) const;
+        bool operator==(const MaterialKey &other) const;
     };
 
     struct DecodeStats {
         int cacheHits = 0;
         int cacheMisses = 0;
-        int decodedTiles = 0;
+        int decodedMaterials = 0;
         qint64 rgbaBytes = 0;
     };
 
-    QImage decodeTile(const VramSnapshot &vram, const TileKey &key, const QRect &regionOnPage,
-                      QString *errorOut = nullptr);
-    QImage cachedTile(const TileKey &key) const;
+    static BitDepth bitDepthFromTpage(uint16_t tpage);
+    static void clutCoordsFromClutWord(uint16_t clut, uint16_t &clutXOut, uint16_t &clutYOut);
+    static MaterialKey materialKeyFromPrim(const PrimRecord &prim);
+    static bool isTexturedPrim(const PrimRecord &prim);
+    static void accumulateUvBounds(const PrimRecord &prim, QRect &boundsOnPage);
+
+    /** Decode texels in @p uvBoundsOnPage (page-local 0..256). Results are cached per MaterialKey. */
+    QImage decodeMaterial(const VramSnapshot &vram, const MaterialKey &key, const QRect &uvBoundsOnPage,
+                          QString *errorOut = nullptr);
+
+    QImage cachedMaterial(const MaterialKey &key) const;
+    QRect cachedBoundsOnPage(const MaterialKey &key) const;
     DecodeStats stats() const { return m_stats; }
-    /** Call when VRAM content changes; cached tiles are keyed by region + tpage/clut. */
+    const QStringList &warnings() const { return m_warnings; }
     void clearCache();
+    void clearWarnings();
+
+    /** Back-compat alias used by older call sites. */
+    using TileKey = MaterialKey;
+    QImage decodeTile(const VramSnapshot &vram, const MaterialKey &key, const QRect &regionOnPage,
+                      QString *errorOut = nullptr)
+    {
+        return decodeMaterial(vram, key, regionOnPage, errorOut);
+    }
+    QImage cachedTile(const MaterialKey &key) const { return cachedMaterial(key); }
 
 private:
-    QHash<TileKey, QImage> m_cache;
+    struct CachedMaterial {
+        QImage image;
+        QRect boundsOnPage;
+    };
+
+    void warnOutOfVram(const QString &message);
+    uint16_t readVramPixel(const VramSnapshot &vram, int x, int y);
+    uint16_t readClutColor(const VramSnapshot &vram, int clutX, int clutY, int index,
+                           BitDepth bitDepth, const MaterialKey &key);
+    QImage decodeRegion(const VramSnapshot &vram, const MaterialKey &key, const QRect &region);
+
+    QHash<MaterialKey, CachedMaterial> m_cache;
     DecodeStats m_stats;
+    QStringList m_warnings;
 };
 
-size_t qHash(const TextureDecoder::TileKey &key, size_t seed = 0);
+size_t qHash(const TextureDecoder::MaterialKey &key, size_t seed = 0);
 
 #endif // TEXTUREDECODER_H

--- a/src/PS1/runtime/TextureDecoder.h
+++ b/src/PS1/runtime/TextureDecoder.h
@@ -77,7 +77,7 @@ private:
     void warnOutOfVram(const QString &message);
     uint16_t readVramPixel(const VramSnapshot &vram, int x, int y);
     uint16_t readClutColor(const VramSnapshot &vram, int clutX, int clutY, int index,
-                           BitDepth bitDepth, const MaterialKey &key);
+                           BitDepth bitDepth);
     QImage decodeRegion(const VramSnapshot &vram, const MaterialKey &key, const QRect &region);
 
     QHash<MaterialKey, CachedMaterial> m_cache;

--- a/src/PS1/runtime/TextureDecoder_test.cpp
+++ b/src/PS1/runtime/TextureDecoder_test.cpp
@@ -104,7 +104,7 @@ TEST(TextureDecoderTest, MaterialKeyDedupesAcrossRegions)
 TEST(TextureDecoderTest, StpBitSetsSemiTransparentAlpha)
 {
     VramSnapshot vram;
-    vram.setPixel(0, 0, PsxVramColor::rgbaToBgr555(255, 0, 0, 128));
+    vram.setPixel(0, 0, PsxVramColor::rgbaToBgr555(255, 0, 0, 127));
     TextureDecoder decoder;
     TextureDecoder::MaterialKey key{};
     key.tpage = 0;
@@ -145,7 +145,7 @@ TEST(TextureDecoderTest, WarnsOnOutOfRangeVramRead)
     TextureDecoder::MaterialKey key{};
     key.tpage = 0;
     key.bitDepth = TextureDecoder::BitDepth::Bpp15;
-    const QImage tile = decoder.decodeMaterial(vram, key, QRect(1020, 0, 8, 1));
+    const QImage tile = decoder.decodeMaterial(vram, key, QRect(254, 0, 4, 1));
     EXPECT_FALSE(tile.isNull());
     EXPECT_FALSE(decoder.warnings().isEmpty());
 }

--- a/src/PS1/runtime/TextureDecoder_test.cpp
+++ b/src/PS1/runtime/TextureDecoder_test.cpp
@@ -143,7 +143,8 @@ TEST(TextureDecoderTest, WarnsOnOutOfRangeVramRead)
     VramSnapshot vram;
     TextureDecoder decoder;
     TextureDecoder::MaterialKey key{};
-    key.tpage = 0;
+    // TPAGE at x=960; page-local (254,0,4,1) reads VRAM x=1214..1217 (>= 1024).
+    key.tpage = 0x000F;
     key.bitDepth = TextureDecoder::BitDepth::Bpp15;
     const QImage tile = decoder.decodeMaterial(vram, key, QRect(254, 0, 4, 1));
     EXPECT_FALSE(tile.isNull());

--- a/src/PS1/runtime/TextureDecoder_test.cpp
+++ b/src/PS1/runtime/TextureDecoder_test.cpp
@@ -4,11 +4,19 @@
 
 #include <gtest/gtest.h>
 
-static void writeClut(VramSnapshot &vram, int clutX, int clutY)
+static void writeClut4(VramSnapshot &vram, int clutX, int clutY)
 {
     for (int i = 0; i < 16; ++i) {
         const uint8_t v = static_cast<uint8_t>(i * 16);
         vram.setPixel(clutX + i, clutY, PsxVramColor::rgbaToBgr555(v, v, v, 255));
+    }
+}
+
+static void writeClut8(VramSnapshot &vram, int clutX, int clutY)
+{
+    for (int i = 0; i < 256; ++i) {
+        const uint8_t v = static_cast<uint8_t>(i);
+        vram.setPixel(clutX + i, clutY, PsxVramColor::rgbaToBgr555(v, 128, 255 - v, 255));
     }
 }
 
@@ -17,19 +25,18 @@ TEST(TextureDecoderTest, Decodes15bppTile)
     VramSnapshot vram;
     vram.setPixel(0, 0, PsxVramColor::rgbaToBgr555(0, 0, 255, 255));
     TextureDecoder decoder;
-    TextureDecoder::TileKey key{};
+    TextureDecoder::MaterialKey key{};
     key.tpage = 0;
     key.bitDepth = TextureDecoder::BitDepth::Bpp15;
     const QRect region(0, 0, 1, 1);
-    const QImage tile = decoder.decodeTile(vram, key, region);
+    const QImage tile = decoder.decodeMaterial(vram, key, region);
     ASSERT_FALSE(tile.isNull());
     EXPECT_EQ(qAlpha(tile.pixel(0, 0)), 255);
-    EXPECT_EQ(decoder.stats().decodedTiles, 1);
+    EXPECT_EQ(decoder.stats().decodedMaterials, 1);
     EXPECT_EQ(decoder.stats().cacheHits, 0);
 
-    key.regionOnPage = region;
-    EXPECT_FALSE(decoder.cachedTile(key).isNull());
-    const QImage cached = decoder.decodeTile(vram, key, region);
+    EXPECT_FALSE(decoder.cachedMaterial(key).isNull());
+    const QImage cached = decoder.decodeMaterial(vram, key, region);
     EXPECT_FALSE(cached.isNull());
     EXPECT_EQ(decoder.stats().cacheHits, 1);
 }
@@ -37,34 +44,118 @@ TEST(TextureDecoderTest, Decodes15bppTile)
 TEST(TextureDecoderTest, Decodes4bppWithClut)
 {
     VramSnapshot vram;
-    writeClut(vram, 0, 480);
-    vram.setPixel(0, 0, 0x000F); // index 15 in low nibble
+    writeClut4(vram, 0, 480);
+    vram.setPixel(0, 0, 0x000F);
     TextureDecoder decoder;
-    TextureDecoder::TileKey key{};
+    TextureDecoder::MaterialKey key{};
     key.tpage = 0;
     key.clutX = 0;
     key.clutY = 480;
     key.bitDepth = TextureDecoder::BitDepth::Bpp4;
-    const QImage tile = decoder.decodeTile(vram, key, QRect(0, 0, 1, 1));
+    const QImage tile = decoder.decodeMaterial(vram, key, QRect(0, 0, 1, 1));
     ASSERT_FALSE(tile.isNull());
     const QRgb px = tile.pixel(0, 0);
     EXPECT_GT(qRed(px), 200);
 }
 
-TEST(TextureDecoderTest, CacheKeyIncludesRegion)
+TEST(TextureDecoderTest, Decodes8bppWithClut)
+{
+    VramSnapshot vram;
+    writeClut8(vram, 64, 480);
+    constexpr uint16_t tpage8 = 0x80; // (tpage >> 7) & 3 == 1 → 8bpp
+    const QRect page = VramSnapshot::tpageRect(tpage8);
+    vram.setPixel(page.x(), page.y(), static_cast<uint16_t>(0x00FF));
+
+    TextureDecoder decoder;
+    TextureDecoder::MaterialKey key{};
+    key.tpage = tpage8;
+    key.clutX = 64;
+    key.clutY = 480;
+    key.bitDepth = TextureDecoder::BitDepth::Bpp8;
+    const QImage tile = decoder.decodeMaterial(vram, key, QRect(0, 0, 1, 1));
+    ASSERT_FALSE(tile.isNull());
+    EXPECT_GT(qGreen(tile.pixel(0, 0)), 100);
+}
+
+TEST(TextureDecoderTest, MaterialKeyDedupesAcrossRegions)
 {
     VramSnapshot vram;
     vram.setPixel(0, 0, PsxVramColor::rgbaToBgr555(255, 0, 0, 255));
     vram.setPixel(1, 0, PsxVramColor::rgbaToBgr555(0, 255, 0, 255));
     TextureDecoder decoder;
-    TextureDecoder::TileKey key{};
+    TextureDecoder::MaterialKey key{};
     key.tpage = 0;
     key.bitDepth = TextureDecoder::BitDepth::Bpp15;
 
-    const QImage a = decoder.decodeTile(vram, key, QRect(0, 0, 1, 1));
-    const QImage b = decoder.decodeTile(vram, key, QRect(1, 0, 1, 1));
+    const QImage a = decoder.decodeMaterial(vram, key, QRect(0, 0, 1, 1));
+    const QImage b = decoder.decodeMaterial(vram, key, QRect(1, 0, 1, 1));
     ASSERT_FALSE(a.isNull());
     ASSERT_FALSE(b.isNull());
     EXPECT_NE(a.pixel(0, 0), b.pixel(0, 0));
-    EXPECT_EQ(decoder.stats().decodedTiles, 2);
+    EXPECT_EQ(decoder.stats().decodedMaterials, 2);
+    EXPECT_EQ(decoder.stats().cacheHits, 0);
+
+    const QImage merged = decoder.decodeMaterial(vram, key, QRect(0, 0, 2, 1));
+    ASSERT_FALSE(merged.isNull());
+    EXPECT_EQ(merged.width(), 2);
+    EXPECT_EQ(decoder.stats().cacheHits, 1);
+}
+
+TEST(TextureDecoderTest, StpBitSetsSemiTransparentAlpha)
+{
+    VramSnapshot vram;
+    vram.setPixel(0, 0, PsxVramColor::rgbaToBgr555(255, 0, 0, 128));
+    TextureDecoder decoder;
+    TextureDecoder::MaterialKey key{};
+    key.tpage = 0;
+    key.bitDepth = TextureDecoder::BitDepth::Bpp15;
+    key.drawModeBits = 1u << 11;
+    const QImage tile = decoder.decodeMaterial(vram, key, QRect(0, 0, 1, 1));
+    ASSERT_FALSE(tile.isNull());
+    EXPECT_EQ(qAlpha(tile.pixel(0, 0)), 128);
+}
+
+TEST(TextureDecoderTest, DrawModeZeroMasksTransparentBlack)
+{
+    VramSnapshot vram;
+    vram.setPixel(0, 0, 0);
+    TextureDecoder decoder;
+    TextureDecoder::MaterialKey opaqueBlack{};
+    opaqueBlack.tpage = 0;
+    opaqueBlack.bitDepth = TextureDecoder::BitDepth::Bpp15;
+    opaqueBlack.drawModeBits = 1u << 11;
+
+    TextureDecoder::MaterialKey transparentBlack = opaqueBlack;
+    transparentBlack.drawModeBits = 0;
+
+    const QImage opaque =
+        decoder.decodeMaterial(vram, opaqueBlack, QRect(0, 0, 1, 1));
+    const QImage transparent =
+        decoder.decodeMaterial(vram, transparentBlack, QRect(0, 0, 1, 1));
+    ASSERT_FALSE(opaque.isNull());
+    ASSERT_FALSE(transparent.isNull());
+    EXPECT_EQ(qAlpha(opaque.pixel(0, 0)), 255);
+    EXPECT_EQ(qAlpha(transparent.pixel(0, 0)), 0);
+}
+
+TEST(TextureDecoderTest, WarnsOnOutOfRangeVramRead)
+{
+    VramSnapshot vram;
+    TextureDecoder decoder;
+    TextureDecoder::MaterialKey key{};
+    key.tpage = 0;
+    key.bitDepth = TextureDecoder::BitDepth::Bpp15;
+    const QImage tile = decoder.decodeMaterial(vram, key, QRect(1020, 0, 8, 1));
+    EXPECT_FALSE(tile.isNull());
+    EXPECT_FALSE(decoder.warnings().isEmpty());
+}
+
+TEST(TextureDecoderTest, MaterialKeySeparatesSemiTransMode)
+{
+    TextureDecoder::MaterialKey a{};
+    TextureDecoder::MaterialKey b{};
+    a.semiTrans = 0;
+    b.semiTrans = 1;
+    EXPECT_TRUE(a.semiTrans != b.semiTrans);
+    EXPECT_NE(qHash(a), qHash(b));
 }


### PR DESCRIPTION
## Summary

- Extends `TextureDecoder` with `MaterialKey` (TPAGE, CLUT, bit depth, semi-transparency, draw mode), UV-bounds cache merge, and 4/8/15 bpp + STP/transparent-black handling.
- Wires `PS1RipMeshBuilder` to pre-decode capture textures, upload to `PS1Rip_Session<N>`, apply PS1 blend modes, and scope/purge Ogre materials per capture so repeat captures do not collide.
- Material Editor lists PS1 capture materials but skips GPU thumbnails (prevents freeze); editing remains read-only.

Closes #421.

## Test plan

- [x] `TextureDecoderTest` unit tests (15/4/8 bpp, STP, draw-mode black, cache merge, VRAM warnings)
- [ ] Capture frame twice in PS1 Rip session — second capture succeeds, textured mesh visible
- [ ] Open Material Editor — no UI freeze; `PS1Rip_*` materials appear in list
- [ ] CI: Windows, macOS, Linux builds + `unit-tests-linux`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More accurate PS1 mesh & texture reconstruction with finer material grouping and semi-transparency/draw-mode-aware handling
  * Faster, cached material-level decoding and session-scoped GPU resource management to reduce UI stalls and rebuilds

* **Bug Fixes**
  * Prevent editing/previewing unsupported PS1/paint-pipeline materials; show an error and skip previews to avoid freezes
  * Better out-of-range VRAM/read warnings and more reliable transparency semantics in decoded textures

* **Tests**
  * Unit tests updated to validate material-keyed decoding, caching, and PS1 transparency behaviors

* **Documentation**
  * Updated design notes describing runtime texture/mesh-building responsibilities and session resource handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/656?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->