### PR TITLE
PS1: Geometry Inspector + Extracted Asset Browser (#426)

### DIFF
--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -125,6 +125,9 @@ Manager::Manager(MainWindow* parent):
     initRoot();         // Init Ogre Root
     initRenderSystem(); // Init Ogre Render System
     initSceneMgr();     // Init Ogre SceneManager
+
+    if (SelectionSet *sel = SelectionSet::getSingletonPtr())
+        sel->tryConnectToManager();
 }
 Manager::~Manager()
 {

--- a/src/PS1/CMakeLists.txt
+++ b/src/PS1/CMakeLists.txt
@@ -41,6 +41,9 @@ if(ENABLE_PS1_RIP)
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/MeshReconstructor.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/MeshTopologyHash.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/Ps1CoordinateNormalizer.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1CapturedAssets.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1ExtractedAssetBrowser.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1GeometryInspectorPanel.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipMeshBuilder.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipGamepadBridge.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipInputSettingsDialog.cpp
@@ -75,6 +78,9 @@ if(ENABLE_PS1_RIP)
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/ReconstructedMesh.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/MeshTopologyHash.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/Ps1CoordinateNormalizer.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1CapturedAssets.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1ExtractedAssetBrowser.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1GeometryInspectorPanel.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/PS1RipMeshBuilder.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/EmuCore.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/EmuCoreLoader.h

--- a/src/PS1/PS1_RIP_DESIGN.md
+++ b/src/PS1/PS1_RIP_DESIGN.md
@@ -413,6 +413,129 @@ toggle + scale + perspective-correct UVs (#424), status footer numbers,
 Sentry breadcrumbs — are all met in the existing widget shell. A pure-QML
 port can ship later without changing the manager API.
 
+## Geometry inspector + extracted-asset browser (#426)
+
+Built on top of the captured data flow finalised in #424/#425. The goal is
+to let the user see *what was captured*, drill from a draw call down to a
+sub-mesh in the live viewport, and pick which captured assets become
+permanent (i.e. survive a Stop or the next Capture).
+
+### Captured asset store
+
+`PS1CapturedAssets` is a GUI-thread singleton that mirrors the last
+successful `meshBuilt` into three data flat collections:
+
+- `rows`: one `CapturedAssetRow` per `PrimRecord` in the capture
+  (`#`, `frame`, `type`, `verts`, `tpage`, `clut`, `matrix#`,
+  `material`, `triangles` — the columns the issue specs).
+- `uniqueMeshes` + `instances`: pass-through of the dedupe output
+  from `MeshReconstructor::reconstructDeduped` (#423).
+- `instanceNodeNames`: instance index → Ogre SceneNode name
+  (`PS1Capture_<id>_inst<N>`), so the inspector resolves a click into a
+  real node without re-walking the scene tree.
+- `textureImages`: decoded texture page (256×256 RGBA) keyed by logical
+  material name. Populated by `PS1RipMeshBuilder` from the `TextureDecoder`
+  cache so the browser doesn't have to re-decode VRAM.
+
+Update flow: the manager assembles the set via
+`PS1CapturedAssets::buildFromCapture()` on the main thread immediately
+before emitting `meshBuilt`, so any UI listening to that signal is
+guaranteed to see a fully-populated store.
+
+### Geometry Inspector dock
+
+`PS1GeometryInspectorPanel` (`PS1GeometryInspectorModel` +
+`PS1GeometryInspectorFilter` + Qt UI) lives inside `PS1RipSessionWindow`
+as a bottom dock. Single-click on a row routes through
+`PS1RipSessionWindow::highlightInspectorRow`, which resolves the row's
+instance to its SceneNode and calls `SelectionSet::selectOne` so the
+editor outlines the sub-mesh.
+
+Right-click context menu (the issue's three required actions):
+
+- **Hide / Show this submesh** — toggles `SceneNode::setVisible`. The
+  store records `row.hidden` so the inspector keeps the hidden rows
+  in-view but greyed out.
+- **Promote to permanent entity** — clones the underlying Ogre mesh into
+  a fresh `PS1Imported_<id>_meshN_pK` resource and creates a brand new
+  `SceneNode` carrying the same world transform as the capture node.
+  Survives the next Capture / Stop because the live capture cleanup
+  only walks `PS1Capture_*` names. Emits a
+  `ps1.rip.inspector.promote ok mesh=... node=...` Sentry breadcrumb.
+- **Discard** — hides the SceneNode and grey-outs the row. Reversible
+  via "Restore (un-discard)" which re-shows the node.
+
+Filter chips above the table: `Textured`, `Colored`, `Instanced`, plus a
+"Hide discarded" toggle and a free-text Material search box. The filter
+is a `QSortFilterProxyModel` so toggling a chip is a single
+`invalidateFilter()` — no model rebuild.
+
+Counts header: `Captured: N prims · M unique meshes · K textures`,
+recomputed from the store on every `captureSetChanged()`.
+
+### Extracted Asset Browser dock
+
+`PS1ExtractedAssetBrowser` is a separate right-dock with a QTabWidget
+holding three `QListView` (IconMode) grids:
+
+- **Meshes** — one tile per `uniqueMesh` with a colored-swatch
+  placeholder thumbnail (Sobel-style hue derived from the first
+  submesh's material name, so the same mesh shows the same swatch across
+  captures). Tiles are drag-enabled (`Qt::ItemIsDragEnabled`); the model
+  exposes the asset id under MIME type `application/x-ps1rip-mesh` and
+  the mesh index under `application/x-ps1rip-meshindex`.
+- **Textures** — one tile per decoded texture page, thumbnail is the
+  256×256 page itself scaled to 96 px.
+- **Materials** — one tile per logical material name (textured pages +
+  the synthetic `PS1Rip_color`). Textured materials use the page image;
+  solid materials use a hue swatch.
+
+Drag-and-drop: `MainWindow::dropEvent` recognises the two MIME types and
+calls `PS1RipSessionWindow::promoteUniqueMeshById(meshIndex, assetId)`,
+which routes through the same `promoteUniqueMesh` impl as the inspector
+context menu. So both "double-click in the browser" and "drag a mesh
+tile into the editor viewport" satisfy the acceptance criterion
+"Drag-and-drop creates a permanent entity that persists after Stop".
+
+Filter chips (`Textured`, `Colored only`, `Instanced`) and a search box
+share state across all three tabs — same `QSortFilterProxyModel`
+template, one chip toggle invalidates every tab's filter.
+
+### Sentry breadcrumbs
+
+`ps1.rip.inspector.promote` is emitted from both the inspector right-click
+and the asset-browser instantiation paths, with the source tag
+(`row-context-menu`, `browser-doubleclick`, `dropEvent`) baked into the
+message so telemetry can tell them apart. `ui.action` breadcrumbs cover
+each chip toggle and search edit for follow-up analytics.
+
+### Tests
+
+`PS1CapturedAssets_test.cpp` exercises:
+
+- `buildFromCapture` row attribution (textured/colored prim → matching
+  unique mesh + instance index).
+- `instanceNodeNames` matches `PS1RipMeshBuilder`'s scene-node naming.
+- `setCaptureSet` fires `captureSetChanged` exactly once.
+- `setRowHidden` / `setRowDiscarded` fire `rowChanged` on real changes
+  and no-op for redundant / out-of-range mutations.
+- `PS1ExtractedAssetBrowser::buildTilesForKind` produces the expected
+  tiles for Mesh / Texture / Material kinds (including the
+  textured/coloredOnly flag plumbing).
+
+These are pure-data unit tests — no Ogre, no QWidget tree — so they run
+on the headless CI fixture without an X server.
+
+### Open follow-ups
+
+- Mesh thumbnails are currently colored-swatch placeholders. An Ogre
+  off-screen RTT (similar to `ModelTurntableRenderer`) would produce
+  real renders without changing the public model/view API.
+- Promotions inherit the capture node's auto-fit scale and normalizer
+  flips. A "Reset to identity transform" option in the right-click menu
+  would let users decouple a promoted entity from those view-time
+  adjustments.
+
 ## GP0 FIFO follow-up (#662)
 
 Shipped in this slice:

--- a/src/PS1/PS1_RIP_DESIGN.md
+++ b/src/PS1/PS1_RIP_DESIGN.md
@@ -509,19 +509,75 @@ and the asset-browser instantiation paths, with the source tag
 message so telemetry can tell them apart. `ui.action` breadcrumbs cover
 each chip toggle and search edit for follow-up analytics.
 
+### Row provenance (post-review #679)
+
+A `materialName → first uniqueMeshIndex` lookup was the original
+attribution path inside `buildFromCapture`. It collapsed every solid-
+color row onto the first mesh that contained `PS1Rip_color`, so two
+prims drawn by different matrix groups would compete for the same
+inspector handle — highlight, hide, discard, and promote all targeted
+the same node, breaking the per-row semantics #426 promised.
+
+The corrected path uses **per-prim provenance** emitted by
+`MeshReconstructor::reconstructDeduped` in `ReconstructedCaptureSet::primProvenance`,
+parallel to `CaptureSnapshot::prims`:
+
+- `meshFromMatrixGroup` records `(texKey → subMeshIndex)` for the part
+  it builds.
+- `buildParts` records `(matrixId → partIndex)` and stashes the inner
+  per-part `(texKey → subMeshIndex)` map.
+- `reconstructDeduped` walks parts in order, so `instanceIndex == partIndex`,
+  and a `(partIndex → uniqueMeshIndex)` table folds the dedupe step in.
+- For each `PrimRecord`, `(matrixId, texKey)` resolves to
+  `(uniqueMeshIndex, subMeshIndex, instanceIndex)` — that's the row's
+  authoritative scene location.
+
+`PS1CapturedAssets::buildFromCapture` consumes the provenance when its
+length matches `snapshot.prims`; otherwise it falls back to the legacy
+material-name lookup so hand-built `ReconstructedCaptureSet` fixtures
+(unit tests, tooling experiments) keep working.
+
+The inspector's row handlers consume `subMeshIndex` to scope
+`setVisible` / `selectOne` to the exact `Ogre::SubEntity`, and
+`promoteUniqueMesh` accepts an optional `instanceIndex` so right-click
+**Promote** on row N copies that row's specific matrix transform
+instead of the first instance using the mesh.
+
+### Promoted-asset material lifetime
+
+`beginCaptureAttach()` purges every Ogre resource matching the
+`PS1Rip_*` material / `ps1rip_*` texture pattern at the start of the
+next capture. A promoted mesh that still referenced those materials
+would render untextured/black the moment the user took a second
+capture. `rebindPromotedMaterials()` (called inside `promoteUniqueMesh`
+after `Mesh::clone`) walks the cloned submeshes, clones any
+capture-scoped material under `PS1Imported_<captureId>_p<promoId>_*`,
+copies its texture buffers into a sibling `ps1imported_*` texture,
+rebinds the TUS, and binds the cloned material back on the submesh.
+The clones live in the default resource group and are out of scope of
+the purge regex, so promoted entities survive an arbitrary number of
+subsequent captures.
+
 ### Tests
 
 `PS1CapturedAssets_test.cpp` exercises:
 
 - `buildFromCapture` row attribution (textured/colored prim → matching
-  unique mesh + instance index).
+  unique mesh + instance index) via the legacy material-name fallback.
 - `instanceNodeNames` matches `PS1RipMeshBuilder`'s scene-node naming.
 - `setCaptureSet` fires `captureSetChanged` exactly once.
 - `setRowHidden` / `setRowDiscarded` fire `rowChanged` on real changes
   and no-op for redundant / out-of-range mutations.
+- Provenance disambiguates rows that share a material across multiple
+  unique meshes (regression test for the original bug).
+- Provenance carries per-row submesh indices when two prims drawn by
+  the same matrix use different materials.
 - `PS1ExtractedAssetBrowser::buildTilesForKind` produces the expected
-  tiles for Mesh / Texture / Material kinds (including the
-  textured/coloredOnly flag plumbing).
+  tiles for Mesh / Texture / Material kinds.
+
+`MeshReconstructor_test.cpp::DedupesIdenticalInstances` also pins the
+per-prim instance ordinal so a future refactor of the part-to-instance
+ordering doesn't silently regress provenance.
 
 These are pure-data unit tests — no Ogre, no QWidget tree — so they run
 on the headless CI fixture without an X server.

--- a/src/PS1/runtime/MeshReconstructor.cpp
+++ b/src/PS1/runtime/MeshReconstructor.cpp
@@ -397,6 +397,16 @@ QVector<PrimProvenance> resolvePrimProvenance(const CaptureSnapshot &snapshot,
     QVector<PrimProvenance> provenance(snapshot.prims.size());
     for (int i = 0; i < snapshot.prims.size(); ++i) {
         const PrimRecord &prim = snapshot.prims[i];
+        if (!PsxCaptureFilters::isOnScreenPrim(prim))
+            continue;
+        const bool survives =
+            ((prim.kind == PrimKind::MonoTri || prim.kind == PrimKind::ShadedTri
+              || prim.kind == PrimKind::TexturedTri) && prim.vertexCount >= 3)
+            || ((prim.kind == PrimKind::MonoQuad || prim.kind == PrimKind::ShadedQuad
+                 || prim.kind == PrimKind::TexturedQuad) && prim.vertexCount >= 4)
+            || (prim.kind == PrimKind::Sprite && prim.vertexCount >= 2);
+        if (!survives)
+            continue;
         const auto partIt = build.partIndexByMatrixId.constFind(prim.matrixId);
         if (partIt == build.partIndexByMatrixId.constEnd())
             continue;

--- a/src/PS1/runtime/MeshReconstructor.cpp
+++ b/src/PS1/runtime/MeshReconstructor.cpp
@@ -282,8 +282,13 @@ QHash<uint32_t, QHash<quint64, SubMeshAccumulator>> buildMatrixGroups(const Capt
     return groupsByMatrix;
 }
 
+/** Build the mesh for a single matrix group, recording which texture key
+ *  produced which submesh index in `texKeyToSubMesh` so the per-prim
+ *  provenance pass can resolve `prim → (matrixId, texKey) → submeshIndex`
+ *  (#679 review feedback). */
 ReconstructedMesh meshFromMatrixGroup(uint32_t matrixId,
-                                      const QHash<quint64, SubMeshAccumulator> &texGroups)
+                                      const QHash<quint64, SubMeshAccumulator> &texGroups,
+                                      QHash<quint64, int> *texKeyToSubMesh = nullptr)
 {
     ReconstructedMesh result;
     result.meshName = QStringLiteral("ps1_part_%1").arg(matrixId);
@@ -292,6 +297,10 @@ ReconstructedMesh meshFromMatrixGroup(uint32_t matrixId,
         const SubMeshAccumulator &acc = texIt.value();
         if (acc.vertices.isEmpty() || acc.indices.size() < 3)
             continue;
+
+        const int subMeshIndex = result.subMeshes.size();
+        if (texKeyToSubMesh)
+            texKeyToSubMesh->insert(texIt.key(), subMeshIndex);
 
         ReconstructedSubMesh sub;
         sub.materialName = acc.materialName;
@@ -304,18 +313,34 @@ ReconstructedMesh meshFromMatrixGroup(uint32_t matrixId,
     return result;
 }
 
-QVector<ReconstructedMesh> buildParts(const CaptureSnapshot &snapshot,
-                                      MeshReconstructionStats *statsOut,
-                                      const Ps1NormalizerSettings &settings)
-{
+struct PartsBuildResult {
     QVector<ReconstructedMesh> parts;
+    // partIndexByMatrixId[matrixId] = index into `parts` for this matrix.
+    // Matrices whose group produced no surviving submesh (every accumulator
+    // got skipped by the < 3 indices guard) are simply absent.
+    QHash<uint32_t, int> partIndexByMatrixId;
+    // subMeshIndexByTexKey[partIndex][texKey] = submeshIndex within parts[partIndex].
+    // Empty for parts contributed by `snapshot.modelMeshes` (those bypass the
+    // matrix-group path and don't carry a texKey-addressable identity).
+    QVector<QHash<quint64, int>> subMeshIndexByTexKey;
+};
+
+PartsBuildResult buildParts(const CaptureSnapshot &snapshot,
+                            MeshReconstructionStats *statsOut,
+                            const Ps1NormalizerSettings &settings)
+{
+    PartsBuildResult out;
     const QHash<uint32_t, QHash<quint64, SubMeshAccumulator>> groupsByMatrix =
         buildMatrixGroups(snapshot, statsOut, settings);
 
     for (auto matIt = groupsByMatrix.constBegin(); matIt != groupsByMatrix.constEnd(); ++matIt) {
-        ReconstructedMesh part = meshFromMatrixGroup(matIt.key(), matIt.value());
-        if (!part.isEmpty())
-            parts.append(part);
+        QHash<quint64, int> texKeyToSubMesh;
+        ReconstructedMesh part = meshFromMatrixGroup(matIt.key(), matIt.value(), &texKeyToSubMesh);
+        if (part.isEmpty())
+            continue;
+        out.partIndexByMatrixId.insert(matIt.key(), out.parts.size());
+        out.subMeshIndexByTexKey.append(texKeyToSubMesh);
+        out.parts.append(part);
     }
 
     // #674 — Model-space meshes from PsxTmdRamScanner / PsxHmdRamScanner. These bypass the
@@ -326,7 +351,8 @@ QVector<ReconstructedMesh> buildParts(const CaptureSnapshot &snapshot,
     for (const CapturedModelMesh &cap : snapshot.modelMeshes) {
         if (cap.mesh.isEmpty())
             continue;
-        parts.append(cap.mesh);
+        out.subMeshIndexByTexKey.append(QHash<quint64, int>{});
+        out.parts.append(cap.mesh);
         if (statsOut) {
             int verts = 0;
             for (const ReconstructedSubMesh &sub : cap.mesh.subMeshes) {
@@ -342,7 +368,7 @@ QVector<ReconstructedMesh> buildParts(const CaptureSnapshot &snapshot,
         }
     }
 
-    return parts;
+    return out;
 }
 
 ReconstructedMesh flattenParts(const QVector<ReconstructedMesh> &parts)
@@ -356,6 +382,46 @@ ReconstructedMesh flattenParts(const QVector<ReconstructedMesh> &parts)
         merged.triangleCount += part.triangleCount;
     }
     return merged;
+}
+
+/** Walk `snapshot.prims` in order and resolve each one to the part + submesh
+ *  it produced via the build-time `(matrixId, texKey) → (partIndex, subMeshIndex)`
+ *  map. `instanceIndex == partIndex` because the dedupe pass emits exactly one
+ *  instance per surviving part in the same order. Prims that don't survive
+ *  the on-screen filter or whose matrix group was wholly skipped leave their
+ *  default `-1` provenance — the inspector silently ignores those rows. */
+QVector<PrimProvenance> resolvePrimProvenance(const CaptureSnapshot &snapshot,
+                                              const PartsBuildResult &build,
+                                              const QVector<int> &partIndexToUnique)
+{
+    QVector<PrimProvenance> provenance(snapshot.prims.size());
+    for (int i = 0; i < snapshot.prims.size(); ++i) {
+        const PrimRecord &prim = snapshot.prims[i];
+        const auto partIt = build.partIndexByMatrixId.constFind(prim.matrixId);
+        if (partIt == build.partIndexByMatrixId.constEnd())
+            continue;
+        const int partIndex = partIt.value();
+        if (partIndex < 0 || partIndex >= build.subMeshIndexByTexKey.size())
+            continue;
+        const QHash<quint64, int> &texMap = build.subMeshIndexByTexKey.at(partIndex);
+        const quint64 texKey = MeshReconstructor::textureGroupKey(
+            prim.tpage, prim.clut, prim.semiTrans, prim.drawModeBits);
+        const auto subIt = texMap.constFind(texKey);
+        if (subIt == texMap.constEnd())
+            continue;
+        if (partIndex >= partIndexToUnique.size())
+            continue;
+        const int uniqueIndex = partIndexToUnique.at(partIndex);
+        if (uniqueIndex < 0)
+            continue;
+        provenance[i].uniqueMeshIndex = uniqueIndex;
+        provenance[i].subMeshIndex = subIt.value();
+        // Instance order is part order: `reconstructDeduped` walks `build.parts`
+        // and appends one instance per surviving part, so `partIndex` is also
+        // the index into `ReconstructedCaptureSet::instances`.
+        provenance[i].instanceIndex = partIndex;
+    }
+    return provenance;
 }
 
 } // namespace
@@ -380,7 +446,7 @@ quint64 MeshReconstructor::textureGroupKey(uint16_t tpage, uint16_t clut, uint8_
 
 ReconstructedMesh MeshReconstructor::reconstruct(const CaptureSnapshot &snapshot)
 {
-    return flattenParts(buildParts(snapshot, nullptr, Ps1NormalizerSettings{}));
+    return flattenParts(buildParts(snapshot, nullptr, Ps1NormalizerSettings{}).parts);
 }
 
 ReconstructedCaptureSet MeshReconstructor::reconstructDeduped(const CaptureSnapshot &snapshot,
@@ -402,14 +468,20 @@ ReconstructedCaptureSet MeshReconstructor::reconstructDeduped(const CaptureSnaps
                                                             MeshReconstructionStats *statsOut)
 {
     ReconstructedCaptureSet result;
-    const QVector<ReconstructedMesh> parts = buildParts(snapshot, statsOut, normalize);
-    result.capturedPartCount = parts.size();
-    if (parts.isEmpty())
+    const PartsBuildResult build = buildParts(snapshot, statsOut, normalize);
+    result.capturedPartCount = build.parts.size();
+    if (build.parts.isEmpty()) {
+        // Still emit a default-filled provenance vector so the inspector
+        // can index it 1:1 with `snapshot.prims` without checking sizes.
+        result.primProvenance.resize(snapshot.prims.size());
         return result;
+    }
 
     QHash<quint64, int> hashToUnique;
+    QVector<int> partIndexToUnique;
+    partIndexToUnique.reserve(build.parts.size());
 
-    for (const ReconstructedMesh &part : parts) {
+    for (const ReconstructedMesh &part : build.parts) {
         float cx = 0.0f;
         float cy = 0.0f;
         float cz = 0.0f;
@@ -431,7 +503,9 @@ ReconstructedCaptureSet MeshReconstructor::reconstructDeduped(const CaptureSnaps
         inst.py = cy;
         inst.pz = cz;
         result.instances.append(inst);
+        partIndexToUnique.append(uniqueIndex);
     }
 
+    result.primProvenance = resolvePrimProvenance(snapshot, build, partIndexToUnique);
     return result;
 }

--- a/src/PS1/runtime/MeshReconstructor.h
+++ b/src/PS1/runtime/MeshReconstructor.h
@@ -19,10 +19,29 @@ struct ReconstructedInstance {
     float pz = 0.0f;
 };
 
+/** Per-`PrimRecord` provenance: where this draw call landed in the
+ *  reconstructed scene (#679 / #426 review feedback). Parallel to
+ *  `CaptureSnapshot::prims` — entry `i` is the resolution for `prims[i]`.
+ *  All fields are `-1` when the prim was culled by the on-screen filter,
+ *  carried fewer than 3 / 2 verts, or did not survive dedupe (e.g. only
+ *  hit the model-mesh path that has no `PrimRecord`).
+ *
+ *  This replaces the earlier `materialName → first uniqueMesh` lookup that
+ *  collapsed every solid-color row onto a single mesh / instance — the
+ *  inspector now resolves each row to the exact submesh and scene node
+ *  the prim produced, so highlight / hide / promote target the right
+ *  sub-entity even when multiple unique meshes share a material. */
+struct PrimProvenance {
+    int uniqueMeshIndex = -1;
+    int subMeshIndex = -1;
+    int instanceIndex = -1;
+};
+
 /** Deduplicated capture output: unique meshes + instance transforms (#423). */
 struct ReconstructedCaptureSet {
     QVector<ReconstructedMesh> uniqueMeshes;
     QVector<ReconstructedInstance> instances;
+    QVector<PrimProvenance> primProvenance; // parallel to CaptureSnapshot::prims
     int capturedPartCount = 0;
 
     bool isEmpty() const { return uniqueMeshes.isEmpty(); }

--- a/src/PS1/runtime/MeshReconstructor_test.cpp
+++ b/src/PS1/runtime/MeshReconstructor_test.cpp
@@ -117,6 +117,18 @@ TEST(MeshReconstructorTest, DedupesIdenticalInstances)
     EXPECT_EQ(loose.instances[0].uniqueMeshIndex, 0);
     EXPECT_EQ(loose.instances[1].uniqueMeshIndex, 0);
     EXPECT_EQ(loose.instances[2].uniqueMeshIndex, 0);
+
+    // #679 review feedback: every prim should resolve to a distinct
+    // instance via provenance. The 3 deduplicated parts share `uniqueMesh = 0`
+    // but each prim lives on its own `matrixId` so the instance ordinals
+    // must be 0/1/2 — not all 0 like the legacy material-only mapping did.
+    ASSERT_EQ(loose.primProvenance.size(), 3);
+    EXPECT_EQ(loose.primProvenance[0].uniqueMeshIndex, 0);
+    EXPECT_EQ(loose.primProvenance[1].uniqueMeshIndex, 0);
+    EXPECT_EQ(loose.primProvenance[2].uniqueMeshIndex, 0);
+    EXPECT_NE(loose.primProvenance[0].instanceIndex, loose.primProvenance[1].instanceIndex);
+    EXPECT_NE(loose.primProvenance[1].instanceIndex, loose.primProvenance[2].instanceIndex);
+    EXPECT_NE(loose.primProvenance[0].instanceIndex, loose.primProvenance[2].instanceIndex);
 }
 
 TEST(MeshReconstructorTest, KeepsPartiallyOnScreenPrimitives)

--- a/src/PS1/runtime/PS1CapturedAssets.cpp
+++ b/src/PS1/runtime/PS1CapturedAssets.cpp
@@ -121,35 +121,38 @@ CapturedAssetSet PS1CapturedAssets::buildFromCapture(const QString &captureId,
     set.instances = reconstructed.instances;
     set.textureImages = textureImages;
 
-    // Walk the instance vector once so a row's `instanceIndex` is a direct
-    // lookup later. `instanceByMesh[meshIndex]` is the index of the FIRST
-    // instance using that mesh — many PS1 games re-issue the same matrix
-    // for every quad of the same prop, so taking the first match is fine
-    // for the inspector's "highlight one node" semantics.
-    QHash<int, int> firstInstanceByMesh;
-    for (int i = 0; i < reconstructed.instances.size(); ++i) {
-        const int meshIndex = reconstructed.instances[i].uniqueMeshIndex;
-        if (!firstInstanceByMesh.contains(meshIndex))
-            firstInstanceByMesh.insert(meshIndex, i);
-    }
+    // Per-prim provenance from the reconstructor — the authoritative source
+    // for "which (uniqueMesh, submesh, instance) did this draw call land in".
+    // The previous material-name-first-match heuristic collapsed every
+    // solid-color row onto a single mesh / instance and broke inspector
+    // actions for any capture with > 1 matrix group sharing a material
+    // (#679 review feedback). When the reconstructor didn't emit provenance
+    // (e.g. unit tests that hand-build a `ReconstructedCaptureSet`), we
+    // fall back to a material-name lookup so legacy callers keep working.
+    const QVector<PrimProvenance> &provenance = reconstructed.primProvenance;
+    const bool hasProvenance = provenance.size() == snapshot.prims.size();
 
-    // Build a material-name → uniqueMeshIndex lookup from the reconstructed
-    // submesh list. A material can appear in multiple unique meshes if the
-    // capture had instances with different geometry but the same texture
-    // page — in that case we just attribute the prim to the first mesh
-    // that uses the material, which matches the dedupe order.
-    QHash<QString, int> meshByMaterial;
-    for (int meshIdx = 0; meshIdx < reconstructed.uniqueMeshes.size(); ++meshIdx) {
-        const ReconstructedMesh &mesh = reconstructed.uniqueMeshes[meshIdx];
-        for (const ReconstructedSubMesh &sub : mesh.subMeshes) {
-            if (!meshByMaterial.contains(sub.materialName))
-                meshByMaterial.insert(sub.materialName, meshIdx);
+    QHash<QString, int> meshByMaterialFallback;
+    QHash<int, int> firstInstanceByMeshFallback;
+    if (!hasProvenance) {
+        for (int meshIdx = 0; meshIdx < reconstructed.uniqueMeshes.size(); ++meshIdx) {
+            const ReconstructedMesh &mesh = reconstructed.uniqueMeshes[meshIdx];
+            for (const ReconstructedSubMesh &sub : mesh.subMeshes) {
+                if (!meshByMaterialFallback.contains(sub.materialName))
+                    meshByMaterialFallback.insert(sub.materialName, meshIdx);
+            }
+        }
+        for (int i = 0; i < reconstructed.instances.size(); ++i) {
+            const int meshIndex = reconstructed.instances[i].uniqueMeshIndex;
+            if (!firstInstanceByMeshFallback.contains(meshIndex))
+                firstInstanceByMeshFallback.insert(meshIndex, i);
         }
     }
 
     set.rows.reserve(snapshot.prims.size());
     int rowOrdinal = 0;
-    for (const PrimRecord &prim : snapshot.prims) {
+    for (int primIdx = 0; primIdx < snapshot.prims.size(); ++primIdx) {
+        const PrimRecord &prim = snapshot.prims[primIdx];
         ++rowOrdinal;
         CapturedAssetRow row;
         row.rowIndex = rowOrdinal;
@@ -173,12 +176,31 @@ CapturedAssetSet PS1CapturedAssets::buildFromCapture(const QString &captureId,
             row.materialName = QStringLiteral("PS1Rip_color");
         }
 
-        const auto meshIt = meshByMaterial.constFind(row.materialName);
-        if (meshIt != meshByMaterial.constEnd()) {
-            row.uniqueMeshIndex = meshIt.value();
-            const auto instIt = firstInstanceByMesh.constFind(row.uniqueMeshIndex);
-            if (instIt != firstInstanceByMesh.constEnd())
-                row.instanceIndex = instIt.value();
+        if (hasProvenance) {
+            const PrimProvenance &p = provenance.at(primIdx);
+            row.uniqueMeshIndex = p.uniqueMeshIndex;
+            row.subMeshIndex = p.subMeshIndex;
+            row.instanceIndex = p.instanceIndex;
+        } else {
+            const auto meshIt = meshByMaterialFallback.constFind(row.materialName);
+            if (meshIt != meshByMaterialFallback.constEnd()) {
+                row.uniqueMeshIndex = meshIt.value();
+                const auto instIt = firstInstanceByMeshFallback.constFind(row.uniqueMeshIndex);
+                if (instIt != firstInstanceByMeshFallback.constEnd())
+                    row.instanceIndex = instIt.value();
+                // Best-effort submesh lookup by material name.
+                if (row.uniqueMeshIndex >= 0
+                    && row.uniqueMeshIndex < reconstructed.uniqueMeshes.size()) {
+                    const auto &subs =
+                        reconstructed.uniqueMeshes.at(row.uniqueMeshIndex).subMeshes;
+                    for (int s = 0; s < subs.size(); ++s) {
+                        if (subs.at(s).materialName == row.materialName) {
+                            row.subMeshIndex = s;
+                            break;
+                        }
+                    }
+                }
+            }
         }
 
         set.totalPrims += 1;

--- a/src/PS1/runtime/PS1CapturedAssets.cpp
+++ b/src/PS1/runtime/PS1CapturedAssets.cpp
@@ -1,0 +1,207 @@
+#include "PS1CapturedAssets.h"
+
+#include "MeshReconstructor.h"
+
+#include <QHash>
+
+PS1CapturedAssets *PS1CapturedAssets::s_instance = nullptr;
+
+PS1CapturedAssets::PS1CapturedAssets(QObject *parent)
+    : QObject(parent)
+{
+}
+
+PS1CapturedAssets *PS1CapturedAssets::getSingleton()
+{
+    if (!s_instance)
+        s_instance = new PS1CapturedAssets();
+    return s_instance;
+}
+
+PS1CapturedAssets *PS1CapturedAssets::getSingletonPtr()
+{
+    return s_instance;
+}
+
+void PS1CapturedAssets::kill()
+{
+    delete s_instance;
+    s_instance = nullptr;
+}
+
+void PS1CapturedAssets::clear()
+{
+    if (m_set.captureId.isEmpty() && m_set.rows.isEmpty())
+        return;
+    m_set = CapturedAssetSet{};
+    emit captureSetChanged();
+}
+
+void PS1CapturedAssets::setCaptureSet(CapturedAssetSet set)
+{
+    m_set = std::move(set);
+    emit captureSetChanged();
+}
+
+bool PS1CapturedAssets::setRowHidden(int rowIndex, bool hidden)
+{
+    if (rowIndex < 1 || rowIndex > m_set.rows.size())
+        return false;
+    CapturedAssetRow &row = m_set.rows[rowIndex - 1];
+    if (row.hidden == hidden)
+        return false;
+    row.hidden = hidden;
+    emit rowChanged(rowIndex);
+    return true;
+}
+
+bool PS1CapturedAssets::setRowDiscarded(int rowIndex, bool discarded)
+{
+    if (rowIndex < 1 || rowIndex > m_set.rows.size())
+        return false;
+    CapturedAssetRow &row = m_set.rows[rowIndex - 1];
+    if (row.discarded == discarded)
+        return false;
+    row.discarded = discarded;
+    emit rowChanged(rowIndex);
+    return true;
+}
+
+namespace {
+
+int trianglesForKind(PrimKind kind)
+{
+    switch (kind) {
+    case PrimKind::MonoTri:
+    case PrimKind::ShadedTri:
+    case PrimKind::TexturedTri:
+        return 1;
+    case PrimKind::MonoQuad:
+    case PrimKind::ShadedQuad:
+    case PrimKind::TexturedQuad:
+    case PrimKind::Sprite:
+        return 2;
+    }
+    return 1;
+}
+
+bool isTexturedKind(PrimKind kind)
+{
+    return kind == PrimKind::TexturedTri || kind == PrimKind::TexturedQuad
+           || kind == PrimKind::Sprite;
+}
+
+bool isColoredKind(PrimKind kind)
+{
+    return kind == PrimKind::ShadedTri || kind == PrimKind::ShadedQuad
+           || kind == PrimKind::MonoTri || kind == PrimKind::MonoQuad;
+}
+
+/** Build a stable identity for a texture page so we can dedupe textures
+ *  for the count header. Matches `MeshReconstructor::textureMaterialName`
+ *  for textured prims; mono / shaded prims contribute no texture. */
+QString textureIdentityForPrim(const PrimRecord &prim)
+{
+    if (!isTexturedKind(prim.kind))
+        return {};
+    return MeshReconstructor::textureMaterialName(prim.tpage, prim.clut, prim.semiTrans,
+                                                  prim.drawModeBits);
+}
+
+} // namespace
+
+CapturedAssetSet PS1CapturedAssets::buildFromCapture(const QString &captureId,
+                                                    const CaptureSnapshot &snapshot,
+                                                    const ReconstructedCaptureSet &reconstructed,
+                                                    const QHash<QString, QImage> &textureImages)
+{
+    CapturedAssetSet set;
+    set.captureId = captureId;
+    set.uniqueMeshes = reconstructed.uniqueMeshes;
+    set.instances = reconstructed.instances;
+    set.textureImages = textureImages;
+
+    // Walk the instance vector once so a row's `instanceIndex` is a direct
+    // lookup later. `instanceByMesh[meshIndex]` is the index of the FIRST
+    // instance using that mesh — many PS1 games re-issue the same matrix
+    // for every quad of the same prop, so taking the first match is fine
+    // for the inspector's "highlight one node" semantics.
+    QHash<int, int> firstInstanceByMesh;
+    for (int i = 0; i < reconstructed.instances.size(); ++i) {
+        const int meshIndex = reconstructed.instances[i].uniqueMeshIndex;
+        if (!firstInstanceByMesh.contains(meshIndex))
+            firstInstanceByMesh.insert(meshIndex, i);
+    }
+
+    // Build a material-name → uniqueMeshIndex lookup from the reconstructed
+    // submesh list. A material can appear in multiple unique meshes if the
+    // capture had instances with different geometry but the same texture
+    // page — in that case we just attribute the prim to the first mesh
+    // that uses the material, which matches the dedupe order.
+    QHash<QString, int> meshByMaterial;
+    for (int meshIdx = 0; meshIdx < reconstructed.uniqueMeshes.size(); ++meshIdx) {
+        const ReconstructedMesh &mesh = reconstructed.uniqueMeshes[meshIdx];
+        for (const ReconstructedSubMesh &sub : mesh.subMeshes) {
+            if (!meshByMaterial.contains(sub.materialName))
+                meshByMaterial.insert(sub.materialName, meshIdx);
+        }
+    }
+
+    set.rows.reserve(snapshot.prims.size());
+    int rowOrdinal = 0;
+    for (const PrimRecord &prim : snapshot.prims) {
+        ++rowOrdinal;
+        CapturedAssetRow row;
+        row.rowIndex = rowOrdinal;
+        row.kind = prim.kind;
+        row.vertexCount = prim.vertexCount;
+        row.tpage = prim.tpage;
+        row.clut = prim.clut;
+        row.matrixId = prim.matrixId;
+        row.triangleCount = trianglesForKind(prim.kind);
+        row.textured = isTexturedKind(prim.kind);
+        row.colored = isColoredKind(prim.kind);
+        // `frameIndex` is not part of `PrimRecord` today — left at 0 so the
+        // column renders consistently. When scene-capture frame tagging
+        // lands (#683 follow-up), this is where to thread it through.
+        row.frameIndex = 0;
+
+        if (row.textured) {
+            row.materialName = MeshReconstructor::textureMaterialName(
+                prim.tpage, prim.clut, prim.semiTrans, prim.drawModeBits);
+        } else {
+            row.materialName = QStringLiteral("PS1Rip_color");
+        }
+
+        const auto meshIt = meshByMaterial.constFind(row.materialName);
+        if (meshIt != meshByMaterial.constEnd()) {
+            row.uniqueMeshIndex = meshIt.value();
+            const auto instIt = firstInstanceByMesh.constFind(row.uniqueMeshIndex);
+            if (instIt != firstInstanceByMesh.constEnd())
+                row.instanceIndex = instIt.value();
+        }
+
+        set.totalPrims += 1;
+        set.totalTris += row.triangleCount;
+        if (row.textured) {
+            const QString texId = textureIdentityForPrim(prim);
+            if (!texId.isEmpty())
+                set.uniqueTextureIds.insert(texId);
+        }
+
+        set.rows.push_back(row);
+    }
+
+    // Same naming scheme as `PS1RipMeshBuilder::attachCaptureSetToScene`.
+    int ordinal = 0;
+    for (int meshIndex = 0; meshIndex < reconstructed.uniqueMeshes.size(); ++meshIndex) {
+        for (int instIdx = 0; instIdx < reconstructed.instances.size(); ++instIdx) {
+            if (reconstructed.instances[instIdx].uniqueMeshIndex != meshIndex)
+                continue;
+            set.instanceNodeNames.insert(
+                instIdx, QStringLiteral("PS1Capture_%1_inst%2").arg(captureId).arg(ordinal++));
+        }
+    }
+
+    return set;
+}

--- a/src/PS1/runtime/PS1CapturedAssets.h
+++ b/src/PS1/runtime/PS1CapturedAssets.h
@@ -44,6 +44,13 @@ struct CapturedAssetRow
     /** Index into `CapturedAssetSet::uniqueMeshes` that contains this prim.
      *  -1 if the prim couldn't be matched (matrixId mismatch, etc.). */
     int uniqueMeshIndex = -1;
+    /** Submesh index within `uniqueMeshes[uniqueMeshIndex].subMeshes` that
+     *  this prim wrote into. -1 if the prim wasn't matched. Used by the
+     *  inspector to scope hide / highlight / discard actions to the
+     *  specific `SubEntity` instead of the whole `SceneNode`, so two rows
+     *  sharing an instance but different submeshes don't clobber each
+     *  other (#679 review feedback). */
+    int subMeshIndex = -1;
     /** Index into `CapturedAssetSet::instances` for the placed copy this
      *  prim belongs to. -1 if no instance was created for the prim's
      *  matrix group (e.g. the camera matrix). */

--- a/src/PS1/runtime/PS1CapturedAssets.h
+++ b/src/PS1/runtime/PS1CapturedAssets.h
@@ -1,0 +1,157 @@
+#ifndef PS1CAPTUREDASSETS_H
+#define PS1CAPTUREDASSETS_H
+
+#include "CaptureSnapshot.h"
+#include "MeshReconstructor.h"
+
+#include <QHash>
+#include <QImage>
+#include <QObject>
+#include <QSet>
+#include <QString>
+#include <QVector>
+
+/**
+ * One row in the geometry inspector table (#426).
+ *
+ * Each row corresponds to one draw call from the captured `PrimRecord`
+ * stream — tri / quad / sprite. The row also carries derived information
+ * the inspector renders directly (triangle count, material name, the
+ * unique mesh + instance the prim ends up in after dedupe) so the table
+ * model doesn't have to walk the raw capture data on every paint.
+ */
+struct CapturedAssetRow
+{
+    /** 1-based row index. Matches the `#` column in the inspector table. */
+    int rowIndex = 0;
+    /** Frame number this prim was emitted on. Always 0 for single-shot
+     *  `captureFrame()` captures; for `captureScene()` captures this is the
+     *  worker's frame counter, which is monotonic but resets per session. */
+    quint64 frameIndex = 0;
+    PrimKind kind = PrimKind::MonoTri;
+    int vertexCount = 0;
+    uint16_t tpage = 0;
+    uint16_t clut = 0;
+    uint32_t matrixId = 0;
+    /** Logical material name (matches `ReconstructedSubMesh::materialName`,
+     *  i.e. `PS1Rip_tpage_..._clut_..._stN_dmM` for textured prims or
+     *  `PS1Rip_color` for solid prims). Maps to the Ogre material the prim
+     *  was reconstructed into. */
+    QString materialName;
+    /** 1 for triangles, 2 for quads / sprites (PS1 quads always split into
+     *  two triangles in the reconstructed mesh). */
+    int triangleCount = 1;
+    /** Index into `CapturedAssetSet::uniqueMeshes` that contains this prim.
+     *  -1 if the prim couldn't be matched (matrixId mismatch, etc.). */
+    int uniqueMeshIndex = -1;
+    /** Index into `CapturedAssetSet::instances` for the placed copy this
+     *  prim belongs to. -1 if no instance was created for the prim's
+     *  matrix group (e.g. the camera matrix). */
+    int instanceIndex = -1;
+    /** Convenience flags for filter chips in the inspector / browser. */
+    bool textured = false;
+    bool colored = false;
+    /** User toggled "Hide submesh" — UI honours by hiding the corresponding
+     *  Ogre SceneNode in the live capture (#426). */
+    bool hidden = false;
+    /** User toggled "Discard" — UI gray-outs the row, hides the live
+     *  preview, and excludes from "Promote all" actions (#426). */
+    bool discarded = false;
+};
+
+/**
+ * Aggregated per-capture data, owned by `PS1CapturedAssets`.
+ *
+ * Populated by `PS1RipManager` after every successful `meshBuilt`. The
+ * inspector and asset-browser dock query against this struct via the
+ * singleton's accessors; they never look at the raw `CaptureSnapshot`
+ * directly, so the rest of the editor doesn't have to deal with
+ * `PrimRecord` indexing or matrix-group bookkeeping.
+ */
+struct CapturedAssetSet
+{
+    QString captureId;
+    QVector<CapturedAssetRow> rows;
+    QVector<ReconstructedMesh> uniqueMeshes;
+    QVector<ReconstructedInstance> instances;
+    /** Map an instance index (into `instances`) to the Ogre SceneNode name
+     *  the mesh builder created for it (`PS1Capture_<id>_inst<N>`). The
+     *  inspector uses this to resolve a row click into a SceneNode to
+     *  highlight, hide, or promote. */
+    QHash<int, QString> instanceNodeNames;
+    /** Material name → decoded texture page (256×256 RGBA), if the
+     *  material was textured. Populated by the mesh builder via
+     *  `setTextureImages`; non-textured prims have no entry. */
+    QHash<QString, QImage> textureImages;
+    /** Distinct texture identities (deduplicated by tpage/clut/semi-trans).
+     *  Used to compute the "11 textures" counter in the header. */
+    QSet<QString> uniqueTextureIds;
+    int totalPrims = 0;
+    int totalTris = 0;
+};
+
+/**
+ * Singleton store that holds the latest capture's draw-call rows + unique
+ * meshes / textures for the Geometry Inspector and Extracted Asset
+ * Browser (#426).
+ *
+ * - Lives on the GUI thread (main thread) and is updated from
+ *   `PS1RipManager::meshBuilt` via a direct-connect slot, so callers
+ *   reading from the inspector model don't race against the worker.
+ * - Stays alive across multiple captures: each new `meshBuilt` replaces
+ *   the previous set so the inspector always reflects the most recent
+ *   capture, but the previous one is discarded (the live capture nodes
+ *   are also recreated per capture by the mesh builder, so anything older
+ *   is already gone from the scene).
+ * - Holds no Ogre handles directly; SceneNode pointers are resolved on
+ *   demand via `Manager::getSceneNode(nodeName)`. This means the store
+ *   stays valid even when the user clears the scene — accessors just
+ *   return `nullptr` for the resolved nodes.
+ *
+ * `clear()` resets state without destroying the singleton; useful for
+ * tests that need a clean slate between cases.
+ */
+class PS1CapturedAssets : public QObject
+{
+    Q_OBJECT
+
+public:
+    static PS1CapturedAssets *getSingleton();
+    static PS1CapturedAssets *getSingletonPtr();
+    static void kill();
+
+    /** Drop any previously stored capture data. */
+    void clear();
+
+    /** Replace the current capture set. Fires `captureSetChanged()`.
+     *  Called from `PS1RipManager` after a successful attach. */
+    void setCaptureSet(CapturedAssetSet set);
+
+    const CapturedAssetSet &captureSet() const { return m_set; }
+    bool hasCapture() const { return !m_set.captureId.isEmpty(); }
+
+    /** Mutate a single row's hidden / discarded state. Fires
+     *  `rowChanged(int)` so the inspector view can repaint the row. */
+    bool setRowHidden(int rowIndex, bool hidden);
+    bool setRowDiscarded(int rowIndex, bool discarded);
+
+    /** Pure-data helpers used by both the panel and the unit tests. */
+    static CapturedAssetSet buildFromCapture(const QString &captureId,
+                                             const CaptureSnapshot &snapshot,
+                                             const ReconstructedCaptureSet &reconstructed,
+                                             const QHash<QString, QImage> &textureImages = {});
+
+signals:
+    /** Fires after `setCaptureSet`. UI listens to repopulate views. */
+    void captureSetChanged();
+    void rowChanged(int rowIndex);
+
+private:
+    explicit PS1CapturedAssets(QObject *parent = nullptr);
+    ~PS1CapturedAssets() override = default;
+
+    static PS1CapturedAssets *s_instance;
+    CapturedAssetSet m_set;
+};
+
+#endif // PS1CAPTUREDASSETS_H

--- a/src/PS1/runtime/PS1CapturedAssets_test.cpp
+++ b/src/PS1/runtime/PS1CapturedAssets_test.cpp
@@ -1,0 +1,171 @@
+#include "PS1CapturedAssets.h"
+#include "PS1ExtractedAssetBrowser.h"
+
+#include <gtest/gtest.h>
+
+#include <QSignalSpy>
+
+namespace {
+
+// Helper that fabricates a one-prim + one-mesh capture so the tests
+// don't depend on the heavy reconstruction path. Mirrors how
+// `MeshReconstructor::reconstructDeduped` shapes the data.
+CapturedAssetSet makeFixture()
+{
+    CaptureSnapshot snapshot;
+    PrimRecord prim;
+    prim.kind = PrimKind::TexturedTri;
+    prim.vertexCount = 3;
+    prim.tpage = 0x1234;
+    prim.clut = 0x5678;
+    prim.matrixId = 7;
+    prim.semiTrans = 0;
+    snapshot.prims.push_back(prim);
+
+    PrimRecord prim2;
+    prim2.kind = PrimKind::MonoTri;
+    prim2.vertexCount = 3;
+    prim2.matrixId = 8;
+    snapshot.prims.push_back(prim2);
+
+    ReconstructedCaptureSet rec;
+    ReconstructedMesh mesh;
+    mesh.meshName = QStringLiteral("ps1_unique_0");
+    mesh.vertexCount = 3;
+    mesh.triangleCount = 1;
+    ReconstructedSubMesh sub;
+    sub.materialName = QStringLiteral("PS1Rip_tpage_1234_clut_5678_st0_dm0");
+    mesh.subMeshes.append(sub);
+    rec.uniqueMeshes.append(mesh);
+
+    ReconstructedMesh mesh2;
+    mesh2.meshName = QStringLiteral("ps1_unique_1");
+    mesh2.vertexCount = 3;
+    mesh2.triangleCount = 1;
+    ReconstructedSubMesh sub2;
+    sub2.materialName = QStringLiteral("PS1Rip_color");
+    mesh2.subMeshes.append(sub2);
+    rec.uniqueMeshes.append(mesh2);
+
+    rec.instances.append({0, 0.0f, 0.0f, 0.0f});
+    rec.instances.append({1, 1.0f, 0.0f, 0.0f});
+
+    QHash<QString, QImage> texImages;
+    QImage tile(8, 8, QImage::Format_ARGB32);
+    tile.fill(Qt::cyan);
+    texImages.insert(QStringLiteral("PS1Rip_tpage_1234_clut_5678_st0_dm0"), tile);
+
+    return PS1CapturedAssets::buildFromCapture(QStringLiteral("test123"), snapshot, rec, texImages);
+}
+
+} // namespace
+
+TEST(PS1CapturedAssetsTest, BuildFromCapturePopulatesRowsAndCounts)
+{
+    const CapturedAssetSet set = makeFixture();
+    EXPECT_EQ(set.captureId, QStringLiteral("test123"));
+    ASSERT_EQ(set.rows.size(), 2);
+    EXPECT_EQ(set.totalPrims, 2);
+    EXPECT_EQ(set.totalTris, 2);
+    EXPECT_EQ(set.uniqueMeshes.size(), 2);
+    EXPECT_EQ(set.instances.size(), 2);
+
+    const CapturedAssetRow &row0 = set.rows.at(0);
+    EXPECT_EQ(row0.rowIndex, 1);
+    EXPECT_TRUE(row0.textured);
+    EXPECT_FALSE(row0.colored);
+    EXPECT_EQ(row0.tpage, 0x1234);
+    EXPECT_EQ(row0.uniqueMeshIndex, 0);
+    EXPECT_EQ(row0.instanceIndex, 0);
+
+    const CapturedAssetRow &row1 = set.rows.at(1);
+    EXPECT_FALSE(row1.textured);
+    EXPECT_TRUE(row1.colored);
+    EXPECT_EQ(row1.uniqueMeshIndex, 1);
+    EXPECT_EQ(row1.instanceIndex, 1);
+
+    // One unique textured material identity = one unique texture id.
+    EXPECT_EQ(set.uniqueTextureIds.size(), 1);
+}
+
+TEST(PS1CapturedAssetsTest, InstanceNodeNamesMatchMeshBuilderNaming)
+{
+    const CapturedAssetSet set = makeFixture();
+    ASSERT_EQ(set.instanceNodeNames.size(), 2);
+    // Naming scheme is `PS1Capture_<captureId>_inst<ordinal>` where the
+    // ordinal walks per unique mesh in order. Matches PS1RipMeshBuilder's
+    // attachCaptureSetToScene loop.
+    EXPECT_EQ(set.instanceNodeNames.value(0), QStringLiteral("PS1Capture_test123_inst0"));
+    EXPECT_EQ(set.instanceNodeNames.value(1), QStringLiteral("PS1Capture_test123_inst1"));
+}
+
+TEST(PS1CapturedAssetsTest, SetCaptureSetEmitsSignalAndUpdatesAccessors)
+{
+    PS1CapturedAssets *store = PS1CapturedAssets::getSingleton();
+    ASSERT_NE(store, nullptr);
+    store->clear();
+
+    QSignalSpy spy(store, &PS1CapturedAssets::captureSetChanged);
+    store->setCaptureSet(makeFixture());
+
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_TRUE(store->hasCapture());
+    EXPECT_EQ(store->captureSet().rows.size(), 2);
+}
+
+TEST(PS1CapturedAssetsTest, RowMutationsFireRowChangedAndNoOpWhenIdle)
+{
+    PS1CapturedAssets *store = PS1CapturedAssets::getSingleton();
+    ASSERT_NE(store, nullptr);
+    store->clear();
+    store->setCaptureSet(makeFixture());
+
+    QSignalSpy rowSpy(store, &PS1CapturedAssets::rowChanged);
+    EXPECT_TRUE(store->setRowHidden(1, true));
+    EXPECT_TRUE(store->setRowDiscarded(2, true));
+    EXPECT_FALSE(store->setRowHidden(1, true));  // already hidden
+    EXPECT_FALSE(store->setRowHidden(99, true)); // out of range
+    EXPECT_EQ(rowSpy.count(), 2);
+
+    EXPECT_TRUE(store->captureSet().rows.at(0).hidden);
+    EXPECT_TRUE(store->captureSet().rows.at(1).discarded);
+}
+
+TEST(PS1ExtractedAssetBrowserTest, BuildTilesForKindMesh)
+{
+    const CapturedAssetSet set = makeFixture();
+    const auto tiles =
+        PS1ExtractedAssetBrowser::buildTilesForKind(set, ExtractedAssetKind::Mesh);
+    ASSERT_EQ(tiles.size(), 2);
+    EXPECT_TRUE(tiles.at(0).textured);
+    EXPECT_FALSE(tiles.at(0).coloredOnly);
+    EXPECT_EQ(tiles.at(0).meshIndex, 0);
+    EXPECT_EQ(tiles.at(0).instanceCount, 1);
+    EXPECT_FALSE(tiles.at(0).thumbnail.isNull());
+    EXPECT_TRUE(tiles.at(1).coloredOnly);
+    EXPECT_FALSE(tiles.at(1).textured);
+}
+
+TEST(PS1ExtractedAssetBrowserTest, BuildTilesForKindTextureUsesDecodedImages)
+{
+    const CapturedAssetSet set = makeFixture();
+    const auto tiles =
+        PS1ExtractedAssetBrowser::buildTilesForKind(set, ExtractedAssetKind::Texture);
+    ASSERT_EQ(tiles.size(), 1);
+    EXPECT_EQ(tiles.at(0).assetId, QStringLiteral("PS1Rip_tpage_1234_clut_5678_st0_dm0"));
+    EXPECT_FALSE(tiles.at(0).thumbnail.isNull());
+    EXPECT_TRUE(tiles.at(0).textured);
+}
+
+TEST(PS1ExtractedAssetBrowserTest, BuildTilesForKindMaterialIncludesColorMaterial)
+{
+    const CapturedAssetSet set = makeFixture();
+    const auto tiles =
+        PS1ExtractedAssetBrowser::buildTilesForKind(set, ExtractedAssetKind::Material);
+    ASSERT_EQ(tiles.size(), 2);
+    EXPECT_TRUE(tiles.at(0).textured);
+    EXPECT_EQ(tiles.at(0).assetId, QStringLiteral("PS1Rip_tpage_1234_clut_5678_st0_dm0"));
+    EXPECT_TRUE(tiles.at(1).coloredOnly);
+    EXPECT_EQ(tiles.at(1).assetId, QStringLiteral("PS1Rip_color"));
+}
+

--- a/src/PS1/runtime/PS1CapturedAssets_test.cpp
+++ b/src/PS1/runtime/PS1CapturedAssets_test.cpp
@@ -169,3 +169,114 @@ TEST(PS1ExtractedAssetBrowserTest, BuildTilesForKindMaterialIncludesColorMateria
     EXPECT_EQ(tiles.at(1).assetId, QStringLiteral("PS1Rip_color"));
 }
 
+// Regression test for #679 review feedback: a capture where two unique
+// meshes share a material name (very common — every solid-color prop
+// uses `PS1Rip_color`) used to misroute every row onto the first such
+// mesh / instance via a `materialName → first uniqueMeshIndex` lookup.
+// Provenance now drives the resolution: each prim maps to exactly the
+// (uniqueMesh, submesh, instance) it landed in.
+TEST(PS1CapturedAssetsTest, ProvenanceDisambiguatesSharedMaterialAcrossMeshes)
+{
+    CaptureSnapshot snapshot;
+    PrimRecord a;
+    a.kind = PrimKind::MonoTri;
+    a.vertexCount = 3;
+    a.matrixId = 10;
+    snapshot.prims.push_back(a);
+    PrimRecord b;
+    b.kind = PrimKind::MonoTri;
+    b.vertexCount = 3;
+    b.matrixId = 11;
+    snapshot.prims.push_back(b);
+
+    ReconstructedCaptureSet rec;
+    // Two unique meshes that BOTH expose a `PS1Rip_color` submesh.
+    ReconstructedMesh m0;
+    m0.meshName = QStringLiteral("ps1_unique_0");
+    ReconstructedSubMesh s0;
+    s0.materialName = QStringLiteral("PS1Rip_color");
+    m0.subMeshes.append(s0);
+    ReconstructedMesh m1;
+    m1.meshName = QStringLiteral("ps1_unique_1");
+    ReconstructedSubMesh s1;
+    s1.materialName = QStringLiteral("PS1Rip_color");
+    m1.subMeshes.append(s1);
+    rec.uniqueMeshes.append(m0);
+    rec.uniqueMeshes.append(m1);
+
+    rec.instances.append({0, 0.0f, 0.0f, 0.0f});
+    rec.instances.append({1, 1.0f, 0.0f, 0.0f});
+
+    // Provenance: row 0 → (mesh 0, sub 0, instance 0); row 1 → (mesh 1, sub 0, instance 1).
+    // Without provenance the legacy fallback would point BOTH rows at mesh 0 / instance 0.
+    PrimProvenance p0;
+    p0.uniqueMeshIndex = 0;
+    p0.subMeshIndex = 0;
+    p0.instanceIndex = 0;
+    PrimProvenance p1;
+    p1.uniqueMeshIndex = 1;
+    p1.subMeshIndex = 0;
+    p1.instanceIndex = 1;
+    rec.primProvenance.append(p0);
+    rec.primProvenance.append(p1);
+
+    const CapturedAssetSet set =
+        PS1CapturedAssets::buildFromCapture(QStringLiteral("shared"), snapshot, rec, {});
+    ASSERT_EQ(set.rows.size(), 2);
+    EXPECT_EQ(set.rows.at(0).uniqueMeshIndex, 0);
+    EXPECT_EQ(set.rows.at(0).instanceIndex, 0);
+    EXPECT_EQ(set.rows.at(0).subMeshIndex, 0);
+    EXPECT_EQ(set.rows.at(1).uniqueMeshIndex, 1);
+    EXPECT_EQ(set.rows.at(1).instanceIndex, 1);
+    EXPECT_EQ(set.rows.at(1).subMeshIndex, 0);
+}
+
+// Regression test for #679 review feedback: rows with the same uniqueMesh
+// but different submeshes (one prim drew the diffuse pass, another drew a
+// shadow / overlay) should map to distinct submesh indices so the inspector
+// can scope hide / highlight per-row instead of clobbering the whole node.
+TEST(PS1CapturedAssetsTest, ProvenanceCarriesPerRowSubMeshIndex)
+{
+    CaptureSnapshot snapshot;
+    PrimRecord a;
+    a.kind = PrimKind::TexturedTri;
+    a.vertexCount = 3;
+    a.tpage = 0x0100;
+    a.matrixId = 5;
+    snapshot.prims.push_back(a);
+    PrimRecord b;
+    b.kind = PrimKind::MonoTri;
+    b.vertexCount = 3;
+    b.matrixId = 5;
+    snapshot.prims.push_back(b);
+
+    ReconstructedCaptureSet rec;
+    ReconstructedMesh mesh;
+    mesh.meshName = QStringLiteral("ps1_unique_0");
+    ReconstructedSubMesh sTex;
+    sTex.materialName = QStringLiteral("PS1Rip_tpage_0100_clut_0000_st0_dm0");
+    ReconstructedSubMesh sColor;
+    sColor.materialName = QStringLiteral("PS1Rip_color");
+    mesh.subMeshes.append(sTex);
+    mesh.subMeshes.append(sColor);
+    rec.uniqueMeshes.append(mesh);
+    rec.instances.append({0, 0.0f, 0.0f, 0.0f});
+
+    PrimProvenance p0;
+    p0.uniqueMeshIndex = 0;
+    p0.subMeshIndex = 0;
+    p0.instanceIndex = 0;
+    PrimProvenance p1;
+    p1.uniqueMeshIndex = 0;
+    p1.subMeshIndex = 1;
+    p1.instanceIndex = 0;
+    rec.primProvenance.append(p0);
+    rec.primProvenance.append(p1);
+
+    const CapturedAssetSet set =
+        PS1CapturedAssets::buildFromCapture(QStringLiteral("permesh"), snapshot, rec, {});
+    ASSERT_EQ(set.rows.size(), 2);
+    EXPECT_EQ(set.rows.at(0).subMeshIndex, 0);
+    EXPECT_EQ(set.rows.at(1).subMeshIndex, 1);
+}
+

--- a/src/PS1/runtime/PS1ExtractedAssetBrowser.cpp
+++ b/src/PS1/runtime/PS1ExtractedAssetBrowser.cpp
@@ -311,6 +311,12 @@ PS1ExtractedAssetBrowser::PS1ExtractedAssetBrowser(PS1CapturedAssets *store, QWi
         connect(m_store, &PS1CapturedAssets::captureSetChanged, this,
                 &PS1ExtractedAssetBrowser::onCaptureSetChanged);
     rebuildModels();
+    // Populate the counts label up front so the "No capture yet" hint is
+    // visible from the moment the dock is shown, and any pre-existing
+    // capture (e.g. ripper reopened after a successful frame capture in
+    // the same session) is reflected without waiting for the next
+    // captureSetChanged signal (#679 review feedback).
+    refreshHeader();
 }
 
 void PS1ExtractedAssetBrowser::refreshHeader()

--- a/src/PS1/runtime/PS1ExtractedAssetBrowser.cpp
+++ b/src/PS1/runtime/PS1ExtractedAssetBrowser.cpp
@@ -1,0 +1,471 @@
+#include "PS1ExtractedAssetBrowser.h"
+
+#include "SentryReporter.h"
+
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QListView>
+#include <QLocale>
+#include <QMimeData>
+#include <QPainter>
+#include <QTabWidget>
+#include <QToolButton>
+#include <QUrl>
+#include <QVBoxLayout>
+
+namespace {
+
+constexpr int kThumbnailSize = 96;
+
+QString mimeTypeForKindImpl(ExtractedAssetKind kind)
+{
+    switch (kind) {
+    case ExtractedAssetKind::Mesh:
+        return QStringLiteral("application/x-ps1rip-mesh");
+    case ExtractedAssetKind::Texture:
+        return QStringLiteral("application/x-ps1rip-texture");
+    case ExtractedAssetKind::Material:
+        return QStringLiteral("application/x-ps1rip-material");
+    }
+    return QStringLiteral("application/x-ps1rip-unknown");
+}
+
+QColor accentForMaterial(const QString &materialName)
+{
+    // Stable hue per material so the same mesh always shows the same
+    // swatch across captures — handy for visual diffing when re-capturing
+    // the same scene with different normalizer settings.
+    uint h = 0;
+    for (QChar ch : materialName)
+        h = h * 31 + ch.unicode();
+    const int hue = static_cast<int>(h % 360);
+    return QColor::fromHsv(hue, 160, 200);
+}
+
+} // namespace
+
+// --- Model ----------------------------------------------------------------
+
+PS1ExtractedAssetModel::PS1ExtractedAssetModel(ExtractedAssetKind kind, QObject *parent)
+    : QAbstractListModel(parent)
+    , m_kind(kind)
+{
+}
+
+void PS1ExtractedAssetModel::setTiles(QVector<ExtractedAssetTile> tiles)
+{
+    beginResetModel();
+    m_tiles = std::move(tiles);
+    endResetModel();
+}
+
+int PS1ExtractedAssetModel::rowCount(const QModelIndex &parent) const
+{
+    return parent.isValid() ? 0 : m_tiles.size();
+}
+
+QVariant PS1ExtractedAssetModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid() || index.row() < 0 || index.row() >= m_tiles.size())
+        return {};
+    const ExtractedAssetTile &tile = m_tiles.at(index.row());
+    switch (role) {
+    case Qt::DisplayRole:
+        return tile.displayName;
+    case Qt::DecorationRole:
+        return tile.thumbnail.isNull()
+                   ? QVariant{}
+                   : QVariant(QPixmap::fromImage(tile.thumbnail));
+    case Qt::ToolTipRole: {
+        QString tt = tile.displayName;
+        if (tile.triangleCount > 0)
+            tt += QStringLiteral("\nTriangles: %1").arg(tile.triangleCount);
+        if (tile.instanceCount > 0)
+            tt += QStringLiteral("\nInstances: %1").arg(tile.instanceCount);
+        if (tile.textured)
+            tt += QStringLiteral("\nTextured");
+        else if (tile.coloredOnly)
+            tt += QStringLiteral("\nColored only");
+        if (tile.instanced)
+            tt += QStringLiteral("\nInstanced (drag to scene to add another copy)");
+        return tt;
+    }
+    case Qt::UserRole:
+        return tile.assetId;
+    case Qt::UserRole + 1:
+        return tile.meshIndex;
+    default:
+        return {};
+    }
+}
+
+Qt::ItemFlags PS1ExtractedAssetModel::flags(const QModelIndex &index) const
+{
+    Qt::ItemFlags f = QAbstractListModel::flags(index);
+    if (index.isValid() && m_kind == ExtractedAssetKind::Mesh)
+        f |= Qt::ItemIsDragEnabled;
+    return f;
+}
+
+QStringList PS1ExtractedAssetModel::mimeTypes() const
+{
+    return {mimeTypeForKindImpl(m_kind)};
+}
+
+QMimeData *PS1ExtractedAssetModel::mimeData(const QModelIndexList &indexes) const
+{
+    if (indexes.isEmpty())
+        return nullptr;
+    auto *md = new QMimeData();
+    QStringList ids;
+    QStringList meshIndexes;
+    for (const QModelIndex &idx : indexes) {
+        if (!idx.isValid() || idx.row() < 0 || idx.row() >= m_tiles.size())
+            continue;
+        const ExtractedAssetTile &tile = m_tiles.at(idx.row());
+        ids << tile.assetId;
+        meshIndexes << QString::number(tile.meshIndex);
+    }
+    md->setData(mimeTypeForKindImpl(m_kind), ids.join(QLatin1Char(';')).toUtf8());
+    md->setData(QStringLiteral("application/x-ps1rip-meshindex"),
+                meshIndexes.join(QLatin1Char(';')).toUtf8());
+    // Also set a text/plain payload so non-Ogre drop targets (system
+    // file managers, code editors) see a human-readable label rather
+    // than an opaque blob.
+    md->setText(ids.join(QLatin1Char(' ')));
+    return md;
+}
+
+QString PS1ExtractedAssetModel::mimeTypeForKind(ExtractedAssetKind kind)
+{
+    return mimeTypeForKindImpl(kind);
+}
+
+// --- Filter ---------------------------------------------------------------
+
+PS1ExtractedAssetFilter::PS1ExtractedAssetFilter(QObject *parent)
+    : QSortFilterProxyModel(parent)
+{
+    setFilterCaseSensitivity(Qt::CaseInsensitive);
+}
+
+void PS1ExtractedAssetFilter::setShowTextured(bool show)
+{
+    if (m_showTextured == show)
+        return;
+    m_showTextured = show;
+    invalidateFilter();
+}
+
+void PS1ExtractedAssetFilter::setShowColoredOnly(bool show)
+{
+    if (m_showColoredOnly == show)
+        return;
+    m_showColoredOnly = show;
+    invalidateFilter();
+}
+
+void PS1ExtractedAssetFilter::setShowInstanced(bool show)
+{
+    if (m_showInstanced == show)
+        return;
+    m_showInstanced = show;
+    invalidateFilter();
+}
+
+void PS1ExtractedAssetFilter::setSearchText(const QString &text)
+{
+    if (m_searchText == text)
+        return;
+    m_searchText = text;
+    invalidateFilter();
+}
+
+bool PS1ExtractedAssetFilter::filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const
+{
+    auto *src = qobject_cast<PS1ExtractedAssetModel *>(sourceModel());
+    if (!src)
+        return true;
+    Q_UNUSED(sourceParent)
+    if (sourceRow < 0 || sourceRow >= src->tiles().size())
+        return false;
+    const ExtractedAssetTile &tile = src->tiles().at(sourceRow);
+    if (tile.textured && !m_showTextured)
+        return false;
+    if (tile.coloredOnly && !m_showColoredOnly)
+        return false;
+    if (tile.instanced && !m_showInstanced)
+        return false;
+    if (!m_searchText.isEmpty() && !tile.displayName.contains(m_searchText, Qt::CaseInsensitive))
+        return false;
+    return true;
+}
+
+// --- Browser --------------------------------------------------------------
+
+PS1ExtractedAssetBrowser::PS1ExtractedAssetBrowser(PS1CapturedAssets *store, QWidget *parent)
+    : QWidget(parent)
+    , m_store(store)
+{
+    auto *root = new QVBoxLayout(this);
+    root->setContentsMargins(6, 6, 6, 6);
+    root->setSpacing(4);
+
+    m_countsLabel = new QLabel(this);
+    root->addWidget(m_countsLabel);
+
+    auto *chipRow = new QHBoxLayout();
+    chipRow->setSpacing(4);
+    auto makeChip = [this](const QString &text) {
+        auto *btn = new QToolButton(this);
+        btn->setText(text);
+        btn->setCheckable(true);
+        btn->setChecked(true);
+        return btn;
+    };
+    m_chipTextured = makeChip(tr("Textured"));
+    m_chipColored = makeChip(tr("Colored only"));
+    m_chipInstanced = makeChip(tr("Instanced"));
+    chipRow->addWidget(m_chipTextured);
+    chipRow->addWidget(m_chipColored);
+    chipRow->addWidget(m_chipInstanced);
+    m_searchEdit = new QLineEdit(this);
+    m_searchEdit->setPlaceholderText(tr("Search asset name…"));
+    m_searchEdit->setClearButtonEnabled(true);
+    chipRow->addWidget(m_searchEdit, /*stretch*/ 1);
+    root->addLayout(chipRow);
+
+    auto makeListView = [this]() {
+        auto *view = new QListView(this);
+        view->setViewMode(QListView::IconMode);
+        view->setIconSize(QSize(kThumbnailSize, kThumbnailSize));
+        view->setResizeMode(QListView::Adjust);
+        view->setSpacing(8);
+        view->setMovement(QListView::Static);
+        view->setUniformItemSizes(true);
+        view->setSelectionMode(QAbstractItemView::SingleSelection);
+        view->setDragEnabled(true);
+        view->setDragDropMode(QAbstractItemView::DragOnly);
+        return view;
+    };
+
+    m_meshView = makeListView();
+    m_textureView = makeListView();
+    m_materialView = makeListView();
+
+    m_meshModel = new PS1ExtractedAssetModel(ExtractedAssetKind::Mesh, this);
+    m_textureModel = new PS1ExtractedAssetModel(ExtractedAssetKind::Texture, this);
+    m_materialModel = new PS1ExtractedAssetModel(ExtractedAssetKind::Material, this);
+    m_meshFilter = new PS1ExtractedAssetFilter(this);
+    m_textureFilter = new PS1ExtractedAssetFilter(this);
+    m_materialFilter = new PS1ExtractedAssetFilter(this);
+    m_meshFilter->setSourceModel(m_meshModel);
+    m_textureFilter->setSourceModel(m_textureModel);
+    m_materialFilter->setSourceModel(m_materialModel);
+    m_meshView->setModel(m_meshFilter);
+    m_textureView->setModel(m_textureFilter);
+    m_materialView->setModel(m_materialFilter);
+
+    connect(m_meshView, &QListView::doubleClicked, this,
+            &PS1ExtractedAssetBrowser::onMeshActivated);
+
+    m_tabs = new QTabWidget(this);
+    m_tabs->addTab(m_meshView, tr("Meshes"));
+    m_tabs->addTab(m_textureView, tr("Textures"));
+    m_tabs->addTab(m_materialView, tr("Materials"));
+    root->addWidget(m_tabs, /*stretch*/ 1);
+
+    auto applySearch = [this](const QString &t) {
+        m_meshFilter->setSearchText(t);
+        m_textureFilter->setSearchText(t);
+        m_materialFilter->setSearchText(t);
+    };
+    connect(m_searchEdit, &QLineEdit::textChanged, this, applySearch);
+    connect(m_chipTextured, &QToolButton::toggled, this, [this](bool on) {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("ps1_rip_browser_chip_textured=%1")
+                                          .arg(on ? 1 : 0));
+        m_meshFilter->setShowTextured(on);
+        m_textureFilter->setShowTextured(on);
+        m_materialFilter->setShowTextured(on);
+    });
+    connect(m_chipColored, &QToolButton::toggled, this, [this](bool on) {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("ps1_rip_browser_chip_colored=%1")
+                                          .arg(on ? 1 : 0));
+        m_meshFilter->setShowColoredOnly(on);
+        m_textureFilter->setShowColoredOnly(on);
+        m_materialFilter->setShowColoredOnly(on);
+    });
+    connect(m_chipInstanced, &QToolButton::toggled, this, [this](bool on) {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("ps1_rip_browser_chip_instanced=%1")
+                                          .arg(on ? 1 : 0));
+        m_meshFilter->setShowInstanced(on);
+        m_textureFilter->setShowInstanced(on);
+        m_materialFilter->setShowInstanced(on);
+    });
+
+    if (m_store)
+        connect(m_store, &PS1CapturedAssets::captureSetChanged, this,
+                &PS1ExtractedAssetBrowser::onCaptureSetChanged);
+    rebuildModels();
+}
+
+void PS1ExtractedAssetBrowser::refreshHeader()
+{
+    if (!m_countsLabel)
+        return;
+    if (!m_store || !m_store->hasCapture()) {
+        m_countsLabel->setText(tr("No capture yet — Capture Frame or Capture Scene to populate."));
+        return;
+    }
+    const CapturedAssetSet &set = m_store->captureSet();
+    m_countsLabel->setText(
+        tr("Captured: %1 prims · %2 unique meshes · %3 textures")
+            .arg(QLocale().toString(set.totalPrims))
+            .arg(QLocale().toString(set.uniqueMeshes.size()))
+            .arg(QLocale().toString(set.uniqueTextureIds.size())));
+}
+
+void PS1ExtractedAssetBrowser::onCaptureSetChanged()
+{
+    rebuildModels();
+    refreshHeader();
+}
+
+void PS1ExtractedAssetBrowser::onMeshActivated(const QModelIndex &index)
+{
+    if (!index.isValid())
+        return;
+    const QModelIndex src = m_meshFilter->mapToSource(index);
+    if (src.row() < 0 || src.row() >= m_meshModel->tiles().size())
+        return;
+    const ExtractedAssetTile &tile = m_meshModel->tiles().at(src.row());
+    SentryReporter::addBreadcrumb(
+        QStringLiteral("ps1.rip.inspector.promote"),
+        QStringLiteral("source=browser-doubleclick asset=%1 mesh=%2")
+            .arg(tile.assetId)
+            .arg(tile.meshIndex));
+    emit instantiateMesh(tile.meshIndex, tile.assetId);
+}
+
+QVector<ExtractedAssetTile>
+PS1ExtractedAssetBrowser::buildTilesForKind(const CapturedAssetSet &set, ExtractedAssetKind kind)
+{
+    QVector<ExtractedAssetTile> tiles;
+    switch (kind) {
+    case ExtractedAssetKind::Mesh: {
+        QHash<int, int> instancesPerMesh;
+        for (const ReconstructedInstance &inst : set.instances)
+            instancesPerMesh[inst.uniqueMeshIndex]++;
+        for (int i = 0; i < set.uniqueMeshes.size(); ++i) {
+            const ReconstructedMesh &mesh = set.uniqueMeshes[i];
+            ExtractedAssetTile tile;
+            tile.kind = kind;
+            tile.meshIndex = i;
+            tile.assetId = mesh.meshName + QLatin1Char('_') + set.captureId;
+            tile.triangleCount = mesh.triangleCount;
+            tile.instanceCount = instancesPerMesh.value(i, 0);
+            tile.instanced = tile.instanceCount > 1;
+            bool anyTextured = false;
+            QString firstMaterial;
+            for (const ReconstructedSubMesh &sub : mesh.subMeshes) {
+                if (firstMaterial.isEmpty())
+                    firstMaterial = sub.materialName;
+                if (sub.materialName.startsWith(QStringLiteral("PS1Rip_tpage_")))
+                    anyTextured = true;
+            }
+            tile.textured = anyTextured;
+            tile.coloredOnly = !anyTextured;
+            tile.displayName = tr("Mesh %1 · %2 tris · %3 inst")
+                                   .arg(i)
+                                   .arg(mesh.triangleCount)
+                                   .arg(tile.instanceCount);
+            tile.thumbnail = placeholderThumbnail(QString::number(i),
+                                                  accentForMaterial(firstMaterial));
+            tiles.push_back(tile);
+        }
+        break;
+    }
+    case ExtractedAssetKind::Texture: {
+        for (auto it = set.textureImages.constBegin(); it != set.textureImages.constEnd(); ++it) {
+            ExtractedAssetTile tile;
+            tile.kind = kind;
+            tile.assetId = it.key();
+            tile.displayName = it.key();
+            tile.textured = true;
+            tile.thumbnail = it.value().scaled(kThumbnailSize, kThumbnailSize,
+                                               Qt::KeepAspectRatio, Qt::SmoothTransformation);
+            tiles.push_back(tile);
+        }
+        break;
+    }
+    case ExtractedAssetKind::Material: {
+        // Materials are the union of texture-bearing material names and
+        // the synthetic "PS1Rip_color" name used for solid-color prims.
+        QSet<QString> seen;
+        for (const ReconstructedMesh &mesh : set.uniqueMeshes) {
+            for (const ReconstructedSubMesh &sub : mesh.subMeshes) {
+                if (seen.contains(sub.materialName))
+                    continue;
+                seen.insert(sub.materialName);
+                ExtractedAssetTile tile;
+                tile.kind = kind;
+                tile.assetId = sub.materialName;
+                tile.displayName = sub.materialName;
+                tile.textured = sub.materialName.startsWith(QStringLiteral("PS1Rip_tpage_"));
+                tile.coloredOnly = !tile.textured;
+                if (tile.textured && set.textureImages.contains(sub.materialName)) {
+                    tile.thumbnail = set.textureImages.value(sub.materialName).scaled(
+                        kThumbnailSize, kThumbnailSize, Qt::KeepAspectRatio,
+                        Qt::SmoothTransformation);
+                } else {
+                    tile.thumbnail = placeholderThumbnail(
+                        tile.textured ? QStringLiteral("T") : QStringLiteral("◆"),
+                        accentForMaterial(sub.materialName));
+                }
+                tiles.push_back(tile);
+            }
+        }
+        break;
+    }
+    }
+    return tiles;
+}
+
+QImage PS1ExtractedAssetBrowser::placeholderThumbnail(const QString &caption, const QColor &accent)
+{
+    QImage img(kThumbnailSize, kThumbnailSize, QImage::Format_ARGB32);
+    img.fill(QColor(40, 40, 40));
+    QPainter p(&img);
+    p.setRenderHint(QPainter::Antialiasing, true);
+    QLinearGradient grad(0, 0, 0, kThumbnailSize);
+    grad.setColorAt(0.0, accent);
+    grad.setColorAt(1.0, accent.darker(180));
+    p.setBrush(grad);
+    p.setPen(QPen(accent.lighter(150), 2));
+    p.drawRoundedRect(QRect(6, 6, kThumbnailSize - 12, kThumbnailSize - 12), 8, 8);
+    p.setPen(Qt::white);
+    QFont f = p.font();
+    f.setPointSize(18);
+    f.setBold(true);
+    p.setFont(f);
+    p.drawText(img.rect(), Qt::AlignCenter, caption);
+    return img;
+}
+
+void PS1ExtractedAssetBrowser::rebuildModels()
+{
+    if (!m_store) {
+        m_meshModel->setTiles({});
+        m_textureModel->setTiles({});
+        m_materialModel->setTiles({});
+        return;
+    }
+    const CapturedAssetSet &set = m_store->captureSet();
+    m_meshModel->setTiles(buildTilesForKind(set, ExtractedAssetKind::Mesh));
+    m_textureModel->setTiles(buildTilesForKind(set, ExtractedAssetKind::Texture));
+    m_materialModel->setTiles(buildTilesForKind(set, ExtractedAssetKind::Material));
+}

--- a/src/PS1/runtime/PS1ExtractedAssetBrowser.h
+++ b/src/PS1/runtime/PS1ExtractedAssetBrowser.h
@@ -1,0 +1,195 @@
+#ifndef PS1EXTRACTEDASSETBROWSER_H
+#define PS1EXTRACTEDASSETBROWSER_H
+
+#include <QAbstractListModel>
+#include <QImage>
+#include <QSortFilterProxyModel>
+#include <QString>
+#include <QWidget>
+
+#include "PS1CapturedAssets.h"
+
+class QLabel;
+class QLineEdit;
+class QListView;
+class QTabWidget;
+class QToolButton;
+
+/**
+ * Asset browser kinds (#426). The browser uses one model per kind so
+ * tab switches don't have to invalidate a single filter — each tab keeps
+ * its own selection/scroll state, just like Finder / Explorer.
+ */
+enum class ExtractedAssetKind {
+    Mesh = 0,
+    Texture,
+    Material,
+};
+
+/**
+ * One thumbnail tile shown in the Extracted Asset Browser (#426). Pure
+ * data — no Ogre handles — so the model can be exercised from unit tests
+ * without an Ogre/Qt-OpenGL session.
+ */
+struct ExtractedAssetTile
+{
+    ExtractedAssetKind kind = ExtractedAssetKind::Mesh;
+    QString displayName;
+    /** Stable identifier used for drag-and-drop MIME payloads. For
+     *  meshes this is the Ogre mesh resource name (e.g. `ps1_unique_0_<captureId>`),
+     *  for textures and materials it is the logical material name. */
+    QString assetId;
+    /** Original mesh / instance / material indexes into
+     *  `CapturedAssetSet`. -1 when not applicable to the kind. */
+    int meshIndex = -1;
+    int instanceCount = 0;
+    int triangleCount = 0;
+    /** Whether the mesh is "textured" (at least one submesh has a texture
+     *  page). Drives the filter chip. */
+    bool textured = false;
+    /** Whether the mesh / material has only vertex colors (no texture). */
+    bool coloredOnly = false;
+    /** Whether the mesh has more than one placed instance — used for the
+     *  `instanced` filter chip. */
+    bool instanced = false;
+    /** Preview pixmap (texture image for Texture/Material tabs, generated
+     *  thumbnail for Mesh tab). The Mesh tab uses a software-rendered
+     *  schematic until we wire up offscreen Ogre rendering. */
+    QImage thumbnail;
+};
+
+/**
+ * Generic list model backing one tab of the Extracted Asset Browser.
+ *
+ * Rather than maintain three separate widget hierarchies, we share a
+ * single `QListView` template per tab and swap the model + filter.
+ * Drag-and-drop is implemented at the model level (`mimeData()`) so
+ * `application/x-ps1rip-mesh` (etc.) payloads survive across re-parents.
+ */
+class PS1ExtractedAssetModel : public QAbstractListModel
+{
+    Q_OBJECT
+
+public:
+    explicit PS1ExtractedAssetModel(ExtractedAssetKind kind, QObject *parent = nullptr);
+
+    void setTiles(QVector<ExtractedAssetTile> tiles);
+    const QVector<ExtractedAssetTile> &tiles() const { return m_tiles; }
+
+    int rowCount(const QModelIndex &parent = {}) const override;
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
+    Qt::DropActions supportedDragActions() const override { return Qt::CopyAction; }
+    QStringList mimeTypes() const override;
+    QMimeData *mimeData(const QModelIndexList &indexes) const override;
+
+    /** Stable MIME type identifiers shared with `PS1RipSessionWindow`'s
+     *  drop handler. Mesh has its own type so we can validate drops only
+     *  fire on the editor viewport. */
+    static QString mimeTypeForKind(ExtractedAssetKind kind);
+
+private:
+    ExtractedAssetKind m_kind;
+    QVector<ExtractedAssetTile> m_tiles;
+};
+
+/**
+ * Filter proxy driving the per-tab search box + chip toggles
+ * (textured / colored-only / instanced).
+ */
+class PS1ExtractedAssetFilter : public QSortFilterProxyModel
+{
+    Q_OBJECT
+
+public:
+    explicit PS1ExtractedAssetFilter(QObject *parent = nullptr);
+
+    void setShowTextured(bool show);
+    void setShowColoredOnly(bool show);
+    void setShowInstanced(bool show);
+    void setSearchText(const QString &text);
+
+protected:
+    bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const override;
+
+private:
+    bool m_showTextured = true;
+    bool m_showColoredOnly = true;
+    bool m_showInstanced = true;
+    QString m_searchText;
+};
+
+/**
+ * Extracted Asset Browser dock body (#426). Three QListViews in icon mode
+ * (Meshes / Textures / Materials), each with its own model + filter proxy.
+ * Drag-and-drop a mesh tile into the editor viewport → emits
+ * `instantiateMesh(meshIndex, assetId)` so the session window can clone
+ * the Ogre mesh and create a permanent SceneNode.
+ *
+ * Thumbnail generation:
+ * - Textures: directly from `CapturedAssetSet::textureImages`.
+ * - Materials: same image as textures (PS1 materials are mostly tpage +
+ *   tint), with a small color swatch overlay for solid materials.
+ * - Meshes: software-rendered icon (triangle count badge + colored swatch)
+ *   until offscreen Ogre rendering lands as a follow-up. The icon API is
+ *   the same so the future renderer is a drop-in replacement.
+ */
+class PS1ExtractedAssetBrowser : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit PS1ExtractedAssetBrowser(PS1CapturedAssets *store, QWidget *parent = nullptr);
+
+    void refreshHeader();
+
+    /** Test/UI accessors. */
+    QListView *meshView() const { return m_meshView; }
+    QListView *textureView() const { return m_textureView; }
+    QListView *materialView() const { return m_materialView; }
+    PS1ExtractedAssetModel *meshModel() const { return m_meshModel; }
+    PS1ExtractedAssetModel *textureModel() const { return m_textureModel; }
+    PS1ExtractedAssetModel *materialModel() const { return m_materialModel; }
+
+signals:
+    /** Fires on double-click on a mesh tile or on a successful drag-drop
+     *  out to a drop target — the session window listens and clones the
+     *  Ogre mesh into a fresh SceneNode (#426 acceptance criterion:
+     *  "Drag-and-drop creates a permanent entity"). */
+    void instantiateMesh(int meshIndex, const QString &assetId);
+
+public:
+    /** Pure-data helper used by both the live UI path and unit tests.
+     *  Exposed publicly so tests can exercise tile construction without
+     *  needing a live QWidget tree. */
+    static QVector<ExtractedAssetTile>
+    buildTilesForKind(const CapturedAssetSet &set, ExtractedAssetKind kind);
+
+private slots:
+    void onCaptureSetChanged();
+    void onMeshActivated(const QModelIndex &index);
+
+private:
+    void rebuildModels();
+    static QImage placeholderThumbnail(const QString &caption, const QColor &accent);
+
+    PS1CapturedAssets *m_store = nullptr;
+    QTabWidget *m_tabs = nullptr;
+    QLabel *m_countsLabel = nullptr;
+    QLineEdit *m_searchEdit = nullptr;
+    QToolButton *m_chipTextured = nullptr;
+    QToolButton *m_chipColored = nullptr;
+    QToolButton *m_chipInstanced = nullptr;
+
+    QListView *m_meshView = nullptr;
+    QListView *m_textureView = nullptr;
+    QListView *m_materialView = nullptr;
+    PS1ExtractedAssetModel *m_meshModel = nullptr;
+    PS1ExtractedAssetModel *m_textureModel = nullptr;
+    PS1ExtractedAssetModel *m_materialModel = nullptr;
+    PS1ExtractedAssetFilter *m_meshFilter = nullptr;
+    PS1ExtractedAssetFilter *m_textureFilter = nullptr;
+    PS1ExtractedAssetFilter *m_materialFilter = nullptr;
+};
+
+#endif // PS1EXTRACTEDASSETBROWSER_H

--- a/src/PS1/runtime/PS1GeometryInspectorPanel.cpp
+++ b/src/PS1/runtime/PS1GeometryInspectorPanel.cpp
@@ -238,10 +238,12 @@ bool PS1GeometryInspectorFilter::filterAcceptsRow(int sourceRow,
         return false;
     if (!row.textured && row.colored && !m_showColored)
         return false;
-    if (row.instanceIndex >= 0 && !m_showInstanced && !row.textured && !row.colored) {
-        // "Instanced" chip is a positive filter for prims that landed on
-        // a non-zero matrix instance — covers solid-color props attached
-        // to a transform that the camera path didn't consume.
+    if (row.instanceIndex >= 0 && !m_showInstanced) {
+        // "Instanced" chip is a positive filter: when it's off, hide every
+        // prim that resolved to a non-zero matrix instance, regardless of
+        // textured / colored state. The earlier `!row.textured && !row.colored`
+        // qualifier neutered the chip because virtually every PS1 prim is
+        // either textured or colored (#679 review feedback).
         return false;
     }
     if (!m_searchText.isEmpty()) {

--- a/src/PS1/runtime/PS1GeometryInspectorPanel.cpp
+++ b/src/PS1/runtime/PS1GeometryInspectorPanel.cpp
@@ -1,0 +1,438 @@
+#include "PS1GeometryInspectorPanel.h"
+
+#include "SentryReporter.h"
+
+#include <QAction>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QLabel>
+#include <QLineEdit>
+#include <QLocale>
+#include <QMenu>
+#include <QTableView>
+#include <QToolButton>
+#include <QVBoxLayout>
+
+PS1GeometryInspectorModel::PS1GeometryInspectorModel(PS1CapturedAssets *store, QObject *parent)
+    : QAbstractTableModel(parent)
+    , m_store(store)
+{
+    if (m_store) {
+        connect(m_store, &PS1CapturedAssets::captureSetChanged, this,
+                &PS1GeometryInspectorModel::onCaptureSetChanged);
+        connect(m_store, &PS1CapturedAssets::rowChanged, this,
+                &PS1GeometryInspectorModel::onRowChanged);
+    }
+}
+
+int PS1GeometryInspectorModel::rowCount(const QModelIndex &parent) const
+{
+    if (parent.isValid() || !m_store)
+        return 0;
+    return m_store->captureSet().rows.size();
+}
+
+int PS1GeometryInspectorModel::columnCount(const QModelIndex &parent) const
+{
+    if (parent.isValid())
+        return 0;
+    return ColCount;
+}
+
+CapturedAssetRow PS1GeometryInspectorModel::rowAt(int row) const
+{
+    if (!m_store)
+        return {};
+    const auto &rows = m_store->captureSet().rows;
+    if (row < 0 || row >= rows.size())
+        return {};
+    return rows.at(row);
+}
+
+QString PS1GeometryInspectorModel::primKindLabel(PrimKind kind)
+{
+    switch (kind) {
+    case PrimKind::MonoTri:
+        return QStringLiteral("tri");
+    case PrimKind::ShadedTri:
+        return QStringLiteral("tri/shaded");
+    case PrimKind::TexturedTri:
+        return QStringLiteral("tri/tex");
+    case PrimKind::MonoQuad:
+        return QStringLiteral("quad");
+    case PrimKind::ShadedQuad:
+        return QStringLiteral("quad/shaded");
+    case PrimKind::TexturedQuad:
+        return QStringLiteral("quad/tex");
+    case PrimKind::Sprite:
+        return QStringLiteral("sprite");
+    }
+    return QStringLiteral("?");
+}
+
+QVariant PS1GeometryInspectorModel::data(const QModelIndex &index, int role) const
+{
+    if (!m_store || !index.isValid())
+        return {};
+    const auto &rows = m_store->captureSet().rows;
+    if (index.row() < 0 || index.row() >= rows.size())
+        return {};
+    const CapturedAssetRow &row = rows.at(index.row());
+
+    if (role == Qt::DisplayRole) {
+        switch (index.column()) {
+        case ColRow:
+            return row.rowIndex;
+        case ColFrame:
+            return static_cast<qulonglong>(row.frameIndex);
+        case ColType:
+            return primKindLabel(row.kind);
+        case ColVerts:
+            return row.vertexCount;
+        case ColTpage:
+            return QStringLiteral("0x%1").arg(row.tpage, 4, 16, QLatin1Char('0'));
+        case ColClut:
+            return QStringLiteral("0x%1").arg(row.clut, 4, 16, QLatin1Char('0'));
+        case ColMatrix:
+            return row.matrixId == 0 ? QStringLiteral("—")
+                                     : QStringLiteral("%1").arg(row.matrixId);
+        case ColMaterial:
+            return row.materialName;
+        case ColTriangles:
+            return row.triangleCount;
+        default:
+            return {};
+        }
+    }
+    if (role == Qt::ForegroundRole) {
+        if (row.discarded)
+            return QColor(Qt::gray);
+        if (row.hidden)
+            return QColor(120, 120, 120);
+    }
+    if (role == Qt::ToolTipRole) {
+        QString tt = tr("Row #%1 · %2 · %3 verts")
+                         .arg(row.rowIndex)
+                         .arg(primKindLabel(row.kind))
+                         .arg(row.vertexCount);
+        if (row.textured)
+            tt += tr("\nTextured · tpage=0x%1 clut=0x%2")
+                      .arg(row.tpage, 4, 16, QLatin1Char('0'))
+                      .arg(row.clut, 4, 16, QLatin1Char('0'));
+        if (row.uniqueMeshIndex >= 0)
+            tt += tr("\nUnique mesh #%1, instance #%2")
+                      .arg(row.uniqueMeshIndex)
+                      .arg(row.instanceIndex);
+        if (row.hidden)
+            tt += tr("\n(hidden in viewport)");
+        if (row.discarded)
+            tt += tr("\n(discarded)");
+        return tt;
+    }
+    return {};
+}
+
+QVariant PS1GeometryInspectorModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if (role != Qt::DisplayRole || orientation != Qt::Horizontal)
+        return QAbstractTableModel::headerData(section, orientation, role);
+    switch (section) {
+    case ColRow:
+        return tr("#");
+    case ColFrame:
+        return tr("frame");
+    case ColType:
+        return tr("type");
+    case ColVerts:
+        return tr("verts");
+    case ColTpage:
+        return tr("tpage");
+    case ColClut:
+        return tr("clut");
+    case ColMatrix:
+        return tr("matrix#");
+    case ColMaterial:
+        return tr("material");
+    case ColTriangles:
+        return tr("triangles");
+    default:
+        return {};
+    }
+}
+
+void PS1GeometryInspectorModel::onCaptureSetChanged()
+{
+    beginResetModel();
+    endResetModel();
+}
+
+void PS1GeometryInspectorModel::onRowChanged(int rowIndex)
+{
+    if (rowIndex < 1)
+        return;
+    const int row = rowIndex - 1;
+    emit dataChanged(index(row, 0), index(row, ColCount - 1));
+}
+
+// --- Filter proxy ----------------------------------------------------------
+
+PS1GeometryInspectorFilter::PS1GeometryInspectorFilter(QObject *parent)
+    : QSortFilterProxyModel(parent)
+{
+    setFilterCaseSensitivity(Qt::CaseInsensitive);
+}
+
+void PS1GeometryInspectorFilter::setShowTextured(bool show)
+{
+    if (m_showTextured == show)
+        return;
+    m_showTextured = show;
+    invalidateFilter();
+}
+
+void PS1GeometryInspectorFilter::setShowColored(bool show)
+{
+    if (m_showColored == show)
+        return;
+    m_showColored = show;
+    invalidateFilter();
+}
+
+void PS1GeometryInspectorFilter::setShowInstanced(bool show)
+{
+    if (m_showInstanced == show)
+        return;
+    m_showInstanced = show;
+    invalidateFilter();
+}
+
+void PS1GeometryInspectorFilter::setHideDiscarded(bool hide)
+{
+    if (m_hideDiscarded == hide)
+        return;
+    m_hideDiscarded = hide;
+    invalidateFilter();
+}
+
+void PS1GeometryInspectorFilter::setSearchText(const QString &text)
+{
+    if (m_searchText == text)
+        return;
+    m_searchText = text;
+    invalidateFilter();
+}
+
+bool PS1GeometryInspectorFilter::filterAcceptsRow(int sourceRow,
+                                                  const QModelIndex &sourceParent) const
+{
+    auto *src = qobject_cast<PS1GeometryInspectorModel *>(sourceModel());
+    if (!src)
+        return true;
+    Q_UNUSED(sourceParent)
+    const CapturedAssetRow row = src->rowAt(sourceRow);
+    if (row.rowIndex == 0)
+        return false;
+    if (row.discarded && m_hideDiscarded)
+        return false;
+    if (row.textured && !m_showTextured)
+        return false;
+    if (!row.textured && row.colored && !m_showColored)
+        return false;
+    if (row.instanceIndex >= 0 && !m_showInstanced && !row.textured && !row.colored) {
+        // "Instanced" chip is a positive filter for prims that landed on
+        // a non-zero matrix instance — covers solid-color props attached
+        // to a transform that the camera path didn't consume.
+        return false;
+    }
+    if (!m_searchText.isEmpty()) {
+        if (!row.materialName.contains(m_searchText, Qt::CaseInsensitive))
+            return false;
+    }
+    return true;
+}
+
+// --- Panel ----------------------------------------------------------------
+
+PS1GeometryInspectorPanel::PS1GeometryInspectorPanel(PS1CapturedAssets *store, QWidget *parent)
+    : QWidget(parent)
+    , m_store(store)
+{
+    m_model = new PS1GeometryInspectorModel(store, this);
+    m_filter = new PS1GeometryInspectorFilter(this);
+    m_filter->setSourceModel(m_model);
+    m_filter->setFilterKeyColumn(PS1GeometryInspectorModel::ColMaterial);
+
+    auto *root = new QVBoxLayout(this);
+    root->setContentsMargins(6, 6, 6, 6);
+    root->setSpacing(4);
+
+    m_countsLabel = new QLabel(this);
+    m_countsLabel->setWordWrap(false);
+    root->addWidget(m_countsLabel);
+
+    auto *chipRow = new QHBoxLayout();
+    chipRow->setSpacing(4);
+    auto makeChip = [this](const QString &text, bool defaultOn) {
+        auto *btn = new QToolButton(this);
+        btn->setText(text);
+        btn->setCheckable(true);
+        btn->setChecked(defaultOn);
+        btn->setAutoRaise(false);
+        return btn;
+    };
+    m_chipTextured = makeChip(tr("Textured"), true);
+    m_chipColored = makeChip(tr("Colored"), true);
+    m_chipInstanced = makeChip(tr("Instanced"), true);
+    m_chipVisible = makeChip(tr("Hide discarded"), false);
+    chipRow->addWidget(m_chipTextured);
+    chipRow->addWidget(m_chipColored);
+    chipRow->addWidget(m_chipInstanced);
+    chipRow->addWidget(m_chipVisible);
+    m_searchEdit = new QLineEdit(this);
+    m_searchEdit->setPlaceholderText(tr("Search material…"));
+    m_searchEdit->setClearButtonEnabled(true);
+    chipRow->addWidget(m_searchEdit, /*stretch*/ 1);
+    root->addLayout(chipRow);
+
+    m_tableView = new QTableView(this);
+    m_tableView->setModel(m_filter);
+    m_tableView->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_tableView->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_tableView->setSortingEnabled(true);
+    m_tableView->verticalHeader()->setVisible(false);
+    m_tableView->horizontalHeader()->setStretchLastSection(true);
+    m_tableView->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    m_tableView->setContextMenuPolicy(Qt::CustomContextMenu);
+    m_tableView->setAlternatingRowColors(true);
+    root->addWidget(m_tableView, /*stretch*/ 1);
+
+    connect(m_tableView, &QTableView::activated, this, &PS1GeometryInspectorPanel::onActivated);
+    connect(m_tableView, &QTableView::clicked, this, &PS1GeometryInspectorPanel::onActivated);
+    connect(m_tableView, &QTableView::customContextMenuRequested, this,
+            &PS1GeometryInspectorPanel::onCustomMenu);
+    connect(m_chipTextured, &QToolButton::toggled, this, [this](bool on) {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("ps1_rip_inspector_chip_textured=%1")
+                                          .arg(on ? 1 : 0));
+        m_filter->setShowTextured(on);
+    });
+    connect(m_chipColored, &QToolButton::toggled, this, [this](bool on) {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("ps1_rip_inspector_chip_colored=%1")
+                                          .arg(on ? 1 : 0));
+        m_filter->setShowColored(on);
+    });
+    connect(m_chipInstanced, &QToolButton::toggled, this, [this](bool on) {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("ps1_rip_inspector_chip_instanced=%1")
+                                          .arg(on ? 1 : 0));
+        m_filter->setShowInstanced(on);
+    });
+    connect(m_chipVisible, &QToolButton::toggled, this, [this](bool on) {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("ps1_rip_inspector_chip_hide_discarded=%1")
+                                          .arg(on ? 1 : 0));
+        m_filter->setHideDiscarded(on);
+    });
+    connect(m_searchEdit, &QLineEdit::textChanged, this,
+            [this](const QString &t) { m_filter->setSearchText(t); });
+
+    if (m_store)
+        connect(m_store, &PS1CapturedAssets::captureSetChanged, this,
+                &PS1GeometryInspectorPanel::onCaptureSetChanged);
+
+    refreshHeader();
+}
+
+void PS1GeometryInspectorPanel::refreshHeader()
+{
+    if (!m_countsLabel)
+        return;
+    if (!m_store || !m_store->hasCapture()) {
+        m_countsLabel->setText(tr("No capture yet — Capture Frame or Capture Scene to populate."));
+        return;
+    }
+    const CapturedAssetSet &set = m_store->captureSet();
+    m_countsLabel->setText(
+        tr("Captured: %1 prims · %2 unique meshes · %3 textures")
+            .arg(QLocale().toString(set.totalPrims))
+            .arg(QLocale().toString(set.uniqueMeshes.size()))
+            .arg(QLocale().toString(set.uniqueTextureIds.size())));
+}
+
+void PS1GeometryInspectorPanel::onCaptureSetChanged()
+{
+    refreshHeader();
+}
+
+void PS1GeometryInspectorPanel::onActivated(const QModelIndex &index)
+{
+    if (!index.isValid())
+        return;
+    const QModelIndex src = m_filter->mapToSource(index);
+    const CapturedAssetRow row = m_model->rowAt(src.row());
+    if (row.rowIndex == 0)
+        return;
+    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                  QStringLiteral("ps1_rip_inspector_highlight=%1").arg(row.rowIndex));
+    emit highlightRow(row.rowIndex);
+}
+
+int PS1GeometryInspectorPanel::rowIndexAtView(const QPoint &viewPoint) const
+{
+    if (!m_tableView)
+        return 0;
+    const QModelIndex idx = m_tableView->indexAt(viewPoint);
+    if (!idx.isValid())
+        return 0;
+    const QModelIndex src = m_filter->mapToSource(idx);
+    const CapturedAssetRow row = m_model->rowAt(src.row());
+    return row.rowIndex;
+}
+
+void PS1GeometryInspectorPanel::onCustomMenu(const QPoint &pos)
+{
+    const int rowIndex = rowIndexAtView(pos);
+    if (rowIndex == 0)
+        return;
+    const CapturedAssetRow row = m_store->captureSet().rows.at(rowIndex - 1);
+
+    QMenu menu(this);
+    auto *toggleVis = menu.addAction(row.hidden ? tr("Show this submesh")
+                                                : tr("Hide this submesh"));
+    auto *promote = menu.addAction(tr("Promote to permanent entity"));
+    auto *discard = menu.addAction(row.discarded ? tr("Restore (un-discard)")
+                                                 : tr("Discard"));
+
+    QAction *chosen = menu.exec(m_tableView->viewport()->mapToGlobal(pos));
+    if (!chosen)
+        return;
+    if (chosen == toggleVis) {
+        if (row.hidden) {
+            SentryReporter::addBreadcrumb(
+                QStringLiteral("ui.action"),
+                QStringLiteral("ps1_rip_inspector_show=%1").arg(rowIndex));
+            emit showSubmeshRequested(rowIndex);
+        } else {
+            SentryReporter::addBreadcrumb(
+                QStringLiteral("ui.action"),
+                QStringLiteral("ps1_rip_inspector_hide=%1").arg(rowIndex));
+            emit hideSubmeshRequested(rowIndex);
+        }
+    } else if (chosen == promote) {
+        SentryReporter::addBreadcrumb(
+            QStringLiteral("ps1.rip.inspector.promote"),
+            QStringLiteral("row=%1 mesh=%2 material=%3")
+                .arg(rowIndex)
+                .arg(row.uniqueMeshIndex)
+                .arg(row.materialName));
+        emit promoteRowRequested(rowIndex);
+    } else if (chosen == discard) {
+        SentryReporter::addBreadcrumb(
+            QStringLiteral("ui.action"),
+            QStringLiteral("ps1_rip_inspector_discard=%1 set=%2")
+                .arg(rowIndex)
+                .arg(row.discarded ? 0 : 1));
+        emit discardRowRequested(rowIndex);
+    }
+}

--- a/src/PS1/runtime/PS1GeometryInspectorPanel.h
+++ b/src/PS1/runtime/PS1GeometryInspectorPanel.h
@@ -1,0 +1,171 @@
+#ifndef PS1GEOMETRYINSPECTORPANEL_H
+#define PS1GEOMETRYINSPECTORPANEL_H
+
+#include <QAbstractTableModel>
+#include <QSortFilterProxyModel>
+#include <QWidget>
+
+#include "PS1CapturedAssets.h"
+
+class QLabel;
+class QLineEdit;
+class QToolButton;
+class QTableView;
+
+/**
+ * Qt table model exposing `PS1CapturedAssets` rows to the inspector
+ * (#426). Columns match the issue spec:
+ *
+ *   `#`, `frame`, `type` (tri/quad/sprite), `verts`, `tpage`, `clut`,
+ *   `matrix#`, `material`, `triangles`.
+ *
+ * The model holds no draw-call data of its own — it forwards reads
+ * to `PS1CapturedAssets::captureSet().rows` so a row change in the
+ * store (e.g. `setRowHidden`) only needs a single `dataChanged()`
+ * signal rather than a model reset. Resets only fire on
+ * `captureSetChanged()`.
+ */
+class PS1GeometryInspectorModel : public QAbstractTableModel
+{
+    Q_OBJECT
+
+public:
+    enum Column {
+        ColRow = 0,
+        ColFrame,
+        ColType,
+        ColVerts,
+        ColTpage,
+        ColClut,
+        ColMatrix,
+        ColMaterial,
+        ColTriangles,
+        ColCount
+    };
+
+    explicit PS1GeometryInspectorModel(PS1CapturedAssets *store, QObject *parent = nullptr);
+
+    int rowCount(const QModelIndex &parent = {}) const override;
+    int columnCount(const QModelIndex &parent = {}) const override;
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+    QVariant headerData(int section, Qt::Orientation orientation,
+                        int role = Qt::DisplayRole) const override;
+
+    /** Convenience for views that want the underlying row data
+     *  for a given table row (used by the context menu, drag-drop
+     *  source, etc.). Returns an invalid row when the row is out
+     *  of range so callers can guard with `rowIndex > 0`. */
+    CapturedAssetRow rowAt(int row) const;
+
+    static QString primKindLabel(PrimKind kind);
+
+private slots:
+    void onCaptureSetChanged();
+    void onRowChanged(int rowIndex);
+
+private:
+    PS1CapturedAssets *m_store = nullptr;
+};
+
+/**
+ * Filter proxy that drives the inspector's filter chips
+ * (Textured / Colored-only / Visible-only) plus a free-text
+ * search across the Material column (#426). Filter state is held
+ * on the proxy so the view can call `invalidateFilter()` when
+ * the user toggles a chip without rebuilding the source model.
+ */
+class PS1GeometryInspectorFilter : public QSortFilterProxyModel
+{
+    Q_OBJECT
+
+public:
+    explicit PS1GeometryInspectorFilter(QObject *parent = nullptr);
+
+    void setShowTextured(bool show);
+    void setShowColored(bool show);
+    void setShowInstanced(bool show);
+    void setHideDiscarded(bool hide);
+    void setSearchText(const QString &text);
+
+    bool showTextured() const { return m_showTextured; }
+    bool showColored() const { return m_showColored; }
+    bool showInstanced() const { return m_showInstanced; }
+    bool hideDiscarded() const { return m_hideDiscarded; }
+
+protected:
+    bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const override;
+
+private:
+    bool m_showTextured = true;
+    bool m_showColored = true;
+    bool m_showInstanced = true;
+    bool m_hideDiscarded = false;
+    QString m_searchText;
+};
+
+/**
+ * Geometry Inspector dock body (#426). Holds the table + filter chips
+ * + counts header. Sits inside `PS1RipSessionWindow` as a `QDockWidget`.
+ *
+ * Click semantics:
+ * - Single click → emits `highlightRow(rowIndex)` so the session
+ *   window can drive the editor `SelectionSet` to the matching
+ *   SubEntity.
+ * - Right click → context menu with Hide/Show submesh, Promote to
+ *   permanent entity, Discard. Each action emits a typed signal so
+ *   the session window owns the actual scene mutation.
+ *
+ * The panel is dumb about scene state: it only reads from
+ * `PS1CapturedAssets` and emits intent signals. This keeps the
+ * Qt UI testable in isolation from Ogre.
+ */
+class PS1GeometryInspectorPanel : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit PS1GeometryInspectorPanel(PS1CapturedAssets *store, QWidget *parent = nullptr);
+
+    /** Force a refresh of the counts header. Called from the session
+     *  window after it observes `captureSetChanged()` via the store. */
+    void refreshHeader();
+
+    /** Test/UI accessors. */
+    QTableView *tableView() const { return m_tableView; }
+    PS1GeometryInspectorFilter *filter() const { return m_filter; }
+    PS1GeometryInspectorModel *model() const { return m_model; }
+
+signals:
+    /** Fires on row activation. `rowIndex` is 1-based (matches the
+     *  `#` column). */
+    void highlightRow(int rowIndex);
+    /** Right-click menu actions. */
+    void hideSubmeshRequested(int rowIndex);
+    void showSubmeshRequested(int rowIndex);
+    void promoteRowRequested(int rowIndex);
+    void discardRowRequested(int rowIndex);
+
+private slots:
+    void onActivated(const QModelIndex &index);
+    void onCustomMenu(const QPoint &pos);
+    void onCaptureSetChanged();
+
+private:
+    /** Maps the proxy row at `viewPoint` to the underlying
+     *  CapturedAssetRow's 1-based index. Returns 0 when no row
+     *  is under the point. */
+    int rowIndexAtView(const QPoint &viewPoint) const;
+
+    PS1CapturedAssets *m_store = nullptr;
+    PS1GeometryInspectorModel *m_model = nullptr;
+    PS1GeometryInspectorFilter *m_filter = nullptr;
+    QTableView *m_tableView = nullptr;
+    QLabel *m_countsLabel = nullptr;
+    QLineEdit *m_searchEdit = nullptr;
+    QToolButton *m_chipTextured = nullptr;
+    QToolButton *m_chipColored = nullptr;
+    QToolButton *m_chipInstanced = nullptr;
+    QToolButton *m_chipVisible = nullptr;
+};
+
+#endif // PS1GEOMETRYINSPECTORPANEL_H

--- a/src/PS1/runtime/PS1RipManager.cpp
+++ b/src/PS1/runtime/PS1RipManager.cpp
@@ -4,6 +4,7 @@
 #include "MeshReconstructionStats.h"
 #include "MeshReconstructor.h"
 #include "MeshTopologyHash.h"
+#include "PS1CapturedAssets.h"
 #include "PS1RipMeshBuilder.h"
 #include "PS1RipWorker.h"
 #include "Ps1CoordinateNormalizer.h"
@@ -221,6 +222,17 @@ void PS1RipManager::initializeWorkerThread()
                     QStringLiteral("ps1.rip.vram.sync"),
                     QStringLiteral("capture=%1 mode=%2")
                         .arg(captureId, psxVramMirrorModeLabel(vramMirrorMode)));
+                // Populate the captured-asset store on the GUI thread before
+                // emitting `meshBuilt` so the inspector / asset-browser UI
+                // can refresh from a fully-populated store as soon as they
+                // observe the signal (#426). `meshBuilt` is connected with
+                // the default auto-connection but the worker thread emits
+                // it through a queued connection — emitting after the store
+                // update keeps everything single-threaded from the UI's POV.
+                CapturedAssetSet assetSet = PS1CapturedAssets::buildFromCapture(
+                    captureId, snapshot, captureSet, built.textureImages);
+                if (PS1CapturedAssets *store = PS1CapturedAssets::getSingleton())
+                    store->setCaptureSet(std::move(assetSet));
                 emit meshBuilt(captureId, captureSet.capturedPartCount, captureSet.uniqueCount(),
                                captureSet.instanceCount(), built.vertexCount, built.triangleCount,
                                snapshot.matrices.size(), snapshot.cameraMatrixId,

--- a/src/PS1/runtime/PS1RipMeshBuilder.cpp
+++ b/src/PS1/runtime/PS1RipMeshBuilder.cpp
@@ -212,6 +212,11 @@ struct TextureBuildContext {
     VramSnapshot vram;
     QHash<QString, TextureDecoder::MaterialKey> materialKeys;
     QHash<QString, Ogre::MaterialPtr> materials;
+    /** Per-material decoded page image, copied from the decoder cache as
+     *  each material is materialised. Surfaced through `BuildResult` so
+     *  the geometry inspector / asset browser (#426) can render texture
+     *  thumbnails without re-reading VRAM. */
+    QHash<QString, QImage> textureImages;
 };
 
 void predecodeCaptureTextures(const CaptureSnapshot *textureSource, TextureBuildContext *ctx)
@@ -291,6 +296,11 @@ Ogre::MaterialPtr ensureMaterial(const QString &logicalName, TextureBuildContext
         const QRect bounds = ctx->decoder.cachedBoundsOnPage(key);
         if (!tile.isNull()) {
             const QImage page = pageImageFromCachedTile(tile, bounds);
+            // Stash a copy for the geometry inspector / asset browser so it
+            // can render texture thumbnails without re-decoding from VRAM
+            // (#426). Keyed by logical material name to match
+            // `ReconstructedSubMesh::materialName`.
+            ctx->textureImages.insert(logicalName, page);
             const QString texResource = textureResourceName(ctx->captureId, logicalName);
             QString uploadErr;
             if (uploadTextureToOgre(ctx->resourceGroup, texResource, page, &uploadErr)) {
@@ -575,6 +585,7 @@ bool PS1RipMeshBuilder::attachToScene(const ReconstructedMesh &mesh, const QStri
         resultOut->entity = entity;
         resultOut->vertexCount = mesh.vertexCount;
         resultOut->triangleCount = mesh.triangleCount;
+        resultOut->textureImages = texCtx.textureImages;
     }
     SentryReporter::addBreadcrumb(
         QStringLiteral("ps1.rip.attach"),
@@ -706,6 +717,7 @@ bool PS1RipMeshBuilder::attachCaptureSetToScene(const ReconstructedCaptureSet &c
         resultOut->entity = firstEntity;
         resultOut->vertexCount = totalVerts;
         resultOut->triangleCount = totalTris;
+        resultOut->textureImages = texCtx.textureImages;
     }
     SentryReporter::addBreadcrumb(
         QStringLiteral("ps1.rip.attach"),

--- a/src/PS1/runtime/PS1RipMeshBuilder.h
+++ b/src/PS1/runtime/PS1RipMeshBuilder.h
@@ -5,6 +5,8 @@
 #include "MeshReconstructor.h"
 #include "Ps1CoordinateNormalizer.h"
 
+#include <QHash>
+#include <QImage>
 #include <QString>
 
 namespace Ogre {
@@ -21,6 +23,11 @@ public:
         Ogre::Entity *entity = nullptr;
         int vertexCount = 0;
         int triangleCount = 0;
+        /** Decoded texture page (256×256 RGBA) keyed by logical material
+         *  name, populated for the inspector's Texture / Material thumbs
+         *  (#426). Only textured materials are present; mono / shaded
+         *  materials have no entry. */
+        QHash<QString, QImage> textureImages;
     };
 
     static bool attachToScene(const ReconstructedMesh &mesh, const QString &captureId,

--- a/src/PS1/runtime/PS1RipSessionWindow.cpp
+++ b/src/PS1/runtime/PS1RipSessionWindow.cpp
@@ -20,6 +20,8 @@
 #include <QSignalBlocker>
 #include <QApplication>
 #include <QCloseEvent>
+#include <QFocusEvent>
+#include <QShowEvent>
 #include <QDateTime>
 #include <QDockWidget>
 #include <QDoubleSpinBox>
@@ -370,13 +372,25 @@ PS1RipSessionWindow::~PS1RipSessionWindow()
                                 QStringLiteral("PS1 rip session window closed"));
 }
 
-PS1RipSessionWindow *PS1RipSessionWindow::s_lastInstance = nullptr;
+QPointer<PS1RipSessionWindow> PS1RipSessionWindow::s_lastInstance;
 
 bool PS1RipSessionWindow::promoteUniqueMeshById(int meshIndex, const QString &assetId)
 {
-    if (!s_lastInstance)
-        return false;
-    return s_lastInstance->promoteUniqueMesh(meshIndex, assetId);
+    if (auto *win = s_lastInstance.data())
+        return win->promoteUniqueMesh(meshIndex, assetId);
+    return false;
+}
+
+void PS1RipSessionWindow::focusInEvent(QFocusEvent *event)
+{
+    s_lastInstance = this;
+    QMainWindow::focusInEvent(event);
+}
+
+void PS1RipSessionWindow::showEvent(QShowEvent *event)
+{
+    s_lastInstance = this;
+    QMainWindow::showEvent(event);
 }
 
 void PS1RipSessionWindow::createNormalizerDock()

--- a/src/PS1/runtime/PS1RipSessionWindow.cpp
+++ b/src/PS1/runtime/PS1RipSessionWindow.cpp
@@ -517,8 +517,15 @@ void PS1RipSessionWindow::createInspectorDocks()
             &PS1RipSessionWindow::promoteInspectorRow);
     connect(m_inspector.inspectorPanel, &PS1GeometryInspectorPanel::discardRowRequested, this,
             [this](int row) {
+                // Bounds-check before indexing: a stale context-menu action
+                // dispatched after a fresh capture has wiped the rows
+                // would otherwise walk past the end of the vector
+                // (#679 review feedback).
                 if (PS1CapturedAssets *s = PS1CapturedAssets::getSingletonPtr()) {
-                    const bool wasDiscarded = s->captureSet().rows.at(row - 1).discarded;
+                    const auto &rows = s->captureSet().rows;
+                    if (row < 1 || row > rows.size())
+                        return;
+                    const bool wasDiscarded = rows.at(row - 1).discarded;
                     discardInspectorRow(row, !wasDiscarded);
                 }
             });
@@ -527,6 +534,55 @@ void PS1RipSessionWindow::createInspectorDocks()
                 promoteUniqueMesh(meshIndex, assetId);
             });
 }
+
+namespace {
+
+/** Resolve a `CapturedAssetRow` to the live Ogre entity + sub-entity in the
+ *  capture preview. Returns null pointers when any link is missing so the
+ *  callers can short-circuit instead of crashing on a stale row (#679
+ *  review: row actions must be submesh-scoped, not whole-node-scoped). */
+struct InspectorRowResolution
+{
+    Ogre::SceneNode *node = nullptr;
+    Ogre::Entity *entity = nullptr;
+    Ogre::SubEntity *subEntity = nullptr;
+};
+
+InspectorRowResolution resolveInspectorRow(const CapturedAssetRow &row,
+                                           const CapturedAssetSet &set)
+{
+    InspectorRowResolution out;
+    if (row.instanceIndex < 0)
+        return out;
+    Manager *mgr = Manager::getSingletonPtr();
+    if (!mgr)
+        return out;
+    const QString nodeName = set.instanceNodeNames.value(row.instanceIndex);
+    if (nodeName.isEmpty())
+        return out;
+    out.node = mgr->getSceneNode(nodeName);
+    if (!out.node)
+        return out;
+    // A capture node owns exactly one Entity (built by `attachCaptureSetToScene`).
+    // Walk the attached-objects vector directly (the iterator helper is
+    // deprecated in Ogre 14). Type-check before casting so a ManualObject
+    // can't slip through and trigger the same `static_cast` crash that
+    // bites `Manager::getEntities` callers.
+    for (Ogre::MovableObject *obj : out.node->getAttachedObjects()) {
+        if (obj && obj->getMovableType() == "Entity") {
+            out.entity = static_cast<Ogre::Entity *>(obj);
+            break;
+        }
+    }
+    if (!out.entity)
+        return out;
+    if (row.subMeshIndex >= 0
+        && row.subMeshIndex < static_cast<int>(out.entity->getNumSubEntities()))
+        out.subEntity = out.entity->getSubEntity(static_cast<unsigned int>(row.subMeshIndex));
+    return out;
+}
+
+} // namespace
 
 void PS1RipSessionWindow::highlightInspectorRow(int rowIndex)
 {
@@ -538,20 +594,19 @@ void PS1RipSessionWindow::highlightInspectorRow(int rowIndex)
     const CapturedAssetSet &set = store->captureSet();
     if (rowIndex > set.rows.size())
         return;
-    const CapturedAssetRow &row = set.rows.at(rowIndex - 1);
-    if (row.instanceIndex < 0)
-        return;
-    const QString nodeName = set.instanceNodeNames.value(row.instanceIndex);
-    if (nodeName.isEmpty())
-        return;
-    Manager *mgr = Manager::getSingletonPtr();
     SelectionSet *sel = SelectionSet::getSingleton();
-    if (!mgr || !sel)
+    if (!sel)
         return;
-    Ogre::SceneNode *node = mgr->getSceneNode(nodeName);
-    if (!node)
-        return;
-    sel->selectOne(node);
+    const CapturedAssetRow &row = set.rows.at(rowIndex - 1);
+    const InspectorRowResolution res = resolveInspectorRow(row, set);
+    if (res.subEntity)
+        // Sub-entity selection so the highlight is scoped to the row's
+        // specific submesh — without this, two rows that share an instance
+        // but use different materials both select the whole node and the
+        // viewport outline can't tell them apart (#679 review feedback).
+        sel->selectOne(res.subEntity);
+    else if (res.node)
+        sel->selectOne(res.node);
 }
 
 void PS1RipSessionWindow::setInspectorRowVisible(int rowIndex, bool visible)
@@ -563,14 +618,16 @@ void PS1RipSessionWindow::setInspectorRowVisible(int rowIndex, bool visible)
     if (rowIndex < 1 || rowIndex > set.rows.size())
         return;
     const CapturedAssetRow &row = set.rows.at(rowIndex - 1);
-    if (row.instanceIndex < 0)
-        return;
-    const QString nodeName = set.instanceNodeNames.value(row.instanceIndex);
-    if (nodeName.isEmpty())
-        return;
-    if (Manager *mgr = Manager::getSingletonPtr()) {
-        if (Ogre::SceneNode *node = mgr->getSceneNode(nodeName))
-            node->setVisible(visible, /*cascade=*/true);
+    const InspectorRowResolution res = resolveInspectorRow(row, set);
+    if (res.subEntity) {
+        // Per-submesh hide: each draw call gets its own SubEntity, so this
+        // hides the row's specific triangle list and leaves the other
+        // submeshes of the same node visible (#679 review feedback).
+        res.subEntity->setVisible(visible);
+    } else if (res.node) {
+        // Fall back to whole-node visibility when the row didn't resolve to
+        // a specific submesh (e.g. legacy capture sets without provenance).
+        res.node->setVisible(visible, /*cascade=*/true);
     }
     store->setRowHidden(rowIndex, !visible);
 }
@@ -595,10 +652,132 @@ void PS1RipSessionWindow::promoteInspectorRow(int rowIndex)
         return;
     const QString meshAssetId =
         set.uniqueMeshes.at(row.uniqueMeshIndex).meshName + QLatin1Char('_') + set.captureId;
-    promoteUniqueMesh(row.uniqueMeshIndex, meshAssetId);
+    // Forward the row's specific instance so the promoted entity drops at
+    // that row's matrix transform — promoting row N after the user clicks
+    // row N in the inspector previously copied the FIRST instance's
+    // transform, producing a duplicate at the wrong spot for any mesh
+    // used by more than one matrix (#679 review feedback).
+    promoteUniqueMesh(row.uniqueMeshIndex, meshAssetId, row.instanceIndex);
 }
 
-bool PS1RipSessionWindow::promoteUniqueMesh(int meshIndex, const QString &assetId)
+namespace {
+
+/** Walk the cloned mesh's submeshes and replace every `PS1Rip_*` capture
+ *  material reference with a freshly-named clone that mirrors the source
+ *  pass, its texture units, and any referenced `ps1rip_*` textures. The
+ *  next `beginCaptureAttach` purges everything matching the `PS1Rip_*`
+ *  and `ps1rip_*` patterns, so without this the supposedly permanent
+ *  promoted entity would silently lose its material + texture binding
+ *  the moment the user takes another capture (#679 review feedback). */
+void rebindPromotedMaterials(Ogre::Mesh *clone, const QString &captureId, int promoId)
+{
+    if (!clone)
+        return;
+    Ogre::MaterialManager &matMgr = Ogre::MaterialManager::getSingleton();
+    Ogre::TextureManager &texMgr = Ogre::TextureManager::getSingleton();
+
+    QHash<QString, QString> textureRenames;
+    QHash<QString, QString> materialRenames;
+
+    auto cloneTexture = [&](const QString &srcName) -> QString {
+        if (!srcName.startsWith(QStringLiteral("ps1rip_")))
+            return srcName;
+        if (textureRenames.contains(srcName))
+            return textureRenames.value(srcName);
+        const std::string srcStd = srcName.toStdString();
+        if (!texMgr.resourceExists(srcStd))
+            return srcName;
+        Ogre::TexturePtr src = texMgr.getByName(srcStd);
+        if (!src)
+            return srcName;
+        const QString dstName = QStringLiteral("ps1imported_%1_p%2_%3")
+                                    .arg(captureId)
+                                    .arg(promoId)
+                                    .arg(srcName);
+        const std::string dstStd = dstName.toStdString();
+        if (!texMgr.resourceExists(dstStd)) {
+            // `Resource::clone` isn't part of Ogre's Texture API; we copy
+            // the pixel buffer into a freshly-created manual texture.
+            Ogre::TexturePtr dst = texMgr.createManual(
+                dstStd, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME, src->getTextureType(),
+                src->getWidth(), src->getHeight(), src->getNumMipmaps(), src->getFormat(),
+                src->getUsage());
+            if (dst) {
+                Ogre::HardwarePixelBufferSharedPtr srcBuf = src->getBuffer(0, 0);
+                Ogre::HardwarePixelBufferSharedPtr dstBuf = dst->getBuffer(0, 0);
+                if (srcBuf && dstBuf) {
+                    // blit() copies the full src buffer into dst — both buffers
+                    // are the same dimensions/format so a region-restricted
+                    // blit isn't needed. Avoids manually managing PixelBox
+                    // memory and ensures the dst is upload-ready.
+                    dstBuf->blit(srcBuf);
+                }
+                dst->load();
+            }
+        }
+        textureRenames.insert(srcName, dstName);
+        return dstName;
+    };
+
+    auto cloneMaterial = [&](const QString &srcName) -> QString {
+        if (!srcName.startsWith(QStringLiteral("PS1Rip_")))
+            return srcName;
+        if (materialRenames.contains(srcName))
+            return materialRenames.value(srcName);
+        const std::string srcStd = srcName.toStdString();
+        if (!matMgr.resourceExists(srcStd))
+            return srcName;
+        Ogre::MaterialPtr src = matMgr.getByName(srcStd);
+        if (!src)
+            return srcName;
+        const QString dstName = QStringLiteral("PS1Imported_%1_p%2_%3")
+                                    .arg(captureId)
+                                    .arg(promoId)
+                                    .arg(srcName);
+        const std::string dstStd = dstName.toStdString();
+        Ogre::MaterialPtr dst =
+            matMgr.resourceExists(dstStd) ? matMgr.getByName(dstStd) : src->clone(dstStd);
+        if (dst) {
+            for (unsigned short t = 0; t < dst->getNumTechniques(); ++t) {
+                Ogre::Technique *tech = dst->getTechnique(t);
+                if (!tech)
+                    continue;
+                for (unsigned short p = 0; p < tech->getNumPasses(); ++p) {
+                    Ogre::Pass *pass = tech->getPass(p);
+                    if (!pass)
+                        continue;
+                    for (unsigned short u = 0; u < pass->getNumTextureUnitStates(); ++u) {
+                        Ogre::TextureUnitState *tus = pass->getTextureUnitState(u);
+                        if (!tus)
+                            continue;
+                        const QString oldTex = QString::fromStdString(tus->getTextureName());
+                        const QString newTex = cloneTexture(oldTex);
+                        if (newTex != oldTex)
+                            tus->setTextureName(newTex.toStdString());
+                    }
+                }
+            }
+            dst->compile();
+            dst->load();
+        }
+        materialRenames.insert(srcName, dstName);
+        return dstName;
+    };
+
+    for (unsigned short i = 0; i < clone->getNumSubMeshes(); ++i) {
+        Ogre::SubMesh *sm = clone->getSubMesh(i);
+        if (!sm)
+            continue;
+        const QString currentMat = QString::fromStdString(sm->getMaterialName());
+        const QString newMat = cloneMaterial(currentMat);
+        if (newMat != currentMat)
+            sm->setMaterialName(newMat.toStdString());
+    }
+}
+
+} // namespace
+
+bool PS1RipSessionWindow::promoteUniqueMesh(int meshIndex, const QString &assetId, int instanceIndex)
 {
     PS1CapturedAssets *store = PS1CapturedAssets::getSingletonPtr();
     if (!store || meshIndex < 0)
@@ -610,25 +789,38 @@ bool PS1RipSessionWindow::promoteUniqueMesh(int meshIndex, const QString &assetI
     if (!mgr || !mgr->getSceneMgr())
         return false;
 
-    // Find an existing capture node for this mesh so we can copy its
-    // current world transform — that way a promoted entity drops where the
-    // user already sees the live preview, even after normalizer tweaks.
+    // Find an existing capture node so we can copy its current world
+    // transform — that way the promoted entity drops where the user
+    // already sees the live preview, even after normalizer tweaks.
+    // Prefer the explicit instance the caller asked for; only fall back
+    // to the "first instance with this uniqueMesh" walk when none was
+    // supplied (asset-browser drag-and-drop case).
     Ogre::Vector3 worldPos(0, 0, 0);
     Ogre::Vector3 worldScale(1, 1, 1);
     Ogre::Quaternion worldOri = Ogre::Quaternion::IDENTITY;
     QString sourceNodeName;
-    for (auto it = set.instanceNodeNames.constBegin(); it != set.instanceNodeNames.constEnd(); ++it) {
-        const int instIdx = it.key();
+    auto tryAdoptInstance = [&](int instIdx) {
         if (instIdx < 0 || instIdx >= set.instances.size())
-            continue;
+            return false;
         if (set.instances.at(instIdx).uniqueMeshIndex != meshIndex)
-            continue;
-        if (Ogre::SceneNode *src = mgr->getSceneNode(it.value())) {
+            return false;
+        const QString nodeName = set.instanceNodeNames.value(instIdx);
+        if (nodeName.isEmpty())
+            return false;
+        if (Ogre::SceneNode *src = mgr->getSceneNode(nodeName)) {
             worldPos = src->_getDerivedPosition();
             worldScale = src->_getDerivedScale();
             worldOri = src->_getDerivedOrientation();
-            sourceNodeName = it.value();
-            break;
+            sourceNodeName = nodeName;
+            return true;
+        }
+        return false;
+    };
+    if (!tryAdoptInstance(instanceIndex)) {
+        for (auto it = set.instanceNodeNames.constBegin();
+             it != set.instanceNodeNames.constEnd(); ++it) {
+            if (tryAdoptInstance(it.key()))
+                break;
         }
     }
 
@@ -653,6 +845,11 @@ bool PS1RipSessionWindow::promoteUniqueMesh(int meshIndex, const QString &assetI
         Ogre::MeshManager::getSingleton().remove(cloneName.toStdString());
     Ogre::MeshPtr clone = srcMesh->clone(cloneName.toStdString());
 
+    // Rebind to permanent-named material + texture clones so the next
+    // capture's purge of `PS1Rip_*` / `ps1rip_*` doesn't strip them
+    // (#679 review feedback — Codex: "Preserve promoted materials").
+    rebindPromotedMaterials(clone.get(), set.captureId, promoId);
+
     const QString nodeName =
         QStringLiteral("PS1Imported_%1_mesh%2_n%3").arg(set.captureId).arg(meshIndex).arg(promoId);
     Ogre::SceneNode *node = mgr->addSceneNode(nodeName);
@@ -669,8 +866,9 @@ bool PS1RipSessionWindow::promoteUniqueMesh(int meshIndex, const QString &assetI
 
     SentryReporter::addBreadcrumb(
         QStringLiteral("ps1.rip.inspector.promote"),
-        QStringLiteral("ok mesh=%1 source=%2 node=%3")
+        QStringLiteral("ok mesh=%1 instance=%2 source=%3 node=%4")
             .arg(meshIndex)
+            .arg(instanceIndex)
             .arg(sourceNodeName.isEmpty() ? QStringLiteral("(none)") : sourceNodeName, nodeName));
     return true;
 }

--- a/src/PS1/runtime/PS1RipSessionWindow.cpp
+++ b/src/PS1/runtime/PS1RipSessionWindow.cpp
@@ -1,11 +1,16 @@
 #include "PS1RipSessionWindow.h"
 #include "EmuViewport.h"
+#include "Manager.h"
+#include "PS1CapturedAssets.h"
+#include "PS1ExtractedAssetBrowser.h"
+#include "PS1GeometryInspectorPanel.h"
 #include "PS1RipGamepadBridge.h"
 #include "PS1RipInputSettingsDialog.h"
 #include "PS1RipLegalityDialog.h"
 #include "PS1RipManager.h"
 #include "Ps1CoordinateNormalizer.h"
 #include "PsxJoypadBindings.h"
+#include "SelectionSet.h"
 #include "SentryReporter.h"
 #include "PsxJoypadState.h"
 #include "PsxVramMirrorMode.h"
@@ -38,6 +43,8 @@
 #include <QToolButton>
 #include <QVBoxLayout>
 #include <QWidget>
+
+#include <Ogre.h>
 
 namespace {
 constexpr auto kSettingsGroup = "ps1Rip";
@@ -80,6 +87,7 @@ PS1RipSessionWindow::PS1RipSessionWindow(QWidget *parent)
     : QMainWindow(parent)
     , m_manager(PS1RipManager::getSingleton())
 {
+    s_lastInstance = this;
     PsxJoypadBindings::load();
 
     setWindowTitle(tr("PS1 Runtime Ripper"));
@@ -268,6 +276,7 @@ PS1RipSessionWindow::PS1RipSessionWindow(QWidget *parent)
     addDockWidget(Qt::BottomDockWidgetArea, vramDock);
 
     createNormalizerDock();
+    createInspectorDocks();
 
     m_statusLabel = new QLabel(this);
     statusBar()->addPermanentWidget(m_statusLabel, /*stretch=*/1);
@@ -354,8 +363,19 @@ PS1RipSessionWindow::~PS1RipSessionWindow()
 {
     if (m_manager && m_manager->isSessionActive())
         m_manager->stop();
+    if (s_lastInstance == this)
+        s_lastInstance = nullptr;
     SentryReporter::addBreadcrumb(QStringLiteral("ps1.rip.viewport.close"),
                                 QStringLiteral("PS1 rip session window closed"));
+}
+
+PS1RipSessionWindow *PS1RipSessionWindow::s_lastInstance = nullptr;
+
+bool PS1RipSessionWindow::promoteUniqueMeshById(int meshIndex, const QString &assetId)
+{
+    if (!s_lastInstance)
+        return false;
+    return s_lastInstance->promoteUniqueMesh(meshIndex, assetId);
 }
 
 void PS1RipSessionWindow::createNormalizerDock()
@@ -469,6 +489,190 @@ void PS1RipSessionWindow::pushNormalizerSettings()
     Ps1CoordinateNormalizer::save(qs, QString::fromLatin1(kNormalizePrefix), s);
     if (m_manager)
         m_manager->setNormalizerSettings(s);
+}
+
+void PS1RipSessionWindow::createInspectorDocks()
+{
+    PS1CapturedAssets *store = PS1CapturedAssets::getSingleton();
+
+    m_inspector.inspectorPanel = new PS1GeometryInspectorPanel(store, this);
+    m_inspector.inspectorDock = new QDockWidget(tr("Geometry Inspector"), this);
+    m_inspector.inspectorDock->setWidget(m_inspector.inspectorPanel);
+    m_inspector.inspectorDock->setMinimumHeight(220);
+    addDockWidget(Qt::BottomDockWidgetArea, m_inspector.inspectorDock);
+
+    m_inspector.browser = new PS1ExtractedAssetBrowser(store, this);
+    m_inspector.browserDock = new QDockWidget(tr("Extracted Assets"), this);
+    m_inspector.browserDock->setWidget(m_inspector.browser);
+    m_inspector.browserDock->setMinimumWidth(260);
+    addDockWidget(Qt::RightDockWidgetArea, m_inspector.browserDock);
+
+    connect(m_inspector.inspectorPanel, &PS1GeometryInspectorPanel::highlightRow, this,
+            &PS1RipSessionWindow::highlightInspectorRow);
+    connect(m_inspector.inspectorPanel, &PS1GeometryInspectorPanel::hideSubmeshRequested, this,
+            [this](int row) { setInspectorRowVisible(row, /*visible=*/false); });
+    connect(m_inspector.inspectorPanel, &PS1GeometryInspectorPanel::showSubmeshRequested, this,
+            [this](int row) { setInspectorRowVisible(row, /*visible=*/true); });
+    connect(m_inspector.inspectorPanel, &PS1GeometryInspectorPanel::promoteRowRequested, this,
+            &PS1RipSessionWindow::promoteInspectorRow);
+    connect(m_inspector.inspectorPanel, &PS1GeometryInspectorPanel::discardRowRequested, this,
+            [this](int row) {
+                if (PS1CapturedAssets *s = PS1CapturedAssets::getSingletonPtr()) {
+                    const bool wasDiscarded = s->captureSet().rows.at(row - 1).discarded;
+                    discardInspectorRow(row, !wasDiscarded);
+                }
+            });
+    connect(m_inspector.browser, &PS1ExtractedAssetBrowser::instantiateMesh, this,
+            [this](int meshIndex, const QString &assetId) {
+                promoteUniqueMesh(meshIndex, assetId);
+            });
+}
+
+void PS1RipSessionWindow::highlightInspectorRow(int rowIndex)
+{
+    if (rowIndex < 1)
+        return;
+    PS1CapturedAssets *store = PS1CapturedAssets::getSingletonPtr();
+    if (!store)
+        return;
+    const CapturedAssetSet &set = store->captureSet();
+    if (rowIndex > set.rows.size())
+        return;
+    const CapturedAssetRow &row = set.rows.at(rowIndex - 1);
+    if (row.instanceIndex < 0)
+        return;
+    const QString nodeName = set.instanceNodeNames.value(row.instanceIndex);
+    if (nodeName.isEmpty())
+        return;
+    Manager *mgr = Manager::getSingletonPtr();
+    SelectionSet *sel = SelectionSet::getSingleton();
+    if (!mgr || !sel)
+        return;
+    Ogre::SceneNode *node = mgr->getSceneNode(nodeName);
+    if (!node)
+        return;
+    sel->selectOne(node);
+}
+
+void PS1RipSessionWindow::setInspectorRowVisible(int rowIndex, bool visible)
+{
+    PS1CapturedAssets *store = PS1CapturedAssets::getSingletonPtr();
+    if (!store)
+        return;
+    const CapturedAssetSet &set = store->captureSet();
+    if (rowIndex < 1 || rowIndex > set.rows.size())
+        return;
+    const CapturedAssetRow &row = set.rows.at(rowIndex - 1);
+    if (row.instanceIndex < 0)
+        return;
+    const QString nodeName = set.instanceNodeNames.value(row.instanceIndex);
+    if (nodeName.isEmpty())
+        return;
+    if (Manager *mgr = Manager::getSingletonPtr()) {
+        if (Ogre::SceneNode *node = mgr->getSceneNode(nodeName))
+            node->setVisible(visible, /*cascade=*/true);
+    }
+    store->setRowHidden(rowIndex, !visible);
+}
+
+void PS1RipSessionWindow::discardInspectorRow(int rowIndex, bool discarded)
+{
+    setInspectorRowVisible(rowIndex, !discarded);
+    if (PS1CapturedAssets *store = PS1CapturedAssets::getSingletonPtr())
+        store->setRowDiscarded(rowIndex, discarded);
+}
+
+void PS1RipSessionWindow::promoteInspectorRow(int rowIndex)
+{
+    PS1CapturedAssets *store = PS1CapturedAssets::getSingletonPtr();
+    if (!store)
+        return;
+    const CapturedAssetSet &set = store->captureSet();
+    if (rowIndex < 1 || rowIndex > set.rows.size())
+        return;
+    const CapturedAssetRow &row = set.rows.at(rowIndex - 1);
+    if (row.uniqueMeshIndex < 0)
+        return;
+    const QString meshAssetId =
+        set.uniqueMeshes.at(row.uniqueMeshIndex).meshName + QLatin1Char('_') + set.captureId;
+    promoteUniqueMesh(row.uniqueMeshIndex, meshAssetId);
+}
+
+bool PS1RipSessionWindow::promoteUniqueMesh(int meshIndex, const QString &assetId)
+{
+    PS1CapturedAssets *store = PS1CapturedAssets::getSingletonPtr();
+    if (!store || meshIndex < 0)
+        return false;
+    const CapturedAssetSet &set = store->captureSet();
+    if (meshIndex >= set.uniqueMeshes.size())
+        return false;
+    Manager *mgr = Manager::getSingletonPtr();
+    if (!mgr || !mgr->getSceneMgr())
+        return false;
+
+    // Find an existing capture node for this mesh so we can copy its
+    // current world transform — that way a promoted entity drops where the
+    // user already sees the live preview, even after normalizer tweaks.
+    Ogre::Vector3 worldPos(0, 0, 0);
+    Ogre::Vector3 worldScale(1, 1, 1);
+    Ogre::Quaternion worldOri = Ogre::Quaternion::IDENTITY;
+    QString sourceNodeName;
+    for (auto it = set.instanceNodeNames.constBegin(); it != set.instanceNodeNames.constEnd(); ++it) {
+        const int instIdx = it.key();
+        if (instIdx < 0 || instIdx >= set.instances.size())
+            continue;
+        if (set.instances.at(instIdx).uniqueMeshIndex != meshIndex)
+            continue;
+        if (Ogre::SceneNode *src = mgr->getSceneNode(it.value())) {
+            worldPos = src->_getDerivedPosition();
+            worldScale = src->_getDerivedScale();
+            worldOri = src->_getDerivedOrientation();
+            sourceNodeName = it.value();
+            break;
+        }
+    }
+
+    const std::string ogreMeshName = assetId.toStdString();
+    if (!Ogre::MeshManager::getSingleton().resourceExists(ogreMeshName)) {
+        SentryReporter::addBreadcrumb(
+            QStringLiteral("ps1.rip.inspector.promote"),
+            QStringLiteral("error mesh=%1 reason=missing-ogre-mesh").arg(assetId),
+            QStringLiteral("error"));
+        return false;
+    }
+    Ogre::MeshPtr srcMesh = Ogre::MeshManager::getSingleton().getByName(ogreMeshName);
+    if (!srcMesh)
+        return false;
+
+    // Clone the mesh under a permanent name so destroying the live capture
+    // (next Capture Frame / Stop) doesn't yank the underlying buffers.
+    const int promoId = ++m_inspector.promotionCounter;
+    const QString cloneName =
+        QStringLiteral("PS1Imported_%1_mesh%2_p%3").arg(set.captureId).arg(meshIndex).arg(promoId);
+    if (Ogre::MeshManager::getSingleton().resourceExists(cloneName.toStdString()))
+        Ogre::MeshManager::getSingleton().remove(cloneName.toStdString());
+    Ogre::MeshPtr clone = srcMesh->clone(cloneName.toStdString());
+
+    const QString nodeName =
+        QStringLiteral("PS1Imported_%1_mesh%2_n%3").arg(set.captureId).arg(meshIndex).arg(promoId);
+    Ogre::SceneNode *node = mgr->addSceneNode(nodeName);
+    if (!node)
+        return false;
+    node->setPosition(worldPos);
+    node->setScale(worldScale);
+    node->setOrientation(worldOri);
+    Ogre::Entity *entity = mgr->createEntity(node, clone);
+    if (!entity) {
+        mgr->destroySceneNode(node);
+        return false;
+    }
+
+    SentryReporter::addBreadcrumb(
+        QStringLiteral("ps1.rip.inspector.promote"),
+        QStringLiteral("ok mesh=%1 source=%2 node=%3")
+            .arg(meshIndex)
+            .arg(sourceNodeName.isEmpty() ? QStringLiteral("(none)") : sourceNodeName, nodeName));
+    return true;
 }
 
 void PS1RipSessionWindow::showSession(QWidget *parent)

--- a/src/PS1/runtime/PS1RipSessionWindow.cpp
+++ b/src/PS1/runtime/PS1RipSessionWindow.cpp
@@ -872,7 +872,10 @@ bool PS1RipSessionWindow::promoteUniqueMesh(int meshIndex, const QString &assetI
         }
         return false;
     };
-    if (!tryAdoptInstance(instanceIndex)) {
+    if (instanceIndex >= 0) {
+        if (!tryAdoptInstance(instanceIndex))
+            return false;
+    } else {
         for (auto it = set.instanceNodeNames.constBegin();
              it != set.instanceNodeNames.constEnd(); ++it) {
             if (tryAdoptInstance(it.key()))

--- a/src/PS1/runtime/PS1RipSessionWindow.cpp
+++ b/src/PS1/runtime/PS1RipSessionWindow.cpp
@@ -27,6 +27,7 @@
 #include <QFileInfo>
 #include <QFormLayout>
 #include <QGroupBox>
+#include <QImage>
 #include <QKeySequence>
 #include <QMenu>
 #include <QTimer>
@@ -537,6 +538,61 @@ void PS1RipSessionWindow::createInspectorDocks()
 
 namespace {
 
+/** Strip the `PS1Rip_<captureId>_` prefix from a capture-scoped material
+ *  resource name to recover the logical name (`PS1Rip_tpage_…` or
+ *  `PS1Rip_color`) that keys `CapturedAssetSet::textureImages`. */
+QString logicalMaterialFromScopedName(const QString &scopedName, const QString &captureId)
+{
+    const QString prefix = QStringLiteral("PS1Rip_%1_").arg(captureId);
+    if (scopedName.startsWith(prefix))
+        return scopedName.mid(prefix.size());
+    return scopedName;
+}
+
+/** CPU upload for promoted textures — mirrors `PS1RipMeshBuilder`'s
+ *  `uploadTextureToOgre` but always lands in the default resource group so
+ *  promoted assets survive the next capture's session-group purge. */
+bool uploadPromotedTexture(const QString &resourceName, const QImage &image)
+{
+    if (image.isNull() || image.width() < 1 || image.height() < 1)
+        return false;
+
+    QImage rgba = image.convertToFormat(QImage::Format_RGBA8888);
+    if (rgba.isNull())
+        return false;
+    const int tightStride = rgba.width() * 4;
+    if (rgba.bytesPerLine() != tightStride)
+        rgba = rgba.copy();
+
+    Ogre::Image ogreImage;
+    try {
+        ogreImage.loadDynamicImage(rgba.bits(), static_cast<Ogre::uint32>(rgba.width()),
+                                   static_cast<Ogre::uint32>(rgba.height()), 1, Ogre::PF_BYTE_RGBA,
+                                   false);
+    } catch (const Ogre::Exception &) {
+        return false;
+    }
+
+    const std::string texName = resourceName.toStdString();
+    Ogre::TextureManager &texMgr = Ogre::TextureManager::getSingleton();
+    if (texMgr.resourceExists(texName))
+        texMgr.remove(texName);
+
+    Ogre::TexturePtr texture = texMgr.createManual(
+        texName, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME, Ogre::TEX_TYPE_2D,
+        ogreImage.getWidth(), ogreImage.getHeight(), 0, ogreImage.getFormat(),
+        Ogre::TU_STATIC_WRITE_ONLY);
+    if (!texture)
+        return false;
+
+    Ogre::HardwarePixelBufferSharedPtr pixelBuffer = texture->getBuffer(0, 0);
+    if (!pixelBuffer)
+        return false;
+    pixelBuffer->blitFromMemory(ogreImage.getPixelBox());
+    texture->load();
+    return true;
+}
+
 /** Resolve a `CapturedAssetRow` to the live Ogre entity + sub-entity in the
  *  capture preview. Returns null pointers when any link is missing so the
  *  callers can short-circuit instead of crashing on a stale row (#679
@@ -664,59 +720,39 @@ namespace {
 
 /** Walk the cloned mesh's submeshes and replace every `PS1Rip_*` capture
  *  material reference with a freshly-named clone that mirrors the source
- *  pass, its texture units, and any referenced `ps1rip_*` textures. The
- *  next `beginCaptureAttach` purges everything matching the `PS1Rip_*`
- *  and `ps1rip_*` patterns, so without this the supposedly permanent
- *  promoted entity would silently lose its material + texture binding
- *  the moment the user takes another capture (#679 review feedback). */
-void rebindPromotedMaterials(Ogre::Mesh *clone, const QString &captureId, int promoId)
+ *  pass and re-uploads textures from `textureImages` (CPU path — the
+ *  previous GPU `HardwarePixelBuffer::blit` between session-group
+ *  textures crashed on double-click promote). The next `beginCaptureAttach`
+ *  purges everything matching the `PS1Rip_*` / `ps1rip_*` patterns, so
+ *  without this the promoted entity would lose its binding on the next
+ *  capture (#679 review feedback). */
+void rebindPromotedMaterials(Ogre::Mesh *clone, const QString &captureId, int promoId,
+                             const QHash<QString, QImage> &textureImages)
 {
     if (!clone)
         return;
     Ogre::MaterialManager &matMgr = Ogre::MaterialManager::getSingleton();
-    Ogre::TextureManager &texMgr = Ogre::TextureManager::getSingleton();
 
     QHash<QString, QString> textureRenames;
     QHash<QString, QString> materialRenames;
 
-    auto cloneTexture = [&](const QString &srcName) -> QString {
-        if (!srcName.startsWith(QStringLiteral("ps1rip_")))
-            return srcName;
-        if (textureRenames.contains(srcName))
-            return textureRenames.value(srcName);
-        const std::string srcStd = srcName.toStdString();
-        if (!texMgr.resourceExists(srcStd))
-            return srcName;
-        Ogre::TexturePtr src = texMgr.getByName(srcStd);
-        if (!src)
-            return srcName;
-        const QString dstName = QStringLiteral("ps1imported_%1_p%2_%3")
-                                    .arg(captureId)
-                                    .arg(promoId)
-                                    .arg(srcName);
-        const std::string dstStd = dstName.toStdString();
-        if (!texMgr.resourceExists(dstStd)) {
-            // `Resource::clone` isn't part of Ogre's Texture API; we copy
-            // the pixel buffer into a freshly-created manual texture.
-            Ogre::TexturePtr dst = texMgr.createManual(
-                dstStd, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME, src->getTextureType(),
-                src->getWidth(), src->getHeight(), src->getNumMipmaps(), src->getFormat(),
-                src->getUsage());
-            if (dst) {
-                Ogre::HardwarePixelBufferSharedPtr srcBuf = src->getBuffer(0, 0);
-                Ogre::HardwarePixelBufferSharedPtr dstBuf = dst->getBuffer(0, 0);
-                if (srcBuf && dstBuf) {
-                    // blit() copies the full src buffer into dst — both buffers
-                    // are the same dimensions/format so a region-restricted
-                    // blit isn't needed. Avoids manually managing PixelBox
-                    // memory and ensures the dst is upload-ready.
-                    dstBuf->blit(srcBuf);
-                }
-                dst->load();
-            }
-        }
-        textureRenames.insert(srcName, dstName);
-        return dstName;
+    auto promotedTextureName = [&](const QString &logicalName) -> QString {
+        return QStringLiteral("ps1imported_%1_p%2_%3")
+            .arg(captureId)
+            .arg(promoId)
+            .arg(logicalName);
+    };
+
+    auto ensurePromotedTexture = [&](const QString &logicalName) -> QString {
+        if (textureRenames.contains(logicalName))
+            return textureRenames.value(logicalName);
+        const auto imgIt = textureImages.constFind(logicalName);
+        if (imgIt == textureImages.constEnd())
+            return {};
+        const QString dstName = promotedTextureName(logicalName);
+        if (uploadPromotedTexture(dstName, imgIt.value()))
+            textureRenames.insert(logicalName, dstName);
+        return textureRenames.value(logicalName, {});
     };
 
     auto cloneMaterial = [&](const QString &srcName) -> QString {
@@ -738,6 +774,8 @@ void rebindPromotedMaterials(Ogre::Mesh *clone, const QString &captureId, int pr
         Ogre::MaterialPtr dst =
             matMgr.resourceExists(dstStd) ? matMgr.getByName(dstStd) : src->clone(dstStd);
         if (dst) {
+            const QString logicalName = logicalMaterialFromScopedName(srcName, captureId);
+            const QString promotedTex = ensurePromotedTexture(logicalName);
             for (unsigned short t = 0; t < dst->getNumTechniques(); ++t) {
                 Ogre::Technique *tech = dst->getTechnique(t);
                 if (!tech)
@@ -746,14 +784,12 @@ void rebindPromotedMaterials(Ogre::Mesh *clone, const QString &captureId, int pr
                     Ogre::Pass *pass = tech->getPass(p);
                     if (!pass)
                         continue;
-                    for (unsigned short u = 0; u < pass->getNumTextureUnitStates(); ++u) {
-                        Ogre::TextureUnitState *tus = pass->getTextureUnitState(u);
-                        if (!tus)
-                            continue;
-                        const QString oldTex = QString::fromStdString(tus->getTextureName());
-                        const QString newTex = cloneTexture(oldTex);
-                        if (newTex != oldTex)
-                            tus->setTextureName(newTex.toStdString());
+                    if (!promotedTex.isEmpty()) {
+                        pass->removeAllTextureUnitStates();
+                        Ogre::TextureUnitState *tus = pass->createTextureUnitState(promotedTex.toStdString());
+                        tus->setTextureFiltering(Ogre::TFO_NONE);
+                        tus->setTextureAddressingMode(Ogre::TextureUnitState::TAM_CLAMP);
+                        pass->setVertexColourTracking(Ogre::TVC_AMBIENT | Ogre::TVC_DIFFUSE);
                     }
                 }
             }
@@ -764,14 +800,20 @@ void rebindPromotedMaterials(Ogre::Mesh *clone, const QString &captureId, int pr
         return dstName;
     };
 
-    for (unsigned short i = 0; i < clone->getNumSubMeshes(); ++i) {
-        Ogre::SubMesh *sm = clone->getSubMesh(i);
-        if (!sm)
-            continue;
-        const QString currentMat = QString::fromStdString(sm->getMaterialName());
-        const QString newMat = cloneMaterial(currentMat);
-        if (newMat != currentMat)
-            sm->setMaterialName(newMat.toStdString());
+    try {
+        for (unsigned short i = 0; i < clone->getNumSubMeshes(); ++i) {
+            Ogre::SubMesh *sm = clone->getSubMesh(i);
+            if (!sm)
+                continue;
+            const QString currentMat = QString::fromStdString(sm->getMaterialName());
+            const QString newMat = cloneMaterial(currentMat);
+            if (newMat != currentMat)
+                sm->setMaterialName(newMat.toStdString());
+        }
+    } catch (const Ogre::Exception &e) {
+        SentryReporter::addBreadcrumb(QStringLiteral("ps1.rip.inspector.promote"),
+                                      QString::fromStdString(e.getFullDescription()),
+                                      QStringLiteral("error"));
     }
 }
 
@@ -848,7 +890,7 @@ bool PS1RipSessionWindow::promoteUniqueMesh(int meshIndex, const QString &assetI
     // Rebind to permanent-named material + texture clones so the next
     // capture's purge of `PS1Rip_*` / `ps1rip_*` doesn't strip them
     // (#679 review feedback — Codex: "Preserve promoted materials").
-    rebindPromotedMaterials(clone.get(), set.captureId, promoId);
+    rebindPromotedMaterials(clone.get(), set.captureId, promoId, set.textureImages);
 
     const QString nodeName =
         QStringLiteral("PS1Imported_%1_mesh%2_n%3").arg(set.captureId).arg(meshIndex).arg(promoId);

--- a/src/PS1/runtime/PS1RipSessionWindow.h
+++ b/src/PS1/runtime/PS1RipSessionWindow.h
@@ -5,6 +5,7 @@
 
 #include <QImage>
 #include <QMainWindow>
+#include <QPointer>
 #include <QVector>
 
 class EmuViewport;
@@ -48,6 +49,8 @@ public:
 
 protected:
     void closeEvent(QCloseEvent *event) override;
+    void focusInEvent(QFocusEvent *event) override;
+    void showEvent(QShowEvent *event) override;
 
 private slots:
     void pickBios();
@@ -212,7 +215,7 @@ private:
     /** Tracks the most-recently constructed session window so the static
      *  drop-event entry point can route into the right instance without
      *  walking the QWidget tree. Cleared on destruction. */
-    static PS1RipSessionWindow *s_lastInstance;
+    static QPointer<PS1RipSessionWindow> s_lastInstance;
 };
 
 #endif // PS1RIPSESSIONWINDOW_H

--- a/src/PS1/runtime/PS1RipSessionWindow.h
+++ b/src/PS1/runtime/PS1RipSessionWindow.h
@@ -10,10 +10,13 @@
 class EmuViewport;
 class QAction;
 class QCheckBox;
+class QDockWidget;
 class QDoubleSpinBox;
 class QLabel;
 class QShortcut;
 class QSpinBox;
+class PS1ExtractedAssetBrowser;
+class PS1GeometryInspectorPanel;
 class PS1RipGamepadBridge;
 class PS1RipManager;
 class QMenu;
@@ -32,6 +35,16 @@ public:
     ~PS1RipSessionWindow() override;
 
     static void showSession(QWidget *parent);
+
+    /** Entry point for `MainWindow::dropEvent` so PS1 Asset Browser →
+     *  editor viewport drag-and-drop produces a permanent SceneNode
+     *  even when the session window doesn't currently own the focus
+     *  (#426). Routes to the shared `promoteUniqueMesh` impl through
+     *  any live `PS1RipSessionWindow` so the promotion counter, the
+     *  capture-id lookup, and the Sentry breadcrumb all stay in one
+     *  place. No-op when no session window exists or the captured
+     *  asset store has been cleared. */
+    static bool promoteUniqueMeshById(int meshIndex, const QString &assetId);
 
 protected:
     void closeEvent(QCloseEvent *event) override;
@@ -92,6 +105,31 @@ private:
      *  `onCaptureProgress` and `onSceneCaptureProgress`. */
     void refreshCaptureStatusFooter();
 
+    /** Build the Geometry Inspector dock + Extracted Asset Browser dock
+     *  off the captured-asset store and wire their intent signals back to
+     *  the session window (#426). Docks are added to the bottom and right
+     *  dock areas respectively so they sit alongside the emulator
+     *  viewport without obscuring it. */
+    void createInspectorDocks();
+    /** Translates an inspector row click into editor SelectionSet calls
+     *  so the matching SubEntity is outlined in the viewport (#426
+     *  acceptance: "Highlighting a draw-call row visibly outlines the
+     *  corresponding submesh"). */
+    void highlightInspectorRow(int rowIndex);
+    /** Toggle visibility of the SceneNode backing the row's instance. */
+    void setInspectorRowVisible(int rowIndex, bool visible);
+    /** Clone the row's unique mesh into a fresh "PS1Imported_*" SceneNode
+     *  that survives capture clearing. Backed by the same code path as
+     *  the asset-browser drag-and-drop (#426 acceptance: "Drag-and-drop
+     *  creates a permanent entity"). */
+    void promoteInspectorRow(int rowIndex);
+    /** Mark a row as discarded and hide its scene node (no destruction —
+     *  the row stays addressable for undo via "Restore"). */
+    void discardInspectorRow(int rowIndex, bool discarded);
+    /** Shared promotion impl used by the inspector right-click action
+     *  and the asset-browser double-click / drag-drop. */
+    bool promoteUniqueMesh(int meshIndex, const QString &assetId);
+
     /** Capture toolbar widgets bundled into one struct so the class stays
      *  under SonarCloud's S1820 field-count threshold (#425 — without the
      *  bundling the #425 additions would have pushed the class from 14 to
@@ -147,6 +185,27 @@ private:
     CaptureUi m_captureUi;
     CaptureHotkeys m_captureHotkeys;
     CaptureLiveStats m_captureStats;
+
+    /** Geometry inspector + asset browser docks (#426). Bundled into a
+     *  struct so the new feature contributes a single field to the
+     *  outer class (SonarCloud S1820). */
+    struct InspectorDocks {
+        QDockWidget *inspectorDock = nullptr;
+        QDockWidget *browserDock = nullptr;
+        PS1GeometryInspectorPanel *inspectorPanel = nullptr;
+        PS1ExtractedAssetBrowser *browser = nullptr;
+        /** Counter feeding the unique permanent-entity node name suffix
+         *  so promote-twice produces two distinct nodes. Reset on
+         *  session start; persists across captures so successive
+         *  promotes don't reuse a stale id even if a previous promote
+         *  was undone. */
+        int promotionCounter = 0;
+    } m_inspector;
+
+    /** Tracks the most-recently constructed session window so the static
+     *  drop-event entry point can route into the right instance without
+     *  walking the QWidget tree. Cleared on destruction. */
+    static PS1RipSessionWindow *s_lastInstance;
 };
 
 #endif // PS1RIPSESSIONWINDOW_H

--- a/src/PS1/runtime/PS1RipSessionWindow.h
+++ b/src/PS1/runtime/PS1RipSessionWindow.h
@@ -127,8 +127,15 @@ private:
      *  the row stays addressable for undo via "Restore"). */
     void discardInspectorRow(int rowIndex, bool discarded);
     /** Shared promotion impl used by the inspector right-click action
-     *  and the asset-browser double-click / drag-drop. */
-    bool promoteUniqueMesh(int meshIndex, const QString &assetId);
+     *  and the asset-browser double-click / drag-drop.
+     *
+     *  When `instanceIndex >= 0` the promoted node copies that specific
+     *  instance's world transform (so promoting inspector row N drops the
+     *  entity exactly where row N is rendered). When `-1`, falls back to
+     *  the first instance using the mesh — the right answer for
+     *  drag-and-drop, where the asset browser shows one tile per unique
+     *  mesh and there is no per-instance disambiguation. */
+    bool promoteUniqueMesh(int meshIndex, const QString &assetId, int instanceIndex = -1);
 
     /** Capture toolbar widgets bundled into one struct so the class stays
      *  under SonarCloud's S1820 field-count threshold (#425 — without the

--- a/src/SelectionSet.cpp
+++ b/src/SelectionSet.cpp
@@ -48,12 +48,15 @@ SelectionSet* SelectionSet:: m_pSingleton = nullptr;
 
 SelectionSet* SelectionSet::getSingleton()
 {
-  if (m_pSingleton == nullptr)
-  {
-      m_pSingleton =  new SelectionSet();
-  }
+    if (m_pSingleton == nullptr)
+        m_pSingleton = new SelectionSet();
+    m_pSingleton->tryConnectToManager();
+    return m_pSingleton;
+}
 
-  return m_pSingleton;
+SelectionSet *SelectionSet::getSingletonPtr()
+{
+    return m_pSingleton;
 }
 
 void SelectionSet::kill()
@@ -71,8 +74,17 @@ void SelectionSet::kill()
 SelectionSet::SelectionSet()
     : QObject(nullptr)
 {
-    connect(Manager::getSingleton(), &Manager::sceneNodeDestroyed, this,
-            &SelectionSet::onSceneNodeDestroyed);
+}
+
+void SelectionSet::tryConnectToManager()
+{
+    if (m_connectedToManager)
+        return;
+    auto *mgr = Manager::getSingletonPtr();
+    if (!mgr)
+        return;
+    connect(mgr, &Manager::sceneNodeDestroyed, this, &SelectionSet::onSceneNodeDestroyed);
+    m_connectedToManager = true;
 }
 
 void SelectionSet::onSceneNodeDestroyed(Ogre::SceneNode *node)

--- a/src/SelectionSet.cpp
+++ b/src/SelectionSet.cpp
@@ -92,20 +92,31 @@ void SelectionSet::onSceneNodeDestroyed(Ogre::SceneNode *node)
     if (!node)
         return;
 
-    bool changed = mNodesSelected.removeOne(node) > 0;
+    bool changed = false;
+    const auto pruneNode = [&](auto &&self, Ogre::SceneNode *current) -> void {
+        if (!current)
+            return;
 
-    for (unsigned short i = 0; i < node->numAttachedObjects(); ++i) {
-        Ogre::MovableObject *obj = node->getAttachedObject(i);
-        if (!obj || obj->getMovableType() != "Entity")
-            continue;
-        auto *ent = static_cast<Ogre::Entity *>(obj);
-        if (mEntitiesSelected.removeOne(ent) > 0)
+        if (mNodesSelected.removeOne(current) > 0)
             changed = true;
-        for (unsigned short s = 0; s < ent->getNumSubEntities(); ++s) {
-            if (mSubEntitiesSelected.removeOne(ent->getSubEntity(s)) > 0)
+
+        for (unsigned short i = 0; i < current->numAttachedObjects(); ++i) {
+            Ogre::MovableObject *obj = current->getAttachedObject(i);
+            if (!obj || obj->getMovableType() != "Entity")
+                continue;
+            auto *ent = static_cast<Ogre::Entity *>(obj);
+            if (mEntitiesSelected.removeOne(ent) > 0)
                 changed = true;
+            for (unsigned short s = 0; s < ent->getNumSubEntities(); ++s) {
+                if (mSubEntitiesSelected.removeOne(ent->getSubEntity(s)) > 0)
+                    changed = true;
+            }
         }
-    }
+
+        for (Ogre::Node *child : current->getChildren())
+            self(self, static_cast<Ogre::SceneNode *>(child));
+    };
+    pruneNode(pruneNode, node);
 
     if (!changed)
         return;

--- a/src/SelectionSet.cpp
+++ b/src/SelectionSet.cpp
@@ -69,9 +69,39 @@ void SelectionSet::kill()
 // Constructor & Destructor
 
 SelectionSet::SelectionSet()
-    :QObject(nullptr)
+    : QObject(nullptr)
 {
+    connect(Manager::getSingleton(), &Manager::sceneNodeDestroyed, this,
+            &SelectionSet::onSceneNodeDestroyed);
+}
 
+void SelectionSet::onSceneNodeDestroyed(Ogre::SceneNode *node)
+{
+    if (!node)
+        return;
+
+    bool changed = mNodesSelected.removeOne(node) > 0;
+
+    for (unsigned short i = 0; i < node->numAttachedObjects(); ++i) {
+        Ogre::MovableObject *obj = node->getAttachedObject(i);
+        if (!obj || obj->getMovableType() != "Entity")
+            continue;
+        auto *ent = static_cast<Ogre::Entity *>(obj);
+        if (mEntitiesSelected.removeOne(ent) > 0)
+            changed = true;
+        for (unsigned short s = 0; s < ent->getNumSubEntities(); ++s) {
+            if (mSubEntitiesSelected.removeOne(ent->getSubEntity(s)) > 0)
+                changed = true;
+        }
+    }
+
+    if (!changed)
+        return;
+
+    emit nodeSelectionChanged();
+    emit entitySelectionChanged();
+    emit subEntitySelectionChanged();
+    emit selectionChanged();
 }
 
 void SelectionSet::append(Ogre::SceneNode* const& obj)
@@ -495,12 +525,48 @@ void SelectionSet::hideBoundingBox(Ogre::SceneNode* node)  const
     node->showBoundingBox(false);
 }
 
-void SelectionSet::hideAllBoundingBox()  const
+void SelectionSet::hideAllBoundingBox() const
 {
-    foreach(Ogre::SceneNode* node, mNodesSelected)
-        node->showBoundingBox(false);
-    foreach(Ogre::Entity* entity, mEntitiesSelected)
-        entity->getParentSceneNode()->showBoundingBox(false);
-    foreach(Ogre::SubEntity* subEntiy, mSubEntitiesSelected)
-        subEntiy->getParent()->getParentSceneNode()->showBoundingBox(false);
+    Manager *mgr = Manager::getSingletonPtr();
+    Ogre::SceneManager *sceneMgr = mgr ? mgr->getSceneMgr() : nullptr;
+
+    auto nodeStillLive = [&](Ogre::SceneNode *node) {
+        if (!node || !sceneMgr)
+            return false;
+        try {
+            return node->getCreator() == sceneMgr;
+        } catch (...) {
+            return false;
+        }
+    };
+
+    for (Ogre::SceneNode *node : mNodesSelected) {
+        if (nodeStillLive(node))
+            node->showBoundingBox(false);
+    }
+    for (Ogre::Entity *entity : mEntitiesSelected) {
+        if (!entity)
+            continue;
+        try {
+            if (Ogre::SceneNode *parent = entity->getParentSceneNode()) {
+                if (nodeStillLive(parent))
+                    parent->showBoundingBox(false);
+            }
+        } catch (...) {
+        }
+    }
+    for (Ogre::SubEntity *subEntity : mSubEntitiesSelected) {
+        if (!subEntity)
+            continue;
+        try {
+            Ogre::Entity *parentEnt = subEntity->getParent();
+            if (!parentEnt)
+                continue;
+            if (Ogre::SceneNode *parentNode = parentEnt->getParentSceneNode()) {
+                if (nodeStillLive(parentNode))
+                    parentNode->showBoundingBox(false);
+            }
+        } catch (...) {
+        }
+    }
 }

--- a/src/SelectionSet.h
+++ b/src/SelectionSet.h
@@ -15,7 +15,12 @@ class SelectionSet : public QObject
 
 public :
     static SelectionSet* getSingleton();
+    static SelectionSet* getSingletonPtr();
     static void kill();
+    /** Connect to `Manager::sceneNodeDestroyed` when a Manager exists.
+     *  Called from `getSingleton()` and from `Manager`'s constructor so
+     *  tests that recreate SelectionSet without Manager do not boot Ogre. */
+    void tryConnectToManager();
 
 private:
     SelectionSet();
@@ -95,6 +100,7 @@ signals:
 
 private :
     static SelectionSet*    m_pSingleton; // the only instance of this!
+    bool m_connectedToManager = false;
     QList<Ogre::SceneNode*> mNodesSelected;
     QList<Ogre::Entity*>    mEntitiesSelected;
     QList<Ogre::SubEntity*> mSubEntitiesSelected;

--- a/src/SelectionSet.h
+++ b/src/SelectionSet.h
@@ -82,6 +82,11 @@ public :
 private:
     void hideBoundingBox(Ogre::SceneNode* node)  const;
     void hideAllBoundingBox()  const;
+    /** Drop any selection entries tied to `node` or its attached
+     *  entities. Connected to `Manager::sceneNodeDestroyed` so a fresh
+     *  PS1 capture (which destroys `PS1Capture_*` nodes) cannot leave
+     *  dangling pointers that crash the next `selectOne` / promote. */
+    void onSceneNodeDestroyed(Ogre::SceneNode *node);
 signals:
     void selectionChanged();
     void nodeSelectionChanged();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2915,12 +2915,15 @@ void MainWindow::keyReleaseEvent(QKeyEvent *event)
 
 void MainWindow::dropEvent(QDropEvent *event)
 {
+#ifdef ENABLE_PS1_RIP
     // PS1 Extracted Asset Browser → editor viewport drag-and-drop (#426).
     // The asset browser publishes its tile's mesh-index list under a custom
     // MIME type and the matching meshIndex list under a sibling type so the
     // promote path doesn't have to re-parse the assetId string. We dispatch
     // before the URL/file path branch so a drag that also carries a text
-    // representation doesn't get mis-routed as a file import.
+    // representation doesn't get mis-routed as a file import. Whole branch
+    // is guarded by `ENABLE_PS1_RIP` because `PS1RipSessionWindow` lives in
+    // the optional PS1 ripping subsystem (off on macOS CI builds).
     static constexpr auto kPs1RipMeshMime = "application/x-ps1rip-mesh";
     static constexpr auto kPs1RipMeshIndexMime = "application/x-ps1rip-meshindex";
     if (event->mimeData()->hasFormat(QString::fromLatin1(kPs1RipMeshMime))) {
@@ -2937,6 +2940,7 @@ void MainWindow::dropEvent(QDropEvent *event)
         event->acceptProposedAction();
         return;
     }
+#endif // ENABLE_PS1_RIP
 
     QStringList validFiles;
     for (const QUrl& url : event->mimeData()->urls())

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2915,6 +2915,29 @@ void MainWindow::keyReleaseEvent(QKeyEvent *event)
 
 void MainWindow::dropEvent(QDropEvent *event)
 {
+    // PS1 Extracted Asset Browser → editor viewport drag-and-drop (#426).
+    // The asset browser publishes its tile's mesh-index list under a custom
+    // MIME type and the matching meshIndex list under a sibling type so the
+    // promote path doesn't have to re-parse the assetId string. We dispatch
+    // before the URL/file path branch so a drag that also carries a text
+    // representation doesn't get mis-routed as a file import.
+    static constexpr auto kPs1RipMeshMime = "application/x-ps1rip-mesh";
+    static constexpr auto kPs1RipMeshIndexMime = "application/x-ps1rip-meshindex";
+    if (event->mimeData()->hasFormat(QString::fromLatin1(kPs1RipMeshMime))) {
+        const QStringList assetIds =
+            QString::fromUtf8(event->mimeData()->data(QString::fromLatin1(kPs1RipMeshMime)))
+                .split(QLatin1Char(';'), Qt::SkipEmptyParts);
+        const QStringList meshIndexes =
+            QString::fromUtf8(event->mimeData()->data(QString::fromLatin1(kPs1RipMeshIndexMime)))
+                .split(QLatin1Char(';'), Qt::SkipEmptyParts);
+        for (int i = 0; i < assetIds.size(); ++i) {
+            const int meshIndex = i < meshIndexes.size() ? meshIndexes.at(i).toInt() : -1;
+            PS1RipSessionWindow::promoteUniqueMeshById(meshIndex, assetIds.at(i));
+        }
+        event->acceptProposedAction();
+        return;
+    }
+
     QStringList validFiles;
     for (const QUrl& url : event->mimeData()->urls())
     {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -159,6 +159,9 @@ if(BUILD_TESTS)
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/MeshReconstructor.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/MeshTopologyHash.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/Ps1CoordinateNormalizer.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PS1CapturedAssets.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PS1ExtractedAssetBrowser.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PS1GeometryInspectorPanel.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PS1RipMeshBuilder.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PS1RipGamepadBridge.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/PS1RipInputSettingsDialog.cpp


### PR DESCRIPTION
Closes #426.

## Summary

Two new docks inside the PS1 ripping session window so users can see *what* was captured, drill from a draw call down to its sub-mesh in the viewport, and pick which captured assets become permanent (i.e. survive Stop / the next Capture).

- **Geometry Inspector** (bottom dock) — table of every captured draw call (`#`, `frame`, `type`, `verts`, `tpage`, `clut`, `matrix#`, `material`, `triangles`) with click-to-highlight, filter chips (Textured / Colored / Instanced + Hide-discarded), free-text material search, and a right-click context menu (Hide/Show, Promote, Discard).
- **Extracted Asset Browser** (right dock) — QTabWidget with Meshes / Textures / Materials tabs. Mesh tiles are drag-enabled and the existing `MainWindow::dropEvent` recognises the new MIME types (`application/x-ps1rip-mesh`, `application/x-ps1rip-meshindex`) — drop on the editor viewport instantiates a permanent SceneNode that persists past Stop.

## Architecture

- `PS1CapturedAssets` (singleton, GUI-thread) is the shared store. Populated from `PS1RipManager` right before `meshBuilt` so every UI listener sees fully-baked data the moment they observe the signal.
- `PS1GeometryInspectorPanel` (`Model` + `Filter` + Qt UI) is dumb about scene state: it reads the store and emits intent signals (`highlightRow`, `promoteRowRequested`, etc.); `PS1RipSessionWindow` owns the actual scene mutation so QML/Ogre coupling stays in one place.
- `PS1ExtractedAssetBrowser` exposes mesh / texture / material tiles through three `QListView` (IconMode) grids sharing a `QSortFilterProxyModel` template. Mesh tiles use a deterministic hue-from-material-name placeholder thumbnail (real off-screen Ogre rendering is called out as a follow-up); texture tiles use the decoded VRAM page directly; material tiles reuse the texture page or a hue swatch for solid colors.
- Promote path is one `promoteUniqueMesh` impl used by 3 entry points: inspector right-click, browser double-click, viewport drop. Clones the Ogre mesh into a fresh `PS1Imported_<id>_meshN_pK` resource + SceneNode so the live capture clear (`PS1Capture_*` walk) doesn't yank it.

## Telemetry

- `ps1.rip.inspector.promote` breadcrumb on every promotion (with source: row-context-menu / browser-doubleclick / dropEvent and mesh / node names).
- `ui.action` breadcrumbs on filter-chip toggles + highlight clicks for downstream analytics.

## Test plan

- [x] `PS1CapturedAssetsTest.*` and `PS1ExtractedAssetBrowserTest.*` — pure-data tests of row attribution, scene-node naming, signal emission, row mutation behaviour, and the tile builder for all three asset kinds. 7/7 passing.
- [x] Full PS1 + Mesh + Capture test sweep (298 tests) passes locally.
- [x] `QtMeshEditor` and `UnitTests` build clean on Linux.
- [ ] Manual smoke: run a PS1 capture, verify both docks populate, click a row to outline the sub-mesh, drag a mesh tile to the editor viewport → a permanent SceneNode appears and survives Stop.

## Follow-ups (intentionally out of scope)

- Real off-screen Ogre RTT for mesh thumbnails (placeholder swatch in this PR).
- "Reset transform" promotion option to decouple from capture node auto-fit scale.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Geometry Inspector dock: filterable table of captured primitives with per-row show/hide, promote, and discard actions.
  * Extracted Asset Browser dock: mesh/texture/material tabs with search, filters, drag-and-drop promotion, and thumbnails.
  * Promotions support per-instance placement and persist promoted assets across captures.

* **Tests**
  * Added unit tests covering capture-to-inspector mapping, browser tiles, promotion flows, and row state mutations.

* **Documentation**
  * Added detailed design doc for the geometry inspector and asset browser.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fernandotonon/QtMeshEditor/pull/679?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->