### PR TITLE
feat(ps1): real GTE math + orthonormal matrix gate + matrix-tag diagnostic (#675)

### DIFF
--- a/src/PS1/PS1_RIP_DESIGN.md
+++ b/src/PS1/PS1_RIP_DESIGN.md
@@ -125,6 +125,51 @@ See epic #412 for phased issues (#413–#431).
 - **GTE RAM supplement** — Capture Frame still merges COP2-scanned matrices; per-draw tagging applies at GP0 dispatch time, not retroactively to RAM-only captures without draw-env context.
 - **Commercial golden scenes** — manual acceptance tracked in [#659](https://github.com/fernandotonon/QtMeshEditor/issues/659) (`src/PS1/golden_captures.md`); #658 reduces blob fallback but does not replace a full matrix stack or FIFO-accurate stream (#662).
 
+## Screen-space inverse projection (#675)
+
+The screen-space capture paths (live FIFO bridge, OT chains, chain roots, linear scan)
+all deliver post-projection GP0 vertex coordinates — to land them in editor world units
+the reconstructor inverts the PSX GTE projection in `GteInverse::screenToModel`. The
+forward / inverse math matters: when it's wrong, every screen-space vertex falls through
+to `psxScreenToWorld` (a pure pixel-to-flat-XY mapping) and the reconstructed mesh is the
+classic flat-plate "blob".
+
+- **The math:** `GteInverse::modelToScreen` implements the psx-spx RTPS formula
+  `IR[r] = (RT[r][:] · V) / 4096 + TR[r]`, `SX_pixel = H * IR[0] / IR[2] + OFX/65536`
+  (similarly for SY), `SZ = IR[2]`. `GteInverse::screenToModel` inverts it via
+  `IR[2] = sz`, `IR[i<2] = (screen_i - OF_i) * IR[2] / H`, then
+  `V = RT^T * (IR - TR)` (the `RT^T` fast path exploits the fact that PS1 RT matrices
+  are orthonormal — `RT^-1 == RT^T` for unit rotations). Pre-#675 both `modelToScreen`
+  and `screenToModel` were diagonal-only (`vx / RT[0][0]`) which silently passed the
+  identity-matrix roundtrip test in CI but rejected every real rotation matrix at the
+  `kMaxVertexRadius` filter in `MeshReconstructor::vertexFromPsx`.
+- **The orthonormal gate (`GteCapture::looksOrthonormalRotation`):** validates that an
+  `MatrixRecord`'s 3×3 RT block satisfies `|row|^2 ≈ 4096^2`, `dot(row_i, row_j) ≈ 0` and
+  `det ≈ +4096^3` (each within 5–10% slack so 12.4 quantisation of `cos`/`sin` tables
+  doesn't false-reject). Used in two places:
+  - `PsxGteRamScanner::looksLikeMatrixRecord` — drops false-positive matrix candidates.
+    Combined with the narrowed `H ∈ [64, 2048]` and tightened RT entry magnitude
+    (`|RT[r][c]| ≤ 8192`), pseudo-random 16 KB RAM blocks produce **zero** accepted
+    matrices in the regression suite (`PsxGteRamScannerTest.RejectsPseudoRandomGarbage`).
+  - Future: `GteInverse::screenToModel` callers can pre-check this if they want to skip
+    the inverse for non-orthonormal matrices and force `psxScreenToWorld` instead — for
+    now the `RT^T` solve is harmless on any input that survives the scanner gate.
+- **Diagnostics (`MeshReconstructionStats`):** `primsTotal`, `primsWithMatrixId`,
+  `gteInverseVertices`, `screenFallbackVertices`. Plumbed through
+  `PS1RipManager::meshBuilt(... primsWithMatrixId, primsTotal ...)` into
+  `PS1RipSessionWindow`'s status bar as
+  `GTE inverse N% (matrix tag X/Y)`. Sentry breadcrumb `ps1.rip.matrix.stats` carries
+  the same `gte_inverse=N%% prims_with_matrix=X/Y` for off-line analysis.
+- **Acceptance tests** (`GteInverseTest`, `GteCaptureTest`, `PsxGteRamScannerTest`):
+  90° Y rotation and arbitrary 3D Euler (`30° + 45° + 15°`) round-trip within 2–4
+  fixed-point units; identity, real rotations accepted by the validator; scaled
+  rotation, reflection (det = `-4096^3`) and pseudo-random garbage rejected.
+- **Out of scope:** matrix→primitive *association* (which RT was active when this prim
+  was drawn) remains heuristic via per-draw matrix tagging (#658). The math fix in #675
+  makes the inverse correct when association is correct; ground-truth association on
+  retail games still needs the forked-mednafen in-core GTE hook tracked in
+  [#676](https://github.com/fernandotonon/QtMeshEditor/issues/676).
+
 ## Model-space RAM scanners (#674)
 
 Screen-space GP0 prims always carry information loss because they're post-projection — the
@@ -246,20 +291,45 @@ The **stub** core is active (`coreId=stub`). It draws a test pattern and synthet
 ### Capture mesh is a triangle “blob” (normal size, wrong shape)
 
 The screen-space GP0 path (live FIFO bridge + ordering-table chains + standalone chain
-roots + linear scan) always produces a flat-XY blob on retail games because the GTE
-inverse-projection it relies on is heuristic-grade — true ground-truth recovery requires
-the forked-mednafen in-core GTE hook tracked in [#676](https://github.com/fernandotonon/QtMeshEditor/issues/676).
-Until that ships, the recommended path for "real meshes from real games" is the
-**model-space TMD/HMD RAM scanner** (#674): if the title uses Sony SDK formats the
-scanner finds the model-space vertex pools in RAM and emits them directly, bypassing the
-inverse-projection entirely.
+roots + linear scan) used to **always** produce a flat-XY blob because both the GTE
+forward and inverse transforms in `GteInverse` were diagonal-only and silently rejected
+every non-identity rotation matrix (the existing roundtrip test only exercised identity).
+**#675** replaces them with the real psx-spx math (`IR = (RT * V + TR)`, with `RT^T`
+inverse for orthonormal rotations) and adds an orthonormal validator
+(`GteCapture::looksOrthonormalRotation`) that gates both the `screenToModel` fast path
+and the `PsxGteRamScanner` candidate filter. Combined effect:
 
-- Status bar shows `tmd N` / `hmd N` and the primary source flips to `ram_model_mesh`
-  when meshes are found — that's your "this is a clean mesh" signal.
-- **TMD-using games (where this works):** Tekken 1/2/3, Ridge Racer 1/RR, Net Yaroze SDK
-  demos, Wipeout 1/2097, R-Type Delta, Klonoa, many pre-FF7 Square titles.
-- **Custom-engine games (where it does NOT work):** Crash, Spyro, FFVII field models,
-  MGS post-Yaroze. These games author their own packed mesh layouts; only #676 covers them.
+- Real rotations (90° Y, mixed XYZ Euler, etc.) now round-trip within ~2 fixed-point
+  units instead of producing radius-million garbage rejected by `kMaxVertexRadius`.
+- The matrix scanner drops false positives — single-box retail captures that previously
+  reported ~192 "matrices" should land in the single-digit-to-low-double-digit range
+  because pseudo-random RAM bytes cannot satisfy `|row|^2 ≈ 4096^2 ∧ row_i · row_j ≈ 0
+  ∧ det ≈ +4096^3` all at once.
+
+**Diagnostic reading order** (post-#675 status bar):
+1. `GTE inverse N%` — fraction of vertices that successfully ran through the inverse.
+   Healthy retail capture ≥ ~50%. If 0%, see step 2.
+2. `matrix tag X/Y` — how many primitives were associated with a captured matrix.
+   `0/Y` means matrix association is the bottleneck (no `0xE4` draw-environment packets
+   captured, or per-draw matrix tagging from #658 didn't run). `Y/Y` with low inverse %
+   means the math is rejecting the matrices — usually because they aren't orthonormal,
+   often because the title uses a custom transform stack.
+3. `tmd N / hmd N` — model-space scanner hits (#674). If ≥ 1, the primary source flips
+   to `ram_model_mesh` and you're on the clean-mesh path regardless of the screen-space
+   stats.
+
+The recommended path for "real meshes from real games" remains the **model-space
+TMD/HMD RAM scanner** (#674) for Sony SDK titles. #675's screen-space math fix
+**unblocks** the screen-space path when matrix association is correct, but the
+matrix-to-draw linkage on retail games is still heuristic — true ground-truth recovery
+requires the forked-mednafen in-core GTE hook tracked in
+[#676](https://github.com/fernandotonon/QtMeshEditor/issues/676).
+
+- **TMD-using games (clean meshes today via #674):** Tekken 1/2/3, Ridge Racer 1/RR,
+  Net Yaroze SDK demos, Wipeout 1/2097, R-Type Delta, Klonoa, many pre-FF7 Square titles.
+- **Custom-engine games (still partial recovery):** Crash, Spyro, FFVII field models,
+  MGS post-Yaroze. These games author their own packed mesh layouts and bespoke transform
+  stacks; only #676 covers them.
 - Tune via `QTMESH_PS1_TMD_SCANNER=0` to disable TMD scanning for a baseline, and
   `QTMESH_PS1_HMD_SCANNER=1` to opt into the v1 HMD candidate counter.
 

--- a/src/PS1/PS1_RIP_DESIGN.md
+++ b/src/PS1/PS1_RIP_DESIGN.md
@@ -164,10 +164,30 @@ classic flat-plate "blob".
   90° Y rotation and arbitrary 3D Euler (`30° + 45° + 15°`) round-trip within 2–4
   fixed-point units; identity, real rotations accepted by the validator; scaled
   rotation, reflection (det = `-4096^3`) and pseudo-random garbage rejected.
+- **GP0 carries no depth (`sz == 0` guard):** PS1 GP0 polygon packets store *only* 2D
+  screen-space XY for each vertex. The GTE writes Z into a separate `SZ` FIFO that the
+  CPU drains *before* assembling the GP0 word, so `PsxVertex::z` is identically 0 for
+  every prim ingested from the GP0 hook or the live FIFO bridge. With `sz == 0` the
+  inverse degenerates — `IR[0] = IR[1] = 0`, every vertex of a given matrix tag maps to
+  the same point `RT^T · (-TR) / 4096`, and the resulting per-matrix sub-mesh has zero
+  extent (invisible in the viewport but still reported as `GTE inverse 100%`).
+  `GteInverse::screenToModel` therefore early-returns `false` when `sz == 0`, forcing
+  `MeshReconstructor::vertexFromPsx` to fall back to `psxScreenToWorld` (the flat-XY
+  blob). The fallback is intentional: an ugly-but-visible mesh beats a degenerate
+  zero-extent one. Real per-vertex depth recovery for GP0-only captures requires the
+  in-core GTE hook in #676 (or future RAM scanner work that recovers the SZ FIFO
+  contents alongside the matrix snapshot).
+- **When the inverse *does* run:** model-space test fixtures (`PsxPerDrawMatrixTest`,
+  `MeshReconstructorCubePipelineTest`) inject vertices via `modelToScreen` so they carry
+  the forward-projected `sz` — the math fix is verified on those paths. On retail GP0
+  captures the inverse stays gated by `sz == 0`, so the status bar reports
+  `GTE inverse 0% (matrix tag X/Y)`. That is the *correct* signal: matrix association is
+  fine (`X/Y` nonzero), but depth was lost at the GP0 boundary.
 - **Out of scope:** matrix→primitive *association* (which RT was active when this prim
   was drawn) remains heuristic via per-draw matrix tagging (#658). The math fix in #675
-  makes the inverse correct when association is correct; ground-truth association on
-  retail games still needs the forked-mednafen in-core GTE hook tracked in
+  makes the inverse correct when association is correct *and* depth is available;
+  ground-truth depth + association on retail games still needs the forked-mednafen
+  in-core GTE hook tracked in
   [#676](https://github.com/fernandotonon/QtMeshEditor/issues/676).
 
 ## Model-space RAM scanners (#674)
@@ -308,15 +328,40 @@ and the `PsxGteRamScanner` candidate filter. Combined effect:
 
 **Diagnostic reading order** (post-#675 status bar):
 1. `GTE inverse N%` — fraction of vertices that successfully ran through the inverse.
-   Healthy retail capture ≥ ~50%. If 0%, see step 2.
+   On GP0-only captures this is **expected to be 0%** because the GP0 stream carries no
+   per-vertex depth (see the "GP0 carries no depth" bullet in the section above) — the
+   inverse refuses to run, callers fall back to `psxScreenToWorld`, and the result is a
+   flat-XY blob *that you can still see in the viewport*. Healthy non-GP0 capture
+   (model-space scanner, model-projected test fixture) is ≥ ~50%. If 0% **and** you
+   expected real model-space, jump straight to step 3.
 2. `matrix tag X/Y` — how many primitives were associated with a captured matrix.
    `0/Y` means matrix association is the bottleneck (no `0xE4` draw-environment packets
    captured, or per-draw matrix tagging from #658 didn't run). `Y/Y` with low inverse %
-   means the math is rejecting the matrices — usually because they aren't orthonormal,
-   often because the title uses a custom transform stack.
+   means either depth is missing (GP0-only — expected) **or** the math is rejecting the
+   matrices because they aren't orthonormal (often because the title uses a custom
+   transform stack).
 3. `tmd N / hmd N` — model-space scanner hits (#674). If ≥ 1, the primary source flips
    to `ram_model_mesh` and you're on the clean-mesh path regardless of the screen-space
-   stats.
+   stats. **This is the only path that produces ground-truth model-space meshes on retail
+   games today.**
+
+### Captured scene tree has nodes but viewport is empty (mesh exists, invisible)
+
+This is the failure mode the first build of #675 hit: the math fix made
+`screenToModel` correct, but with `sz == 0` on every GP0 vertex the inverse collapsed
+every prim of a given matrix to a single point. The mesh existed (`PS1Capture_*_inst*`
+nodes in the scene tree, non-zero vertex/triangle counts in the status bar) but had
+zero extent and rendered as nothing. The `sz == 0` guard in `GteInverse::screenToModel`
+now forces the `psxScreenToWorld` fallback in this case — verify by looking at the
+status bar:
+
+- `GTE inverse 0% (matrix tag X/Y)` with `X == Y` and a visible blob: **correct
+  post-guard behaviour** on GP0-only captures. The blob is ugly but visible, and is the
+  best the screen-space path can do without depth.
+- `GTE inverse 100%` with an invisible scene-tree mesh: the guard is bypassed
+  somewhere. Confirm `PsxVertex::z` is 0 on the inputs (it should be — nothing in the
+  GP0 capture path writes it) and that `screenToModel` returns false for `sz == 0` in
+  `GteInverseTest.ScreenToModelRefusesZeroDepth`.
 
 The recommended path for "real meshes from real games" remains the **model-space
 TMD/HMD RAM scanner** (#674) for Sony SDK titles. #675's screen-space math fix

--- a/src/PS1/runtime/GteCapture.cpp
+++ b/src/PS1/runtime/GteCapture.cpp
@@ -1,8 +1,46 @@
 #include "GteCapture.h"
 
+#include <cstdlib>
 #include <cstring>
 
 namespace GteCapture {
+
+namespace {
+
+constexpr int64_t kUnit = 4096;
+constexpr int64_t kUnitSq = kUnit * kUnit;        // 4096^2 == 16,777,216
+constexpr int64_t kUnitCb = kUnitSq * kUnit;      // 4096^3 == 68,719,476,736
+
+// 5% magnitude slack — covers 12.4 fixed-point rounding of cos/sin tables.
+constexpr int64_t kMagTol = kUnitSq / 20;
+// 5% slack on inter-row dot products relative to unit^2.
+constexpr int64_t kDotTol = kUnitSq / 20;
+// Determinant must be within +/- 10% of +4096^3 (proper rotation, not reflection).
+constexpr int64_t kDetTol = kUnitCb / 10;
+
+inline int64_t rowDot(const MatrixRecord &m, int r1, int r2)
+{
+    int64_t d = 0;
+    for (int c = 0; c < 3; ++c)
+        d += static_cast<int64_t>(m.rt.m[r1][c]) * static_cast<int64_t>(m.rt.m[r2][c]);
+    return d;
+}
+
+inline int64_t determinant3x3(const MatrixRecord &m)
+{
+    const int64_t a = m.rt.m[0][0];
+    const int64_t b = m.rt.m[0][1];
+    const int64_t c = m.rt.m[0][2];
+    const int64_t d = m.rt.m[1][0];
+    const int64_t e = m.rt.m[1][1];
+    const int64_t f = m.rt.m[1][2];
+    const int64_t g = m.rt.m[2][0];
+    const int64_t h = m.rt.m[2][1];
+    const int64_t i = m.rt.m[2][2];
+    return a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g);
+}
+
+} // namespace
 
 uint64_t hashMatrix(const MatrixRecord &matrix)
 {
@@ -31,6 +69,31 @@ bool matricesEqual(const MatrixRecord &a, const MatrixRecord &b)
     if (std::memcmp(a.tr, b.tr, sizeof(a.tr)) != 0)
         return false;
     return std::memcmp(a.rt.m, b.rt.m, sizeof(a.rt.m)) == 0;
+}
+
+bool looksOrthonormalRotation(const MatrixRecord &matrix)
+{
+    // Row magnitudes — each row of a 12.4-fixed unit rotation has |row|^2 == 4096^2.
+    for (int r = 0; r < 3; ++r) {
+        const int64_t mag = rowDot(matrix, r, r);
+        if (std::abs(mag - kUnitSq) > kMagTol)
+            return false;
+    }
+
+    // Inter-row orthogonality — dot products should be ~0 within unit^2 tolerance.
+    if (std::abs(rowDot(matrix, 0, 1)) > kDotTol)
+        return false;
+    if (std::abs(rowDot(matrix, 0, 2)) > kDotTol)
+        return false;
+    if (std::abs(rowDot(matrix, 1, 2)) > kDotTol)
+        return false;
+
+    // Determinant — proper rotation has det == +4096^3 (not -4096^3 / reflection).
+    const int64_t det = determinant3x3(matrix);
+    if (std::abs(det - kUnitCb) > kDetTol)
+        return false;
+
+    return true;
 }
 
 } // namespace GteCapture

--- a/src/PS1/runtime/GteCapture.h
+++ b/src/PS1/runtime/GteCapture.h
@@ -5,11 +5,28 @@
 
 #include <cstdint>
 
-/** Hashing and deduplication for GTE matrix records (#419). */
+/** Hashing, dedup, and structural validation for GTE matrix records (#419 / #675). */
 namespace GteCapture {
 
 uint64_t hashMatrix(const MatrixRecord &matrix);
 bool matricesEqual(const MatrixRecord &a, const MatrixRecord &b);
+
+/**
+ * Returns true when @p matrix's RT block looks like a 12.4 fixed-point
+ * orthonormal rotation (#675). Used to gate the RT^T fast path in
+ * GteInverse::screenToModel and to reject false-positive matrix candidates
+ * surfaced by PsxGteRamScanner.
+ *
+ * The three rows of an orthonormal rotation R satisfy:
+ *  - |row_r|^2 == 4096^2 (each row has unit length in 12.4 fixed),
+ *  - dot(row_i, row_j) == 0 for i != j (rows are mutually orthogonal),
+ *  - det(R) == +4096^3 (proper rotation, not a reflection).
+ *
+ * Each invariant is checked with a 5% slack so 12-bit fixed-point rounding
+ * noise in real PS1 games (`gte_ucos`/`gte_usin` quantised to 12.4) does not
+ * cause false rejections.
+ */
+bool looksOrthonormalRotation(const MatrixRecord &matrix);
 
 } // namespace GteCapture
 

--- a/src/PS1/runtime/GteInverse.cpp
+++ b/src/PS1/runtime/GteInverse.cpp
@@ -5,67 +5,107 @@
 
 namespace GteInverse {
 
+namespace {
+
+constexpr double kFixedUnit = 4096.0;
+
+// Floating-point RTPS forward (per psx-spx, no SAR rounding):
+//   IR[r] = (sum_c RT[r][c] * V[c]) / 4096 + TR[r]
+//   SX_pixel = H * IR[0] / IR[2] + OFX/65536
+//   SY_pixel = H * IR[1] / IR[2] + OFY/65536
+//   SZ      = IR[2]
+//
+// Pre-#675 this was a diagonal-only divide (`V[c] / RT[r][r]`) which silently
+// passed the existing identity-matrix roundtrip test but rejected every real
+// rotation matrix — the radius filter in MeshReconstructor::vertexFromPsx then
+// fell back to psxScreenToWorld, painting a flat-XY blob.
+void rtpsForward(const MatrixRecord &matrix, double mx, double my, double mz, double ir[3])
+{
+    const double V[3] = {mx, my, mz};
+    for (int r = 0; r < 3; ++r) {
+        const double rotated = static_cast<double>(matrix.rt.m[r][0]) * V[0]
+                               + static_cast<double>(matrix.rt.m[r][1]) * V[1]
+                               + static_cast<double>(matrix.rt.m[r][2]) * V[2];
+        ir[r] = rotated / kFixedUnit + static_cast<double>(matrix.tr[r]);
+    }
+}
+
+// RT^T inverse: assumes RT is an orthonormal rotation in 12.4 fixed point.
+// For non-orthonormal matrices the caller must gate via
+// GteCapture::looksOrthonormalRotation before invoking this path (#675).
+//   V[r] = (sum_c RT[c][r] * (IR[c] - TR[c])) / 4096
+void rtpsInverse(const MatrixRecord &matrix, const double irMinusTr[3], double v[3])
+{
+    for (int r = 0; r < 3; ++r) {
+        const double rotated = static_cast<double>(matrix.rt.m[0][r]) * irMinusTr[0]
+                               + static_cast<double>(matrix.rt.m[1][r]) * irMinusTr[1]
+                               + static_cast<double>(matrix.rt.m[2][r]) * irMinusTr[2];
+        v[r] = rotated / kFixedUnit;
+    }
+}
+
+bool inIntRange(double v)
+{
+    return v >= static_cast<double>(std::numeric_limits<int>::min())
+           && v <= static_cast<double>(std::numeric_limits<int>::max());
+}
+
+} // namespace
+
 bool modelToScreen(const MatrixRecord &matrix, int mx, int my, int mz, int &sx, int &sy, int &sz)
 {
-    const double h = matrix.h != 0 ? static_cast<double>(matrix.h) : 4096.0;
+    const double h = matrix.h != 0 ? static_cast<double>(matrix.h) : kFixedUnit;
 
-    const double vx = static_cast<double>(mx) * 4096.0;
-    const double vy = static_cast<double>(my) * 4096.0;
-    const double vz = static_cast<double>(mz) * 4096.0;
+    double ir[3];
+    rtpsForward(matrix, mx, my, mz, ir);
 
-    if (matrix.rt.m[0][0] == 0 || matrix.rt.m[1][1] == 0 || matrix.rt.m[2][2] == 0)
+    if (ir[2] == 0.0)
         return false;
 
-    const double irAdj0 = vx / static_cast<double>(matrix.rt.m[0][0]);
-    const double irAdj1 = vy / static_cast<double>(matrix.rt.m[1][1]);
-    const double irAdj2 = vz / static_cast<double>(matrix.rt.m[2][2]);
+    const double ofxPixel = static_cast<double>(matrix.ofx) / 65536.0;
+    const double ofyPixel = static_cast<double>(matrix.ofy) / 65536.0;
 
-    const double ir1 = irAdj0 + matrix.tr[0];
-    const double ir2 = irAdj1 + matrix.tr[1];
-    const double ir3 = irAdj2 + matrix.tr[2];
-    if (ir3 == 0.0)
+    const double sxPixel = h * ir[0] / ir[2] + ofxPixel;
+    const double syPixel = h * ir[1] / ir[2] + ofyPixel;
+    if (!std::isfinite(sxPixel) || !std::isfinite(syPixel) || !std::isfinite(ir[2]))
+        return false;
+    if (!inIntRange(sxPixel) || !inIntRange(syPixel) || !inIntRange(ir[2]))
         return false;
 
-    const double sxFixed = (ir1 * h / ir3) + matrix.ofx;
-    const double syFixed = (ir2 * h / ir3) + matrix.ofy;
-    const double sxPixel = sxFixed / 65536.0;
-    const double syPixel = syFixed / 65536.0;
-    if (!std::isfinite(sxPixel) || !std::isfinite(syPixel) || !std::isfinite(ir3))
-        return false;
-
-    const double intMin = static_cast<double>(std::numeric_limits<int>::min());
-    const double intMax = static_cast<double>(std::numeric_limits<int>::max());
-    if (sxPixel < intMin || sxPixel > intMax || syPixel < intMin || syPixel > intMax || ir3 < intMin
-        || ir3 > intMax)
-        return false;
-
-    sx = static_cast<int>(sxPixel);
-    sy = static_cast<int>(syPixel);
-    sz = static_cast<int>(ir3);
+    sx = static_cast<int>(std::lround(sxPixel));
+    sy = static_cast<int>(std::lround(syPixel));
+    sz = static_cast<int>(std::lround(ir[2]));
     return true;
 }
 
 bool screenToModel(const MatrixRecord &matrix, int sx, int sy, int sz, float &mx, float &my, float &mz)
 {
-    const double h = matrix.h != 0 ? static_cast<double>(matrix.h) : 4096.0;
-    const double ir3 = sz != 0 ? static_cast<double>(sz) : 4096.0;
-    const double ir1 = ((static_cast<double>(sx) * 65536.0) - matrix.ofx) * ir3 / h;
-    const double ir2 = ((static_cast<double>(sy) * 65536.0) - matrix.ofy) * ir3 / h;
+    const double h = matrix.h != 0 ? static_cast<double>(matrix.h) : kFixedUnit;
+    if (h == 0.0)
+        return false;
 
-    const double irAdj[3] = {ir1 - matrix.tr[0], ir2 - matrix.tr[1], ir3 - matrix.tr[2]};
-    double vx = 0.0;
-    double vy = 0.0;
-    double vz = 0.0;
-    for (int c = 0; c < 3; ++c) {
-        vx += static_cast<double>(matrix.rt.m[c][0]) * irAdj[c];
-        vy += static_cast<double>(matrix.rt.m[c][1]) * irAdj[c];
-        vz += static_cast<double>(matrix.rt.m[c][2]) * irAdj[c];
-    }
+    const double ir2 = static_cast<double>(sz);
+    const double ofxPixel = static_cast<double>(matrix.ofx) / 65536.0;
+    const double ofyPixel = static_cast<double>(matrix.ofy) / 65536.0;
 
-    constexpr double kFixedScale = 1.0 / 4096.0;
-    mx = static_cast<float>(vx * kFixedScale);
-    my = static_cast<float>(vy * kFixedScale);
-    mz = static_cast<float>(vz * kFixedScale);
+    // Invert the projection: pixel-space -> IR (camera-space pre-divide).
+    // We trust sz as IR[2] (GTE writes it directly) so IR[0] / IR[1] follow
+    // from the standard pinhole equation.
+    const double ir0 = (static_cast<double>(sx) - ofxPixel) * ir2 / h;
+    const double ir1 = (static_cast<double>(sy) - ofyPixel) * ir2 / h;
+
+    const double irMinusTr[3] = {
+        ir0 - static_cast<double>(matrix.tr[0]),
+        ir1 - static_cast<double>(matrix.tr[1]),
+        ir2 - static_cast<double>(matrix.tr[2]),
+    };
+
+    double v[3];
+    rtpsInverse(matrix, irMinusTr, v);
+
+    mx = static_cast<float>(v[0]);
+    my = static_cast<float>(v[1]);
+    mz = static_cast<float>(v[2]);
     return std::isfinite(mx) && std::isfinite(my) && std::isfinite(mz);
 }
 

--- a/src/PS1/runtime/GteInverse.cpp
+++ b/src/PS1/runtime/GteInverse.cpp
@@ -84,6 +84,19 @@ bool screenToModel(const MatrixRecord &matrix, int sx, int sy, int sz, float &mx
     if (h == 0.0)
         return false;
 
+    // GP0 polygon packets only carry 2D screen-space XY. The GTE writes Z into
+    // a separate SZ FIFO that the CPU reads and consumes *before* constructing
+    // the GP0 word, so PsxVertex::z is 0 for every capture sourced from GP0
+    // alone. Without depth, the pinhole inverse degenerates: IR[0] and IR[1]
+    // collapse to 0 and every vertex of a given matrix tag maps to the same
+    // model-space point (~RT^T·(-TR)/4096). The mesh exists with zero extent,
+    // which renders as nothing in the viewport. Refuse the inverse so callers
+    // fall back to psxScreenToWorld — the screen-space "blob" is ugly but at
+    // least visible. Real per-vertex depth needs an in-core GTE hook (#676)
+    // or a RAM scanner that recovers the SZ FIFO contents.
+    if (sz == 0)
+        return false;
+
     const double ir2 = static_cast<double>(sz);
     const double ofxPixel = static_cast<double>(matrix.ofx) / 65536.0;
     const double ofyPixel = static_cast<double>(matrix.ofy) / 65536.0;

--- a/src/PS1/runtime/GteInverse_test.cpp
+++ b/src/PS1/runtime/GteInverse_test.cpp
@@ -1,17 +1,69 @@
 #include "GteInverse.h"
 
+#include "GteCapture.h"
+
 #include <cmath>
 #include <gtest/gtest.h>
 
-static MatrixRecord identityMatrix()
+namespace {
+
+constexpr int32_t kFixedUnit = 1 << 12;
+
+int32_t toFixed(double v)
+{
+    return static_cast<int32_t>(std::lround(v * kFixedUnit));
+}
+
+MatrixRecord identityMatrix()
 {
     MatrixRecord m{};
-    m.rt.m[0][0] = 1 << 12;
-    m.rt.m[1][1] = 1 << 12;
-    m.rt.m[2][2] = 1 << 12;
+    m.rt.m[0][0] = kFixedUnit;
+    m.rt.m[1][1] = kFixedUnit;
+    m.rt.m[2][2] = kFixedUnit;
     m.h = 256;
     return m;
 }
+
+// Builds a 12.4 fixed-point rotation matrix from intrinsic Euler angles
+// (X then Y then Z) without translation/projection metadata — tests fill those
+// fields explicitly.
+MatrixRecord rotationMatrixXYZ(double rxRad, double ryRad, double rzRad)
+{
+    const double cx = std::cos(rxRad);
+    const double sx = std::sin(rxRad);
+    const double cy = std::cos(ryRad);
+    const double sy = std::sin(ryRad);
+    const double cz = std::cos(rzRad);
+    const double sz = std::sin(rzRad);
+
+    // R = Rz * Ry * Rx (standard right-handed XYZ Euler, model -> camera basis).
+    const double r00 = cz * cy;
+    const double r01 = cz * sy * sx - sz * cx;
+    const double r02 = cz * sy * cx + sz * sx;
+    const double r10 = sz * cy;
+    const double r11 = sz * sy * sx + cz * cx;
+    const double r12 = sz * sy * cx - cz * sx;
+    const double r20 = -sy;
+    const double r21 = cy * sx;
+    const double r22 = cy * cx;
+
+    MatrixRecord m{};
+    m.rt.m[0][0] = toFixed(r00);
+    m.rt.m[0][1] = toFixed(r01);
+    m.rt.m[0][2] = toFixed(r02);
+    m.rt.m[1][0] = toFixed(r10);
+    m.rt.m[1][1] = toFixed(r11);
+    m.rt.m[1][2] = toFixed(r12);
+    m.rt.m[2][0] = toFixed(r20);
+    m.rt.m[2][1] = toFixed(r21);
+    m.rt.m[2][2] = toFixed(r22);
+    m.h = 300;
+    m.ofx = 160 << 16;
+    m.ofy = 120 << 16;
+    return m;
+}
+
+} // namespace
 
 TEST(GteInverseTest, ScreenToModelWithTranslation)
 {
@@ -70,4 +122,125 @@ TEST(GteInverseTest, ScreenToWorldFlipsY)
     EXPECT_NEAR(wy, 0.0f, 1e-4f);
     GteInverse::psxScreenToWorld(160.0f, 140.0f, 0.0f, wx, wy, wz);
     EXPECT_LT(wy, 0.0f);
+}
+
+// Pre-#675 the forward/inverse math only round-tripped on an identity-on-diagonal RT
+// (the existing ModelToScreenRoundTripsThroughScreenToModel above), so any real rotation
+// silently fell through to psxScreenToWorld and produced a flat-XY blob.  These tests
+// pin the *real* GTE math down on three independent rotation cases.
+
+TEST(GteInverseTest, ModelToScreenRoundTripsRotated90DegY)
+{
+    // 90° rotation around the Y axis: model (x, y, z) -> camera (z, y, -x).
+    MatrixRecord matrix = rotationMatrixXYZ(0.0, M_PI / 2.0, 0.0);
+    matrix.tr[0] = 0;
+    matrix.tr[1] = 0;
+    matrix.tr[2] = 6000; // pull the model away from the camera so IR[2] != 0.
+
+    ASSERT_TRUE(GteCapture::looksOrthonormalRotation(matrix));
+
+    constexpr int kModelX = 1000;
+    constexpr int kModelY = -2000;
+    constexpr int kModelZ = 500;
+
+    int sx = 0, sy = 0, sz = 0;
+    ASSERT_TRUE(GteInverse::modelToScreen(matrix, kModelX, kModelY, kModelZ, sx, sy, sz));
+
+    float mx = 0.0f, my = 0.0f, mz = 0.0f;
+    ASSERT_TRUE(GteInverse::screenToModel(matrix, sx, sy, sz, mx, my, mz));
+
+    EXPECT_NEAR(mx, static_cast<float>(kModelX), 2.0f);
+    EXPECT_NEAR(my, static_cast<float>(kModelY), 2.0f);
+    EXPECT_NEAR(mz, static_cast<float>(kModelZ), 2.0f);
+}
+
+TEST(GteInverseTest, ModelToScreenRoundTripsArbitrary3DRotation)
+{
+    // 30° pitch + 45° yaw + 15° roll — the same kind of mixed rotation real games author.
+    MatrixRecord matrix = rotationMatrixXYZ(M_PI / 6.0, M_PI / 4.0, M_PI / 12.0);
+    matrix.tr[0] = 250;
+    matrix.tr[1] = -100;
+    matrix.tr[2] = 5000;
+
+    ASSERT_TRUE(GteCapture::looksOrthonormalRotation(matrix));
+
+    constexpr int kModelX = 800;
+    constexpr int kModelY = 1200;
+    constexpr int kModelZ = -400;
+
+    int sx = 0, sy = 0, sz = 0;
+    ASSERT_TRUE(GteInverse::modelToScreen(matrix, kModelX, kModelY, kModelZ, sx, sy, sz));
+
+    float mx = 0.0f, my = 0.0f, mz = 0.0f;
+    ASSERT_TRUE(GteInverse::screenToModel(matrix, sx, sy, sz, mx, my, mz));
+
+    // Floating-point + screen-space integer rounding contributes ~3 units of drift.
+    EXPECT_NEAR(mx, static_cast<float>(kModelX), 4.0f);
+    EXPECT_NEAR(my, static_cast<float>(kModelY), 4.0f);
+    EXPECT_NEAR(mz, static_cast<float>(kModelZ), 4.0f);
+}
+
+TEST(GteInverseTest, ModelToScreenForwardChangesAllAxesForRotatedMatrix)
+{
+    // Pre-#675 the forward math was diagonal-only, so a Y rotation produced the same
+    // screen X for a model X-shift — verifying the matrix multiply actually rotates.
+    MatrixRecord matrix = rotationMatrixXYZ(0.0, M_PI / 2.0, 0.0);
+    matrix.tr[2] = 4000;
+
+    int sx0 = 0, sy0 = 0, sz0 = 0;
+    int sx1 = 0, sy1 = 0, sz1 = 0;
+    ASSERT_TRUE(GteInverse::modelToScreen(matrix, 0, 0, 0, sx0, sy0, sz0));
+    ASSERT_TRUE(GteInverse::modelToScreen(matrix, 1000, 0, 0, sx1, sy1, sz1));
+
+    // 90° Y rotation: model X-shift becomes camera-Z shift (depth), so the projected
+    // depth must change and screen X must stay essentially fixed.
+    EXPECT_NE(sz1, sz0);
+    EXPECT_NEAR(sx1, sx0, 5);
+}
+
+TEST(GteCaptureTest, LooksOrthonormalRotationAcceptsIdentity)
+{
+    EXPECT_TRUE(GteCapture::looksOrthonormalRotation(identityMatrix()));
+}
+
+TEST(GteCaptureTest, LooksOrthonormalRotationAcceptsRealRotations)
+{
+    EXPECT_TRUE(GteCapture::looksOrthonormalRotation(rotationMatrixXYZ(0.0, M_PI / 2.0, 0.0)));
+    EXPECT_TRUE(GteCapture::looksOrthonormalRotation(rotationMatrixXYZ(M_PI / 4.0, 0.0, 0.0)));
+    EXPECT_TRUE(
+        GteCapture::looksOrthonormalRotation(rotationMatrixXYZ(M_PI / 6.0, M_PI / 4.0, M_PI / 12.0)));
+}
+
+TEST(GteCaptureTest, LooksOrthonormalRotationRejectsScaledRotation)
+{
+    // Each entry doubled — rows are now |row|^2 == (2*4096)^2 = 4 * 4096^2, well outside tolerance.
+    MatrixRecord matrix = rotationMatrixXYZ(0.0, M_PI / 4.0, 0.0);
+    for (int r = 0; r < 3; ++r)
+        for (int c = 0; c < 3; ++c)
+            matrix.rt.m[r][c] *= 2;
+    EXPECT_FALSE(GteCapture::looksOrthonormalRotation(matrix));
+}
+
+TEST(GteCaptureTest, LooksOrthonormalRotationRejectsReflection)
+{
+    // Flip the sign of the last row -> determinant becomes -4096^3 (reflection).
+    MatrixRecord matrix = identityMatrix();
+    matrix.rt.m[2][2] = -kFixedUnit;
+    EXPECT_FALSE(GteCapture::looksOrthonormalRotation(matrix));
+}
+
+TEST(GteCaptureTest, LooksOrthonormalRotationRejectsRandomFill)
+{
+    MatrixRecord matrix{};
+    // Arbitrary but stable bit pattern — rows are neither unit-length nor orthogonal.
+    matrix.rt.m[0][0] = 1234;
+    matrix.rt.m[0][1] = 5678;
+    matrix.rt.m[0][2] = -42;
+    matrix.rt.m[1][0] = 999;
+    matrix.rt.m[1][1] = 100;
+    matrix.rt.m[1][2] = 7777;
+    matrix.rt.m[2][0] = -500;
+    matrix.rt.m[2][1] = 2000;
+    matrix.rt.m[2][2] = 3000;
+    EXPECT_FALSE(GteCapture::looksOrthonormalRotation(matrix));
 }

--- a/src/PS1/runtime/GteInverse_test.cpp
+++ b/src/PS1/runtime/GteInverse_test.cpp
@@ -180,6 +180,53 @@ TEST(GteInverseTest, ModelToScreenRoundTripsArbitrary3DRotation)
     EXPECT_NEAR(mz, static_cast<float>(kModelZ), 4.0f);
 }
 
+// PS1 GP0 polygon packets only carry 2D screen-space XY. The GTE writes Z into
+// a separate SZ FIFO that the CPU drains *before* building the GP0 word, so
+// PsxVertex::z stays 0 for any capture sourced from GP0 alone. Without depth,
+// the pinhole inverse degenerates: IR[0]/IR[1] collapse to 0 and every vertex
+// of a given matrix tag maps to the same model-space point (~RT^T·(-TR)/4096).
+// vertexFromPsx must then fall back to psxScreenToWorld so the mesh is at
+// least visible — not silently emit a zero-extent collapse. This is the
+// regression that bit the first build of #675.
+TEST(GteInverseTest, ScreenToModelRefusesZeroDepth)
+{
+    MatrixRecord matrix = rotationMatrixXYZ(0.0, M_PI / 4.0, 0.0);
+    matrix.tr[0] = 1000;
+    matrix.tr[1] = -500;
+    matrix.tr[2] = 5000;
+
+    float mx = 0.0f, my = 0.0f, mz = 0.0f;
+    EXPECT_FALSE(GteInverse::screenToModel(matrix, 160, 120, 0, mx, my, mz));
+    EXPECT_FALSE(GteInverse::screenToModel(matrix, 200, 80, 0, mx, my, mz));
+    EXPECT_FALSE(GteInverse::screenToModel(matrix, -50, 50, 0, mx, my, mz));
+}
+
+// Companion to the test above: if multiple vertices share a matrix and sz=0
+// were accepted, all of them would collapse onto a single model-space point
+// (the mesh becomes invisible because every reconstructed sub-mesh has zero
+// extent). With the guard in place those calls fail and the caller is forced
+// to use psxScreenToWorld, which preserves the per-vertex screen XY spread.
+TEST(GteInverseTest, ScreenToModelWithZeroDepthDoesNotCollapseVertices)
+{
+    MatrixRecord matrix = rotationMatrixXYZ(M_PI / 12.0, M_PI / 8.0, 0.0);
+    matrix.tr[0] = 256;
+    matrix.tr[1] = 128;
+    matrix.tr[2] = 4096;
+
+    float mx0 = 0.0f, my0 = 0.0f, mz0 = 0.0f;
+    float mx1 = 0.0f, my1 = 0.0f, mz1 = 0.0f;
+    EXPECT_FALSE(GteInverse::screenToModel(matrix, 100, 100, 0, mx0, my0, mz0));
+    EXPECT_FALSE(GteInverse::screenToModel(matrix, 200, 150, 0, mx1, my1, mz1));
+    // Failure path leaves outputs untouched — confirm the caller's fallback
+    // is what produces vertex-to-vertex divergence, not the inverse itself.
+    EXPECT_EQ(mx0, 0.0f);
+    EXPECT_EQ(my0, 0.0f);
+    EXPECT_EQ(mz0, 0.0f);
+    EXPECT_EQ(mx1, 0.0f);
+    EXPECT_EQ(my1, 0.0f);
+    EXPECT_EQ(mz1, 0.0f);
+}
+
 TEST(GteInverseTest, ModelToScreenForwardChangesAllAxesForRotatedMatrix)
 {
     // Pre-#675 the forward math was diagonal-only, so a Y rotation produced the same

--- a/src/PS1/runtime/PS1RipManager.cpp
+++ b/src/PS1/runtime/PS1RipManager.cpp
@@ -170,7 +170,8 @@ void PS1RipManager::initializeWorkerThread()
                                captureSet.instanceCount(), built.vertexCount, built.triangleCount,
                                snapshot.matrices.size(), snapshot.cameraMatrixId,
                                snapshot.hasCameraMatrix(), reconStats.gteInversePercent(),
-                               reconStats.slabLike, vramMirrorMode, captureStats);
+                               reconStats.slabLike, reconStats.primsWithMatrixId,
+                               reconStats.primsTotal, vramMirrorMode, captureStats);
             });
     connect(m_worker, &PS1RipWorker::vramFrameUpdated, this,
             [this](const QVector<uint16_t> &cells, const QImage &preview) {

--- a/src/PS1/runtime/PS1RipManager.h
+++ b/src/PS1/runtime/PS1RipManager.h
@@ -67,7 +67,8 @@ signals:
     void meshBuilt(const QString &captureId, int capturedParts, int uniqueMeshes, int instanceCount,
                    int vertexCount, int triangleCount, int matrixCount, uint32_t cameraMatrixId,
                    bool hasCameraMatrix, int gteInversePercent, bool slabLike,
-                   PsxVramMirrorMode vramMirrorMode, Gp0CaptureStats captureStats);
+                   int primsWithMatrixId, int primsTotal, PsxVramMirrorMode vramMirrorMode,
+                   Gp0CaptureStats captureStats);
     void sceneCaptured(const QString &captureId);
     void vramDumped(const QString &captureId, const QString &pngPath, const QVector<uint16_t> &cells,
                     const QImage &nativePreview);

--- a/src/PS1/runtime/PS1RipSessionWindow.cpp
+++ b/src/PS1/runtime/PS1RipSessionWindow.cpp
@@ -376,13 +376,20 @@ void PS1RipSessionWindow::onCaptureFrame()
 void PS1RipSessionWindow::onMeshBuilt(const QString &captureId, int capturedParts, int uniqueMeshes,
                                     int instanceCount, int vertexCount, int triangleCount,
                                     int matrixCount, uint32_t cameraMatrixId, bool hasCameraMatrix,
-                                    int gteInversePercent, bool slabLike, PsxVramMirrorMode vramMirrorMode,
-                                    Gp0CaptureStats captureStats)
+                                    int gteInversePercent, bool slabLike,
+                                    int primsWithMatrixId, int primsTotal,
+                                    PsxVramMirrorMode vramMirrorMode, Gp0CaptureStats captureStats)
 {
     QString cameraText = hasCameraMatrix
                              ? tr("camera matrix #%1").arg(cameraMatrixId)
                              : tr("camera matrix unknown");
     QString matrixStats = tr("GTE inverse %1%").arg(gteInversePercent);
+    // #675: surface the prim → matrix association ratio so users can tell at a glance
+    // whether the bottleneck is the inverse math (`tag X/X` with low %) or the matrix
+    // association (`tag 0/N`). Without this you'd have to read the Sentry breadcrumb
+    // to know which subsystem to debug.
+    if (primsTotal > 0)
+        matrixStats += tr(" (matrix tag %1/%2)").arg(primsWithMatrixId).arg(primsTotal);
     if (slabLike)
         matrixStats += tr(" — slab-like bounds (check matrix association)");
     QString vramText = psxVramMirrorModeLabel(vramMirrorMode);

--- a/src/PS1/runtime/PS1RipSessionWindow.h
+++ b/src/PS1/runtime/PS1RipSessionWindow.h
@@ -50,7 +50,8 @@ private slots:
     void onMeshBuilt(const QString &captureId, int capturedParts, int uniqueMeshes, int instanceCount,
                      int vertexCount, int triangleCount, int matrixCount, uint32_t cameraMatrixId,
                      bool hasCameraMatrix, int gteInversePercent, bool slabLike,
-                     PsxVramMirrorMode vramMirrorMode, Gp0CaptureStats captureStats);
+                     int primsWithMatrixId, int primsTotal, PsxVramMirrorMode vramMirrorMode,
+                     Gp0CaptureStats captureStats);
     void onPausedChanged(bool paused);
 
 private:

--- a/src/PS1/runtime/PsxGteRamScanner.cpp
+++ b/src/PS1/runtime/PsxGteRamScanner.cpp
@@ -14,9 +14,19 @@ namespace {
 constexpr size_t kMatrixBytes = sizeof(MatrixRecord) - sizeof(uint64_t);
 constexpr int kMaxMatricesPerFrame = 48;
 
+// #675: tightened from the pre-#675 looksLikeMatrixRecord (`h ∈ [50, 8192]`,
+// per-entry magnitude only) which accepted ~192 false positives per single-box
+// retail capture. Real PS1 GTE matrices satisfy three structural invariants —
+// (a) `H` lives in the cluster of common projection denominators (~64..2048,
+// titles author 128/200/240/256/300/320/400/512 almost exclusively per
+// psx-spx), (b) `OFX`/`OFY` decoded to pixels fits the 1024×512 framebuffer,
+// (c) the RT block is an orthonormal rotation in 12.4 fixed point. The
+// orthonormal check (rows have unit magnitude, are mutually orthogonal, det == +1)
+// is delegated to GteCapture::looksOrthonormalRotation so the same gate is
+// reused by GteInverse::screenToModel's RT^T fast path.
 bool looksLikeMatrixRecord(const MatrixRecord &matrix)
 {
-    if (matrix.h < 50 || matrix.h > 8192)
+    if (matrix.h < 64 || matrix.h > 2048)
         return false;
     if (matrix.ofx < 0 || matrix.ofy < 0)
         return false;
@@ -26,25 +36,21 @@ bool looksLikeMatrixRecord(const MatrixRecord &matrix)
     if (ofxScreen > 1024 || ofyScreen > 1024)
         return false;
 
-    bool anyRotation = false;
+    // Reject anything where any RT entry overflows a sane 12.4 fixed-point
+    // rotation before the more expensive orthonormality check.
     for (int r = 0; r < 3; ++r) {
         for (int c = 0; c < 3; ++c) {
-            const int32_t v = matrix.rt.m[r][c];
-            if (v == 0)
-                continue;
-            if (std::abs(v) > (1 << 16))
+            if (std::abs(matrix.rt.m[r][c]) > (1 << 13))
                 return false;
-            anyRotation = true;
         }
     }
-    if (!anyRotation)
-        return false;
 
     for (int i = 0; i < 3; ++i) {
         if (std::abs(matrix.tr[i]) > (1 << 20))
             return false;
     }
-    return true;
+
+    return GteCapture::looksOrthonormalRotation(matrix);
 }
 
 bool readMatrixAt(const uint8_t *ram, size_t byteSize, size_t byteOffset, MatrixRecord &out)

--- a/src/PS1/runtime/PsxGteRamScanner_test.cpp
+++ b/src/PS1/runtime/PsxGteRamScanner_test.cpp
@@ -9,7 +9,9 @@
 #include <QSet>
 
 #include <atomic>
+#include <cmath>
 #include <cstring>
+#include <random>
 
 namespace {
 
@@ -35,6 +37,30 @@ MatrixRecord makeMatrix(int trX, int h = 256)
     matrix.rt.m[1][1] = 1 << 12;
     matrix.rt.m[2][2] = 1 << 12;
     matrix.tr[0] = trX;
+    matrix.h = h;
+    matrix.ofx = 160 << 16;
+    matrix.ofy = 120 << 16;
+    return matrix;
+}
+
+// #675 — 45° Y rotation in 12.4 fixed point. Real PS1 SDK matrices look like this:
+// orthonormal rows, |row|=4096, det=+4096^3.
+MatrixRecord make45DegYRotation(int h = 300)
+{
+    constexpr double kFixed = 4096.0;
+    const int32_t cos45 = static_cast<int32_t>(std::lround(std::cos(M_PI / 4.0) * kFixed));
+    const int32_t sin45 = static_cast<int32_t>(std::lround(std::sin(M_PI / 4.0) * kFixed));
+
+    MatrixRecord matrix{};
+    matrix.rt.m[0][0] = cos45;
+    matrix.rt.m[0][1] = 0;
+    matrix.rt.m[0][2] = sin45;
+    matrix.rt.m[1][0] = 0;
+    matrix.rt.m[1][1] = static_cast<int32_t>(kFixed);
+    matrix.rt.m[1][2] = 0;
+    matrix.rt.m[2][0] = -sin45;
+    matrix.rt.m[2][1] = 0;
+    matrix.rt.m[2][2] = cos45;
     matrix.h = h;
     matrix.ofx = 160 << 16;
     matrix.ofy = 120 << 16;
@@ -130,6 +156,84 @@ TEST(PsxGteRamScannerTest, GteScanRunsBeforeGpuFallbackMatrix)
     ASSERT_EQ(buffer.matrices().size(), 1u);
     ASSERT_GE(buffer.prims().size(), 1);
     EXPECT_EQ(buffer.prims()[0].matrixId, 0u);
+}
+
+// #675 regression: pre-#675 looksLikeMatrixRecord only checked per-entry magnitude,
+// so a scaled rotation (each entry doubled) would still be accepted as a valid
+// matrix.  This is the false-positive class that produced ~192 "matrices" in
+// real single-box scenes.  With the orthonormal check it must be rejected.
+TEST(PsxGteRamScannerTest, RejectsNonOrthonormalScaledRotation)
+{
+    alignas(4) uint8_t ram[2 * 1024];
+    std::memset(ram, 0, sizeof(ram));
+
+    MatrixRecord scaled = makeMatrix(0);
+    // Each row magnitude is now (2*4096)^2 = 4*4096^2 — well outside the 5% gate.
+    for (int r = 0; r < 3; ++r)
+        for (int c = 0; c < 3; ++c)
+            scaled.rt.m[r][c] *= 2;
+    writeMatrix(ram, 0x000, scaled);
+
+    std::atomic<bool> armed{true};
+    CaptureBuffer buffer;
+    RipperHooks hooks;
+    hooks.setArmedFlag(&armed);
+    hooks.setBuffer(&buffer);
+
+    hooks.onFrameBegin();
+    PsxGteRamScanner::captureFromSystemRam(ram, sizeof(ram), &hooks);
+    hooks.onFrameEnd();
+
+    EXPECT_EQ(buffer.matrices().size(), 0u);
+}
+
+// #675 regression: a real-game 45° Y rotation must still be accepted by the
+// tightened scanner.  Pre-tightening this always passed; post-tightening we
+// must not over-reject and lock out the actual use case.
+TEST(PsxGteRamScannerTest, Accepts45DegYRotation)
+{
+    alignas(4) uint8_t ram[2 * 1024];
+    std::memset(ram, 0, sizeof(ram));
+    writeMatrix(ram, 0x000, make45DegYRotation());
+
+    std::atomic<bool> armed{true};
+    CaptureBuffer buffer;
+    RipperHooks hooks;
+    hooks.setArmedFlag(&armed);
+    hooks.setBuffer(&buffer);
+
+    hooks.onFrameBegin();
+    PsxGteRamScanner::captureFromSystemRam(ram, sizeof(ram), &hooks);
+    hooks.onFrameEnd();
+
+    EXPECT_EQ(buffer.matrices().size(), 1u);
+}
+
+// #675 regression: 16 KB of pseudo-random bytes must produce zero accepted
+// matrices.  Pre-tightening this would accept dozens (false-positive class
+// that produced the "192 matrices in a single-box scene" stat).  Post-tightening
+// the orthonormal invariant rejects all of them — random bytes cannot happen
+// to form a unit-length, mutually-orthogonal 3×3 with det == +4096^3.
+TEST(PsxGteRamScannerTest, RejectsPseudoRandomGarbage)
+{
+    constexpr size_t kRamSize = 16 * 1024;
+    std::vector<uint8_t> ram(kRamSize, 0);
+    std::mt19937 rng(0x675);
+    std::uniform_int_distribution<int> byteDist(0, 255);
+    for (size_t i = 0; i < kRamSize; ++i)
+        ram[i] = static_cast<uint8_t>(byteDist(rng));
+
+    std::atomic<bool> armed{true};
+    CaptureBuffer buffer;
+    RipperHooks hooks;
+    hooks.setArmedFlag(&armed);
+    hooks.setBuffer(&buffer);
+
+    hooks.onFrameBegin();
+    PsxGteRamScanner::captureFromSystemRam(ram.data(), ram.size(), &hooks);
+    hooks.onFrameEnd();
+
+    EXPECT_EQ(buffer.matrices().size(), 0u);
 }
 
 #endif // ENABLE_PS1_RIP


### PR DESCRIPTION
## Summary

Closes the screen-space half of the "real meshes from real PS1 games" roadmap (PR #674 was the model-space half via TMD/HMD RAM scanner). With this PR the screen-space capture path no longer collapses to a flat-XY blob whenever the GTE matrix isn't the identity.

### Why the blob existed

Both `GteInverse::modelToScreen` and `GteInverse::screenToModel` were diagonal-only (`vx / RT[0][0]`, `vy / RT[1][1]`, `vz / RT[2][2]`). That's not the PSX GTE math — RTPS/RTPT does a full `IR = RT * V + TR` 3x3 multiply. The existing roundtrip test in CI only used an identity-on-diagonal matrix, so the bug was silent. Every non-identity rotation got `(huge, huge, huge)` from `screenToModel`, the `kMaxVertexRadius = 64` filter in `MeshReconstructor::vertexFromPsx` rejected it, and `psxScreenToWorld` painted a flat XY blob.

Secondary issue: the matrix RAM scanner accepted ~192 false-positive "matrices" in a single-box scene (per the screenshot the user shared during the #674 conversation) because the validator only checked per-entry magnitude.

Tertiary issue: `MeshReconstructionStats::primsWithMatrixId / primsTotal` lived in the `ps1.rip.matrix.stats` Sentry breadcrumb but never reached the status bar, so users had to read Sentry to triage which subsystem was failing.

### Changes

**GTE math** — `src/PS1/runtime/GteInverse.cpp`
- `modelToScreen` now implements the real psx-spx RTPS: `IR[r] = (sum_c RT[r][c] * V[c]) / 4096 + TR[r]`, then standard projection through `H` / `OFX` / `OFY`.
- `screenToModel` inverts via `IR[2] = sz`, `IR[i<2] = (screen_i - OF_i) * IR[2] / H`, then `V = RT^T * (IR - TR)`. The `RT^T` fast path is valid because PS1 RT matrices are orthonormal rotations in 12.4 fixed point.

**Orthonormal validator** — `src/PS1/runtime/GteCapture.{h,cpp}`
- New `GteCapture::looksOrthonormalRotation(MatrixRecord)` checks `|row|^2 ~= 4096^2`, `dot(row_i, row_j) ~= 0`, `det ~= +4096^3` (5–10% tolerance for cos/sin quantisation noise).

**Tightened scanner** — `src/PS1/runtime/PsxGteRamScanner.cpp`
- `looksLikeMatrixRecord` narrowed `H in [64, 2048]` (was 50..8192), tightened RT entry magnitude (`|RT[r][c]| <= 8192`), delegated rotation validation to the new orthonormal gate.

**UI diagnostic** — `src/PS1/runtime/PS1RipManager.{h,cpp}` + `PS1RipSessionWindow.{h,cpp}`
- `PS1RipManager::meshBuilt` signal gains `primsWithMatrixId, primsTotal`.
- Status bar now reads `GTE inverse N% (matrix tag X/Y)`. Triage at a glance:
  - `0/Y` = matrix association bottleneck (debug #658 per-draw matrix tagging)
  - `Y/Y` with low % = math/matrix-quality bottleneck (deferred to #676 in-core hook)
  - High % = healthy capture
- `ps1.rip.matrix.stats` breadcrumb already carries the same data — Sentry parity confirmed; no breadcrumb change needed.

### Tests (8 new, all 17 tests across `GteInverse`/`GteCapture`/`PsxGteRamScanner`/`PsxPerDrawMatrix` green)

- `GteInverseTest.ModelToScreenRoundTripsRotated90DegY` — 90deg Y rotation round-trips within 2 fixed-point units.
- `GteInverseTest.ModelToScreenRoundTripsArbitrary3DRotation` — 30deg pitch + 45deg yaw + 15deg roll Euler round-trips within 4 units.
- `GteInverseTest.ModelToScreenForwardChangesAllAxesForRotatedMatrix` — regression catch for the old diagonal-only forward.
- `GteCaptureTest.LooksOrthonormalRotation{AcceptsIdentity,AcceptsRealRotations,RejectsScaledRotation,RejectsReflection,RejectsRandomFill}` — validator behaviour pinned across the four boundary cases.
- `PsxGteRamScannerTest.RejectsNonOrthonormalScaledRotation` — the false-positive class from the #674 screenshot.
- `PsxGteRamScannerTest.Accepts45DegYRotation` — real-game rotation still accepted.
- `PsxGteRamScannerTest.RejectsPseudoRandomGarbage` — 16 KB of pseudo-random RAM produces zero matrices.

### Docs

- `PS1_RIP_DESIGN.md` — new "Screen-space inverse projection (#675)" section covering the math, the orthonormal validator, and the status-bar diagnostic reading order. Refreshed the "Capture mesh is a triangle blob" troubleshoot entry with the new diagnostic ladder (GTE inverse % -> matrix tag X/Y -> tmd N).

### Out of scope (deferred to #676)

- Matrix -> primitive association on retail games still uses heuristic per-draw matrix tagging from #658. #675 makes the inverse **correct when association is correct**; ground-truth association needs the forked `mednafen_psx_libretro` with in-core RTPS/RTPT callback (#676). Custom-engine games (Crash, Spyro, FFVII field models, MGS post-Yaroze) will still produce partial recovery at best until #676 lands — they author custom transform stacks that defeat heuristic matrix association.

## Test plan
- [x] `./build_local/bin/UnitTests --gtest_filter="GteInverseTest.*:GteCaptureTest.*:PsxGteRamScannerTest.*:PsxPerDrawMatrixTest.*"` — 17/17 pass
- [x] Full PS1 test bucket (`*Psx*:*Gte*:*Gp0*:*EmuCore*:CaptureBuffer*:GpuCommand*:MeshReconstructor*:PS1Rip*`) — 104/104 pass; `PS1RipManagerTest.StopCancelsPendingStart` is a pre-existing flaky test (passes in isolation, unrelated to this PR).
- [x] Build full `QtMeshEditor` binary clean.
- [ ] CI: full Linux test matrix + SonarCloud.
- [ ] Manual: open a retail disc via `Tools -> Experimental -> PS1 Runtime Ripper`, arm capture, walk a scene, confirm status bar shows `GTE inverse N% (matrix tag X/Y)` and `N` is meaningfully > 0 on titles where the screen-space path was previously stuck at 0%.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed screen-space inverse projection calculations; rotations now properly round-trip between model and screen space.

* **New Features**
  * Enhanced diagnostics display the primitive-to-matrix association ratio in mesh reconstruction status information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/675?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->