### PR TITLE
feat(ps1): model-space TMD/HMD RAM scanner (#674)

### DIFF
--- a/src/PS1/CMakeLists.txt
+++ b/src/PS1/CMakeLists.txt
@@ -55,6 +55,8 @@ if(ENABLE_PS1_RIP)
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxCaptureFilters.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxGpuRamScanner.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxGteRamScanner.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxHmdRamScanner.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxTmdRamScanner.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/RipperHooks.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/TextureDecoder.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/VramSnapshot.cpp
@@ -62,11 +64,14 @@ if(ENABLE_PS1_RIP)
     )
     list(APPEND HEADER_FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/CaptureBuffer.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/CapturedModelMesh.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/CaptureSnapshot.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/CaptureTypes.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/GteInverse.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/MeshReconstructionStats.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/MeshReconstructor.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxModelRamScanCommon.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/ReconstructedMesh.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/MeshTopologyHash.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipMeshBuilder.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/EmuCore.h
@@ -98,6 +103,8 @@ if(ENABLE_PS1_RIP)
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxGteInstructionCapture.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxMipsGteRunner.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxGteRamScanner.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxHmdRamScanner.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxTmdRamScanner.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipWorker.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxVramColor.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/TextureDecoder.h

--- a/src/PS1/PS1_RIP_DESIGN.md
+++ b/src/PS1/PS1_RIP_DESIGN.md
@@ -165,13 +165,20 @@ yields clean meshes with no inverse step.
   on TMD-using games.
 
 - **Stats / UI / Sentry**:
-  - `Gp0CaptureStats::ramTmdMeshes` / `ramHmdMeshes` track per-frame counts.
-  - `Gp0CaptureSource::RamModelMesh` (label `ram_model_mesh`) is the new primary source
-    when *any* TMD/HMD surfaced, overriding the prim-count-winner from `pickPrimarySource`.
-  - Status bar: `GP0 <source> (hook X / ot Y / chain Z / linear W / tmd T / hmd H)`.
+  - `Gp0CaptureStats::ramTmdMeshes` / `ramHmdMeshes` track per-frame **emitted** mesh
+    counts (i.e. successful `EmuHooks::onModelMesh` calls). HMD v1 always reports 0
+    here — it doesn't emit yet.
+  - `Gp0CaptureStats::ramHmdCandidates` is the v1 diagnostics count of plausible HMD
+    magic-bytes hits and **does not** flip the primary source. It exists so testers can
+    confirm the magic-bytes scan works on HMD-using titles before the walker lands.
+  - `Gp0CaptureSource::RamModelMesh` (label `ram_model_mesh`) becomes the primary
+    source only when actual model-mesh emissions happened (`ramTmdMeshes > 0`
+    or `ramHmdMeshes > 0`) — bare candidate counts never promote the label.
+  - Status bar: `GP0 <source> (hook X / ot Y / chain Z / linear W / tmd T / hmd H / hmd_cand C)`.
   - Sentry breadcrumbs: `ps1.rip.capture.gp0_hook` and `ps1.rip.capture.summary` carry
-    `tmd=…  hmd=…`; new `ps1.rip.capture.modelmesh` fires only when meshes were emitted;
-    `ps1.rip.matrix.stats` adds `model_meshes=…`.
+    `tmd=…  hmd=…  hmd_cand=…`; new `ps1.rip.capture.modelmesh` fires only when meshes
+    were actually emitted (not candidate-only); `ps1.rip.matrix.stats` adds
+    `model_meshes=…`.
 
 - **Per-format coverage:**
 

--- a/src/PS1/PS1_RIP_DESIGN.md
+++ b/src/PS1/PS1_RIP_DESIGN.md
@@ -76,12 +76,14 @@ See epic #412 for phased issues (#413–#431).
   - **Linear (`ram_linear`):** opcode-by-opcode fallback for buffers without OT/chain headers.
   All four share one dedupe set (no early return after a weak OT). Linked DR tags carry the opcode in bits 24–31 and the next packet address in bits 2–23 (`PsxGp0Opcode.h`). Sentry breadcrumb `ps1.rip.capture.gp0_hook` records per-path counts; session status bar surfaces `GP0 <source> (hook X / ot Y / chain Z / linear W)` after each capture.
 - **Per-core capability (#662, #674):**
+
   | Core | VRAM | GP0 FIFO source | TMD/HMD scan | Notes |
   |------|------|-----------------|--------------|-------|
   | `mednafen_psx_libretro` (software) | full 1024×512 (#660) | live FIFO bridge (`gp0_hook`) + merged RAM | TMD active, HMD opt-in | recommended |
   | `beetle_psx_libretro` (software) | full 1024×512 (#660) | live FIFO bridge (`gp0_hook`) + merged RAM | TMD active, HMD opt-in | recommended |
   | `beetle_psx_hw_*` | none | excluded — `gp0_hook` path unavailable | excluded (no RAM access) | rejected by `LibretroCoreOptions` |
   | `stub` (`qtmesh_ps1core_stub`) | synthetic test pattern | direct stub via `submitGp0Words` (`gp0_hook`) | not scanned (synthetic RAM is GP0-only) | CI / no-disc smoke |
+
 - **Libretro live frame:** While capture is armed, each `retro_run()` end calls `captureGpuFromRam(false, true)` → `Gp0HookDispatch::captureFrameFromSystemRam`. Inside that pass, the FIFO bridge fires first (DirectHook attribution) and the merged RAM scan runs second (Ram* attribution). Primitives accumulate with cross-frame dedupe (`m_liveDedupe`) until **Capture Frame** runs a final GTE+RAM merge. Disable live ingest with `QTMESH_PS1_GP0_LIVE_CAPTURE=0`. Baseline RAM-only behavior (OT then linear, no chain-root pass, no FIFO bridge) via `QTMESH_PS1_GP0_RAM_LEGACY=1` + `QTMESH_PS1_GP0_FIFO_BRIDGE=0`.
 - **Stub core** (`coreId=stub`): seven-flavor capture is now emitted as a contiguous GP0 word buffer routed through `submitGp0Words` (#662) — the production stub matches the same code path retail captures use.
 - **Libretro core** (`coreId=libretro`): live FIFO bridge ships in this slice (#662). True packet-for-packet in-core mednafen GP0 hooks (i.e. patched `mednafen_psx_libretro` with a `RipperHooks`-aware GPU_Write callback) remain out of scope until a forked core ships — the bridge approximates FIFO ordering by walking DMA chains per frame, which is sufficient to surface `gp0_hook` attribution and to feed the canonical hook code path on retail captures.

--- a/src/PS1/PS1_RIP_DESIGN.md
+++ b/src/PS1/PS1_RIP_DESIGN.md
@@ -75,13 +75,13 @@ See epic #412 for phased issues (#413–#431).
   - **Chain root (`ram_chain_root`):** `PsxGp0ChainRootScanner` finds standalone linked roots that no OT pointer touched.
   - **Linear (`ram_linear`):** opcode-by-opcode fallback for buffers without OT/chain headers.
   All four share one dedupe set (no early return after a weak OT). Linked DR tags carry the opcode in bits 24–31 and the next packet address in bits 2–23 (`PsxGp0Opcode.h`). Sentry breadcrumb `ps1.rip.capture.gp0_hook` records per-path counts; session status bar surfaces `GP0 <source> (hook X / ot Y / chain Z / linear W)` after each capture.
-- **Per-core capability (#662):**
-  | Core | VRAM | GP0 FIFO source | Notes |
-  |------|------|-----------------|-------|
-  | `mednafen_psx_libretro` (software) | full 1024×512 (#660) | live FIFO bridge (`gp0_hook`) + merged RAM | recommended |
-  | `beetle_psx_libretro` (software) | full 1024×512 (#660) | live FIFO bridge (`gp0_hook`) + merged RAM | recommended |
-  | `beetle_psx_hw_*` | none | excluded — `gp0_hook` path unavailable | rejected by `LibretroCoreOptions` |
-  | `stub` (`qtmesh_ps1core_stub`) | synthetic test pattern | direct stub via `submitGp0Words` (`gp0_hook`) | CI / no-disc smoke |
+- **Per-core capability (#662, #674):**
+  | Core | VRAM | GP0 FIFO source | TMD/HMD scan | Notes |
+  |------|------|-----------------|--------------|-------|
+  | `mednafen_psx_libretro` (software) | full 1024×512 (#660) | live FIFO bridge (`gp0_hook`) + merged RAM | TMD active, HMD opt-in | recommended |
+  | `beetle_psx_libretro` (software) | full 1024×512 (#660) | live FIFO bridge (`gp0_hook`) + merged RAM | TMD active, HMD opt-in | recommended |
+  | `beetle_psx_hw_*` | none | excluded — `gp0_hook` path unavailable | excluded (no RAM access) | rejected by `LibretroCoreOptions` |
+  | `stub` (`qtmesh_ps1core_stub`) | synthetic test pattern | direct stub via `submitGp0Words` (`gp0_hook`) | not scanned (synthetic RAM is GP0-only) | CI / no-disc smoke |
 - **Libretro live frame:** While capture is armed, each `retro_run()` end calls `captureGpuFromRam(false, true)` → `Gp0HookDispatch::captureFrameFromSystemRam`. Inside that pass, the FIFO bridge fires first (DirectHook attribution) and the merged RAM scan runs second (Ram* attribution). Primitives accumulate with cross-frame dedupe (`m_liveDedupe`) until **Capture Frame** runs a final GTE+RAM merge. Disable live ingest with `QTMESH_PS1_GP0_LIVE_CAPTURE=0`. Baseline RAM-only behavior (OT then linear, no chain-root pass, no FIFO bridge) via `QTMESH_PS1_GP0_RAM_LEGACY=1` + `QTMESH_PS1_GP0_FIFO_BRIDGE=0`.
 - **Stub core** (`coreId=stub`): seven-flavor capture is now emitted as a contiguous GP0 word buffer routed through `submitGp0Words` (#662) — the production stub matches the same code path retail captures use.
 - **Libretro core** (`coreId=libretro`): live FIFO bridge ships in this slice (#662). True packet-for-packet in-core mednafen GP0 hooks (i.e. patched `mednafen_psx_libretro` with a `RipperHooks`-aware GPU_Write callback) remain out of scope until a forked core ships — the bridge approximates FIFO ordering by walking DMA chains per frame, which is sufficient to surface `gp0_hook` attribution and to feed the canonical hook code path on retail captures.
@@ -122,6 +122,77 @@ See epic #412 for phased issues (#413–#431).
 - **Shared matrix across OT** — one `currentMatrixId` per chain walk; dual-pass / multi-buffer games may still share a matrix across unrelated draws.
 - **GTE RAM supplement** — Capture Frame still merges COP2-scanned matrices; per-draw tagging applies at GP0 dispatch time, not retroactively to RAM-only captures without draw-env context.
 - **Commercial golden scenes** — manual acceptance tracked in [#659](https://github.com/fernandotonon/QtMeshEditor/issues/659) (`src/PS1/golden_captures.md`); #658 reduces blob fallback but does not replace a full matrix stack or FIFO-accurate stream (#662).
+
+## Model-space RAM scanners (#674)
+
+Screen-space GP0 prims always carry information loss because they're post-projection — the
+GTE has applied rotation, translation, perspective divide, and 16-bit truncation by the
+time they hit RAM. Inverse-projecting them requires recovering the exact GTE matrix used
+for each draw, which on retail games is heuristic-grade and produces flat-XY "blob"
+meshes when the math drifts. Sony's TMD / HMD / PMD asset formats sidestep this entirely:
+the assets sit in RAM as **model-space** structures with 16-bit fixed-point vertex pools
+and packet-encoded primitives. Scanning RAM for them and emitting the vertices directly
+yields clean meshes with no inverse step.
+
+- **`PsxTmdRamScanner`** — sweeps RAM (4-byte stride) for `0x00000041`-tagged TMD blobs.
+  For each candidate validates `flags ∈ {0, 1}`, `numObj ∈ [1, 256]`, every object header's
+  vertex/normal/primitive offsets resolve in-bounds, counts ≤ 8192, and the primitive walk
+  produces ≥ 1 emitted triangle (the false-positive filter). Both `flag=0` (offsets
+  relative to file-byte 12, on-disk form) and `flag=1` (offsets are KSEG0 RAM pointers,
+  masked with `0x001FFFFF`) are supported. Coordinate transform mirrors the on-disk
+  `PS1TMD::importTmd`: PSX 12.4 fixed × editor uniform scale × 180° Z rotation. Primitive
+  set covers `0x20`, `0x30` (ilen 4 & 6), `0x24`, `0x34`, `0x28` (flag 0 & 4), `0x25`,
+  `0x35` — the bread-and-butter Sony SDK packets. Each unique TMD found emits via
+  `EmuHooks::onModelMesh(CapturedModelMesh)`; the `CaptureBuffer` dedupes by FNV-1a 64-bit
+  hash of the TMD byte span so the same asset encountered every frame only stores once.
+  Material names for textured packets use the standard `MeshReconstructor::textureMaterialName`
+  format (`PS1Rip_tpage_XXXX_clut_YYYY_stN_dmN`), so the existing capture texture-decode
+  path (#421) binds them with zero extra wiring.
+
+- **`PsxHmdRamScanner`** — v1 stub for `0x00000050`-tagged HMD blobs. The HMD layout
+  embeds a hierarchical primitive-node tree whose tag types are significantly more
+  involved than TMD's flat object table, and parsing it speculatively from RAM is a
+  documented source of false positives. v1 ships the scaffold + a magic-bytes candidate
+  count so per-title testing can be enabled via `QTMESH_PS1_HMD_SCANNER=1` without code
+  changes; the actual primitive walk lands once a known-good HMD asset is available.
+
+- **`MeshReconstructor::buildParts`** — after the screen-space `buildMatrixGroups` pass,
+  every `snapshot.modelMeshes[i].mesh` is appended as an additional part. They flow
+  through the same `MeshTopologyHash`-based dedupe in `reconstructDeduped`, so byte-identical
+  TMDs collapse to one unique mesh + N instance transforms (matching the screen-space dedupe
+  semantics). Stats: `MeshReconstructionStats::modelMeshVertices` plus `gteInversePercent`
+  now treats model-mesh verts as trusted, so the quality indicator flips from 0% to ~100%
+  on TMD-using games.
+
+- **Stats / UI / Sentry**:
+  - `Gp0CaptureStats::ramTmdMeshes` / `ramHmdMeshes` track per-frame counts.
+  - `Gp0CaptureSource::RamModelMesh` (label `ram_model_mesh`) is the new primary source
+    when *any* TMD/HMD surfaced, overriding the prim-count-winner from `pickPrimarySource`.
+  - Status bar: `GP0 <source> (hook X / ot Y / chain Z / linear W / tmd T / hmd H)`.
+  - Sentry breadcrumbs: `ps1.rip.capture.gp0_hook` and `ps1.rip.capture.summary` carry
+    `tmd=…  hmd=…`; new `ps1.rip.capture.modelmesh` fires only when meshes were emitted;
+    `ps1.rip.matrix.stats` adds `model_meshes=…`.
+
+- **Per-format coverage:**
+
+  | Format | Magic | Where used | v1 scanner |
+  |--------|-------|-----------|------------|
+  | TMD | `0x00000041` | static models — most Sony SDK titles (Tekken 1/2/3, Ridge Racer 1/RR, Net Yaroze homebrew, Wipeout 1/2097, R-Type Delta, Klonoa, many Square pre-FF7) | **emits meshes** |
+  | HMD | `0x00000050` | hierarchical/skinned models — Sony SDK animations | stub (counts candidates only) |
+  | PMD | n/a (engine) | Net Yaroze homebrew TMD subset — handled by TMD scanner | — (TMD path) |
+  | TIM | `0x00000010` | textures — bound via the VRAM mirror, not model-space | — (texture path) |
+  | RSD / PLY / MAT / GRP | text | disc/artist formats — compiled to TMD before being loaded; not present in RAM during gameplay | — (offline) |
+
+- **Out of scope (#675, #676, #677):**
+  - `#675` — heuristic + math fix for the screen-space inverse path (tighten matrix scanner,
+    real-rotation inverse roundtrip tests, surface `prims_with_matrix=X/N`).
+  - `#676` — forked `mednafen_psx_libretro` with an in-core RTPS/RTPT callback for
+    ground-truth model-space recovery on any game including custom engines (Crash, Spyro,
+    FFVII field models, MGS).
+  - `#677` — disc/ISO scanner for RSD/PLY/MAT/GRP/TIX off-line ripping (separate CLI/MCP).
+
+- **Disable:** `QTMESH_PS1_TMD_SCANNER=0` skips the TMD pass entirely (debug / golden
+  baselines). HMD scanner is opt-in (`QTMESH_PS1_HMD_SCANNER=1`).
 
 ## GP0 FIFO follow-up (#662)
 
@@ -165,7 +236,30 @@ The **stub** core is active (`coreId=stub`). It draws a test pattern and synthet
 
 ### Capture mesh is a triangle “blob” (normal size, wrong shape)
 
-Capture uses **live per-frame merged RAM ingest** while armed (libretro), then a final GTE+RAM pass on **Capture Frame**. Four strategies feed the same dedupe set: the **live FIFO bridge** (DMA chain walk → `submitGp0Words`, #662), ordering-table chains, standalone linked GP0 chain roots, and linear opcode scan. Status bar surfaces the per-source breakdown — if `hook` is 0 and the mesh still looks wrong, the title likely streams chains the bridge isn't recognizing, or draws outside RAM-visible layouts. Filters drop off-screen coordinates and cap at 2048 primitives per ingest pass. Per-draw matrix tagging (#658) reduces screen-space blob fallback when draw-environment packets precede primitives in the captured buffer. True packet-for-packet in-core mednafen GP0 hooks (a forked `mednafen_psx_libretro`) remain future work — see [#662](https://github.com/fernandotonon/QtMeshEditor/issues/662).
+The screen-space GP0 path (live FIFO bridge + ordering-table chains + standalone chain
+roots + linear scan) always produces a flat-XY blob on retail games because the GTE
+inverse-projection it relies on is heuristic-grade — true ground-truth recovery requires
+the forked-mednafen in-core GTE hook tracked in [#676](https://github.com/fernandotonon/QtMeshEditor/issues/676).
+Until that ships, the recommended path for "real meshes from real games" is the
+**model-space TMD/HMD RAM scanner** (#674): if the title uses Sony SDK formats the
+scanner finds the model-space vertex pools in RAM and emits them directly, bypassing the
+inverse-projection entirely.
+
+- Status bar shows `tmd N` / `hmd N` and the primary source flips to `ram_model_mesh`
+  when meshes are found — that's your "this is a clean mesh" signal.
+- **TMD-using games (where this works):** Tekken 1/2/3, Ridge Racer 1/RR, Net Yaroze SDK
+  demos, Wipeout 1/2097, R-Type Delta, Klonoa, many pre-FF7 Square titles.
+- **Custom-engine games (where it does NOT work):** Crash, Spyro, FFVII field models,
+  MGS post-Yaroze. These games author their own packed mesh layouts; only #676 covers them.
+- Tune via `QTMESH_PS1_TMD_SCANNER=0` to disable TMD scanning for a baseline, and
+  `QTMESH_PS1_HMD_SCANNER=1` to opt into the v1 HMD candidate counter.
+
+If the scanner produces meshes but they look wrong (wrong axis flip, wrong scale), the
+coordinate transform in `PsxTmdRamScanner` mirrors `PS1TMD::importTmd` — if the on-disk
+TMD importer is also wrong, fix it in `PS1TMD.cpp` and the RAM scanner picks it up via
+the matching constants. Per-draw matrix tagging (#658) and the live FIFO bridge (#662)
+still help on the screen-space side but cannot reconstruct topology from screen-space
+prims alone.
 
 ### Libretro integration tests (local only)
 

--- a/src/PS1/runtime/CaptureBuffer.cpp
+++ b/src/PS1/runtime/CaptureBuffer.cpp
@@ -52,11 +52,25 @@ void CaptureBuffer::addDrawMode(const DrawModeRecord &mode)
     m_drawModes.append(mode);
 }
 
+bool CaptureBuffer::addModelMesh(const CapturedModelMesh &mesh)
+{
+    if (mesh.mesh.isEmpty())
+        return false;
+    if (mesh.contentHash != 0 && m_modelMeshHashes.contains(mesh.contentHash))
+        return false;
+    m_modelMeshes.append(mesh);
+    if (mesh.contentHash != 0)
+        m_modelMeshHashes.insert(mesh.contentHash);
+    return true;
+}
+
 void CaptureBuffer::clear()
 {
     m_prims.clear();
     m_matrices.clear();
     m_drawModes.clear();
+    m_modelMeshes.clear();
+    m_modelMeshHashes.clear();
     m_matrixIndexByHash.clear();
     m_matrixUseCount.clear();
     m_cameraMatrixId = UINT32_MAX;

--- a/src/PS1/runtime/CaptureBuffer.h
+++ b/src/PS1/runtime/CaptureBuffer.h
@@ -1,9 +1,11 @@
 #ifndef CAPTUREBUFFER_H
 #define CAPTUREBUFFER_H
 
+#include "CapturedModelMesh.h"
 #include "CaptureTypes.h"
 
 #include <QHash>
+#include <QSet>
 #include <QVector>
 
 #include <cstdint>
@@ -21,9 +23,14 @@ public:
     void addPrim(PrimRecord prim);
     void addDrawMode(const DrawModeRecord &mode);
 
+    /** Append a model-space mesh produced by a format-aware scanner (#674). Deduplicates by
+     *  content hash so the same TMD encountered repeatedly only emits once per session. */
+    bool addModelMesh(const CapturedModelMesh &mesh);
+
     const QVector<PrimRecord> &prims() const { return m_prims; }
     const QVector<MatrixRecord> &matrices() const { return m_matrices; }
     const QVector<DrawModeRecord> &drawModes() const { return m_drawModes; }
+    const QVector<CapturedModelMesh> &modelMeshes() const { return m_modelMeshes; }
 
     uint32_t cameraMatrixId() const { return m_cameraMatrixId; }
     bool hasCameraMatrix() const { return m_cameraMatrixId != UINT32_MAX; }
@@ -34,6 +41,8 @@ private:
     QVector<PrimRecord> m_prims;
     QVector<MatrixRecord> m_matrices;
     QVector<DrawModeRecord> m_drawModes;
+    QVector<CapturedModelMesh> m_modelMeshes;
+    QSet<uint64_t> m_modelMeshHashes;
     QHash<uint64_t, uint32_t> m_matrixIndexByHash;
     QHash<uint32_t, int> m_matrixUseCount;
     uint32_t m_cameraMatrixId = UINT32_MAX;

--- a/src/PS1/runtime/CaptureSnapshot.cpp
+++ b/src/PS1/runtime/CaptureSnapshot.cpp
@@ -7,6 +7,7 @@ CaptureSnapshot CaptureSnapshot::fromBuffer(const CaptureBuffer &buffer,
     CaptureSnapshot snap;
     snap.prims = buffer.prims();
     snap.matrices = buffer.matrices();
+    snap.modelMeshes = buffer.modelMeshes();
     snap.cameraMatrixId = buffer.cameraMatrixId();
     snap.vramCells = vramCells;
     return snap;

--- a/src/PS1/runtime/CaptureSnapshot.h
+++ b/src/PS1/runtime/CaptureSnapshot.h
@@ -1,6 +1,7 @@
 #ifndef CAPTURESNAPSHOT_H
 #define CAPTURESNAPSHOT_H
 
+#include "CapturedModelMesh.h"
 #include "CaptureTypes.h"
 
 #include <QMetaType>
@@ -15,6 +16,8 @@ struct CaptureSnapshot
 {
     QVector<PrimRecord> prims;
     QVector<MatrixRecord> matrices;
+    /** Model-space meshes from format-aware RAM scanners (TMD/HMD/..., #674). */
+    QVector<CapturedModelMesh> modelMeshes;
     uint32_t cameraMatrixId = UINT32_MAX;
     /** Live VRAM cells (1024×512) copied at capture time for texture decode. */
     QVector<uint16_t> vramCells;

--- a/src/PS1/runtime/CapturedModelMesh.h
+++ b/src/PS1/runtime/CapturedModelMesh.h
@@ -1,0 +1,27 @@
+#ifndef CAPTUREDMODELMESH_H
+#define CAPTUREDMODELMESH_H
+
+#include "ReconstructedMesh.h"
+
+#include <QString>
+
+#include <cstdint>
+
+/**
+ * One mesh ripped from RAM in *model space* (no GTE inverse needed) via a format-aware scanner
+ * (TMD/HMD/PMD/HMD/...). The reconstruction pipeline appends these as additional parts alongside
+ * the screen-space GP0 prim path; on TMD-using games this is what turns "blob of triangles" into
+ * recognizable geometry (#674).
+ */
+struct CapturedModelMesh {
+    /** Mesh data already in editor world units. */
+    ReconstructedMesh mesh;
+    /** RAM byte offset where the scanner found the source structure (informational/debug). */
+    uint32_t sourceAddress = 0;
+    /** Short label for the producing format: "tmd", "hmd", ... */
+    QString format;
+    /** Content hash used for cross-frame dedupe and instance-grouping. */
+    uint64_t contentHash = 0;
+};
+
+#endif // CAPTUREDMODELMESH_H

--- a/src/PS1/runtime/EmuHooks.h
+++ b/src/PS1/runtime/EmuHooks.h
@@ -1,6 +1,7 @@
 #ifndef EMUHOOKS_H
 #define EMUHOOKS_H
 
+#include "CapturedModelMesh.h"
 #include "CaptureTypes.h"
 #include "Gp0CaptureStats.h"
 
@@ -76,6 +77,19 @@ public:
         (void)ram;
         (void)byteSize;
         return 0;
+    }
+
+    /**
+     * Format-aware model-space scanner emission (#674). Called by `PsxTmdRamScanner` and
+     * friends when they recognize a Sony SDK mesh structure (TMD/HMD/...) in RAM. The
+     * mesh arrives already in editor world units so no GTE inverse is needed; the receiver
+     * is expected to dedupe by `CapturedModelMesh::contentHash` and append to the capture
+     * buffer. Returns `true` if accepted (newly added), `false` if dedupe rejected it.
+     */
+    virtual bool onModelMesh(const CapturedModelMesh &mesh)
+    {
+        (void)mesh;
+        return false;
     }
 
     /** Live armed capture: shared dedupe keys across frames (nullptr when not accumulating). */

--- a/src/PS1/runtime/Gp0CaptureStats.cpp
+++ b/src/PS1/runtime/Gp0CaptureStats.cpp
@@ -11,6 +11,8 @@ QString Gp0CaptureStats::primarySourceLabel() const
         return QStringLiteral("ram_linear");
     case Gp0CaptureSource::RamChainRoot:
         return QStringLiteral("ram_chain_root");
+    case Gp0CaptureSource::RamModelMesh:
+        return QStringLiteral("ram_model_mesh");
     case Gp0CaptureSource::None:
     default:
         return QStringLiteral("none");

--- a/src/PS1/runtime/Gp0CaptureStats.h
+++ b/src/PS1/runtime/Gp0CaptureStats.h
@@ -27,10 +27,16 @@ struct Gp0CaptureStats {
     int ramOtPrims = 0;
     int ramLinearPrims = 0;
     int ramChainRootPrims = 0;
-    /** Unique TMD meshes accepted from `PsxTmdRamScanner` this frame (#674). */
+    /** Unique TMD meshes accepted (via `EmuHooks::onModelMesh`) from
+     *  `PsxTmdRamScanner` this frame (#674). */
     int ramTmdMeshes = 0;
-    /** HMD candidates found (or meshes emitted, once v2 lands) by `PsxHmdRamScanner`. */
+    /** HMD meshes accepted (via `EmuHooks::onModelMesh`) from `PsxHmdRamScanner`
+     *  this frame. Zero until the v2 walker actually emits meshes (#674). */
     int ramHmdMeshes = 0;
+    /** Plausible HMD magic-bytes candidates found in RAM this frame.
+     *  v1 is a diagnostics count only — it does NOT prove model-mesh capture
+     *  succeeded, so it must not flip `primarySource` to `RamModelMesh`. */
+    int ramHmdCandidates = 0;
     int totalPrims = 0;
     bool liveFrame = false;
 

--- a/src/PS1/runtime/Gp0CaptureStats.h
+++ b/src/PS1/runtime/Gp0CaptureStats.h
@@ -17,6 +17,8 @@ enum class Gp0CaptureSource : uint8_t {
     RamLinear,
     /** Standalone linked GP0 chain roots in RAM. */
     RamChainRoot,
+    /** Model-space TMD/HMD blob found by a format-aware RAM scanner (#674). */
+    RamModelMesh,
 };
 
 struct Gp0CaptureStats {
@@ -25,6 +27,10 @@ struct Gp0CaptureStats {
     int ramOtPrims = 0;
     int ramLinearPrims = 0;
     int ramChainRootPrims = 0;
+    /** Unique TMD meshes accepted from `PsxTmdRamScanner` this frame (#674). */
+    int ramTmdMeshes = 0;
+    /** HMD candidates found (or meshes emitted, once v2 lands) by `PsxHmdRamScanner`. */
+    int ramHmdMeshes = 0;
     int totalPrims = 0;
     bool liveFrame = false;
 

--- a/src/PS1/runtime/Gp0HookDispatch.cpp
+++ b/src/PS1/runtime/Gp0HookDispatch.cpp
@@ -425,7 +425,12 @@ Gp0CaptureStats Gp0HookDispatch::captureFromSystemRam(const uint8_t *ram, size_t
     stats.ramLinearPrims = primCount - linearBefore;
 
     stats.totalPrims = primCount;
-    stats.primarySource = promoteModelMeshSource(stats, pickPrimarySource(stats));
+    // Model-mesh promotion is deferred to the outer captureFrameFromSystemRam
+    // wrapper — this function never sees TMD/HMD counts (those are owned by the
+    // model-space scanners that run alongside it), so promoting here is a no-op
+    // that just hides the bug if you ever start relying on its return value
+    // outside the wrapper (#674 review).
+    stats.primarySource = pickPrimarySource(stats);
     return stats;
 }
 
@@ -528,6 +533,11 @@ Gp0CaptureStats Gp0HookDispatch::captureFrameFromSystemRam(const uint8_t *ram, s
     // ramHmdMeshes stays 0 until the v2 HMD walker emits actual meshes — until
     // then the candidate count is surfaced separately for diagnostics (#674).
     stats.ramHmdCandidates = hmdCandidates;
+    // Re-evaluate primary source now that model-mesh counts are populated —
+    // captureFromSystemRam() above couldn't see them (#674 review). Without this
+    // line, RamModelMesh could only be picked by the fallback path inside
+    // RipperHooks::endGpuCapturePass.
+    stats.primarySource = promoteModelMeshSource(stats, stats.primarySource);
     stats.liveFrame = liveFrame;
 
     hooks->onFrameEnd();

--- a/src/PS1/runtime/Gp0HookDispatch.cpp
+++ b/src/PS1/runtime/Gp0HookDispatch.cpp
@@ -76,8 +76,10 @@ Gp0CaptureSource pickPrimarySource(const Gp0CaptureStats &stats)
 }
 
 /** Model-space meshes always beat screen-space prims for quality, so if any TMD or HMD
- *  surfaced this frame the primary label flips to ram_model_mesh regardless of the GP0
- *  prim count winner from `pickPrimarySource`. (#674) */
+ *  actually surfaced (i.e. emitted via `EmuHooks::onModelMesh`) this frame, the primary
+ *  label flips to ram_model_mesh regardless of the GP0 prim count winner from
+ *  `pickPrimarySource`. Bare HMD candidate counts (`ramHmdCandidates`) do NOT count —
+ *  the v1 stub records candidates without emitting geometry (#674 review). */
 Gp0CaptureSource promoteModelMeshSource(const Gp0CaptureStats &stats, Gp0CaptureSource fallback)
 {
     if (stats.ramTmdMeshes > 0 || stats.ramHmdMeshes > 0)
@@ -496,10 +498,13 @@ Gp0CaptureStats Gp0HookDispatch::captureFrameFromSystemRam(const uint8_t *ram, s
     const bool tmdScannerDisabled = qEnvironmentVariableIsSet("QTMESH_PS1_TMD_SCANNER")
                                     && qEnvironmentVariableIntValue("QTMESH_PS1_TMD_SCANNER") == 0;
     int tmdMeshes = 0;
-    int hmdMeshes = 0;
+    // HMD v1 returns candidate counts, not emitted-mesh counts (the walker is a
+    // follow-up). The two are recorded separately so the candidate count never
+    // promotes primary source to RamModelMesh (#674 review).
+    int hmdCandidates = 0;
     if (!tmdScannerDisabled)
         tmdMeshes = PsxTmdRamScanner::captureFromSystemRam(ram, scanSize, hooks);
-    hmdMeshes = PsxHmdRamScanner::captureFromSystemRam(ram, scanSize, hooks);
+    hmdCandidates = PsxHmdRamScanner::captureFromSystemRam(ram, scanSize, hooks);
 
     // #662 live FIFO bridge: route contiguous RAM-resident DMA chains through
     // submitGp0Words so each prim is attributed to Gp0CaptureSource::DirectHook
@@ -520,7 +525,9 @@ Gp0CaptureStats Gp0HookDispatch::captureFrameFromSystemRam(const uint8_t *ram, s
         stats = captureFromSystemRam(ram, scanSize, hooks, seen);
     }
     stats.ramTmdMeshes = tmdMeshes;
-    stats.ramHmdMeshes = hmdMeshes;
+    // ramHmdMeshes stays 0 until the v2 HMD walker emits actual meshes — until
+    // then the candidate count is surfaced separately for diagnostics (#674).
+    stats.ramHmdCandidates = hmdCandidates;
     stats.liveFrame = liveFrame;
 
     hooks->onFrameEnd();

--- a/src/PS1/runtime/Gp0HookDispatch.cpp
+++ b/src/PS1/runtime/Gp0HookDispatch.cpp
@@ -8,7 +8,9 @@
 #include "PsxGp0Opcode.h"
 #include "PsxGteInstructionCapture.h"
 #include "PsxGteRamScanner.h"
+#include "PsxHmdRamScanner.h"
 #include "PsxOrderingTableScanner.h"
+#include "PsxTmdRamScanner.h"
 
 #include <QSet>
 #include <QString>
@@ -71,6 +73,16 @@ Gp0CaptureSource pickPrimarySource(const Gp0CaptureStats &stats)
         source = Gp0CaptureSource::RamLinear;
     }
     return source;
+}
+
+/** Model-space meshes always beat screen-space prims for quality, so if any TMD or HMD
+ *  surfaced this frame the primary label flips to ram_model_mesh regardless of the GP0
+ *  prim count winner from `pickPrimarySource`. (#674) */
+Gp0CaptureSource promoteModelMeshSource(const Gp0CaptureStats &stats, Gp0CaptureSource fallback)
+{
+    if (stats.ramTmdMeshes > 0 || stats.ramHmdMeshes > 0)
+        return Gp0CaptureSource::RamModelMesh;
+    return fallback;
 }
 
 QString primDedupeKeyImpl(const PrimRecord &prim)
@@ -411,7 +423,7 @@ Gp0CaptureStats Gp0HookDispatch::captureFromSystemRam(const uint8_t *ram, size_t
     stats.ramLinearPrims = primCount - linearBefore;
 
     stats.totalPrims = primCount;
-    stats.primarySource = pickPrimarySource(stats);
+    stats.primarySource = promoteModelMeshSource(stats, pickPrimarySource(stats));
     return stats;
 }
 
@@ -475,6 +487,20 @@ Gp0CaptureStats Gp0HookDispatch::captureFrameFromSystemRam(const uint8_t *ram, s
     }
     ensureCaptureProjectionMatrix(hooks);
 
+    // #674 model-space RAM scanners: look for Sony SDK TMD (0x00000041) blobs in main RAM
+    // and emit them as fully-formed model-space meshes via EmuHooks::onModelMesh. Unlike
+    // the screen-space GP0 path below, these bypass MeshReconstructor::screenToModel
+    // entirely — they're the only reliable way to recover model-space geometry from
+    // closed-source retail games until #676 (forked mednafen with in-core GTE hook) lands.
+    // Disable per-format with QTMESH_PS1_TMD_SCANNER=0; HMD is opt-in via QTMESH_PS1_HMD_SCANNER=1.
+    const bool tmdScannerDisabled = qEnvironmentVariableIsSet("QTMESH_PS1_TMD_SCANNER")
+                                    && qEnvironmentVariableIntValue("QTMESH_PS1_TMD_SCANNER") == 0;
+    int tmdMeshes = 0;
+    int hmdMeshes = 0;
+    if (!tmdScannerDisabled)
+        tmdMeshes = PsxTmdRamScanner::captureFromSystemRam(ram, scanSize, hooks);
+    hmdMeshes = PsxHmdRamScanner::captureFromSystemRam(ram, scanSize, hooks);
+
     // #662 live FIFO bridge: route contiguous RAM-resident DMA chains through
     // submitGp0Words so each prim is attributed to Gp0CaptureSource::DirectHook
     // before the merged RAM scan runs. The bridge runs in-pass; RipperHooks
@@ -493,6 +519,8 @@ Gp0CaptureStats Gp0HookDispatch::captureFrameFromSystemRam(const uint8_t *ram, s
     } else {
         stats = captureFromSystemRam(ram, scanSize, hooks, seen);
     }
+    stats.ramTmdMeshes = tmdMeshes;
+    stats.ramHmdMeshes = hmdMeshes;
     stats.liveFrame = liveFrame;
 
     hooks->onFrameEnd();

--- a/src/PS1/runtime/MeshReconstructionStats.cpp
+++ b/src/PS1/runtime/MeshReconstructionStats.cpp
@@ -7,7 +7,10 @@ int MeshReconstructionStats::gteInversePercent() const
 {
     if (totalVertices <= 0)
         return 0;
-    return (gteInverseVertices * 100) / totalVertices;
+    // Model-mesh verts are trusted-by-construction (already in model space), so they
+    // count toward the "quality" numerator the same way GTE-inverted verts do (#674).
+    const int trusted = gteInverseVertices + modelMeshVertices;
+    return (trusted * 100) / totalVertices;
 }
 
 bool MeshReconstructionStats::hasBounds() const

--- a/src/PS1/runtime/MeshReconstructionStats.h
+++ b/src/PS1/runtime/MeshReconstructionStats.h
@@ -1,11 +1,13 @@
 #ifndef MESHRECONSTRUCTIONSTATS_H
 #define MESHRECONSTRUCTIONSTATS_H
 
-/** Post-reconstruction quality metrics for PS1 capture (#658). */
+/** Post-reconstruction quality metrics for PS1 capture (#658, #674). */
 struct MeshReconstructionStats {
     int totalVertices = 0;
     int gteInverseVertices = 0;
     int screenFallbackVertices = 0;
+    /** Vertices that arrived already in model space via PsxTmdRamScanner/PsxHmdRamScanner. */
+    int modelMeshVertices = 0;
     int primsTotal = 0;
     int primsWithMatrixId = 0;
     float boundsMinX = 0.0f;
@@ -16,6 +18,7 @@ struct MeshReconstructionStats {
     float boundsMaxZ = 0.0f;
     bool slabLike = false;
 
+    /** % of vertices that are "trusted" (GTE-inverted or model-mesh) out of all. */
     int gteInversePercent() const;
     bool hasBounds() const;
     /** Sets slabLike from axis extents (min/max ratio below 0.12). Requires hasBounds(). */

--- a/src/PS1/runtime/MeshReconstructor.cpp
+++ b/src/PS1/runtime/MeshReconstructor.cpp
@@ -8,6 +8,7 @@
 
 #include <QHash>
 
+#include <algorithm>
 #include <cmath>
 
 namespace {
@@ -208,6 +209,43 @@ QVector<ReconstructedMesh> buildParts(const CaptureSnapshot &snapshot,
         if (!part.isEmpty())
             parts.append(part);
     }
+
+    // #674 — Model-space meshes from PsxTmdRamScanner / PsxHmdRamScanner. These bypass the
+    // screen-space inverse-projection path entirely and arrive in editor world units, so
+    // they're appended as additional parts. The dedupe pass in `reconstructDeduped` then
+    // collapses byte-identical copies via MeshTopologyHash, the same way it does for
+    // matrix-grouped screen-space parts.
+    for (const CapturedModelMesh &cap : snapshot.modelMeshes) {
+        if (cap.mesh.isEmpty())
+            continue;
+        parts.append(cap.mesh);
+        if (statsOut) {
+            int verts = 0;
+            for (const ReconstructedSubMesh &sub : cap.mesh.subMeshes) {
+                verts += sub.vertices.size();
+                for (const ReconstructedVertex &v : sub.vertices) {
+                    // Match accumulateVertexStats: use `hasBounds()` to detect the very
+                    // first vertex (otherwise bounds start at 0/0/0 and we'd anchor an
+                    // all-positive mesh to the origin incorrectly).
+                    if (!statsOut->hasBounds()) {
+                        statsOut->boundsMinX = statsOut->boundsMaxX = v.px;
+                        statsOut->boundsMinY = statsOut->boundsMaxY = v.py;
+                        statsOut->boundsMinZ = statsOut->boundsMaxZ = v.pz;
+                    } else {
+                        statsOut->boundsMinX = std::min(statsOut->boundsMinX, v.px);
+                        statsOut->boundsMaxX = std::max(statsOut->boundsMaxX, v.px);
+                        statsOut->boundsMinY = std::min(statsOut->boundsMinY, v.py);
+                        statsOut->boundsMaxY = std::max(statsOut->boundsMaxY, v.py);
+                        statsOut->boundsMinZ = std::min(statsOut->boundsMinZ, v.pz);
+                        statsOut->boundsMaxZ = std::max(statsOut->boundsMaxZ, v.pz);
+                    }
+                }
+            }
+            statsOut->modelMeshVertices += verts;
+            statsOut->totalVertices += verts;
+        }
+    }
+
     return parts;
 }
 

--- a/src/PS1/runtime/MeshReconstructor.cpp
+++ b/src/PS1/runtime/MeshReconstructor.cpp
@@ -77,14 +77,12 @@ ReconstructedVertex vertexFromPsx(const PsxVertex &v, const MatrixRecord *matrix
     return out;
 }
 
-void accumulateVertexStats(const ReconstructedVertex &v, MeshReconstructionStats &stats, bool usedGte)
+/** Expand `stats`' AABB to include `v`. First call initialises the bounds to the
+ *  vertex (we can't anchor at 0 — meshes that live entirely on one side of the
+ *  origin would lose their min or max). Shared by every code path that needs to
+ *  fold a vertex into stats so the behavior stays in lock-step (#674 review). */
+void expandBounds(MeshReconstructionStats &stats, const ReconstructedVertex &v)
 {
-    ++stats.totalVertices;
-    if (usedGte)
-        ++stats.gteInverseVertices;
-    else
-        ++stats.screenFallbackVertices;
-
     if (!stats.hasBounds()) {
         stats.boundsMinX = stats.boundsMaxX = v.px;
         stats.boundsMinY = stats.boundsMaxY = v.py;
@@ -97,6 +95,16 @@ void accumulateVertexStats(const ReconstructedVertex &v, MeshReconstructionStats
     stats.boundsMaxY = std::max(stats.boundsMaxY, v.py);
     stats.boundsMinZ = std::min(stats.boundsMinZ, v.pz);
     stats.boundsMaxZ = std::max(stats.boundsMaxZ, v.pz);
+}
+
+void accumulateVertexStats(const ReconstructedVertex &v, MeshReconstructionStats &stats, bool usedGte)
+{
+    ++stats.totalVertices;
+    if (usedGte)
+        ++stats.gteInverseVertices;
+    else
+        ++stats.screenFallbackVertices;
+    expandBounds(stats, v);
 }
 
 void emitPrimitive(const PrimRecord &prim, const MatrixRecord *matrix, SubMeshAccumulator &acc,
@@ -223,23 +231,11 @@ QVector<ReconstructedMesh> buildParts(const CaptureSnapshot &snapshot,
             int verts = 0;
             for (const ReconstructedSubMesh &sub : cap.mesh.subMeshes) {
                 verts += sub.vertices.size();
-                for (const ReconstructedVertex &v : sub.vertices) {
-                    // Match accumulateVertexStats: use `hasBounds()` to detect the very
-                    // first vertex (otherwise bounds start at 0/0/0 and we'd anchor an
-                    // all-positive mesh to the origin incorrectly).
-                    if (!statsOut->hasBounds()) {
-                        statsOut->boundsMinX = statsOut->boundsMaxX = v.px;
-                        statsOut->boundsMinY = statsOut->boundsMaxY = v.py;
-                        statsOut->boundsMinZ = statsOut->boundsMaxZ = v.pz;
-                    } else {
-                        statsOut->boundsMinX = std::min(statsOut->boundsMinX, v.px);
-                        statsOut->boundsMaxX = std::max(statsOut->boundsMaxX, v.px);
-                        statsOut->boundsMinY = std::min(statsOut->boundsMinY, v.py);
-                        statsOut->boundsMaxY = std::max(statsOut->boundsMaxY, v.py);
-                        statsOut->boundsMinZ = std::min(statsOut->boundsMinZ, v.pz);
-                        statsOut->boundsMaxZ = std::max(statsOut->boundsMaxZ, v.pz);
-                    }
-                }
+                // Share the bounds-update helper with accumulateVertexStats so a
+                // future tweak to the bounds anchoring stays in lock-step
+                // (#674 review).
+                for (const ReconstructedVertex &v : sub.vertices)
+                    expandBounds(*statsOut, v);
             }
             statsOut->modelMeshVertices += verts;
             statsOut->totalVertices += verts;

--- a/src/PS1/runtime/MeshReconstructor.h
+++ b/src/PS1/runtime/MeshReconstructor.h
@@ -3,39 +3,12 @@
 
 #include "CaptureSnapshot.h"
 #include "MeshReconstructionStats.h"
+#include "ReconstructedMesh.h"
 
 #include <QString>
 #include <QVector>
 
 enum class MeshDedupeMode;
-
-/** One vertex in reconstructed editor space (#422). */
-struct ReconstructedVertex {
-    float px = 0.0f;
-    float py = 0.0f;
-    float pz = 0.0f;
-    float nx = 0.0f;
-    float ny = 0.0f;
-    float nz = 0.0f;
-    float u = 0.0f;
-    float v = 0.0f;
-    uint32_t diffuseArgb = 0xFFFFFFFFu;
-};
-
-struct ReconstructedSubMesh {
-    QString materialName;
-    QVector<ReconstructedVertex> vertices;
-    QVector<uint32_t> indices;
-};
-
-struct ReconstructedMesh {
-    QString meshName;
-    QVector<ReconstructedSubMesh> subMeshes;
-    int vertexCount = 0;
-    int triangleCount = 0;
-
-    bool isEmpty() const { return subMeshes.isEmpty(); }
-};
 
 /** One placed copy of a deduplicated mesh (#423). */
 struct ReconstructedInstance {

--- a/src/PS1/runtime/PS1RipManager.cpp
+++ b/src/PS1/runtime/PS1RipManager.cpp
@@ -153,11 +153,12 @@ void PS1RipManager::initializeWorkerThread()
                     QStringLiteral("ps1.rip.mesh.built"),
                     QStringLiteral("%1 verts %2 tris").arg(built.vertexCount).arg(built.triangleCount));
                 QString matrixStats =
-                    QStringLiteral("gte_inverse=%1%% prims_with_matrix=%2/%3 slab=%4")
+                    QStringLiteral("gte_inverse=%1%% prims_with_matrix=%2/%3 slab=%4 model_meshes=%5")
                         .arg(reconStats.gteInversePercent())
                         .arg(reconStats.primsWithMatrixId)
                         .arg(reconStats.primsTotal)
-                        .arg(reconStats.slabLike ? QStringLiteral("yes") : QStringLiteral("no"));
+                        .arg(reconStats.slabLike ? QStringLiteral("yes") : QStringLiteral("no"))
+                        .arg(snapshot.modelMeshes.size());
                 if (!goldenId.isEmpty())
                     matrixStats += QStringLiteral(" golden_id=%1").arg(goldenId);
                 SentryReporter::addBreadcrumb(QStringLiteral("ps1.rip.matrix.stats"), matrixStats);

--- a/src/PS1/runtime/PS1RipSessionWindow.cpp
+++ b/src/PS1/runtime/PS1RipSessionWindow.cpp
@@ -393,15 +393,19 @@ void PS1RipSessionWindow::onMeshBuilt(const QString &captureId, int capturedPart
     // path produced the geometry (gp0_hook vs ram_*).
     // #674: append TMD / HMD counts so users see the model-space scanner contribution.
     // On TMD-using games this is what flips the source label to `ram_model_mesh` and the
-    // GTE inverse % to non-zero.
-    const QString gp0Text = tr("GP0 %1 (hook %2 / ot %3 / chain %4 / linear %5 / tmd %6 / hmd %7)")
-                                .arg(captureStats.primarySourceLabel())
-                                .arg(captureStats.directHookPrims)
-                                .arg(captureStats.ramOtPrims)
-                                .arg(captureStats.ramChainRootPrims)
-                                .arg(captureStats.ramLinearPrims)
-                                .arg(captureStats.ramTmdMeshes)
-                                .arg(captureStats.ramHmdMeshes);
+    // GTE inverse % to non-zero. `hmd` is emitted-meshes (zero until v2 walker lands);
+    // `hmd_cand` is the v1 diagnostics count of plausible HMD magic-byte candidates so
+    // testers can confirm magic detection without the walker (#674 review).
+    const QString gp0Text =
+        tr("GP0 %1 (hook %2 / ot %3 / chain %4 / linear %5 / tmd %6 / hmd %7 / hmd_cand %8)")
+            .arg(captureStats.primarySourceLabel())
+            .arg(captureStats.directHookPrims)
+            .arg(captureStats.ramOtPrims)
+            .arg(captureStats.ramChainRootPrims)
+            .arg(captureStats.ramLinearPrims)
+            .arg(captureStats.ramTmdMeshes)
+            .arg(captureStats.ramHmdMeshes)
+            .arg(captureStats.ramHmdCandidates);
     m_statusLabel->setText(
         tr("Mesh %1 — captured %2 / unique %3 / instances %4 (%5 verts, %6 tris, %7 GTE matrices, "
            "%8, %9, VRAM: %10, %11)")

--- a/src/PS1/runtime/PS1RipSessionWindow.cpp
+++ b/src/PS1/runtime/PS1RipSessionWindow.cpp
@@ -391,12 +391,17 @@ void PS1RipSessionWindow::onMeshBuilt(const QString &captureId, int capturedPart
     // GP0 capture-source breakdown surfaces the #662 FIFO bridge attribution
     // alongside the merged-RAM scan paths so users can see at a glance which
     // path produced the geometry (gp0_hook vs ram_*).
-    const QString gp0Text = tr("GP0 %1 (hook %2 / ot %3 / chain %4 / linear %5)")
+    // #674: append TMD / HMD counts so users see the model-space scanner contribution.
+    // On TMD-using games this is what flips the source label to `ram_model_mesh` and the
+    // GTE inverse % to non-zero.
+    const QString gp0Text = tr("GP0 %1 (hook %2 / ot %3 / chain %4 / linear %5 / tmd %6 / hmd %7)")
                                 .arg(captureStats.primarySourceLabel())
                                 .arg(captureStats.directHookPrims)
                                 .arg(captureStats.ramOtPrims)
                                 .arg(captureStats.ramChainRootPrims)
-                                .arg(captureStats.ramLinearPrims);
+                                .arg(captureStats.ramLinearPrims)
+                                .arg(captureStats.ramTmdMeshes)
+                                .arg(captureStats.ramHmdMeshes);
     m_statusLabel->setText(
         tr("Mesh %1 — captured %2 / unique %3 / instances %4 (%5 verts, %6 tris, %7 GTE matrices, "
            "%8, %9, VRAM: %10, %11)")

--- a/src/PS1/runtime/PS1RipWorker.cpp
+++ b/src/PS1/runtime/PS1RipWorker.cpp
@@ -318,7 +318,7 @@ void PS1RipWorker::finalizeFrameCapture()
     }
     SentryReporter::addBreadcrumb(
         QStringLiteral("ps1.rip.capture.summary"),
-        QStringLiteral("capture=%1 source=%2 total=%3 hook=%4 ot=%5 chain=%6 linear=%7 legacy=%8")
+        QStringLiteral("capture=%1 source=%2 total=%3 hook=%4 ot=%5 chain=%6 linear=%7 tmd=%8 hmd=%9 legacy=%10")
             .arg(captureId)
             .arg(stats.primarySourceLabel())
             .arg(stats.totalPrims)
@@ -326,10 +326,22 @@ void PS1RipWorker::finalizeFrameCapture()
             .arg(stats.ramOtPrims)
             .arg(stats.ramChainRootPrims)
             .arg(stats.ramLinearPrims)
+            .arg(stats.ramTmdMeshes)
+            .arg(stats.ramHmdMeshes)
             .arg(qEnvironmentVariableIsSet("QTMESH_PS1_GP0_RAM_LEGACY")
                          && qEnvironmentVariableIntValue("QTMESH_PS1_GP0_RAM_LEGACY") != 0
                      ? QStringLiteral("yes")
                      : QStringLiteral("no")));
+
+    if (stats.ramTmdMeshes > 0 || stats.ramHmdMeshes > 0) {
+        SentryReporter::addBreadcrumb(
+            QStringLiteral("ps1.rip.capture.modelmesh"),
+            QStringLiteral("capture=%1 tmd=%2 hmd=%3 buffer_modelmeshes=%4")
+                .arg(captureId)
+                .arg(stats.ramTmdMeshes)
+                .arg(stats.ramHmdMeshes)
+                .arg(m_captureBuffer ? m_captureBuffer->modelMeshes().size() : 0));
+    }
 
     emit frameCaptureReady(captureId, CaptureSnapshot::fromBuffer(*m_captureBuffer, vramCells),
                            prims.size(), vramMode, stats);

--- a/src/PS1/runtime/PS1RipWorker.cpp
+++ b/src/PS1/runtime/PS1RipWorker.cpp
@@ -318,7 +318,8 @@ void PS1RipWorker::finalizeFrameCapture()
     }
     SentryReporter::addBreadcrumb(
         QStringLiteral("ps1.rip.capture.summary"),
-        QStringLiteral("capture=%1 source=%2 total=%3 hook=%4 ot=%5 chain=%6 linear=%7 tmd=%8 hmd=%9 legacy=%10")
+        QStringLiteral("capture=%1 source=%2 total=%3 hook=%4 ot=%5 chain=%6 linear=%7 tmd=%8 "
+                       "hmd=%9 hmd_cand=%10 legacy=%11")
             .arg(captureId)
             .arg(stats.primarySourceLabel())
             .arg(stats.totalPrims)
@@ -328,18 +329,23 @@ void PS1RipWorker::finalizeFrameCapture()
             .arg(stats.ramLinearPrims)
             .arg(stats.ramTmdMeshes)
             .arg(stats.ramHmdMeshes)
+            .arg(stats.ramHmdCandidates)
             .arg(qEnvironmentVariableIsSet("QTMESH_PS1_GP0_RAM_LEGACY")
                          && qEnvironmentVariableIntValue("QTMESH_PS1_GP0_RAM_LEGACY") != 0
                      ? QStringLiteral("yes")
                      : QStringLiteral("no")));
 
+    // Only log the modelmesh breadcrumb when actual model-mesh emissions happened.
+    // ramHmdCandidates by itself is just a diagnostics count of plausible HMD magic
+    // bytes — it does NOT indicate a successful capture (#674 review).
     if (stats.ramTmdMeshes > 0 || stats.ramHmdMeshes > 0) {
         SentryReporter::addBreadcrumb(
             QStringLiteral("ps1.rip.capture.modelmesh"),
-            QStringLiteral("capture=%1 tmd=%2 hmd=%3 buffer_modelmeshes=%4")
+            QStringLiteral("capture=%1 tmd=%2 hmd=%3 hmd_cand=%4 buffer_modelmeshes=%5")
                 .arg(captureId)
                 .arg(stats.ramTmdMeshes)
                 .arg(stats.ramHmdMeshes)
+                .arg(stats.ramHmdCandidates)
                 .arg(m_captureBuffer ? m_captureBuffer->modelMeshes().size() : 0));
     }
 

--- a/src/PS1/runtime/PsxHmdRamScanner.cpp
+++ b/src/PS1/runtime/PsxHmdRamScanner.cpp
@@ -1,0 +1,65 @@
+#include "PsxHmdRamScanner.h"
+
+#include "EmuHooks.h"
+#include "PsxModelRamScanCommon.h"
+
+#include <QtGlobal>
+
+namespace {
+
+constexpr uint32_t kHmdMagic = 0x00000050u;
+constexpr size_t kScanStrideBytes = 4u;
+constexpr int kMaxCandidates = 32;
+
+bool plausibleHmdHeader(const uint8_t *ram, size_t byteSize, size_t offset)
+{
+    // The first u32 is the magic (already checked). The next u32 is the "map length" in
+    // dwords; subsequent fields are primitive header counts that should be modest. The
+    // checks below filter the vast majority of noise — they aren't strong enough to fully
+    // validate an HMD, which is why v1 stops short of mesh extraction.
+    if (offset + 16u > byteSize)
+        return false;
+    const uint32_t mapLen = PsxModelRamScan::readU32le(ram + offset + 4);
+    const uint32_t numPrimHeaders = PsxModelRamScan::readU32le(ram + offset + 8);
+    if (mapLen == 0u || mapLen > 0x40000u)
+        return false;
+    if (numPrimHeaders == 0u || numPrimHeaders > 4096u)
+        return false;
+    return true;
+}
+
+} // namespace
+
+int PsxHmdRamScanner::countHmdCandidates(const uint8_t *ram, size_t byteSize)
+{
+    if (!ram || byteSize < 16u)
+        return 0;
+    int count = 0;
+    for (size_t offset = 0; offset + 4 <= byteSize && count < kMaxCandidates;
+         offset += kScanStrideBytes) {
+        if (PsxModelRamScan::readU32le(ram + offset) != kHmdMagic)
+            continue;
+        if (!plausibleHmdHeader(ram, byteSize, offset))
+            continue;
+        ++count;
+    }
+    return count;
+}
+
+int PsxHmdRamScanner::captureFromSystemRam(const uint8_t *ram, size_t byteSize, EmuHooks *hooks)
+{
+    if (!ram || !hooks || !hooks->isCaptureEnabled())
+        return 0;
+
+    const bool enabled = qEnvironmentVariableIsSet("QTMESH_PS1_HMD_SCANNER")
+                         && qEnvironmentVariableIntValue("QTMESH_PS1_HMD_SCANNER") != 0;
+    if (!enabled)
+        return 0;
+
+    // v1: count candidates for diagnostics, but don't emit meshes — extracting from the
+    // hierarchical scene graph requires parsing primitive header types (4-byte tag +
+    // type-specific layout) which we haven't validated against a known-good asset yet.
+    // The candidate count is logged so testers can confirm the magic-bytes path works on
+    // HMD-using titles; the actual walker lands in a follow-up.
+    return countHmdCandidates(ram, byteSize);
+}

--- a/src/PS1/runtime/PsxHmdRamScanner.h
+++ b/src/PS1/runtime/PsxHmdRamScanner.h
@@ -1,0 +1,30 @@
+#ifndef PSXHMDRAMSCANNER_H
+#define PSXHMDRAMSCANNER_H
+
+#include <cstddef>
+#include <cstdint>
+
+class EmuHooks;
+
+/**
+ * Scan PS1 system RAM for Sony SDK HMD (`0x00000050` magic) hierarchical mesh structures.
+ * v1 is a *stub* — HMD's hierarchical primitive-node layout is significantly more involved
+ * than TMD's flat object table and parsing it speculatively from RAM is a common source of
+ * false-positives. The scaffold exists so per-title testing can be enabled at runtime via
+ * `QTMESH_PS1_HMD_SCANNER=1` without needing a code change; future revisions will land the
+ * actual primitive walk here once we have a known-good HMD asset to test against (#674).
+ */
+class PsxHmdRamScanner
+{
+public:
+    /** Returns the number of meshes accepted by `hooks->onModelMesh`. v1 returns 0 unless
+     *  `QTMESH_PS1_HMD_SCANNER` env var is set, in which case the magic-only scan runs to
+     *  surface candidate addresses via Sentry breadcrumbs (still 0 meshes emitted). */
+    static int captureFromSystemRam(const uint8_t *ram, size_t byteSize, EmuHooks *hooks);
+
+    /** Probe for HMD magic bytes only. Used by the v1 stub to count candidates without
+     *  emitting meshes. Exposed for unit tests. */
+    static int countHmdCandidates(const uint8_t *ram, size_t byteSize);
+};
+
+#endif // PSXHMDRAMSCANNER_H

--- a/src/PS1/runtime/PsxHmdRamScanner_test.cpp
+++ b/src/PS1/runtime/PsxHmdRamScanner_test.cpp
@@ -1,0 +1,68 @@
+#ifdef ENABLE_PS1_RIP
+
+#include <gtest/gtest.h>
+
+#include "PS1/runtime/CaptureBuffer.h"
+#include "PS1/runtime/PsxHmdRamScanner.h"
+#include "PS1/runtime/RipperHooks.h"
+
+#include <atomic>
+#include <cstdint>
+#include <vector>
+
+namespace {
+
+constexpr uint32_t kHmdMagic = 0x00000050u;
+
+void writeU32le(uint8_t *dst, uint32_t value)
+{
+    dst[0] = static_cast<uint8_t>(value & 0xFFu);
+    dst[1] = static_cast<uint8_t>((value >> 8) & 0xFFu);
+    dst[2] = static_cast<uint8_t>((value >> 16) & 0xFFu);
+    dst[3] = static_cast<uint8_t>((value >> 24) & 0xFFu);
+}
+
+} // namespace
+
+TEST(PsxHmdRamScannerTest, CountsPlausibleHmdCandidates)
+{
+    std::vector<uint8_t> ram(64u * 1024u, 0u);
+    // Plausible-looking HMD header at 0x2000.
+    writeU32le(ram.data() + 0x2000, kHmdMagic);
+    writeU32le(ram.data() + 0x2000 + 4, 0x1000u);  // mapLen — within bounds
+    writeU32le(ram.data() + 0x2000 + 8, 4u);       // numPrimHeaders — modest
+    writeU32le(ram.data() + 0x2000 + 12, 0u);
+
+    EXPECT_EQ(PsxHmdRamScanner::countHmdCandidates(ram.data(), ram.size()), 1);
+
+    // A nonsense "HMD" with insane map length should NOT count.
+    writeU32le(ram.data() + 0x4000, kHmdMagic);
+    writeU32le(ram.data() + 0x4000 + 4, 0xFFFFFFFFu); // mapLen way out of bounds
+    writeU32le(ram.data() + 0x4000 + 8, 1u);
+
+    EXPECT_EQ(PsxHmdRamScanner::countHmdCandidates(ram.data(), ram.size()), 1)
+        << "Out-of-range mapLen must be filtered out";
+}
+
+TEST(PsxHmdRamScannerTest, EmitsNothingByDefault)
+{
+    // v1 is opt-in via QTMESH_PS1_HMD_SCANNER. With the env var unset, the scanner returns
+    // 0 even when valid-looking candidates exist — no model meshes should be emitted.
+    qunsetenv("QTMESH_PS1_HMD_SCANNER");
+
+    std::vector<uint8_t> ram(64u * 1024u, 0u);
+    writeU32le(ram.data() + 0x2000, kHmdMagic);
+    writeU32le(ram.data() + 0x2000 + 4, 0x1000u);
+    writeU32le(ram.data() + 0x2000 + 8, 4u);
+
+    std::atomic<bool> armed{true};
+    CaptureBuffer buffer;
+    RipperHooks hooks;
+    hooks.setArmedFlag(&armed);
+    hooks.setBuffer(&buffer);
+
+    EXPECT_EQ(PsxHmdRamScanner::captureFromSystemRam(ram.data(), ram.size(), &hooks), 0);
+    EXPECT_EQ(buffer.modelMeshes().size(), 0);
+}
+
+#endif // ENABLE_PS1_RIP

--- a/src/PS1/runtime/PsxHmdRamScanner_test.cpp
+++ b/src/PS1/runtime/PsxHmdRamScanner_test.cpp
@@ -3,6 +3,8 @@
 #include <gtest/gtest.h>
 
 #include "PS1/runtime/CaptureBuffer.h"
+#include "PS1/runtime/Gp0CaptureStats.h"
+#include "PS1/runtime/Gp0HookDispatch.h"
 #include "PS1/runtime/PsxHmdRamScanner.h"
 #include "PS1/runtime/RipperHooks.h"
 
@@ -63,6 +65,36 @@ TEST(PsxHmdRamScannerTest, EmitsNothingByDefault)
 
     EXPECT_EQ(PsxHmdRamScanner::captureFromSystemRam(ram.data(), ram.size(), &hooks), 0);
     EXPECT_EQ(buffer.modelMeshes().size(), 0);
+}
+
+// #674 review: a bare HMD-candidate hit (no actual onModelMesh emission) must NOT
+// flip primarySource to RamModelMesh. The frame-capture pipeline writes the count
+// into Gp0CaptureStats::ramHmdCandidates instead.
+TEST(PsxHmdRamScannerTest, HmdCandidatesDoNotPromoteModelMeshSource)
+{
+    qputenv("QTMESH_PS1_HMD_SCANNER", QByteArrayLiteral("1"));
+
+    std::vector<uint8_t> ram(64u * 1024u, 0u);
+    writeU32le(ram.data() + 0x2000, kHmdMagic);
+    writeU32le(ram.data() + 0x2000 + 4, 0x1000u);
+    writeU32le(ram.data() + 0x2000 + 8, 4u);
+
+    std::atomic<bool> armed{true};
+    CaptureBuffer buffer;
+    RipperHooks hooks;
+    hooks.setArmedFlag(&armed);
+    hooks.setBuffer(&buffer);
+
+    const Gp0CaptureStats stats =
+        Gp0HookDispatch::captureFrameFromSystemRam(ram.data(), ram.size(), &hooks,
+                                                   /*scanGteRam=*/false,
+                                                   /*accumulate=*/false);
+    qunsetenv("QTMESH_PS1_HMD_SCANNER");
+
+    EXPECT_GE(stats.ramHmdCandidates, 1);
+    EXPECT_EQ(stats.ramHmdMeshes, 0);
+    // Without emitted TMD or HMD meshes, primarySource must NOT be RamModelMesh.
+    EXPECT_NE(stats.primarySource, Gp0CaptureSource::RamModelMesh);
 }
 
 #endif // ENABLE_PS1_RIP

--- a/src/PS1/runtime/PsxModelRamScanCommon.h
+++ b/src/PS1/runtime/PsxModelRamScanCommon.h
@@ -1,0 +1,57 @@
+#ifndef PSXMODELRAMSCANCOMMON_H
+#define PSXMODELRAMSCANCOMMON_H
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+/**
+ * Tiny shared helpers for PsxTmdRamScanner / PsxHmdRamScanner / other model-space
+ * format scanners (#674). Header-only so each scanner stays self-contained.
+ */
+namespace PsxModelRamScan {
+
+inline uint32_t readU32le(const uint8_t *p)
+{
+    return static_cast<uint32_t>(p[0]) | (static_cast<uint32_t>(p[1]) << 8)
+           | (static_cast<uint32_t>(p[2]) << 16) | (static_cast<uint32_t>(p[3]) << 24);
+}
+
+inline uint16_t readU16le(const uint8_t *p)
+{
+    return static_cast<uint16_t>(static_cast<uint16_t>(p[0])
+                                | static_cast<uint16_t>(static_cast<uint16_t>(p[1]) << 8));
+}
+
+inline int16_t readI16le(const uint8_t *p)
+{
+    return static_cast<int16_t>(readU16le(p));
+}
+
+/** Bounds-checked u32 fetch. Returns 0 (i.e. usually "fails validation") on OOB. */
+inline uint32_t safeReadU32(const uint8_t *ram, size_t byteSize, size_t offset)
+{
+    if (offset + 4 > byteSize)
+        return 0;
+    return readU32le(ram + offset);
+}
+
+/**
+ * FNV-1a 64-bit hash over a byte range. Used as a content-hash for cross-frame TMD/HMD
+ * dedupe — same blob at the same offset across many frames should only emit once.
+ */
+inline uint64_t fnv1a64(const uint8_t *data, size_t size)
+{
+    constexpr uint64_t kFnvOffset = 1469598103934665603ULL;
+    constexpr uint64_t kFnvPrime = 1099511628211ULL;
+    uint64_t hash = kFnvOffset;
+    for (size_t i = 0; i < size; ++i) {
+        hash ^= static_cast<uint64_t>(data[i]);
+        hash *= kFnvPrime;
+    }
+    return hash;
+}
+
+} // namespace PsxModelRamScan
+
+#endif // PSXMODELRAMSCANCOMMON_H

--- a/src/PS1/runtime/PsxModelRamScanCommon.h
+++ b/src/PS1/runtime/PsxModelRamScanCommon.h
@@ -42,8 +42,11 @@ inline uint32_t safeReadU32(const uint8_t *ram, size_t byteSize, size_t offset)
  */
 inline uint64_t fnv1a64(const uint8_t *data, size_t size)
 {
-    constexpr uint64_t kFnvOffset = 1469598103934665603ULL;
-    constexpr uint64_t kFnvPrime = 1099511628211ULL;
+    // Canonical FNV-1a 64-bit constants (#674 review). The previous offset basis
+    // 1469598103934665603ULL was missing a digit; the real basis is
+    // 0xcbf29ce484222325 = 14695981039346656037.
+    constexpr uint64_t kFnvOffset = 0xcbf29ce484222325ULL;
+    constexpr uint64_t kFnvPrime = 0x100000001b3ULL;
     uint64_t hash = kFnvOffset;
     for (size_t i = 0; i < size; ++i) {
         hash ^= static_cast<uint64_t>(data[i]);

--- a/src/PS1/runtime/PsxTmdRamScanner.cpp
+++ b/src/PS1/runtime/PsxTmdRamScanner.cpp
@@ -145,6 +145,10 @@ struct PrimContext {
     ReconstructedSubMesh *flatColor;
     QHash<quint64, int> *textureSubMeshIndex;
     QVector<ReconstructedSubMesh> *textureSubMeshes;
+    // Highest byte position reached by the primitive walker across every object
+    // in this TMD. Used to size the content hash + scanner skip span correctly,
+    // since primitive packets have variable payloads (#674 review).
+    size_t maxPrimStreamEnd = 0;
 };
 
 ReconstructedSubMesh &ensureTextureSubMesh(PrimContext &ctx, uint16_t tpage, uint16_t clut)
@@ -213,6 +217,8 @@ bool walkPrimitives(const uint8_t *ram, size_t ramSize, uint32_t flags, size_t t
             return false;
         const uint8_t *d = ram + p + 4;
         p += 4 + payload;
+        if (p > ctx.maxPrimStreamEnd)
+            ctx.maxPrimStreamEnd = p;
         ++consumed;
         (void)olen;
 
@@ -409,9 +415,15 @@ bool walkPrimitives(const uint8_t *ram, size_t ramSize, uint32_t flags, size_t t
 
 /** Compute the byte extent covered by all of a TMD's pools and primitive streams. We use
  *  this to (a) build a content hash and (b) skip the scanner past the entire blob so we
- *  don't accidentally rescan inner bytes as a second TMD candidate. */
+ *  don't accidentally rescan inner bytes as a second TMD candidate.
+ *
+ *  `primStreamEnd` is the exact byte position the primitive walker reached across every
+ *  object — primitive packets have variable `ilen`-driven payload sizes (5/6/8/12+ words),
+ *  so the old "8 bytes per prim" assumption underestimated the real extent and could
+ *  cause prefix-equal blobs to dedupe or the scanner to resume inside the same blob
+ *  (#674 review). */
 size_t computeTmdSpan(const uint8_t *ram, size_t ramSize, uint32_t flags, size_t tmdStart,
-                      const QVector<ObjectHeader> &headers)
+                      const QVector<ObjectHeader> &headers, size_t primStreamEnd)
 {
     size_t maxEnd = tmdStart + kTmdHeaderSize + size_t(headers.size()) * kObjHeaderSize;
     for (const ObjectHeader &h : headers) {
@@ -425,14 +437,11 @@ size_t computeTmdSpan(const uint8_t *ram, size_t ramSize, uint32_t flags, size_t
             if (r.ok)
                 maxEnd = std::max(maxEnd, r.base + size_t(h.nNorm) * 8u);
         }
-        if (h.nPrim > 0) {
-            // We don't know prim-payload sizes ahead of time. Conservatively reserve 8 bytes
-            // per prim (smallest packet) — used purely for dedupe range, not for parsing.
-            const auto r = resolveOffset(h.primOff, flags, tmdStart, ramSize, size_t(h.nPrim) * 8u);
-            if (r.ok)
-                maxEnd = std::max(maxEnd, r.base + size_t(h.nPrim) * 8u);
-        }
     }
+    // The walker stops AT the last consumed byte (one past the last payload byte) — use
+    // that directly instead of guessing from header counts.
+    if (primStreamEnd > maxEnd)
+        maxEnd = primStreamEnd;
     return maxEnd > ramSize ? ramSize : maxEnd;
 }
 
@@ -510,9 +519,11 @@ int PsxTmdRamScanner::captureFromSystemRam(const uint8_t *ram, size_t byteSize, 
             continue;
         }
 
-        // Span covers the bytes the TMD actually occupies; we'll skip the scan stride past
-        // this so inner bytes don't get rescanned as second-level candidates.
-        const size_t span = computeTmdSpan(ram, byteSize, flags, offset, headers);
+        // Span covers the bytes the TMD actually occupies — built from the actual primitive
+        // walker end position (see PrimContext::maxPrimStreamEnd) so variable-length prim
+        // packets are accounted for. We use this to (a) hash the full content and (b) skip
+        // the scan stride past it so inner bytes don't get rescanned (#674 review).
+        const size_t span = computeTmdSpan(ram, byteSize, flags, offset, headers, ctx.maxPrimStreamEnd);
 
         ReconstructedMesh mesh;
         mesh.meshName = QStringLiteral("ps1_tmd_at_0x%1").arg(offset, 0, 16);

--- a/src/PS1/runtime/PsxTmdRamScanner.cpp
+++ b/src/PS1/runtime/PsxTmdRamScanner.cpp
@@ -1,0 +1,553 @@
+#include "PsxTmdRamScanner.h"
+
+#include "CapturedModelMesh.h"
+#include "EmuHooks.h"
+#include "MeshReconstructor.h"
+#include "PsxModelRamScanCommon.h"
+#include "ReconstructedMesh.h"
+
+#include <QHash>
+#include <QString>
+#include <QVector>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <numeric>
+
+namespace {
+
+using PsxModelRamScan::fnv1a64;
+using PsxModelRamScan::readI16le;
+using PsxModelRamScan::readU16le;
+using PsxModelRamScan::readU32le;
+
+constexpr uint32_t kTmdMagic = 0x00000041u;
+constexpr size_t kTmdHeaderSize = 12u;
+constexpr size_t kObjHeaderSize = 28u;
+constexpr int kMaxTmdsPerFrame = 16;
+constexpr uint32_t kMaxObjects = 256u;
+constexpr uint32_t kMaxVerts = 8192u;
+constexpr uint32_t kMaxPrims = 8192u;
+constexpr size_t kScanStrideBytes = 4u;
+
+/** Scale factor: PSX 12.4 fixed (1/4096) × editor uniform scale (10.0). Mirrors
+ *  `PS1TMD::kDefaultOgreUnitsPerTmdStep * PS1TMD::kTmdEditorUniformScale`. We use a local
+ *  constant to keep this scanner free of the Ogre-heavy PS1TMD.h dependency. */
+constexpr float kPosScale = 10.0f / 4096.0f;
+
+struct ObjectHeader {
+    uint32_t vertOff = 0;
+    uint32_t nVert = 0;
+    uint32_t normOff = 0;
+    uint32_t nNorm = 0;
+    uint32_t primOff = 0;
+    uint32_t nPrim = 0;
+};
+
+struct ResolvedRange {
+    size_t base = 0;
+    bool ok = false;
+};
+
+/** Resolve a TMD object-header offset to an absolute RAM offset.
+ *  - flags & 1 == 0 (FIX_P off): offsets are relative to the TMD start + 12 (file form).
+ *  - flags & 1 == 1 (FIX_P on):  offsets are KSEG0 RAM pointers; mask 0x001FFFFF. */
+ResolvedRange resolveOffset(uint32_t storedOff, uint32_t flags, size_t tmdStart, size_t ramSize,
+                            size_t payloadBytes)
+{
+    ResolvedRange out;
+    size_t base;
+    if ((flags & 1u) == 0u) {
+        base = tmdStart + kTmdHeaderSize + storedOff;
+    } else {
+        const uint32_t masked = storedOff & 0x001FFFFFu;
+        base = masked;
+    }
+    if (base >= ramSize)
+        return out;
+    if (payloadBytes > 0 && base + payloadBytes > ramSize)
+        return out;
+    out.base = base;
+    out.ok = true;
+    return out;
+}
+
+bool readObjectHeaders(const uint8_t *ram, size_t ramSize, size_t tmdStart, uint32_t numObj,
+                      QVector<ObjectHeader> &out)
+{
+    out.clear();
+    out.reserve(static_cast<int>(numObj));
+    const size_t tableStart = tmdStart + kTmdHeaderSize;
+    if (tableStart + size_t(numObj) * kObjHeaderSize > ramSize)
+        return false;
+    for (uint32_t i = 0; i < numObj; ++i) {
+        const uint8_t *oh = ram + tableStart + size_t(i) * kObjHeaderSize;
+        ObjectHeader h;
+        h.vertOff = readU32le(oh + 0);
+        h.nVert = readU32le(oh + 4);
+        h.normOff = readU32le(oh + 8);
+        h.nNorm = readU32le(oh + 12);
+        h.primOff = readU32le(oh + 16);
+        h.nPrim = readU32le(oh + 20);
+        // Sanity-check counts. A real TMD object always has >= 1 vertex and >= 1 primitive;
+        // normals can be zero on lit-but-flat-shaded variants but never absurdly large.
+        if (h.nVert == 0 || h.nVert > kMaxVerts || h.nPrim == 0 || h.nPrim > kMaxPrims
+            || h.nNorm > kMaxVerts)
+            return false;
+        out.append(h);
+    }
+    return true;
+}
+
+struct ParsedVertex {
+    float x = 0.0f;
+    float y = 0.0f;
+    float z = 0.0f;
+};
+
+bool readVertices(const uint8_t *ram, size_t ramSize, uint32_t flags, size_t tmdStart,
+                  const ObjectHeader &obj, QVector<ParsedVertex> &out)
+{
+    const size_t payload = size_t(obj.nVert) * 8u;
+    const ResolvedRange r = resolveOffset(obj.vertOff, flags, tmdStart, ramSize, payload);
+    if (!r.ok)
+        return false;
+    out.resize(static_cast<int>(obj.nVert));
+    for (uint32_t i = 0; i < obj.nVert; ++i) {
+        const uint8_t *v = ram + r.base + size_t(i) * 8u;
+        const int16_t x = readI16le(v + 0);
+        const int16_t y = readI16le(v + 2);
+        const int16_t z = readI16le(v + 4);
+        // Apply same editor transform as PS1TMD::applyTmdImportWorldTransform:
+        // uniform-scale + 180° Z rotation (x,y → −x,−y).
+        out[static_cast<int>(i)] = ParsedVertex{
+            -static_cast<float>(x) * kPosScale,
+            -static_cast<float>(y) * kPosScale,
+             static_cast<float>(z) * kPosScale,
+        };
+    }
+    return true;
+}
+
+uint32_t packAbgr(uint8_t r, uint8_t g, uint8_t b)
+{
+    return (uint32_t(0xFFu) << 24) | (uint32_t(b) << 16) | (uint32_t(g) << 8) | uint32_t(r);
+}
+
+/** UV / tpage decoding follows the PSX TMD convention used by `PS1TMD.cpp`:
+ *  texel coords are 0..255 inside the 256×256 logical texture page, with a half-texel bias. */
+float decodePs1U(uint8_t u) { return (static_cast<float>(u) + 0.5f) / 256.0f; }
+float decodePs1V(uint8_t v) { return (static_cast<float>(v) + 0.5f) / 256.0f; }
+
+struct PrimContext {
+    const QVector<ParsedVertex> *verts;
+    ReconstructedSubMesh *flatColor;
+    QHash<quint64, int> *textureSubMeshIndex;
+    QVector<ReconstructedSubMesh> *textureSubMeshes;
+};
+
+ReconstructedSubMesh &ensureTextureSubMesh(PrimContext &ctx, uint16_t tpage, uint16_t clut)
+{
+    const quint64 key = MeshReconstructor::textureGroupKey(tpage, clut, 0u, 0u);
+    const auto it = ctx.textureSubMeshIndex->constFind(key);
+    if (it != ctx.textureSubMeshIndex->constEnd())
+        return (*ctx.textureSubMeshes)[it.value()];
+    const int idx = ctx.textureSubMeshes->size();
+    ctx.textureSubMeshIndex->insert(key, idx);
+    ReconstructedSubMesh sub;
+    sub.materialName = MeshReconstructor::textureMaterialName(tpage, clut, 0u, 0u);
+    ctx.textureSubMeshes->append(sub);
+    return (*ctx.textureSubMeshes)[idx];
+}
+
+/** Push a triangle into the sub-mesh, swapping v1/v2 to match Ogre CCW front-face winding
+ *  (same swap `PS1TMD::importTmd` applies — see appendTri in PS1TMD.cpp). */
+void emitTri(ReconstructedSubMesh &sub, const ParsedVertex &p0, const ParsedVertex &p1,
+             const ParsedVertex &p2, uint32_t c0, uint32_t c1, uint32_t c2,
+             float u0, float v0, float u1, float v1, float u2, float v2, bool textured)
+{
+    const uint32_t base = static_cast<uint32_t>(sub.vertices.size());
+    auto push = [&](const ParsedVertex &p, uint32_t c, float u, float v) {
+        ReconstructedVertex rv;
+        rv.px = p.x;
+        rv.py = p.y;
+        rv.pz = p.z;
+        rv.diffuseArgb = c;
+        rv.u = textured ? u : 0.0f;
+        rv.v = textured ? v : 0.0f;
+        sub.vertices.append(rv);
+    };
+    push(p0, c0, u0, v0);
+    // Swap idx 1 and 2 to match Ogre CCW front (PSX packets are CW).
+    push(p2, c2, u2, v2);
+    push(p1, c1, u1, v1);
+    sub.indices.append(base);
+    sub.indices.append(base + 1);
+    sub.indices.append(base + 2);
+}
+
+/** Walk one object's primitive packet stream and emit triangles. Returns false on a packet
+ *  parse error so the candidate is rejected entirely (we don't want partial dumps that
+ *  mis-bind to a different TMD overlapping in RAM). */
+bool walkPrimitives(const uint8_t *ram, size_t ramSize, uint32_t flags, size_t tmdStart,
+                    const ObjectHeader &obj, PrimContext &ctx)
+{
+    const ResolvedRange r = resolveOffset(obj.primOff, flags, tmdStart, ramSize, 4u);
+    if (!r.ok)
+        return false;
+    const uint32_t nVert = obj.nVert;
+    size_t p = r.base;
+    uint32_t consumed = 0;
+    while (consumed < obj.nPrim) {
+        if (p + 4 > ramSize)
+            return false;
+        const uint8_t olen = ram[p + 0];
+        const uint8_t ilen = ram[p + 1];
+        const uint8_t flag = ram[p + 2];
+        const uint8_t mode = ram[p + 3];
+        const size_t payload = size_t(ilen) * 4u;
+        if (ilen == 0 || ilen > 32)
+            return false;
+        if (p + 4 + payload > ramSize)
+            return false;
+        const uint8_t *d = ram + p + 4;
+        p += 4 + payload;
+        ++consumed;
+        (void)olen;
+
+        auto getVert = [&](uint16_t idx) -> const ParsedVertex * {
+            if (idx >= nVert)
+                return nullptr;
+            return &(*ctx.verts)[static_cast<int>(idx)];
+        };
+
+        // Bread-and-butter primitive set. Anything else is silently skipped (consumed,
+        // not failed) so an unknown packet flavor doesn't sink the whole TMD object.
+
+        // 0x20 flag=0 ilen=3 — flat-shaded triangle (lit, mono color)
+        if (mode == 0x20 && flag == 0 && ilen == 3) {
+            const uint32_t c = packAbgr(d[0], d[1], d[2]);
+            const uint16_t i0 = readU16le(d + 6);
+            const uint16_t i1 = readU16le(d + 8);
+            const uint16_t i2 = readU16le(d + 10);
+            const ParsedVertex *p0 = getVert(i0);
+            const ParsedVertex *p1 = getVert(i1);
+            const ParsedVertex *p2 = getVert(i2);
+            if (p0 && p1 && p2)
+                emitTri(*ctx.flatColor, *p0, *p1, *p2, c, c, c, 0, 0, 0, 0, 0, 0, false);
+            continue;
+        }
+        // 0x30 flag=0 ilen=4 — flat-shaded tri (lit, mono color, full-normal-per-vert variant)
+        if (mode == 0x30 && flag == 0 && ilen == 4) {
+            const uint32_t c = packAbgr(d[0], d[1], d[2]);
+            const uint16_t v0 = readU16le(d + 6);
+            const uint16_t v1 = readU16le(d + 10);
+            const uint16_t v2 = readU16le(d + 14);
+            const ParsedVertex *p0 = getVert(v0);
+            const ParsedVertex *p1 = getVert(v1);
+            const ParsedVertex *p2 = getVert(v2);
+            if (p0 && p1 && p2)
+                emitTri(*ctx.flatColor, *p0, *p1, *p2, c, c, c, 0, 0, 0, 0, 0, 0, false);
+            continue;
+        }
+        // 0x30 flag=0 ilen=6 — Gouraud tri (per-vertex RGB, lit)
+        if (mode == 0x30 && flag == 0 && ilen == 6) {
+            const uint32_t c0 = packAbgr(d[0], d[1], d[2]);
+            const uint32_t c1 = packAbgr(d[4], d[5], d[6]);
+            const uint32_t c2 = packAbgr(d[8], d[9], d[10]);
+            const uint16_t v0 = readU16le(d + 14);
+            const uint16_t v1 = readU16le(d + 18);
+            const uint16_t v2 = readU16le(d + 22);
+            const ParsedVertex *p0 = getVert(v0);
+            const ParsedVertex *p1 = getVert(v1);
+            const ParsedVertex *p2 = getVert(v2);
+            if (p0 && p1 && p2)
+                emitTri(*ctx.flatColor, *p0, *p1, *p2, c0, c1, c2, 0, 0, 0, 0, 0, 0, false);
+            continue;
+        }
+        // 0x24 flag=0 ilen=5 — textured tri (lit)
+        if (mode == 0x24 && flag == 0 && ilen == 5) {
+            const float u0 = decodePs1U(d[0]);
+            const float v0 = decodePs1V(d[1]);
+            const uint16_t clut = readU16le(d + 2);
+            const float u1 = decodePs1U(d[4]);
+            const float v1 = decodePs1V(d[5]);
+            const uint16_t tpage = readU16le(d + 6);
+            const float u2 = decodePs1U(d[8]);
+            const float v2 = decodePs1V(d[9]);
+            const uint16_t i0 = readU16le(d + 14);
+            const uint16_t i1 = readU16le(d + 16);
+            const uint16_t i2 = readU16le(d + 18);
+            const ParsedVertex *pp0 = getVert(i0);
+            const ParsedVertex *pp1 = getVert(i1);
+            const ParsedVertex *pp2 = getVert(i2);
+            if (pp0 && pp1 && pp2) {
+                ReconstructedSubMesh &sub = ensureTextureSubMesh(ctx, tpage, clut);
+                const uint32_t c = packAbgr(0x80u, 0x80u, 0x80u);
+                emitTri(sub, *pp0, *pp1, *pp2, c, c, c, u0, v0, u1, v1, u2, v2, true);
+            }
+            continue;
+        }
+        // 0x34 flag=0 ilen=6 — Gouraud textured tri (lit). Per PS1TMD.cpp: bytes 0..11 are
+        // UV0/CLUT/UV1/TPAGE/UV2/pad, bytes 12..23 are (n_idx, v_idx) × 3. The texture
+        // provides the visible color so we bind neutral grey for the FFP modulate.
+        if (mode == 0x34 && flag == 0 && ilen == 6) {
+            const float u0 = decodePs1U(d[0]);
+            const float v0 = decodePs1V(d[1]);
+            const uint16_t clut = readU16le(d + 2);
+            const float u1 = decodePs1U(d[4]);
+            const float v1 = decodePs1V(d[5]);
+            const uint16_t tpage = readU16le(d + 6);
+            const float u2 = decodePs1U(d[8]);
+            const float v2 = decodePs1V(d[9]);
+            const uint16_t i0 = readU16le(d + 14);
+            const uint16_t i1 = readU16le(d + 18);
+            const uint16_t i2 = readU16le(d + 22);
+            const ParsedVertex *pp0 = getVert(i0);
+            const ParsedVertex *pp1 = getVert(i1);
+            const ParsedVertex *pp2 = getVert(i2);
+            if (pp0 && pp1 && pp2) {
+                ReconstructedSubMesh &sub = ensureTextureSubMesh(ctx, tpage, clut);
+                const uint32_t c = packAbgr(0x80u, 0x80u, 0x80u);
+                emitTri(sub, *pp0, *pp1, *pp2, c, c, c, u0, v0, u1, v1, u2, v2, true);
+            }
+            continue;
+        }
+        // 0x28 flag=0 ilen=4 — mono-quad (lit)
+        if (mode == 0x28 && flag == 0 && ilen == 4) {
+            const uint32_t c = packAbgr(d[0], d[1], d[2]);
+            const uint16_t i0 = readU16le(d + 6);
+            const uint16_t i1 = readU16le(d + 8);
+            const uint16_t i2 = readU16le(d + 10);
+            const uint16_t i3 = readU16le(d + 12);
+            const ParsedVertex *p0 = getVert(i0);
+            const ParsedVertex *p1 = getVert(i1);
+            const ParsedVertex *p2 = getVert(i2);
+            const ParsedVertex *p3 = getVert(i3);
+            if (p0 && p1 && p2 && p3) {
+                emitTri(*ctx.flatColor, *p0, *p1, *p2, c, c, c, 0, 0, 0, 0, 0, 0, false);
+                emitTri(*ctx.flatColor, *p1, *p3, *p2, c, c, c, 0, 0, 0, 0, 0, 0, false);
+            }
+            continue;
+        }
+        // 0x28 flag=4 ilen=7 — Gouraud-quad (lit, per-vertex RGB)
+        if (mode == 0x28 && flag == 4 && ilen == 7) {
+            const uint32_t c0 = packAbgr(d[0], d[1], d[2]);
+            const uint32_t c1 = packAbgr(d[4], d[5], d[6]);
+            const uint32_t c2 = packAbgr(d[8], d[9], d[10]);
+            const uint32_t c3 = packAbgr(d[12], d[13], d[14]);
+            const uint16_t i0 = readU16le(d + 18);
+            const uint16_t i1 = readU16le(d + 20);
+            const uint16_t i2 = readU16le(d + 22);
+            const uint16_t i3 = readU16le(d + 24);
+            const ParsedVertex *p0 = getVert(i0);
+            const ParsedVertex *p1 = getVert(i1);
+            const ParsedVertex *p2 = getVert(i2);
+            const ParsedVertex *p3 = getVert(i3);
+            if (p0 && p1 && p2 && p3) {
+                emitTri(*ctx.flatColor, *p0, *p1, *p2, c0, c1, c2, 0, 0, 0, 0, 0, 0, false);
+                emitTri(*ctx.flatColor, *p1, *p3, *p2, c1, c3, c2, 0, 0, 0, 0, 0, 0, false);
+            }
+            continue;
+        }
+        // 0x25 flag=1 ilen=6 — textured tri (no-light, per-vertex RGB at 12..14 ignored)
+        if (mode == 0x25 && flag == 1 && ilen == 6) {
+            const float u0 = decodePs1U(d[0]);
+            const float v0 = decodePs1V(d[1]);
+            const uint16_t clut = readU16le(d + 2);
+            const float u1 = decodePs1U(d[4]);
+            const float v1 = decodePs1V(d[5]);
+            const uint16_t tpage = readU16le(d + 6);
+            const float u2 = decodePs1U(d[8]);
+            const float v2 = decodePs1V(d[9]);
+            const uint16_t i0 = readU16le(d + 16);
+            const uint16_t i1 = readU16le(d + 18);
+            const uint16_t i2 = readU16le(d + 20);
+            const ParsedVertex *pp0 = getVert(i0);
+            const ParsedVertex *pp1 = getVert(i1);
+            const ParsedVertex *pp2 = getVert(i2);
+            if (pp0 && pp1 && pp2) {
+                ReconstructedSubMesh &sub = ensureTextureSubMesh(ctx, tpage, clut);
+                const uint32_t c = packAbgr(0x80u, 0x80u, 0x80u);
+                emitTri(sub, *pp0, *pp1, *pp2, c, c, c, u0, v0, u1, v1, u2, v2, true);
+            }
+            continue;
+        }
+        // 0x35 flag=1 ilen=8 — Gouraud textured tri (no-light)
+        if (mode == 0x35 && flag == 1 && ilen == 8) {
+            const float u0 = decodePs1U(d[0]);
+            const float v0 = decodePs1V(d[1]);
+            const uint16_t clut = readU16le(d + 2);
+            const float u1 = decodePs1U(d[4]);
+            const float v1 = decodePs1V(d[5]);
+            const uint16_t tpage = readU16le(d + 6);
+            const float u2 = decodePs1U(d[8]);
+            const float v2 = decodePs1V(d[9]);
+            const uint16_t i0 = readU16le(d + 24);
+            const uint16_t i1 = readU16le(d + 26);
+            const uint16_t i2 = readU16le(d + 28);
+            const ParsedVertex *pp0 = getVert(i0);
+            const ParsedVertex *pp1 = getVert(i1);
+            const ParsedVertex *pp2 = getVert(i2);
+            if (pp0 && pp1 && pp2) {
+                ReconstructedSubMesh &sub = ensureTextureSubMesh(ctx, tpage, clut);
+                const uint32_t c = packAbgr(0x80u, 0x80u, 0x80u);
+                emitTri(sub, *pp0, *pp1, *pp2, c, c, c, u0, v0, u1, v1, u2, v2, true);
+            }
+            continue;
+        }
+
+        // Unknown / unsupported primitive flavor — skip the payload, keep walking. (We
+        // already advanced `p` and `consumed` above.) Don't return false: a typical TMD
+        // mixes flavors and missing one shouldn't sink the whole object.
+        (void)flag;
+        (void)mode;
+    }
+    return true;
+}
+
+/** Compute the byte extent covered by all of a TMD's pools and primitive streams. We use
+ *  this to (a) build a content hash and (b) skip the scanner past the entire blob so we
+ *  don't accidentally rescan inner bytes as a second TMD candidate. */
+size_t computeTmdSpan(const uint8_t *ram, size_t ramSize, uint32_t flags, size_t tmdStart,
+                      const QVector<ObjectHeader> &headers)
+{
+    size_t maxEnd = tmdStart + kTmdHeaderSize + size_t(headers.size()) * kObjHeaderSize;
+    for (const ObjectHeader &h : headers) {
+        if (h.nVert > 0) {
+            const auto r = resolveOffset(h.vertOff, flags, tmdStart, ramSize, size_t(h.nVert) * 8u);
+            if (r.ok)
+                maxEnd = std::max(maxEnd, r.base + size_t(h.nVert) * 8u);
+        }
+        if (h.nNorm > 0) {
+            const auto r = resolveOffset(h.normOff, flags, tmdStart, ramSize, size_t(h.nNorm) * 8u);
+            if (r.ok)
+                maxEnd = std::max(maxEnd, r.base + size_t(h.nNorm) * 8u);
+        }
+        if (h.nPrim > 0) {
+            // We don't know prim-payload sizes ahead of time. Conservatively reserve 8 bytes
+            // per prim (smallest packet) — used purely for dedupe range, not for parsing.
+            const auto r = resolveOffset(h.primOff, flags, tmdStart, ramSize, size_t(h.nPrim) * 8u);
+            if (r.ok)
+                maxEnd = std::max(maxEnd, r.base + size_t(h.nPrim) * 8u);
+        }
+    }
+    return maxEnd > ramSize ? ramSize : maxEnd;
+}
+
+} // namespace
+
+int PsxTmdRamScanner::captureFromSystemRam(const uint8_t *ram, size_t byteSize, EmuHooks *hooks)
+{
+    if (!ram || byteSize < kTmdHeaderSize + kObjHeaderSize || !hooks || !hooks->isCaptureEnabled())
+        return 0;
+
+    int found = 0;
+    size_t offset = 0;
+    while (offset + kTmdHeaderSize <= byteSize && found < kMaxTmdsPerFrame) {
+        const uint32_t magic = readU32le(ram + offset);
+        if (magic != kTmdMagic) {
+            offset += kScanStrideBytes;
+            continue;
+        }
+        const uint32_t flags = readU32le(ram + offset + 4);
+        const uint32_t numObj = readU32le(ram + offset + 8);
+        if ((flags & ~1u) != 0u || numObj == 0u || numObj > kMaxObjects) {
+            offset += kScanStrideBytes;
+            continue;
+        }
+
+        QVector<ObjectHeader> headers;
+        if (!readObjectHeaders(ram, byteSize, offset, numObj, headers)) {
+            offset += kScanStrideBytes;
+            continue;
+        }
+
+        // Pre-walk pass: read all vertex/normal pools + walk primitives. If anything looks
+        // bogus (OOB pointer, bad packet header, zero vertex output) we reject the whole
+        // candidate. This is the false-positive filter: random RAM that happens to start
+        // with 0x41 + plausible flags but doesn't form a real TMD gets thrown out here.
+        ReconstructedSubMesh flatColor;
+        flatColor.materialName = QStringLiteral("PS1Rip_tmd_vertcolor");
+        QVector<ReconstructedSubMesh> textureSubMeshes;
+        QHash<quint64, int> textureIndex;
+        PrimContext ctx;
+        ctx.flatColor = &flatColor;
+        ctx.textureSubMeshes = &textureSubMeshes;
+        ctx.textureSubMeshIndex = &textureIndex;
+
+        bool allObjectsOk = true;
+        int totalEmittedTris = 0;
+        for (const ObjectHeader &h : headers) {
+            QVector<ParsedVertex> verts;
+            if (!readVertices(ram, byteSize, flags, offset, h, verts)) {
+                allObjectsOk = false;
+                break;
+            }
+            ctx.verts = &verts;
+            const int trisBefore =
+                flatColor.indices.size() / 3
+                + std::accumulate(textureSubMeshes.constBegin(), textureSubMeshes.constEnd(), 0,
+                                  [](int acc, const ReconstructedSubMesh &sub) {
+                                      return acc + sub.indices.size() / 3;
+                                  });
+            if (!walkPrimitives(ram, byteSize, flags, offset, h, ctx)) {
+                allObjectsOk = false;
+                break;
+            }
+            const int trisAfter =
+                flatColor.indices.size() / 3
+                + std::accumulate(textureSubMeshes.constBegin(), textureSubMeshes.constEnd(), 0,
+                                  [](int acc, const ReconstructedSubMesh &sub) {
+                                      return acc + sub.indices.size() / 3;
+                                  });
+            totalEmittedTris += (trisAfter - trisBefore);
+        }
+
+        if (!allObjectsOk || totalEmittedTris == 0) {
+            offset += kScanStrideBytes;
+            continue;
+        }
+
+        // Span covers the bytes the TMD actually occupies; we'll skip the scan stride past
+        // this so inner bytes don't get rescanned as second-level candidates.
+        const size_t span = computeTmdSpan(ram, byteSize, flags, offset, headers);
+
+        ReconstructedMesh mesh;
+        mesh.meshName = QStringLiteral("ps1_tmd_at_0x%1").arg(offset, 0, 16);
+        if (!flatColor.vertices.isEmpty() && flatColor.indices.size() >= 3) {
+            mesh.subMeshes.append(flatColor);
+            mesh.vertexCount += flatColor.vertices.size();
+            mesh.triangleCount += flatColor.indices.size() / 3;
+        }
+        for (const ReconstructedSubMesh &sub : textureSubMeshes) {
+            if (sub.vertices.isEmpty() || sub.indices.size() < 3)
+                continue;
+            mesh.subMeshes.append(sub);
+            mesh.vertexCount += sub.vertices.size();
+            mesh.triangleCount += sub.indices.size() / 3;
+        }
+        if (mesh.isEmpty()) {
+            offset += kScanStrideBytes;
+            continue;
+        }
+
+        CapturedModelMesh cap;
+        cap.mesh = mesh;
+        cap.sourceAddress = static_cast<uint32_t>(offset);
+        cap.format = QStringLiteral("tmd");
+        // Content hash over the full TMD byte span (header + pools + primitives).
+        const size_t hashBytes = span > offset ? span - offset : kTmdHeaderSize;
+        cap.contentHash = fnv1a64(ram + offset, hashBytes);
+
+        if (hooks->onModelMesh(cap))
+            ++found;
+
+        // Skip past the parsed blob to avoid rescanning inner data. Align up to the next
+        // 4-byte boundary so the outer stride stays well-formed.
+        const size_t advance = std::max(span - offset, kScanStrideBytes);
+        offset += (advance + 3u) & ~size_t(3u);
+    }
+    return found;
+}

--- a/src/PS1/runtime/PsxTmdRamScanner.h
+++ b/src/PS1/runtime/PsxTmdRamScanner.h
@@ -1,0 +1,38 @@
+#ifndef PSXTMDRAMSCANNER_H
+#define PSXTMDRAMSCANNER_H
+
+#include <cstddef>
+#include <cstdint>
+
+class EmuHooks;
+
+/**
+ * Scan PS1 system RAM for Sony SDK TMD (`0x00000041` magic) mesh structures and emit each
+ * unique find as a model-space mesh via `EmuHooks::onModelMesh` (#674).
+ *
+ * Unlike the screen-space GP0 path (`PsxOrderingTableScanner` / `PsxGp0ChainRootScanner` /
+ * linear), TMD data sits in RAM in *model space* — vertex coordinates are pre-projection,
+ * pre-camera-transform. The scanner therefore bypasses `MeshReconstructor::screenToModel`
+ * entirely; meshes arrive in editor world units (PSX 12.4 fixed × `kTmdEditorUniformScale`
+ * × 180° Z rotation, matching the on-disk TMD importer in `PS1TMD::importTmd`).
+ *
+ * Supports both `flag=0` (offsets relative to file-byte 12, the on-disk form) and
+ * `flag=1` (offsets are absolute KSEG0 RAM addresses, the post-fixup runtime form).
+ * Walks the bread-and-butter primitive set:
+ *   0x20 mono tri (lit)         0x28 mono quad (lit)
+ *   0x30 flat/gouraud tri (lit) 0x28 flag=4 gouraud quad
+ *   0x24 textured tri (lit)     0x25 flag=1 textured tri (no light)
+ *   0x34 gouraud textured tri   0x35 flag=1 gouraud textured tri (no light)
+ *
+ * Disabled with `QTMESH_PS1_TMD_SCANNER=0`. Defaults to enabled.
+ */
+class PsxTmdRamScanner
+{
+public:
+    /** Sweep `ram` (size `byteSize`) for TMDs. Stops after `kMaxTmdsPerFrame` finds to bound
+     *  per-frame cost. Returns the number of unique meshes accepted by the hooks
+     *  (`EmuHooks::onModelMesh` returning true). */
+    static int captureFromSystemRam(const uint8_t *ram, size_t byteSize, EmuHooks *hooks);
+};
+
+#endif // PSXTMDRAMSCANNER_H

--- a/src/PS1/runtime/PsxTmdRamScanner_test.cpp
+++ b/src/PS1/runtime/PsxTmdRamScanner_test.cpp
@@ -342,4 +342,79 @@ TEST(PsxTmdRamScannerTest, EmitsCorrectMaterialNameForTexturedPrim)
     EXPECT_TRUE(foundTextured) << "Textured prim must produce a PS1Rip_tpage_* sub-mesh";
 }
 
+// #674 review: computeTmdSpan must cover the full primitive payload, not a fixed 8 bytes
+// per prim. Two TMDs that differ only DEEP inside the primitive payload (past the old
+// 8-byte-per-prim window) must produce DIFFERENT contentHash values so they are NOT
+// dedupe-merged into one.
+TEST(PsxTmdRamScannerTest, ContentHashCoversFullPrimitivePayload)
+{
+    // Build a TMD with one 0x28 flag=0 ilen=4 prim (mono quad — 16-byte payload).
+    // The prim parser at this mode reads v3 index from d[12..13]. Old computeTmdSpan
+    // hashed only the first 8 bytes of the prim packet (header + 4 payload bytes),
+    // so changes to v3 — at offset 12..13 within payload — would NOT change the hash.
+    auto buildMonoQuadTmd = [](uint8_t *ram, size_t tmdStart, uint16_t v3Idx) {
+        writeU32le(ram + tmdStart + 0, kTmdMagic);
+        writeU32le(ram + tmdStart + 4, 0u);
+        writeU32le(ram + tmdStart + 8, 1u);
+
+        constexpr size_t kVertOffRel = kObjHeaderSize;
+        constexpr size_t kNormOffRel = kVertOffRel + 4u * 8u;
+        constexpr size_t kPrimOffRel = kNormOffRel + 1u * 8u;
+        const size_t objHdr = tmdStart + kTmdHeaderSize;
+        writeU32le(ram + objHdr + 0, static_cast<uint32_t>(kVertOffRel));
+        writeU32le(ram + objHdr + 4, 4u);
+        writeU32le(ram + objHdr + 8, static_cast<uint32_t>(kNormOffRel));
+        writeU32le(ram + objHdr + 12, 1u);
+        writeU32le(ram + objHdr + 16, static_cast<uint32_t>(kPrimOffRel));
+        writeU32le(ram + objHdr + 20, 1u);
+
+        const size_t vertBase = tmdStart + kTmdHeaderSize + kVertOffRel;
+        for (int i = 0; i < 4; ++i)
+            writeI16le(ram + vertBase + i * 8 + 0, static_cast<int16_t>(100 + i * 10));
+
+        const size_t normBase = tmdStart + kTmdHeaderSize + kNormOffRel;
+        writeI16le(ram + normBase + 4, 4096);
+
+        // 0x28 flag=0 ilen=4 packet (mono quad, 16-byte payload). Per parser at
+        // line ~317: d[0..2] = color, d[6..7] = v0, d[8..9] = v1, d[10..11] = v2,
+        // d[12..13] = v3. We vary v3 between the two builds to exercise the "deep
+        // payload" coverage of computeTmdSpan/contentHash.
+        const size_t primBase = tmdStart + kTmdHeaderSize + kPrimOffRel;
+        ram[primBase + 0] = 4;     // olen
+        ram[primBase + 1] = 4;     // ilen
+        ram[primBase + 2] = 0;     // flag
+        ram[primBase + 3] = 0x28;  // mode
+        ram[primBase + 4 + 0] = 0x80;
+        ram[primBase + 4 + 1] = 0x80;
+        ram[primBase + 4 + 2] = 0x80;
+        ram[primBase + 4 + 6] = 0;    // v0
+        ram[primBase + 4 + 8] = 1;    // v1
+        ram[primBase + 4 + 10] = 2;   // v2
+        ram[primBase + 4 + 12] = static_cast<uint8_t>(v3Idx & 0xFFu);
+        ram[primBase + 4 + 13] = static_cast<uint8_t>((v3Idx >> 8) & 0xFFu);
+    };
+
+    auto captureHash = [&](uint16_t v3) -> uint64_t {
+        std::vector<uint8_t> ram(64u * 1024u, 0u);
+        buildMonoQuadTmd(ram.data(), 0x1000, v3);
+        std::atomic<bool> armed{true};
+        CaptureBuffer buffer;
+        RipperHooks hooks;
+        hooks.setArmedFlag(&armed);
+        hooks.setBuffer(&buffer);
+        EXPECT_EQ(PsxTmdRamScanner::captureFromSystemRam(ram.data(), ram.size(), &hooks), 1);
+        if (buffer.modelMeshes().isEmpty())
+            return 0ULL;
+        return buffer.modelMeshes().front().contentHash;
+    };
+
+    const uint64_t hashV3_3 = captureHash(3);
+    const uint64_t hashV3_2 = captureHash(2);
+    ASSERT_NE(hashV3_3, 0ULL);
+    ASSERT_NE(hashV3_2, 0ULL);
+    EXPECT_NE(hashV3_3, hashV3_2)
+        << "contentHash must cover the full primitive payload — a byte change at "
+           "offset 12 inside a 16-byte payload must change the hash";
+}
+
 #endif // ENABLE_PS1_RIP

--- a/src/PS1/runtime/PsxTmdRamScanner_test.cpp
+++ b/src/PS1/runtime/PsxTmdRamScanner_test.cpp
@@ -1,0 +1,345 @@
+#ifdef ENABLE_PS1_RIP
+
+#include <gtest/gtest.h>
+
+#include "PS1/runtime/CaptureBuffer.h"
+#include "PS1/runtime/PsxTmdRamScanner.h"
+#include "PS1/runtime/RipperHooks.h"
+
+#include <QString>
+
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <random>
+#include <vector>
+
+namespace {
+
+constexpr uint32_t kTmdMagic = 0x00000041u;
+constexpr size_t kTmdHeaderSize = 12u;
+constexpr size_t kObjHeaderSize = 28u;
+
+/** Write a little-endian u32 to `dst`. */
+void writeU32le(uint8_t *dst, uint32_t value)
+{
+    dst[0] = static_cast<uint8_t>(value & 0xFFu);
+    dst[1] = static_cast<uint8_t>((value >> 8) & 0xFFu);
+    dst[2] = static_cast<uint8_t>((value >> 16) & 0xFFu);
+    dst[3] = static_cast<uint8_t>((value >> 24) & 0xFFu);
+}
+
+/** Write a little-endian i16 to `dst`. */
+void writeI16le(uint8_t *dst, int16_t value)
+{
+    const uint16_t u = static_cast<uint16_t>(value);
+    dst[0] = static_cast<uint8_t>(u & 0xFFu);
+    dst[1] = static_cast<uint8_t>((u >> 8) & 0xFFu);
+}
+
+/**
+ * Build a minimal 1-object TMD blob at `ram + tmdStart`:
+ *   - 3 vertices (forming one triangle)
+ *   - 1 normal
+ *   - 1 primitive packet, type 0x20 (mono-color flat-shaded tri) ilen=3
+ * Returns the total span (bytes) the blob occupies starting at `tmdStart`.
+ */
+size_t writeSimpleTmd(uint8_t *ram, size_t tmdStart)
+{
+    // File header.
+    writeU32le(ram + tmdStart + 0, kTmdMagic);
+    writeU32le(ram + tmdStart + 4, 0u); // flags: offsets relative to byte 12
+    writeU32le(ram + tmdStart + 8, 1u); // numObj
+
+    // Object header (28 bytes).
+    constexpr size_t kVertOffRel = kObjHeaderSize;                       // immediately after obj header
+    constexpr size_t kNormOffRel = kVertOffRel + 3u * 8u;                // after 3 verts (×8 bytes)
+    constexpr size_t kPrimOffRel = kNormOffRel + 1u * 8u;                // after 1 normal
+
+    const size_t objHdr = tmdStart + kTmdHeaderSize;
+    writeU32le(ram + objHdr + 0, static_cast<uint32_t>(kVertOffRel));
+    writeU32le(ram + objHdr + 4, 3u); // nVert
+    writeU32le(ram + objHdr + 8, static_cast<uint32_t>(kNormOffRel));
+    writeU32le(ram + objHdr + 12, 1u); // nNorm
+    writeU32le(ram + objHdr + 16, static_cast<uint32_t>(kPrimOffRel));
+    writeU32le(ram + objHdr + 20, 1u); // nPrim
+    writeU32le(ram + objHdr + 24, 0u); // scale (unused)
+
+    // Vertex pool: 3 verts × 8 bytes (i16 x,y,z + pad).
+    const size_t vertBase = tmdStart + kTmdHeaderSize + kVertOffRel;
+    writeI16le(ram + vertBase + 0 * 8 + 0, 100);
+    writeI16le(ram + vertBase + 0 * 8 + 2, 0);
+    writeI16le(ram + vertBase + 0 * 8 + 4, 0);
+    writeI16le(ram + vertBase + 1 * 8 + 0, -100);
+    writeI16le(ram + vertBase + 1 * 8 + 2, 100);
+    writeI16le(ram + vertBase + 1 * 8 + 4, 0);
+    writeI16le(ram + vertBase + 2 * 8 + 0, 0);
+    writeI16le(ram + vertBase + 2 * 8 + 2, 0);
+    writeI16le(ram + vertBase + 2 * 8 + 4, 100);
+
+    // Normal pool: 1 normal (i16 0, 0, 4096 = unit +Z in 12.4 fixed).
+    const size_t normBase = tmdStart + kTmdHeaderSize + kNormOffRel;
+    writeI16le(ram + normBase + 0, 0);
+    writeI16le(ram + normBase + 2, 0);
+    writeI16le(ram + normBase + 4, 4096);
+
+    // Primitive packet: mode=0x20, flag=0, ilen=3, olen=3 + RGB(80,80,80) + n_idx + v0/v1/v2
+    const size_t primBase = tmdStart + kTmdHeaderSize + kPrimOffRel;
+    ram[primBase + 0] = 0x03;           // olen
+    ram[primBase + 1] = 0x03;           // ilen (3 dwords = 12 bytes payload)
+    ram[primBase + 2] = 0x00;           // flag
+    ram[primBase + 3] = 0x20;           // mode
+    const uint8_t *payloadStart = ram + primBase + 4;
+    (void)payloadStart;
+    // Payload: RGB (3 bytes) + pad (1) + n_idx (u16) + v0 (u16) + v1 (u16) + v2 (u16) = 12 bytes.
+    ram[primBase + 4] = 0x80;           // R
+    ram[primBase + 5] = 0x80;           // G
+    ram[primBase + 6] = 0x80;           // B
+    ram[primBase + 7] = 0x00;           // pad / mode tag
+    writeU32le(ram + primBase + 8, 0u); // n_idx (u16) + v0 (u16) packed as u32 below
+    // Re-write the last 8 bytes with the actual indices:
+    ram[primBase + 8] = 0x00;           // n_idx lo
+    ram[primBase + 9] = 0x00;           // n_idx hi (normal 0)
+    ram[primBase + 10] = 0x00;          // v0 lo
+    ram[primBase + 11] = 0x00;          // v0 hi (vertex 0)
+    ram[primBase + 12] = 0x01;          // v1 lo
+    ram[primBase + 13] = 0x00;          // v1 hi (vertex 1)
+    ram[primBase + 14] = 0x02;          // v2 lo
+    ram[primBase + 15] = 0x00;          // v2 hi (vertex 2)
+
+    return kTmdHeaderSize + kObjHeaderSize + 3u * 8u + 1u * 8u + 4u + 12u; // 12+28+24+8+4+12 = 88
+}
+
+} // namespace
+
+TEST(PsxTmdRamScannerTest, FindsSingleTmdAtOffset)
+{
+    std::vector<uint8_t> ram(2u * 1024u * 1024u, 0u);
+    constexpr size_t kTmdStart = 0x10000;
+    const size_t span = writeSimpleTmd(ram.data(), kTmdStart);
+    ASSERT_GT(span, 0u);
+
+    std::atomic<bool> armed{true};
+    CaptureBuffer buffer;
+    RipperHooks hooks;
+    hooks.setArmedFlag(&armed);
+    hooks.setBuffer(&buffer);
+
+    const int found = PsxTmdRamScanner::captureFromSystemRam(ram.data(), ram.size(), &hooks);
+    EXPECT_EQ(found, 1);
+    ASSERT_EQ(buffer.modelMeshes().size(), 1);
+
+    const CapturedModelMesh &cap = buffer.modelMeshes().front();
+    EXPECT_EQ(cap.sourceAddress, kTmdStart);
+    EXPECT_EQ(cap.format, QStringLiteral("tmd"));
+    EXPECT_NE(cap.contentHash, 0ULL);
+    EXPECT_FALSE(cap.mesh.isEmpty());
+    EXPECT_GE(cap.mesh.vertexCount, 3);
+    EXPECT_GE(cap.mesh.triangleCount, 1);
+
+    // Position must be finite and on the order of the editor world unit scale (PSX 12.4
+    // fixed × 10.0 / 4096 ≈ 0.244 for vertex magnitude 100).
+    ASSERT_FALSE(cap.mesh.subMeshes.isEmpty());
+    const ReconstructedVertex &v = cap.mesh.subMeshes.front().vertices.front();
+    EXPECT_TRUE(std::isfinite(v.px));
+    EXPECT_TRUE(std::isfinite(v.py));
+    EXPECT_TRUE(std::isfinite(v.pz));
+}
+
+TEST(PsxTmdRamScannerTest, RejectsGarbageHeader)
+{
+    std::vector<uint8_t> ram(64u * 1024u, 0u);
+
+    // Wrong magic — must not match.
+    writeU32le(ram.data() + 0, 0xDEADBEEFu);
+    writeU32le(ram.data() + 4, 0u);
+    writeU32le(ram.data() + 8, 1u);
+
+    // Correct magic but absurd object count.
+    writeU32le(ram.data() + 0x1000, kTmdMagic);
+    writeU32le(ram.data() + 0x1000 + 4, 0u);
+    writeU32le(ram.data() + 0x1000 + 8, 999999u); // numObj way out of range
+
+    // Correct magic but bad flags.
+    writeU32le(ram.data() + 0x2000, kTmdMagic);
+    writeU32le(ram.data() + 0x2000 + 4, 0xCAFEBABEu); // flags must be 0 or 1
+    writeU32le(ram.data() + 0x2000 + 8, 1u);
+
+    // Correct magic, flags=0, numObj=1, but object header OOB (vertOff points past end).
+    writeU32le(ram.data() + 0x3000, kTmdMagic);
+    writeU32le(ram.data() + 0x3000 + 4, 0u);
+    writeU32le(ram.data() + 0x3000 + 8, 1u);
+    const size_t objHdr = 0x3000 + kTmdHeaderSize;
+    writeU32le(ram.data() + objHdr + 0, 0x7FFFFFFFu); // vertOff far past RAM end
+    writeU32le(ram.data() + objHdr + 4, 3u);
+    writeU32le(ram.data() + objHdr + 8, 0u);
+    writeU32le(ram.data() + objHdr + 12, 0u);
+    writeU32le(ram.data() + objHdr + 16, 0u);
+    writeU32le(ram.data() + objHdr + 20, 1u);
+
+    std::atomic<bool> armed{true};
+    CaptureBuffer buffer;
+    RipperHooks hooks;
+    hooks.setArmedFlag(&armed);
+    hooks.setBuffer(&buffer);
+
+    const int found = PsxTmdRamScanner::captureFromSystemRam(ram.data(), ram.size(), &hooks);
+    EXPECT_EQ(found, 0);
+    EXPECT_EQ(buffer.modelMeshes().size(), 0);
+}
+
+TEST(PsxTmdRamScannerTest, DedupesIdenticalCopies)
+{
+    std::vector<uint8_t> ram(2u * 1024u * 1024u, 0u);
+    constexpr size_t kTmdA = 0x10000;
+    constexpr size_t kTmdB = 0x20000;
+    const size_t spanA = writeSimpleTmd(ram.data(), kTmdA);
+    const size_t spanB = writeSimpleTmd(ram.data(), kTmdB);
+    EXPECT_EQ(spanA, spanB);
+
+    std::atomic<bool> armed{true};
+    CaptureBuffer buffer;
+    RipperHooks hooks;
+    hooks.setArmedFlag(&armed);
+    hooks.setBuffer(&buffer);
+
+    const int found = PsxTmdRamScanner::captureFromSystemRam(ram.data(), ram.size(), &hooks);
+    // Scanner sees both magics and emits both via hooks->onModelMesh; the buffer dedupes
+    // them by content hash so only one survives.
+    EXPECT_EQ(buffer.modelMeshes().size(), 1);
+    // `found` reflects only the unique meshes the hooks accepted.
+    EXPECT_EQ(found, 1);
+}
+
+TEST(PsxTmdRamScannerTest, RejectsZeroVertexObject)
+{
+    std::vector<uint8_t> ram(64u * 1024u, 0u);
+    constexpr size_t kTmdStart = 0x1000;
+    writeU32le(ram.data() + kTmdStart + 0, kTmdMagic);
+    writeU32le(ram.data() + kTmdStart + 4, 0u);
+    writeU32le(ram.data() + kTmdStart + 8, 1u);
+    const size_t objHdr = kTmdStart + kTmdHeaderSize;
+    writeU32le(ram.data() + objHdr + 0, kObjHeaderSize); // vertOff
+    writeU32le(ram.data() + objHdr + 4, 0u);             // nVert = 0 — invalid
+    writeU32le(ram.data() + objHdr + 8, kObjHeaderSize);
+    writeU32le(ram.data() + objHdr + 12, 0u);
+    writeU32le(ram.data() + objHdr + 16, kObjHeaderSize);
+    writeU32le(ram.data() + objHdr + 20, 1u);
+
+    std::atomic<bool> armed{true};
+    CaptureBuffer buffer;
+    RipperHooks hooks;
+    hooks.setArmedFlag(&armed);
+    hooks.setBuffer(&buffer);
+
+    EXPECT_EQ(PsxTmdRamScanner::captureFromSystemRam(ram.data(), ram.size(), &hooks), 0);
+    EXPECT_EQ(buffer.modelMeshes().size(), 0);
+}
+
+TEST(PsxTmdRamScannerTest, HandlesPureRandomEntropyWithoutFalsePositives)
+{
+    // 64 KiB of deterministic pseudo-random bytes. Random data has a 1-in-2^32 chance per
+    // 4-byte word of matching kTmdMagic; in 64 KiB / 4 B = 16K candidates that's 4 expected
+    // magic matches. None should pass the full validation chain (flags + counts + OOB).
+    std::vector<uint8_t> ram(64u * 1024u);
+    std::mt19937 rng(42);
+    std::uniform_int_distribution<uint32_t> dist(0u, 255u);
+    for (size_t i = 0; i < ram.size(); ++i)
+        ram[i] = static_cast<uint8_t>(dist(rng));
+
+    std::atomic<bool> armed{true};
+    CaptureBuffer buffer;
+    RipperHooks hooks;
+    hooks.setArmedFlag(&armed);
+    hooks.setBuffer(&buffer);
+
+    const int found = PsxTmdRamScanner::captureFromSystemRam(ram.data(), ram.size(), &hooks);
+    // Allow up to 1 false positive in extremely improbable cases — we expect 0 in
+    // practice with this seed, but keep the bound loose so the seed isn't a hard
+    // dependency of the test.
+    EXPECT_LE(found, 1) << "Random entropy must not false-positive at scale";
+}
+
+TEST(PsxTmdRamScannerTest, EmitsCorrectMaterialNameForTexturedPrim)
+{
+    // 1-object TMD with a single textured-tri (mode=0x24, flag=0, ilen=5). Vertices share
+    // the simple non-textured layout above but with a 0x24 prim packet so we hit the
+    // textureSubMesh material-naming path.
+    std::vector<uint8_t> ram(64u * 1024u, 0u);
+    constexpr size_t kTmdStart = 0x1000;
+    writeU32le(ram.data() + kTmdStart + 0, kTmdMagic);
+    writeU32le(ram.data() + kTmdStart + 4, 0u); // flags=0
+    writeU32le(ram.data() + kTmdStart + 8, 1u); // numObj=1
+
+    constexpr size_t kVertOffRel = kObjHeaderSize;
+    constexpr size_t kNormOffRel = kVertOffRel + 3u * 8u;
+    constexpr size_t kPrimOffRel = kNormOffRel + 1u * 8u;
+    const size_t objHdr = kTmdStart + kTmdHeaderSize;
+    writeU32le(ram.data() + objHdr + 0, static_cast<uint32_t>(kVertOffRel));
+    writeU32le(ram.data() + objHdr + 4, 3u);
+    writeU32le(ram.data() + objHdr + 8, static_cast<uint32_t>(kNormOffRel));
+    writeU32le(ram.data() + objHdr + 12, 1u);
+    writeU32le(ram.data() + objHdr + 16, static_cast<uint32_t>(kPrimOffRel));
+    writeU32le(ram.data() + objHdr + 20, 1u);
+    writeU32le(ram.data() + objHdr + 24, 0u);
+
+    const size_t vertBase = kTmdStart + kTmdHeaderSize + kVertOffRel;
+    writeI16le(ram.data() + vertBase + 0 * 8 + 0, 100);
+    writeI16le(ram.data() + vertBase + 1 * 8 + 0, -100);
+    writeI16le(ram.data() + vertBase + 1 * 8 + 2, 100);
+    writeI16le(ram.data() + vertBase + 2 * 8 + 4, 100);
+
+    const size_t normBase = kTmdStart + kTmdHeaderSize + kNormOffRel;
+    writeI16le(ram.data() + normBase + 4, 4096); // n=(0,0,1)
+
+    // Mode 0x24 flag=0 ilen=5 packet — payload 20 bytes:
+    //  +0: U0   +1: V0   +2..3: CLUT (u16)
+    //  +4: U1   +5: V1   +6..7: TPAGE (u16)
+    //  +8: U2   +9: V2   +10..11: pad
+    //  +12: n_idx (u16)  +14..15: v0 (u16)
+    //  +16: v1 (u16)     +18: v2 (u16)
+    const size_t primBase = kTmdStart + kTmdHeaderSize + kPrimOffRel;
+    ram[primBase + 0] = 5; // olen
+    ram[primBase + 1] = 5; // ilen
+    ram[primBase + 2] = 0; // flag
+    ram[primBase + 3] = 0x24; // mode
+    ram[primBase + 4 + 0] = 0x10;
+    ram[primBase + 4 + 1] = 0x10;
+    ram[primBase + 4 + 2] = 0xCD; // CLUT lo
+    ram[primBase + 4 + 3] = 0xAB; // CLUT hi → CLUT=0xABCD
+    ram[primBase + 4 + 4] = 0x20;
+    ram[primBase + 4 + 5] = 0x20;
+    ram[primBase + 4 + 6] = 0x34; // TPAGE lo
+    ram[primBase + 4 + 7] = 0x12; // TPAGE hi → TPAGE=0x1234
+    ram[primBase + 4 + 8] = 0x30;
+    ram[primBase + 4 + 9] = 0x30;
+    // 12..13 = n_idx (0); 14..15 = v0 (0); 16..17 = v1 (1); 18..19 = v2 (2)
+    ram[primBase + 4 + 16] = 0x01;
+    ram[primBase + 4 + 18] = 0x02;
+
+    std::atomic<bool> armed{true};
+    CaptureBuffer buffer;
+    RipperHooks hooks;
+    hooks.setArmedFlag(&armed);
+    hooks.setBuffer(&buffer);
+
+    EXPECT_EQ(PsxTmdRamScanner::captureFromSystemRam(ram.data(), ram.size(), &hooks), 1);
+    ASSERT_EQ(buffer.modelMeshes().size(), 1);
+
+    const CapturedModelMesh &cap = buffer.modelMeshes().front();
+    ASSERT_FALSE(cap.mesh.subMeshes.isEmpty());
+
+    // Find the textured sub-mesh and verify the material name matches the standard
+    // `PS1Rip_tpage_XXXX_clut_YYYY_stN_dmN` template used by MeshReconstructor.
+    bool foundTextured = false;
+    for (const ReconstructedSubMesh &sub : cap.mesh.subMeshes) {
+        if (sub.materialName.startsWith(QStringLiteral("PS1Rip_tpage_"))) {
+            EXPECT_TRUE(sub.materialName.contains(QStringLiteral("1234"))); // TPAGE
+            EXPECT_TRUE(sub.materialName.contains(QStringLiteral("abcd"))); // CLUT
+            foundTextured = true;
+        }
+    }
+    EXPECT_TRUE(foundTextured) << "Textured prim must produce a PS1Rip_tpage_* sub-mesh";
+}
+
+#endif // ENABLE_PS1_RIP

--- a/src/PS1/runtime/PsxTmdRamScanner_test.cpp
+++ b/src/PS1/runtime/PsxTmdRamScanner_test.cpp
@@ -3,6 +3,9 @@
 #include <gtest/gtest.h>
 
 #include "PS1/runtime/CaptureBuffer.h"
+#include "PS1/runtime/Gp0CaptureStats.h"
+#include "PS1/runtime/Gp0HookDispatch.h"
+#include "PS1/runtime/PsxModelRamScanCommon.h"
 #include "PS1/runtime/PsxTmdRamScanner.h"
 #include "PS1/runtime/RipperHooks.h"
 
@@ -415,6 +418,43 @@ TEST(PsxTmdRamScannerTest, ContentHashCoversFullPrimitivePayload)
     EXPECT_NE(hashV3_3, hashV3_2)
         << "contentHash must cover the full primitive payload — a byte change at "
            "offset 12 inside a 16-byte payload must change the hash";
+}
+
+// #674 review: FNV-1a 64-bit constants must match the canonical spec. Regression
+// guard against the missing-digit offset basis we shipped initially.
+TEST(PsxTmdRamScannerTest, Fnv1a64MatchesCanonicalReference)
+{
+    // Canonical FNV-1a 64-bit hash of "foobar" per http://isthe.com/chongo/tech/comp/fnv/
+    // (also matches https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function).
+    const uint8_t input[] = {'f', 'o', 'o', 'b', 'a', 'r'};
+    EXPECT_EQ(PsxModelRamScan::fnv1a64(input, sizeof(input)), 0x85944171f73967e8ULL);
+    // Empty input must return the offset basis unchanged.
+    EXPECT_EQ(PsxModelRamScan::fnv1a64(nullptr, 0), 0xcbf29ce484222325ULL);
+}
+
+// #674 review: a TMD found in RAM must flip Gp0CaptureStats::primarySource to
+// RamModelMesh in the captureFrameFromSystemRam wrapper. Without the post-counter
+// promoteModelMeshSource call, the source was picked while ramTmdMeshes was still
+// zero and RamModelMesh could never win.
+TEST(PsxTmdRamScannerTest, CaptureFramePromotesPrimarySourceWhenTmdEmitted)
+{
+    std::vector<uint8_t> ram(2u * 1024u * 1024u, 0u);
+    constexpr size_t kTmdStart = 0x10000;
+    ASSERT_GT(writeSimpleTmd(ram.data(), kTmdStart), 0u);
+
+    std::atomic<bool> armed{true};
+    CaptureBuffer buffer;
+    RipperHooks hooks;
+    hooks.setArmedFlag(&armed);
+    hooks.setBuffer(&buffer);
+
+    const Gp0CaptureStats stats =
+        Gp0HookDispatch::captureFrameFromSystemRam(ram.data(), ram.size(), &hooks,
+                                                   /*scanGteRam=*/false,
+                                                   /*accumulate=*/false);
+
+    EXPECT_GE(stats.ramTmdMeshes, 1);
+    EXPECT_EQ(stats.primarySource, Gp0CaptureSource::RamModelMesh);
 }
 
 #endif // ENABLE_PS1_RIP

--- a/src/PS1/runtime/ReconstructedMesh.h
+++ b/src/PS1/runtime/ReconstructedMesh.h
@@ -1,0 +1,37 @@
+#ifndef RECONSTRUCTEDMESH_H
+#define RECONSTRUCTEDMESH_H
+
+#include <QString>
+#include <QVector>
+
+#include <cstdint>
+
+/** One vertex in reconstructed editor space (#422). */
+struct ReconstructedVertex {
+    float px = 0.0f;
+    float py = 0.0f;
+    float pz = 0.0f;
+    float nx = 0.0f;
+    float ny = 0.0f;
+    float nz = 0.0f;
+    float u = 0.0f;
+    float v = 0.0f;
+    uint32_t diffuseArgb = 0xFFFFFFFFu;
+};
+
+struct ReconstructedSubMesh {
+    QString materialName;
+    QVector<ReconstructedVertex> vertices;
+    QVector<uint32_t> indices;
+};
+
+struct ReconstructedMesh {
+    QString meshName;
+    QVector<ReconstructedSubMesh> subMeshes;
+    int vertexCount = 0;
+    int triangleCount = 0;
+
+    bool isEmpty() const { return subMeshes.isEmpty(); }
+};
+
+#endif // RECONSTRUCTEDMESH_H

--- a/src/PS1/runtime/RipperHooks.cpp
+++ b/src/PS1/runtime/RipperHooks.cpp
@@ -35,7 +35,8 @@ void RipperHooks::endGpuCapturePass(Gp0CaptureStats &stats)
                >= stats.ramOtPrims + stats.ramLinearPrims + stats.ramChainRootPrims)
         stats.primarySource = Gp0CaptureSource::DirectHook;
     // #674: model-space meshes always beat any screen-space source for quality, so flip
-    // the label here AFTER the DirectHook override above.
+    // the label here AFTER the DirectHook override above. Only actually emitted meshes
+    // count — bare HMD candidate counts must not flip the label (#674 review).
     if (stats.ramTmdMeshes > 0 || stats.ramHmdMeshes > 0)
         stats.primarySource = Gp0CaptureSource::RamModelMesh;
     m_lastStats = stats;
@@ -46,7 +47,8 @@ void RipperHooks::endGpuCapturePass(Gp0CaptureStats &stats)
 
     SentryReporter::addBreadcrumb(
         QStringLiteral("ps1.rip.capture.gp0_hook"),
-        QStringLiteral("source:%1 total:%2 hook:%3 ot:%4 linear:%5 chain:%6 tmd:%7 hmd:%8 live:%9")
+        QStringLiteral(
+            "source:%1 total:%2 hook:%3 ot:%4 linear:%5 chain:%6 tmd:%7 hmd:%8 hmd_cand:%9 live:%10")
             .arg(stats.primarySourceLabel())
             .arg(stats.totalPrims)
             .arg(stats.directHookPrims)
@@ -55,6 +57,7 @@ void RipperHooks::endGpuCapturePass(Gp0CaptureStats &stats)
             .arg(stats.ramChainRootPrims)
             .arg(stats.ramTmdMeshes)
             .arg(stats.ramHmdMeshes)
+            .arg(stats.ramHmdCandidates)
             .arg(stats.liveFrame ? QStringLiteral("yes") : QStringLiteral("no")));
 }
 

--- a/src/PS1/runtime/RipperHooks.cpp
+++ b/src/PS1/runtime/RipperHooks.cpp
@@ -34,6 +34,10 @@ void RipperHooks::endGpuCapturePass(Gp0CaptureStats &stats)
         && stats.directHookPrims
                >= stats.ramOtPrims + stats.ramLinearPrims + stats.ramChainRootPrims)
         stats.primarySource = Gp0CaptureSource::DirectHook;
+    // #674: model-space meshes always beat any screen-space source for quality, so flip
+    // the label here AFTER the DirectHook override above.
+    if (stats.ramTmdMeshes > 0 || stats.ramHmdMeshes > 0)
+        stats.primarySource = Gp0CaptureSource::RamModelMesh;
     m_lastStats = stats;
     m_lastStatsFresh = true;
     m_ramCaptureActive = false;
@@ -42,13 +46,15 @@ void RipperHooks::endGpuCapturePass(Gp0CaptureStats &stats)
 
     SentryReporter::addBreadcrumb(
         QStringLiteral("ps1.rip.capture.gp0_hook"),
-        QStringLiteral("source:%1 total:%2 hook:%3 ot:%4 linear:%5 chain:%6 live:%7")
+        QStringLiteral("source:%1 total:%2 hook:%3 ot:%4 linear:%5 chain:%6 tmd:%7 hmd:%8 live:%9")
             .arg(stats.primarySourceLabel())
             .arg(stats.totalPrims)
             .arg(stats.directHookPrims)
             .arg(stats.ramOtPrims)
             .arg(stats.ramLinearPrims)
             .arg(stats.ramChainRootPrims)
+            .arg(stats.ramTmdMeshes)
+            .arg(stats.ramHmdMeshes)
             .arg(stats.liveFrame ? QStringLiteral("yes") : QStringLiteral("no")));
 }
 
@@ -114,6 +120,13 @@ void RipperHooks::onGpuPrim(const PrimRecord &prim)
     }
 
     m_buffer->addPrim(prim);
+}
+
+bool RipperHooks::onModelMesh(const CapturedModelMesh &mesh)
+{
+    if (!isCaptureEnabled() || !m_buffer)
+        return false;
+    return m_buffer->addModelMesh(mesh);
 }
 
 void RipperHooks::onVramWrite(uint16_t x, uint16_t y, uint16_t w, uint16_t h, const uint16_t *pixels)

--- a/src/PS1/runtime/RipperHooks.h
+++ b/src/PS1/runtime/RipperHooks.h
@@ -54,6 +54,7 @@ public:
 
     uint32_t onGteMatrix(const MatrixRecord &matrix) override;
     void onGpuPrim(const PrimRecord &prim) override;
+    bool onModelMesh(const CapturedModelMesh &mesh) override;
     void onVramWrite(uint16_t x, uint16_t y, uint16_t w, uint16_t h,
                      const uint16_t *pixels) override;
     void onVramRead(uint16_t x, uint16_t y, uint16_t w, uint16_t h) override;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -173,6 +173,8 @@ if(BUILD_TESTS)
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PsxCaptureFilters.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PsxGpuRamScanner.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PsxGteRamScanner.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PsxHmdRamScanner.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PsxTmdRamScanner.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/RipperHooks.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/TextureDecoder.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/VramSnapshot.cpp


### PR DESCRIPTION
## Summary

Adds two format-aware runtime scanners that find Sony SDK mesh structures in PS1 system RAM and emit them as model-space `ReconstructedMesh` parts, bypassing the inverse-projection screen-space path. On TMD-using games this is what turns the "blob of triangles" output into recognizable geometry without waiting on #676 (forked mednafen with in-core GTE hook).

- `PsxTmdRamScanner` — sweeps RAM (4-byte stride) for the `0x00000041` TMD magic. Validates flags / numObj / offsets / counts, walks vertex pools + primitive packets (mono/Gouraud tri & quad, textured + no-light variants), and emits via the new `EmuHooks::onModelMesh` hook. Material names for textured packets use the standard `PS1Rip_tpage_XXXX_clut_YYYY_stN_dmN` template so the existing capture texture-decode pipeline (#421) binds them with no extra wiring. Supports both `flag=0` (on-disk relative offsets) and `flag=1` (KSEG0 absolute pointers).
- `PsxHmdRamScanner` — v1 stub for the `0x00000050` HMD magic. Opt-in via `QTMESH_PS1_HMD_SCANNER=1`; surfaces candidate counts for diagnostics. Full primitive walk lands once a known-good HMD asset is available to validate against (HMD's hierarchical layout is a documented false-positive source).
- `CaptureBuffer::addModelMesh` dedupes by FNV-1a 64-bit content hash so the same asset encountered every frame only stores once.
- `MeshReconstructor::buildParts` appends `snapshot.modelMeshes` to the parts list; the existing `MeshTopologyHash` dedupe in `reconstructDeduped` collapses byte-identical TMDs into one unique mesh + N instance transforms.
- `MeshReconstructionStats::modelMeshVertices` flows into `gteInversePercent` as trusted vertices, so the quality indicator flips from 0% → ~100% on TMD-using games.
- UI / Sentry: status bar appends `tmd N / hmd N`; new `Gp0CaptureSource::RamModelMesh` (label `ram_model_mesh`) wins the primary-source label whenever any TMD/HMD surfaced; new `ps1.rip.capture.modelmesh` Sentry breadcrumb; `ps1.rip.matrix.stats` adds `model_meshes=N`.

Builds on #662 (live GP0 FIFO bridge); rebase against master once #662 is merged.

## Coverage

| Format | Where used | v1 |
|---|---|---|
| TMD (`0x41`) | Sony SDK statics — Tekken 1/2/3, Ridge Racer 1/RR, Net Yaroze homebrew, Wipeout 1/2097, R-Type Delta, Klonoa, many pre-FF7 Square | **emits meshes** |
| HMD (`0x50`) | Sony SDK hierarchical/skinned | stub (candidate count only) |
| Custom engines (Crash, Spyro, FFVII field, MGS) | proprietary packed layouts | **out of scope** — needs #676 |

## Test plan

- [x] `PsxTmdRamScannerTest.FindsSingleTmdAtOffset` — hand-crafted 1-object 1-tri TMD at byte 0x10000 of 2 MiB zeroed RAM → 1 mesh, 3 verts, finite world-space positions.
- [x] `PsxTmdRamScannerTest.RejectsGarbageHeader` — wrong magic / oversized numObj / bad flags / OOB pointers → 0 meshes.
- [x] `PsxTmdRamScannerTest.DedupesIdenticalCopies` — two byte-identical TMDs at different offsets → 1 mesh (content-hash dedupe).
- [x] `PsxTmdRamScannerTest.RejectsZeroVertexObject` — degenerate object header → 0 meshes.
- [x] `PsxTmdRamScannerTest.HandlesPureRandomEntropyWithoutFalsePositives` — 64 KiB of seeded random bytes → 0 false positives.
- [x] `PsxTmdRamScannerTest.EmitsCorrectMaterialNameForTexturedPrim` — `0x24` textured-tri packet → `PS1Rip_tpage_1234_clut_abcd_...` material binding.
- [x] `PsxHmdRamScannerTest.CountsPlausibleHmdCandidates` — magic + plausible map length → counted; OOB map length → rejected.
- [x] `PsxHmdRamScannerTest.EmitsNothingByDefault` — env-gated stub returns 0 meshes by default.
- [x] All 67 existing PS1-related tests across 17 suites still pass (CaptureBuffer / Gp0HookDispatch / Gp0CapturePaths / MeshReconstructor / MeshTopologyHash / PsxOrderingTable / PsxGteRamScanner / PsxGpuRamScanner / PsxGteCop2 / PsxGteIsoDedupe / GteCapture / GpuCommandParser / PS1Rip*).
- [ ] Manual smoke on a TMD-using game (Net Yaroze SDK demo or Ridge Racer 1 disc): confirm `tmd N` shows non-zero in the status bar and source flips to `ram_model_mesh`.
- [ ] Manual smoke on Crash/Spyro: confirm `tmd 0` (as expected — custom engines fall through to the screen-space path).

## Out of scope (queued follow-ups)

- **#675** — heuristic + math fix for the screen-space inverse path.
- **#676** — forked `mednafen_psx_libretro` with in-core RTPS/RTPT callback for ground-truth model-space recovery on any game.
- **#677** — disc/ISO scanner for RSD/PLY/MAT/GRP/TIX off-line ripping.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for capturing model-space meshes directly from PS1 system RAM using format-aware scanners for Sony SDK mesh structures.

* **Improvements**
  * Enhanced session window display and diagnostics with additional model mesh statistics and candidate counts.
  * Expanded mesh reconstruction to include captured model meshes as additional mesh parts.

* **Documentation**
  * Updated PS1 runtime geometry extraction design documentation with model-space RAM scanning strategy and new scanner capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/674?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->