### PR TITLE
feat(ps1): in-core GP0 draw-call capture (#657)

### DIFF
--- a/plugins/ps1core_libretro/CMakeLists.txt
+++ b/plugins/ps1core_libretro/CMakeLists.txt
@@ -14,7 +14,9 @@ add_library(qtmesh_ps1core_libretro MODULE
     LibretroEmuCore.cpp
     LibretroEmuCorePlugin.cpp
     LibretroHost.cpp
+    ${CMAKE_SOURCE_DIR}/src/PS1/runtime/Gp0CaptureStats.cpp
     ${CMAKE_SOURCE_DIR}/src/PS1/runtime/Gp0HookDispatch.cpp
+    ${CMAKE_SOURCE_DIR}/src/PS1/runtime/PsxGp0ChainRootScanner.cpp
     ${CMAKE_SOURCE_DIR}/src/PS1/runtime/GteCapture.cpp
     ${CMAKE_SOURCE_DIR}/src/PS1/runtime/PsxGteEngine.cpp
     ${CMAKE_SOURCE_DIR}/src/PS1/runtime/PsxGteInstructionCapture.cpp

--- a/plugins/ps1core_libretro/LibretroEmuCore.cpp
+++ b/plugins/ps1core_libretro/LibretroEmuCore.cpp
@@ -6,6 +6,7 @@
 #include "PsxVramColor.h"
 
 #include <QCoreApplication>
+#include <QtGlobal>
 #include <QDebug>
 #include <QDir>
 #include <QFile>
@@ -447,7 +448,13 @@ void LibretroEmuCore::runFrame()
 
     m_host.retro_run();
     syncVramFromCore();
-    // GPU/GTE RAM capture runs only on explicit Capture Frame (ingestCaptureFrame).
+
+    if (m_hooks && m_hooks->isCaptureEnabled()) {
+        const bool liveDisabled = qEnvironmentVariableIsSet("QTMESH_PS1_GP0_LIVE_CAPTURE")
+                                  && qEnvironmentVariableIntValue("QTMESH_PS1_GP0_LIVE_CAPTURE") == 0;
+        if (!liveDisabled)
+            captureGpuFromRam(false, true);
+    }
 }
 
 void LibretroEmuCore::reset()
@@ -543,7 +550,7 @@ void LibretroEmuCore::syncCaptureMirrors()
 
 void LibretroEmuCore::ingestCaptureFrame()
 {
-    captureGpuFromRam(true);
+    captureGpuFromRam(true, true);
 }
 
 void LibretroEmuCore::mirrorFramebufferToVram()
@@ -584,7 +591,7 @@ void LibretroEmuCore::syncVramFromCore()
     mirrorFramebufferToVram();
 }
 
-void LibretroEmuCore::captureGpuFromRam(bool scanGteRam)
+void LibretroEmuCore::captureGpuFromRam(bool scanGteRam, bool accumulate)
 {
     if (!m_hooks || !m_hooks->isCaptureEnabled())
         return;
@@ -597,8 +604,8 @@ void LibretroEmuCore::captureGpuFromRam(bool scanGteRam)
     if (!ram || ramSize < 4096)
         return;
 
-    Gp0HookDispatch::captureFrameFromSystemRam(static_cast<const uint8_t *>(ram), ramSize, m_hooks,
-                                               scanGteRam);
+    m_hooks->ingestSystemRamForGpuCapture(static_cast<const uint8_t *>(ram), ramSize, scanGteRam,
+                                          accumulate);
 }
 
 void LibretroEmuCore::presentVideo(const void *data, unsigned width, unsigned height, size_t pitch)

--- a/plugins/ps1core_libretro/LibretroEmuCore.h
+++ b/plugins/ps1core_libretro/LibretroEmuCore.h
@@ -41,7 +41,7 @@ private:
     void refreshVramPointer();
     void mirrorFramebufferToVram();
     void syncVramFromCore();
-    void captureGpuFromRam(bool scanGteRam = false);
+    void captureGpuFromRam(bool scanGteRam = false, bool accumulate = false);
     void presentVideo(const void *data, unsigned width, unsigned height, size_t pitch);
 
     static bool environmentCallback(unsigned cmd, void *data);

--- a/src/PS1/CMakeLists.txt
+++ b/src/PS1/CMakeLists.txt
@@ -27,7 +27,9 @@ if(ENABLE_PS1_RIP)
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/EmuCoreLoader.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/GteInverse.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/EmuViewport.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/Gp0CaptureStats.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/Gp0HookDispatch.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxGp0ChainRootScanner.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxGp0ChainWalker.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxOrderingTableScanner.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/GpuCommandParser.cpp
@@ -68,7 +70,9 @@ if(ENABLE_PS1_RIP)
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/EmuCoreLoader.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/EmuFramebuffer.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/EmuHooks.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/Gp0CaptureStats.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/Gp0HookDispatch.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxGp0ChainRootScanner.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxGp0ChainWalker.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxGp0Opcode.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxOrderingTableScanner.h

