### PR TITLE
feat(cloud): move account control to objects toolbar

### DIFF
--- a/resources/cloud_account_user.svg
+++ b/resources/cloud_account_user.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path stroke="#c8c8c8" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"
+        d="M12 4.2a3.4 3.4 0 1 0 0 6.8 3.4 3.4 0 0 0 0-6.8z"/>
+  <path stroke="#c8c8c8" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"
+        d="M5.2 18.6c1.4-2.2 4-3.6 6.8-3.6s5.4 1.4 6.8 3.6"/>
+  <path stroke="#9ab4d0" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+        d="M17.2 6.2a3.8 3.8 0 0 0-5.2 3.1"/>
+  <path stroke="#9ab4d0" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+        d="M17.8 5.4v2.4h2.2"/>
+</svg>

--- a/resources/resource.qrc
+++ b/resources/resource.qrc
@@ -17,6 +17,7 @@
         <file>roundedbox.png</file>
         <file>addVertice.png</file>
         <file>paintbrush.svg</file>
+        <file>cloud_account_user.svg</file>
         <file>spring.png</file>
         <file>scale.png</file>
     </qresource>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -122,6 +122,7 @@ PlatformProfile.cpp
 QtMeshCloudClient.cpp
 CloudCredentialStore.cpp
 CloudUploadPlanner.cpp
+CloudAccountMenuButton.cpp
 AssetBrowserController.cpp
 MaterialPreviewRenderer.cpp
 ModelTurntableRenderer.cpp

--- a/src/CloudAccountMenuButton.cpp
+++ b/src/CloudAccountMenuButton.cpp
@@ -106,7 +106,7 @@ protected:
     }
 
 private:
