### PR TITLE
feat(scan): add --target alias for platform profiles (#363)

### DIFF
--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -579,6 +579,7 @@ void CLIPipeline::printUsage()
         "  material --list-presets         List the built-in preset names\n"
         "\n"
         "Scan options:\n"
+        "  --target <id>             Alias for --profile (CI-friendly). Built-in targets include: example-minimal, example-base\n"
         "  --profile <id>            Built-in platform profile (e.g. example-minimal) or path to .json\n"
         "  --list-profiles           List built-in platform profile ids and exit\n"
         "  --config <file>           Config file (default: qtmesh.yml, qtmesh.json)\n"
@@ -3774,6 +3775,7 @@ int CLIPipeline::cmdScan(int argc, char* argv[])
     QString scanRoot;
     QString configPath;
     QString profileIdArg;
+    QString targetIdArg;
     bool listProfiles = false;
     QString tokenArg;
     bool strictUpload = false;
@@ -3877,7 +3879,10 @@ int CLIPipeline::cmdScan(int argc, char* argv[])
         if (arg == "--no-upload") { noUpload = true; continue; }
         if (arg == "--list-profiles") { listProfiles = true; continue; }
         QString value;
-        ParseValueResult parseResult = parseValueArg(arg, "--profile", i, value);
+        ParseValueResult parseResult = parseValueArg(arg, "--target", i, value);
+        if (parseResult == ParseValueResult::Error) return 2;
+        if (parseResult == ParseValueResult::Matched) { targetIdArg = value; continue; }
+        parseResult = parseValueArg(arg, "--profile", i, value);
         if (parseResult == ParseValueResult::Error) return 2;
         if (parseResult == ParseValueResult::Matched) { profileIdArg = value; continue; }
         parseResult = parseValueArg(arg, "--config", i, value);
@@ -4054,6 +4059,7 @@ int CLIPipeline::cmdScan(int argc, char* argv[])
     // 4) CLI flags (below)
     ScanConfig config = ScanConfig::defaults();
     QVariantMap projectRoot;
+    QString activeProfileId;
 
     if (!configPath.isEmpty()) {
         if (!QFileInfo::exists(configPath)) {
@@ -4109,6 +4115,15 @@ int CLIPipeline::cmdScan(int argc, char* argv[])
     }
 
     QString profileId = profileIdArg.trimmed();
+    const QString targetId = targetIdArg.trimmed();
+    if (!targetId.isEmpty()) {
+        if (!profileId.isEmpty() && profileId != targetId) {
+            err() << "Error: --target and --profile both provided with different values ("
+                  << targetId << " vs " << profileId << ")" << Qt::endl;
+            return 2;
+        }
+        profileId = targetId;
+    }
     if (profileId.isEmpty())
         profileId = projectRoot.value(QStringLiteral("profile")).toString().trimmed();
 
@@ -4123,6 +4138,7 @@ int CLIPipeline::cmdScan(int argc, char* argv[])
         for (const QString& w : loaded.warnings)
             err() << "Warning: " << w << Qt::endl;
         applyPlatformProfile(config, loaded.profile);
+        activeProfileId = loaded.profile.id;
         err() << "Note: Using platform profile '" << loaded.profile.id << "'." << Qt::endl;
         SentryReporter::addBreadcrumb(QStringLiteral("cli.scan"),
             QStringLiteral("platform profile=%1").arg(loaded.profile.id));
@@ -4292,12 +4308,16 @@ int CLIPipeline::cmdScan(int argc, char* argv[])
         }
     }
 
-    const QJsonObject reportJson = ScanEngine::scanReportToJsonObject(result);
+    QJsonObject reportJson = ScanEngine::scanReportToJsonObject(result);
+    if (!activeProfileId.isEmpty())
+        reportJson.insert(QStringLiteral("profile"), activeProfileId);
 
     // Output to terminal
     if (jsonOutput) {
         cliWrite(QString::fromUtf8(QJsonDocument(reportJson).toJson(QJsonDocument::Indented)) + "\n");
     } else {
+        if (!activeProfileId.isEmpty())
+            cliWrite(QStringLiteral("Profile: %1\n").arg(activeProfileId));
         cliWrite(formatScanSummary(result, colorizeTextOutput));
     }
 
