### PR TITLE
feat(ps1): full VRAM access via software libretro renderer (#660)

### DIFF
--- a/plugins/ps1core_libretro/LibretroEmuCore.cpp
+++ b/plugins/ps1core_libretro/LibretroEmuCore.cpp
@@ -16,7 +16,10 @@
 #include <cstdarg>
 #include <cstring>
 
+#include <QList>
+#include <QPair>
 #include <QString>
+#include <QStringList>
 
 namespace {
 
@@ -209,19 +212,47 @@ bool installBiosAliases(const QString &biosPath, const QString &biosLabel)
     return QFile::copy(biosPath, target);
 }
 
+// Merge our keys into an existing Beetle PSX.cfg rather than truncating it,
+// so unrelated user/core settings (and other libretro frontends sharing the
+// directory) survive across rip sessions. Review feedback on PR #671.
 void writeSoftwareRendererCoreConfig(const QString &biosDirPath)
 {
     if (LibretroCoreOptions::rendererPreferenceFromEnv() != "software")
         return;
 
-    const QString cfgPath = QDir(biosDirPath).filePath(QStringLiteral("Beetle PSX.cfg"));
-    QFile cfg(cfgPath);
-    if (!cfg.open(QIODevice::WriteOnly | QIODevice::Text))
-        return;
+    const QList<QPair<QByteArray, QByteArray>> managed = {
+        {QByteArrayLiteral("beetle_psx_renderer"), QByteArrayLiteral("software")},
+        {QByteArrayLiteral("beetle_psx_skip_bios"), QByteArrayLiteral("enabled")},
+        {QByteArrayLiteral("beetle_psx_override_bios"), QByteArrayLiteral("disabled")},
+    };
 
-    cfg.write("beetle_psx_renderer = \"software\"\n");
-    cfg.write("beetle_psx_skip_bios = \"enabled\"\n");
-    cfg.write("beetle_psx_override_bios = \"disabled\"\n");
+    const QString cfgPath = QDir(biosDirPath).filePath(QStringLiteral("Beetle PSX.cfg"));
+
+    QStringList existingLines;
+    {
+        QFile in(cfgPath);
+        if (in.exists() && in.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            while (!in.atEnd()) {
+                QByteArray raw = in.readLine();
+                while (raw.endsWith('\n') || raw.endsWith('\r'))
+                    raw.chop(1);
+                existingLines.append(QString::fromUtf8(raw));
+            }
+        }
+    }
+
+    const QStringList outLines = LibretroCoreOptions::mergeCoreConfigLines(existingLines, managed);
+
+    QFile out(cfgPath);
+    if (!out.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
+        qWarning() << "[ps1-rip] Failed to write Beetle PSX core config:"
+                   << cfgPath << out.errorString();
+        return;
+    }
+    for (const QString &line : outLines) {
+        out.write(line.toUtf8());
+        out.write("\n");
+    }
 }
 
 } // namespace

--- a/plugins/ps1core_libretro/LibretroEmuCore.cpp
+++ b/plugins/ps1core_libretro/LibretroEmuCore.cpp
@@ -1,6 +1,7 @@
 #include "LibretroEmuCore.h"
 #include "EmuFramebuffer.h"
 #include "Gp0HookDispatch.h"
+#include "LibretroCoreOptions.h"
 #include "PsxBiosValidator.h"
 #include "PsxDiscResolver.h"
 #include "PsxVramColor.h"
@@ -25,19 +26,17 @@ constexpr size_t kPsxVramBytes = static_cast<size_t>(kPsxVramWidth) * kPsxVramHe
 
 QStringList libretroCoreCandidates()
 {
+    // Software-capable cores only (#660). beetle_psx_hw keeps VRAM on the GPU.
     QStringList names;
 #if defined(Q_OS_WIN)
     names << QStringLiteral("mednafen_psx_libretro.dll")
-          << QStringLiteral("beetle_psx_libretro.dll")
-          << QStringLiteral("beetle_psx_hw_libretro.dll");
+          << QStringLiteral("beetle_psx_libretro.dll");
 #elif defined(Q_OS_MACOS)
     names << QStringLiteral("mednafen_psx_libretro.dylib")
-          << QStringLiteral("beetle_psx_libretro.dylib")
-          << QStringLiteral("beetle_psx_hw_libretro.dylib");
+          << QStringLiteral("beetle_psx_libretro.dylib");
 #else
     names << QStringLiteral("mednafen_psx_libretro.so")
-          << QStringLiteral("beetle_psx_libretro.so")
-          << QStringLiteral("beetle_psx_hw_libretro.so");
+          << QStringLiteral("beetle_psx_libretro.so");
 #endif
     return names;
 }
@@ -210,12 +209,28 @@ bool installBiosAliases(const QString &biosPath, const QString &biosLabel)
     return QFile::copy(biosPath, target);
 }
 