-    void paintStatusBadge(QPainter& painter)
+    void paintStatusBadge(QPainter& painter) const
     {
         const int badgeD = 7;
         const QRect badge(rect().right() - badgeD - 1,
@@ -135,7 +135,7 @@ QString CloudAccountMenuButton::initialsFromDisplayName(const QString& displayNa
     if (parts.isEmpty())
         return QString();
 
-    auto firstChar = [](const QString& word) -> QChar {
+    auto firstChar = [](const QString& word) {
         for (const QChar ch : word) {
             if (ch.isLetter())
                 return ch.toUpper();
@@ -256,9 +256,7 @@ void CloudAccountMenuButton::buildMenu()
 
 void CloudAccountMenuButton::updateHeader(const QString& displayName, bool signedIn)
 {
-    const bool showHeader = signedIn && !displayName.isEmpty();
-
-    if (showHeader) {
+    if (const bool showHeader = signedIn && !displayName.isEmpty(); showHeader) {
         m_headerNameLabel->setText(displayName);
         m_headerSubtitleLabel->setText(tr("Signed in to QtMesh Cloud"));
 

--- a/src/CloudAccountMenuButton.cpp
+++ b/src/CloudAccountMenuButton.cpp
@@ -260,6 +260,7 @@ void CloudAccountMenuButton::updateHeader(const QString& displayName, bool signe
 
     if (showHeader) {
         m_headerNameLabel->setText(displayName);
+        m_headerSubtitleLabel->setText(tr("Signed in to QtMesh Cloud"));
 
         // Ensure the header is actually present in the menu, otherwise the menu can
         // end up drawing stale pixels behind items when we toggle auth state while

--- a/src/CloudAccountMenuButton.cpp
+++ b/src/CloudAccountMenuButton.cpp
@@ -1,0 +1,310 @@
+#include "CloudAccountMenuButton.h"
+
+#include "AppSettingsKeys.h"
+#include "CloudCredentialStore.h"
+
+#include <QAction>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QMenu>
+#include <QPainter>
+#include <QRegularExpression>
+#include <QSettings>
+#include <QToolButton>
+#include <QVBoxLayout>
+#include <QWidgetAction>
+
+namespace {
+
+QString cloudDisplayName()
+{
+    QSettings settings;
+    QString display = settings.value(AppSettingsKeys::cloudUserName()).toString().trimmed();
+    if (display.isEmpty())
+        display = settings.value(AppSettingsKeys::cloudUserSlug()).toString().trimmed();
+    if (display.isEmpty())
+        display = CloudCredentialStore::loadSession().email.trimmed();
+    return display;
+}
+
+} // namespace
+
+class CloudAccountMenuButton::AvatarButton : public QToolButton {
+public:
+    explicit AvatarButton(QWidget* parent = nullptr)
+        : QToolButton(parent)
+    {
+        setFixedSize(28, 28);
+        setAutoRaise(true);
+        setPopupMode(QToolButton::InstantPopup);
+        setToolButtonStyle(Qt::ToolButtonIconOnly);
+        setCursor(Qt::PointingHandCursor);
+        setStyleSheet(QStringLiteral(
+            "QToolButton { padding: 0; border: none; background: transparent; }"
+            "QToolButton:hover { background: palette(midlight); border-radius: 14px; }"
+            "QToolButton:pressed { background: palette(mid); border-radius: 14px; }"));
+    }
+
+    void setSignedIn(bool signedIn, const QString& initials)
+    {
+        m_signedIn = signedIn;
+        m_initials = initials;
+        if (signedIn && !initials.isEmpty()) {
+            setIcon(QIcon());
+            setText(QString());
+            setToolButtonStyle(Qt::ToolButtonIconOnly);
+        } else {
+            setText(QString());
+            setToolButtonStyle(Qt::ToolButtonIconOnly);
+            if (m_loggedOutIcon.isNull())
+                m_loggedOutIcon = QIcon(QStringLiteral(":/icones/cloud_account_user.svg"));
+            setIcon(m_loggedOutIcon);
+        }
+        update();
+    }
+
+protected:
+    void paintEvent(QPaintEvent* event) override
+    {
+        if (m_signedIn && !m_initials.isEmpty()) {
+            QPainter painter(this);
+            painter.setRenderHint(QPainter::Antialiasing, true);
+
+            const QRect r = rect().adjusted(2, 2, -2, -2);
+            painter.setPen(Qt::NoPen);
+            painter.setBrush(QColor(0x4a, 0x7a, 0xa8));
+            painter.drawEllipse(r);
+            QFont font = painter.font();
+            font.setBold(true);
+            font.setPixelSize(10);
+            painter.setFont(font);
+            painter.setPen(QColor(0xf0, 0xf4, 0xf8));
+            painter.drawText(r, Qt::AlignCenter, m_initials);
+            paintStatusBadge(painter);
+            return;
+        }
+
+        if (m_signedIn) {
+            if (m_loggedOutIcon.isNull())
+                m_loggedOutIcon = QIcon(QStringLiteral(":/icones/cloud_account_user.svg"));
+            const QRect r = rect().adjusted(2, 2, -2, -2);
+            const QPixmap pix = m_loggedOutIcon.pixmap(r.size());
+            if (!pix.isNull()) {
+                QPainter painter(this);
+                painter.setRenderHint(QPainter::Antialiasing, true);
+                painter.drawPixmap(r, pix);
+                paintStatusBadge(painter);
+                return;
+            }
+        }
+
+        QToolButton::paintEvent(event);
+
+        QPainter painter(this);
+        painter.setRenderHint(QPainter::Antialiasing, true);
+        paintStatusBadge(painter);
+    }
+
+private:
+    void paintStatusBadge(QPainter& painter)
+    {
+        const int badgeD = 7;
+        const QRect badge(rect().right() - badgeD - 1,
+                          rect().bottom() - badgeD - 1,
+                          badgeD,
+                          badgeD);
+        painter.setPen(QPen(QColor(0x2b, 0x2b, 0x2b), 1.5));
+        painter.setBrush(m_signedIn ? QColor(0x4c, 0xaf, 0x50) : QColor(0x6e, 0x6e, 0x6e));
+        painter.drawEllipse(badge);
+    }
+
+private:
+    bool m_signedIn = false;
+    QString m_initials;
+    QIcon m_loggedOutIcon;
+};
+
+QString CloudAccountMenuButton::initialsFromDisplayName(const QString& displayName)
+{
+    const QString trimmed = displayName.trimmed();
+    if (trimmed.isEmpty())
+        return QString();
+
+    const QStringList parts =
+        trimmed.split(QRegularExpression(QStringLiteral("\\s+")), Qt::SkipEmptyParts);
+    if (parts.isEmpty())
+        return QString();
+
+    auto firstChar = [](const QString& word) -> QChar {
+        for (const QChar ch : word) {
+            if (ch.isLetter())
+                return ch.toUpper();
+        }
+        return QChar();
+    };
+
+    if (parts.size() == 1) {
+        const QChar a = firstChar(parts.front());
+        return a.isNull() ? QString() : QString(a);
+    }
+
+    const QChar first = firstChar(parts.front());
+    const QChar last = firstChar(parts.back());
+    if (first.isNull() && last.isNull())
+        return QString();
+    if (first.isNull())
+        return QString(last);
+    if (last.isNull())
+        return QString(first);
+    return QString(first) + last;
+}
+
+CloudAccountMenuButton::CloudAccountMenuButton(QWidget* parent)
+    : QWidget(parent)
+{
+    auto* layout = new QHBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(0);
+
+    m_button = new AvatarButton(this);
+    m_button->setObjectName(QStringLiteral("cloudAccountButton"));
+
+    m_menu = new QMenu(this);
+    m_menu->setObjectName(QStringLiteral("menuCloud"));
+    applyMenuStyle();
+    buildMenu();
+
+    m_button->setMenu(m_menu);
+    layout->addWidget(m_button);
+
+    connect(m_menu, &QMenu::aboutToShow, this, &CloudAccountMenuButton::refresh);
+
+    refresh();
+}
+
+void CloudAccountMenuButton::applyMenuStyle()
+{
+    m_menu->setStyleSheet(QStringLiteral(
+        "QMenu {"
+        "  background-color: #2b2b2b;"
+        "  border: 1px solid #3d3d3d;"
+        "  padding: 4px 0;"
+        "}"
+        "QMenu::item {"
+        "  padding: 7px 20px;"
+        "  color: #e0e0e0;"
+        "}"
+        "QMenu::item:selected {"
+        "  background-color: #3a3a3a;"
+        "}"
+        "QMenu::item:disabled {"
+        "  color: #9a9a9a;"
+        "}"
+        "QMenu::separator {"
+        "  height: 1px;"
+        "  background: #3d3d3d;"
+        "  margin: 5px 10px;"
+        "}"));
+}
+
+void CloudAccountMenuButton::buildMenu()
+{
+    m_headerWidget = new QWidget(m_menu);
+    m_headerWidget->setObjectName(QStringLiteral("cloudAccountMenuHeader"));
+    auto* headerLayout = new QVBoxLayout(m_headerWidget);
+    headerLayout->setContentsMargins(14, 10, 14, 8);
+    headerLayout->setSpacing(2);
+
+    m_headerNameLabel = new QLabel(m_headerWidget);
+    m_headerNameLabel->setObjectName(QStringLiteral("cloudAccountMenuHeaderName"));
+    m_headerNameLabel->setStyleSheet(QStringLiteral(
+        "color: #ececec; font-size: 13px; font-weight: 600; background: transparent;"));
+    m_headerNameLabel->setWordWrap(true);
+
+    m_headerSubtitleLabel = new QLabel(tr("QtMesh Cloud account"), m_headerWidget);
+    m_headerSubtitleLabel->setObjectName(QStringLiteral("cloudAccountMenuHeaderSubtitle"));
+    m_headerSubtitleLabel->setStyleSheet(QStringLiteral(
+        "color: #9a9a9a; font-size: 11px; background: transparent;"));
+
+    headerLayout->addWidget(m_headerNameLabel);
+    headerLayout->addWidget(m_headerSubtitleLabel);
+
+    m_headerAction = new QWidgetAction(m_menu);
+    m_headerAction->setDefaultWidget(m_headerWidget);
+    m_headerAction->setEnabled(false);
+    m_menu->addAction(m_headerAction);
+    m_headerSeparator = m_menu->addSeparator();
+
+    m_openProjectsAction = m_menu->addAction(tr("Open My Projects"));
+    m_openProjectsAction->setObjectName(QStringLiteral("actionQtMeshCloudOpenProjects"));
+    connect(m_openProjectsAction, &QAction::triggered, this, &CloudAccountMenuButton::openProjectsRequested);
+
+    m_uploadAction = m_menu->addAction(tr("Upload Files..."));
+    m_uploadAction->setObjectName(QStringLiteral("actionQtMeshCloudUploadFiles"));
+    connect(m_uploadAction, &QAction::triggered, this, &CloudAccountMenuButton::uploadFilesRequested);
+
+    m_mainSeparator = m_menu->addSeparator();
+
+    m_signOutAction = m_menu->addAction(tr("Sign out"));
+    m_signOutAction->setObjectName(QStringLiteral("actionQtMeshCloudSignOut"));
+    connect(m_signOutAction, &QAction::triggered, this, &CloudAccountMenuButton::signOutRequested);
+
+    m_signInAction = m_menu->addAction(tr("Sign in to QtMesh Cloud"));
+    m_signInAction->setObjectName(QStringLiteral("actionQtMeshCloudSignIn"));
+    connect(m_signInAction, &QAction::triggered, this, &CloudAccountMenuButton::signInRequested);
+}
+
+void CloudAccountMenuButton::updateHeader(const QString& displayName, bool signedIn)
+{
+    const bool showHeader = signedIn && !displayName.isEmpty();
+
+    if (showHeader) {
+        m_headerNameLabel->setText(displayName);
+
+        // Ensure the header is actually present in the menu, otherwise the menu can
+        // end up drawing stale pixels behind items when we toggle auth state while
+        // the menu is open.
+        if (!m_menu->actions().contains(m_headerAction))
+            m_menu->insertAction(m_openProjectsAction, m_headerAction);
+        if (!m_menu->actions().contains(m_headerSeparator))
+            m_menu->insertAction(m_openProjectsAction, m_headerSeparator);
+    } else {
+        m_headerNameLabel->clear();
+        if (m_menu->actions().contains(m_headerAction))
+            m_menu->removeAction(m_headerAction);
+        if (m_menu->actions().contains(m_headerSeparator))
+            m_menu->removeAction(m_headerSeparator);
+    }
+
+    m_menu->updateGeometry();
+    m_menu->adjustSize();
+    m_menu->update();
+}
+
+void CloudAccountMenuButton::refresh()
+{
+    CloudCredentialStore::migrateLegacySettingsIfNeeded();
+    const bool signedIn = CloudCredentialStore::hasSession();
+    const QString display = cloudDisplayName();
+
+    if (signedIn && !display.isEmpty()) {
+        m_button->setToolTip(
+            tr("QtMesh Cloud: signed in as %1").arg(display));
+    } else {
+        m_button->setToolTip(tr("Sign in to QtMesh Cloud"));
+    }
+
+    const QString initials = signedIn ? initialsFromDisplayName(display) : QString();
+    if (auto* avatar = dynamic_cast<AvatarButton*>(m_button))
+        avatar->setSignedIn(signedIn, initials);
+
+    updateHeader(display, signedIn);
+
+    m_openProjectsAction->setEnabled(signedIn);
+    m_uploadAction->setEnabled(true);
+
+    m_signInAction->setVisible(!signedIn);
+    m_signInAction->setEnabled(!signedIn);
+    m_signOutAction->setVisible(signedIn);
+    m_signOutAction->setEnabled(signedIn);
+}

--- a/src/CloudAccountMenuButton.h
+++ b/src/CloudAccountMenuButton.h
@@ -1,0 +1,57 @@
+#ifndef CLOUD_ACCOUNT_MENU_BUTTON_H
+#define CLOUD_ACCOUNT_MENU_BUTTON_H
+
+#include <QWidget>
+
+class QAction;
+class QLabel;
+class QMenu;
+class QToolButton;
+class QWidgetAction;
+
+/// VS Code-style QtMesh Cloud account control: avatar button + popup menu.
+/// Self-contained so MainWindow can host it on the objects toolbar today and
+/// move it to a top bar later without rewiring auth logic.
+class CloudAccountMenuButton : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit CloudAccountMenuButton(QWidget* parent = nullptr);
+
+    QToolButton* toolButton() const { return m_button; }
+    QMenu* menu() const { return m_menu; }
+
+    /// Reads CloudCredentialStore / QSettings and updates button + menu visibility.
+    void refresh();
+
+    /// Exposed for unit tests.
+    static QString initialsFromDisplayName(const QString& displayName);
+
+signals:
+    void signInRequested();
+    void signOutRequested();
+    void uploadFilesRequested();
+    void openProjectsRequested();
+
+private:
+    class AvatarButton;
+
+    void buildMenu();
+    void applyMenuStyle();
+    void updateHeader(const QString& displayName, bool signedIn);
+
+    QToolButton* m_button = nullptr;
+    QMenu* m_menu = nullptr;
+    QWidget* m_headerWidget = nullptr;
+    QLabel* m_headerNameLabel = nullptr;
+    QLabel* m_headerSubtitleLabel = nullptr;
+    QWidgetAction* m_headerAction = nullptr;
+    QAction* m_headerSeparator = nullptr;
+    QAction* m_mainSeparator = nullptr;
+    QAction* m_signInAction = nullptr;
+    QAction* m_signOutAction = nullptr;
+    QAction* m_uploadAction = nullptr;
+    QAction* m_openProjectsAction = nullptr;
+};
+
+#endif

--- a/src/CloudAccountMenuButton_test.cpp
+++ b/src/CloudAccountMenuButton_test.cpp
@@ -3,10 +3,13 @@
 #include "AppSettingsKeys.h"
 #include "CloudCredentialStore.h"
 
+#include <QAction>
 #include <QApplication>
 #include <QCoreApplication>
 #include <QLabel>
+#include <QMenu>
 #include <QSettings>
+#include <QWidgetAction>
 #include <gtest/gtest.h>
 
 class CloudAccountMenuButtonTest : public ::testing::Test {
@@ -61,12 +64,25 @@ TEST_F(CloudAccountMenuButtonTest, SignedOutButtonRepaintsWithoutCrash)
     button.repaint();
     QApplication::processEvents();
 
-    auto* subtitle = button.findChild<QLabel*>(QStringLiteral("cloudAccountMenuHeaderSubtitle"));
+    auto* subtitle = button.findChild<QLabel*>(QStringLiteral("cloudAccountMenuHeaderSubtitle"),
+                                               Qt::FindChildrenRecursively);
     ASSERT_NE(subtitle, nullptr);
     EXPECT_EQ(subtitle->text(), QStringLiteral("Signed in to QtMesh Cloud"));
 
     CloudCredentialStore::clearSession();
+    QSettings().remove(AppSettingsKeys::cloudUserName());
     button.refresh();
     button.repaint();
     QApplication::processEvents();
+
+    bool headerListedInMenu = false;
+    for (QAction* action : button.menu()->actions()) {
+        auto* widgetAction = qobject_cast<QWidgetAction*>(action);
+        if (!widgetAction)
+            continue;
+        QWidget* widget = widgetAction->defaultWidget();
+        if (widget && widget->objectName() == QStringLiteral("cloudAccountMenuHeader"))
+            headerListedInMenu = true;
+    }
+    EXPECT_FALSE(headerListedInMenu);
 }

--- a/src/CloudAccountMenuButton_test.cpp
+++ b/src/CloudAccountMenuButton_test.cpp
@@ -1,0 +1,41 @@
+#include "CloudAccountMenuButton.h"
+
+#include "CloudCredentialStore.h"
+
+#include <QApplication>
+#include <gtest/gtest.h>
+
+TEST(CloudAccountMenuButtonTest, InitialsFromDisplayName)
+{
+    EXPECT_EQ(CloudAccountMenuButton::initialsFromDisplayName(QStringLiteral("Fernando Tonon")),
+              QStringLiteral("FT"));
+    EXPECT_EQ(CloudAccountMenuButton::initialsFromDisplayName(QStringLiteral("Dev User")),
+              QStringLiteral("DU"));
+    EXPECT_EQ(CloudAccountMenuButton::initialsFromDisplayName(QStringLiteral("Ada")),
+              QStringLiteral("A"));
+    EXPECT_EQ(CloudAccountMenuButton::initialsFromDisplayName(QStringLiteral("  ")), QString());
+}
+
+TEST(CloudAccountMenuButtonTest, SignedOutButtonRepaintsWithoutCrash)
+{
+    CloudCredentialStore::clearSession();
+
+    CloudAccountMenuButton button;
+    button.show();
+    button.refresh();
+    button.repaint();
+    QApplication::processEvents();
+
+    CloudSession session;
+    session.token = QStringLiteral("test-token");
+    session.email = QStringLiteral("dev@example.com");
+    ASSERT_TRUE(CloudCredentialStore::saveSession(session));
+    button.refresh();
+    button.repaint();
+    QApplication::processEvents();
+
+    CloudCredentialStore::clearSession();
+    button.refresh();
+    button.repaint();
+    QApplication::processEvents();
+}

--- a/src/CloudAccountMenuButton_test.cpp
+++ b/src/CloudAccountMenuButton_test.cpp
@@ -1,11 +1,39 @@
 #include "CloudAccountMenuButton.h"
 
+#include "AppSettingsKeys.h"
 #include "CloudCredentialStore.h"
 
 #include <QApplication>
+#include <QCoreApplication>
+#include <QLabel>
+#include <QSettings>
 #include <gtest/gtest.h>
 
-TEST(CloudAccountMenuButtonTest, InitialsFromDisplayName)
+class CloudAccountMenuButtonTest : public ::testing::Test {
+protected:
+    QString previousOrganizationName;
+    QString previousApplicationName;
+
+    void SetUp() override
+    {
+        previousOrganizationName = QCoreApplication::organizationName();
+        previousApplicationName = QCoreApplication::applicationName();
+        QCoreApplication::setOrganizationName(QStringLiteral("QtMeshEditorTests"));
+        QCoreApplication::setApplicationName(QStringLiteral("CloudAccountMenuButtonTest"));
+        QSettings().clear();
+        CloudCredentialStore::clearSession();
+    }
+
+    void TearDown() override
+    {
+        CloudCredentialStore::clearSession();
+        QSettings().clear();
+        QCoreApplication::setOrganizationName(previousOrganizationName);
+        QCoreApplication::setApplicationName(previousApplicationName);
+    }
+};
+
+TEST_F(CloudAccountMenuButtonTest, InitialsFromDisplayName)
 {
     EXPECT_EQ(CloudAccountMenuButton::initialsFromDisplayName(QStringLiteral("Fernando Tonon")),
               QStringLiteral("FT"));
@@ -16,10 +44,8 @@ TEST(CloudAccountMenuButtonTest, InitialsFromDisplayName)
     EXPECT_EQ(CloudAccountMenuButton::initialsFromDisplayName(QStringLiteral("  ")), QString());
 }
 
-TEST(CloudAccountMenuButtonTest, SignedOutButtonRepaintsWithoutCrash)
+TEST_F(CloudAccountMenuButtonTest, SignedOutButtonRepaintsWithoutCrash)
 {
-    CloudCredentialStore::clearSession();
-
     CloudAccountMenuButton button;
     button.show();
     button.refresh();
@@ -30,9 +56,14 @@ TEST(CloudAccountMenuButtonTest, SignedOutButtonRepaintsWithoutCrash)
     session.token = QStringLiteral("test-token");
     session.email = QStringLiteral("dev@example.com");
     ASSERT_TRUE(CloudCredentialStore::saveSession(session));
+    QSettings().setValue(AppSettingsKeys::cloudUserName(), QStringLiteral("Dev User"));
     button.refresh();
     button.repaint();
     QApplication::processEvents();
+
+    auto* subtitle = button.findChild<QLabel*>(QStringLiteral("cloudAccountMenuHeaderSubtitle"));
+    ASSERT_NE(subtitle, nullptr);
+    EXPECT_EQ(subtitle->text(), QStringLiteral("Signed in to QtMesh Cloud"));
 
     CloudCredentialStore::clearSession();
     button.refresh();

--- a/src/CloudCredentialStore.cpp
+++ b/src/CloudCredentialStore.cpp
@@ -79,8 +79,7 @@ bool writeFallbackFile(const QByteArray& payload)
         return false;
 
     const QFileInfo info(path);
-    QDir dir = info.dir();
-    if (!dir.exists() && !dir.mkpath(QStringLiteral(".")))
+    if (QDir dir = info.dir(); !dir.exists() && !dir.mkpath(QStringLiteral(".")))
         return false;
 
     QFile file(path);
@@ -108,9 +107,7 @@ void removeFallbackFile()
 
 bool storeSecretBytes(const QByteArray& payload)
 {
-    if (useIsolatedTestStorage())
-        return writeFallbackFile(payload);
-
+    if (!useIsolatedTestStorage()) {
 #if defined(Q_OS_MACOS)
     const QByteArray service = QByteArrayLiteral("QtMeshEditor");
     const QByteArray account = QByteArrayLiteral("QtMeshCloud");
@@ -161,18 +158,15 @@ bool storeSecretBytes(const QByteArray& payload)
     return CredWriteW(&cred, 0) != FALSE;
 
 #elif defined(Q_OS_LINUX) && defined(HAVE_LIBSECRET)
-    return qtmesh_cloud_secret_store(payload.constData()) != 0;
-
-#else
-    return writeFallbackFile(payload);
+        return qtmesh_cloud_secret_store(payload.constData()) != 0;
 #endif
+    }
+    return writeFallbackFile(payload);
 }
 
 QByteArray loadSecretBytes()
 {
-    if (useIsolatedTestStorage())
-        return readFallbackFile();
-
+    if (!useIsolatedTestStorage()) {
 #if defined(Q_OS_MACOS)
     const QByteArray service = QByteArrayLiteral("QtMeshEditor");
     const QByteArray account = QByteArrayLiteral("QtMeshCloud");
@@ -208,25 +202,20 @@ QByteArray loadSecretBytes()
     return payload;
 
 #elif defined(Q_OS_LINUX) && defined(HAVE_LIBSECRET)
-    char* raw = qtmesh_cloud_secret_load();
-    if (!raw)
-        return {};
-    const QByteArray payload(raw);
-    qtmesh_cloud_secret_free(raw);
-    return payload;
-
-#else
-    return readFallbackFile();
+        char* raw = qtmesh_cloud_secret_load();
+        if (!raw)
+            return {};
+        const QByteArray payload(raw);
+        qtmesh_cloud_secret_free(raw);
+        return payload;
 #endif
+    }
+    return readFallbackFile();
 }
 
 void deleteSecretBytes()
 {
-    if (useIsolatedTestStorage()) {
-        removeFallbackFile();
-        return;
-    }
-
+    if (!useIsolatedTestStorage()) {
 #if defined(Q_OS_MACOS)
     const QByteArray service = QByteArrayLiteral("QtMeshEditor");
     const QByteArray account = QByteArrayLiteral("QtMeshCloud");
@@ -244,11 +233,10 @@ void deleteSecretBytes()
     CredDeleteW(L"QtMeshEditor/QtMeshCloud", CRED_TYPE_GENERIC, 0);
 
 #elif defined(Q_OS_LINUX) && defined(HAVE_LIBSECRET)
-    qtmesh_cloud_secret_delete();
-
-#else
-    removeFallbackFile();
+        qtmesh_cloud_secret_delete();
 #endif
+    }
+    removeFallbackFile();
 }
 
 } // namespace

--- a/src/CloudCredentialStore.cpp
+++ b/src/CloudCredentialStore.cpp
@@ -1,7 +1,10 @@
 #include "CloudCredentialStore.h"
 #include "AppSettingsKeys.h"
 
+#include <QCoreApplication>
+#include <QDir>
 #include <QFile>
+#include <QFileInfo>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QSettings>
@@ -27,6 +30,13 @@
 #endif
 
 namespace {
+
+constexpr auto kTestOrganizationName = "QtMeshEditorTests";
+
+bool useIsolatedTestStorage()
+{
+    return QCoreApplication::organizationName() == QLatin1StringView(kTestOrganizationName);
+}
 
 QByteArray sessionToPayload(const CloudSession& session)
 {
@@ -65,6 +75,14 @@ QString fallbackFilePath()
 bool writeFallbackFile(const QByteArray& payload)
 {
     const QString path = fallbackFilePath();
+    if (path.isEmpty())
+        return false;
+
+    const QFileInfo info(path);
+    QDir dir = info.dir();
+    if (!dir.exists() && !dir.mkpath(QStringLiteral(".")))
+        return false;
+
     QFile file(path);
     if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate))
         return false;
@@ -90,6 +108,9 @@ void removeFallbackFile()
 
 bool storeSecretBytes(const QByteArray& payload)
 {
+    if (useIsolatedTestStorage())
+        return writeFallbackFile(payload);
+
 #if defined(Q_OS_MACOS)
     const QByteArray service = QByteArrayLiteral("QtMeshEditor");
     const QByteArray account = QByteArrayLiteral("QtMeshCloud");
@@ -149,6 +170,9 @@ bool storeSecretBytes(const QByteArray& payload)
 
 QByteArray loadSecretBytes()
 {
+    if (useIsolatedTestStorage())
+        return readFallbackFile();
+
 #if defined(Q_OS_MACOS)
     const QByteArray service = QByteArrayLiteral("QtMeshEditor");
     const QByteArray account = QByteArrayLiteral("QtMeshCloud");
@@ -198,6 +222,11 @@ QByteArray loadSecretBytes()
 
 void deleteSecretBytes()
 {
+    if (useIsolatedTestStorage()) {
+        removeFallbackFile();
+        return;
+    }
+
 #if defined(Q_OS_MACOS)
     const QByteArray service = QByteArrayLiteral("QtMeshEditor");
     const QByteArray account = QByteArrayLiteral("QtMeshCloud");

--- a/src/CloudCredentialStore_test.cpp
+++ b/src/CloudCredentialStore_test.cpp
@@ -63,5 +63,6 @@ TEST_F(CloudCredentialStoreTest, MigratesLegacyPlaintextSettings)
     EXPECT_EQ(loaded.expiresAt, 42);
     EXPECT_EQ(loaded.email, QStringLiteral("legacy@example.com"));
     EXPECT_TRUE(settings.value(AppSettingsKeys::cloudToken()).toString().isEmpty());
+    EXPECT_TRUE(settings.value(AppSettingsKeys::cloudTokenExpiresAt()).toString().isEmpty());
     EXPECT_TRUE(settings.value(AppSettingsKeys::cloudUserEmail()).toString().isEmpty());
 }

--- a/src/CloudCredentialStore_test.cpp
+++ b/src/CloudCredentialStore_test.cpp
@@ -6,10 +6,32 @@
 #include <QCoreApplication>
 #include <QSettings>
 
-TEST(CloudCredentialStoreTest, RoundTripAndClear)
-{
-    CloudCredentialStore::clearSession();
+class CloudCredentialStoreTest : public ::testing::Test {
+protected:
+    QString previousOrganizationName;
+    QString previousApplicationName;
 
+    void SetUp() override
+    {
+        previousOrganizationName = QCoreApplication::organizationName();
+        previousApplicationName = QCoreApplication::applicationName();
+        QCoreApplication::setOrganizationName(QStringLiteral("QtMeshEditorTests"));
+        QCoreApplication::setApplicationName(QStringLiteral("CloudCredentialStoreTest"));
+        QSettings().clear();
+        CloudCredentialStore::clearSession();
+    }
+
+    void TearDown() override
+    {
+        CloudCredentialStore::clearSession();
+        QSettings().clear();
+        QCoreApplication::setOrganizationName(previousOrganizationName);
+        QCoreApplication::setApplicationName(previousApplicationName);
+    }
+};
+
+TEST_F(CloudCredentialStoreTest, RoundTripAndClear)
+{
     CloudSession session;
     session.token = QStringLiteral("test-token");
     session.expiresAt = 1234567890;
@@ -26,10 +48,8 @@ TEST(CloudCredentialStoreTest, RoundTripAndClear)
     EXPECT_FALSE(CloudCredentialStore::hasSession());
 }
 
-TEST(CloudCredentialStoreTest, MigratesLegacyPlaintextSettings)
+TEST_F(CloudCredentialStoreTest, MigratesLegacyPlaintextSettings)
 {
-    CloudCredentialStore::clearSession();
-
     QSettings settings;
     settings.setValue(AppSettingsKeys::cloudToken(), QStringLiteral("legacy-token"));
     settings.setValue(AppSettingsKeys::cloudTokenExpiresAt(), 42);
@@ -44,6 +64,4 @@ TEST(CloudCredentialStoreTest, MigratesLegacyPlaintextSettings)
     EXPECT_EQ(loaded.email, QStringLiteral("legacy@example.com"));
     EXPECT_TRUE(settings.value(AppSettingsKeys::cloudToken()).toString().isEmpty());
     EXPECT_TRUE(settings.value(AppSettingsKeys::cloudUserEmail()).toString().isEmpty());
-
-    CloudCredentialStore::clearSession();
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2304,25 +2304,46 @@ void MainWindow::setupCloudAccountStatusControl()
 
     m_cloudSignInAction = m_cloudAccountMenu->addAction(tr("Sign in to QtMesh Cloud..."));
     m_cloudSignInAction->setObjectName(QStringLiteral("actionQtMeshCloudSignIn"));
-    connect(m_cloudSignInAction, &QAction::triggered, this, &MainWindow::signInToQtMeshCloud);
+    connect(m_cloudSignInAction, &QAction::triggered, this, [this]() {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("Cloud toolbar: Sign in"));
+        signInToQtMeshCloud();
+    });
 
     m_cloudSignOutAction = m_cloudAccountMenu->addAction(tr("Sign out"));
     m_cloudSignOutAction->setObjectName(QStringLiteral("actionQtMeshCloudSignOut"));
-    connect(m_cloudSignOutAction, &QAction::triggered, this, &MainWindow::signOutOfQtMeshCloud);
+    connect(m_cloudSignOutAction, &QAction::triggered, this, [this]() {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("Cloud toolbar: Sign out"));
+        signOutOfQtMeshCloud();
+    });
 
     m_cloudAccountMenu->addSeparator();
 
     m_cloudUploadFilesAction = m_cloudAccountMenu->addAction(tr("Upload Files..."));
     m_cloudUploadFilesAction->setObjectName(QStringLiteral("actionQtMeshCloudUploadFiles"));
-    connect(m_cloudUploadFilesAction, &QAction::triggered, this, &MainWindow::uploadFilesToQtMeshCloud);
+    connect(m_cloudUploadFilesAction, &QAction::triggered, this, [this]() {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("Cloud toolbar: Upload Files"));
+        uploadFilesToQtMeshCloud();
+    });
 
     m_cloudOpenDashboardAction = m_cloudAccountMenu->addAction(tr("Open My Projects"));
     m_cloudOpenDashboardAction->setObjectName(QStringLiteral("actionQtMeshCloudOpenProjects"));
-    connect(m_cloudOpenDashboardAction, &QAction::triggered, this, []() {
-        QDesktopServices::openUrl(QUrl(QStringLiteral(QTMESH_CLOUD_WEB_URL)));
+    connect(m_cloudOpenDashboardAction, &QAction::triggered, this, [this]() {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("Cloud toolbar: Open My Projects"));
+        if (!QDesktopServices::openUrl(QUrl(QStringLiteral(QTMESH_CLOUD_WEB_URL)))) {
+            QMessageBox::warning(this, tr("QtMesh Cloud"),
+                                 tr("Could not open QtMesh Cloud in your browser."));
+        }
     });
 
-    connect(m_cloudAccountMenu, &QMenu::aboutToShow, this, &MainWindow::updateCloudAuthActions);
+    connect(m_cloudAccountMenu, &QMenu::aboutToShow, this, [this]() {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("Cloud toolbar menu opened"));
+        updateCloudAuthActions();
+    });
 
     // Push the account control to the bottom of the left objects toolbar (VS Code-style).
     QWidget* toolbarStretch = new QWidget(ui->objectsToolbar);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -40,6 +40,7 @@
 #include "mainwindow.h"
 #include "AppConsoleLog.h"
 #include "AppSettingsKeys.h"
+#include "CloudAccountMenuButton.h"
 #include "CloudCredentialStore.h"
 #include "CloudUploadPlanner.h"
 #include "ui_mainwindow.h"
@@ -2294,43 +2295,24 @@ const QPalette &MainWindow::darkPalette()
 
 void MainWindow::setupCloudAccountStatusControl()
 {
-    m_cloudAccountMenu = new QMenu(this);
-    m_cloudAccountMenu->setObjectName(QStringLiteral("menuCloud"));
+    m_cloudAccountControl = new CloudAccountMenuButton(this);
 
-    m_cloudAccountInfoAction = m_cloudAccountMenu->addAction(tr("Signed in"));
-    m_cloudAccountInfoAction->setObjectName(QStringLiteral("actionQtMeshCloudAccountInfo"));
-    m_cloudAccountInfoAction->setEnabled(false);
-    m_cloudAccountInfoSeparator = m_cloudAccountMenu->addSeparator();
-
-    m_cloudSignInAction = m_cloudAccountMenu->addAction(tr("Sign in to QtMesh Cloud..."));
-    m_cloudSignInAction->setObjectName(QStringLiteral("actionQtMeshCloudSignIn"));
-    connect(m_cloudSignInAction, &QAction::triggered, this, [this]() {
+    connect(m_cloudAccountControl, &CloudAccountMenuButton::signInRequested, this, [this]() {
         SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
                                       QStringLiteral("Cloud toolbar: Sign in"));
         signInToQtMeshCloud();
     });
-
-    m_cloudSignOutAction = m_cloudAccountMenu->addAction(tr("Sign out"));
-    m_cloudSignOutAction->setObjectName(QStringLiteral("actionQtMeshCloudSignOut"));
-    connect(m_cloudSignOutAction, &QAction::triggered, this, [this]() {
+    connect(m_cloudAccountControl, &CloudAccountMenuButton::signOutRequested, this, [this]() {
         SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
                                       QStringLiteral("Cloud toolbar: Sign out"));
         signOutOfQtMeshCloud();
     });
-
-    m_cloudAccountMenu->addSeparator();
-
-    m_cloudUploadFilesAction = m_cloudAccountMenu->addAction(tr("Upload Files..."));
-    m_cloudUploadFilesAction->setObjectName(QStringLiteral("actionQtMeshCloudUploadFiles"));
-    connect(m_cloudUploadFilesAction, &QAction::triggered, this, [this]() {
+    connect(m_cloudAccountControl, &CloudAccountMenuButton::uploadFilesRequested, this, [this]() {
         SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
                                       QStringLiteral("Cloud toolbar: Upload Files"));
         uploadFilesToQtMeshCloud();
     });
-
-    m_cloudOpenDashboardAction = m_cloudAccountMenu->addAction(tr("Open My Projects"));
-    m_cloudOpenDashboardAction->setObjectName(QStringLiteral("actionQtMeshCloudOpenProjects"));
-    connect(m_cloudOpenDashboardAction, &QAction::triggered, this, [this]() {
+    connect(m_cloudAccountControl, &CloudAccountMenuButton::openProjectsRequested, this, [this]() {
         SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
                                       QStringLiteral("Cloud toolbar: Open My Projects"));
         if (!QDesktopServices::openUrl(QUrl(QStringLiteral(QTMESH_CLOUD_WEB_URL)))) {
@@ -2338,11 +2320,9 @@ void MainWindow::setupCloudAccountStatusControl()
                                  tr("Could not open QtMesh Cloud in your browser."));
         }
     });
-
-    connect(m_cloudAccountMenu, &QMenu::aboutToShow, this, [this]() {
+    connect(m_cloudAccountControl->menu(), &QMenu::aboutToShow, this, []() {
         SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
                                       QStringLiteral("Cloud toolbar menu opened"));
-        updateCloudAuthActions();
     });
 
     // Push the account control to the bottom of the left objects toolbar (VS Code-style).
@@ -2352,68 +2332,15 @@ void MainWindow::setupCloudAccountStatusControl()
     QAction* stretchAction = ui->objectsToolbar->addWidget(toolbarStretch);
     stretchAction->setObjectName(QStringLiteral("modeAnyObjectsToolbarStretch"));
 
-    m_cloudAccountButton = new QToolButton(ui->objectsToolbar);
-    m_cloudAccountButton->setObjectName(QStringLiteral("cloudAccountButton"));
-    m_cloudAccountButton->setAutoRaise(true);
-    m_cloudAccountButton->setPopupMode(QToolButton::InstantPopup);
-    m_cloudAccountButton->setToolButtonStyle(Qt::ToolButtonIconOnly);
-    m_cloudAccountButton->setMenu(m_cloudAccountMenu);
-
-    QIcon cloudIcon = QIcon::fromTheme(QStringLiteral("internet-services"));
-    if (cloudIcon.isNull())
-        cloudIcon = style()->standardIcon(QStyle::SP_DriveNetIcon);
-    m_cloudAccountButton->setIcon(cloudIcon);
-    m_cloudAccountButton->setStyleSheet(
-        QStringLiteral("QToolButton { padding: 4px; border: none; }"
-                       "QToolButton:hover { background: palette(midlight); }"
-                       "QToolButton:pressed { background: palette(mid); }"));
-
-    QAction* cloudAction = ui->objectsToolbar->addWidget(m_cloudAccountButton);
+    QAction* cloudAction = ui->objectsToolbar->addWidget(m_cloudAccountControl);
     cloudAction->setObjectName(QStringLiteral("modeAnyCloudAccountAction"));
     updateCloudAuthActions();
 }
 
 void MainWindow::updateCloudAuthActions()
 {
-    QSettings settings;
-    CloudCredentialStore::migrateLegacySettingsIfNeeded();
-    const bool signedIn = CloudCredentialStore::hasSession();
-    const QString display = storedCloudDisplayName();
-
-    if (m_cloudAccountButton) {
-        if (signedIn && !display.isEmpty()) {
-            m_cloudAccountButton->setToolTip(
-                tr("Signed in as %1. Click for QtMesh Cloud account options.").arg(display));
-        } else {
-            m_cloudAccountButton->setToolTip(tr("QtMesh Cloud — click to sign in"));
-        }
-    }
-
-    if (m_cloudAccountInfoAction) {
-        if (signedIn) {
-            m_cloudAccountInfoAction->setText(display.isEmpty()
-                ? tr("Signed in")
-                : tr("Signed in as %1").arg(display));
-            m_cloudAccountInfoAction->setVisible(true);
-        } else {
-            m_cloudAccountInfoAction->setVisible(false);
-        }
-    }
-    if (m_cloudAccountInfoSeparator)
-        m_cloudAccountInfoSeparator->setVisible(signedIn);
-
-    if (m_cloudSignInAction) {
-        m_cloudSignInAction->setVisible(!signedIn);
-        m_cloudSignInAction->setEnabled(!signedIn);
-    }
-    if (m_cloudSignOutAction) {
-        m_cloudSignOutAction->setVisible(signedIn);
-        m_cloudSignOutAction->setEnabled(signedIn);
-    }
-    if (m_cloudUploadFilesAction)
-        m_cloudUploadFilesAction->setEnabled(true);
-    if (m_cloudOpenDashboardAction)
-        m_cloudOpenDashboardAction->setEnabled(signedIn);
+    if (m_cloudAccountControl)
+        m_cloudAccountControl->refresh();
 }
 
 void MainWindow::signInToQtMeshCloud()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -98,6 +98,7 @@
 #include <QQuickWidget>
 #include <QQmlContext>
 #include <QToolButton>
+#include <QStyle>
 #include <QMenu>
 #include <QWidgetAction>
 #include <QSlider>
@@ -1981,6 +1982,8 @@ void MainWindow::initToolBar()
             this, refreshTopoButtons);
     connect(EditorModeController::instance(), &EditorModeController::modeChanged,
             this, &MainWindow::updateToolRailForMode);
+
+    setupCloudAccountStatusControl();
     updateToolRailForMode();
 
     connect(pAddCube,       SIGNAL(triggered()),m_pPrimitivesWidget,SLOT(createCube()));
@@ -2176,25 +2179,6 @@ void MainWindow::initToolBar()
         m_viewCubeController->setActiveWidget(mDockWidgetList.first()->getOgreWidget());
     m_viewCubeController->setVisible(true);
 
-    QMenu* cloudMenu = menuBar()->addMenu(tr("&Cloud"));
-    cloudMenu->setObjectName(QStringLiteral("menuCloud"));
-    m_cloudSignInAction = cloudMenu->addAction(tr("Sign in to QtMesh Cloud..."));
-    m_cloudSignInAction->setObjectName(QStringLiteral("actionQtMeshCloudSignIn"));
-    connect(m_cloudSignInAction, &QAction::triggered, this, &MainWindow::signInToQtMeshCloud);
-    m_cloudSignOutAction = cloudMenu->addAction(tr("Sign out"));
-    m_cloudSignOutAction->setObjectName(QStringLiteral("actionQtMeshCloudSignOut"));
-    connect(m_cloudSignOutAction, &QAction::triggered, this, &MainWindow::signOutOfQtMeshCloud);
-    cloudMenu->addSeparator();
-    m_cloudUploadFilesAction = cloudMenu->addAction(tr("Upload Files..."));
-    m_cloudUploadFilesAction->setObjectName(QStringLiteral("actionQtMeshCloudUploadFiles"));
-    connect(m_cloudUploadFilesAction, &QAction::triggered, this, &MainWindow::uploadFilesToQtMeshCloud);
-    m_cloudOpenDashboardAction = cloudMenu->addAction(tr("Open My Projects"));
-    m_cloudOpenDashboardAction->setObjectName(QStringLiteral("actionQtMeshCloudOpenProjects"));
-    connect(m_cloudOpenDashboardAction, &QAction::triggered, this, []() {
-        QDesktopServices::openUrl(QUrl(QStringLiteral(QTMESH_CLOUD_WEB_URL)));
-    });
-    updateCloudAuthActions();
-
     // AI Settings menu
     QMenu* aiMenu = menuBar()->addMenu(tr("&AI"));
     aiMenu->setObjectName("menuAI");
@@ -2308,20 +2292,103 @@ const QPalette &MainWindow::darkPalette()
     return (*darkPalette);
 }
 
+void MainWindow::setupCloudAccountStatusControl()
+{
+    m_cloudAccountMenu = new QMenu(this);
+    m_cloudAccountMenu->setObjectName(QStringLiteral("menuCloud"));
+
+    m_cloudAccountInfoAction = m_cloudAccountMenu->addAction(tr("Signed in"));
+    m_cloudAccountInfoAction->setObjectName(QStringLiteral("actionQtMeshCloudAccountInfo"));
+    m_cloudAccountInfoAction->setEnabled(false);
+    m_cloudAccountInfoSeparator = m_cloudAccountMenu->addSeparator();
+
+    m_cloudSignInAction = m_cloudAccountMenu->addAction(tr("Sign in to QtMesh Cloud..."));
+    m_cloudSignInAction->setObjectName(QStringLiteral("actionQtMeshCloudSignIn"));
+    connect(m_cloudSignInAction, &QAction::triggered, this, &MainWindow::signInToQtMeshCloud);
+
+    m_cloudSignOutAction = m_cloudAccountMenu->addAction(tr("Sign out"));
+    m_cloudSignOutAction->setObjectName(QStringLiteral("actionQtMeshCloudSignOut"));
+    connect(m_cloudSignOutAction, &QAction::triggered, this, &MainWindow::signOutOfQtMeshCloud);
+
+    m_cloudAccountMenu->addSeparator();
+
+    m_cloudUploadFilesAction = m_cloudAccountMenu->addAction(tr("Upload Files..."));
+    m_cloudUploadFilesAction->setObjectName(QStringLiteral("actionQtMeshCloudUploadFiles"));
+    connect(m_cloudUploadFilesAction, &QAction::triggered, this, &MainWindow::uploadFilesToQtMeshCloud);
+
+    m_cloudOpenDashboardAction = m_cloudAccountMenu->addAction(tr("Open My Projects"));
+    m_cloudOpenDashboardAction->setObjectName(QStringLiteral("actionQtMeshCloudOpenProjects"));
+    connect(m_cloudOpenDashboardAction, &QAction::triggered, this, []() {
+        QDesktopServices::openUrl(QUrl(QStringLiteral(QTMESH_CLOUD_WEB_URL)));
+    });
+
+    connect(m_cloudAccountMenu, &QMenu::aboutToShow, this, &MainWindow::updateCloudAuthActions);
+
+    // Push the account control to the bottom of the left objects toolbar (VS Code-style).
+    QWidget* toolbarStretch = new QWidget(ui->objectsToolbar);
+    toolbarStretch->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
+    toolbarStretch->setMinimumSize(0, 0);
+    QAction* stretchAction = ui->objectsToolbar->addWidget(toolbarStretch);
+    stretchAction->setObjectName(QStringLiteral("modeAnyObjectsToolbarStretch"));
+
+    m_cloudAccountButton = new QToolButton(ui->objectsToolbar);
+    m_cloudAccountButton->setObjectName(QStringLiteral("cloudAccountButton"));
+    m_cloudAccountButton->setAutoRaise(true);
+    m_cloudAccountButton->setPopupMode(QToolButton::InstantPopup);
+    m_cloudAccountButton->setToolButtonStyle(Qt::ToolButtonIconOnly);
+    m_cloudAccountButton->setMenu(m_cloudAccountMenu);
+
+    QIcon cloudIcon = QIcon::fromTheme(QStringLiteral("internet-services"));
+    if (cloudIcon.isNull())
+        cloudIcon = style()->standardIcon(QStyle::SP_DriveNetIcon);
+    m_cloudAccountButton->setIcon(cloudIcon);
+    m_cloudAccountButton->setStyleSheet(
+        QStringLiteral("QToolButton { padding: 4px; border: none; }"
+                       "QToolButton:hover { background: palette(midlight); }"
+                       "QToolButton:pressed { background: palette(mid); }"));
+
+    QAction* cloudAction = ui->objectsToolbar->addWidget(m_cloudAccountButton);
+    cloudAction->setObjectName(QStringLiteral("modeAnyCloudAccountAction"));
+    updateCloudAuthActions();
+}
+
 void MainWindow::updateCloudAuthActions()
 {
     QSettings settings;
     CloudCredentialStore::migrateLegacySettingsIfNeeded();
     const bool signedIn = CloudCredentialStore::hasSession();
     const QString display = storedCloudDisplayName();
-    if (m_cloudSignInAction) {
-        m_cloudSignInAction->setEnabled(!signedIn);
-        m_cloudSignInAction->setText(signedIn && !display.isEmpty()
-            ? tr("Signed in as %1").arg(display)
-            : tr("Sign in to QtMesh Cloud..."));
+
+    if (m_cloudAccountButton) {
+        if (signedIn && !display.isEmpty()) {
+            m_cloudAccountButton->setToolTip(
+                tr("Signed in as %1. Click for QtMesh Cloud account options.").arg(display));
+        } else {
+            m_cloudAccountButton->setToolTip(tr("QtMesh Cloud — click to sign in"));
+        }
     }
-    if (m_cloudSignOutAction)
+
+    if (m_cloudAccountInfoAction) {
+        if (signedIn) {
+            m_cloudAccountInfoAction->setText(display.isEmpty()
+                ? tr("Signed in")
+                : tr("Signed in as %1").arg(display));
+            m_cloudAccountInfoAction->setVisible(true);
+        } else {
+            m_cloudAccountInfoAction->setVisible(false);
+        }
+    }
+    if (m_cloudAccountInfoSeparator)
+        m_cloudAccountInfoSeparator->setVisible(signedIn);
+
+    if (m_cloudSignInAction) {
+        m_cloudSignInAction->setVisible(!signedIn);
+        m_cloudSignInAction->setEnabled(!signedIn);
+    }
+    if (m_cloudSignOutAction) {
+        m_cloudSignOutAction->setVisible(signedIn);
         m_cloudSignOutAction->setEnabled(signedIn);
+    }
     if (m_cloudUploadFilesAction)
         m_cloudUploadFilesAction->setEnabled(true);
     if (m_cloudOpenDashboardAction)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2326,7 +2326,7 @@ void MainWindow::setupCloudAccountStatusControl()
     });
 
     // Push the account control to the bottom of the left objects toolbar (VS Code-style).
-    QWidget* toolbarStretch = new QWidget(ui->objectsToolbar);
+    auto* toolbarStretch = new QWidget(ui->objectsToolbar);
     toolbarStretch->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
     toolbarStretch->setMinimumSize(0, 0);
     QAction* stretchAction = ui->objectsToolbar->addWidget(toolbarStretch);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2357,12 +2357,19 @@ void MainWindow::signInToQtMeshCloud()
 
     QDialog prompt(this);
     prompt.setWindowTitle(tr("Sign in to QtMesh Cloud"));
+    prompt.setWindowModality(Qt::WindowModal);
     auto* layout = new QVBoxLayout(&prompt);
     auto* label = new QLabel(
-        tr("A browser window will open for QtMesh Cloud sign in.\n\nCode: %1").arg(code.userCode),
+        tr("Enter this code on the QtMesh Cloud website, or click Open Browser.\n\n"
+           "Code: %1")
+            .arg(code.userCode),
         &prompt);
     label->setTextInteractionFlags(Qt::TextSelectableByMouse);
     layout->addWidget(label);
+
+    auto* statusLabel = new QLabel(tr("Waiting for approval…"), &prompt);
+    statusLabel->setWordWrap(true);
+    layout->addWidget(statusLabel);
 
     auto* buttons = new QHBoxLayout();
     auto* copyButton = new QPushButton(tr("Copy Code"), &prompt);
@@ -2373,86 +2380,115 @@ void MainWindow::signInToQtMeshCloud()
     buttons->addWidget(cancelButton);
     buttons->addWidget(openButton);
     layout->addLayout(buttons);
-    connect(copyButton, &QPushButton::clicked, this, [userCode = code.userCode]() {
-        if (QApplication::clipboard())
-            QApplication::clipboard()->setText(userCode);
-    });
-    connect(cancelButton, &QPushButton::clicked, &prompt, &QDialog::reject);
-    connect(openButton, &QPushButton::clicked, &prompt, &QDialog::accept);
-    openButton->setDefault(true);
-    prompt.resize(420, prompt.sizeHint().height());
-    if (prompt.exec() != QDialog::Accepted)
-        return;
 
-    QDesktopServices::openUrl(QUrl(code.verificationUriComplete));
-
-    QProgressDialog progress(tr("Waiting for browser approval..."), tr("Cancel"), 0, 0, this);
-    progress.setWindowTitle(tr("QtMesh Cloud Sign In"));
-    progress.setWindowModality(Qt::WindowModal);
-    progress.setMinimumDuration(0);
-    progress.show();
-
+    QTimer pollTimer(&prompt);
+    bool signedIn = false;
     int intervalMs = qMax(1, code.intervalSeconds) * 1000;
     const int maxAttempts = qMax(1, code.expiresInSeconds / qMax(1, code.intervalSeconds) + 2);
-    for (int attempt = 0; attempt < maxAttempts && !progress.wasCanceled(); ++attempt) {
+    int attempts = 0;
+
+    const auto applyToken = [&](const QtMeshCloudClient::DeviceTokenResult& token) -> bool {
+        CloudSession session;
+        session.token = token.token;
+        session.expiresAt = token.expiresAt;
+        session.email = token.user.value(QStringLiteral("email")).toString();
+        if (!CloudCredentialStore::saveSession(session)) {
+            QMessageBox::warning(this, tr("QtMesh Cloud Sign In"),
+                                 tr("Signed in, but the session could not be saved securely."));
+            return false;
+        }
+
+        QSettings settings;
+        settings.setValue(AppSettingsKeys::cloudUserName(),
+                          token.user.value(QStringLiteral("name")).toString());
+        settings.setValue(AppSettingsKeys::cloudUserSlug(),
+                          token.user.value(QStringLiteral("slug")).toString());
+        settings.remove(AppSettingsKeys::cloudToken());
+        settings.remove(AppSettingsKeys::cloudTokenExpiresAt());
+        settings.remove(AppSettingsKeys::cloudUserEmail());
+        settings.sync();
+        updateCloudAuthActions();
+        return true;
+    };
+
+    const auto failSignIn = [&](const QString& message) {
+        pollTimer.stop();
+        QMessageBox::warning(this, tr("QtMesh Cloud Sign In"), message);
+        prompt.reject();
+    };
+
+    const auto pollOnce = [&]() {
+        if (attempts >= maxAttempts) {
+            failSignIn(tr("The sign-in request expired. Start sign in again."));
+            return;
+        }
+        ++attempts;
+
         const auto token = QtMeshCloudClient::pollDeviceToken(code.deviceCode);
         if (token.ok) {
-            CloudSession session;
-            session.token = token.token;
-            session.expiresAt = token.expiresAt;
-            session.email = token.user.value(QStringLiteral("email")).toString();
-            if (!CloudCredentialStore::saveSession(session)) {
-                progress.close();
-                QMessageBox::warning(this, tr("QtMesh Cloud Sign In"),
-                                     tr("Signed in, but the session could not be saved securely."));
-                return;
+            pollTimer.stop();
+            if (applyToken(token)) {
+                signedIn = true;
+                prompt.accept();
+            } else {
+                prompt.reject();
             }
-
-            QSettings settings;
-            settings.setValue(AppSettingsKeys::cloudUserName(), token.user.value(QStringLiteral("name")).toString());
-            settings.setValue(AppSettingsKeys::cloudUserSlug(), token.user.value(QStringLiteral("slug")).toString());
-            settings.remove(AppSettingsKeys::cloudToken());
-            settings.remove(AppSettingsKeys::cloudTokenExpiresAt());
-            settings.remove(AppSettingsKeys::cloudUserEmail());
-            settings.sync();
-            updateCloudAuthActions();
-            progress.close();
-            QMessageBox::information(this, tr("QtMesh Cloud Sign In"),
-                                     tr("Signed in to QtMesh Cloud as %1.")
-                                         .arg(storedCloudDisplayName()));
-            SentryReporter::addBreadcrumb(QStringLiteral("cloud.auth"),
-                                          QStringLiteral("QtMesh Cloud sign-in completed"));
             return;
         }
 
         if (token.errorCode == QStringLiteral("authorization_pending")) {
-            progress.setLabelText(tr("Waiting for browser approval...\nCode: %1").arg(code.userCode));
-        } else if (token.errorCode == QStringLiteral("slow_down")) {
-            intervalMs = qMax(intervalMs + 2000, qMax(1, token.intervalSeconds) * 1000);
-            progress.setLabelText(tr("Waiting for browser approval...\nCode: %1").arg(code.userCode));
-        } else if (token.errorCode == QStringLiteral("access_denied")) {
-            progress.close();
-            QMessageBox::warning(this, tr("QtMesh Cloud Sign In"),
-                                 tr("Sign in was denied in the browser."));
-            return;
-        } else if (token.errorCode == QStringLiteral("expired_token")) {
-            progress.close();
-            QMessageBox::warning(this, tr("QtMesh Cloud Sign In"),
-                                 tr("The sign-in code expired. Start sign in again."));
-            return;
-        } else {
-            progress.close();
-            QMessageBox::warning(this, tr("QtMesh Cloud Sign In"),
-                                 tr("Sign in failed.\n\n%1").arg(token.errorString));
+            statusLabel->setText(tr("Waiting for approval…"));
             return;
         }
+        if (token.errorCode == QStringLiteral("slow_down")) {
+            intervalMs = qMax(intervalMs + 2000, qMax(1, token.intervalSeconds) * 1000);
+            pollTimer.setInterval(intervalMs);
+            statusLabel->setText(tr("Waiting for approval…"));
+            return;
+        }
+        if (token.errorCode == QStringLiteral("access_denied")) {
+            failSignIn(tr("Sign in was denied in the browser."));
+            return;
+        }
+        if (token.errorCode == QStringLiteral("expired_token")) {
+            failSignIn(tr("The sign-in code expired. Start sign in again."));
+            return;
+        }
+        failSignIn(tr("Sign in failed.\n\n%1").arg(token.errorString));
+    };
 
-        waitWithEvents(intervalMs, &progress);
-    }
+    connect(copyButton, &QPushButton::clicked, this, [userCode = code.userCode]() {
+        if (QApplication::clipboard())
+            QApplication::clipboard()->setText(userCode);
+    });
+    connect(cancelButton, &QPushButton::clicked, &prompt, [&pollTimer, &prompt]() {
+        pollTimer.stop();
+        prompt.reject();
+    });
+    connect(openButton, &QPushButton::clicked, &prompt, [this, statusLabel, verificationUri = code.verificationUriComplete]() {
+        if (!QDesktopServices::openUrl(QUrl(verificationUri))) {
+            QMessageBox::warning(this, tr("QtMesh Cloud"),
+                                 tr("Could not open QtMesh Cloud in your browser."));
+            return;
+        }
+        statusLabel->setText(tr("Complete sign-in in your browser…"));
+    });
+    connect(&pollTimer, &QTimer::timeout, pollOnce);
 
-    if (!progress.wasCanceled()) {
-        QMessageBox::warning(this, tr("QtMesh Cloud Sign In"),
-                             tr("The sign-in request expired. Start sign in again."));
+    openButton->setDefault(true);
+    prompt.resize(420, prompt.sizeHint().height());
+
+    pollTimer.start(intervalMs);
+    pollOnce();
+    prompt.exec();
+    pollTimer.stop();
+
+    if (signedIn) {
+        QMessageBox::information(this, tr("QtMesh Cloud Sign In"),
+                                 tr("Signed in to QtMesh Cloud as %1.")
+                                     .arg(storedCloudDisplayName()));
+        SentryReporter::addBreadcrumb(QStringLiteral("cloud.auth"),
+                                      QStringLiteral("QtMesh Cloud sign-in completed"));
     }
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -27,6 +27,7 @@ class QLabel;
 class QToolBar;
 class QAction;
 class QToolButton;
+class CloudAccountMenuButton;
 class OgreWidget;
 
 namespace Ui {
@@ -191,14 +192,7 @@ private:
     QToolBar* m_modeBarShell = nullptr;
     QToolBar* m_topBarStretch = nullptr;
     QQuickWidget* m_modeBar = nullptr;
-    QToolButton* m_cloudAccountButton = nullptr;
-    QMenu* m_cloudAccountMenu = nullptr;
-    QAction* m_cloudAccountInfoAction = nullptr;
-    QAction* m_cloudAccountInfoSeparator = nullptr;
-    QAction* m_cloudSignInAction = nullptr;
-    QAction* m_cloudSignOutAction = nullptr;
-    QAction* m_cloudUploadFilesAction = nullptr;
-    QAction* m_cloudOpenDashboardAction = nullptr;
+    CloudAccountMenuButton* m_cloudAccountControl = nullptr;
 
     /// View menu entries for bottom tabbed docks — checked state follows user
     /// preference, not QDockWidget::isVisible() (inactive tabs would otherwise

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -26,6 +26,7 @@ class QPlainTextEdit;
 class QLabel;
 class QToolBar;
 class QAction;
+class QToolButton;
 class OgreWidget;
 
 namespace Ui {
@@ -190,6 +191,10 @@ private:
     QToolBar* m_modeBarShell = nullptr;
     QToolBar* m_topBarStretch = nullptr;
     QQuickWidget* m_modeBar = nullptr;
+    QToolButton* m_cloudAccountButton = nullptr;
+    QMenu* m_cloudAccountMenu = nullptr;
+    QAction* m_cloudAccountInfoAction = nullptr;
+    QAction* m_cloudAccountInfoSeparator = nullptr;
     QAction* m_cloudSignInAction = nullptr;
     QAction* m_cloudSignOutAction = nullptr;
     QAction* m_cloudUploadFilesAction = nullptr;
@@ -224,6 +229,7 @@ private:
     void showBottomToolDock(QDockWidget* dock);
     void tabifyBottomToolDocks();
     void updateToolRailForMode();
+    void setupCloudAccountStatusControl();
     void updateCloudAuthActions();
 };
 

--- a/src/mainwindow_test.cpp
+++ b/src/mainwindow_test.cpp
@@ -384,7 +384,6 @@ TEST_F(MainWindowTest, CloudAccountControlLivesAtBottomOfObjectsToolbar)
 
 TEST_F(MainWindowTest, CloudAccountMenuShowsSignedInHeader)
 {
-    CloudCredentialStore::clearSession();
     CloudSession session;
     session.token = QStringLiteral("test-token");
     session.email = QStringLiteral("dev@example.com");
@@ -401,10 +400,14 @@ TEST_F(MainWindowTest, CloudAccountMenuShowsSignedInHeader)
     ASSERT_NE(signIn, nullptr);
     ASSERT_NE(signOut, nullptr);
     EXPECT_EQ(headerName->text(), QStringLiteral("Dev User"));
+    auto* headerSubtitle = window->findChild<QLabel*>(QStringLiteral("cloudAccountMenuHeaderSubtitle"));
+    ASSERT_NE(headerSubtitle, nullptr);
+    EXPECT_EQ(headerSubtitle->text(), QStringLiteral("Signed in to QtMesh Cloud"));
     EXPECT_FALSE(signIn->isVisible());
     EXPECT_TRUE(signOut->isVisible());
 
     CloudCredentialStore::clearSession();
+    QSettings().remove(AppSettingsKeys::cloudUserName());
     window->updateCloudAuthActions();
     app->processEvents();
     EXPECT_TRUE(signIn->isVisible());

--- a/src/mainwindow_test.cpp
+++ b/src/mainwindow_test.cpp
@@ -86,6 +86,11 @@ protected:
     void TearDown() override {
         delete window;
         window = nullptr;
+        CloudCredentialStore::clearSession();
+        QSettings settings;
+        settings.remove(AppSettingsKeys::cloudUserName());
+        settings.remove(AppSettingsKeys::cloudUserSlug());
+        settings.remove(AppSettingsKeys::cloudUserEmail());
         // Tests below switch the editor mode (Animation/Material/etc). Reset
         // the singleton so subsequent test cases see a fresh ObjectMode
         // controller — otherwise stale state leaks into m_editModeLabel and

--- a/src/mainwindow_test.cpp
+++ b/src/mainwindow_test.cpp
@@ -37,6 +37,8 @@
 #include "EditorModeController.h"
 #include "MeshInfoOverlay.h"
 #include "MeshValidator.h"
+#include "CloudCredentialStore.h"
+#include "AppSettingsKeys.h"
 #include "TestHelpers.h"
 #include "EditorViewport.h"
 #include "ViewportSettingsKeys.h"
@@ -350,6 +352,90 @@ TEST_F(MainWindowTest, ContextualToolRailAiChatPrecedesAddPrimitive)
     EXPECT_GE(aiIdx, 0);
     EXPECT_GE(primIdx, 0);
     EXPECT_LT(aiIdx, primIdx) << "Open AI Chat should appear before Add Primitive on the rail";
+}
+
+TEST_F(MainWindowTest, CloudAccountControlLivesAtBottomOfObjectsToolbar)
+{
+    QAction* stretch = findActionByObjectName(QStringLiteral("modeAnyObjectsToolbarStretch"));
+    QAction* cloud = findActionByObjectName(QStringLiteral("modeAnyCloudAccountAction"));
+    ASSERT_NE(stretch, nullptr);
+    ASSERT_NE(cloud, nullptr);
+
+    const QList<QAction*> actions = window->ui->objectsToolbar->actions();
+    const int stretchIdx = actions.indexOf(stretch);
+    const int cloudIdx = actions.indexOf(cloud);
+    EXPECT_GE(stretchIdx, 0);
+    EXPECT_GE(cloudIdx, 0);
+    EXPECT_LT(stretchIdx, cloudIdx);
+    EXPECT_EQ(cloudIdx, actions.size() - 1) << "Cloud account should be the last rail item";
+
+    auto* cloudButton = qobject_cast<QToolButton*>(window->ui->objectsToolbar->widgetForAction(cloud));
+    ASSERT_NE(cloudButton, nullptr);
+    EXPECT_EQ(cloudButton->objectName(), QStringLiteral("cloudAccountButton"));
+    ASSERT_NE(window->findChild<QMenu*>(QStringLiteral("menuCloud")), nullptr);
+}
+
+TEST_F(MainWindowTest, CloudAccountMenuShowsConnectedUserAsDisabledRow)
+{
+    CloudCredentialStore::clearSession();
+    CloudSession session;
+    session.token = QStringLiteral("test-token");
+    session.email = QStringLiteral("dev@example.com");
+    ASSERT_TRUE(CloudCredentialStore::saveSession(session));
+    QSettings().setValue(AppSettingsKeys::cloudUserName(), QStringLiteral("Dev User"));
+
+    window->updateCloudAuthActions();
+    app->processEvents();
+
+    QAction* info = findActionByObjectName(QStringLiteral("actionQtMeshCloudAccountInfo"));
+    QAction* signIn = findActionByObjectName(QStringLiteral("actionQtMeshCloudSignIn"));
+    QAction* signOut = findActionByObjectName(QStringLiteral("actionQtMeshCloudSignOut"));
+    ASSERT_NE(info, nullptr);
+    ASSERT_NE(signIn, nullptr);
+    ASSERT_NE(signOut, nullptr);
+    EXPECT_TRUE(info->isVisible());
+    EXPECT_FALSE(info->isEnabled());
+    EXPECT_EQ(info->text(), QStringLiteral("Signed in as Dev User"));
+    EXPECT_FALSE(signIn->isVisible());
+    EXPECT_TRUE(signOut->isVisible());
+
+    CloudCredentialStore::clearSession();
+    window->updateCloudAuthActions();
+    app->processEvents();
+    EXPECT_FALSE(info->isVisible());
+    EXPECT_TRUE(signIn->isVisible());
+    EXPECT_FALSE(signOut->isVisible());
+}
+
+TEST_F(MainWindowTest, CloudAccountControlVisibleInEveryEditorMode)
+{
+    QAction* cloud = findActionByObjectName(QStringLiteral("modeAnyCloudAccountAction"));
+    ASSERT_NE(cloud, nullptr);
+    auto* modeController = EditorModeController::instance();
+    const QList<int> modes = {
+        EditorModeController::ObjectMode,
+        EditorModeController::EditMode,
+        EditorModeController::AnimationMode,
+        EditorModeController::MaterialMode,
+        EditorModeController::ValidationMode,
+    };
+    for (int mode : modes) {
+        modeController->requestMode(mode);
+        app->processEvents();
+        EXPECT_TRUE(cloud->isVisible()) << "mode index " << mode;
+    }
+}
+
+TEST_F(MainWindowTest, CloudMenuIsNotOnMenuBar)
+{
+    bool cloudTopLevel = false;
+    for (QAction* action : window->menuBar()->actions()) {
+        if (action->menu() && action->menu()->objectName() == QStringLiteral("menuCloud")) {
+            cloudTopLevel = true;
+            break;
+        }
+    }
+    EXPECT_FALSE(cloudTopLevel);
 }
 
 TEST_F(MainWindowTest, ContextualToolRailKeepsSharedMenuActionsReachable)

--- a/src/mainwindow_test.cpp
+++ b/src/mainwindow_test.cpp
@@ -5,6 +5,7 @@
 #include <QDir>
 #include <QFile>
 #include <QKeyEvent>
+#include <QLabel>
 #include <QMenu>
 #include <QMenuBar>
 #include <QMetaObject>
@@ -374,13 +375,14 @@ TEST_F(MainWindowTest, CloudAccountControlLivesAtBottomOfObjectsToolbar)
     EXPECT_LT(stretchIdx, cloudIdx);
     EXPECT_EQ(cloudIdx, actions.size() - 1) << "Cloud account should be the last rail item";
 
-    auto* cloudButton = qobject_cast<QToolButton*>(window->ui->objectsToolbar->widgetForAction(cloud));
+    auto* cloudWidget = window->ui->objectsToolbar->widgetForAction(cloud);
+    ASSERT_NE(cloudWidget, nullptr);
+    auto* cloudButton = cloudWidget->findChild<QToolButton*>(QStringLiteral("cloudAccountButton"));
     ASSERT_NE(cloudButton, nullptr);
-    EXPECT_EQ(cloudButton->objectName(), QStringLiteral("cloudAccountButton"));
     ASSERT_NE(window->findChild<QMenu*>(QStringLiteral("menuCloud")), nullptr);
 }
 
-TEST_F(MainWindowTest, CloudAccountMenuShowsConnectedUserAsDisabledRow)
+TEST_F(MainWindowTest, CloudAccountMenuShowsSignedInHeader)
 {
     CloudCredentialStore::clearSession();
     CloudSession session;
@@ -392,22 +394,19 @@ TEST_F(MainWindowTest, CloudAccountMenuShowsConnectedUserAsDisabledRow)
     window->updateCloudAuthActions();
     app->processEvents();
 
-    QAction* info = findActionByObjectName(QStringLiteral("actionQtMeshCloudAccountInfo"));
+    auto* headerName = window->findChild<QLabel*>(QStringLiteral("cloudAccountMenuHeaderName"));
     QAction* signIn = findActionByObjectName(QStringLiteral("actionQtMeshCloudSignIn"));
     QAction* signOut = findActionByObjectName(QStringLiteral("actionQtMeshCloudSignOut"));
-    ASSERT_NE(info, nullptr);
+    ASSERT_NE(headerName, nullptr);
     ASSERT_NE(signIn, nullptr);
     ASSERT_NE(signOut, nullptr);
-    EXPECT_TRUE(info->isVisible());
-    EXPECT_FALSE(info->isEnabled());
-    EXPECT_EQ(info->text(), QStringLiteral("Signed in as Dev User"));
+    EXPECT_EQ(headerName->text(), QStringLiteral("Dev User"));
     EXPECT_FALSE(signIn->isVisible());
     EXPECT_TRUE(signOut->isVisible());
 
     CloudCredentialStore::clearSession();
     window->updateCloudAuthActions();
     app->processEvents();
-    EXPECT_FALSE(info->isVisible());
     EXPECT_TRUE(signIn->isVisible());
     EXPECT_FALSE(signOut->isVisible());
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -65,6 +65,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/QtMeshCloudClient.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/CloudCredentialStore.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/CloudUploadPlanner.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/CloudAccountMenuButton.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/RTShaderHelper.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/QMLMaterialHighlighter.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/ViewCube/ViewCubeController.cpp


### PR DESCRIPTION
## Summary
- Removes the top-level **Cloud** menu bar entry and adds a VS Code-style QtMesh Cloud account control pinned to the bottom of the left objects toolbar.
- Introduces reusable `CloudAccountMenuButton`: outline user/cloud icon when signed out, initials avatar + connected badge when signed in.
- Popup menu: non-clickable header (display name + “QtMesh Cloud account”), **Open My Projects** / **Upload Files…**, then **Sign in** or **Sign out** depending on auth state.
- Fixes signed-out segfault (nested `QPainter` in custom button paint) and ghost header text after sign-out (remove header actions from menu instead of only hiding).

## Test plan
- [x] `./build_local/bin/UnitTests --gtest_filter="MainWindowTest.CloudAccount*"`
- [x] `./build_local/bin/UnitTests --gtest_filter="MainWindowTest.CloudMenuIsNotOnMenuBar"`
- [x] `./build_local/bin/UnitTests --gtest_filter="CloudAccountMenuButtonTest.*"`
- [ ] Manual: sign in → open menu → sign out → open menu (no name ghosting, no crash)
- [ ] CI green on Linux/macOS/Windows builds + unit-tests-linux

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloud account moved to a toolbar account button with avatar and status badge.

* **UI Changes**
  * Button shows sign-in state, display name/initials, tooltip and a styled popup with actions (Sign in/out, Upload Files, Open My Projects). Cloud entry removed from the main menu.
  * Added cloud user icon asset.

* **Bug Fixes**
  * Showing a warning if opening the cloud web URL fails.

* **Tests**
  * New unit and UI tests for the account button, menu behavior, initials logic, and session teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->