@@ -4315,7 +4335,7 @@ int CLIPipeline::cmdScan(int argc, char* argv[])
         QFile f(sarifPath);
         QDir().mkpath(QFileInfo(sarifPath).path());
         if (f.open(QIODevice::WriteOnly | QIODevice::Text))
-            f.write(ScanEngine::formatSarif(result).toUtf8());
+            f.write(ScanEngine::formatSarif(result, activeProfileId).toUtf8());
         else
             err() << "Warning: Could not write SARIF report to " << sarifPath << Qt::endl;
     }
@@ -4326,7 +4346,7 @@ int CLIPipeline::cmdScan(int argc, char* argv[])
         QDir().mkpath(QFileInfo(config.reportOutput).path());
         if (f.open(QIODevice::WriteOnly | QIODevice::Text)) {
             if (config.reportFormat == "text")
-                f.write(ScanEngine::formatText(result, config, false).toUtf8());
+                f.write(ScanEngine::formatText(result, config, false, activeProfileId).toUtf8());
             else
                 f.write(QJsonDocument(reportJson).toJson(QJsonDocument::Indented));
         }
@@ -4335,7 +4355,7 @@ int CLIPipeline::cmdScan(int argc, char* argv[])
         QFile f(config.sarifOutput);
         QDir().mkpath(QFileInfo(config.sarifOutput).path());
         if (f.open(QIODevice::WriteOnly | QIODevice::Text))
-            f.write(ScanEngine::formatSarif(result).toUtf8());
+            f.write(ScanEngine::formatSarif(result, activeProfileId).toUtf8());
     }
 
     bool uploadOk = true;

--- a/src/CLIPipeline_test.cpp
+++ b/src/CLIPipeline_test.cpp
@@ -2606,7 +2606,8 @@ TEST(CLIPipelineCmdScan, WritesJsonAndSarifReports)
     QByteArray configBa = configPath.toUtf8();
     QByteArray reportBa = reportPath.toUtf8();
     QByteArray sarifBa = sarifPath.toUtf8();