--- a/src/PS1/PS1_RIP_DESIGN.md
+++ b/src/PS1/PS1_RIP_DESIGN.md
@@ -68,9 +68,13 @@ See epic #412 for phased issues (#413–#431).
 
 - `CaptureTypes`, `GpuCommandParser`, `CaptureBuffer`, `RipperHooks`, `Gp0HookDispatch` (#418).
 - `EmuHooks` included from `EmuCore.h` (issue #418 API surface).
-- **GTE capture (#419):** On **Capture Frame**, `PsxGteInstructionCapture` scans RAM for COP2 **RTPS/RTPT**, executes setup sequences via `PsxMipsGteRunner` + `PsxGteEngine`, then `PsxGteRamScanner` supplements with matrix blobs. GP0 ingest tags primitives with `latestMatrixId`. Hash dedupe + `cameraMatrixId` heuristic in the session status bar after mesh build. Not run while armed during live play (avoids 2 MiB scans and buffer races).
-- **Libretro capture path:** `Gp0HookDispatch` in the plugin walks **ordering-table linked GP0 chains** first (`PsxOrderingTableScanner` + `PsxGp0ChainWalker`), then falls back to linear RAM opcode scan when no OT is found. OT entries are resolved as **24-bit absolute RAM pointers** (libgpu `getaddr` layout), with a relative-to-OT-base fallback for synthetic tests. Linked DR tags carry the opcode in bits 24–31 and the next packet address in bits 2–23 (`PsxGp0Opcode.h`); drawing-environment commands (0xE1–0xE6) stay in the low byte.
-- **Stub core** emits all seven GP0 primitive flavors for CI when `QTMESH_PS1_FORCE_STUB=1` or no libretro core is present.
+- **GTE capture (#419):** On **Capture Frame**, `PsxGteInstructionCapture` scans RAM for COP2 **RTPS/RTPT**, executes setup sequences via `PsxMipsGteRunner` + `PsxGteEngine`, then `PsxGteRamScanner` supplements with matrix blobs. GP0 ingest tags primitives with `latestMatrixId`. Hash dedupe + `cameraMatrixId` heuristic in the session status bar after mesh build. GTE RAM scans run on final capture ingest only (not on per-frame live GPU ticks).
+- **GP0 capture (#657):** Three paths feed `RipperHooks::onGpuPrim`:
+  - **Direct hook (`gp0_hook`):** `EmuHooks::submitGp0Words` — used by the **stub** core (synthetic seven-flavor capture via `onGpuPrim`) and reserved for true in-core mednafen FIFO hooks. Sentry breadcrumb `ps1.rip.capture.gp0_hook` records `source:gp0_hook|ram_ot|ram_linear|ram_chain_root` and per-path counts.
+  - **Libretro live frame (`ram_*`):** While capture is armed, each `retro_run()` end triggers a lightweight RAM ingest (OT + standalone chain roots + linear, no GTE scan). Primitives accumulate with cross-frame dedupe until **Capture Frame** runs a final GTE+RAM merge. Disable live ingest with `QTMESH_PS1_GP0_LIVE_CAPTURE=0`. Baseline RAM-only behavior (OT then linear, no chain-root pass) via `QTMESH_PS1_GP0_RAM_LEGACY=1`.
+  - **Merged RAM scan:** `PsxOrderingTableScanner` → `PsxGp0ChainRootScanner` → linear fallback share one dedupe set (no early return after a weak OT). OT entries use **24-bit absolute RAM pointers** (libgpu `getaddr` layout), with a relative-to-OT-base fallback for synthetic tests. Linked DR tags carry the opcode in bits 24–31 and the next packet address in bits 2–23 (`PsxGp0Opcode.h`).
+- **Stub core** (`coreId=stub`): direct `onGpuPrim` hook path for CI when `QTMESH_PS1_FORCE_STUB=1` or no libretro core is present.
+- **Libretro core** (`coreId=libretro`): live merged RAM capture at frame boundary; true mednafen GP0 FIFO dispatch hooks remain future work when the core exposes them.
 - `armCapture` / `captureFrame` wire capture to the worker thread; CSV dump to temp for verification.
 - Sentry breadcrumb `ps1.rip.capture.frame_armed` via `ui.action`.
 - Tests: synthetic OT/homebrew RAM layout, seven-flavor CSV round-trip, disarmed capture &lt;1% `runFrame` overhead (stub + optional libretro integration).
@@ -122,7 +126,7 @@ The **stub** core is active (`coreId=stub`). It draws a test pattern and synthet
 
 ### Capture mesh is a triangle “blob” (normal size, wrong shape)
 
-Capture reads GP0 packets from **ordering-table chains** when present (typical homebrew/commercial frame setup), otherwise falls back to a linear RAM opcode scan. Expect coarse geometry on titles that stream primitives outside OT/DMA-visible RAM. Filters drop off-screen coordinates and cap at 2048 primitives per ingest pass. True in-core mednafen FIFO hooks remain future work.
+Capture uses **live per-frame merged RAM ingest** while armed (libretro), then a final GTE+RAM pass on **Capture Frame**. RAM strategies: ordering-table chains, standalone linked GP0 chain roots, and linear opcode scan. Expect coarse geometry on titles that stream primitives outside RAM-visible layouts. Filters drop off-screen coordinates and cap at 2048 primitives per ingest pass. True in-core mednafen FIFO dispatch (packet-for-packet as the GPU receives them) is not wired yet — see issue #657 follow-up when beetle/mednafen exposes hooks.
 
 ### Libretro integration tests (local only)
 

--- a/src/PS1/runtime/EmuHooks.h
+++ b/src/PS1/runtime/EmuHooks.h
@@ -2,12 +2,16 @@
 #define EMUHOOKS_H
 
 #include "CaptureTypes.h"
+#include "Gp0CaptureStats.h"
+
+#include <QSet>
+#include <QString>
 
 #include <cstddef>
 #include <cstdint>
 
 /**
- * GPU/GTE interception callbacks (Phase 2 — #418, #419).
+ * GPU/GTE interception callbacks (Phase 2 — #418, #419; GP0 hook path #657).
  * Implemented by RipperHooks in the app; invoked from the emulator plugin worker thread.
  */
 class EmuHooks
@@ -34,12 +38,32 @@ public:
     virtual void onVramRead(uint16_t x, uint16_t y, uint16_t w, uint16_t h) { (void)x; (void)y; (void)w; (void)h; }
     virtual void onDrawMode(const DrawModeRecord &mode) { (void)mode; }
 
-    /** Libretro path: scan main RAM for GP0 packets when capture is armed (#418). */
-    virtual void ingestSystemRamForGpuCapture(const uint8_t *ram, size_t byteSize)
+    /** Core GP0 FIFO path (#657): sequential GP0 packets as submitted by the plugin. */
+    virtual int submitGp0Words(const uint32_t *words, size_t wordCount)
+    {
+        (void)words;
+        (void)wordCount;
+        return 0;
+    }
+
+    /** Libretro path: scan main RAM for GP0 packets when capture is armed (#418, #657). */
+    virtual void ingestSystemRamForGpuCapture(const uint8_t *ram, size_t byteSize, bool scanGteRam = true,
+                                            bool accumulate = false)
     {
         (void)ram;
         (void)byteSize;
+        (void)scanGteRam;
+        (void)accumulate;
     }
+
+    /** Live armed capture: shared dedupe keys across frames (nullptr when not accumulating). */
+    virtual QSet<QString> *livePrimDedupeKeys() { return nullptr; }
+
+    virtual void beginGpuCapturePass(bool accumulate) { (void)accumulate; }
+    virtual void endGpuCapturePass(Gp0CaptureStats &stats) { (void)stats; }
+
+    virtual int capturePrimCount() const { return 0; }
+    virtual int lastDirectHookPrimCount() const { return 0; }
 };
 
 #endif // EMUHOOKS_H

--- a/src/PS1/runtime/Gp0CapturePaths_test.cpp
+++ b/src/PS1/runtime/Gp0CapturePaths_test.cpp
@@ -1,0 +1,87 @@
+#ifdef ENABLE_PS1_RIP
+
+#include <gtest/gtest.h>
+
+#include "PS1/runtime/CaptureBuffer.h"
+#include "PS1/runtime/Gp0HookDispatch.h"
+#include "PS1/runtime/RipperHooks.h"
+
+#include <QSet>
+#include <atomic>
+#include <cstring>
+
+namespace {
+
+uint32_t colorCmd(uint8_t opcode, uint8_t r, uint8_t g, uint8_t b)
+{
+    return static_cast<uint32_t>(opcode) | (static_cast<uint32_t>(r) << 8)
+           | (static_cast<uint32_t>(g) << 16) | (static_cast<uint32_t>(b) << 24);
+}
+
+uint32_t pos(int x, int y)
+{
+    return static_cast<uint32_t>((y & 0xFFFF) << 16) | static_cast<uint32_t>(x & 0xFFFF);
+}
+
+} // namespace
+
+TEST(Gp0CapturePathsTest, DirectHookSubmitGp0MatchesLinearBaseline)
+{
+    const uint32_t words[] = {
+        colorCmd(0x20, 30, 20, 10),
+        pos(8, 16),
+        pos(40, 16),
+        pos(24, 32),
+    };
+
+    alignas(4) uint8_t ram[sizeof(words)];
+    std::memcpy(ram, words, sizeof(words));
+
+    std::atomic<bool> armed{true};
+    CaptureBuffer buffer;
+    RipperHooks hooks;
+    hooks.setArmedFlag(&armed);
+    hooks.setBuffer(&buffer);
+
+    const Gp0CaptureStats legacy =
+        Gp0HookDispatch::captureFromSystemRamLegacy(ram, sizeof(ram), &hooks);
+    ASSERT_GE(legacy.totalPrims, 1);
+
+    buffer.clear();
+    const int hookPrims = hooks.submitGp0Words(words, 4);
+    EXPECT_GE(hookPrims, 1);
+    EXPECT_EQ(buffer.prims().size(), legacy.totalPrims);
+}
+
+TEST(Gp0CapturePathsTest, MergedRamCaptureIncludesLinearWhenOtEmpty)
+{
+    const uint32_t words[] = {
+        colorCmd(0x20, 5, 6, 7),
+        pos(12, 20),
+        pos(44, 20),
+        pos(28, 36),
+    };
+
+    alignas(4) uint8_t ram[sizeof(words)];
+    std::memcpy(ram, words, sizeof(words));
+
+    std::atomic<bool> armed{true};
+    CaptureBuffer buffer;
+    RipperHooks hooks;
+    hooks.setArmedFlag(&armed);
+    hooks.setBuffer(&buffer);
+
+    QSet<QString> seen;
+    const Gp0CaptureStats merged =
+        Gp0HookDispatch::captureFromSystemRam(ram, sizeof(ram), &hooks, &seen);
+    EXPECT_GE(merged.totalPrims, 1);
+    EXPECT_GE(merged.ramLinearPrims, 1);
+
+    buffer.clear();
+    seen.clear();
+    const Gp0CaptureStats legacy =
+        Gp0HookDispatch::captureFromSystemRamLegacy(ram, sizeof(ram), &hooks);
+    EXPECT_GE(merged.totalPrims, legacy.totalPrims);
+}
+
+#endif // ENABLE_PS1_RIP

--- a/src/PS1/runtime/Gp0CaptureStats.cpp
+++ b/src/PS1/runtime/Gp0CaptureStats.cpp
@@ -1,0 +1,18 @@
+#include "Gp0CaptureStats.h"
+
+QString Gp0CaptureStats::primarySourceLabel() const
+{
+    switch (primarySource) {
+    case Gp0CaptureSource::DirectHook:
+        return QStringLiteral("gp0_hook");
+    case Gp0CaptureSource::RamOrderingTable:
+        return QStringLiteral("ram_ot");
+    case Gp0CaptureSource::RamLinear:
+        return QStringLiteral("ram_linear");
+    case Gp0CaptureSource::RamChainRoot:
+        return QStringLiteral("ram_chain_root");
+    case Gp0CaptureSource::None:
+    default:
+        return QStringLiteral("none");
+    }
+}

--- a/src/PS1/runtime/Gp0CaptureStats.h
+++ b/src/PS1/runtime/Gp0CaptureStats.h
@@ -1,0 +1,33 @@
+#ifndef GP0CAPTURESTATS_H
+#define GP0CAPTURESTATS_H
+
+#include <QString>
+
+/**
+ * How GP0 primitives reached the capture buffer (#657).
+ */
+enum class Gp0CaptureSource : uint8_t {
+    None = 0,
+    /** Core/plugin called EmuHooks::submitGp0Words (stub FIFO simulation). */
+    DirectHook,
+    /** Ordering-table chain walk from system RAM. */
+    RamOrderingTable,
+    /** Linear opcode scan fallback. */
+    RamLinear,
+    /** Standalone linked GP0 chain roots in RAM. */
+    RamChainRoot,
+};
+
+struct Gp0CaptureStats {
+    Gp0CaptureSource primarySource = Gp0CaptureSource::None;
+    int directHookPrims = 0;
+    int ramOtPrims = 0;
+    int ramLinearPrims = 0;
+    int ramChainRootPrims = 0;
+    int totalPrims = 0;
+    bool liveFrame = false;
+
+    QString primarySourceLabel() const;
+};
+
+#endif // GP0CAPTURESTATS_H

--- a/src/PS1/runtime/Gp0HookDispatch.cpp
+++ b/src/PS1/runtime/Gp0HookDispatch.cpp
@@ -1,7 +1,10 @@
 #include "Gp0HookDispatch.h"
 
+#include <QtGlobal>
+
 #include "EmuHooks.h"
 #include "PsxCaptureFilters.h"
+#include "PsxGp0ChainRootScanner.h"
 #include "PsxGp0Opcode.h"
 #include "PsxGteInstructionCapture.h"
 #include "PsxGteRamScanner.h"
@@ -46,7 +49,29 @@ void applyDrawMode(PrimRecord &prim, const DrawModeRecord &mode)
     }
 }
 
-QString primDedupeKey(const PrimRecord &prim)
+Gp0CaptureSource pickPrimarySource(const Gp0CaptureStats &stats)
+{
+    int best = 0;
+    Gp0CaptureSource source = Gp0CaptureSource::None;
+    if (stats.directHookPrims > best) {
+        best = stats.directHookPrims;
+        source = Gp0CaptureSource::DirectHook;
+    }
+    if (stats.ramOtPrims > best) {
+        best = stats.ramOtPrims;
+        source = Gp0CaptureSource::RamOrderingTable;
+    }
+    if (stats.ramChainRootPrims > best) {
+        best = stats.ramChainRootPrims;
+        source = Gp0CaptureSource::RamChainRoot;
+    }
+    if (stats.ramLinearPrims > best) {
+        source = Gp0CaptureSource::RamLinear;
+    }
+    return source;
+}
+
+QString primDedupeKeyImpl(const PrimRecord &prim)
 {
     QString key = QStringLiteral("%1|%2").arg(static_cast<int>(prim.kind)).arg(prim.vertexCount);
     for (int v = 0; v < 4; ++v)
@@ -60,6 +85,11 @@ QString primDedupeKey(const PrimRecord &prim)
 }
 
 } // namespace
+
+QString Gp0HookDispatch::primDedupeKey(const PrimRecord &prim)
+{
+    return primDedupeKeyImpl(prim);
+}
 
 void Gp0HookDispatch::dispatchStep(const GpuCommandParser::Gp0Step &step, EmuHooks *hooks,
                                    DrawModeRecord &currentMode, int &primCount)
@@ -94,8 +124,36 @@ void Gp0HookDispatch::dispatchStep(const GpuCommandParser::Gp0Step &step, EmuHoo
     ++primCount;
 }
 
+int Gp0HookDispatch::submitGp0Words(const uint32_t *words, size_t wordCount, EmuHooks *hooks)
+{
+    if (!words || wordCount < 4 || !hooks || !hooks->isCaptureEnabled())
+        return 0;
+
+    DrawModeRecord currentMode{};
+    int primCount = 0;
+    size_t offset = 0;
+    while (offset < wordCount) {
+        if (primCount >= kMaxPrimsPerFrame)
+            break;
+
+        const size_t remaining = wordCount - offset;
+        const GpuCommandParser::Gp0Step step = GpuCommandParser::stepGp0(words + offset, remaining);
+        if (step.wordsConsumed == 0)
+            break;
+        if (!step.error.isEmpty()) {
+            offset += 1;
+            continue;
+        }
+
+        dispatchStep(step, hooks, currentMode, primCount);
+        offset += step.wordsConsumed;
+    }
+    return primCount;
+}
+
 void Gp0HookDispatch::captureLinearScan(const uint8_t *ram, size_t byteSize, EmuHooks *hooks,
-                                      QSet<QString> &seen, DrawModeRecord &currentMode, int &primCount)
+                                          QSet<QString> &seen, DrawModeRecord &currentMode,
+                                          int &primCount)
 {
     if (!ram || byteSize < 16 || !hooks)
         return;
@@ -138,7 +196,7 @@ void Gp0HookDispatch::captureLinearScan(const uint8_t *ram, size_t byteSize, Emu
             if (matrixId != UINT32_MAX)
                 prim.matrixId = matrixId;
 
-            const QString key = primDedupeKey(prim);
+            const QString key = primDedupeKeyImpl(prim);
             if (seen.contains(key)) {
                 offset += step.wordsConsumed;
                 continue;
@@ -151,20 +209,61 @@ void Gp0HookDispatch::captureLinearScan(const uint8_t *ram, size_t byteSize, Emu
     }
 }
 
-void Gp0HookDispatch::captureFromSystemRam(const uint8_t *ram, size_t byteSize, EmuHooks *hooks)
+Gp0CaptureStats Gp0HookDispatch::captureFromSystemRam(const uint8_t *ram, size_t byteSize,
+                                                      EmuHooks *hooks, QSet<QString> *seenPrimKeys)
 {
+    Gp0CaptureStats stats;
     if (!ram || byteSize < 16 || !hooks || !hooks->isCaptureEnabled())
-        return;
+        return stats;
+
+    QSet<QString> localSeen;
+    QSet<QString> &seen = seenPrimKeys ? *seenPrimKeys : localSeen;
+    DrawModeRecord currentMode{};
+    int primCount = hooks->capturePrimCount();
+
+    const int otBefore = primCount;
+    PsxOrderingTableScanner::captureFromOrderingTables(ram, byteSize, hooks, &seen, primCount);
+    stats.ramOtPrims = primCount - otBefore;
+
+    stats.ramChainRootPrims =
+        PsxGp0ChainRootScanner::captureFromChainRoots(ram, byteSize, hooks, &seen, primCount);
+
+    const int linearBefore = primCount;
+    captureLinearScan(ram, byteSize, hooks, seen, currentMode, primCount);
+    stats.ramLinearPrims = primCount - linearBefore;
+
+    stats.totalPrims = primCount;
+    stats.primarySource = pickPrimarySource(stats);
+    return stats;
+}
+
+Gp0CaptureStats Gp0HookDispatch::captureFromSystemRamLegacy(const uint8_t *ram, size_t byteSize,
+                                                            EmuHooks *hooks)
+{
+    Gp0CaptureStats stats;
+    if (!ram || byteSize < 16 || !hooks || !hooks->isCaptureEnabled())
+        return stats;
 
     QSet<QString> seen;
     DrawModeRecord currentMode{};
     int primCount = 0;
 
-    const int otPrims = PsxOrderingTableScanner::captureFromOrderingTables(ram, byteSize, hooks);
-    if (otPrims > 0)
-        return;
+    const int otBefore = primCount;
+    PsxOrderingTableScanner::captureFromOrderingTables(ram, byteSize, hooks, &seen, primCount);
+    stats.ramOtPrims = primCount - otBefore;
+    if (stats.ramOtPrims > 0) {
+        stats.totalPrims = primCount;
+        stats.primarySource = Gp0CaptureSource::RamOrderingTable;
+        return stats;
+    }
 
+    const int linearBefore = primCount;
     captureLinearScan(ram, byteSize, hooks, seen, currentMode, primCount);
+    stats.ramLinearPrims = primCount - linearBefore;
+    stats.totalPrims = primCount;
+    stats.primarySource =
+        stats.ramLinearPrims > 0 ? Gp0CaptureSource::RamLinear : Gp0CaptureSource::None;
+    return stats;
 }
 
 namespace {
@@ -178,20 +277,34 @@ size_t clampPs1RamSize(size_t byteSize)
 
 } // namespace
 
-void Gp0HookDispatch::captureFrameFromSystemRam(const uint8_t *ram, size_t byteSize,
-                                                EmuHooks *hooks, bool scanGteRam)
+Gp0CaptureStats Gp0HookDispatch::captureFrameFromSystemRam(const uint8_t *ram, size_t byteSize,
+                                                           EmuHooks *hooks, bool scanGteRam,
+                                                           bool accumulate)
 {
+    Gp0CaptureStats stats;
     if (!hooks || !hooks->isCaptureEnabled() || !ram || byteSize < 16)
-        return;
+        return stats;
 
     const size_t scanSize = clampPs1RamSize(byteSize);
+    stats.liveFrame = accumulate;
 
+    hooks->beginGpuCapturePass(accumulate);
     hooks->onFrameBegin();
     if (scanGteRam) {
         PsxGteInstructionCapture::captureFromSystemRam(ram, scanSize, hooks);
         PsxGteRamScanner::captureFromSystemRam(ram, scanSize, hooks);
     }
     ensureCaptureProjectionMatrix(hooks);
-    captureFromSystemRam(ram, scanSize, hooks);
+
+    QSet<QString> *seen = hooks->livePrimDedupeKeys();
+    if (qEnvironmentVariableIsSet("QTMESH_PS1_GP0_RAM_LEGACY")
+        && qEnvironmentVariableIntValue("QTMESH_PS1_GP0_RAM_LEGACY") != 0) {
+        stats = captureFromSystemRamLegacy(ram, scanSize, hooks);
+    } else {
+        stats = captureFromSystemRam(ram, scanSize, hooks, seen);
+    }
+
     hooks->onFrameEnd();
+    hooks->endGpuCapturePass(stats);
+    return stats;
 }

--- a/src/PS1/runtime/Gp0HookDispatch.cpp
+++ b/src/PS1/runtime/Gp0HookDispatch.cpp
@@ -286,7 +286,7 @@ Gp0CaptureStats Gp0HookDispatch::captureFrameFromSystemRam(const uint8_t *ram, s
         return stats;
 
     const size_t scanSize = clampPs1RamSize(byteSize);
-    stats.liveFrame = accumulate;
+    const bool liveFrame = accumulate;
 
     hooks->beginGpuCapturePass(accumulate);
     hooks->onFrameBegin();
@@ -303,6 +303,7 @@ Gp0CaptureStats Gp0HookDispatch::captureFrameFromSystemRam(const uint8_t *ram, s
     } else {
         stats = captureFromSystemRam(ram, scanSize, hooks, seen);
     }
+    stats.liveFrame = liveFrame;
 
     hooks->onFrameEnd();
     hooks->endGpuCapturePass(stats);

--- a/src/PS1/runtime/Gp0HookDispatch.h
+++ b/src/PS1/runtime/Gp0HookDispatch.h
@@ -1,9 +1,12 @@
 #ifndef GP0HOOKDISPATCH_H
 #define GP0HOOKDISPATCH_H
 
+#include "CaptureTypes.h"
 #include "GpuCommandParser.h"
+#include "Gp0CaptureStats.h"
 
 #include <QSet>
+#include <QString>
 
 #include <cstddef>
 #include <cstdint>
@@ -12,31 +15,45 @@ class EmuHooks;
 
 /**
  * GP0 opcode dispatch → EmuHooks (#418). Linked by emulator plugins so GP0 decode
- * stays on the plugin side of the GPL boundary.
+ * stays on the plugin side of the GPL boundary (#657 live + merged RAM paths).
  */
 class Gp0HookDispatch
 {
 public:
+    static QString primDedupeKey(const PrimRecord &prim);
+
     /** Dispatch one decoded GP0 step to @p hooks (primitives, draw mode, VRAM I/O). */
     static void dispatchStep(const GpuCommandParser::Gp0Step &step, EmuHooks *hooks,
                              DrawModeRecord &currentMode, int &primCount);
 
     /**
-     * OT-first capture from main RAM, then linear GP0 opcode scan as fallback (#418).
+     * Submit GP0 packets as the core would (#657 direct-hook path).
+     * @return primitives dispatched.
      */
-    static void captureFromSystemRam(const uint8_t *ram, size_t byteSize, EmuHooks *hooks);
+    static int submitGp0Words(const uint32_t *words, size_t wordCount, EmuHooks *hooks);
 
-    /** Fallback linear scan when no ordering table is found. */
+    /**
+     * Merged RAM capture: OT chains, standalone chain roots, then linear scan (#657).
+     */
+    static Gp0CaptureStats captureFromSystemRam(const uint8_t *ram, size_t byteSize,
+                                                EmuHooks *hooks, QSet<QString> *seenPrimKeys);
+
+    /** Legacy RAM-only baseline (OT then linear, no chain-root pass). */
+    static Gp0CaptureStats captureFromSystemRamLegacy(const uint8_t *ram, size_t byteSize,
+                                                    EmuHooks *hooks);
+
     static void captureLinearScan(const uint8_t *ram, size_t byteSize, EmuHooks *hooks,
                                   QSet<QString> &seenPrimKeys, DrawModeRecord &currentMode,
                                   int &primCount);
 
     /**
-     * Frame capture with optional GTE instruction + RAM scan (#418, #419).
+     * Frame capture with optional GTE instruction + RAM scan (#418, #419, #657).
      * @p scanGteRam When false, skips the 2 MiB matrix heuristic (use on per-frame ticks).
+     * @p accumulate When true, RipperHooks keeps prior primitives (live armed capture).
      */
-    static void captureFrameFromSystemRam(const uint8_t *ram, size_t byteSize, EmuHooks *hooks,
-                                          bool scanGteRam = true);
+    static Gp0CaptureStats captureFrameFromSystemRam(const uint8_t *ram, size_t byteSize,
+                                                     EmuHooks *hooks, bool scanGteRam = true,
+                                                     bool accumulate = false);
 };
 
 #endif // GP0HOOKDISPATCH_H

--- a/src/PS1/runtime/Gp0HookDispatch_test.cpp
+++ b/src/PS1/runtime/Gp0HookDispatch_test.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "PS1/runtime/CaptureBuffer.h"
+#include "PS1/runtime/Gp0CaptureStats.h"
 #include "PS1/runtime/Gp0HookDispatch.h"
 #include "PS1/runtime/RipperHooks.h"
 
@@ -46,8 +47,9 @@ TEST(Gp0HookDispatchTest, DisarmedCaptureDoesNotRecordPrimitives)
     EXPECT_TRUE(buffer.prims().isEmpty());
 
     armed.store(true, std::memory_order_release);
-    hooks.ingestSystemRamForGpuCapture(ram, sizeof(ram));
+    hooks.ingestSystemRamForGpuCapture(ram, sizeof(ram), true, false);
     EXPECT_GE(buffer.prims().size(), 1);
+    EXPECT_EQ(hooks.lastCaptureStats().primarySource, Gp0CaptureSource::RamLinear);
 }
 
 #endif // ENABLE_PS1_RIP

--- a/src/PS1/runtime/PS1RipWorker.cpp
+++ b/src/PS1/runtime/PS1RipWorker.cpp
@@ -188,11 +188,11 @@ void PS1RipWorker::runFrameTick()
 void PS1RipWorker::setCaptureArmed(bool armed)
 {
     m_captureArmed.store(armed, std::memory_order_release);
-    // Do not clear while emulation is running — runFrame capture may be writing the buffer.
-    if (!armed) {
-        m_captureBuffer->clear();
+    if (armed) {
         m_ripperHooks->resetLiveCaptureState();
-    } else if (!m_running) {
+        if (!m_running)
+            m_captureBuffer->clear();
+    } else {
         m_captureBuffer->clear();
         m_ripperHooks->resetLiveCaptureState();
     }

--- a/src/PS1/runtime/PS1RipWorker.cpp
+++ b/src/PS1/runtime/PS1RipWorker.cpp
@@ -189,10 +189,13 @@ void PS1RipWorker::setCaptureArmed(bool armed)
 {
     m_captureArmed.store(armed, std::memory_order_release);
     // Do not clear while emulation is running — runFrame capture may be writing the buffer.
-    if (!armed)
+    if (!armed) {
         m_captureBuffer->clear();
-    else if (!m_running)
+        m_ripperHooks->resetLiveCaptureState();
+    } else if (!m_running) {
         m_captureBuffer->clear();
+        m_ripperHooks->resetLiveCaptureState();
+    }
 }
 
 void PS1RipWorker::setJoypadButton(unsigned port, unsigned buttonId, bool pressed)
@@ -219,9 +222,9 @@ void PS1RipWorker::finalizeFrameCapture()
         return;
     }
 
-    m_captureBuffer->clear();
-    m_core->runFrame();
     m_core->syncCaptureMirrors();
+    if (m_captureBuffer->prims().isEmpty())
+        m_core->runFrame();
     m_core->ingestCaptureFrame();
 
     const QVector<PrimRecord> &prims = m_captureBuffer->prims();

--- a/src/PS1/runtime/PsxGp0ChainRootScanner.cpp
+++ b/src/PS1/runtime/PsxGp0ChainRootScanner.cpp
@@ -1,0 +1,135 @@
+#include "PsxGp0ChainRootScanner.h"
+
+#include <QtGlobal>
+
+#include "EmuHooks.h"
+#include "Gp0HookDispatch.h"
+#include "PsxGp0ChainWalker.h"
+#include "PsxGp0Opcode.h"
+
+#include <QSet>
+#include <QString>
+#include <QVector>
+
+#include <algorithm>
+#include <cstring>
+
+namespace {
+
+constexpr int kMaxPrimsPerFrame = 2048;
+constexpr int kMaxRootsToWalk = 48;
+constexpr int kMinChainPackets = 2;
+constexpr size_t kScanStrideBytes = 16;
+
+struct ChainRootCandidate {
+    uint32_t byteAddr = 0;
+    int packetEstimate = 0;
+};
+
+int estimateChainPackets(const uint8_t *ram, size_t byteSize, uint32_t startAddr)
+{
+    uint32_t addr = startAddr;
+    int packets = 0;
+    for (int guard = 0; guard < 64; ++guard) {
+        if (addr + 4 > byteSize || (addr % 4) != 0)
+            break;
+
+        uint32_t word = 0;
+        std::memcpy(&word, ram + addr, sizeof(word));
+        if (!psxLooksLikeGp0Opcode(word))
+            break;
+
+        const size_t remainingWords = (byteSize - addr) / 4;
+        const auto *words = reinterpret_cast<const uint32_t *>(ram + addr);
+        const GpuCommandParser::Gp0Step step =
+            GpuCommandParser::stepGp0(words, remainingWords);
+        if (step.wordsConsumed == 0 || !step.error.isEmpty())
+            break;
+
+        ++packets;
+        if ((word & 1u) == 0)
+            break;
+
+        const uint32_t nextAddr = psxGp0TagNextByteAddr(word);
+        if (nextAddr == addr || nextAddr + 4 > byteSize || (nextAddr % 4) != 0)
+            break;
+        addr = nextAddr;
+    }
+    return packets;
+}
+
+bool regionsOverlap(uint32_t aStart, int aPackets, uint32_t bStart, int bPackets)
+{
+    const uint32_t aEnd = aStart + static_cast<uint32_t>(aPackets) * 64u;
+    const uint32_t bEnd = bStart + static_cast<uint32_t>(bPackets) * 64u;
+    return !(aEnd <= bStart || bEnd <= aStart);
+}
+
+} // namespace
+
+int PsxGp0ChainRootScanner::captureFromChainRoots(const uint8_t *ram, size_t byteSize,
+                                                  EmuHooks *hooks, QSet<QString> *seenPrimKeys,
+                                                  int &primCount)
+{
+    if (!ram || byteSize < 64 || !hooks || !hooks->isCaptureEnabled() || !seenPrimKeys)
+        return 0;
+
+    if (qEnvironmentVariableIsSet("QTMESH_PS1_GP0_CHAIN_ROOT_SCAN")
+        && qEnvironmentVariableIntValue("QTMESH_PS1_GP0_CHAIN_ROOT_SCAN") == 0)
+        return 0;
+
+    QVector<ChainRootCandidate> candidates;
+    candidates.reserve(256);
+
+    const size_t scanLimit = byteSize > (512u * 1024u) ? (512u * 1024u) : byteSize;
+    for (size_t off = 0; off + 4 <= scanLimit; off += kScanStrideBytes) {
+        uint32_t word = 0;
+        std::memcpy(&word, ram + off, sizeof(word));
+        if ((word & 1u) == 0u)
+            continue;
+        if (!psxLooksLikeGp0Opcode(word))
+            continue;
+
+        const int packets = estimateChainPackets(ram, byteSize, static_cast<uint32_t>(off));
+        if (packets < kMinChainPackets)
+            continue;
+
+        candidates.append({static_cast<uint32_t>(off), packets});
+    }
+
+    if (candidates.isEmpty())
+        return 0;
+
+    std::sort(candidates.begin(), candidates.end(),
+              [](const ChainRootCandidate &a, const ChainRootCandidate &b) {
+                  return a.packetEstimate > b.packetEstimate;
+              });
+
+    DrawModeRecord currentMode{};
+    int before = primCount;
+    QVector<ChainRootCandidate> walked;
+
+    for (const ChainRootCandidate &root : candidates) {
+        if (primCount >= kMaxPrimsPerFrame || walked.size() >= kMaxRootsToWalk)
+            break;
+
+        bool overlaps = false;
+        for (const ChainRootCandidate &prior : walked) {
+            if (regionsOverlap(root.byteAddr, root.packetEstimate, prior.byteAddr,
+                               prior.packetEstimate)) {
+                overlaps = true;
+                break;
+            }
+        }
+        if (overlaps)
+            continue;
+
+        const PsxGp0ChainWalker::WalkResult result =
+            PsxGp0ChainWalker::walkChain(ram, byteSize, root.byteAddr, hooks, currentMode,
+                                         primCount, *seenPrimKeys);
+        if (result.packetsParsed > 0)
+            walked.append(root);
+    }
+
+    return primCount - before;
+}

--- a/src/PS1/runtime/PsxGp0ChainRootScanner.h
+++ b/src/PS1/runtime/PsxGp0ChainRootScanner.h
@@ -1,0 +1,22 @@
+#ifndef PSXGP0CHAINROOTSCANNER_H
+#define PSXGP0CHAINROOTSCANNER_H
+
+#include <QSet>
+
+#include <cstddef>
+#include <cstdint>
+
+class EmuHooks;
+
+/**
+ * Finds standalone linked GP0 packet chains in main RAM (#657).
+ * Complements ordering-table walks when OT heuristics miss retail layouts.
+ */
+class PsxGp0ChainRootScanner
+{
+public:
+    static int captureFromChainRoots(const uint8_t *ram, size_t byteSize, EmuHooks *hooks,
+                                     QSet<QString> *seenPrimKeys, int &primCount);
+};
+
+#endif // PSXGP0CHAINROOTSCANNER_H

--- a/src/PS1/runtime/PsxGp0ChainRootScanner.h
+++ b/src/PS1/runtime/PsxGp0ChainRootScanner.h
@@ -2,6 +2,7 @@
 #define PSXGP0CHAINROOTSCANNER_H
 
 #include <QSet>
+#include <QString>
 
 #include <cstddef>
 #include <cstdint>

--- a/src/PS1/runtime/PsxGpuRamScanner.cpp
+++ b/src/PS1/runtime/PsxGpuRamScanner.cpp
@@ -1,9 +1,12 @@
 #include "PsxGpuRamScanner.h"
 
 #include "Gp0HookDispatch.h"
+
+#include <QSet>
 #include "EmuHooks.h"
 
 void PsxGpuRamScanner::captureFromSystemRam(const uint8_t *ram, size_t byteSize, EmuHooks *hooks)
 {
-    Gp0HookDispatch::captureFromSystemRam(ram, byteSize, hooks);
+    QSet<QString> seen;
+    Gp0HookDispatch::captureFromSystemRam(ram, byteSize, hooks, &seen);
 }

--- a/src/PS1/runtime/PsxGteRamScanner_test.cpp
+++ b/src/PS1/runtime/PsxGteRamScanner_test.cpp
@@ -6,6 +6,8 @@
 #include "PS1/runtime/PsxGteRamScanner.h"
 #include "PS1/runtime/RipperHooks.h"
 
+#include <QSet>
+
 #include <atomic>
 #include <cstring>
 
@@ -82,7 +84,8 @@ TEST(PsxGteRamScannerTest, SyntheticGteRamLayoutDedupesMatricesAndTagsPrims)
 
     hooks.onFrameBegin();
     PsxGteRamScanner::captureFromSystemRam(ram, kGpuPacket, &hooks);
-    Gp0HookDispatch::captureFromSystemRam(ram + kGpuPacket, sizeof(ram) - kGpuPacket, &hooks);
+    QSet<QString> seen;
+    Gp0HookDispatch::captureFromSystemRam(ram + kGpuPacket, sizeof(ram) - kGpuPacket, &hooks, &seen);
     hooks.onFrameEnd();
 
     ASSERT_EQ(buffer.matrices().size(), 2);
@@ -120,7 +123,8 @@ TEST(PsxGteRamScannerTest, GteScanRunsBeforeGpuFallbackMatrix)
 
     hooks.onFrameBegin();
     PsxGteRamScanner::captureFromSystemRam(ram, kGpuOffset, &hooks);
-    Gp0HookDispatch::captureFromSystemRam(ram + kGpuOffset, sizeof(ram) - kGpuOffset, &hooks);
+    QSet<QString> seen2;
+    Gp0HookDispatch::captureFromSystemRam(ram + kGpuOffset, sizeof(ram) - kGpuOffset, &hooks, &seen2);
     hooks.onFrameEnd();
 
     ASSERT_EQ(buffer.matrices().size(), 1u);

--- a/src/PS1/runtime/PsxOrderingTableScanner.cpp
+++ b/src/PS1/runtime/PsxOrderingTableScanner.cpp
@@ -123,18 +123,18 @@ QVector<OtCandidate> findOrderingTableCandidates(const uint8_t *ram, size_t byte
 } // namespace
 
 int PsxOrderingTableScanner::captureFromOrderingTables(const uint8_t *ram, size_t byteSize,
-                                                       EmuHooks *hooks)
+                                                       EmuHooks *hooks, QSet<QString> *seenPrimKeys,
+                                                       int &primCount)
 {
-    if (!ram || byteSize < 256 || !hooks || !hooks->isCaptureEnabled())
+    if (!ram || byteSize < 256 || !hooks || !hooks->isCaptureEnabled() || !seenPrimKeys)
         return 0;
 
     const QVector<OtCandidate> tables = findOrderingTableCandidates(ram, byteSize);
     if (tables.isEmpty())
         return 0;
 
-    QSet<QString> seenPrimKeys;
+    const int before = primCount;
     DrawModeRecord currentMode{};
-    int primCount = 0;
     int chainsWalked = 0;
 
     for (const OtCandidate &table : tables) {
@@ -149,12 +149,12 @@ int PsxOrderingTableScanner::captureFromOrderingTables(const uint8_t *ram, size_
             if (chainAddr == UINT32_MAX)
                 continue;
             const PsxGp0ChainWalker::WalkResult walked =
-                PsxGp0ChainWalker::walkChain(ram, byteSize, chainAddr, hooks, currentMode,
-                                             primCount, seenPrimKeys);
+                PsxGp0ChainWalker::walkChain(ram, byteSize, chainAddr, hooks, currentMode, primCount,
+                                             *seenPrimKeys);
             if (walked.packetsParsed > 0)
                 ++chainsWalked;
         }
     }
 
-    return primCount;
+    return primCount - before;
 }

--- a/src/PS1/runtime/PsxOrderingTableScanner.h
+++ b/src/PS1/runtime/PsxOrderingTableScanner.h
@@ -1,6 +1,8 @@
 #ifndef PSXORDERINGTABLESCANNER_H
 #define PSXORDERINGTABLESCANNER_H
 
+#include <QSet>
+
 #include <cstddef>
 #include <cstdint>
 
@@ -13,8 +15,9 @@ class EmuHooks;
 class PsxOrderingTableScanner
 {
 public:
-    /** Returns number of primitives dispatched from OT chains. */
-    static int captureFromOrderingTables(const uint8_t *ram, size_t byteSize, EmuHooks *hooks);
+    /** Appends primitives from OT chains; returns count added this pass. */
+    static int captureFromOrderingTables(const uint8_t *ram, size_t byteSize, EmuHooks *hooks,
+                                       QSet<QString> *seenPrimKeys, int &primCount);
 };
 
 #endif // PSXORDERINGTABLESCANNER_H

--- a/src/PS1/runtime/PsxOrderingTableScanner_test.cpp
+++ b/src/PS1/runtime/PsxOrderingTableScanner_test.cpp
@@ -8,6 +8,8 @@
 #include "PS1/runtime/PsxOrderingTableScanner.h"
 #include "PS1/runtime/RipperHooks.h"
 
+#include <QSet>
+
 #include <atomic>
 #include <cstring>
 
@@ -68,7 +70,10 @@ TEST(PsxOrderingTableScannerTest, CapturesPrimitivesFromSyntheticOrderingTable)
     hooks.setArmedFlag(&armed);
     hooks.setBuffer(&buffer);
 
-    const int prims = PsxOrderingTableScanner::captureFromOrderingTables(ram, sizeof(ram), &hooks);
+    QSet<QString> seen;
+    int primCount = 0;
+    const int prims =
+        PsxOrderingTableScanner::captureFromOrderingTables(ram, sizeof(ram), &hooks, &seen, primCount);
     EXPECT_GE(prims, 2);
     EXPECT_GE(buffer.prims().size(), 2);
 
@@ -119,7 +124,10 @@ TEST(PsxOrderingTableScannerTest, LinkedChainCapture)
     hooks.setArmedFlag(&armed);
     hooks.setBuffer(&buffer);
 
-    const int prims = PsxOrderingTableScanner::captureFromOrderingTables(ram, sizeof(ram), &hooks);
+    QSet<QString> seen;
+    int primCount = 0;
+    const int prims =
+        PsxOrderingTableScanner::captureFromOrderingTables(ram, sizeof(ram), &hooks, &seen, primCount);
     EXPECT_GE(prims, 2);
 }
 
@@ -147,7 +155,10 @@ TEST(PsxOrderingTableScannerTest, AbsoluteOtEntryPointers)
     hooks.setArmedFlag(&armed);
     hooks.setBuffer(&buffer);
 
-    const int prims = PsxOrderingTableScanner::captureFromOrderingTables(ram, sizeof(ram), &hooks);
+    QSet<QString> seen;
+    int primCount = 0;
+    const int prims =
+        PsxOrderingTableScanner::captureFromOrderingTables(ram, sizeof(ram), &hooks, &seen, primCount);
     EXPECT_GE(prims, 1);
     ASSERT_GE(buffer.prims().size(), 1);
     EXPECT_EQ(buffer.prims()[0].kind, PrimKind::MonoTri);

--- a/src/PS1/runtime/RipperHooks.cpp
+++ b/src/PS1/runtime/RipperHooks.cpp
@@ -1,10 +1,68 @@
 #include "RipperHooks.h"
+
 #include "Gp0HookDispatch.h"
+#include "SentryReporter.h"
 #include "VramSnapshot.h"
+
+#include <QString>
+
+void RipperHooks::resetLiveCaptureState()
+{
+    m_liveDedupe.clear();
+    m_directHookPrimPass = 0;
+}
 
 bool RipperHooks::isCaptureEnabled() const
 {
     return m_armed && m_armed->load(std::memory_order_acquire);
+}
+
+void RipperHooks::beginGpuCapturePass(bool accumulate)
+{
+    m_accumulatePass = accumulate && isCaptureEnabled();
+    m_clearPrimsOnFrameBegin = !m_accumulatePass;
+    m_ramCaptureActive = true;
+    m_directHookPrimPass = 0;
+}
+
+void RipperHooks::endGpuCapturePass(Gp0CaptureStats &stats)
+{
+    stats.directHookPrims = m_directHookPrimPass;
+    stats.totalPrims = capturePrimCount();
+    if (stats.directHookPrims > 0
+        && stats.directHookPrims
+               >= stats.ramOtPrims + stats.ramLinearPrims + stats.ramChainRootPrims)
+        stats.primarySource = Gp0CaptureSource::DirectHook;
+    m_lastStats = stats;
+    m_ramCaptureActive = false;
+    if (!isCaptureEnabled())
+        return;
+
+    SentryReporter::addBreadcrumb(
+        QStringLiteral("ps1.rip.capture.gp0_hook"),
+        QStringLiteral("source:%1 total:%2 hook:%3 ot:%4 linear:%5 chain:%6 live:%7")
+            .arg(stats.primarySourceLabel())
+            .arg(stats.totalPrims)
+            .arg(stats.directHookPrims)
+            .arg(stats.ramOtPrims)
+            .arg(stats.ramLinearPrims)
+            .arg(stats.ramChainRootPrims)
+            .arg(stats.liveFrame ? QStringLiteral("yes") : QStringLiteral("no")));
+}
+
+int RipperHooks::capturePrimCount() const
+{
+    return m_buffer ? m_buffer->prims().size() : 0;
+}
+
+int RipperHooks::lastDirectHookPrimCount() const
+{
+    return m_directHookPrimPass;
+}
+
+QSet<QString> *RipperHooks::livePrimDedupeKeys()
+{
+    return m_accumulatePass ? &m_liveDedupe : nullptr;
 }
 
 void RipperHooks::onFrameBegin()
@@ -12,14 +70,16 @@ void RipperHooks::onFrameBegin()
     if (!isCaptureEnabled() || !m_buffer)
         return;
     m_latestMatrixId = UINT32_MAX;
-    m_buffer->beginFrame();
+    if (m_clearPrimsOnFrameBegin)
+        m_buffer->beginFrame();
 }
 
 void RipperHooks::onFrameEnd()
 {
     if (!isCaptureEnabled() || !m_buffer)
         return;
-    m_buffer->endFrame();
+    if (!m_accumulatePass)
+        m_buffer->endFrame();
 }
 
 uint32_t RipperHooks::onGteMatrix(const MatrixRecord &matrix)
