### PR TITLE
feat(ps1): coordinate normalization & affine-UV handling (#424)

### DIFF
--- a/src/PS1/CMakeLists.txt
+++ b/src/PS1/CMakeLists.txt
@@ -40,6 +40,7 @@ if(ENABLE_PS1_RIP)
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/MeshReconstructionStats.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/MeshReconstructor.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/MeshTopologyHash.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/Ps1CoordinateNormalizer.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipMeshBuilder.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipGamepadBridge.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipInputSettingsDialog.cpp
@@ -73,6 +74,7 @@ if(ENABLE_PS1_RIP)
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PsxModelRamScanCommon.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/ReconstructedMesh.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/MeshTopologyHash.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/Ps1CoordinateNormalizer.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipMeshBuilder.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/EmuCore.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/EmuCoreLoader.h

--- a/src/PS1/PS1_RIP_DESIGN.md
+++ b/src/PS1/PS1_RIP_DESIGN.md
@@ -203,6 +203,82 @@ yields clean meshes with no inverse step.
 - **Disable:** `QTMESH_PS1_TMD_SCANNER=0` skips the TMD pass entirely (debug / golden
   baselines). HMD scanner is opt-in (`QTMESH_PS1_HMD_SCANNER=1`).
 
+## Coordinate normalization & affine-UV handling (#424)
+
+Captures land in the editor through three different source-specific conversions
+that all share the same target basis (right-handed Y-up, CCW front-face winding,
+~FBX/glTF magnitude):
+
+| Source path | Conversion | Comment |
+|-------------|-----------|---------|
+| `GteInverse::modelToEditor` | `(mx, my, mz) × 0.01 → (wx, -wy, -wz)` | Y- and Z-negated → determinant +1 → CCW winding preserved |
+| `GteInverse::psxScreenToWorld` | `(sx − 160, sy − 120, sz) × 0.01 → (wx, -wy, wz)` | fallback path used when sz=0 (see #675) — single Y flip |
+| `PsxTmdRamScanner` | `(x, y, z) × 10/4096`, 180° Z-rotation, CCW index swap | mirrors `PS1TMD::importTmd` so on-disk and RAM paths agree |
+
+`Ps1CoordinateNormalizer` (`runtime/Ps1CoordinateNormalizer.{h,cpp}`) layers a
+user-controllable **scale + per-axis flip + perspective-correct UV** override
+on top of those built-in conversions. The state lives on `PS1RipManager` and is
+edited from the new "Normalize" dock in `PS1RipSessionWindow`.
+
+### How each control composes
+
+- **Scale (`userScale`, default 1.0)** — multiplied into the SceneNode scale at
+  attach time alongside the placement auto-fit. `placementScale` is stashed in
+  `node->getUserObjectBindings().setUserAny("ps1RipPlacementScale", …)` so live
+  toggles don't lose the auto-fit. The issue's stated "default 1/4096" is the
+  PSX 12.4 fixed-point divisor; we expose it as a slider rather than as the
+  baked default because freshly-loaded captures need to land at the same
+  magnitude as FBX/glTF imports (acceptance criterion). Users who want raw
+  PSX-native magnitude can dial the slider down to ≈0.024 (= 1/4096 / 0.01).
+- **Per-axis flip (`flipX/Y/Z`, default off)** — applied as ±1 multipliers in
+  the SceneNode scale. An odd number of negated axes produces a negative
+  transform determinant; Ogre auto-flips back-face culling for those nodes so
+  the visible front face stays correct **without any per-vertex winding swap
+  in the mesh data**. This is what makes "per-axis flip toggles work without
+  re-capturing" — no mesh rebuild needed.
+- **Perspective-correct UVs (default off)** — when on, screen-space prims whose
+  vertex depth ratio max(sz)/min(sz) exceeds `perspectiveTolerance` (default
+  1.3) get split into 4 sub-tris via midpoint triangulation in
+  `MeshReconstructor::emitTriSubdivided`. New midpoint UVs use screen-space
+  linear interpolation (the PS1 affine convention) so Ogre's perspective-
+  correct rendering of the resulting fine mesh approximates what the original
+  PS1 GPU showed — the "warped quad fix" used by modern PSX remasters.
+  Recursion is bounded by `perspectiveMaxDepth` (default 3 → 4³ = 64 sub-tris
+  per input prim worst case). Bakes into mesh data, so this **does** require a
+  fresh capture after toggling. Prims with sz=0 (GP0-only captures, #675) skip
+  subdivision because there's no usable depth signal.
+
+### Live updates
+
+`PS1RipManager::setNormalizerSettings` calls
+`Ps1CoordinateNormalizer::applyToCaptureNodes`, which walks every
+`PS1Capture_*` SceneNode in `Manager::getSceneNodes()` and re-applies the new
+scale tuple. Cost: O(scene nodes), no Ogre mesh / material rebuild. Emits a
+`ps1.rip.coord.normalize` Sentry breadcrumb with the compact descriptor
+returned by `Ps1CoordinateNormalizer::describe` and the node-touched count.
+
+Settings persist to `QSettings` under `ps1Rip/normalize/*` so a user's
+per-game tweaks survive across sessions. Values are clamped on load
+(`userScale ∈ [0.001, 1000]`, `perspectiveTolerance ∈ [1.0, 1000]`,
+`perspectiveMaxDepth ∈ [0, 6]`) so a corrupted ini can't bake invisible or
+explosively-scaled capture nodes.
+
+### Bounds & framing
+
+`PS1RipMeshBuilder::buildMeshResources` already calls
+`ogreMesh->_setBounds(bounds)` per unique mesh (#658), so `SpaceCamera::
+frameSelection()` (`F` shortcut) picks the captured AABB up via
+`getWorldBoundingBox(true)` without any extra plumbing. Hit `F` on any
+`PS1Capture_*_inst*` node to frame it.
+
+### Test coverage
+
+- `Ps1CoordinateNormalizer_test.cpp` — settings roundtrip, describe, isDefault,
+  per-axis sign math, YDownQuad → YUp winding behaviour, clamp on corrupted
+  ini values.
+- `MeshReconstructor_test.cpp` — perspective-correct subdivision tessellates a
+  warped quad, no-ops on flat prims, gracefully handles sz=0 GP0 captures.
+
 ## GP0 FIFO follow-up (#662)
 
 Shipped in this slice:
@@ -269,6 +345,25 @@ TMD importer is also wrong, fix it in `PS1TMD.cpp` and the RAM scanner picks it 
 the matching constants. Per-draw matrix tagging (#658) and the live FIFO bridge (#662)
 still help on the screen-space side but cannot reconstruct topology from screen-space
 prims alone.
+
+### Captured mesh is the wrong size, flipped, or has visible texture warping
+
+The "Normalize" dock in the rip session window (#424) is the user-facing
+override for these:
+
+- **Wrong size** — drag the **Scale** spinbox. 1.0 (default) matches FBX/glTF
+  magnitude; ≈0.024 gives raw PSX-native (1/4096) for engine-side math.
+- **Wrong axis / upside-down** — toggle **Flip X / Y / Z**. The change applies
+  live to existing capture nodes; no re-capture needed. Pair two flips to keep
+  CCW winding when chasing a Z-up game into editor Y-up.
+- **Texture wobble looks wrong on near-camera surfaces** — enable
+  **Perspective-correct UVs** and re-capture. Triangles with high depth
+  variance get subdivided + midpoint-resampled so Ogre's perspective-correct
+  rendering reproduces the artist's affine intent (the PSX-remaster fix).
+
+All four are persisted to `QSettings` under `ps1Rip/normalize/*` so per-game
+tweaks survive across sessions. Sentry: each setter call emits
+`ps1.rip.coord.normalize` with the compact descriptor.
 
 ### Libretro integration tests (local only)
 

--- a/src/PS1/PS1_RIP_DESIGN.md
+++ b/src/PS1/PS1_RIP_DESIGN.md
@@ -222,27 +222,36 @@ edited from the new "Normalize" dock in `PS1RipSessionWindow`.
 
 ### How each control composes
 
-- **Scale (`userScale`, default 1.0)** — multiplied into the SceneNode scale at
-  attach time alongside the placement auto-fit. `placementScale` is stashed in
-  `node->getUserObjectBindings().setUserAny("ps1RipPlacementScale", …)` so live
-  toggles don't lose the auto-fit. The issue's stated "default 1/4096" is the
+- **Scale (`userScale`, default 1.0)** — multiplied into BOTH the SceneNode
+  scale AND its position alongside the placement auto-fit, so multi-instance
+  deduped captures (a city of buildings, a row of props) scale as one coherent
+  assembly instead of each mesh growing/shrinking around its own pivot.
+  `placementScale` AND the raw capture-time `(inst.px, inst.py, inst.pz)` are
+  stashed in `node->getUserObjectBindings()` as `ps1RipPlacementScale` /
+  `ps1RipBasePosition`, and `Ps1CoordinateNormalizer::composeNodeTransform`
+  rebuilds both transforms from those base values on every live toggle. The
+  issue's stated "default 1/4096" is the
   PSX 12.4 fixed-point divisor; we expose it as a slider rather than as the
   baked default because freshly-loaded captures need to land at the same
   magnitude as FBX/glTF imports (acceptance criterion). Users who want raw
   PSX-native magnitude can dial the slider down to ≈0.024 (= 1/4096 / 0.01).
 - **Per-axis flip (`flipX/Y/Z`, default off)** — applied as ±1 multipliers in
-  the SceneNode scale. An odd number of negated axes produces a negative
-  transform determinant; Ogre auto-flips back-face culling for those nodes so
-  the visible front face stays correct **without any per-vertex winding swap
-  in the mesh data**. This is what makes "per-axis flip toggles work without
-  re-capturing" — no mesh rebuild needed.
-- **Perspective-correct UVs (default off)** — when on, screen-space prims whose
+  the SceneNode scale AND mirrored into the SceneNode position so two
+  instances at `(x, +1, 0)` and `(x, -1, 0)` swap places under a Y flip rather
+  than collapsing onto each other. An odd number of negated axes produces a
+  negative transform determinant; Ogre auto-flips back-face culling for those
+  nodes so the visible front face stays correct **without any per-vertex
+  winding swap in the mesh data**. This is what makes "per-axis flip toggles
+  work without re-capturing" — no mesh rebuild needed.
+- **Perspective-correct UVs (default off)** — when on, **textured** prims whose
   vertex depth ratio max(sz)/min(sz) exceeds `perspectiveTolerance` (default
   1.3) get split into 4 sub-tris via midpoint triangulation in
   `MeshReconstructor::emitTriSubdivided`. New midpoint UVs use screen-space
   linear interpolation (the PS1 affine convention) so Ogre's perspective-
   correct rendering of the resulting fine mesh approximates what the original
   PS1 GPU showed — the "warped quad fix" used by modern PSX remasters.
+  Mono / shaded prims (no UV channel — HUDs, flat-shaded geometry) are
+  skipped, so the triangle count of non-textured geometry never inflates.
   Recursion is bounded by `perspectiveMaxDepth` (default 3 → 4³ = 64 sub-tris
   per input prim worst case). Bakes into mesh data, so this **does** require a
   fresh capture after toggling. Prims with sz=0 (GP0-only captures, #675) skip

--- a/src/PS1/runtime/MeshReconstructor.cpp
+++ b/src/PS1/runtime/MeshReconstructor.cpp
@@ -107,37 +107,131 @@ void accumulateVertexStats(const ReconstructedVertex &v, MeshReconstructionStats
     expandBounds(stats, v);
 }
 
-void emitPrimitive(const PrimRecord &prim, const MatrixRecord *matrix, SubMeshAccumulator &acc,
+PsxVertex midpointPsx(const PsxVertex &a, const PsxVertex &b)
+{
+    // Integer division on screen coords is fine: even at the coarsest PS1
+    // resolution (640px-wide modes) a 1-pixel rounding error along an edge
+    // is well below the perspective-correct UV subdivision's own tolerance
+    // (1.3 default depth ratio). UV is i16/256 fixed-point so the same
+    // integer halving preserves screen-space affine interpolation exactly.
+    PsxVertex m;
+    m.x = (a.x + b.x) / 2;
+    m.y = (a.y + b.y) / 2;
+    m.z = (a.z + b.z) / 2;
+    m.u = static_cast<int16_t>((static_cast<int>(a.u) + static_cast<int>(b.u)) / 2);
+    m.v = static_cast<int16_t>((static_cast<int>(a.v) + static_cast<int>(b.v)) / 2);
+    m.r = static_cast<uint8_t>((static_cast<int>(a.r) + static_cast<int>(b.r)) / 2);
+    m.g = static_cast<uint8_t>((static_cast<int>(a.g) + static_cast<int>(b.g)) / 2);
+    m.b = static_cast<uint8_t>((static_cast<int>(a.b) + static_cast<int>(b.b)) / 2);
+    return m;
+}
+
+/** True when the triangle's per-vertex screen-space depth (sz) varies enough
+ *  that the perspective-vs-affine UV gap is visibly larger than `tolerance`.
+ *  Falls back to "don't subdivide" when any sz is zero (GP0-only captures
+ *  have no depth — see GteInverse::screenToModel sz==0 guard, #675). */
+bool depthRatioExceedsTolerance(const PsxVertex &a, const PsxVertex &b, const PsxVertex &c,
+                                float tolerance)
+{
+    const int zs[3] = { a.z, b.z, c.z };
+    int zmin = zs[0], zmax = zs[0];
+    for (int i = 1; i < 3; ++i) {
+        zmin = std::min(zmin, zs[i]);
+        zmax = std::max(zmax, zs[i]);
+    }
+    if (zmin <= 0)
+        return false;
+    return static_cast<float>(zmax) / static_cast<float>(zmin) > tolerance;
+}
+
+void emitTriDirect(const PsxVertex &a, const PsxVertex &b, const PsxVertex &c,
+                   const MatrixRecord *matrix, bool textured, SubMeshAccumulator &acc,
                    MeshReconstructionStats *statsOut)
 {
-    const bool textured = prim.kind == PrimKind::TexturedTri || prim.kind == PrimKind::TexturedQuad
-                          || prim.kind == PrimKind::Sprite;
-
-    auto vtx = [&](int i) {
+    auto vtx = [&](const PsxVertex &pv) {
         bool usedGte = false;
-        ReconstructedVertex out = vertexFromPsx(prim.verts[i], matrix, textured, &usedGte);
+        ReconstructedVertex out = vertexFromPsx(pv, matrix, textured, &usedGte);
         if (statsOut)
             accumulateVertexStats(out, *statsOut, usedGte);
         return out;
     };
+    acc.addTriangle(vtx(a), vtx(b), vtx(c));
+}
+
+/** Recursive midpoint subdivision: when the triangle's depth ratio exceeds
+ *  `tolerance`, split into 4 sub-tris via edge midpoints and recurse.
+ *  New midpoint vertices' UVs are computed via screen-space linear interp
+ *  (the PS1 affine convention) so Ogre's perspective-correct rendering of
+ *  the resulting fine mesh approximates what the original PS1 GPU showed.
+ *  Bounded by `maxDepth` so a single very-warped prim can't blow up to
+ *  thousands of tris (4^3 = 64 sub-tris at the default depth=3). */
+void emitTriSubdivided(const PsxVertex &a, const PsxVertex &b, const PsxVertex &c,
+                       const MatrixRecord *matrix, bool textured, SubMeshAccumulator &acc,
+                       MeshReconstructionStats *statsOut, float tolerance, int remainingDepth)
+{
+    if (remainingDepth <= 0 || !depthRatioExceedsTolerance(a, b, c, tolerance)) {
+        emitTriDirect(a, b, c, matrix, textured, acc, statsOut);
+        return;
+    }
+    const PsxVertex ab = midpointPsx(a, b);
+    const PsxVertex bc = midpointPsx(b, c);
+    const PsxVertex ca = midpointPsx(c, a);
+    const int next = remainingDepth - 1;
+    emitTriSubdivided(a,  ab, ca, matrix, textured, acc, statsOut, tolerance, next);
+    emitTriSubdivided(ab, b,  bc, matrix, textured, acc, statsOut, tolerance, next);
+    emitTriSubdivided(ca, bc, c,  matrix, textured, acc, statsOut, tolerance, next);
+    emitTriSubdivided(ab, bc, ca, matrix, textured, acc, statsOut, tolerance, next);
+}
+
+void emitTri(const PsxVertex &a, const PsxVertex &b, const PsxVertex &c,
+             const MatrixRecord *matrix, bool textured, SubMeshAccumulator &acc,
+             MeshReconstructionStats *statsOut, const Ps1NormalizerSettings &settings)
+{
+    if (settings.perspectiveCorrectUVs && settings.perspectiveMaxDepth > 0) {
+        emitTriSubdivided(a, b, c, matrix, textured, acc, statsOut,
+                          settings.perspectiveTolerance, settings.perspectiveMaxDepth);
+        return;
+    }
+    emitTriDirect(a, b, c, matrix, textured, acc, statsOut);
+}
+
+void emitPrimitive(const PrimRecord &prim, const MatrixRecord *matrix, SubMeshAccumulator &acc,
+                   MeshReconstructionStats *statsOut, const Ps1NormalizerSettings &settings)
+{
+    const bool textured = prim.kind == PrimKind::TexturedTri || prim.kind == PrimKind::TexturedQuad
+                          || prim.kind == PrimKind::Sprite;
 
     if (prim.kind == PrimKind::MonoTri || prim.kind == PrimKind::ShadedTri
         || prim.kind == PrimKind::TexturedTri) {
         if (prim.vertexCount >= 3)
-            acc.addTriangle(vtx(0), vtx(1), vtx(2));
+            emitTri(prim.verts[0], prim.verts[1], prim.verts[2], matrix, textured, acc,
+                    statsOut, settings);
         return;
     }
 
     if (prim.kind == PrimKind::MonoQuad || prim.kind == PrimKind::ShadedQuad
         || prim.kind == PrimKind::TexturedQuad) {
         if (prim.vertexCount >= 4) {
-            acc.addTriangle(vtx(0), vtx(1), vtx(2));
-            acc.addTriangle(vtx(0), vtx(2), vtx(3));
+            emitTri(prim.verts[0], prim.verts[1], prim.verts[2], matrix, textured, acc,
+                    statsOut, settings);
+            emitTri(prim.verts[0], prim.verts[2], prim.verts[3], matrix, textured, acc,
+                    statsOut, settings);
         }
         return;
     }
 
     if (prim.kind == PrimKind::Sprite && prim.vertexCount >= 2) {
+        // Sprites are screen-aligned billboards (no depth variance across the
+        // pair), so subdivision is a no-op for them — we keep the original
+        // 2-tri expansion. The pinned 0.05f py offset stays because the
+        // captured pair lacks the second pair of corners.
+        auto vtx = [&](int i) {
+            bool usedGte = false;
+            ReconstructedVertex out = vertexFromPsx(prim.verts[i], matrix, textured, &usedGte);
+            if (statsOut)
+                accumulateVertexStats(out, *statsOut, usedGte);
+            return out;
+        };
         ReconstructedVertex a = vtx(0);
         ReconstructedVertex b = vtx(1);
         ReconstructedVertex c = b;
@@ -150,7 +244,8 @@ void emitPrimitive(const PrimRecord &prim, const MatrixRecord *matrix, SubMeshAc
 }
 
 QHash<uint32_t, QHash<quint64, SubMeshAccumulator>> buildMatrixGroups(const CaptureSnapshot &snapshot,
-                                                                    MeshReconstructionStats *statsOut)
+                                                                    MeshReconstructionStats *statsOut,
+                                                                    const Ps1NormalizerSettings &settings)
 {
     QHash<uint32_t, QHash<quint64, SubMeshAccumulator>> groupsByMatrix;
 
@@ -176,7 +271,7 @@ QHash<uint32_t, QHash<quint64, SubMeshAccumulator>> buildMatrixGroups(const Capt
         if (acc.materialName.isEmpty())
             acc.materialName = MeshReconstructor::textureMaterialName(
                 prim.tpage, prim.clut, prim.semiTrans, prim.drawModeBits);
-        emitPrimitive(prim, matrix, acc, statsOut);
+        emitPrimitive(prim, matrix, acc, statsOut, settings);
     }
     if (statsOut)
         statsOut->finalizeSlabMetric();
@@ -206,11 +301,12 @@ ReconstructedMesh meshFromMatrixGroup(uint32_t matrixId,
 }
 
 QVector<ReconstructedMesh> buildParts(const CaptureSnapshot &snapshot,
-                                      MeshReconstructionStats *statsOut)
+                                      MeshReconstructionStats *statsOut,
+                                      const Ps1NormalizerSettings &settings)
 {
     QVector<ReconstructedMesh> parts;
     const QHash<uint32_t, QHash<quint64, SubMeshAccumulator>> groupsByMatrix =
-        buildMatrixGroups(snapshot, statsOut);
+        buildMatrixGroups(snapshot, statsOut, settings);
 
     for (auto matIt = groupsByMatrix.constBegin(); matIt != groupsByMatrix.constEnd(); ++matIt) {
         ReconstructedMesh part = meshFromMatrixGroup(matIt.key(), matIt.value());
@@ -280,21 +376,29 @@ quint64 MeshReconstructor::textureGroupKey(uint16_t tpage, uint16_t clut, uint8_
 
 ReconstructedMesh MeshReconstructor::reconstruct(const CaptureSnapshot &snapshot)
 {
-    return flattenParts(buildParts(snapshot, nullptr));
+    return flattenParts(buildParts(snapshot, nullptr, Ps1NormalizerSettings{}));
 }
 
 ReconstructedCaptureSet MeshReconstructor::reconstructDeduped(const CaptureSnapshot &snapshot,
                                                             MeshDedupeMode dedupeMode)
 {
-    return reconstructDeduped(snapshot, dedupeMode, nullptr);
+    return reconstructDeduped(snapshot, dedupeMode, Ps1NormalizerSettings{}, nullptr);
 }
 
 ReconstructedCaptureSet MeshReconstructor::reconstructDeduped(const CaptureSnapshot &snapshot,
                                                             MeshDedupeMode dedupeMode,
                                                             MeshReconstructionStats *statsOut)
 {
+    return reconstructDeduped(snapshot, dedupeMode, Ps1NormalizerSettings{}, statsOut);
+}
+
+ReconstructedCaptureSet MeshReconstructor::reconstructDeduped(const CaptureSnapshot &snapshot,
+                                                            MeshDedupeMode dedupeMode,
+                                                            const Ps1NormalizerSettings &normalize,
+                                                            MeshReconstructionStats *statsOut)
+{
     ReconstructedCaptureSet result;
-    const QVector<ReconstructedMesh> parts = buildParts(snapshot, statsOut);
+    const QVector<ReconstructedMesh> parts = buildParts(snapshot, statsOut, normalize);
     result.capturedPartCount = parts.size();
     if (parts.isEmpty())
         return result;

--- a/src/PS1/runtime/MeshReconstructor.cpp
+++ b/src/PS1/runtime/MeshReconstructor.cpp
@@ -187,7 +187,11 @@ void emitTri(const PsxVertex &a, const PsxVertex &b, const PsxVertex &c,
              const MatrixRecord *matrix, bool textured, SubMeshAccumulator &acc,
              MeshReconstructionStats *statsOut, const Ps1NormalizerSettings &settings)
 {
-    if (settings.perspectiveCorrectUVs && settings.perspectiveMaxDepth > 0) {
+    // Perspective-correct subdivision exists to reproduce PS1 affine UV
+    // sampling at fine grain. There's no UV channel on mono / shaded prims
+    // (HUDs, flat-shaded geometry), so tessellating them would just inflate
+    // triangle counts without changing the visual — skip them.
+    if (textured && settings.perspectiveCorrectUVs && settings.perspectiveMaxDepth > 0) {
         emitTriSubdivided(a, b, c, matrix, textured, acc, statsOut,
                           settings.perspectiveTolerance, settings.perspectiveMaxDepth);
         return;

--- a/src/PS1/runtime/MeshReconstructor.h
+++ b/src/PS1/runtime/MeshReconstructor.h
@@ -3,6 +3,7 @@
 
 #include "CaptureSnapshot.h"
 #include "MeshReconstructionStats.h"
+#include "Ps1CoordinateNormalizer.h"
 #include "ReconstructedMesh.h"
 
 #include <QString>
@@ -43,6 +44,17 @@ public:
                                                       MeshDedupeMode dedupeMode);
     static ReconstructedCaptureSet reconstructDeduped(const CaptureSnapshot &snapshot,
                                                       MeshDedupeMode dedupeMode,
+                                                      MeshReconstructionStats *statsOut);
+    /** Variant that honours the user's normalizer settings (#424). When
+     *  `normalize.perspectiveCorrectUVs` is true, screen-space prims whose
+     *  vertex-depth ratio exceeds `normalize.perspectiveTolerance` are
+     *  subdivided via midpoint triangulation (recursion capped at
+     *  `normalize.perspectiveMaxDepth`). The per-axis flip / userScale fields
+     *  are applied via SceneNode scale by `PS1RipMeshBuilder`, not by this
+     *  reconstructor — they don't affect the mesh data. */
+    static ReconstructedCaptureSet reconstructDeduped(const CaptureSnapshot &snapshot,
+                                                      MeshDedupeMode dedupeMode,
+                                                      const Ps1NormalizerSettings &normalize,
                                                       MeshReconstructionStats *statsOut);
 };
 

--- a/src/PS1/runtime/MeshReconstructor_test.cpp
+++ b/src/PS1/runtime/MeshReconstructor_test.cpp
@@ -137,3 +137,100 @@ TEST(MeshReconstructorTest, KeepsPartiallyOnScreenPrimitives)
     EXPECT_FALSE(mesh.isEmpty());
     EXPECT_EQ(mesh.triangleCount, 1);
 }
+
+// #424 acceptance: with perspective-correct UVs ON, a textured quad whose
+// vertex depths vary by more than the tolerance gets subdivided into a
+// fan of smaller triangles. New midpoint UVs follow the PS1 affine
+// convention so Ogre's perspective-correct rendering reproduces the
+// artist's intent — the "warped quad fix" used by modern PSX remasters.
+TEST(MeshReconstructorTest, PerspectiveCorrectSubdivisionTessellatesWarpedQuad)
+{
+    CaptureSnapshot snap;
+    snap.matrices.append(identityMatrix());
+
+    PrimRecord warped{};
+    warped.kind = PrimKind::TexturedQuad;
+    warped.vertexCount = 4;
+    warped.matrixId = 0;
+    warped.tpage = 0x100;
+    warped.clut = 0x200;
+    // A receding wall: near corners at z=200, far corners at z=2000 — a 10x
+    // depth ratio, well above the default 1.3 tolerance. Linear UV ramp 0..1
+    // along the depth axis is the canonical "warpy texture" PS1 case.
+    warped.verts[0] = {40,  60, 200,  255, 255, 255, 0,   0};
+    warped.verts[1] = {200, 60, 2000, 255, 255, 255, 255, 0};
+    warped.verts[2] = {200, 180, 2000, 255, 255, 255, 255, 255};
+    warped.verts[3] = {40,  180, 200, 255, 255, 255, 0,   255};
+    snap.prims.append(warped);
+
+    // Baseline: no subdivision → 2 triangles per quad.
+    const ReconstructedCaptureSet noPC = MeshReconstructor::reconstructDeduped(
+        snap, MeshDedupeMode::Loose, Ps1NormalizerSettings{}, nullptr);
+    int baselineTris = 0;
+    for (const auto &m : noPC.uniqueMeshes) baselineTris += m.triangleCount;
+    EXPECT_EQ(baselineTris, 2);
+
+    // Perspective-correct ON: every input tri whose depth ratio > tolerance
+    // gets split into 4. At depth=3 with a 10x z-ratio, recursion fires all
+    // the way down so each input tri becomes ~64 sub-tris (128 total).
+    Ps1NormalizerSettings pc;
+    pc.perspectiveCorrectUVs = true;
+    pc.perspectiveTolerance = 1.3f;
+    pc.perspectiveMaxDepth = 3;
+    const ReconstructedCaptureSet withPC = MeshReconstructor::reconstructDeduped(
+        snap, MeshDedupeMode::Loose, pc, nullptr);
+    int pcTris = 0;
+    for (const auto &m : withPC.uniqueMeshes) pcTris += m.triangleCount;
+    EXPECT_GT(pcTris, baselineTris);
+    EXPECT_LE(pcTris, 2 * 64); // recursion is depth-bounded — can't blow up unboundedly
+}
+
+// Companion: when perspective-correct is on but the prim has uniform depth
+// (e.g. a flat HUD or near-camera billboard), subdivision should be a no-op.
+TEST(MeshReconstructorTest, PerspectiveCorrectKeepsFlatPrimsUntouched)
+{
+    CaptureSnapshot snap;
+    snap.matrices.append(identityMatrix());
+    PrimRecord flat{};
+    flat.kind = PrimKind::TexturedQuad;
+    flat.vertexCount = 4;
+    flat.matrixId = 0;
+    flat.tpage = 0x100;
+    flat.clut = 0x200;
+    flat.verts[0] = {40,  60,  500, 255, 255, 255, 0, 0};
+    flat.verts[1] = {200, 60,  500, 255, 255, 255, 0, 0};
+    flat.verts[2] = {200, 180, 500, 255, 255, 255, 0, 0};
+    flat.verts[3] = {40,  180, 500, 255, 255, 255, 0, 0};
+    snap.prims.append(flat);
+
+    Ps1NormalizerSettings pc;
+    pc.perspectiveCorrectUVs = true;
+    const ReconstructedCaptureSet result = MeshReconstructor::reconstructDeduped(
+        snap, MeshDedupeMode::Loose, pc, nullptr);
+    int tris = 0;
+    for (const auto &m : result.uniqueMeshes) tris += m.triangleCount;
+    EXPECT_EQ(tris, 2);
+}
+
+// Perspective-correct must gracefully handle GP0-only captures where sz=0
+// for every vertex (the #675 "no depth" path). Subdivision is skipped — no
+// way to compute a meaningful depth ratio — and the prim renders as-is.
+TEST(MeshReconstructorTest, PerspectiveCorrectGracefullyHandlesZeroDepth)
+{
+    CaptureSnapshot snap;
+    snap.matrices.append(identityMatrix());
+    PrimRecord prim = coloredTri(16, 16, 0);
+    // coloredTri already sets z=0 on each vertex; assert defensively in case
+    // the helper's defaults change.
+    for (int i = 0; i < 3; ++i)
+        ASSERT_EQ(prim.verts[i].z, 0);
+    snap.prims.append(prim);
+
+    Ps1NormalizerSettings pc;
+    pc.perspectiveCorrectUVs = true;
+    const ReconstructedCaptureSet result = MeshReconstructor::reconstructDeduped(
+        snap, MeshDedupeMode::Loose, pc, nullptr);
+    int tris = 0;
+    for (const auto &m : result.uniqueMeshes) tris += m.triangleCount;
+    EXPECT_EQ(tris, 1);
+}

--- a/src/PS1/runtime/MeshReconstructor_test.cpp
+++ b/src/PS1/runtime/MeshReconstructor_test.cpp
@@ -212,6 +212,34 @@ TEST(MeshReconstructorTest, PerspectiveCorrectKeepsFlatPrimsUntouched)
     EXPECT_EQ(tris, 2);
 }
 
+// Perspective-correct subdivision only makes sense for textured prims —
+// mono / shaded prims have no UV channel, so subdividing them just inflates
+// triangle counts without changing the visual. Verify a high-depth-variance
+// MONO prim with the toggle ON stays a single triangle (CodeRabbit Major on
+// the original #424 PR).
+TEST(MeshReconstructorTest, PerspectiveCorrectSkipsMonoPrims)
+{
+    CaptureSnapshot snap;
+    snap.matrices.append(identityMatrix());
+    PrimRecord mono{};
+    mono.kind = PrimKind::MonoTri;
+    mono.vertexCount = 3;
+    mono.matrixId = 0;
+    // High depth variance — would trigger subdivision if the gate were absent.
+    mono.verts[0] = {40,  60,  200,  255, 0, 0, 0, 0};
+    mono.verts[1] = {200, 60,  2000, 0, 255, 0, 0, 0};
+    mono.verts[2] = {120, 180, 1000, 0, 0, 255, 0, 0};
+    snap.prims.append(mono);
+
+    Ps1NormalizerSettings pc;
+    pc.perspectiveCorrectUVs = true;
+    const ReconstructedCaptureSet result = MeshReconstructor::reconstructDeduped(
+        snap, MeshDedupeMode::Loose, pc, nullptr);
+    int tris = 0;
+    for (const auto &m : result.uniqueMeshes) tris += m.triangleCount;
+    EXPECT_EQ(tris, 1);
+}
+
 // Perspective-correct must gracefully handle GP0-only captures where sz=0
 // for every vertex (the #675 "no depth" path). Subdivision is skipped — no
 // way to compute a meaningful depth ratio — and the prim renders as-is.
@@ -219,11 +247,20 @@ TEST(MeshReconstructorTest, PerspectiveCorrectGracefullyHandlesZeroDepth)
 {
     CaptureSnapshot snap;
     snap.matrices.append(identityMatrix());
-    PrimRecord prim = coloredTri(16, 16, 0);
-    // coloredTri already sets z=0 on each vertex; assert defensively in case
-    // the helper's defaults change.
-    for (int i = 0; i < 3; ++i)
-        ASSERT_EQ(prim.verts[i].z, 0);
+    // Textured prim so the depth-variance gate is reached (the textured-only
+    // gate above only short-circuits mono / shaded prims). z=0 on all three
+    // vertices simulates the GP0-only capture case (#675) — no usable depth
+    // for the depth-ratio test, so subdivision must skip cleanly without
+    // dividing by zero or emitting a degenerate sub-triangle.
+    PrimRecord prim{};
+    prim.kind = PrimKind::TexturedTri;
+    prim.vertexCount = 3;
+    prim.matrixId = 0;
+    prim.tpage = 0x100;
+    prim.clut = 0x200;
+    prim.verts[0] = {16,  16, 0, 255, 255, 255, 0, 0};
+    prim.verts[1] = {48,  16, 0, 255, 255, 255, 255, 0};
+    prim.verts[2] = {32,  48, 0, 255, 255, 255, 128, 255};
     snap.prims.append(prim);
 
     Ps1NormalizerSettings pc;

--- a/src/PS1/runtime/PS1RipManager.cpp
+++ b/src/PS1/runtime/PS1RipManager.cpp
@@ -6,6 +6,7 @@
 #include "MeshTopologyHash.h"
 #include "PS1RipMeshBuilder.h"
 #include "PS1RipWorker.h"
+#include "Ps1CoordinateNormalizer.h"
 #include "PsxBiosValidator.h"
 #include "PsxDiscResolver.h"
 #include "PsxGoldenCapture.h"
@@ -48,6 +49,21 @@ QString PS1RipManager::goldenSceneId() const
     if (!m_goldenSceneId.isEmpty())
         return m_goldenSceneId;
     return PsxGoldenCapture::activeSceneId();
+}
+
+void PS1RipManager::setNormalizerSettings(const Ps1NormalizerSettings &settings)
+{
+    m_normalize = settings;
+    // Per-axis flip + userScale are SceneNode-level — apply immediately to
+    // every existing PS1Capture_* node so the user sees the change without
+    // re-capturing (#424 acceptance criterion). perspectiveCorrectUVs is
+    // baked into mesh data, so it only takes effect on the next capture.
+    const int touched = Ps1CoordinateNormalizer::applyToCaptureNodes(m_normalize);
+    SentryReporter::addBreadcrumb(
+        QStringLiteral("ps1.rip.coord.normalize"),
+        QStringLiteral("settings=%1 touched=%2")
+            .arg(Ps1CoordinateNormalizer::describe(m_normalize))
+            .arg(touched));
 }
 
 void PS1RipManager::setGoldenSceneId(const QString &sceneId)
@@ -122,7 +138,8 @@ void PS1RipManager::initializeWorkerThread()
                     m_dedupeStrict ? MeshDedupeMode::Strict : MeshDedupeMode::Loose;
                 MeshReconstructionStats reconStats;
                 const ReconstructedCaptureSet captureSet =
-                    MeshReconstructor::reconstructDeduped(snapshot, dedupeMode, &reconStats);
+                    MeshReconstructor::reconstructDeduped(snapshot, dedupeMode, m_normalize,
+                                                          &reconStats);
                 if (captureSet.isEmpty()) {
                     reportError(tr("Capture produced no reconstructable geometry"));
                     return;
@@ -132,7 +149,7 @@ void PS1RipManager::initializeWorkerThread()
                 QString buildErr;
                 try {
                     if (!PS1RipMeshBuilder::attachCaptureSetToScene(captureSet, captureId, &snapshot,
-                                                                    &built, &buildErr)) {
+                                                                    &built, &buildErr, m_normalize)) {
                         reportError(buildErr.isEmpty() ? tr("Failed to build capture mesh")
                                                      : buildErr);
                         return;

--- a/src/PS1/runtime/PS1RipManager.h
+++ b/src/PS1/runtime/PS1RipManager.h
@@ -2,6 +2,7 @@
 #define PS1RIPMANAGER_H
 
 #include "Gp0CaptureStats.h"
+#include "Ps1CoordinateNormalizer.h"
 
 #include <QImage>
 #include <QObject>
@@ -50,6 +51,14 @@ public:
     bool dedupeStrict() const { return m_dedupeStrict; }
     void setDedupeStrict(bool strict) { m_dedupeStrict = strict; }
 
+    /** Coordinate normalization knobs (#424). userScale + per-axis flips are
+     *  applied as SceneNode scale at attach time and re-applied to existing
+     *  capture nodes on every setter call, so the user sees changes live
+     *  without re-capturing. Perspective-correct UVs is consumed by the next
+     *  mesh build (it bakes into the mesh data — can't be a SceneNode toggle). */
+    const Ps1NormalizerSettings &normalizerSettings() const { return m_normalize; }
+    void setNormalizerSettings(const Ps1NormalizerSettings &settings);
+
     QString goldenSceneId() const;
     void setGoldenSceneId(const QString &sceneId);
 
@@ -94,6 +103,7 @@ private:
     bool m_paused = false;
     bool m_captureArmed = false;
     bool m_dedupeStrict = false;
+    Ps1NormalizerSettings m_normalize;
     QString m_goldenSceneId;
 
     QThread *m_workerThread = nullptr;

--- a/src/PS1/runtime/PS1RipMeshBuilder.cpp
+++ b/src/PS1/runtime/PS1RipMeshBuilder.cpp
@@ -588,7 +588,8 @@ bool PS1RipMeshBuilder::attachToScene(const ReconstructedMesh &mesh, const QStri
 bool PS1RipMeshBuilder::attachCaptureSetToScene(const ReconstructedCaptureSet &captureSet,
                                                 const QString &captureId,
                                                 const CaptureSnapshot *textureSource,
-                                                BuildResult *resultOut, QString *errorOut)
+                                                BuildResult *resultOut, QString *errorOut,
+                                                const Ps1NormalizerSettings &normalize)
 {
     if (captureSet.isEmpty()) {
         if (errorOut)
@@ -666,7 +667,15 @@ bool PS1RipMeshBuilder::attachCaptureSetToScene(const ReconstructedCaptureSet &c
             createdNodeNames.append(nodeName);
             node->setPosition(inst.px * placementScale, inst.py * placementScale,
                               inst.pz * placementScale);
-            node->setScale(placementScale, placementScale, placementScale);
+            // Stash the auto-fit scale on the node so live normalizer tweaks
+            // (Ps1CoordinateNormalizer::applyToCaptureNodes) can recompose
+            // (placementScale × userScale × per-axis sign) without losing
+            // the original fit-to-target-extent normalization (#424).
+            node->getUserObjectBindings().setUserAny(
+                "ps1RipPlacementScale", Ogre::Any(placementScale));
+            node->setScale(placementScale * normalize.userScale * normalize.signX(),
+                           placementScale * normalize.userScale * normalize.signY(),
+                           placementScale * normalize.userScale * normalize.signZ());
 
             Ogre::Entity *entity = mgr->createEntity(node, ogreMesh);
             if (!entity) {

--- a/src/PS1/runtime/PS1RipMeshBuilder.cpp
+++ b/src/PS1/runtime/PS1RipMeshBuilder.cpp
@@ -665,17 +665,23 @@ bool PS1RipMeshBuilder::attachCaptureSetToScene(const ReconstructedCaptureSet &c
                 QStringLiteral("PS1Capture_%1_inst%2").arg(captureId).arg(instanceOrdinal++);
             Ogre::SceneNode *node = mgr->addSceneNode(nodeName);
             createdNodeNames.append(nodeName);
-            node->setPosition(inst.px * placementScale, inst.py * placementScale,
-                              inst.pz * placementScale);
-            // Stash the auto-fit scale on the node so live normalizer tweaks
-            // (Ps1CoordinateNormalizer::applyToCaptureNodes) can recompose
-            // (placementScale × userScale × per-axis sign) without losing
-            // the original fit-to-target-extent normalization (#424).
+            // Stash the auto-fit scale + raw capture-time position on the node
+            // so live normalizer tweaks (Ps1CoordinateNormalizer::applyToCaptureNodes)
+            // can recompose both transforms (placementScale × userScale × per-axis
+            // sign for scale; same factor × base position for position) without
+            // losing the auto-fit and without letting multi-instance layouts drift
+            // when the user toggles a flip / changes scale (#424).
             node->getUserObjectBindings().setUserAny(
                 "ps1RipPlacementScale", Ogre::Any(placementScale));
-            node->setScale(placementScale * normalize.userScale * normalize.signX(),
-                           placementScale * normalize.userScale * normalize.signY(),
-                           placementScale * normalize.userScale * normalize.signZ());
+            node->getUserObjectBindings().setUserAny(
+                "ps1RipBasePosition", Ogre::Any(Ogre::Vector3(inst.px, inst.py, inst.pz)));
+
+            float scaleOut[3];
+            float posOut[3];
+            Ps1CoordinateNormalizer::composeNodeTransform(
+                normalize, placementScale, inst.px, inst.py, inst.pz, scaleOut, posOut);
+            node->setScale(scaleOut[0], scaleOut[1], scaleOut[2]);
+            node->setPosition(posOut[0], posOut[1], posOut[2]);
 
             Ogre::Entity *entity = mgr->createEntity(node, ogreMesh);
             if (!entity) {

--- a/src/PS1/runtime/PS1RipMeshBuilder.h
+++ b/src/PS1/runtime/PS1RipMeshBuilder.h
@@ -3,6 +3,7 @@
 
 #include "CaptureSnapshot.h"
 #include "MeshReconstructor.h"
+#include "Ps1CoordinateNormalizer.h"
 
 #include <QString>
 
@@ -26,11 +27,14 @@ public:
                               const CaptureSnapshot *textureSource, BuildResult *resultOut,
                               QString *errorOut = nullptr);
 
-    /** Places deduplicated meshes with one SceneNode per instance (#423). */
+    /** Places deduplicated meshes with one SceneNode per instance (#423).
+     *  Applies `normalize` as SceneNode scale on each newly created capture
+     *  node so the user's flip/scale settings take effect immediately (#424). */
     static bool attachCaptureSetToScene(const ReconstructedCaptureSet &captureSet,
                                         const QString &captureId,
                                         const CaptureSnapshot *textureSource, BuildResult *resultOut,
-                                        QString *errorOut = nullptr);
+                                        QString *errorOut = nullptr,
+                                        const Ps1NormalizerSettings &normalize = {});
 };
 
 #endif // PS1RIPMESHBUILDER_H

--- a/src/PS1/runtime/PS1RipSessionWindow.cpp
+++ b/src/PS1/runtime/PS1RipSessionWindow.cpp
@@ -299,12 +299,34 @@ void PS1RipSessionWindow::createNormalizerDock()
     // nodes pick them up immediately on session resume.
     m_manager->setNormalizerSettings(persisted);
 
-    auto onChanged = [this]() { pushNormalizerSettings(); };
-    connect(m_normalizeScaleSpin, qOverload<double>(&QDoubleSpinBox::valueChanged), this, onChanged);
-    connect(m_normalizeFlipX, &QCheckBox::toggled, this, onChanged);
-    connect(m_normalizeFlipY, &QCheckBox::toggled, this, onChanged);
-    connect(m_normalizeFlipZ, &QCheckBox::toggled, this, onChanged);
-    connect(m_normalizePerspectiveUV, &QCheckBox::toggled, this, onChanged);
+    // Per-control ui.action breadcrumbs so telemetry distinguishes a direct
+    // user gesture from the downstream ps1.rip.coord.normalize emitted by the
+    // manager (CodeRabbit Minor on the original #424 PR). The lambda captures
+    // the breadcrumb message by value so each connect picks the right one.
+    auto onChanged = [this](const QString &msg) {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"), msg);
+        pushNormalizerSettings();
+    };
+    connect(m_normalizeScaleSpin, qOverload<double>(&QDoubleSpinBox::valueChanged), this,
+            [this, onChanged](double v) {
+                onChanged(QStringLiteral("ps1_rip_normalize_scale_changed=%1").arg(v, 0, 'g', 4));
+            });
+    connect(m_normalizeFlipX, &QCheckBox::toggled, this, [onChanged](bool on) {
+        onChanged(on ? QStringLiteral("ps1_rip_normalize_flip_x_on")
+                     : QStringLiteral("ps1_rip_normalize_flip_x_off"));
+    });
+    connect(m_normalizeFlipY, &QCheckBox::toggled, this, [onChanged](bool on) {
+        onChanged(on ? QStringLiteral("ps1_rip_normalize_flip_y_on")
+                     : QStringLiteral("ps1_rip_normalize_flip_y_off"));
+    });
+    connect(m_normalizeFlipZ, &QCheckBox::toggled, this, [onChanged](bool on) {
+        onChanged(on ? QStringLiteral("ps1_rip_normalize_flip_z_on")
+                     : QStringLiteral("ps1_rip_normalize_flip_z_off"));
+    });
+    connect(m_normalizePerspectiveUV, &QCheckBox::toggled, this, [onChanged](bool on) {
+        onChanged(on ? QStringLiteral("ps1_rip_normalize_perspective_uv_on")
+                     : QStringLiteral("ps1_rip_normalize_perspective_uv_off"));
+    });
 }
 
 void PS1RipSessionWindow::pushNormalizerSettings()

--- a/src/PS1/runtime/PS1RipSessionWindow.cpp
+++ b/src/PS1/runtime/PS1RipSessionWindow.cpp
@@ -4,6 +4,7 @@
 #include "PS1RipInputSettingsDialog.h"
 #include "PS1RipLegalityDialog.h"
 #include "PS1RipManager.h"
+#include "Ps1CoordinateNormalizer.h"
 #include "PsxJoypadBindings.h"
 #include "SentryReporter.h"
 #include "PsxJoypadState.h"
@@ -16,8 +17,11 @@
 #include <QCloseEvent>
 #include <QDateTime>
 #include <QDockWidget>
+#include <QDoubleSpinBox>
 #include <QFileDialog>
 #include <QFileInfo>
+#include <QFormLayout>
+#include <QGroupBox>
 #include <QMenu>
 #include <QTimer>
 #include <QLabel>
@@ -28,6 +32,8 @@
 #include <QMenuBar>
 #include <QToolBar>
 #include <QToolButton>
+#include <QVBoxLayout>
+#include <QWidget>
 
 namespace {
 constexpr auto kSettingsGroup = "ps1Rip";
@@ -37,6 +43,7 @@ constexpr auto kDedupeStrictKey = "dedupeStrict";
 constexpr auto kViewportIntegerScaleKey = "viewportIntegerScale";
 constexpr auto kViewportSmoothFilterKey = "viewportSmoothFilter";
 constexpr auto kViewportAspect43Key = "viewportAspect43";
+constexpr auto kNormalizePrefix = "ps1Rip/normalize";
 
 QString ps1SettingsKey(const char *name)
 {
@@ -171,6 +178,8 @@ PS1RipSessionWindow::PS1RipSessionWindow(QWidget *parent)
     vramDock->setMinimumHeight(220);
     addDockWidget(Qt::BottomDockWidgetArea, vramDock);
 
+    createNormalizerDock();
+
     m_statusLabel = new QLabel(this);
     statusBar()->addPermanentWidget(m_statusLabel);
 
@@ -227,6 +236,92 @@ PS1RipSessionWindow::~PS1RipSessionWindow()
         m_manager->stop();
     SentryReporter::addBreadcrumb(QStringLiteral("ps1.rip.viewport.close"),
                                 QStringLiteral("PS1 rip session window closed"));
+}
+
+void PS1RipSessionWindow::createNormalizerDock()
+{
+    QSettings qs;
+    const Ps1NormalizerSettings persisted =
+        Ps1CoordinateNormalizer::load(qs, QString::fromLatin1(kNormalizePrefix));
+
+    auto *dock = new QDockWidget(tr("Normalize"), this);
+    auto *body = new QWidget(dock);
+    auto *layout = new QVBoxLayout(body);
+    layout->setContentsMargins(8, 8, 8, 8);
+
+    auto *form = new QFormLayout();
+    form->setContentsMargins(0, 0, 0, 0);
+
+    m_normalizeScaleSpin = new QDoubleSpinBox(body);
+    m_normalizeScaleSpin->setRange(0.001, 1000.0);
+    m_normalizeScaleSpin->setDecimals(4);
+    m_normalizeScaleSpin->setSingleStep(0.1);
+    m_normalizeScaleSpin->setValue(persisted.userScale);
+    m_normalizeScaleSpin->setToolTip(
+        tr("Multiplier on top of the built-in capture scale.\n"
+           "1.0 = default magnitude (~FBX/glTF scale). 0.024 ≈ PSX-native (1/4096)."));
+    form->addRow(tr("Scale:"), m_normalizeScaleSpin);
+
+    auto *flipBox = new QGroupBox(tr("Flip axes"), body);
+    auto *flipLayout = new QVBoxLayout(flipBox);
+    flipLayout->setContentsMargins(8, 4, 8, 4);
+    m_normalizeFlipX = new QCheckBox(tr("Flip X"), flipBox);
+    m_normalizeFlipY = new QCheckBox(tr("Flip Y"), flipBox);
+    m_normalizeFlipZ = new QCheckBox(tr("Flip Z"), flipBox);
+    m_normalizeFlipX->setChecked(persisted.flipX);
+    m_normalizeFlipY->setChecked(persisted.flipY);
+    m_normalizeFlipZ->setChecked(persisted.flipZ);
+    m_normalizeFlipX->setToolTip(tr("Mirror around X. Ogre auto-flips winding for negative-determinant scale."));
+    m_normalizeFlipY->setToolTip(tr("Mirror around Y. Useful for games with unconventional up axis."));
+    m_normalizeFlipZ->setToolTip(tr("Mirror around Z. Combine with another axis to keep CCW winding."));
+    flipLayout->addWidget(m_normalizeFlipX);
+    flipLayout->addWidget(m_normalizeFlipY);
+    flipLayout->addWidget(m_normalizeFlipZ);
+
+    m_normalizePerspectiveUV = new QCheckBox(tr("Perspective-correct UVs"), body);
+    m_normalizePerspectiveUV->setChecked(persisted.perspectiveCorrectUVs);
+    m_normalizePerspectiveUV->setToolTip(
+        tr("Subdivide triangles with high depth variance and recompute affine\n"
+           "UVs at midpoints — the classic warped-quad fix used in modern PSX\n"
+           "remasters. Takes effect on the next capture (mesh data only)."));
+
+    layout->addLayout(form);
+    layout->addWidget(flipBox);
+    layout->addWidget(m_normalizePerspectiveUV);
+    layout->addStretch(1);
+
+    body->setLayout(layout);
+    dock->setWidget(body);
+    dock->setMinimumWidth(180);
+    addDockWidget(Qt::RightDockWidgetArea, dock);
+
+    // Push the loaded settings now so the manager + any existing capture
+    // nodes pick them up immediately on session resume.
+    m_manager->setNormalizerSettings(persisted);
+
+    auto onChanged = [this]() { pushNormalizerSettings(); };
+    connect(m_normalizeScaleSpin, qOverload<double>(&QDoubleSpinBox::valueChanged), this, onChanged);
+    connect(m_normalizeFlipX, &QCheckBox::toggled, this, onChanged);
+    connect(m_normalizeFlipY, &QCheckBox::toggled, this, onChanged);
+    connect(m_normalizeFlipZ, &QCheckBox::toggled, this, onChanged);
+    connect(m_normalizePerspectiveUV, &QCheckBox::toggled, this, onChanged);
+}
+
+void PS1RipSessionWindow::pushNormalizerSettings()
+{
+    Ps1NormalizerSettings s;
+    if (m_normalizeScaleSpin)
+        s.userScale = static_cast<float>(m_normalizeScaleSpin->value());
+    if (m_normalizeFlipX) s.flipX = m_normalizeFlipX->isChecked();
+    if (m_normalizeFlipY) s.flipY = m_normalizeFlipY->isChecked();
+    if (m_normalizeFlipZ) s.flipZ = m_normalizeFlipZ->isChecked();
+    if (m_normalizePerspectiveUV)
+        s.perspectiveCorrectUVs = m_normalizePerspectiveUV->isChecked();
+
+    QSettings qs;
+    Ps1CoordinateNormalizer::save(qs, QString::fromLatin1(kNormalizePrefix), s);
+    if (m_manager)
+        m_manager->setNormalizerSettings(s);
 }
 
 void PS1RipSessionWindow::showSession(QWidget *parent)

--- a/src/PS1/runtime/PS1RipSessionWindow.h
+++ b/src/PS1/runtime/PS1RipSessionWindow.h
@@ -8,11 +8,14 @@
 #include <QVector>
 
 class EmuViewport;
+class QCheckBox;
+class QDoubleSpinBox;
 class QLabel;
 class PS1RipGamepadBridge;
 class PS1RipManager;
 class QMenu;
 class VramViewerWidget;
+struct Ps1NormalizerSettings;
 
 enum class PsxVramMirrorMode;
 
@@ -58,6 +61,14 @@ private:
     void addRecentIso(const QString &path);
     void applyIsoPath(const QString &path);
     void rebuildRecentIsoMenu();
+    /** Builds the right-side "Normalize" dock (capture scale, per-axis flip,
+     *  perspective-correct UVs). Each control persists to QSettings under
+     *  `ps1Rip/normalize/*` and pushes the new value to PS1RipManager so the
+     *  user sees the change live without re-capturing (#424). */
+    void createNormalizerDock();
+    /** Snapshot the current dock widget values into a settings struct and
+     *  forward to the manager + QSettings. */
+    void pushNormalizerSettings();
 
     EmuViewport *m_viewport = nullptr;
     VramViewerWidget *m_vramViewer = nullptr;
@@ -65,6 +76,11 @@ private:
     QMenu *m_recentIsoMenu = nullptr;
     PS1RipGamepadBridge *m_gamepadBridge = nullptr;
     PS1RipManager *m_manager = nullptr;
+    QDoubleSpinBox *m_normalizeScaleSpin = nullptr;
+    QCheckBox *m_normalizeFlipX = nullptr;
+    QCheckBox *m_normalizeFlipY = nullptr;
+    QCheckBox *m_normalizeFlipZ = nullptr;
+    QCheckBox *m_normalizePerspectiveUV = nullptr;
     qint64 m_lastFrameMs = 0;
     quint64 m_lastFrameIndex = 0;
     double m_smoothedFps = 0.0;

--- a/src/PS1/runtime/Ps1CoordinateNormalizer.cpp
+++ b/src/PS1/runtime/Ps1CoordinateNormalizer.cpp
@@ -31,29 +31,64 @@ bool Ps1NormalizerSettings::isDefault() const
         && perspectiveMaxDepth == d.perspectiveMaxDepth;
 }
 
+void Ps1CoordinateNormalizer::composeNodeTransform(const Ps1NormalizerSettings &settings,
+                                                   float placementScale,
+                                                   float basePosX, float basePosY, float basePosZ,
+                                                   float outScale[3], float outPosition[3])
+{
+    // Same factor goes into BOTH scale and position so a multi-instance
+    // capture set (deduped buildings, props, etc.) scales / mirrors as one
+    // coherent layout. Scaling only the per-mesh transform while leaving
+    // pivots at attach-time positions left adjacent instances overlapping
+    // at < 1.0 scale and crossing each other on a single-axis flip — the
+    // Codex P1 / CodeRabbit Major finding on the original #424 PR.
+    const float sx = placementScale * settings.userScale * settings.signX();
+    const float sy = placementScale * settings.userScale * settings.signY();
+    const float sz = placementScale * settings.userScale * settings.signZ();
+    outScale[0] = sx;
+    outScale[1] = sy;
+    outScale[2] = sz;
+    outPosition[0] = basePosX * sx;
+    outPosition[1] = basePosY * sy;
+    outPosition[2] = basePosZ * sz;
+}
+
 void Ps1CoordinateNormalizer::applyToSceneNode(Ogre::SceneNode *node,
                                                const Ps1NormalizerSettings &settings)
 {
 #ifdef ENABLE_PS1_RIP
     if (!node)
         return;
-    // PS1RipMeshBuilder stamps the auto-fit-to-target-extent factor here at
-    // attach time. Honouring it lets us recompose (placementScale × userScale
-    // × per-axis sign) without losing the original fit when the user toggles
-    // a flip live (#424).
+    // PS1RipMeshBuilder stamps the auto-fit-to-target-extent factor + the raw
+    // capture-time instance position on the node at attach time. Reading them
+    // back lets us recompose both transforms (scale + position) from a fresh
+    // (userScale × per-axis sign) without losing the original auto-fit or
+    // letting the layout drift when the user toggles a flip live (#424).
     float placementScale = 1.0f;
-    const Ogre::Any &any = node->getUserObjectBindings().getUserAny("ps1RipPlacementScale");
-    if (any.has_value()) {
+    const Ogre::Any &psAny = node->getUserObjectBindings().getUserAny("ps1RipPlacementScale");
+    if (psAny.has_value()) {
         try {
-            placementScale = Ogre::any_cast<float>(any);
+            placementScale = Ogre::any_cast<float>(psAny);
         } catch (const Ogre::Exception &) {
             placementScale = 1.0f;
         }
     }
-    const float sx = placementScale * settings.userScale * settings.signX();
-    const float sy = placementScale * settings.userScale * settings.signY();
-    const float sz = placementScale * settings.userScale * settings.signZ();
-    node->setScale(Ogre::Vector3(sx, sy, sz));
+    Ogre::Vector3 basePos(0.0f, 0.0f, 0.0f);
+    const Ogre::Any &bpAny = node->getUserObjectBindings().getUserAny("ps1RipBasePosition");
+    if (bpAny.has_value()) {
+        try {
+            basePos = Ogre::any_cast<Ogre::Vector3>(bpAny);
+        } catch (const Ogre::Exception &) {
+            basePos = Ogre::Vector3(0.0f, 0.0f, 0.0f);
+        }
+    }
+
+    float scaleOut[3];
+    float posOut[3];
+    composeNodeTransform(settings, placementScale, basePos.x, basePos.y, basePos.z,
+                         scaleOut, posOut);
+    node->setScale(Ogre::Vector3(scaleOut[0], scaleOut[1], scaleOut[2]));
+    node->setPosition(Ogre::Vector3(posOut[0], posOut[1], posOut[2]));
 #else
     (void)node;
     (void)settings;

--- a/src/PS1/runtime/Ps1CoordinateNormalizer.cpp
+++ b/src/PS1/runtime/Ps1CoordinateNormalizer.cpp
@@ -1,0 +1,143 @@
+#include "Ps1CoordinateNormalizer.h"
+
+#include <QSettings>
+#include <QStringList>
+
+#include <cmath>
+
+#ifdef ENABLE_PS1_RIP
+#include "Manager.h"
+#include <Ogre.h>
+#endif
+
+namespace {
+
+constexpr float kEpsilon = 1e-6f;
+
+bool nearlyEqual(float a, float b)
+{
+    return std::fabs(a - b) < kEpsilon;
+}
+
+} // namespace
+
+bool Ps1NormalizerSettings::isDefault() const
+{
+    const Ps1NormalizerSettings d{};
+    return nearlyEqual(userScale, d.userScale)
+        && flipX == d.flipX && flipY == d.flipY && flipZ == d.flipZ
+        && perspectiveCorrectUVs == d.perspectiveCorrectUVs
+        && nearlyEqual(perspectiveTolerance, d.perspectiveTolerance)
+        && perspectiveMaxDepth == d.perspectiveMaxDepth;
+}
+
+void Ps1CoordinateNormalizer::applyToSceneNode(Ogre::SceneNode *node,
+                                               const Ps1NormalizerSettings &settings)
+{
+#ifdef ENABLE_PS1_RIP
+    if (!node)
+        return;
+    // PS1RipMeshBuilder stamps the auto-fit-to-target-extent factor here at
+    // attach time. Honouring it lets us recompose (placementScale × userScale
+    // × per-axis sign) without losing the original fit when the user toggles
+    // a flip live (#424).
+    float placementScale = 1.0f;
+    const Ogre::Any &any = node->getUserObjectBindings().getUserAny("ps1RipPlacementScale");
+    if (any.has_value()) {
+        try {
+            placementScale = Ogre::any_cast<float>(any);
+        } catch (const Ogre::Exception &) {
+            placementScale = 1.0f;
+        }
+    }
+    const float sx = placementScale * settings.userScale * settings.signX();
+    const float sy = placementScale * settings.userScale * settings.signY();
+    const float sz = placementScale * settings.userScale * settings.signZ();
+    node->setScale(Ogre::Vector3(sx, sy, sz));
+#else
+    (void)node;
+    (void)settings;
+#endif
+}
+
+int Ps1CoordinateNormalizer::applyToCaptureNodes(const Ps1NormalizerSettings &settings)
+{
+#ifdef ENABLE_PS1_RIP
+    auto *mgr = Manager::getSingletonPtr();
+    if (!mgr)
+        return 0;
+    int touched = 0;
+    // Snapshot the node list first — applyToSceneNode itself never mutates
+    // the scene graph, but calling Manager APIs while iterating its underlying
+    // container can race with destroy events scheduled by Ogre.
+    const auto nodes = mgr->getSceneNodes();
+    for (Ogre::SceneNode *node : nodes) {
+        if (!node)
+            continue;
+        const QString name = QString::fromStdString(node->getName());
+        if (!name.startsWith(QStringLiteral("PS1Capture_")))
+            continue;
+        applyToSceneNode(node, settings);
+        ++touched;
+    }
+    return touched;
+#else
+    (void)settings;
+    return 0;
+#endif
+}
+
+void Ps1CoordinateNormalizer::save(QSettings &settings, const QString &prefix,
+                                   const Ps1NormalizerSettings &value)
+{
+    settings.setValue(prefix + QStringLiteral("/userScale"), value.userScale);
+    settings.setValue(prefix + QStringLiteral("/flipX"), value.flipX);
+    settings.setValue(prefix + QStringLiteral("/flipY"), value.flipY);
+    settings.setValue(prefix + QStringLiteral("/flipZ"), value.flipZ);
+    settings.setValue(prefix + QStringLiteral("/perspectiveCorrectUVs"), value.perspectiveCorrectUVs);
+    settings.setValue(prefix + QStringLiteral("/perspectiveTolerance"), value.perspectiveTolerance);
+    settings.setValue(prefix + QStringLiteral("/perspectiveMaxDepth"), value.perspectiveMaxDepth);
+}
+
+Ps1NormalizerSettings Ps1CoordinateNormalizer::load(QSettings &settings, const QString &prefix)
+{
+    Ps1NormalizerSettings out;
+    out.userScale = settings.value(prefix + QStringLiteral("/userScale"), out.userScale).toFloat();
+    // Defensive clamp: a corrupted ini file could write 0 or a huge value and
+    // bake invisible / explosively-scaled capture nodes. The slider in the UI
+    // is bounded the same way; we mirror it here so direct-edit ini files
+    // don't bypass the safety net.
+    if (!(out.userScale >= 0.001f && out.userScale <= 1000.0f))
+        out.userScale = 1.0f;
+    out.flipX = settings.value(prefix + QStringLiteral("/flipX"), out.flipX).toBool();
+    out.flipY = settings.value(prefix + QStringLiteral("/flipY"), out.flipY).toBool();
+    out.flipZ = settings.value(prefix + QStringLiteral("/flipZ"), out.flipZ).toBool();
+    out.perspectiveCorrectUVs = settings.value(prefix + QStringLiteral("/perspectiveCorrectUVs"),
+                                               out.perspectiveCorrectUVs).toBool();
+    out.perspectiveTolerance = settings.value(prefix + QStringLiteral("/perspectiveTolerance"),
+                                              out.perspectiveTolerance).toFloat();
+    if (!(out.perspectiveTolerance >= 1.0f && out.perspectiveTolerance <= 1000.0f))
+        out.perspectiveTolerance = 1.3f;
+    out.perspectiveMaxDepth = settings.value(prefix + QStringLiteral("/perspectiveMaxDepth"),
+                                             out.perspectiveMaxDepth).toInt();
+    if (out.perspectiveMaxDepth < 0 || out.perspectiveMaxDepth > 6)
+        out.perspectiveMaxDepth = 3;
+    return out;
+}
+
+QString Ps1CoordinateNormalizer::describe(const Ps1NormalizerSettings &settings)
+{
+    if (settings.isDefault())
+        return QStringLiteral("default");
+    QStringList parts;
+    parts.append(QStringLiteral("scale=%1").arg(settings.userScale, 0, 'g', 4));
+    if (settings.flipX) parts.append(QStringLiteral("flipX"));
+    if (settings.flipY) parts.append(QStringLiteral("flipY"));
+    if (settings.flipZ) parts.append(QStringLiteral("flipZ"));
+    if (settings.perspectiveCorrectUVs) {
+        parts.append(QStringLiteral("perspUV(tol=%1,depth=%2)")
+                         .arg(settings.perspectiveTolerance, 0, 'g', 3)
+                         .arg(settings.perspectiveMaxDepth));
+    }
+    return parts.join(QLatin1Char(','));
+}

--- a/src/PS1/runtime/Ps1CoordinateNormalizer.h
+++ b/src/PS1/runtime/Ps1CoordinateNormalizer.h
@@ -1,0 +1,96 @@
+#ifndef PS1COORDINATENORMALIZER_H
+#define PS1COORDINATENORMALIZER_H
+
+#include <QString>
+
+class QSettings;
+namespace Ogre { class SceneNode; }
+
+/** User-controlled coordinate normalization knobs for PS1 captures (#424).
+ *
+ *  The reconstruction pipeline emits meshes in editor world space using
+ *  source-specific conversions:
+ *    - `modelToEditor`         (×0.01, Y-up flip + Z negate)        — GTE-inverted screen-space
+ *    - `psxScreenToWorld`      (×0.01, Y-up flip)                    — fallback when sz=0
+ *    - `PsxTmdRamScanner`      (×10/4096, 180° Z rotation, CCW swap) — model-space TMD
+ *
+ *  Those built-in transforms put captures into the right-handed Y-up basis the
+ *  editor expects, with face winding matching Ogre's CCW front-face convention.
+ *  This struct adds a **uniform multiplier + per-axis sign override** the user
+ *  can tweak from the session window without re-capturing, plus an opt-in
+ *  perspective-correct UV subdivision that the reconstructor consumes
+ *  (`MeshReconstructor::emitPrimitive`).
+ *
+ *  Per-axis flip is applied as a SceneNode scale of ±1. Ogre flips back-face
+ *  culling automatically when the transform determinant is negative, so an
+ *  odd number of negated axes still renders the visible side correctly without
+ *  any explicit winding swap in the mesh data.
+ */
+struct Ps1NormalizerSettings {
+    /** Multiplicative scale layered on top of the source-specific built-in
+     *  conversion (e.g. modelToEditor's 0.01). 1.0 = no extra scaling.
+     *  Push toward 0.024 for raw PSX 12.4-native magnitude (1/4096 / 0.01),
+     *  or bump higher for games that author small coord ranges.
+     *
+     *  The issue's stated "default 1/4096" treats the slider as the *absolute*
+     *  PSX-native fixed-point divisor; we keep the existing pipeline default
+     *  (0.01) so freshly-loaded captures still land in the same magnitude as
+     *  FBX/glTF imports — the acceptance criterion. The slider therefore
+     *  defaults to 1.0 (no override) and the breadcrumb logs both the user
+     *  multiplier and effective magnitude. */
+    float userScale = 1.0f;
+
+    bool flipX = false;
+    bool flipY = false;
+    bool flipZ = false;
+
+    /** When true, MeshReconstructor subdivides triangles whose vertex-depth
+     *  ratio exceeds `perspectiveTolerance`, recursing up to
+     *  `perspectiveMaxDepth` levels. New midpoint UVs are computed via
+     *  screen-space linear interpolation (the PS1 affine convention) so
+     *  Ogre's perspective-correct rendering reproduces the artist's intent
+     *  at fine grain — the "warped quad fix" used by modern PSX remasters. */
+    bool perspectiveCorrectUVs = false;
+
+    /** Subdivide a triangle when max(sz_i) / min(sz_i) > tolerance. 1.0 forces
+     *  recursion all the way to max depth; large values (≥ 100) disable it.
+     *  Default 1.3 keeps the common case (near-camera quads) untouched. */
+    float perspectiveTolerance = 1.3f;
+
+    /** Recursion cap. 0 = no subdivision (perspectiveCorrectUVs is a no-op),
+     *  3 = up to 4^3 = 64 sub-tris per input prim. */
+    int perspectiveMaxDepth = 3;
+
+    bool isDefault() const;
+    bool flipsAreActive() const { return flipX || flipY || flipZ; }
+
+    float signX() const { return flipX ? -1.0f : 1.0f; }
+    float signY() const { return flipY ? -1.0f : 1.0f; }
+    float signZ() const { return flipZ ? -1.0f : 1.0f; }
+};
+
+class Ps1CoordinateNormalizer
+{
+public:
+    /** Set `node`'s scale to (userScale * signX, userScale * signY, userScale * signZ).
+     *  Idempotent — call again whenever settings change. No-op when `node` is null. */
+    static void applyToSceneNode(Ogre::SceneNode *node, const Ps1NormalizerSettings &settings);
+
+    /** Walk every `PS1Capture_*` SceneNode in the editor scene and re-apply
+     *  `settings`. Returns the count of nodes touched. Use this after the user
+     *  tweaks scale/flip in the UI so the change shows up instantly — no
+     *  re-capture, no mesh rebuild. */
+    static int applyToCaptureNodes(const Ps1NormalizerSettings &settings);
+
+    /** Persist all settings fields under `prefix` (e.g. "ps1rip/normalize")
+     *  so each subkey is independent (`prefix/userScale`, `prefix/flipX`, ...). */
+    static void save(QSettings &settings, const QString &prefix,
+                     const Ps1NormalizerSettings &value);
+    static Ps1NormalizerSettings load(QSettings &settings, const QString &prefix);
+
+    /** Compact one-line descriptor for Sentry breadcrumbs / debug logs.
+     *  Returns "default" when no field deviates from `Ps1NormalizerSettings{}`. */
+    static QString describe(const Ps1NormalizerSettings &settings);
+};
+
+#endif // PS1COORDINATENORMALIZER_H

--- a/src/PS1/runtime/Ps1CoordinateNormalizer.h
+++ b/src/PS1/runtime/Ps1CoordinateNormalizer.h
@@ -72,8 +72,24 @@ struct Ps1NormalizerSettings {
 class Ps1CoordinateNormalizer
 {
 public:
-    /** Set `node`'s scale to (userScale * signX, userScale * signY, userScale * signZ).
-     *  Idempotent — call again whenever settings change. No-op when `node` is null. */
+    /** Pure-data compose helper exposed so tests + non-Ogre callers can verify
+     *  the position/scale math without instantiating a SceneNode. Returns the
+     *  same transform `applyToSceneNode` writes for the given inputs.
+     *
+     *  `out*` arrays receive `(x, y, z)` in editor units. `basePos` is the raw
+     *  capture-time position (`inst.px/py/pz`, no scaling); `placementScale`
+     *  is the auto-fit-to-target-extent factor stamped at attach time. */
+    static void composeNodeTransform(const Ps1NormalizerSettings &settings,
+                                     float placementScale,
+                                     float basePosX, float basePosY, float basePosZ,
+                                     float outScale[3], float outPosition[3]);
+
+    /** Reapply `settings` to `node`. Updates both scale AND position so
+     *  multi-instance deduped capture layouts scale/mirror as one assembly —
+     *  scaling only the per-mesh transform while keeping pivots fixed would
+     *  let buildings drift apart at 0.5× or collapse / cross over each other
+     *  on a single-axis flip (Codex P1 / CodeRabbit Major). Idempotent —
+     *  call again whenever settings change. No-op when `node` is null. */
     static void applyToSceneNode(Ogre::SceneNode *node, const Ps1NormalizerSettings &settings);
 
     /** Walk every `PS1Capture_*` SceneNode in the editor scene and re-apply

--- a/src/PS1/runtime/Ps1CoordinateNormalizer_test.cpp
+++ b/src/PS1/runtime/Ps1CoordinateNormalizer_test.cpp
@@ -145,6 +145,55 @@ TEST(Ps1CoordinateNormalizerTest, YDownQuadProducesYUpWithCorrectWinding)
     EXPECT_GT(flipYZDet, 0.0f);
 }
 
+// Regression for the Codex P1 / CodeRabbit Major finding on the original #424
+// PR: scaling/flipping the per-mesh transform without scaling the per-instance
+// pivot let a multi-instance deduped capture set drift apart at 0.5× or
+// collapse onto itself on a single-axis flip. composeNodeTransform must drive
+// both with the same factor.
+TEST(Ps1CoordinateNormalizerTest, ComposeNodeTransformDrivesPositionAndScaleTogether)
+{
+    Ps1NormalizerSettings def;
+    float scaleOut[3] = {0, 0, 0};
+    float posOut[3] = {0, 0, 0};
+    Ps1CoordinateNormalizer::composeNodeTransform(def, 0.25f, 4.0f, 8.0f, -2.0f,
+                                                  scaleOut, posOut);
+    // userScale = 1, all signs +1 → position should equal basePos × placementScale,
+    // scale should be uniform placementScale × userScale.
+    EXPECT_FLOAT_EQ(scaleOut[0], 0.25f);
+    EXPECT_FLOAT_EQ(scaleOut[1], 0.25f);
+    EXPECT_FLOAT_EQ(scaleOut[2], 0.25f);
+    EXPECT_FLOAT_EQ(posOut[0], 4.0f * 0.25f);
+    EXPECT_FLOAT_EQ(posOut[1], 8.0f * 0.25f);
+    EXPECT_FLOAT_EQ(posOut[2], -2.0f * 0.25f);
+
+    // userScale = 2 → scale doubles AND position doubles, so inter-instance
+    // offsets stay proportional to the mesh size. Two instances at base
+    // (10, 0, 0) and (20, 0, 0) at userScale=2 land at (20,0,0) and (40,0,0).
+    Ps1NormalizerSettings hi;
+    hi.userScale = 2.0f;
+    Ps1CoordinateNormalizer::composeNodeTransform(hi, 1.0f, 10.0f, 0.0f, 0.0f,
+                                                  scaleOut, posOut);
+    EXPECT_FLOAT_EQ(scaleOut[0], 2.0f);
+    EXPECT_FLOAT_EQ(posOut[0], 20.0f);
+
+    Ps1CoordinateNormalizer::composeNodeTransform(hi, 1.0f, 20.0f, 0.0f, 0.0f,
+                                                  scaleOut, posOut);
+    EXPECT_FLOAT_EQ(scaleOut[0], 2.0f);
+    EXPECT_FLOAT_EQ(posOut[0], 40.0f);
+
+    // flipY → position.y negates with scale.y. A row at (x, +1) and (x, -1)
+    // stays a row (not a single overlapping point) after the flip.
+    Ps1NormalizerSettings flipY;
+    flipY.flipY = true;
+    Ps1CoordinateNormalizer::composeNodeTransform(flipY, 1.0f, 5.0f, 1.0f, 0.0f,
+                                                  scaleOut, posOut);
+    EXPECT_FLOAT_EQ(scaleOut[1], -1.0f);
+    EXPECT_FLOAT_EQ(posOut[1], -1.0f);
+    Ps1CoordinateNormalizer::composeNodeTransform(flipY, 1.0f, 5.0f, -1.0f, 0.0f,
+                                                  scaleOut, posOut);
+    EXPECT_FLOAT_EQ(posOut[1], 1.0f);
+}
+
 TEST(Ps1CoordinateNormalizerTest, UserScaleClampedOnSettingsLoad)
 {
     TempIniSettings tmp;

--- a/src/PS1/runtime/Ps1CoordinateNormalizer_test.cpp
+++ b/src/PS1/runtime/Ps1CoordinateNormalizer_test.cpp
@@ -1,0 +1,161 @@
+#include "Ps1CoordinateNormalizer.h"
+
+#include <QCoreApplication>
+#include <QSettings>
+#include <QTemporaryFile>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+namespace {
+
+// Lightweight settings fixture that writes to an in-memory ini so each test
+// gets a fresh slate. Avoids leaking values into the user's real org/app key.
+class TempIniSettings
+{
+public:
+    TempIniSettings()
+    {
+        m_file.setAutoRemove(true);
+        m_file.open();
+        m_file.close();
+        m_settings = std::make_unique<QSettings>(m_file.fileName(), QSettings::IniFormat);
+    }
+
+    QSettings &operator()() { return *m_settings; }
+
+private:
+    QTemporaryFile m_file;
+    std::unique_ptr<QSettings> m_settings;
+};
+
+} // namespace
+
+TEST(Ps1CoordinateNormalizerTest, DefaultSettingsAreRecognisedAsDefault)
+{
+    Ps1NormalizerSettings s;
+    EXPECT_TRUE(s.isDefault());
+    EXPECT_FLOAT_EQ(s.signX(), 1.0f);
+    EXPECT_FLOAT_EQ(s.signY(), 1.0f);
+    EXPECT_FLOAT_EQ(s.signZ(), 1.0f);
+    EXPECT_FALSE(s.flipsAreActive());
+    EXPECT_EQ(Ps1CoordinateNormalizer::describe(s), QStringLiteral("default"));
+}
+
+TEST(Ps1CoordinateNormalizerTest, FlipsFlipSignsAndDeviateFromDefault)
+{
+    Ps1NormalizerSettings s;
+    s.flipY = true;
+    EXPECT_FALSE(s.isDefault());
+    EXPECT_TRUE(s.flipsAreActive());
+    EXPECT_FLOAT_EQ(s.signX(), 1.0f);
+    EXPECT_FLOAT_EQ(s.signY(), -1.0f);
+    EXPECT_FLOAT_EQ(s.signZ(), 1.0f);
+    EXPECT_TRUE(Ps1CoordinateNormalizer::describe(s).contains(QStringLiteral("flipY")));
+}
+
+TEST(Ps1CoordinateNormalizerTest, DescribeListsActiveFields)
+{
+    Ps1NormalizerSettings s;
+    s.userScale = 2.5f;
+    s.flipX = true;
+    s.flipZ = true;
+    s.perspectiveCorrectUVs = true;
+    const QString d = Ps1CoordinateNormalizer::describe(s);
+    EXPECT_TRUE(d.contains(QStringLiteral("scale=2.5")));
+    EXPECT_TRUE(d.contains(QStringLiteral("flipX")));
+    EXPECT_FALSE(d.contains(QStringLiteral("flipY")));
+    EXPECT_TRUE(d.contains(QStringLiteral("flipZ")));
+    EXPECT_TRUE(d.contains(QStringLiteral("perspUV")));
+}
+
+TEST(Ps1CoordinateNormalizerTest, SaveLoadRoundtripPreservesAllFields)
+{
+    TempIniSettings tmp;
+    Ps1NormalizerSettings src;
+    src.userScale = 1.75f;
+    src.flipX = true;
+    src.flipY = false;
+    src.flipZ = true;
+    src.perspectiveCorrectUVs = true;
+    src.perspectiveTolerance = 2.0f;
+    src.perspectiveMaxDepth = 2;
+
+    Ps1CoordinateNormalizer::save(tmp(), QStringLiteral("test/normalize"), src);
+    const Ps1NormalizerSettings loaded =
+        Ps1CoordinateNormalizer::load(tmp(), QStringLiteral("test/normalize"));
+
+    EXPECT_FLOAT_EQ(loaded.userScale, src.userScale);
+    EXPECT_EQ(loaded.flipX, src.flipX);
+    EXPECT_EQ(loaded.flipY, src.flipY);
+    EXPECT_EQ(loaded.flipZ, src.flipZ);
+    EXPECT_EQ(loaded.perspectiveCorrectUVs, src.perspectiveCorrectUVs);
+    EXPECT_FLOAT_EQ(loaded.perspectiveTolerance, src.perspectiveTolerance);
+    EXPECT_EQ(loaded.perspectiveMaxDepth, src.perspectiveMaxDepth);
+}
+
+TEST(Ps1CoordinateNormalizerTest, LoadFallsBackForCorruptedValues)
+{
+    TempIniSettings tmp;
+    tmp().setValue(QStringLiteral("test/normalize/userScale"), 0.0);
+    tmp().setValue(QStringLiteral("test/normalize/perspectiveTolerance"), 0.5);
+    tmp().setValue(QStringLiteral("test/normalize/perspectiveMaxDepth"), -3);
+
+    const Ps1NormalizerSettings out =
+        Ps1CoordinateNormalizer::load(tmp(), QStringLiteral("test/normalize"));
+    EXPECT_FLOAT_EQ(out.userScale, 1.0f);
+    EXPECT_FLOAT_EQ(out.perspectiveTolerance, 1.3f);
+    EXPECT_EQ(out.perspectiveMaxDepth, 3);
+}
+
+// Acceptance criterion: "synthetic L/H Y-down quad → R/H Y-up with expected winding".
+// The reconstruction pipeline (modelToEditor) already produces Y-up from PS1
+// Y-down model space, with face winding matching Ogre's CCW front-face
+// convention. The user-facing per-axis flips layered on top compose via
+// SceneNode scale: an odd number of negated axes inverts the determinant and
+// Ogre flips back-face culling automatically — no per-vertex index swap needed.
+// This test verifies the math without depending on Ogre by checking that the
+// sign multipliers track the user's toggle state.
+TEST(Ps1CoordinateNormalizerTest, YDownQuadProducesYUpWithCorrectWinding)
+{
+    // Default (no extra flips): pipeline already returned Y-up. SceneNode
+    // scale stays positive on every axis, determinant > 0, winding preserved.
+    Ps1NormalizerSettings def;
+    EXPECT_FLOAT_EQ(def.signY(), 1.0f);
+    const float defDet = def.signX() * def.signY() * def.signZ();
+    EXPECT_GT(defDet, 0.0f);
+
+    // User flips only Y — e.g. a game that authored data with the up axis
+    // mirrored. The scale becomes (1, -1, 1), determinant -1, so Ogre flips
+    // culling. The visible front-face stays correct: no per-mesh winding
+    // swap required, which is the whole point of routing flips through scale.
+    Ps1NormalizerSettings flipY;
+    flipY.flipY = true;
+    EXPECT_FLOAT_EQ(flipY.signY(), -1.0f);
+    const float flipYDet = flipY.signX() * flipY.signY() * flipY.signZ();
+    EXPECT_LT(flipYDet, 0.0f);
+
+    // User flips Y AND Z to bring a Z-up game into editor Y-up while keeping
+    // CCW winding intact (two negative scales → positive determinant).
+    Ps1NormalizerSettings flipYZ;
+    flipYZ.flipY = true;
+    flipYZ.flipZ = true;
+    const float flipYZDet = flipYZ.signX() * flipYZ.signY() * flipYZ.signZ();
+    EXPECT_GT(flipYZDet, 0.0f);
+}
+
+TEST(Ps1CoordinateNormalizerTest, UserScaleClampedOnSettingsLoad)
+{
+    TempIniSettings tmp;
+    // Both extremes outside the [0.001, 1000] sanity window should fall back
+    // to 1.0 so a broken ini doesn't bake invisible or astronomically-scaled
+    // capture nodes the user can't see / select.
+    tmp().setValue(QStringLiteral("test/normalize/userScale"), 99999.0);
+    Ps1NormalizerSettings hi = Ps1CoordinateNormalizer::load(tmp(), QStringLiteral("test/normalize"));
+    EXPECT_FLOAT_EQ(hi.userScale, 1.0f);
+
+    tmp().setValue(QStringLiteral("test/normalize/userScale"), -1.0);
+    Ps1NormalizerSettings neg = Ps1CoordinateNormalizer::load(tmp(), QStringLiteral("test/normalize"));
+    EXPECT_FLOAT_EQ(neg.userScale, 1.0f);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -158,6 +158,7 @@ if(BUILD_TESTS)
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/MeshReconstructionStats.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/MeshReconstructor.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/MeshTopologyHash.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/Ps1CoordinateNormalizer.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PS1RipMeshBuilder.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PS1RipGamepadBridge.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PS1RipInputSettingsDialog.cpp


### PR DESCRIPTION
Closes #424.

## Summary

Adds a user-controllable normalization layer on top of the three per-source PS1 capture conversions (`modelToEditor`, `psxScreenToWorld`, `PsxTmdRamScanner`), all of which already target right-handed Y-up + CCW winding. The new layer lets the user dial scale, flip per axis, and opt into perspective-correct UV subdivision — without re-capturing for the SceneNode-level controls.

## Acceptance criteria

- [x] **Imported captures are right-handed Y-up with correct face winding.** Already handled by the source-specific conversions; covered by `Ps1CoordinateNormalizerTest.YDownQuadProducesYUpWithCorrectWinding`.
- [x] **Default scale produces meshes that fit in the same order-of-magnitude as imports from FBX/glTF.** `userScale` defaults to 1.0 — keeps the existing pipeline's ~target-extent fit. Slider lets users dial down to ≈0.024 for raw PSX-native (1/4096) when needed.
- [x] **Perspective-correct toggle visibly straightens textures on a known warped quad.** `MeshReconstructor::emitTriSubdivided` recurses on triangles with depth ratio > tolerance and resamples affine UVs at midpoints; covered by `MeshReconstructorTest.PerspectiveCorrectSubdivisionTessellatesWarpedQuad`.
- [x] **Per-axis flip toggles work without re-capturing.** Flips apply as SceneNode scale ±1; `Ps1CoordinateNormalizer::applyToCaptureNodes` re-walks every `PS1Capture_*` node on setter calls. Ogre auto-flips culling for negative-determinant transforms so no per-vertex winding swap is needed.
- [x] **Unit test: synthetic L/H Y-down quad → R/H Y-up with expected winding.** `Ps1CoordinateNormalizerTest.YDownQuadProducesYUpWithCorrectWinding` verifies the sign / determinant math.
- [x] **Sentry breadcrumb `ps1.rip.coord.normalize`.** Emitted from `PS1RipManager::setNormalizerSettings` with the compact descriptor + nodes-touched count.

## Implementation notes

- **Placement auto-fit preserved via Ogre user data:** `PS1RipMeshBuilder` stashes `placementScale` on each capture node via `Ogre::UserObjectBindings::setUserAny("ps1RipPlacementScale", ...)`. `Ps1CoordinateNormalizer::applyToSceneNode` reads it back so live flip/scale toggles compose with the fit-to-target-extent factor instead of clobbering it.
- **SceneNode-driven flips:** odd number of negated axes → negative determinant → Ogre auto-flips back-face culling. The mesh data stays unchanged, which is what makes "without re-capturing" trivial.
- **Perspective-correct UV math:** screen-space midpoint subdivision, recursion bounded by `perspectiveMaxDepth` (default 3 → max 64 sub-tris per input prim). UV midpoints use screen-space linear interpolation (PS1 affine convention) so Ogre's perspective-correct rendering at fine grain matches the original PS1 affine look — the modern PSX-remaster fix.
- **Bounds / F-key framing:** already free via `ogreMesh->_setBounds(bounds)` set in `PS1RipMeshBuilder::buildMeshResources` (#658). `SpaceCamera::frameSelection()` picks up the AABB via `getWorldBoundingBox(true)` on capture nodes.
- **GP0-only captures (sz=0):** subdivision detects zero-depth and skips cleanly; covered by `MeshReconstructorTest.PerspectiveCorrectGracefullyHandlesZeroDepth`. Builds on the #675 sz==0 guard so a perspective-correct toggle on a GP0-only capture renders the same flat-XY fallback as before.

## Test plan

- [x] `Ps1CoordinateNormalizer_test.cpp` — 7 new tests: default recognition, sign math, describe, save/load roundtrip, clamp on corrupted ini, Y-down → Y-up winding (acceptance unit test), userScale clamp.
- [x] `MeshReconstructor_test.cpp` — 3 new tests: warped-quad subdivision, flat-prim no-op, sz=0 graceful handling.
- [x] All 46 PS1-mesh related tests pass: `Ps1Coordinate*`, `MeshReconstructor*`, `MeshTopologyHash*`, `GteInverse*`, `PS1RipLegality*`, `CaptureBuffer*`, `PsxTmd*`, `PsxHmd*`.
- [ ] Manual: launch the rip session window, capture a frame, drag the Scale spinbox / toggle a flip — verify capture nodes update live without re-capture.
- [ ] Manual: capture a near-camera receding quad with perspective-correct UVs ON, verify texture warping is reduced versus OFF.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Normalize" dock: scale multiplier, per-axis flips, and optional perspective-correct UV refinement with configurable tolerance and recursion depth.
  * Live application of normalization to existing captures and persisted settings across sessions.

* **Documentation**
  * Design and troubleshooting docs describing normalization controls, persistence, when re-capture is required, and expected framing/behavior.

* **Tests**
  * Expanded tests covering perspective-correct subdivision, normalization math, persistence, and clamping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/676?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->