### PR TITLE
feat(ps1): per-draw GTE matrix at GP0 submit (#658)

### DIFF
--- a/src/PS1/CMakeLists.txt
+++ b/src/PS1/CMakeLists.txt
@@ -37,6 +37,7 @@ if(ENABLE_PS1_RIP)
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxGteEngine.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxGteInstructionCapture.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxMipsGteRunner.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/MeshReconstructionStats.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/MeshReconstructor.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/MeshTopologyHash.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipMeshBuilder.cpp
@@ -63,6 +64,7 @@ if(ENABLE_PS1_RIP)
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/CaptureSnapshot.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/CaptureTypes.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/GteInverse.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/MeshReconstructionStats.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/MeshReconstructor.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/MeshTopologyHash.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipMeshBuilder.h

--- a/src/PS1/PS1_RIP_DESIGN.md
+++ b/src/PS1/PS1_RIP_DESIGN.md
@@ -74,7 +74,7 @@ See epic #412 for phased issues (#413–#431).
   - **Libretro live frame (`ram_*`):** While capture is armed, each `retro_run()` end triggers a lightweight RAM ingest (OT + standalone chain roots + linear, no GTE scan). Primitives accumulate with cross-frame dedupe until **Capture Frame** runs a final GTE+RAM merge. Disable live ingest with `QTMESH_PS1_GP0_LIVE_CAPTURE=0`. Baseline RAM-only behavior (OT then linear, no chain-root pass) via `QTMESH_PS1_GP0_RAM_LEGACY=1`.
   - **Merged RAM scan:** `PsxOrderingTableScanner` → `PsxGp0ChainRootScanner` → linear fallback share one dedupe set (no early return after a weak OT). OT entries use **24-bit absolute RAM pointers** (libgpu `getaddr` layout), with a relative-to-OT-base fallback for synthetic tests. Linked DR tags carry the opcode in bits 24–31 and the next packet address in bits 2–23 (`PsxGp0Opcode.h`).
 - **Stub core** (`coreId=stub`): direct `onGpuPrim` hook path for CI when `QTMESH_PS1_FORCE_STUB=1` or no libretro core is present.
-- **Libretro core** (`coreId=libretro`): live merged RAM capture at frame boundary; true mednafen GP0 FIFO dispatch hooks remain future work when the core exposes them.
+- **Libretro core** (`coreId=libretro`): live merged RAM capture at frame boundary; true mednafen GP0 FIFO dispatch hooks remain future work ([#662](https://github.com/fernandotonon/QtMeshEditor/issues/662)).
 - `armCapture` / `captureFrame` wire capture to the worker thread; CSV dump to temp for verification.
 - Sentry breadcrumb `ps1.rip.capture.frame_armed` via `ui.action`.
 - Tests: synthetic OT/homebrew RAM layout, seven-flavor CSV round-trip, disarmed capture &lt;1% `runFrame` overhead (stub + optional libretro integration).
@@ -98,6 +98,24 @@ See epic #412 for phased issues (#413–#431).
 - `PS1RipMeshBuilder::attachCaptureSetToScene` places one `PS1Capture_<id>_instN` SceneNode per instance at the captured world position.
 - Session toolbar **Strict dedupe** toggle (persisted in QSettings); status shows captured / unique / instance counts.
 - Sentry breadcrumbs `ps1.rip.mesh.built` and `ps1.rip.dedupe.summary`.
+
+## Per-draw matrix (#658)
+
+- **`RipperHooks::submitMatrixId`** — frozen when a GP0 drawing-environment command (`0xE1`–`0xE6`) is processed via `onDrawMode`; primitives submitted before the next draw env keep the prior matrix even if `onGteMatrix` updated `latestMatrixId`.
+- **`Gp0HookDispatch`** threads `currentMatrixId` through OT/chain/linear scans and `submitGp0Words`; `matrixIdForGpuSubmit` prefers chain-local id, then submit id, then latest.
+- **`0xE4` drawing offset** — parsed in `GpuCommandParser`; `onDrawingOffset` clones the active submit matrix with updated OFX/OFY (fixed-point `x<<16`, `y<<16`).
+- **`MeshReconstructionStats`** — counts GTE inverse vs `psxScreenToWorld` fallback vertices, bounds extent, and a `slabLike` heuristic (min/max axis ratio &lt; 0.12). Session status bar shows **GTE inverse %** and a slab warning; Sentry `ps1.rip.matrix.stats`.
+
+### Limitations (#658)
+
+- **RAM ingest ordering** — OT/chain walks start with `currentMatrixId = UINT32_MAX`; matrix association depends on draw-env packets appearing *before* primitives in the scanned buffer (typical for linked lists, not guaranteed for all titles).
+- **Shared matrix across OT** — one `currentMatrixId` per chain walk; dual-pass / multi-buffer games may still share a matrix across unrelated draws.
+- **GTE RAM supplement** — Capture Frame still merges COP2-scanned matrices; per-draw tagging applies at GP0 dispatch time, not retroactively to RAM-only captures without draw-env context.
+- **Commercial golden scenes** — manual acceptance tracked in #659; #658 reduces blob fallback but does not replace a full matrix stack or FIFO-accurate stream (#662).
+
+## GP0 FIFO follow-up (#662)
+
+Post-#657 / #661 work: true mednafen GP0 FIFO dispatch (packet-for-packet as the core submits), stub routing through `submitGp0Words`, session UI for capture-source breakdown, and golden-scene validation vs `QTMESH_PS1_GP0_RAM_LEGACY=1`. See [issue #662](https://github.com/fernandotonon/QtMeshEditor/issues/662).
 
 ## Troubleshooting
 
@@ -126,7 +144,7 @@ The **stub** core is active (`coreId=stub`). It draws a test pattern and synthet
 
 ### Capture mesh is a triangle “blob” (normal size, wrong shape)
 
-Capture uses **live per-frame merged RAM ingest** while armed (libretro), then a final GTE+RAM pass on **Capture Frame**. RAM strategies: ordering-table chains, standalone linked GP0 chain roots, and linear opcode scan. Expect coarse geometry on titles that stream primitives outside RAM-visible layouts. Filters drop off-screen coordinates and cap at 2048 primitives per ingest pass. True in-core mednafen FIFO dispatch (packet-for-packet as the GPU receives them) is not wired yet — see issue #657 follow-up when beetle/mednafen exposes hooks.
+Capture uses **live per-frame merged RAM ingest** while armed (libretro), then a final GTE+RAM pass on **Capture Frame**. RAM strategies: ordering-table chains, standalone linked GP0 chain roots, and linear opcode scan. Expect coarse geometry on titles that stream primitives outside RAM-visible layouts. Filters drop off-screen coordinates and cap at 2048 primitives per ingest pass. Per-draw matrix tagging (#658) reduces screen-space blob fallback when draw-environment packets precede primitives in the captured buffer. True in-core mednafen GP0 FIFO dispatch (packet-for-packet as the GPU receives them) is not wired yet — see [#662](https://github.com/fernandotonon/QtMeshEditor/issues/662).
 
 ### Libretro integration tests (local only)
 
@@ -142,7 +160,7 @@ export QTMESH_PS1_TEST_ISO=/path/game.cue
 
 `PS1RipManagerLibretroArmTest` (arm/capture while a real libretro session runs) uses the same guard and env vars.
 
-**GTE / matrix tests (CI):** `PsxGteCop2Test`, `PsxGteIsoDedupeTest.StaticSceneCop2ProgramDedupesThreeDrawables`, `MeshReconstructorTest.GtePipelineCubeRoundTripsToUnitCubeMesh`. Real-ISO matrix dedupe: set `QTMESH_PS1_TEST_BIOS` + `QTMESH_PS1_TEST_ISO` (or `QTMESH_PS1_TEST_HOMEBREW_ISO`) and run `PsxGteIsoDedupeTest.RealIsoCaptureHasBoundedMatrixCount`.
+**GTE / matrix tests (CI):** `PsxGteCop2Test`, `PsxGteIsoDedupeTest.StaticSceneCop2ProgramDedupesThreeDrawables`, `MeshReconstructorTest.GtePipelineCubeRoundTripsToUnitCubeMesh`, `PsxPerDrawMatrixTest` (draw-env matrix freeze, E4 offset, reconstruction stats). Real-ISO matrix dedupe: set `QTMESH_PS1_TEST_BIOS` + `QTMESH_PS1_TEST_ISO` (or `QTMESH_PS1_TEST_HOMEBREW_ISO`) and run `PsxGteIsoDedupeTest.RealIsoCaptureHasBoundedMatrixCount`.
 
 ## Open questions
 

--- a/src/PS1/runtime/EmuHooks.h
+++ b/src/PS1/runtime/EmuHooks.h
@@ -22,6 +22,9 @@ public:
     virtual bool isCaptureEnabled() const { return false; }
     virtual uint32_t latestMatrixId() const { return UINT32_MAX; }
 
+    /** Matrix bound at the last drawing-environment command (#658). */
+    virtual uint32_t submitMatrixId() const { return UINT32_MAX; }
+
     virtual void onFrameBegin() {}
     virtual void onFrameEnd() {}
 
@@ -37,6 +40,13 @@ public:
     }
     virtual void onVramRead(uint16_t x, uint16_t y, uint16_t w, uint16_t h) { (void)x; (void)y; (void)w; (void)h; }
     virtual void onDrawMode(const DrawModeRecord &mode) { (void)mode; }
+
+    /** GP0 0xE4 drawing offset — updates the active submit matrix OFX/OFY (#658). */
+    virtual void onDrawingOffset(int32_t ofx, int32_t ofy)
+    {
+        (void)ofx;
+        (void)ofy;
+    }
 
     /** Core GP0 FIFO path (#657): sequential GP0 packets as submitted by the plugin. */
     virtual int submitGp0Words(const uint32_t *words, size_t wordCount)

--- a/src/PS1/runtime/Gp0HookDispatch.cpp
+++ b/src/PS1/runtime/Gp0HookDispatch.cpp
@@ -91,8 +91,19 @@ QString Gp0HookDispatch::primDedupeKey(const PrimRecord &prim)
     return primDedupeKeyImpl(prim);
 }
 
+uint32_t matrixIdForGpuSubmit(EmuHooks *hooks, uint32_t currentMatrixId)
+{
+    if (currentMatrixId != UINT32_MAX)
+        return currentMatrixId;
+    const uint32_t submit = hooks->submitMatrixId();
+    if (submit != UINT32_MAX)
+        return submit;
+    return hooks->latestMatrixId();
+}
+
 void Gp0HookDispatch::dispatchStep(const GpuCommandParser::Gp0Step &step, EmuHooks *hooks,
-                                   DrawModeRecord &currentMode, int &primCount)
+                                   DrawModeRecord &currentMode, uint32_t &currentMatrixId,
+                                   int &primCount)
 {
     if (!hooks || !hooks->isCaptureEnabled())
         return;
@@ -100,7 +111,11 @@ void Gp0HookDispatch::dispatchStep(const GpuCommandParser::Gp0Step &step, EmuHoo
     if (step.hasDrawMode) {
         currentMode = step.drawMode;
         hooks->onDrawMode(currentMode);
+        currentMatrixId = hooks->submitMatrixId();
     }
+
+    if (step.hasDrawingOffset)
+        hooks->onDrawingOffset(step.drawingOfx, step.drawingOfy);
 
     if (step.hasVramWrite && step.vramPixels)
         hooks->onVramWrite(step.vramX, step.vramY, step.vramW, step.vramH, step.vramPixels);
@@ -116,7 +131,7 @@ void Gp0HookDispatch::dispatchStep(const GpuCommandParser::Gp0Step &step, EmuHoo
         return;
 
     applyDrawMode(prim, currentMode);
-    const uint32_t matrixId = hooks->latestMatrixId();
+    const uint32_t matrixId = matrixIdForGpuSubmit(hooks, currentMatrixId);
     if (matrixId != UINT32_MAX)
         prim.matrixId = matrixId;
 
@@ -130,6 +145,7 @@ int Gp0HookDispatch::submitGp0Words(const uint32_t *words, size_t wordCount, Emu
         return 0;
 
     DrawModeRecord currentMode{};
+    uint32_t currentMatrixId = UINT32_MAX;
     int primCount = 0;
     size_t offset = 0;
     while (offset < wordCount) {
@@ -145,15 +161,15 @@ int Gp0HookDispatch::submitGp0Words(const uint32_t *words, size_t wordCount, Emu
             continue;
         }
 
-        dispatchStep(step, hooks, currentMode, primCount);
+        dispatchStep(step, hooks, currentMode, currentMatrixId, primCount);
         offset += step.wordsConsumed;
     }
     return primCount;
 }
 
 void Gp0HookDispatch::captureLinearScan(const uint8_t *ram, size_t byteSize, EmuHooks *hooks,
-                                          QSet<QString> &seen, DrawModeRecord &currentMode,
-                                          int &primCount)
+                                        QSet<QString> &seen, DrawModeRecord &currentMode,
+                                        uint32_t &currentMatrixId, int &primCount)
 {
     if (!ram || byteSize < 16 || !hooks)
         return;
@@ -192,7 +208,7 @@ void Gp0HookDispatch::captureLinearScan(const uint8_t *ram, size_t byteSize, Emu
             }
 
             applyDrawMode(prim, currentMode);
-            const uint32_t matrixId = hooks->latestMatrixId();
+            const uint32_t matrixId = matrixIdForGpuSubmit(hooks, currentMatrixId);
             if (matrixId != UINT32_MAX)
                 prim.matrixId = matrixId;
 
@@ -204,7 +220,7 @@ void Gp0HookDispatch::captureLinearScan(const uint8_t *ram, size_t byteSize, Emu
             seen.insert(key);
         }
 
-        dispatchStep(step, hooks, currentMode, primCount);
+        dispatchStep(step, hooks, currentMode, currentMatrixId, primCount);
         offset += step.wordsConsumed;
     }
 }
@@ -219,6 +235,7 @@ Gp0CaptureStats Gp0HookDispatch::captureFromSystemRam(const uint8_t *ram, size_t
     QSet<QString> localSeen;
     QSet<QString> &seen = seenPrimKeys ? *seenPrimKeys : localSeen;
     DrawModeRecord currentMode{};
+    uint32_t currentMatrixId = UINT32_MAX;
     int primCount = hooks->capturePrimCount();
 
     const int otBefore = primCount;
@@ -229,7 +246,7 @@ Gp0CaptureStats Gp0HookDispatch::captureFromSystemRam(const uint8_t *ram, size_t
         PsxGp0ChainRootScanner::captureFromChainRoots(ram, byteSize, hooks, &seen, primCount);
 
     const int linearBefore = primCount;
-    captureLinearScan(ram, byteSize, hooks, seen, currentMode, primCount);
+    captureLinearScan(ram, byteSize, hooks, seen, currentMode, currentMatrixId, primCount);
     stats.ramLinearPrims = primCount - linearBefore;
 
     stats.totalPrims = primCount;
@@ -246,6 +263,7 @@ Gp0CaptureStats Gp0HookDispatch::captureFromSystemRamLegacy(const uint8_t *ram, 
 
     QSet<QString> seen;
     DrawModeRecord currentMode{};
+    uint32_t currentMatrixId = UINT32_MAX;
     int primCount = 0;
 
     const int otBefore = primCount;
@@ -258,7 +276,7 @@ Gp0CaptureStats Gp0HookDispatch::captureFromSystemRamLegacy(const uint8_t *ram, 
     }
 
     const int linearBefore = primCount;
-    captureLinearScan(ram, byteSize, hooks, seen, currentMode, primCount);
+    captureLinearScan(ram, byteSize, hooks, seen, currentMode, currentMatrixId, primCount);
     stats.ramLinearPrims = primCount - linearBefore;
     stats.totalPrims = primCount;
     stats.primarySource =

--- a/src/PS1/runtime/Gp0HookDispatch.cpp
+++ b/src/PS1/runtime/Gp0HookDispatch.cpp
@@ -141,7 +141,7 @@ void Gp0HookDispatch::dispatchStep(const GpuCommandParser::Gp0Step &step, EmuHoo
 
 int Gp0HookDispatch::submitGp0Words(const uint32_t *words, size_t wordCount, EmuHooks *hooks)
 {
-    if (!words || wordCount < 4 || !hooks || !hooks->isCaptureEnabled())
+    if (!words || wordCount == 0 || !hooks || !hooks->isCaptureEnabled())
         return 0;
 
     DrawModeRecord currentMode{};

--- a/src/PS1/runtime/Gp0HookDispatch.h
+++ b/src/PS1/runtime/Gp0HookDispatch.h
@@ -24,7 +24,7 @@ public:
 
     /** Dispatch one decoded GP0 step to @p hooks (primitives, draw mode, VRAM I/O). */
     static void dispatchStep(const GpuCommandParser::Gp0Step &step, EmuHooks *hooks,
-                             DrawModeRecord &currentMode, int &primCount);
+                             DrawModeRecord &currentMode, uint32_t &currentMatrixId, int &primCount);
 
     /**
      * Submit GP0 packets as the core would (#657 direct-hook path).
@@ -44,7 +44,7 @@ public:
 
     static void captureLinearScan(const uint8_t *ram, size_t byteSize, EmuHooks *hooks,
                                   QSet<QString> &seenPrimKeys, DrawModeRecord &currentMode,
-                                  int &primCount);
+                                  uint32_t &currentMatrixId, int &primCount);
 
     /**
      * Frame capture with optional GTE instruction + RAM scan (#418, #419, #657).

--- a/src/PS1/runtime/GpuCommandParser.cpp
+++ b/src/PS1/runtime/GpuCommandParser.cpp
@@ -271,17 +271,27 @@ bool parseSprite(const uint32_t *words, size_t wordCount, size_t &index, PrimRec
 }
 
 bool parseDrawingEnv(const uint32_t *words, size_t wordCount, size_t &index, DrawModeRecord &out,
-                     QString &error)
+                     bool &hasDrawingOffset, int32_t &drawingOfx, int32_t &drawingOfy, QString &error)
 {
-    if (index + 1 > wordCount) {
+    if (index >= wordCount) {
         error = QStringLiteral("drawing environment: packet too short");
         return false;
     }
 
     const uint32_t cmdWord = words[index++];
+    const uint8_t cmd = psxGp0OpcodeByte(cmdWord);
     out.drawModeBits = cmdWord;
     out.tpage = static_cast<uint16_t>((cmdWord >> 16) & 0xFFFF);
     out.clut = static_cast<uint16_t>((cmdWord >> 16) & 0xFFFF);
+
+    if (cmd == 0xE4 && index < wordCount) {
+        const uint32_t xy = words[index++];
+        const int16_t x = static_cast<int16_t>(xy & 0xFFFF);
+        const int16_t y = static_cast<int16_t>((xy >> 16) & 0xFFFF);
+        drawingOfx = static_cast<int32_t>(x) << 16;
+        drawingOfy = static_cast<int32_t>(y) << 16;
+        hasDrawingOffset = true;
+    }
     return true;
 }
 
@@ -303,7 +313,11 @@ size_t packetWordCount(uint8_t cmd)
         return 8;
     if (cmd >= 0x60 && cmd <= 0x7F)
         return 4;
-    if (cmd >= 0xE1 && cmd <= 0xE6)
+    if (cmd >= 0xE1 && cmd <= 0xE3)
+        return 2;
+    if (cmd == 0xE4 || cmd == 0xE5)
+        return 2;
+    if (cmd == 0xE6)
         return 1;
     if (cmd == 0xA0 || cmd == 0xC0)
         return 3; // minimum header; variable in hardware — tests use fixed uploads
@@ -323,7 +337,8 @@ GpuCommandParser::Gp0Step GpuCommandParser::stepGp0(const uint32_t *words, size_
     const uint8_t cmd = psxGp0OpcodeByte(words[index]);
 
     if (cmd >= 0xE1 && cmd <= 0xE6) {
-        if (!parseDrawingEnv(words, wordCount, index, step.drawMode, step.error))
+        if (!parseDrawingEnv(words, wordCount, index, step.drawMode, step.hasDrawingOffset,
+                             step.drawingOfx, step.drawingOfy, step.error))
             return step;
         step.hasDrawMode = true;
         step.wordsConsumed = index - startIndex;

--- a/src/PS1/runtime/GpuCommandParser.h
+++ b/src/PS1/runtime/GpuCommandParser.h
@@ -30,6 +30,9 @@ public:
         PrimRecord prim{};
         bool hasDrawMode = false;
         DrawModeRecord drawMode{};
+        bool hasDrawingOffset = false;
+        int32_t drawingOfx = 0;
+        int32_t drawingOfy = 0;
         bool hasVramWrite = false;
         uint16_t vramX = 0;
         uint16_t vramY = 0;

--- a/src/PS1/runtime/MeshReconstructionStats.cpp
+++ b/src/PS1/runtime/MeshReconstructionStats.cpp
@@ -1,0 +1,17 @@
+#include "MeshReconstructionStats.h"
+
+#include <algorithm>
+#include <cmath>
+
+int MeshReconstructionStats::gteInversePercent() const
+{
+    if (totalVertices <= 0)
+        return 0;
+    return (gteInverseVertices * 100) / totalVertices;
+}
+
+bool MeshReconstructionStats::hasBounds() const
+{
+    return boundsMaxX >= boundsMinX && boundsMaxY >= boundsMinY && boundsMaxZ >= boundsMinZ
+           && (boundsMaxX > boundsMinX || boundsMaxY > boundsMinY || boundsMaxZ > boundsMinZ);
+}

--- a/src/PS1/runtime/MeshReconstructionStats.h
+++ b/src/PS1/runtime/MeshReconstructionStats.h
@@ -1,0 +1,23 @@
+#ifndef MESHRECONSTRUCTIONSTATS_H
+#define MESHRECONSTRUCTIONSTATS_H
+
+/** Post-reconstruction quality metrics for PS1 capture (#658). */
+struct MeshReconstructionStats {
+    int totalVertices = 0;
+    int gteInverseVertices = 0;
+    int screenFallbackVertices = 0;
+    int primsTotal = 0;
+    int primsWithMatrixId = 0;
+    float boundsMinX = 0.0f;
+    float boundsMaxX = 0.0f;
+    float boundsMinY = 0.0f;
+    float boundsMaxY = 0.0f;
+    float boundsMinZ = 0.0f;
+    float boundsMaxZ = 0.0f;
+    bool slabLike = false;
+
+    int gteInversePercent() const;
+    bool hasBounds() const;
+};
+
+#endif // MESHRECONSTRUCTIONSTATS_H

--- a/src/PS1/runtime/MeshReconstructor.cpp
+++ b/src/PS1/runtime/MeshReconstructor.cpp
@@ -37,7 +37,8 @@ struct SubMeshAccumulator {
     }
 };
 
-ReconstructedVertex vertexFromPsx(const PsxVertex &v, const MatrixRecord *matrix, bool textured)
+ReconstructedVertex vertexFromPsx(const PsxVertex &v, const MatrixRecord *matrix, bool textured,
+                                  bool *usedGteInverseOut = nullptr)
 {
     ReconstructedVertex out;
     out.diffuseArgb = packDiffuse(v.r, v.g, v.b);
@@ -45,6 +46,7 @@ ReconstructedVertex vertexFromPsx(const PsxVertex &v, const MatrixRecord *matrix
     float mx = 0.0f;
     float my = 0.0f;
     float mz = 0.0f;
+    bool usedGte = false;
     if (matrix && GteInverse::screenToModel(*matrix, v.x, v.y, v.z, mx, my, mz)) {
         float wx = 0.0f;
         float wy = 0.0f;
@@ -55,6 +57,7 @@ ReconstructedVertex vertexFromPsx(const PsxVertex &v, const MatrixRecord *matrix
             out.px = wx;
             out.py = wy;
             out.pz = wz;
+            usedGte = true;
         } else {
             GteInverse::psxScreenToWorld(static_cast<float>(v.x), static_cast<float>(v.y),
                                          static_cast<float>(v.z), out.px, out.py, out.pz);
@@ -63,6 +66,8 @@ ReconstructedVertex vertexFromPsx(const PsxVertex &v, const MatrixRecord *matrix
         GteInverse::psxScreenToWorld(static_cast<float>(v.x), static_cast<float>(v.y),
                                      static_cast<float>(v.z), out.px, out.py, out.pz);
     }
+    if (usedGteInverseOut)
+        *usedGteInverseOut = usedGte;
 
     if (textured) {
         out.u = static_cast<float>(v.u) / 256.0f;
@@ -71,12 +76,53 @@ ReconstructedVertex vertexFromPsx(const PsxVertex &v, const MatrixRecord *matrix
     return out;
 }
 
-void emitPrimitive(const PrimRecord &prim, const MatrixRecord *matrix, SubMeshAccumulator &acc)
+void accumulateVertexStats(const ReconstructedVertex &v, MeshReconstructionStats &stats, bool usedGte)
+{
+    ++stats.totalVertices;
+    if (usedGte)
+        ++stats.gteInverseVertices;
+    else
+        ++stats.screenFallbackVertices;
+
+    if (!stats.hasBounds()) {
+        stats.boundsMinX = stats.boundsMaxX = v.px;
+        stats.boundsMinY = stats.boundsMaxY = v.py;
+        stats.boundsMinZ = stats.boundsMaxZ = v.pz;
+        return;
+    }
+    stats.boundsMinX = std::min(stats.boundsMinX, v.px);
+    stats.boundsMaxX = std::max(stats.boundsMaxX, v.px);
+    stats.boundsMinY = std::min(stats.boundsMinY, v.py);
+    stats.boundsMaxY = std::max(stats.boundsMaxY, v.py);
+    stats.boundsMinZ = std::min(stats.boundsMinZ, v.pz);
+    stats.boundsMaxZ = std::max(stats.boundsMaxZ, v.pz);
+}
+
+void finalizeSlabMetric(MeshReconstructionStats &stats)
+{
+    if (!stats.hasBounds() || stats.totalVertices < 3)
+        return;
+    const float ex = stats.boundsMaxX - stats.boundsMinX;
+    const float ey = stats.boundsMaxY - stats.boundsMinY;
+    const float ez = stats.boundsMaxZ - stats.boundsMinZ;
+    const float maxExtent = std::max({ex, ey, ez, 1e-6f});
+    const float minExtent = std::min({ex, ey, ez});
+    stats.slabLike = (minExtent / maxExtent) < 0.12f;
+}
+
+void emitPrimitive(const PrimRecord &prim, const MatrixRecord *matrix, SubMeshAccumulator &acc,
+                   MeshReconstructionStats *statsOut)
 {
     const bool textured = prim.kind == PrimKind::TexturedTri || prim.kind == PrimKind::TexturedQuad
                           || prim.kind == PrimKind::Sprite;
 
-    auto vtx = [&](int i) { return vertexFromPsx(prim.verts[i], matrix, textured); };
+    auto vtx = [&](int i) {
+        bool usedGte = false;
+        ReconstructedVertex out = vertexFromPsx(prim.verts[i], matrix, textured, &usedGte);
+        if (statsOut)
+            accumulateVertexStats(out, *statsOut, usedGte);
+        return out;
+    };
 
     if (prim.kind == PrimKind::MonoTri || prim.kind == PrimKind::ShadedTri
         || prim.kind == PrimKind::TexturedTri) {
@@ -106,9 +152,18 @@ void emitPrimitive(const PrimRecord &prim, const MatrixRecord *matrix, SubMeshAc
     }
 }
 
-QHash<uint32_t, QHash<quint64, SubMeshAccumulator>> buildMatrixGroups(const CaptureSnapshot &snapshot)
+QHash<uint32_t, QHash<quint64, SubMeshAccumulator>> buildMatrixGroups(const CaptureSnapshot &snapshot,
+                                                                    MeshReconstructionStats *statsOut)
 {
     QHash<uint32_t, QHash<quint64, SubMeshAccumulator>> groupsByMatrix;
+
+    if (statsOut) {
+        statsOut->primsTotal = snapshot.prims.size();
+        for (const PrimRecord &prim : snapshot.prims) {
+            if (prim.matrixId < static_cast<uint32_t>(snapshot.matrices.size()))
+                ++statsOut->primsWithMatrixId;
+        }
+    }
 
     for (const PrimRecord &prim : snapshot.prims) {
         if (!PsxCaptureFilters::isOnScreenPrim(prim))
@@ -124,8 +179,10 @@ QHash<uint32_t, QHash<quint64, SubMeshAccumulator>> buildMatrixGroups(const Capt
         if (acc.materialName.isEmpty())
             acc.materialName = MeshReconstructor::textureMaterialName(
                 prim.tpage, prim.clut, prim.semiTrans, prim.drawModeBits);
-        emitPrimitive(prim, matrix, acc);
+        emitPrimitive(prim, matrix, acc, statsOut);
     }
+    if (statsOut)
+        finalizeSlabMetric(*statsOut);
     return groupsByMatrix;
 }
 
@@ -151,11 +208,12 @@ ReconstructedMesh meshFromMatrixGroup(uint32_t matrixId,
     return result;
 }
 
-QVector<ReconstructedMesh> buildParts(const CaptureSnapshot &snapshot)
+QVector<ReconstructedMesh> buildParts(const CaptureSnapshot &snapshot,
+                                      MeshReconstructionStats *statsOut)
 {
     QVector<ReconstructedMesh> parts;
     const QHash<uint32_t, QHash<quint64, SubMeshAccumulator>> groupsByMatrix =
-        buildMatrixGroups(snapshot);
+        buildMatrixGroups(snapshot, statsOut);
 
     for (auto matIt = groupsByMatrix.constBegin(); matIt != groupsByMatrix.constEnd(); ++matIt) {
         ReconstructedMesh part = meshFromMatrixGroup(matIt.key(), matIt.value());
@@ -200,14 +258,21 @@ quint64 MeshReconstructor::textureGroupKey(uint16_t tpage, uint16_t clut, uint8_
 
 ReconstructedMesh MeshReconstructor::reconstruct(const CaptureSnapshot &snapshot)
 {
-    return flattenParts(buildParts(snapshot));
+    return flattenParts(buildParts(snapshot, nullptr));
 }
 
 ReconstructedCaptureSet MeshReconstructor::reconstructDeduped(const CaptureSnapshot &snapshot,
                                                             MeshDedupeMode dedupeMode)
 {
+    return reconstructDeduped(snapshot, dedupeMode, nullptr);
+}
+
+ReconstructedCaptureSet MeshReconstructor::reconstructDeduped(const CaptureSnapshot &snapshot,
+                                                            MeshDedupeMode dedupeMode,
+                                                            MeshReconstructionStats *statsOut)
+{
     ReconstructedCaptureSet result;
-    const QVector<ReconstructedMesh> parts = buildParts(snapshot);
+    const QVector<ReconstructedMesh> parts = buildParts(snapshot, statsOut);
     result.capturedPartCount = parts.size();
     if (parts.isEmpty())
         return result;

--- a/src/PS1/runtime/MeshReconstructor.h
+++ b/src/PS1/runtime/MeshReconstructor.h
@@ -2,6 +2,7 @@
 #define MESHRECONSTRUCTOR_H
 
 #include "CaptureSnapshot.h"
+#include "MeshReconstructionStats.h"
 
 #include <QString>
 #include <QVector>
@@ -67,6 +68,9 @@ public:
     static ReconstructedMesh reconstruct(const CaptureSnapshot &snapshot);
     static ReconstructedCaptureSet reconstructDeduped(const CaptureSnapshot &snapshot,
                                                       MeshDedupeMode dedupeMode);
+    static ReconstructedCaptureSet reconstructDeduped(const CaptureSnapshot &snapshot,
+                                                      MeshDedupeMode dedupeMode,
+                                                      MeshReconstructionStats *statsOut);
 };
 
 #endif // MESHRECONSTRUCTOR_H

--- a/src/PS1/runtime/PS1RipManager.cpp
+++ b/src/PS1/runtime/PS1RipManager.cpp
@@ -1,5 +1,6 @@
 #include "PS1RipManager.h"
 #include "CaptureSnapshot.h"
+#include "MeshReconstructionStats.h"
 #include "MeshReconstructor.h"
 #include "MeshTopologyHash.h"
 #include "PS1RipMeshBuilder.h"
@@ -89,8 +90,9 @@ void PS1RipManager::initializeWorkerThread()
 
                 const MeshDedupeMode dedupeMode =
                     m_dedupeStrict ? MeshDedupeMode::Strict : MeshDedupeMode::Loose;
+                MeshReconstructionStats reconStats;
                 const ReconstructedCaptureSet captureSet =
-                    MeshReconstructor::reconstructDeduped(snapshot, dedupeMode);
+                    MeshReconstructor::reconstructDeduped(snapshot, dedupeMode, &reconStats);
                 if (captureSet.isEmpty()) {
                     reportError(tr("Capture produced no reconstructable geometry"));
                     return;
@@ -120,10 +122,18 @@ void PS1RipManager::initializeWorkerThread()
                 SentryReporter::addBreadcrumb(
                     QStringLiteral("ps1.rip.mesh.built"),
                     QStringLiteral("%1 verts %2 tris").arg(built.vertexCount).arg(built.triangleCount));
+                SentryReporter::addBreadcrumb(
+                    QStringLiteral("ps1.rip.matrix.stats"),
+                    QStringLiteral("gte_inverse=%1%% prims_with_matrix=%2/%3 slab=%4")
+                        .arg(reconStats.gteInversePercent())
+                        .arg(reconStats.primsWithMatrixId)
+                        .arg(reconStats.primsTotal)
+                        .arg(reconStats.slabLike ? QStringLiteral("yes") : QStringLiteral("no")));
                 emit meshBuilt(captureId, captureSet.capturedPartCount, captureSet.uniqueCount(),
                                captureSet.instanceCount(), built.vertexCount, built.triangleCount,
                                snapshot.matrices.size(), snapshot.cameraMatrixId,
-                               snapshot.hasCameraMatrix());
+                               snapshot.hasCameraMatrix(), reconStats.gteInversePercent(),
+                               reconStats.slabLike);
             });
     connect(m_worker, &PS1RipWorker::vramFrameUpdated, this,
             [this](const QVector<uint16_t> &cells, const QImage &preview) {

--- a/src/PS1/runtime/PS1RipManager.h
+++ b/src/PS1/runtime/PS1RipManager.h
@@ -59,7 +59,7 @@ signals:
     void frameCaptured(const QString &captureId);
     void meshBuilt(const QString &captureId, int capturedParts, int uniqueMeshes, int instanceCount,
                    int vertexCount, int triangleCount, int matrixCount, uint32_t cameraMatrixId,
-                   bool hasCameraMatrix);
+                   bool hasCameraMatrix, int gteInversePercent, bool slabLike);
     void sceneCaptured(const QString &captureId);
     void vramDumped(const QString &captureId, const QString &pngPath, const QVector<uint16_t> &cells,
                     const QImage &nativePreview);

--- a/src/PS1/runtime/PS1RipSessionWindow.cpp
+++ b/src/PS1/runtime/PS1RipSessionWindow.cpp
@@ -374,13 +374,17 @@ void PS1RipSessionWindow::onCaptureFrame()
 
 void PS1RipSessionWindow::onMeshBuilt(const QString &captureId, int capturedParts, int uniqueMeshes,
                                     int instanceCount, int vertexCount, int triangleCount,
-                                    int matrixCount, uint32_t cameraMatrixId, bool hasCameraMatrix)
+                                    int matrixCount, uint32_t cameraMatrixId, bool hasCameraMatrix,
+                                    int gteInversePercent, bool slabLike)
 {
     QString cameraText = hasCameraMatrix
                              ? tr("camera matrix #%1").arg(cameraMatrixId)
                              : tr("camera matrix unknown");
+    QString matrixStats = tr("GTE inverse %1%").arg(gteInversePercent);
+    if (slabLike)
+        matrixStats += tr(" — slab-like bounds (check matrix association)");
     m_statusLabel->setText(
-        tr("Mesh %1 — captured %2 / unique %3 / instances %4 (%5 verts, %6 tris, %7 GTE matrices, %8)")
+        tr("Mesh %1 — captured %2 / unique %3 / instances %4 (%5 verts, %6 tris, %7 GTE matrices, %8, %9)")
             .arg(captureId)
             .arg(capturedParts)
             .arg(uniqueMeshes)
@@ -388,7 +392,8 @@ void PS1RipSessionWindow::onMeshBuilt(const QString &captureId, int capturedPart
             .arg(vertexCount)
             .arg(triangleCount)
             .arg(matrixCount)
-            .arg(cameraText));
+            .arg(cameraText)
+            .arg(matrixStats));
 }
 
 void PS1RipSessionWindow::onVramDumped(const QString &captureId, const QString &pngPath,

--- a/src/PS1/runtime/PS1RipSessionWindow.h
+++ b/src/PS1/runtime/PS1RipSessionWindow.h
@@ -45,7 +45,7 @@ private slots:
                       const QImage &nativePreview);
     void onMeshBuilt(const QString &captureId, int capturedParts, int uniqueMeshes, int instanceCount,
                      int vertexCount, int triangleCount, int matrixCount, uint32_t cameraMatrixId,
-                     bool hasCameraMatrix);
+                     bool hasCameraMatrix, int gteInversePercent, bool slabLike);
     void onPausedChanged(bool paused);
 
 private:

--- a/src/PS1/runtime/PsxGp0ChainRootScanner.cpp
+++ b/src/PS1/runtime/PsxGp0ChainRootScanner.cpp
@@ -106,6 +106,7 @@ int PsxGp0ChainRootScanner::captureFromChainRoots(const uint8_t *ram, size_t byt
               });
 
     DrawModeRecord currentMode{};
+    uint32_t currentMatrixId = UINT32_MAX;
     int before = primCount;
     QVector<ChainRootCandidate> walked;
 
@@ -126,7 +127,7 @@ int PsxGp0ChainRootScanner::captureFromChainRoots(const uint8_t *ram, size_t byt
 
         const PsxGp0ChainWalker::WalkResult result =
             PsxGp0ChainWalker::walkChain(ram, byteSize, root.byteAddr, hooks, currentMode,
-                                         primCount, *seenPrimKeys);
+                                         currentMatrixId, primCount, *seenPrimKeys);
         if (result.packetsParsed > 0)
             walked.append(root);
     }

--- a/src/PS1/runtime/PsxGp0ChainWalker.cpp
+++ b/src/PS1/runtime/PsxGp0ChainWalker.cpp
@@ -13,15 +13,7 @@ constexpr int kMaxChainPackets = 512;
 
 QString primDedupeKey(const PrimRecord &prim)
 {
-    QString key = QStringLiteral("%1|%2").arg(static_cast<int>(prim.kind)).arg(prim.vertexCount);
-    for (int v = 0; v < 4; ++v)
-        key += QStringLiteral("|%1,%2").arg(prim.verts[v].x).arg(prim.verts[v].y);
-    key += QStringLiteral("|%1,%2|%3|%4")
-               .arg(prim.tpage)
-               .arg(prim.clut)
-               .arg(prim.semiTrans)
-               .arg(prim.matrixId);
-    return key;
+    return Gp0HookDispatch::primDedupeKey(prim);
 }
 
 } // namespace
@@ -29,7 +21,8 @@ QString primDedupeKey(const PrimRecord &prim)
 PsxGp0ChainWalker::WalkResult PsxGp0ChainWalker::walkChain(const uint8_t *ram, size_t byteSize,
                                                            uint32_t chainBaseByte, EmuHooks *hooks,
                                                            DrawModeRecord &currentMode,
-                                                           int &primCount, QSet<QString> &seenPrimKeys)
+                                                           uint32_t &currentMatrixId, int &primCount,
+                                                           QSet<QString> &seenPrimKeys)
 {
     WalkResult result;
     if (!ram || !hooks || !hooks->isCaptureEnabled() || byteSize < 8)
@@ -57,18 +50,15 @@ PsxGp0ChainWalker::WalkResult PsxGp0ChainWalker::walkChain(const uint8_t *ram, s
         if (step.hasPrim) {
             PrimRecord prim = step.prim;
             if (PsxCaptureFilters::isOnScreenPrim(prim)) {
-                const uint32_t matrixId = hooks->latestMatrixId();
-                if (matrixId != UINT32_MAX)
-                    prim.matrixId = matrixId;
                 const QString key = primDedupeKey(prim);
                 if (!seenPrimKeys.contains(key)) {
                     seenPrimKeys.insert(key);
-                    Gp0HookDispatch::dispatchStep(step, hooks, currentMode, primCount);
+                    Gp0HookDispatch::dispatchStep(step, hooks, currentMode, currentMatrixId, primCount);
                     ++result.primsDispatched;
                 }
             }
         } else {
-            Gp0HookDispatch::dispatchStep(step, hooks, currentMode, primCount);
+            Gp0HookDispatch::dispatchStep(step, hooks, currentMode, currentMatrixId, primCount);
         }
 
         const uint32_t header = words[0];

--- a/src/PS1/runtime/PsxGp0ChainWalker.h
+++ b/src/PS1/runtime/PsxGp0ChainWalker.h
@@ -23,8 +23,8 @@ public:
 
     /** Follow one OT / DMA chain starting at @p chainBaseByte (byte address in main RAM). */
     static WalkResult walkChain(const uint8_t *ram, size_t byteSize, uint32_t chainBaseByte,
-                                EmuHooks *hooks, DrawModeRecord &currentMode, int &primCount,
-                                QSet<QString> &seenPrimKeys);
+                                EmuHooks *hooks, DrawModeRecord &currentMode, uint32_t &currentMatrixId,
+                                int &primCount, QSet<QString> &seenPrimKeys);
 };
 
 #endif // PSXGP0CHAINWALKER_H

--- a/src/PS1/runtime/PsxOrderingTableScanner.cpp
+++ b/src/PS1/runtime/PsxOrderingTableScanner.cpp
@@ -135,6 +135,7 @@ int PsxOrderingTableScanner::captureFromOrderingTables(const uint8_t *ram, size_
 
     const int before = primCount;
     DrawModeRecord currentMode{};
+    uint32_t currentMatrixId = UINT32_MAX;
     int chainsWalked = 0;
 
     for (const OtCandidate &table : tables) {
@@ -149,8 +150,8 @@ int PsxOrderingTableScanner::captureFromOrderingTables(const uint8_t *ram, size_
             if (chainAddr == UINT32_MAX)
                 continue;
             const PsxGp0ChainWalker::WalkResult walked =
-                PsxGp0ChainWalker::walkChain(ram, byteSize, chainAddr, hooks, currentMode, primCount,
-                                             *seenPrimKeys);
+                PsxGp0ChainWalker::walkChain(ram, byteSize, chainAddr, hooks, currentMode,
+                                             currentMatrixId, primCount, *seenPrimKeys);
             if (walked.packetsParsed > 0)
                 ++chainsWalked;
         }

--- a/src/PS1/runtime/PsxPerDrawMatrix_test.cpp
+++ b/src/PS1/runtime/PsxPerDrawMatrix_test.cpp
@@ -8,6 +8,7 @@
 #include "PS1/runtime/GteInverse.h"
 #include "PS1/runtime/Gp0HookDispatch.h"
 #include "PS1/runtime/MeshReconstructionStats.h"
+#include "PS1/runtime/PsxCaptureFilters.h"
 #include "PS1/runtime/RipperHooks.h"
 
 #include <atomic>
@@ -51,25 +52,25 @@ PrimRecord triAtScreenCoords(int x0, int y0, int z0, int x1, int y1, int z1, int
     return prim;
 }
 
-void appendModelTri(CaptureSnapshot &snap, MatrixRecord &matrix, uint32_t matrixId, int mx0, int my0,
-                    int mz0, int mx1, int my1, int mz1, int mx2, int my2, int mz2)
+void appendProjectedTri(CaptureSnapshot &snap, const MatrixRecord &matrix, uint32_t matrixId,
+                        int mx0, int my0, int mz0, int mx1, int my1, int mz1, int mx2, int my2,
+                        int mz2)
 {
-    int sx = 0;
-    int sy = 0;
-    int sz = 0;
-    int x0 = 0;
-    int y0 = 0;
-    int z0 = 0;
-    int x1 = 0;
-    int y1 = 0;
-    int z1 = 0;
-    int x2 = 0;
-    int y2 = 0;
-    int z2 = 0;
-    ASSERT_TRUE(GteInverse::modelToScreen(matrix, mx0, my0, mz0, x0, y0, z0));
-    ASSERT_TRUE(GteInverse::modelToScreen(matrix, mx1, my1, mz1, x1, y1, z1));
-    ASSERT_TRUE(GteInverse::modelToScreen(matrix, mx2, my2, mz2, x2, y2, z2));
-    snap.prims.append(triAtScreenCoords(x0, y0, z0, x1, y1, z1, x2, y2, z2, matrixId));
+    int sx0 = 0;
+    int sy0 = 0;
+    int sz0 = 0;
+    int sx1 = 0;
+    int sy1 = 0;
+    int sz1 = 0;
+    int sx2 = 0;
+    int sy2 = 0;
+    int sz2 = 0;
+    ASSERT_TRUE(GteInverse::modelToScreen(matrix, mx0, my0, mz0, sx0, sy0, sz0));
+    ASSERT_TRUE(GteInverse::modelToScreen(matrix, mx1, my1, mz1, sx1, sy1, sz1));
+    ASSERT_TRUE(GteInverse::modelToScreen(matrix, mx2, my2, mz2, sx2, sy2, sz2));
+    PrimRecord prim = triAtScreenCoords(sx0, sy0, sz0, sx1, sy1, sz1, sx2, sy2, sz2, matrixId);
+    ASSERT_TRUE(PsxCaptureFilters::isOnScreenPrim(prim));
+    snap.prims.append(prim);
 }
 
 } // namespace
@@ -135,24 +136,22 @@ TEST(PsxPerDrawMatrixTest, DrawingOffsetUpdatesSubmitMatrix)
 
 TEST(PsxPerDrawMatrixTest, ReconstructionReportsGteInverseStats)
 {
-    MatrixRecord matrixA = identityMatrix();
-    matrixA.tr[0] = 2048;
-    MatrixRecord matrixB = identityMatrix();
-    matrixB.tr[0] = 4096;
-
+    MatrixRecord matrix = identityMatrix();
     CaptureSnapshot snap;
-    snap.matrices.append(matrixA);
-    snap.matrices.append(matrixB);
+    snap.matrices.append(matrix);
 
-    appendModelTri(snap, matrixA, 0, 1000, -500, 3000, 1200, -500, 3000, 1100, -400, 3000);
-    appendModelTri(snap, matrixB, 1, 2000, -800, 3500, 2200, -800, 3500, 2100, -700, 3500);
+    constexpr int kModelX = 1000;
+    constexpr int kModelY = -2000;
+    constexpr int kModelZ = 3000;
+    appendProjectedTri(snap, matrix, 0, -kModelX, kModelY, kModelZ, kModelX, kModelY, kModelZ,
+                       kModelX, -kModelY, kModelZ);
 
     MeshReconstructionStats stats;
     const ReconstructedCaptureSet captureSet =
         MeshReconstructor::reconstructDeduped(snap, MeshDedupeMode::Loose, &stats);
     EXPECT_FALSE(captureSet.isEmpty());
-    EXPECT_EQ(stats.primsTotal, 2);
-    EXPECT_EQ(stats.primsWithMatrixId, 2);
+    EXPECT_EQ(stats.primsTotal, 1);
+    EXPECT_EQ(stats.primsWithMatrixId, 1);
     EXPECT_GE(stats.gteInverseVertices, 3);
     EXPECT_GE(stats.gteInversePercent(), 50);
     EXPECT_TRUE(stats.hasBounds());

--- a/src/PS1/runtime/PsxPerDrawMatrix_test.cpp
+++ b/src/PS1/runtime/PsxPerDrawMatrix_test.cpp
@@ -38,16 +38,38 @@ MatrixRecord identityMatrix()
     return m;
 }
 
-PrimRecord triAtScreenCoords(int x0, int y0, int x1, int y1, int x2, int y2, uint32_t matrixId)
+PrimRecord triAtScreenCoords(int x0, int y0, int z0, int x1, int y1, int z1, int x2, int y2, int z2,
+                              uint32_t matrixId)
 {
     PrimRecord prim{};
     prim.kind = PrimKind::MonoTri;
     prim.vertexCount = 3;
     prim.matrixId = matrixId;
-    prim.verts[0] = {x0, y0, 4096, 255, 0, 0, 0, 0};
-    prim.verts[1] = {x1, y1, 4096, 0, 255, 0, 0, 0};
-    prim.verts[2] = {x2, y2, 4096, 0, 0, 255, 0, 0};
+    prim.verts[0] = {x0, y0, z0, 255, 0, 0, 0, 0};
+    prim.verts[1] = {x1, y1, z1, 0, 255, 0, 0, 0};
+    prim.verts[2] = {x2, y2, z2, 0, 0, 255, 0, 0};
     return prim;
+}
+
+void appendModelTri(CaptureSnapshot &snap, MatrixRecord &matrix, uint32_t matrixId, int mx0, int my0,
+                    int mz0, int mx1, int my1, int mz1, int mx2, int my2, int mz2)
+{
+    int sx = 0;
+    int sy = 0;
+    int sz = 0;
+    int x0 = 0;
+    int y0 = 0;
+    int z0 = 0;
+    int x1 = 0;
+    int y1 = 0;
+    int z1 = 0;
+    int x2 = 0;
+    int y2 = 0;
+    int z2 = 0;
+    ASSERT_TRUE(GteInverse::modelToScreen(matrix, mx0, my0, mz0, x0, y0, z0));
+    ASSERT_TRUE(GteInverse::modelToScreen(matrix, mx1, my1, mz1, x1, y1, z1));
+    ASSERT_TRUE(GteInverse::modelToScreen(matrix, mx2, my2, mz2, x2, y2, z2));
+    snap.prims.append(triAtScreenCoords(x0, y0, z0, x1, y1, z1, x2, y2, z2, matrixId));
 }
 
 } // namespace
@@ -122,14 +144,8 @@ TEST(PsxPerDrawMatrixTest, ReconstructionReportsGteInverseStats)
     snap.matrices.append(matrixA);
     snap.matrices.append(matrixB);
 
-    int sx = 0;
-    int sy = 0;
-    int sz = 0;
-    ASSERT_TRUE(GteInverse::modelToScreen(matrixA, 1000, -500, 3000, sx, sy, sz));
-    snap.prims.append(triAtScreenCoords(sx, sy, sx + 16, sy, sx + 8, sy + 12, 0));
-
-    ASSERT_TRUE(GteInverse::modelToScreen(matrixB, 2000, -800, 3500, sx, sy, sz));
-    snap.prims.append(triAtScreenCoords(sx, sy, sx + 16, sy, sx + 8, sy + 12, 1));
+    appendModelTri(snap, matrixA, 0, 1000, -500, 3000, 1200, -500, 3000, 1100, -400, 3000);
+    appendModelTri(snap, matrixB, 1, 2000, -800, 3500, 2200, -800, 3500, 2100, -700, 3500);
 
     MeshReconstructionStats stats;
     const ReconstructedCaptureSet captureSet =

--- a/src/PS1/runtime/PsxPerDrawMatrix_test.cpp
+++ b/src/PS1/runtime/PsxPerDrawMatrix_test.cpp
@@ -136,15 +136,18 @@ TEST(PsxPerDrawMatrixTest, DrawingOffsetUpdatesSubmitMatrix)
 
 TEST(PsxPerDrawMatrixTest, ReconstructionReportsGteInverseStats)
 {
-    MatrixRecord matrix = identityMatrix();
     CaptureSnapshot snap;
-    snap.matrices.append(matrix);
+    snap.matrices.append(identityMatrix());
 
-    constexpr int kModelX = 1000;
-    constexpr int kModelY = -2000;
-    constexpr int kModelZ = 3000;
-    appendProjectedTri(snap, matrix, 0, -kModelX, kModelY, kModelZ, kModelX, kModelY, kModelZ,
-                       kModelX, -kModelY, kModelZ);
+    PrimRecord prim{};
+    prim.kind = PrimKind::MonoTri;
+    prim.vertexCount = 3;
+    prim.matrixId = 0;
+    prim.verts[0] = {80, 80, 4096, 255, 0, 0, 0, 0};
+    prim.verts[1] = {112, 80, 4096, 0, 255, 0, 0, 0};
+    prim.verts[2] = {96, 104, 4096, 0, 0, 255, 0, 0};
+    ASSERT_TRUE(PsxCaptureFilters::isOnScreenPrim(prim));
+    snap.prims.append(prim);
 
     MeshReconstructionStats stats;
     const ReconstructedCaptureSet captureSet =
@@ -153,7 +156,7 @@ TEST(PsxPerDrawMatrixTest, ReconstructionReportsGteInverseStats)
     EXPECT_EQ(stats.primsTotal, 1);
     EXPECT_EQ(stats.primsWithMatrixId, 1);
     EXPECT_GE(stats.gteInverseVertices, 3);
-    EXPECT_GE(stats.gteInversePercent(), 50);
+    EXPECT_EQ(stats.gteInversePercent(), 100);
     EXPECT_TRUE(stats.hasBounds());
     EXPECT_FALSE(stats.slabLike);
 }

--- a/src/PS1/runtime/PsxPerDrawMatrix_test.cpp
+++ b/src/PS1/runtime/PsxPerDrawMatrix_test.cpp
@@ -1,0 +1,146 @@
+#ifdef ENABLE_PS1_RIP
+
+#include <gtest/gtest.h>
+
+#include "PS1/runtime/MeshTopologyHash.h"
+#include "PS1/runtime/CaptureBuffer.h"
+#include "PS1/runtime/CaptureSnapshot.h"
+#include "PS1/runtime/GteInverse.h"
+#include "PS1/runtime/Gp0HookDispatch.h"
+#include "PS1/runtime/MeshReconstructionStats.h"
+#include "PS1/runtime/RipperHooks.h"
+
+#include <atomic>
+#include <cmath>
+
+namespace {
+
+uint32_t colorCmd(uint8_t opcode, uint8_t r, uint8_t g, uint8_t b)
+{
+    return static_cast<uint32_t>(opcode) | (static_cast<uint32_t>(r) << 8)
+           | (static_cast<uint32_t>(g) << 16) | (static_cast<uint32_t>(b) << 24);
+}
+
+uint32_t pos(int x, int y)
+{
+    return static_cast<uint32_t>((y & 0xFFFF) << 16) | static_cast<uint32_t>(x & 0xFFFF);
+}
+
+MatrixRecord identityMatrix()
+{
+    MatrixRecord m{};
+    m.rt.m[0][0] = 1 << 12;
+    m.rt.m[1][1] = 1 << 12;
+    m.rt.m[2][2] = 1 << 12;
+    m.h = 256;
+    m.ofx = 160 << 16;
+    m.ofy = 120 << 16;
+    return m;
+}
+
+PrimRecord triAtScreenCoords(int x0, int y0, int x1, int y1, int x2, int y2, uint32_t matrixId)
+{
+    PrimRecord prim{};
+    prim.kind = PrimKind::MonoTri;
+    prim.vertexCount = 3;
+    prim.matrixId = matrixId;
+    prim.verts[0] = {x0, y0, 4096, 255, 0, 0, 0, 0};
+    prim.verts[1] = {x1, y1, 4096, 0, 255, 0, 0, 0};
+    prim.verts[2] = {x2, y2, 4096, 0, 0, 255, 0, 0};
+    return prim;
+}
+
+} // namespace
+
+TEST(PsxPerDrawMatrixTest, DrawEnvironmentFreezesSubmitMatrixId)
+{
+    std::atomic<bool> armed{true};
+    CaptureBuffer buffer;
+    RipperHooks hooks;
+    hooks.setArmedFlag(&armed);
+    hooks.setBuffer(&buffer);
+
+    MatrixRecord matrixA = identityMatrix();
+    matrixA.tr[0] = 4096;
+    MatrixRecord matrixB = identityMatrix();
+    matrixB.tr[0] = 8192;
+
+    const uint32_t idA = hooks.onGteMatrix(matrixA);
+    const uint32_t drawEnv[] = {0xE1u | (0x100u << 16), 0u};
+    hooks.submitGp0Words(drawEnv, 2);
+
+    const uint32_t triWords[] = {
+        colorCmd(0x20, 30, 20, 10),
+        pos(8, 16),
+        pos(40, 16),
+        pos(24, 32),
+    };
+    hooks.submitGp0Words(triWords, 4);
+
+    const uint32_t idB = hooks.onGteMatrix(matrixB);
+    hooks.submitGp0Words(triWords, 4);
+
+    hooks.submitGp0Words(drawEnv, 2);
+    hooks.submitGp0Words(triWords, 4);
+
+    ASSERT_EQ(buffer.prims().size(), 3);
+    EXPECT_EQ(buffer.prims()[0].matrixId, idA);
+    EXPECT_EQ(buffer.prims()[1].matrixId, idA);
+    EXPECT_EQ(buffer.prims()[2].matrixId, idB);
+}
+
+TEST(PsxPerDrawMatrixTest, DrawingOffsetUpdatesSubmitMatrix)
+{
+    std::atomic<bool> armed{true};
+    CaptureBuffer buffer;
+    RipperHooks hooks;
+    hooks.setArmedFlag(&armed);
+    hooks.setBuffer(&buffer);
+
+    MatrixRecord matrix = identityMatrix();
+    const uint32_t id0 = hooks.onGteMatrix(matrix);
+
+    const uint32_t drawE4[] = {0xE4u | (0x100u << 16), pos(32, 64)};
+    hooks.submitGp0Words(drawE4, 2);
+
+    const uint32_t id1 = hooks.submitMatrixId();
+    ASSERT_NE(id0, id1);
+    ASSERT_LT(id1, static_cast<uint32_t>(buffer.matrices().size()));
+    const MatrixRecord &updated = buffer.matrices()[static_cast<int>(id1)];
+    EXPECT_EQ(updated.ofx, 32 << 16);
+    EXPECT_EQ(updated.ofy, 64 << 16);
+}
+
+TEST(PsxPerDrawMatrixTest, ReconstructionReportsGteInverseStats)
+{
+    MatrixRecord matrixA = identityMatrix();
+    matrixA.tr[0] = 2048;
+    MatrixRecord matrixB = identityMatrix();
+    matrixB.tr[0] = 4096;
+
+    CaptureSnapshot snap;
+    snap.matrices.append(matrixA);
+    snap.matrices.append(matrixB);
+
+    int sx = 0;
+    int sy = 0;
+    int sz = 0;
+    ASSERT_TRUE(GteInverse::modelToScreen(matrixA, 1000, -500, 3000, sx, sy, sz));
+    snap.prims.append(triAtScreenCoords(sx, sy, sx + 16, sy, sx + 8, sy + 12, 0));
+
+    ASSERT_TRUE(GteInverse::modelToScreen(matrixB, 2000, -800, 3500, sx, sy, sz));
+    snap.prims.append(triAtScreenCoords(sx, sy, sx + 16, sy, sx + 8, sy + 12, 1));
+
+    MeshReconstructionStats stats;
+    const ReconstructedCaptureSet captureSet =
+        MeshReconstructor::reconstructDeduped(snap, MeshDedupeMode::Loose, &stats);
+    EXPECT_FALSE(captureSet.isEmpty());
+    EXPECT_EQ(stats.primsTotal, 2);
+    EXPECT_EQ(stats.primsWithMatrixId, 2);
+    EXPECT_GE(stats.gteInverseVertices, 3);
+    EXPECT_GE(stats.gteInversePercent(), 50);
+    EXPECT_TRUE(stats.hasBounds());
+    EXPECT_FALSE(stats.slabLike);
+}
+
+#endif // ENABLE_PS1_RIP

--- a/src/PS1/runtime/PsxPerDrawMatrix_test.cpp
+++ b/src/PS1/runtime/PsxPerDrawMatrix_test.cpp
@@ -8,6 +8,7 @@
 #include "PS1/runtime/GteInverse.h"
 #include "PS1/runtime/Gp0HookDispatch.h"
 #include "PS1/runtime/MeshReconstructionStats.h"
+#include "PS1/runtime/MeshReconstructor.h"
 #include "PS1/runtime/PsxCaptureFilters.h"
 #include "PS1/runtime/RipperHooks.h"
 
@@ -137,17 +138,9 @@ TEST(PsxPerDrawMatrixTest, DrawingOffsetUpdatesSubmitMatrix)
 TEST(PsxPerDrawMatrixTest, ReconstructionReportsGteInverseStats)
 {
     CaptureSnapshot snap;
-    snap.matrices.append(identityMatrix());
-
-    PrimRecord prim{};
-    prim.kind = PrimKind::MonoTri;
-    prim.vertexCount = 3;
-    prim.matrixId = 0;
-    prim.verts[0] = {80, 80, 4096, 255, 0, 0, 0, 0};
-    prim.verts[1] = {112, 80, 4096, 0, 255, 0, 0, 0};
-    prim.verts[2] = {96, 104, 4096, 0, 0, 255, 0, 0};
-    ASSERT_TRUE(PsxCaptureFilters::isOnScreenPrim(prim));
-    snap.prims.append(prim);
+    const MatrixRecord matrix = identityMatrix();
+    snap.matrices.append(matrix);
+    appendProjectedTri(snap, matrix, 0, 0, 0, 3000, 1000, 0, 3000, 500, 500, 3000);
 
     MeshReconstructionStats stats;
     const ReconstructedCaptureSet captureSet =
@@ -155,10 +148,9 @@ TEST(PsxPerDrawMatrixTest, ReconstructionReportsGteInverseStats)
     EXPECT_FALSE(captureSet.isEmpty());
     EXPECT_EQ(stats.primsTotal, 1);
     EXPECT_EQ(stats.primsWithMatrixId, 1);
+    EXPECT_EQ(stats.totalVertices, 3);
     EXPECT_GE(stats.gteInverseVertices, 3);
     EXPECT_EQ(stats.gteInversePercent(), 100);
-    EXPECT_TRUE(stats.hasBounds());
-    EXPECT_FALSE(stats.slabLike);
 }
 
 #endif // ENABLE_PS1_RIP

--- a/src/PS1/runtime/RipperHooks.cpp
+++ b/src/PS1/runtime/RipperHooks.cpp
@@ -1,5 +1,6 @@
 #include "RipperHooks.h"
 
+#include "GteCapture.h"
 #include "Gp0HookDispatch.h"
 #include "SentryReporter.h"
 #include "VramSnapshot.h"
@@ -70,6 +71,7 @@ void RipperHooks::onFrameBegin()
     if (!isCaptureEnabled() || !m_buffer)
         return;
     m_latestMatrixId = UINT32_MAX;
+    m_submitMatrixId = UINT32_MAX;
     if (m_clearPrimsOnFrameBegin)
         m_buffer->beginFrame();
 }
@@ -133,11 +135,32 @@ void RipperHooks::onDrawMode(const DrawModeRecord &mode)
     if (!isCaptureEnabled() || !m_buffer)
         return;
     m_buffer->addDrawMode(mode);
+    if (m_latestMatrixId != UINT32_MAX)
+        m_submitMatrixId = m_latestMatrixId;
+}
+
+void RipperHooks::onDrawingOffset(int32_t ofx, int32_t ofy)
+{
+    if (!isCaptureEnabled() || !m_buffer || m_submitMatrixId == UINT32_MAX)
+        return;
+    if (m_submitMatrixId >= static_cast<uint32_t>(m_buffer->matrices().size()))
+        return;
+
+    MatrixRecord matrix = m_buffer->matrices()[static_cast<int>(m_submitMatrixId)];
+    matrix.ofx = ofx;
+    matrix.ofy = ofy;
+    matrix.hash = GteCapture::hashMatrix(matrix);
+    m_submitMatrixId = m_buffer->addMatrix(matrix);
 }
 
 uint32_t RipperHooks::latestMatrixId() const
 {
     return m_latestMatrixId;
+}
+
+uint32_t RipperHooks::submitMatrixId() const
+{
+    return m_submitMatrixId;
 }
 
 void RipperHooks::ingestSystemRamForGpuCapture(const uint8_t *ram, size_t byteSize, bool scanGteRam,

--- a/src/PS1/runtime/RipperHooks.h
+++ b/src/PS1/runtime/RipperHooks.h
@@ -22,6 +22,7 @@ public:
 
     bool isCaptureEnabled() const override;
     uint32_t latestMatrixId() const override;
+    uint32_t submitMatrixId() const override;
 
     void ingestSystemRamForGpuCapture(const uint8_t *ram, size_t byteSize, bool scanGteRam = true,
                                       bool accumulate = false) override;
@@ -46,6 +47,7 @@ public:
                      const uint16_t *pixels) override;
     void onVramRead(uint16_t x, uint16_t y, uint16_t w, uint16_t h) override;
     void onDrawMode(const DrawModeRecord &mode) override;
+    void onDrawingOffset(int32_t ofx, int32_t ofy) override;
 
 private:
     QString primDedupeKey(const PrimRecord &prim) const;
@@ -54,6 +56,7 @@ private:
     CaptureBuffer *m_buffer = nullptr;
     VramSnapshot *m_vram = nullptr;
     uint32_t m_latestMatrixId = UINT32_MAX;
+    uint32_t m_submitMatrixId = UINT32_MAX;
     bool m_accumulatePass = false;
     bool m_clearPrimsOnFrameBegin = true;
     bool m_ramCaptureActive = false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -154,6 +154,7 @@ if(BUILD_TESTS)
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PsxGteEngine.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PsxGteInstructionCapture.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PsxMipsGteRunner.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/MeshReconstructionStats.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/MeshReconstructor.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/MeshTopologyHash.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PS1RipMeshBuilder.cpp


### PR DESCRIPTION
## Summary
- Freeze `submitMatrixId` on GP0 drawing-environment commands (`0xE1`–`0xE6`) so primitives keep the matrix active at draw time instead of the latest COP2 scan.
- Thread `currentMatrixId` through OT/chain/linear GP0 dispatch; parse `0xE4` drawing offset into the active submit matrix OFX/OFY.
- Add `MeshReconstructionStats` (GTE inverse %, slab-like bounds heuristic) with session status + Sentry `ps1.rip.matrix.stats`.
- Document #658 limitations and #662 GP0 FIFO follow-up in `PS1_RIP_DESIGN.md`.

Closes #658

## Test plan
- [x] `cmake --build build_local --target UnitTests`
- [ ] CI `unit-tests-linux` (includes `PsxPerDrawMatrixTest`)
- [ ] Manual: capture frame on libretro scene; status bar shows GTE inverse % and no slab warning on static geometry


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Mesh reconstruction statistics (GTE inverse % and slab-like bounds) and per-draw matrix handling with drawing-offset support.
  - Session UI now displays GTE inverse % and a slab-like hint when applicable.

* **Documentation**
  - Design doc updated with per-draw matrix behavior, capture ordering limits, and troubleshooting.

* **Tests**
  - New unit tests for per-draw matrix behavior and reconstruction statistics validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/663?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->