@@ -30,10 +90,26 @@ uint32_t RipperHooks::onGteMatrix(const MatrixRecord &matrix)
     return m_latestMatrixId;
 }
 
+QString RipperHooks::primDedupeKey(const PrimRecord &prim) const
+{
+    return Gp0HookDispatch::primDedupeKey(prim);
+}
+
 void RipperHooks::onGpuPrim(const PrimRecord &prim)
 {
     if (!isCaptureEnabled() || !m_buffer)
         return;
+
+    if (!m_ramCaptureActive)
+        ++m_directHookPrimPass;
+
+    if (m_accumulatePass) {
+        const QString key = primDedupeKey(prim);
+        if (m_liveDedupe.contains(key))
+            return;
+        m_liveDedupe.insert(key);
+    }
+
     m_buffer->addPrim(prim);
 }
 
@@ -48,7 +124,6 @@ void RipperHooks::onVramRead(uint16_t x, uint16_t y, uint16_t w, uint16_t h)
 {
     if (!m_vram || w == 0 || h == 0)
         return;
-    // GP0 0xC0 read-back hook (#418): record that VRAM was sampled (no CPU FIFO replay).
     (void)x;
     (void)y;
 }
@@ -65,7 +140,15 @@ uint32_t RipperHooks::latestMatrixId() const
     return m_latestMatrixId;
 }
 