+void writeSoftwareRendererCoreConfig(const QString &biosDirPath)
+{
+    if (LibretroCoreOptions::rendererPreferenceFromEnv() != "software")
+        return;
+
+    const QString cfgPath = QDir(biosDirPath).filePath(QStringLiteral("Beetle PSX.cfg"));
+    QFile cfg(cfgPath);
+    if (!cfg.open(QIODevice::WriteOnly | QIODevice::Text))
+        return;
+
+    cfg.write("beetle_psx_renderer = \"software\"\n");
+    cfg.write("beetle_psx_skip_bios = \"enabled\"\n");
+    cfg.write("beetle_psx_override_bios = \"disabled\"\n");
+}
+
 } // namespace
 
 LibretroEmuCore *LibretroEmuCore::s_active = nullptr;
 
 LibretroEmuCore::LibretroEmuCore()
 {
+    m_rendererPreference = LibretroCoreOptions::rendererPreferenceFromEnv();
     resetJoypad();
     for (EmuFramebuffer &buf : m_buffers) {
         buf.width = 320;
@@ -244,8 +259,19 @@ QString LibretroEmuCore::coreId() const
 QString LibretroEmuCore::resolveLibretroCorePath(QString *errorOut)
 {
     const QString envPath = envCorePath();
-    if (!envPath.isEmpty() && QFileInfo::exists(envPath))
-        return QFileInfo(envPath).absoluteFilePath();
+    if (!envPath.isEmpty()) {
+        if (LibretroCoreOptions::isHardwareOnlyCorePath(envPath)) {
+            if (errorOut) {
+                *errorOut = QObject::tr(
+                    "QTMESH_PS1_LIBRETRO_CORE points at a hardware-only core (%1). Use "
+                    "mednafen_psx_libretro for texture ripping.")
+                        .arg(QFileInfo(envPath).fileName());
+            }
+            return {};
+        }
+        if (QFileInfo::exists(envPath))
+            return QFileInfo(envPath).absoluteFilePath();
+    }
 
     const QString appDir = QCoreApplication::applicationDirPath();
     // Only load cores shipped next to the app (or via env). Distro libretro builds are often
@@ -288,6 +314,7 @@ bool LibretroEmuCore::loadBios(const QString &biosPath)
     m_biosPath = info.absoluteFilePath();
     m_biosLabel = fp.knownLabel;
     installBiosAliases(m_biosPath, m_biosLabel);
+    writeSoftwareRendererCoreConfig(QFileInfo(m_biosPath).absolutePath());
     return true;
 }
 
@@ -323,6 +350,15 @@ bool LibretroEmuCore::ensureInitialized(QString *errorOut)
     m_corePath = resolveLibretroCorePath(errorOut);
     if (m_corePath.isEmpty())
         return false;
+
+    if (LibretroCoreOptions::isHardwareOnlyCorePath(m_corePath)) {
+        if (errorOut) {
+            *errorOut = QObject::tr(
+                "beetle_psx_hw does not expose VRAM for texture ripping. Install "
+                "mednafen_psx_libretro (software) into PS1Cores/.");
+        }
+        return false;
+    }
 
     prependCoreDirToLibraryPath(m_corePath);
 
@@ -407,6 +443,7 @@ void LibretroEmuCore::unloadGame()
     m_hasVideoFrame = false;
     m_vramPtr = nullptr;
     m_vramBytes = 0;
+    m_lastVramMirrorMode = PsxVramMirrorMode::Unknown;
     m_memoryRegions.clear();
 }
 
@@ -584,11 +621,18 @@ void LibretroEmuCore::syncVramFromCore()
     m_vramUsesFramebufferFallback = false;
     if (src && m_vramBytes >= kPsxVramBytes) {
         m_hooks->onVramWrite(0, 0, kPsxVramWidth, kPsxVramHeight, src);
+        m_lastVramMirrorMode = PsxVramMirrorMode::FullVram;
         return;
     }
 
     m_vramUsesFramebufferFallback = true;
+    m_lastVramMirrorMode = PsxVramMirrorMode::FramebufferFallback;
     mirrorFramebufferToVram();
+}
+
+PsxVramMirrorMode LibretroEmuCore::lastVramMirrorMode() const
+{
+    return m_lastVramMirrorMode;
 }
 
 void LibretroEmuCore::captureGpuFromRam(bool scanGteRam, bool accumulate)
@@ -709,25 +753,14 @@ bool LibretroEmuCore::environmentCallback(unsigned cmd, void *data)
         auto *var = static_cast<retro_variable *>(data);
         if (!var || !var->key)
             return false;