-    TestArgv args({"qtmesh", "scan", rootBa.constData(), "--config", configBa.constData(),
+    TestArgv args({"qtmesh", "scan", rootBa.constData(), "--target", "example-minimal",
+                   "--config", configBa.constData(),
                    "--json", "--report", reportBa.constData(), "--sarif", sarifBa.constData(),
                    "--fail-on", "never"});
 
@@ -2621,6 +2622,7 @@ TEST(CLIPipelineCmdScan, WritesJsonAndSarifReports)
     EXPECT_TRUE(reportContent.contains("\"assets\""));
     EXPECT_TRUE(reportContent.contains("\"scanStartedUtc\""));
     EXPECT_TRUE(reportContent.contains("\"scanCompletedUtc\""));
+    EXPECT_TRUE(reportContent.contains("\"profile\": \"example-minimal\""));
 
     QFile sarifFile(sarifPath);
     ASSERT_TRUE(sarifFile.open(QIODevice::ReadOnly | QIODevice::Text));
@@ -2629,6 +2631,13 @@ TEST(CLIPipelineCmdScan, WritesJsonAndSarifReports)
     EXPECT_TRUE(sarifContent.contains("qtmesh scan"));
     EXPECT_TRUE(sarifContent.contains("\"startTimeUtc\""));
     EXPECT_TRUE(sarifContent.contains("\"endTimeUtc\""));
+    EXPECT_TRUE(sarifContent.contains("\"profile\": \"example-minimal\""));
+}
+
+TEST(CLIPipelineCmdScanError, UnknownTargetReturns2)
+{
+    TestArgv args({"qtmesh", "scan", "--target", "no-such-target"});
+    EXPECT_EQ(CLIPipeline::cmdScan(args.argc(), args.argv()), 2);
 }
 
 TEST(CLIPipelineCmdScan, ReportAndSarifAreWrittenWithFailOnNever)

--- a/src/CLIPipeline_test.cpp
+++ b/src/CLIPipeline_test.cpp
@@ -2608,7 +2608,7 @@ TEST(CLIPipelineCmdScan, WritesJsonAndSarifReports)
     QByteArray sarifBa = sarifPath.toUtf8();
     TestArgv args({"qtmesh", "scan", rootBa.constData(), "--target", "example-minimal",
                    "--config", configBa.constData(),
-                   "--json", "--report", reportBa.constData(), "--sarif", sarifBa.constData(),
+                   "--report", reportBa.constData(), "--sarif", sarifBa.constData(),
                    "--fail-on", "never"});
 
     EXPECT_EQ(CLIPipeline::cmdScan(args.argc(), args.argv()), 0);

--- a/src/ScanEngine.cpp
+++ b/src/ScanEngine.cpp
@@ -1917,11 +1917,15 @@ static QString colorizeToken(const QString& text, const char* ansiColor, bool en
     return QStringLiteral("\x1b[%1m%2\x1b[0m").arg(QString::fromLatin1(ansiColor), text);
 }
 
-QString ScanEngine::formatText(const ScanResult& result, const ScanConfig& config, bool colorize)
+QString ScanEngine::formatText(const ScanResult& result, const ScanConfig& config, bool colorize,
+                               const QString& activeProfileId)
 {
     Q_UNUSED(config);
     QString out;
     QTextStream s(&out);
+
+    if (!activeProfileId.isEmpty())
+        s << "Profile: " << activeProfileId << "\n\n";
 
     // Per-asset output
     for (const auto& asset : result.assets) {
@@ -2174,7 +2178,7 @@ QString ScanEngine::formatJson(const ScanResult& result)
 // SARIF formatter (Static Analysis Results Interchange Format 2.1.0)
 // ---------------------------------------------------------------------------
 
-QString ScanEngine::formatSarif(const ScanResult& result)
+QString ScanEngine::formatSarif(const ScanResult& result, const QString& activeProfileId)
 {
     // Build rule definitions from unique rule IDs
     QMap<QString, QString> ruleDescriptions;
@@ -2275,6 +2279,11 @@ QString ScanEngine::formatSarif(const ScanResult& result)
 
     QJsonObject run;
     run["tool"] = tool;
+    if (!activeProfileId.isEmpty()) {
+        QJsonObject props;
+        props["profile"] = activeProfileId;
+        run["properties"] = props;
+    }
     run["results"] = resultsArr;
     QString sarifStart, sarifEnd;
     scanReportUtcTimes(result, &sarifStart, &sarifEnd);

--- a/src/ScanEngine.h
+++ b/src/ScanEngine.h
@@ -149,7 +149,8 @@ public:
 
     // --- Formatters ---
 
-    static QString formatText(const ScanResult& result, const ScanConfig& config, bool colorize = false);
+    static QString formatText(const ScanResult& result, const ScanConfig& config, bool colorize = false,
+                              const QString& activeProfileId = QString());
     /// Canonical JSON object for `--json`, report files, and QtMesh Cloud upload (identical schema).
     static QJsonObject scanReportToJsonObject(const ScanResult& result);
 
@@ -159,7 +160,7 @@ public:
     /// UTC ISO-8601 timestamps for reports (`scanStartedUtc` / `scanCompletedUtc`); missing values use `scanCompletedUtc` or current UTC.
     static void scanReportUtcTimes(const ScanResult& result, QString* scanStartedUtc, QString* scanCompletedUtc);
     static QString formatJson(const ScanResult& result);
-    static QString formatSarif(const ScanResult& result);
+    static QString formatSarif(const ScanResult& result, const QString& activeProfileId = QString());
 
     // --- Helpers (public for testing) ---
 


### PR DESCRIPTION
## Summary
- Adds `qtmesh scan --target <profileId>` as a CI-friendly alias for selecting a bundled platform profile (same merge path as `--profile`).
- Emits the active profile id into JSON report (`profile`), SARIF (`run.properties.profile`), and text output (header line).
- Adds unit tests for `--target` happy-path and unknown id error.

## Merge precedence
Defaults → platform profile → project config → CLI flags (unchanged).

## Test plan
- [x] `UnitTests --gtest_filter=CLIPipelineCmdScan*`

Closes #363

Made with [Cursor](https://cursor.com)