-void RipperHooks::ingestSystemRamForGpuCapture(const uint8_t *ram, size_t byteSize)
+void RipperHooks::ingestSystemRamForGpuCapture(const uint8_t *ram, size_t byteSize, bool scanGteRam,
+                                               bool accumulate)
 {
-    Gp0HookDispatch::captureFrameFromSystemRam(ram, byteSize, this);
+    Gp0HookDispatch::captureFrameFromSystemRam(ram, byteSize, this, scanGteRam, accumulate);
+}
+
+int RipperHooks::submitGp0Words(const uint32_t *words, size_t wordCount)
+{
+    if (!isCaptureEnabled())
+        return 0;
+    return Gp0HookDispatch::submitGp0Words(words, wordCount, this);
 }

--- a/src/PS1/runtime/RipperHooks.h
+++ b/src/PS1/runtime/RipperHooks.h
@@ -3,6 +3,7 @@
 
 #include "CaptureBuffer.h"
 #include "EmuHooks.h"
+#include "Gp0CaptureStats.h"
 
 #include <atomic>
 #include <cstdint>
@@ -10,7 +11,7 @@
 class VramSnapshot;
 
 /**
- * Concrete EmuHooks that records into CaptureBuffer when capture is armed (#418).
+ * Concrete EmuHooks that records into CaptureBuffer when capture is armed (#418, #657).
  */
 class RipperHooks final : public EmuHooks
 {
@@ -21,7 +22,20 @@ public:
 
     bool isCaptureEnabled() const override;
     uint32_t latestMatrixId() const override;
-    void ingestSystemRamForGpuCapture(const uint8_t *ram, size_t byteSize) override;
+
+    void ingestSystemRamForGpuCapture(const uint8_t *ram, size_t byteSize, bool scanGteRam = true,
+                                      bool accumulate = false) override;
+    int submitGp0Words(const uint32_t *words, size_t wordCount) override;
+
+    QSet<QString> *livePrimDedupeKeys() override;
+    void beginGpuCapturePass(bool accumulate) override;
+    void endGpuCapturePass(Gp0CaptureStats &stats) override;
+    int capturePrimCount() const override;
+    int lastDirectHookPrimCount() const override;
+
+    void resetLiveCaptureState();
+
+    const Gp0CaptureStats &lastCaptureStats() const { return m_lastStats; }
 
     void onFrameBegin() override;
     void onFrameEnd() override;
@@ -34,10 +48,18 @@ public:
     void onDrawMode(const DrawModeRecord &mode) override;
 
 private:
+    QString primDedupeKey(const PrimRecord &prim) const;
+
     std::atomic<bool> *m_armed = nullptr;
     CaptureBuffer *m_buffer = nullptr;
     VramSnapshot *m_vram = nullptr;
     uint32_t m_latestMatrixId = UINT32_MAX;
+    bool m_accumulatePass = false;
+    bool m_clearPrimsOnFrameBegin = true;
+    bool m_ramCaptureActive = false;
+    QSet<QString> m_liveDedupe;
+    int m_directHookPrimPass = 0;
+    Gp0CaptureStats m_lastStats;
 };
 
 #endif // RIPPERHOOKS_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -144,7 +144,9 @@ if(BUILD_TESTS)
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/EmuCoreLoader.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/GteInverse.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/EmuViewport.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/Gp0CaptureStats.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/Gp0HookDispatch.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PsxGp0ChainRootScanner.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PsxGp0ChainWalker.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PsxOrderingTableScanner.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/GpuCommandParser.cpp