-        if (strcmp(var->key, "beetle_psx_skip_bios") == 0) {
-            self->m_envVarUtf8 = "enabled";
-            var->value = self->m_envVarUtf8.constData();
-            return true;
-        }
-        if (strcmp(var->key, "beetle_psx_override_bios") == 0) {
-            self->m_envVarUtf8 = "disabled";
-            var->value = self->m_envVarUtf8.constData();
-            return true;
-        }
-        // Hardware/Vulkan renderers keep VRAM on the GPU and do not expose it via
-        // RETRO_MEMORY_VIDEO_RAM or SET_MEMORY_MAPS. Software renderer is required for
-        // VRAM dump / texture decode in the rip pipeline.
-        if (strcmp(var->key, "beetle_psx_renderer") == 0) {
-            self->m_envVarUtf8 = "software";
-            var->value = self->m_envVarUtf8.constData();
-            return true;
-        }
-        return false;
+        const char *value =
+            LibretroCoreOptions::valueForKey(var->key, self->m_rendererPreference);
+        if (!value)
+            return false;
+        const QByteArray keyBytes(var->key);
+        self->m_coreVariableStorage[keyBytes] = QByteArray(value);
+        var->value = self->m_coreVariableStorage[keyBytes].constData();
+        return true;
     }
     case RETRO_ENVIRONMENT_SET_MEMORY_MAPS: {
         auto *map = static_cast<retro_memory_map *>(data);

--- a/plugins/ps1core_libretro/LibretroEmuCore.h
+++ b/plugins/ps1core_libretro/LibretroEmuCore.h
@@ -3,8 +3,10 @@
 
 #include "EmuCore.h"
 #include "LibretroHost.h"
+#include "PsxVramMirrorMode.h"
 
 #include <QByteArray>
+#include <QHash>
 #include <QString>
 #include <QVector>
 
@@ -27,6 +29,7 @@ public:
     void setHooks(EmuHooks *hooks) override;
     void syncCaptureMirrors() override;
     void ingestCaptureFrame() override;
+    PsxVramMirrorMode lastVramMirrorMode() const override;
     QString lastError() const override { return m_lastError; }
     void setJoypadButton(unsigned port, unsigned buttonId, bool pressed) override;
     void resetJoypad(unsigned port = 0) override;
@@ -64,11 +67,13 @@ private:
     retro_pixel_format m_pixelFormat = RETRO_PIXEL_FORMAT_0RGB1555;
     bool m_hasVideoFrame = false;
     QString m_lastError;
-    QByteArray m_envVarUtf8;
     QByteArray m_envSystemDirUtf8;
+    QByteArray m_rendererPreference;
+    QHash<QByteArray, QByteArray> m_coreVariableStorage;
     const uint16_t *m_vramPtr = nullptr;
     size_t m_vramBytes = 0;
     bool m_vramUsesFramebufferFallback = false;
+    PsxVramMirrorMode m_lastVramMirrorMode = PsxVramMirrorMode::Unknown;
 
     struct MemoryRegion {
         const void *ptr = nullptr;

--- a/scripts/install-ps1-libretro-core.sh
+++ b/scripts/install-ps1-libretro-core.sh
@@ -62,7 +62,7 @@ if [[ -n "${QTMESH_PS1_LIBRETRO_CORE:-}" ]]; then
 fi
 
 if fetch_buildbot_beetle; then
-  echo "Using libretro buildbot mednafen_psx_libretro (recommended for .iso rips)."
+  echo "Using libretro buildbot mednafen_psx_libretro (software renderer — required for VRAM texture rip #660)."
   exit 0
 fi
 

--- a/src/PS1/PS1_RIP_DESIGN.md
+++ b/src/PS1/PS1_RIP_DESIGN.md
@@ -86,7 +86,7 @@ See epic #412 for phased issues (#413–#431).
 - `TextureDecoder` — CLUT-aware 4/8/15 bpp decode keyed by `(TPAGE, CLUT, bit depth, semiTrans, draw mode)` with UV-bounds cache merge and STP/alpha via `PsxVramColor`.
 - `PS1RipMeshBuilder` — pre-decodes capture textures, uploads to `PS1Rip_Session<N>` resource group, applies PS1 semi-transparency blend modes, Sentry `ps1.rip.texture.decoded`. Ogre material resources are scoped per capture (`PS1Rip_<captureId>_tpage_…`); prior capture meshes/materials/textures are purged before each rebuild. Runtime materials use the `PS1Rip_` prefix (listed in Material Editor, read-only; GPU thumbnails are skipped to avoid UI freezes).
 - `dumpVRAM()` saves `<AppData>/ps1_rip/captures/<id>_vram.png` and feeds `VramViewerWidget` in the session window.
-- **Libretro:** `syncVramFromCore()` mirrors live core VRAM every frame; capture snapshots include a VRAM cell copy for textured mesh export.
+- **Libretro:** `syncVramFromCore()` mirrors live core VRAM every frame; capture snapshots include a VRAM cell copy for textured mesh export. Software renderer (`beetle_psx_renderer=software`, #660) is required for full TPAGE/CLUT decode on retail captures; framebuffer-only fallback remains for unsupported cores.
 - Stub core fills CLUT + 4/8/15 bpp test regions via `stubFillVramPattern` when capture is armed or on `syncCaptureMirrors` (CI only).
 
 ## Phase 4 status (#422 / #423)
@@ -140,7 +140,11 @@ The **stub** core is active (`coreId=stub`). It draws a test pattern and synthet
 
 1. **Empty while the game viewport is black** — the mirror is filled from libretro each frame. Press **Start**, wait until you see gameplay in the PS1 viewport, then dump again.
 2. **Session died after the warning** — non-fatal dump/capture issues use `sessionWarning` only. Older builds used `emulationError` and stopped the session, so a second dump showed “no session”.
-3. **Hardware renderer (mednafen default)** — `RETRO_MEMORY_VIDEO_RAM` is often **not** exposed (VRAM stays on the GPU). QtMeshEditor falls back to mirroring the **visible framebuffer** into the top-left of the VRAM snapshot so dump/preview still work. This is **not** the full 1024×512 texture atlas — only what is on screen. Full VRAM needs a software-renderer core build that exports memory maps (future improvement).
+3. **Hardware renderer (mednafen default)** — `beetle_psx_hw` and hardware GL/Vulkan renderers keep VRAM on the GPU and do **not** expose `RETRO_MEMORY_VIDEO_RAM`. QtMeshEditor forces **`beetle_psx_renderer = software`** via libretro core options (override + `Beetle PSX.cfg` in the BIOS folder) and **excludes** `beetle_psx_hw_*` from auto-discovery. With software mednafen/beetle, texture decode (#421) reads the full 1024×512 VRAM snapshot at capture time.
+
+   If the status bar still shows **VRAM: framebuffer mirror only**, the loaded core is not exposing VRAM — confirm `PS1Cores/mednafen_psx_libretro.*` (not `_hw_`), unset `QTMESH_PS1_LIBRETRO_RENDERER=auto` unless debugging, and re-run `scripts/install-ps1-libretro-core.sh`. Optional env: `QTMESH_PS1_LIBRETRO_RENDERER=software|hardware|auto` (default **software**).
+
+   **Partial tier:** when only the visible framebuffer is mirrored, GP0 VRAM-upload packets during armed capture may still patch texture pages outside the FB rect (**framebuffer + GP0 texture patches**). Golden-scene geometry-only passes are documented in `src/PS1/golden_captures.md`.
 
 ### Capture mesh is a triangle “blob” (normal size, wrong shape)
 
@@ -166,8 +170,15 @@ export QTMESH_PS1_TEST_ISO=/path/game.cue
 
 - **Doc:** `src/PS1/golden_captures.md` — homebrew + two retail acceptance scenes, manual checklist, env var names.
 - **Env:** `QTMESH_PS1_GOLDEN_SCENE_ID`, `QTMESH_PS1_GOLDEN_HOMEBREW_ISO`, `QTMESH_PS1_GOLDEN_RETAIL_A_ISO`, `QTMESH_PS1_GOLDEN_RETAIL_B_ISO` (plus legacy `QTMESH_PS1_TEST_*` aliases).
-- **CI:** `MeshReconstructorGoldenTest.SlabMetricHeuristic*` / `ScreenCubeReconstructionHasVolume` run without ROMs. `ConfiguredGoldenIsoReconstructsWithVolume` runs when BIOS + at least one golden ISO path is set (skips in CI by default).
+- **CI:** `MeshReconstructorGoldenTest.SlabMetricHeuristic*` / `ScreenCubeReconstructionHasVolume` run without ROMs. `ConfiguredGoldenIsoReconstructsWithVolume` is a no-op when BIOS/ISO paths are unset.
 - **Telemetry:** `ps1.rip.capture.golden` and `ps1.rip.matrix.stats` include `golden_id=` when `QTMESH_PS1_GOLDEN_SCENE_ID` is set or `PS1RipManager::setGoldenSceneId()` is used (session UI picker: #425).
+
+### Full VRAM / textures (#660)
+
+- **Software renderer:** libretro host forces `beetle_psx_renderer=software` (env override `QTMESH_PS1_LIBRETRO_RENDERER`, default software) and rejects `beetle_psx_hw_*` cores.
+- **Status bar:** after capture, `VRAM: full VRAM` vs `framebuffer mirror only` vs `framebuffer + GP0 texture patches`.
+- **Sentry:** `ps1.rip.vram.sync` breadcrumb on capture with mode label.
+- **Tests:** `LibretroCoreOptionsTest`, `VramSnapshotTest.HasNonZeroOutsideRectDetectsTpageRegion`, stub VRAM tests unchanged.
 
 ## Open questions
 

--- a/src/PS1/golden_captures.md
+++ b/src/PS1/golden_captures.md
@@ -22,7 +22,7 @@ Epic close requires **at least 2 of 3** scenes to pass the manual checklist on a
 
 1. **Capture Frame** → non-empty mesh in the editor (vertex/triangle counts in status).
 2. Mesh is **visually recognizable** (not a flat screen-space slab) — compare to the PS1 viewport screenshot.
-3. Vertex colors and at least one texture page look plausible, **or** note a **geometry-only** pass in the test log.
+3. Vertex colors and at least one texture page look plausible, **or** note a **geometry-only** pass in the test log (acceptable when VRAM status shows framebuffer mirror only — see #660).
 4. Export to glTF ([#427](https://github.com/fernandotonon/QtMeshEditor/issues/427)) opens in an external viewer without fatal errors.
 
 Record pass/fail and QtMeshEditor version in your PR or release notes when claiming epic #412.
@@ -57,6 +57,8 @@ export QTMESH_PS1_GOLDEN_SCENE_ID=retail-a
 `ConfiguredGoldenIsoReconstructsWithVolume` is a no-op when BIOS/ISO paths are unset (CI has no retail ISOs). When configured locally, it boots libretro, captures ~240 frames, and asserts non-empty reconstruction, `!slabLike`, and `hasBounds()`.
 
 Unset `QTMESH_PS1_FORCE_STUB` locally (CI forces stub).
+
+**Textures (#660):** use `mednafen_psx_libretro` / `beetle_psx_libretro` (software renderer). Avoid `beetle_psx_hw`. After capture, the session status bar shows `VRAM: full VRAM` when texture decode can read TPAGE/CLUT pages.
 
 ## Related issues
 

--- a/src/PS1/runtime/EmuCore.h
+++ b/src/PS1/runtime/EmuCore.h
@@ -3,6 +3,7 @@
 
 #include "EmuFramebuffer.h"
 #include "EmuHooks.h"
+#include "PsxVramMirrorMode.h"
 
 #include <QString>
 #include <memory>
@@ -29,6 +30,7 @@ public:
     virtual void syncCaptureMirrors() {}
     /** Re-scan emulated RAM for GPU packets into the capture buffer (libretro path). */
     virtual void ingestCaptureFrame() {}
+    virtual PsxVramMirrorMode lastVramMirrorMode() const { return PsxVramMirrorMode::Unknown; }
     virtual QString lastError() const { return QString(); }
 
     virtual void setJoypadButton(unsigned port, unsigned buttonId, bool pressed)

--- a/src/PS1/runtime/LibretroCoreOptions.h
+++ b/src/PS1/runtime/LibretroCoreOptions.h
@@ -1,0 +1,68 @@
+#ifndef LIBRETROCOREOPTIONS_H
+#define LIBRETROCOREOPTIONS_H
+
+#include <QByteArray>
+#include <QFileInfo>
+#include <QString>
+
+#include <QtGlobal>
+
+#include <cstring>
+
+/** libretro core-option overrides for PS1 rip (#660). */
+namespace LibretroCoreOptions {
+
+inline bool isHardwareOnlyCorePath(const QString &corePath)
+{
+    const QString base = QFileInfo(corePath).fileName();
+    return base.contains(QStringLiteral("beetle_psx_hw"), Qt::CaseInsensitive)
+           || base.contains(QStringLiteral("_hw_libretro"), Qt::CaseInsensitive);
+}
+
+/** software (default), hardware, or auto (do not override renderer keys). */
+inline QByteArray rendererPreferenceFromEnv()
+{
+    const QByteArray env = qgetenv("QTMESH_PS1_LIBRETRO_RENDERER").trimmed().toLower();
+    if (env == "hardware" || env == "hardware_gl" || env == "hardware_vk")
+        return QByteArray("hardware_gl");
+    if (env == "auto")
+        return {};
+    return QByteArray("software");
+}
+
+inline bool isRendererVariableKey(const char *key)
+{
+    if (!key)
+        return false;
+    return strcmp(key, "beetle_psx_renderer") == 0
+           || strcmp(key, "beetle_psx_hw_renderer") == 0
+           || strcmp(key, "mednafen_psx_renderer") == 0;
+}
+
+/** Returns nullptr when the frontend should not override this key. */
+inline const char *valueForKey(const char *key, const QByteArray &rendererPreference)
+{
+    if (!key)
+        return nullptr;
+
+    if (strcmp(key, "beetle_psx_skip_bios") == 0)
+        return "enabled";
+    if (strcmp(key, "beetle_psx_override_bios") == 0)
+        return "disabled";
+
+    if (isRendererVariableKey(key)) {
+        if (rendererPreference.isEmpty())
+            return nullptr;
+        if (rendererPreference == "software")
+            return "software";
+        if (rendererPreference == "hardware_gl")
+            return "hardware_gl";
+        return rendererPreference.constData();
+    }
+
+    return nullptr;
+}
+
+} // namespace LibretroCoreOptions
+
+#endif // LIBRETROCOREOPTIONS_H

--- a/src/PS1/runtime/LibretroCoreOptions.h
+++ b/src/PS1/runtime/LibretroCoreOptions.h
@@ -3,7 +3,11 @@
 
 #include <QByteArray>
 #include <QFileInfo>
+#include <QList>
+#include <QPair>
+#include <QSet>
 #include <QString>
+#include <QStringList>
 
 #include <QtGlobal>
 
@@ -61,6 +65,41 @@ inline const char *valueForKey(const char *key, const QByteArray &rendererPrefer
     }
 
     return nullptr;
+}
+
+/**
+ * Merge `managed` `key = "value"` pairs into an existing core-config line set,
+ * preserving every untouched line (comments, blank lines, unrelated keys) in
+ * its original order. Managed keys are removed in-place and re-appended at the
+ * end so multiple QtMeshEditor sessions converge to the same canonical layout.
+ */
+inline QStringList mergeCoreConfigLines(
+    const QStringList &existingLines,
+    const QList<QPair<QByteArray, QByteArray>> &managed)
+{
+    QSet<QString> managedKeys;
+    for (const auto &kv : managed)
+        managedKeys.insert(QString::fromLatin1(kv.first));
+
+    QStringList out;
+    out.reserve(existingLines.size() + managed.size());
+    for (const QString &line : existingLines) {
+        const int eq = line.indexOf(QLatin1Char('='));
+        if (eq < 0) {
+            out.append(line);
+            continue;
+        }
+        const QString key = line.left(eq).trimmed();
+        if (managedKeys.contains(key))
+            continue;
+        out.append(line);
+    }
+    for (const auto &kv : managed) {
+        out.append(QStringLiteral("%1 = \"%2\"")
+                       .arg(QString::fromLatin1(kv.first),
+                            QString::fromLatin1(kv.second)));
+    }
+    return out;
 }
 
 } // namespace LibretroCoreOptions

--- a/src/PS1/runtime/LibretroCoreOptions_test.cpp
+++ b/src/PS1/runtime/LibretroCoreOptions_test.cpp
@@ -4,6 +4,35 @@
 
 #include <gtest/gtest.h>
 
+namespace {
+
+// RAII helper that snapshots QTMESH_PS1_LIBRETRO_RENDERER for the lifetime of a
+// test and restores the original value (or unsets the variable) on destruction.
+// Prevents tests from leaking process-global env state to neighbouring tests.
+class RendererEnvGuard
+{
+public:
+    RendererEnvGuard()
+        : m_hadValue(qEnvironmentVariableIsSet("QTMESH_PS1_LIBRETRO_RENDERER")),
+          m_previous(qgetenv("QTMESH_PS1_LIBRETRO_RENDERER"))
+    {
+    }
+
+    ~RendererEnvGuard()
+    {
+        if (m_hadValue)
+            qputenv("QTMESH_PS1_LIBRETRO_RENDERER", m_previous);
+        else
+            qunsetenv("QTMESH_PS1_LIBRETRO_RENDERER");
+    }
+
+private:
+    bool m_hadValue;
+    QByteArray m_previous;
+};
+
+} // namespace
+
 TEST(LibretroCoreOptionsTest, DetectsHardwareOnlyCorePaths)
 {
     EXPECT_TRUE(LibretroCoreOptions::isHardwareOnlyCorePath(
@@ -16,6 +45,7 @@ TEST(LibretroCoreOptionsTest, DetectsHardwareOnlyCorePaths)
 
 TEST(LibretroCoreOptionsTest, SoftwareRendererIsDefaultOverride)
 {
+    RendererEnvGuard guard;
     qunsetenv("QTMESH_PS1_LIBRETRO_RENDERER");
     EXPECT_EQ(LibretroCoreOptions::rendererPreferenceFromEnv(), QByteArray("software"));
     EXPECT_STREQ(LibretroCoreOptions::valueForKey("beetle_psx_renderer",
@@ -25,12 +55,12 @@ TEST(LibretroCoreOptionsTest, SoftwareRendererIsDefaultOverride)
 
 TEST(LibretroCoreOptionsTest, AutoRendererDoesNotOverride)
 {
+    RendererEnvGuard guard;
     qputenv("QTMESH_PS1_LIBRETRO_RENDERER", "auto");
     EXPECT_TRUE(LibretroCoreOptions::rendererPreferenceFromEnv().isEmpty());
     EXPECT_EQ(LibretroCoreOptions::valueForKey("beetle_psx_renderer",
                                                LibretroCoreOptions::rendererPreferenceFromEnv()),
               nullptr);
-    qunsetenv("QTMESH_PS1_LIBRETRO_RENDERER");
 }
 
 TEST(LibretroCoreOptionsTest, SkipBiosVariablesAlwaysProvided)
@@ -40,6 +70,47 @@ TEST(LibretroCoreOptionsTest, SkipBiosVariablesAlwaysProvided)
     EXPECT_STREQ(
         LibretroCoreOptions::valueForKey("beetle_psx_override_bios", QByteArray("software")),
         "disabled");
+}
+
+TEST(LibretroCoreOptionsTest, MergePreservesUnrelatedKeysAndComments)
+{
+    QStringList existing;
+    existing << QStringLiteral("# user config")
+             << QStringLiteral("beetle_psx_renderer = \"hardware_gl\"") // gets replaced
+             << QStringLiteral("beetle_psx_widescreen_hack = \"enabled\"") // preserved
+             << QString()                                                   // blank line
+             << QStringLiteral("beetle_psx_skip_bios = \"disabled\""); // gets replaced
+
+    const QList<QPair<QByteArray, QByteArray>> managed = {
+        {QByteArrayLiteral("beetle_psx_renderer"), QByteArrayLiteral("software")},
+        {QByteArrayLiteral("beetle_psx_skip_bios"), QByteArrayLiteral("enabled")},
+        {QByteArrayLiteral("beetle_psx_override_bios"), QByteArrayLiteral("disabled")},
+    };
+
+    const QStringList merged = LibretroCoreOptions::mergeCoreConfigLines(existing, managed);
+
+    EXPECT_TRUE(merged.contains(QStringLiteral("# user config")));
+    EXPECT_TRUE(merged.contains(QStringLiteral("beetle_psx_widescreen_hack = \"enabled\"")));
+    EXPECT_TRUE(merged.contains(QString()));
+
+    EXPECT_FALSE(merged.contains(QStringLiteral("beetle_psx_renderer = \"hardware_gl\"")));
+    EXPECT_FALSE(merged.contains(QStringLiteral("beetle_psx_skip_bios = \"disabled\"")));
+
+    EXPECT_TRUE(merged.contains(QStringLiteral("beetle_psx_renderer = \"software\"")));
+    EXPECT_TRUE(merged.contains(QStringLiteral("beetle_psx_skip_bios = \"enabled\"")));
+    EXPECT_TRUE(merged.contains(QStringLiteral("beetle_psx_override_bios = \"disabled\"")));
+}
+
+TEST(LibretroCoreOptionsTest, MergeOnEmptyInputProducesManagedKeysOnly)
+{
+    const QList<QPair<QByteArray, QByteArray>> managed = {
+        {QByteArrayLiteral("beetle_psx_renderer"), QByteArrayLiteral("software")},
+    };
+
+    const QStringList merged = LibretroCoreOptions::mergeCoreConfigLines({}, managed);
+
+    ASSERT_EQ(merged.size(), 1);
+    EXPECT_EQ(merged.first(), QStringLiteral("beetle_psx_renderer = \"software\""));
 }
 
 #endif // ENABLE_PS1_RIP

--- a/src/PS1/runtime/LibretroCoreOptions_test.cpp
+++ b/src/PS1/runtime/LibretroCoreOptions_test.cpp
@@ -1,0 +1,45 @@
+#ifdef ENABLE_PS1_RIP
+
+#include "LibretroCoreOptions.h"
+
+#include <gtest/gtest.h>
+
+TEST(LibretroCoreOptionsTest, DetectsHardwareOnlyCorePaths)
+{
+    EXPECT_TRUE(LibretroCoreOptions::isHardwareOnlyCorePath(
+        QStringLiteral("/PS1Cores/beetle_psx_hw_libretro.so")));
+    EXPECT_TRUE(LibretroCoreOptions::isHardwareOnlyCorePath(
+        QStringLiteral("beetle_psx_hw_libretro.dll")));
+    EXPECT_FALSE(LibretroCoreOptions::isHardwareOnlyCorePath(
+        QStringLiteral("/PS1Cores/mednafen_psx_libretro.so")));
+}
+
+TEST(LibretroCoreOptionsTest, SoftwareRendererIsDefaultOverride)
+{
+    qunsetenv("QTMESH_PS1_LIBRETRO_RENDERER");
+    EXPECT_EQ(LibretroCoreOptions::rendererPreferenceFromEnv(), QByteArray("software"));
+    EXPECT_STREQ(LibretroCoreOptions::valueForKey("beetle_psx_renderer",
+                                                 LibretroCoreOptions::rendererPreferenceFromEnv()),
+                "software");
+}
+
+TEST(LibretroCoreOptionsTest, AutoRendererDoesNotOverride)
+{
+    qputenv("QTMESH_PS1_LIBRETRO_RENDERER", "auto");
+    EXPECT_TRUE(LibretroCoreOptions::rendererPreferenceFromEnv().isEmpty());
+    EXPECT_EQ(LibretroCoreOptions::valueForKey("beetle_psx_renderer",
+                                               LibretroCoreOptions::rendererPreferenceFromEnv()),
+              nullptr);
+    qunsetenv("QTMESH_PS1_LIBRETRO_RENDERER");
+}
+
+TEST(LibretroCoreOptionsTest, SkipBiosVariablesAlwaysProvided)
+{
+    EXPECT_STREQ(LibretroCoreOptions::valueForKey("beetle_psx_skip_bios", QByteArray("software")),
+                "enabled");
+    EXPECT_STREQ(
+        LibretroCoreOptions::valueForKey("beetle_psx_override_bios", QByteArray("software")),
+        "disabled");
+}
+
+#endif // ENABLE_PS1_RIP

--- a/src/PS1/runtime/PS1RipManager.cpp
+++ b/src/PS1/runtime/PS1RipManager.cpp
@@ -1,5 +1,6 @@
 #include "PS1RipManager.h"
 #include "CaptureSnapshot.h"
+#include "LibretroCoreOptions.h"
 #include "MeshReconstructionStats.h"
 #include "MeshReconstructor.h"
 #include "MeshTopologyHash.h"
@@ -268,6 +269,17 @@ bool PS1RipManager::loadBios(const QString &path)
     else if (fp.sizeOk)
         biosMsg += QStringLiteral(" known=unknown");
     SentryReporter::addBreadcrumb(QStringLiteral("ps1.rip.bios.load"), biosMsg);
+
+    // #660: record which libretro renderer we'll request so rip sessions can be
+    // correlated with VRAM-mode telemetry below. The plugin can't link Sentry
+    // (it's a runtime-loaded MODULE), so the breadcrumb originates here.
+    const QByteArray rendererPref = LibretroCoreOptions::rendererPreferenceFromEnv();
+    SentryReporter::addBreadcrumb(
+        QStringLiteral("ps1.rip.renderer"),
+        QStringLiteral("preference=%1")
+            .arg(rendererPref.isEmpty() ? QStringLiteral("auto")
+                                        : QString::fromUtf8(rendererPref)));
+
     syncWorkerSession();
     return true;
 }

--- a/src/PS1/runtime/PS1RipManager.cpp
+++ b/src/PS1/runtime/PS1RipManager.cpp
@@ -8,6 +8,7 @@
 #include "PsxBiosValidator.h"
 #include "PsxDiscResolver.h"
 #include "PsxGoldenCapture.h"
+#include "PsxVramMirrorMode.h"
 #include "SentryReporter.h"
 
 #include <QFileInfo>
@@ -67,6 +68,7 @@ void PS1RipManager::initializeWorkerThread()
 {
     qRegisterMetaType<QVector<uint16_t>>("QVector<uint16_t>");
     qRegisterMetaType<CaptureSnapshot>("CaptureSnapshot");
+    qRegisterMetaType<PsxVramMirrorMode>("PsxVramMirrorMode");
 
     m_workerThread = new QThread(this);
     m_worker = new PS1RipWorker();
@@ -101,7 +103,8 @@ void PS1RipManager::initializeWorkerThread()
     connect(m_worker, &PS1RipWorker::sessionWarning, this, &PS1RipManager::reportError);
     connect(m_worker, &PS1RipWorker::framePresented, this, &PS1RipManager::framePresented);
     connect(m_worker, &PS1RipWorker::frameCaptureReady, this,
-            [this](const QString &captureId, const CaptureSnapshot &snapshot, int) {
+            [this](const QString &captureId, const CaptureSnapshot &snapshot, int,
+                   PsxVramMirrorMode vramMirrorMode) {
                 SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
                                               QStringLiteral("ps1_rip_frame:%1").arg(captureId));
                 const QString goldenId = goldenSceneId();
@@ -156,11 +159,15 @@ void PS1RipManager::initializeWorkerThread()
                 if (!goldenId.isEmpty())
                     matrixStats += QStringLiteral(" golden_id=%1").arg(goldenId);
                 SentryReporter::addBreadcrumb(QStringLiteral("ps1.rip.matrix.stats"), matrixStats);
+                SentryReporter::addBreadcrumb(
+                    QStringLiteral("ps1.rip.vram.sync"),
+                    QStringLiteral("capture=%1 mode=%2")
+                        .arg(captureId, psxVramMirrorModeLabel(vramMirrorMode)));
                 emit meshBuilt(captureId, captureSet.capturedPartCount, captureSet.uniqueCount(),
                                captureSet.instanceCount(), built.vertexCount, built.triangleCount,
                                snapshot.matrices.size(), snapshot.cameraMatrixId,
                                snapshot.hasCameraMatrix(), reconStats.gteInversePercent(),
-                               reconStats.slabLike);
+                               reconStats.slabLike, vramMirrorMode);
             });
     connect(m_worker, &PS1RipWorker::vramFrameUpdated, this,
             [this](const QVector<uint16_t> &cells, const QImage &preview) {

--- a/src/PS1/runtime/PS1RipManager.h
+++ b/src/PS1/runtime/PS1RipManager.h
@@ -9,6 +9,8 @@
 
 class PS1RipWorker;
 
+enum class PsxVramMirrorMode;
+
 /**
  * Main-thread coordinator for PS1 runtime geometry extraction (epic #412).
  */
@@ -62,7 +64,8 @@ signals:
     void frameCaptured(const QString &captureId);
     void meshBuilt(const QString &captureId, int capturedParts, int uniqueMeshes, int instanceCount,
                    int vertexCount, int triangleCount, int matrixCount, uint32_t cameraMatrixId,
-                   bool hasCameraMatrix, int gteInversePercent, bool slabLike);
+                   bool hasCameraMatrix, int gteInversePercent, bool slabLike,
+                   PsxVramMirrorMode vramMirrorMode);
     void sceneCaptured(const QString &captureId);
     void vramDumped(const QString &captureId, const QString &pngPath, const QVector<uint16_t> &cells,
                     const QImage &nativePreview);

--- a/src/PS1/runtime/PS1RipSessionWindow.cpp
+++ b/src/PS1/runtime/PS1RipSessionWindow.cpp
@@ -7,6 +7,7 @@
 #include "PsxJoypadBindings.h"
 #include "SentryReporter.h"
 #include "PsxJoypadState.h"
+#include "PsxVramMirrorMode.h"
 #include "VramViewerWidget.h"
 
 #include <QAction>
@@ -375,7 +376,7 @@ void PS1RipSessionWindow::onCaptureFrame()
 void PS1RipSessionWindow::onMeshBuilt(const QString &captureId, int capturedParts, int uniqueMeshes,
                                     int instanceCount, int vertexCount, int triangleCount,
                                     int matrixCount, uint32_t cameraMatrixId, bool hasCameraMatrix,
-                                    int gteInversePercent, bool slabLike)
+                                    int gteInversePercent, bool slabLike, PsxVramMirrorMode vramMirrorMode)
 {
     QString cameraText = hasCameraMatrix
                              ? tr("camera matrix #%1").arg(cameraMatrixId)
@@ -383,8 +384,12 @@ void PS1RipSessionWindow::onMeshBuilt(const QString &captureId, int capturedPart
     QString matrixStats = tr("GTE inverse %1%").arg(gteInversePercent);
     if (slabLike)
         matrixStats += tr(" — slab-like bounds (check matrix association)");
+    QString vramText = psxVramMirrorModeLabel(vramMirrorMode);
+    if (vramMirrorMode != PsxVramMirrorMode::FullVram)
+        vramText += tr(" — textures may be wrong");
     m_statusLabel->setText(
-        tr("Mesh %1 — captured %2 / unique %3 / instances %4 (%5 verts, %6 tris, %7 GTE matrices, %8, %9)")
+        tr("Mesh %1 — captured %2 / unique %3 / instances %4 (%5 verts, %6 tris, %7 GTE matrices, "
+           "%8, %9, VRAM: %10)")
             .arg(captureId)
             .arg(capturedParts)
             .arg(uniqueMeshes)
@@ -393,7 +398,8 @@ void PS1RipSessionWindow::onMeshBuilt(const QString &captureId, int capturedPart
             .arg(triangleCount)
             .arg(matrixCount)
             .arg(cameraText)
-            .arg(matrixStats));
+            .arg(matrixStats)
+            .arg(vramText));
 }
 
 void PS1RipSessionWindow::onVramDumped(const QString &captureId, const QString &pngPath,

--- a/src/PS1/runtime/PS1RipSessionWindow.h
+++ b/src/PS1/runtime/PS1RipSessionWindow.h
@@ -12,6 +12,8 @@ class PS1RipManager;
 class QMenu;
 class VramViewerWidget;
 
+enum class PsxVramMirrorMode;
+
 /** Temporary host for emulator viewport + transport (#416 / #417). */
 class PS1RipSessionWindow : public QMainWindow
 {
@@ -45,7 +47,8 @@ private slots:
                       const QImage &nativePreview);
     void onMeshBuilt(const QString &captureId, int capturedParts, int uniqueMeshes, int instanceCount,
                      int vertexCount, int triangleCount, int matrixCount, uint32_t cameraMatrixId,
-                     bool hasCameraMatrix, int gteInversePercent, bool slabLike);
+                     bool hasCameraMatrix, int gteInversePercent, bool slabLike,
+                     PsxVramMirrorMode vramMirrorMode);
     void onPausedChanged(bool paused);
 
 private:

--- a/src/PS1/runtime/PS1RipWorker.cpp
+++ b/src/PS1/runtime/PS1RipWorker.cpp
@@ -6,6 +6,7 @@
 #include "EmuFramebuffer.h"
 #include "GpuCommandParser.h"
 #include "PsxGoldenCapture.h"
+#include "PsxVramMirrorMode.h"
 #include "RipperHooks.h"
 #include "SentryReporter.h"
 #include "VramSnapshot.h"
@@ -13,11 +14,34 @@
 #include <QDateTime>
 #include <QDir>
 #include <QFile>
+#include <QRect>
 #include <QStandardPaths>
 #include <QElapsedTimer>
 #include <QTimer>
 
 #include <cstring>
+
+namespace {
+
+PsxVramMirrorMode effectiveVramMirrorMode(const EmuCore *core, const VramSnapshot *vram)
+{
+    if (!core)
+        return PsxVramMirrorMode::Unknown;
+
+    PsxVramMirrorMode mode = core->lastVramMirrorMode();
+    if (mode != PsxVramMirrorMode::FramebufferFallback || !vram)
+        return mode;
+
+    const EmuFramebuffer &fb = core->framebuffer();
+    if (!fb.isValid())
+        return mode;
+
+    if (vram->hasNonZeroOutsideRect(QRect(0, 0, fb.width, fb.height), 8))
+        return PsxVramMirrorMode::Gp0Hybrid;
+    return mode;
+}
+
+} // namespace
 
 PS1RipWorker::PS1RipWorker(QObject *parent)
     : QObject(parent)
@@ -269,12 +293,15 @@ void PS1RipWorker::finalizeFrameCapture()
     if (!goldenId.isEmpty())
         captureMsg += QStringLiteral(" golden_id=%1").arg(goldenId);
     SentryReporter::addBreadcrumb(QStringLiteral("ps1.rip.capture"), captureMsg);
+    const PsxVramMirrorMode vramMode = effectiveVramMirrorMode(m_core.get(), m_vram.get());
+    SentryReporter::addBreadcrumb(QStringLiteral("ps1.rip.vram.sync"),
+                                  QStringLiteral("mode=%1").arg(psxVramMirrorModeLabel(vramMode)));
     QVector<uint16_t> vramCells;
     if (m_vram && !m_vram->isEmpty())
         vramCells = m_vram->mutablePixels();
 
     emit frameCaptureReady(captureId, CaptureSnapshot::fromBuffer(*m_captureBuffer, vramCells),
-                           prims.size());
+                           prims.size(), vramMode);
 }
 
 void PS1RipWorker::dumpVram()
@@ -292,6 +319,17 @@ void PS1RipWorker::dumpVram()
             tr("VRAM mirror is still empty — confirm the game is running (video in the viewport), "
                "then try again."));
         return;
+    }
+
+    const PsxVramMirrorMode vramMode = effectiveVramMirrorMode(m_core.get(), m_vram.get());
+    if (vramMode == PsxVramMirrorMode::FramebufferFallback) {
+        emit sessionWarning(
+            tr("VRAM is framebuffer-only — textures may be missing. Use mednafen_psx_libretro "
+               "(software renderer) in PS1Cores/; avoid beetle_psx_hw."));
+    } else if (vramMode == PsxVramMirrorMode::Gp0Hybrid) {
+        emit sessionWarning(
+            tr("VRAM is partial (framebuffer + GP0 patches). Full texture pages require software "
+               "renderer VRAM access."));
     }
 
     const QString captureId = QString::number(QDateTime::currentMSecsSinceEpoch());

--- a/src/PS1/runtime/PS1RipWorker.h
+++ b/src/PS1/runtime/PS1RipWorker.h
@@ -18,6 +18,8 @@ class EmuCore;
 class QTimer;
 class RipperHooks;
 
+enum class PsxVramMirrorMode;
+
 /**
  * Runs EmuCore on a dedicated QThread owned by PS1RipManager (#415).
  */
@@ -55,7 +57,8 @@ signals:
     void emulationError(const QString &message);
     /** Non-fatal operational warning (does not stop the session). */
     void sessionWarning(const QString &message);
-    void frameCaptureReady(const QString &captureId, const CaptureSnapshot &snapshot, int primCount);
+    void frameCaptureReady(const QString &captureId, const CaptureSnapshot &snapshot, int primCount,
+                           PsxVramMirrorMode vramMirrorMode);
     void vramDumpReady(const QString &captureId, const QString &pngPath, const QVector<uint16_t> &cells,
                        const QImage &nativePreview);
     void vramFrameUpdated(const QVector<uint16_t> &cells, const QImage &nativePreview);

--- a/src/PS1/runtime/PsxVramMirrorMode.h
+++ b/src/PS1/runtime/PsxVramMirrorMode.h
@@ -1,0 +1,32 @@
+#ifndef PSXVRAMMIRRORMODE_H
+#define PSXVRAMMIRRORMODE_H
+
+#include <QString>
+
+/** How the live VRAM snapshot was populated (#660). */
+enum class PsxVramMirrorMode {
+    Unknown = 0,
+    /** Full 1024×512 from RETRO_MEMORY_VIDEO_RAM or core memory map. */
+    FullVram,
+    /** Visible framebuffer copied to VRAM (0,0); texture pages usually missing. */
+    FramebufferFallback,
+    /** Framebuffer mirror plus GP0-derived uploads outside the FB rect. */
+    Gp0Hybrid,
+};
+
+inline QString psxVramMirrorModeLabel(PsxVramMirrorMode mode)
+{
+    switch (mode) {
+    case PsxVramMirrorMode::FullVram:
+        return QStringLiteral("full VRAM");
+    case PsxVramMirrorMode::FramebufferFallback:
+        return QStringLiteral("framebuffer mirror only");
+    case PsxVramMirrorMode::Gp0Hybrid:
+        return QStringLiteral("framebuffer + GP0 texture patches");
+    case PsxVramMirrorMode::Unknown:
+    default:
+        return QStringLiteral("unknown");
+    }
+}
+
+#endif // PSXVRAMMIRRORMODE_H

--- a/src/PS1/runtime/VramSnapshot.cpp
+++ b/src/PS1/runtime/VramSnapshot.cpp
@@ -35,6 +35,26 @@ bool VramSnapshot::hasVisibleContent(int minNonZero) const
     return false;
 }
 
+bool VramSnapshot::hasNonZeroOutsideRect(const QRect &rect, int minNonZero) const
+{
+    if (minNonZero <= 0)
+        return false;
+
+    const QRect clip = rect.intersected(QRect(0, 0, kWidth, kHeight));
+    int count = 0;
+    for (int y = 0; y < kHeight; ++y) {
+        for (int x = 0; x < kWidth; ++x) {
+            if (clip.contains(x, y))
+                continue;
+            if (m_pixels[y * kWidth + x] == 0)
+                continue;
+            if (++count >= minNonZero)
+                return true;
+        }
+    }
+    return false;
+}
+
 void VramSnapshot::writeRect(uint16_t x, uint16_t y, uint16_t w, uint16_t h, const uint16_t *pixels)
 {
     if (!pixels || w == 0 || h == 0)

--- a/src/PS1/runtime/VramSnapshot.h
+++ b/src/PS1/runtime/VramSnapshot.h
@@ -30,6 +30,8 @@ public:
     bool isEmpty() const;
     /** True when at least @p minNonZero cells are non-zero (VRAM may be mostly black in-game). */
     bool hasVisibleContent(int minNonZero = 64) const;
+    /** True when non-zero cells exist outside @p rect (ignores rect interior). */
+    bool hasNonZeroOutsideRect(const QRect &rect, int minNonZero = 8) const;
 
     void writeRect(uint16_t x, uint16_t y, uint16_t w, uint16_t h, const uint16_t *pixels);
     uint16_t pixel(int x, int y) const;

--- a/src/PS1/runtime/VramSnapshot_test.cpp
+++ b/src/PS1/runtime/VramSnapshot_test.cpp
@@ -33,3 +33,13 @@ TEST(VramSnapshotTest, SavePngRoundTrip)
     ASSERT_TRUE(vram.savePng(path));
     EXPECT_TRUE(QFileInfo::exists(path));
 }
+
+TEST(VramSnapshotTest, HasNonZeroOutsideRectDetectsTpageRegion)
+{
+    VramSnapshot vram;
+    vram.setPixel(10, 10, 0x7C00u);
+    EXPECT_FALSE(vram.hasNonZeroOutsideRect(QRect(0, 0, 320, 240), 1));
+
+    vram.setPixel(400, 300, 0x7C00u);
+    EXPECT_TRUE(vram.hasNonZeroOutsideRect(QRect(0, 0, 320, 240), 1));
+}


### PR DESCRIPTION
## Summary

- Forces the software Beetle PSX renderer by default so `RETRO_MEMORY_VIDEO_RAM` exposes the full 1024×512 VRAM cell for TPAGE/CLUT texture decode on retail captures.
- Excludes `beetle_psx_hw` from auto-discovery; tracks VRAM mirror mode (`full VRAM`, `framebuffer fallback`, `GP0 hybrid`) and surfaces it in capture breadcrumbs and the session status bar.
- Adds unit tests for renderer options and VRAM region detection; updates `PS1_RIP_DESIGN.md` and `golden_captures.md` troubleshooting.

Closes #660

## Test plan

- [x] `UnitTests --gtest_filter="LibretroCoreOptionsTest.*:VramSnapshotTest.*:EmuCoreLoaderTest.StubMirrorsVramAfterSync"` — all pass locally
- [ ] Manual: install `mednafen_psx_libretro` (not HW core), run PS1 Runtime Ripper on a golden ISO, confirm status bar shows `VRAM: full VRAM` and reconstructed materials show recognizable albedo


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved VRAM/texture capture: captures now include a reported VRAM mirror mode and embed it into capture metadata; status text shows VRAM mode and warnings when textures may be incomplete.
  * Automatic configuration to prefer software renderers for full texture extraction.

* **Bug Fixes**
  * Hardware-only libretro cores are excluded from core selection.

* **Documentation**
  * PS1 rip guides updated with renderer requirements and VRAM troubleshooting.

* **Tests**
  * Added tests covering renderer preference handling and VRAM-detection logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/671?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->