### PR DESCRIPTION
## Summary
- Add live per-frame GP0 capture on libretro while capture is armed: each `retro_run()` end ingests OT + standalone chain roots + linear RAM with cross-frame dedupe, then **Capture Frame** merges GTE scan without clearing the live buffer.
- Introduce `EmuHooks::submitGp0Words` direct-hook path (stub/CI), `Gp0CaptureStats`, and Sentry breadcrumb `ps1.rip.capture.gp0_hook` with per-path counts (`gp0_hook`, `ram_ot`, `ram_linear`, `ram_chain_root`).
- Merged RAM capture replaces OT-only early return; legacy baseline available via `QTMESH_PS1_GP0_RAM_LEGACY=1`. Document hook availability per core in `PS1_RIP_DESIGN.md`.

Closes #657.

## Test plan
- [x] `Gp0CapturePathsTest` — direct hook vs legacy RAM baseline; merged vs legacy on linear fixture
- [x] Existing CI: `Gp0HookDispatchTest`, `PsxOrderingTableScannerTest`, `PsxGteRamScannerTest`, stub seven-flavor capture
- [ ] CI `unit-tests-linux` green
- [ ] Manual: arm capture on libretro session, play a few seconds, Capture Frame — status shows non-zero prims; Sentry breadcrumb includes capture source


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced GPU capture with improved primitive deduplication across frames
  * Added live per-frame GPU capture mode with accumulation support
  * Implemented chain root scanning for GPU command extraction from memory

* **Documentation**
  * Updated capture behavior documentation with revised extraction strategies and troubleshooting guidance

* **Tests**
  * Added comprehensive GPU capture path verification tests
  * Enhanced existing capture tests with statistics tracking

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/661?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->