### PR TITLE
feat(feedback): in-app Send Feedback (#701), v3.4.1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,13 +56,28 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Scan media/ via Docker (ghcr.io/fernandotonon/qtmesh:latest)
+      # Published :latest may lag behind Dockerfile/runtime deps (e.g. libsecret).
+      # Build from this repo's Dockerfile + the latest release .deb to validate the image.
+      - name: Build qtmesh Docker image for asset scan
+        run: |
+          set -euo pipefail
+          VERSION="$(grep -E '^[[:space:]]*project\([[:space:]]*QtMeshEditor[[:space:]]+VERSION' CMakeLists.txt \
+            | sed -E 's/.*VERSION[[:space:]]+([0-9.]+).*/\1/')"
+          DEB_URL="https://github.com/fernandotonon/QtMeshEditor/releases/download/${VERSION}/qtmesheditor_amd64.deb"
+          if ! curl -fsSL -o qtmesheditor.deb "$DEB_URL"; then
+            echo "::notice::No release .deb for ${VERSION}; using 3.4.0 package for Docker scan build."
+            curl -fsSL -o qtmesheditor.deb \
+              "https://github.com/fernandotonon/QtMeshEditor/releases/download/3.4.0/qtmesheditor_amd64.deb"
+          fi
+          docker build -t ghcr.io/fernandotonon/qtmesh:ci-scan -f Dockerfile --build-arg VERSION="${VERSION}" .
+
+      - name: Scan media/ via Docker (ci-scan image)
         run: |
           set +e
           docker run --rm \
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
-            ghcr.io/fernandotonon/qtmesh:latest \
+            ghcr.io/fernandotonon/qtmesh:ci-scan \
             scan --config /workspace/qtmesh.yml --json > qtmesh-scan-report.json
           scan_exit=$?
           set -e
@@ -130,6 +145,7 @@ jobs:
           command: scan
           input-file: .
           options: --config /workspace/qtmesh.yml
+          image-tag: ci-scan
 
 ####################################################################
 # Windows Deploy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 3.4.0 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 3.4.1 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/DEBIAN-control.in
+++ b/DEBIAN-control.in
@@ -6,7 +6,7 @@ Installed-Size: 757000
 Architecture: amd64 
 Bugs: https://github.com/fernandotonon/QtMeshEditor/issues
 Homepage: https://github.com/fernandotonon/QtMeshEditor 
-Depends: libxcb-cursor0, libqt6core6, libqt6gui6, libqt6widgets6, libqt6network6, libqt6opengl6, libqt6qml6, libqt6quick6
+Depends: libxcb-cursor0, libqt6core6, libqt6gui6, libqt6widgets6, libqt6network6, libqt6opengl6, libqt6qml6, libqt6quick6, libsecret-1-0
 Maintainer: Fernando Tonon de Rossi <tonon.fernando@hotmail.com> 
 Description: Free 3D asset tool for indie game developers
  Merge Mixamo animations, convert between 40+ 3D formats, edit materials

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxcb-icccm4 libxcb-keysyms1 libxcb-render-util0 \
     libxcb-shape0 libxcb-xkb1 libxkbcommon-x11-0 \
     libfontconfig1 libfreetype6 \
+    libsecret-1-0 \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy and install the .deb (skip declared Qt package deps — libs are bundled)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Available on the [GitHub Actions Marketplace](https://github.com/marketplace/act
 **Versioning**
 
 - **Always follow the latest GitHub release** — use the Marketplace floating tag `fernandotonon/QtMeshEditor@v1` (same pattern as the [Marketplace example](https://github.com/marketplace/actions/qtmesheditor)). The composite action defaults to `image-tag: latest`, so the Docker CLI tracks the newest published `ghcr.io/fernandotonon/qtmesh` image.
-- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.4.0**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
+- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.4.1**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
 
 Pinned workflow template (action + `ghcr.io` image aligned):
 
@@ -51,10 +51,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run QtMesh scan
-        uses: fernandotonon/QtMeshEditor@3.4.0
+        uses: fernandotonon/QtMeshEditor@3.4.1
         with:
           command: scan
-          image-tag: "3.4.0"
+          image-tag: "3.4.1"
         env:
           QTMESH_CLOUD_TOKEN: ${{ secrets.QTMESH_CLOUD_TOKEN }}
 ```
@@ -79,37 +79,37 @@ Release tags are listed on the [releases page](https://github.com/fernandotonon/
 
 ```yaml
 # Validate a specific mesh
-- uses: fernandotonon/QtMeshEditor@3.4.0
+- uses: fernandotonon/QtMeshEditor@3.4.1
   with:
     command: validate
     input-file: ./models/character.fbx
-    image-tag: "3.4.0"
+    image-tag: "3.4.1"
 
 # Convert FBX → glTF
-- uses: fernandotonon/QtMeshEditor@3.4.0
+- uses: fernandotonon/QtMeshEditor@3.4.1
   with:
     command: convert
     input-file: ./models/character.fbx
     output-file: ./output/character.gltf2
-    image-tag: "3.4.0"
+    image-tag: "3.4.1"
 
 # Resample Mixamo animations (200+ keyframes → 30)
-- uses: fernandotonon/QtMeshEditor@3.4.0
+- uses: fernandotonon/QtMeshEditor@3.4.1
   with:
     command: anim
     input-file: ./animations/dance.fbx
     output-file: ./output/dance_optimized.fbx
     options: --resample 30
-    image-tag: "3.4.0"
+    image-tag: "3.4.1"
 
 # Get mesh info as JSON
-- uses: fernandotonon/QtMeshEditor@3.4.0
+- uses: fernandotonon/QtMeshEditor@3.4.1
   id: info
   with:
     command: info
     input-file: ./models/character.fbx
     options: --json
-    image-tag: "3.4.0"
+    image-tag: "3.4.1"
 
 # Docker (alternative — :latest tracks newest image; pin :3.4.0 to match semver action ref)
 docker run --rm -v $(pwd):/workspace ghcr.io/fernandotonon/qtmesh:latest scan ./assets --fail-on error

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -123,6 +123,9 @@ QtMeshCloudClient.cpp
 CloudCredentialStore.cpp
 CloudUploadPlanner.cpp
 CloudAccountMenuButton.cpp
+FeedbackDiagnostics.cpp
+FeedbackDialog.cpp
+FeedbackReportHelper.cpp
 AssetBrowserController.cpp
 MaterialPreviewRenderer.cpp
 ModelTurntableRenderer.cpp
@@ -235,6 +238,10 @@ PlatformProfile.h
 QtMeshCloudClient.h
 CloudCredentialStore.h
 CloudUploadPlanner.h
+FeedbackPrefill.h
+FeedbackDiagnostics.h
+FeedbackDialog.h
+FeedbackReportHelper.h
 AssetBrowserController.h
 MaterialPreviewRenderer.h
 ModelTurntableRenderer.h

--- a/src/CloudAccountMenuButton.cpp
+++ b/src/CloudAccountMenuButton.cpp
@@ -256,6 +256,14 @@ void CloudAccountMenuButton::buildMenu()
         emit uploadFilesRequested();
     });
 
+    m_feedbackAction = m_menu->addAction(tr("Send Feedback..."));
+    m_feedbackAction->setObjectName(QStringLiteral("actionQtMeshCloudSendFeedback"));
+    connect(m_feedbackAction, &QAction::triggered, this, [this]() {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("Cloud toolbar: Send Feedback"));
+        emit feedbackRequested();
+    });
+
     m_mainSeparator = m_menu->addSeparator();
 
     m_signOutAction = m_menu->addAction(tr("Sign out"));

--- a/src/CloudAccountMenuButton.h
+++ b/src/CloudAccountMenuButton.h
@@ -32,6 +32,7 @@ signals:
     void signOutRequested();
     void uploadFilesRequested();
     void openProjectsRequested();
+    void feedbackRequested();
 
 private:
     class AvatarButton;
@@ -51,6 +52,7 @@ private:
     QAction* m_signInAction = nullptr;
     QAction* m_signOutAction = nullptr;
     QAction* m_uploadAction = nullptr;
+    QAction* m_feedbackAction = nullptr;
     QAction* m_openProjectsAction = nullptr;
 };
 

--- a/src/FeedbackDiagnostics.cpp
+++ b/src/FeedbackDiagnostics.cpp
@@ -1,0 +1,280 @@
+#include "FeedbackDiagnostics.h"
+
+#include "CloudCredentialStore.h"
+#include "SentryReporter.h"
+
+#include <QCoreApplication>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QLocale>
+#include <QMutex>
+#include <QMutexLocker>
+#include <QRegularExpression>
+#include <QSysInfo>
+#include <QUuid>
+
+namespace {
+
+struct OperationContext {
+    QString operation;
+    QString format;
+    QString errorCode;
+    QString errorMessage;
+};
+
+struct DiagnosticsState {
+    QMutex mutex;
+    QString sessionId;
+    QList<QString> recentEvents;
+    OperationContext operationContext;
+};
+
+DiagnosticsState& state()
+{
+    static DiagnosticsState s;
+    return s;
+}
+
+QString appVersionString()
+{
+    const QString version = QCoreApplication::applicationVersion();
+    return version.isEmpty() ? QStringLiteral("unknown") : version;
+}
+
+QJsonObject featureFlagsObject()
+{
+    QJsonObject flags;
+#ifdef ENABLE_LOCAL_LLM
+    flags.insert(QStringLiteral("localLlm"), true);
+#else
+    flags.insert(QStringLiteral("localLlm"), false);
+#endif
+#ifdef ENABLE_STABLE_DIFFUSION
+    flags.insert(QStringLiteral("stableDiffusion"), true);
+#else
+    flags.insert(QStringLiteral("stableDiffusion"), false);
+#endif
+#ifdef ENABLE_PS1_RIP
+    flags.insert(QStringLiteral("ps1Rip"), true);
+#else
+    flags.insert(QStringLiteral("ps1Rip"), false);
+#endif
+#ifdef ENABLE_SENTRY
+    flags.insert(QStringLiteral("sentry"), true);
+#else
+    flags.insert(QStringLiteral("sentry"), false);
+#endif
+    flags.insert(QStringLiteral("crashReports"), SentryReporter::isEnabled());
+    return flags;
+}
+
+bool looksLikeSecretKey(const QString& key)
+{
+    static const QRegularExpression pattern(
+        QStringLiteral(R"((token|secret|password|authorization|api[_-]?key|signed|dsn))"),
+        QRegularExpression::CaseInsensitiveOption);
+    return pattern.match(key).hasMatch();
+}
+
+QString redactBearerTokens(const QString& value)
+{
+    QString out = value;
+    static const QRegularExpression bearer(
+        QStringLiteral(R"(Bearer\s+[A-Za-z0-9._~+/\-=]+)"),
+        QRegularExpression::CaseInsensitiveOption);
+    return out.replace(bearer, QStringLiteral("Bearer [redacted]"));
+}
+
+QString redactSignedUrls(const QString& value)
+{
+    QString out = value;
+    static const QRegularExpression signedParam(
+        QStringLiteral(R"(([?&](?:X-Amz-Signature|sig|signature|token|access_token)=[^&\s]+))"),
+        QRegularExpression::CaseInsensitiveOption);
+    return out.replace(signedParam, QStringLiteral("[redacted-url-param]"));
+}
+
+QString redactAbsolutePaths(const QString& value)
+{
+    QString out = value;
+#if defined(Q_OS_WIN)
+    static const QRegularExpression winPath(
+        QStringLiteral(R"(([A-Za-z]:\\[^\s\"']+|\\\\[^\s\"']+))"));
+    out.replace(winPath, QStringLiteral("[redacted-path]"));
+#endif
+    static const QRegularExpression unixPath(QStringLiteral(R"(/(?:[^\s\"'/]+/)+[^\s\"'/]+)"));
+    out.replace(unixPath, QStringLiteral("[redacted-path]"));
+    static const QRegularExpression homePath(QStringLiteral(R"(~(?:/[^\s\"']+)+)"));
+    out.replace(homePath, QStringLiteral("[redacted-path]"));
+    return out;
+}
+
+QString redactEnvAssignments(const QString& value)
+{
+    QString out = value;
+    static const QRegularExpression envAssign(
+        QStringLiteral(R"(([A-Z][A-Z0-9_]{2,})=([^\s\"']+))"));
+    return out.replace(envAssign, QStringLiteral("\\1=[redacted]"));
+}
+
+QJsonObject redactJsonObject(const QJsonObject& object)
+{
+    QJsonObject out;
+    for (auto it = object.begin(); it != object.end(); ++it) {
+        if (looksLikeSecretKey(it.key()))
+            continue;
+        out.insert(it.key(), FeedbackDiagnostics::redactJsonValue(it.value()));
+    }
+    return out;
+}
+
+} // namespace
+
+QString FeedbackDiagnostics::editorSessionId()
+{
+    QMutexLocker lock(&state().mutex);
+    if (state().sessionId.isEmpty())
+        state().sessionId = QUuid::createUuid().toString(QUuid::WithoutBraces);
+    return state().sessionId;
+}
+
+void FeedbackDiagnostics::recordRecentEvent(const QString& category, const QString& message)
+{
+    const QString sanitizedCategory = redactString(category.trimmed());
+    const QString sanitizedMessage = redactString(message.trimmed());
+    if (sanitizedCategory.isEmpty() && sanitizedMessage.isEmpty())
+        return;
+
+    QMutexLocker lock(&state().mutex);
+    const QString line = sanitizedCategory.isEmpty()
+        ? sanitizedMessage
+        : QStringLiteral("%1: %2").arg(sanitizedCategory, sanitizedMessage);
+    state().recentEvents.append(line);
+    while (state().recentEvents.size() > kMaxRecentEvents)
+        state().recentEvents.removeFirst();
+}
+
+void FeedbackDiagnostics::setOperationContext(const QString& operation,
+                                              const QString& format,
+                                              const QString& errorCode,
+                                              const QString& errorMessage)
+{
+    QMutexLocker lock(&state().mutex);
+    state().operationContext.operation = operation;
+    state().operationContext.format = format;
+    state().operationContext.errorCode = errorCode;
+    state().operationContext.errorMessage = errorMessage;
+}
+
+void FeedbackDiagnostics::clearOperationContext()
+{
+    QMutexLocker lock(&state().mutex);
+    state().operationContext = {};
+}
+
+QString FeedbackDiagnostics::redactPath(const QString& value)
+{
+    const QString trimmed = value.trimmed();
+    if (trimmed.isEmpty())
+        return trimmed;
+
+    const QStringList parts =
+        trimmed.split(QRegularExpression(QStringLiteral("[/\\\\]")), Qt::SkipEmptyParts);
+    if (!parts.isEmpty())
+        return parts.last();
+
+    return QStringLiteral("[redacted-path]");
+}
+
+QString FeedbackDiagnostics::redactString(const QString& value)
+{
+    QString out = value;
+    out = redactBearerTokens(out);
+    out = redactSignedUrls(out);
+    out = redactAbsolutePaths(out);
+    out = redactEnvAssignments(out);
+    if (out.size() > 512)
+        out = out.left(512) + QStringLiteral("…");
+    return out;
+}
+
+QJsonValue FeedbackDiagnostics::redactJsonValue(const QJsonValue& value)
+{
+    if (value.isString())
+        return redactString(value.toString());
+    if (value.isObject())
+        return redactJsonObject(value.toObject());
+    if (value.isArray()) {
+        QJsonArray array;
+        const QJsonArray in = value.toArray();
+        const int limit = qMin(in.size(), 32);
+        for (int i = 0; i < limit; ++i)
+            array.append(redactJsonValue(in.at(i)));
+        return array;
+    }
+    return value;
+}
+
+QJsonObject FeedbackDiagnostics::collectDiagnostics(bool includeOperationContext)
+{
+    QJsonObject diagnostics;
+    diagnostics.insert(QStringLiteral("appVersion"), appVersionString());
+    diagnostics.insert(QStringLiteral("osName"), QSysInfo::productType());
+    diagnostics.insert(QStringLiteral("osVersion"), QSysInfo::productVersion());
+    diagnostics.insert(QStringLiteral("architecture"), QSysInfo::currentCpuArchitecture());
+    diagnostics.insert(QStringLiteral("locale"), QLocale::system().name());
+    diagnostics.insert(QStringLiteral("editorSessionId"), editorSessionId());
+    diagnostics.insert(QStringLiteral("cloudConnected"), CloudCredentialStore::hasSession());
+    diagnostics.insert(QStringLiteral("featureFlags"), featureFlagsObject());
+
+    {
+        QMutexLocker lock(&state().mutex);
+        QJsonArray events;
+        for (const QString& event : state().recentEvents)
+            events.append(redactString(event));
+        diagnostics.insert(QStringLiteral("recentEvents"), events);
+
+        if (includeOperationContext && !state().operationContext.operation.isEmpty()) {
+            QJsonObject op;
+            op.insert(QStringLiteral("operation"), redactString(state().operationContext.operation));
+            if (!state().operationContext.format.isEmpty())
+                op.insert(QStringLiteral("format"), redactString(state().operationContext.format));
+            if (!state().operationContext.errorCode.isEmpty())
+                op.insert(QStringLiteral("errorCode"), redactString(state().operationContext.errorCode));
+            if (!state().operationContext.errorMessage.isEmpty())
+                op.insert(QStringLiteral("errorMessage"),
+                          redactString(state().operationContext.errorMessage));
+            diagnostics.insert(QStringLiteral("lastOperation"), op);
+        }
+    }
+
+    return redactJsonObject(diagnostics);
+}
+
+QString FeedbackDiagnostics::diagnosticsJsonString(const QJsonObject& diagnostics)
+{
+    QByteArray json = QJsonDocument(diagnostics).toJson(QJsonDocument::Compact);
+    if (json.size() <= kMaxDiagnosticsJsonBytes)
+        return QString::fromUtf8(json);
+
+    QJsonObject trimmed = diagnostics;
+    trimmed.remove(QStringLiteral("recentEvents"));
+    json = QJsonDocument(trimmed).toJson(QJsonDocument::Compact);
+    if (json.size() <= kMaxDiagnosticsJsonBytes)
+        return QString::fromUtf8(json);
+
+    trimmed.remove(QStringLiteral("lastOperation"));
+    json = QJsonDocument(trimmed).toJson(QJsonDocument::Compact);
+    if (json.size() > kMaxDiagnosticsJsonBytes)
+        json = json.left(kMaxDiagnosticsJsonBytes);
+    return QString::fromUtf8(json);
+}
+
+void FeedbackDiagnostics::resetForTests()
+{
+    QMutexLocker lock(&state().mutex);
+    state().sessionId.clear();
+    state().recentEvents.clear();
+    state().operationContext = {};
+}

--- a/src/FeedbackDiagnostics.h
+++ b/src/FeedbackDiagnostics.h
@@ -1,0 +1,47 @@
+#ifndef FEEDBACK_DIAGNOSTICS_H
+#define FEEDBACK_DIAGNOSTICS_H
+
+#include <QJsonObject>
+#include <QString>
+
+/// Privacy-safe diagnostics collection and redaction for in-app feedback (#701).
+class FeedbackDiagnostics {
+public:
+    FeedbackDiagnostics() = delete;
+
+    static constexpr int kMaxDiagnosticsJsonBytes = 8192;
+    static constexpr int kMaxRecentEvents = 20;
+
+    /// Stable per-process UUID (non-PII).
+    static QString editorSessionId();
+
+    /// Record a non-sensitive app event for optional diagnostics attachment.
+    static void recordRecentEvent(const QString& category, const QString& message);
+
+    /// Remember the last import/export failure context for diagnostics / prefill.
+    static void setOperationContext(const QString& operation,
+                                    const QString& format,
+                                    const QString& errorCode,
+                                    const QString& errorMessage);
+    static void clearOperationContext();
+
+    /// Redact a path-like string to filename + extension only.
+    static QString redactPath(const QString& value);
+
+    /// Redact tokens, signed URLs, absolute paths, and env-var-like secrets from free text.
+    static QString redactString(const QString& value);
+
+    /// Deep-redact a JSON value (paths, secrets, oversized strings).
+    static QJsonValue redactJsonValue(const QJsonValue& value);
+
+    /// Build bounded diagnostics JSON suitable for `diagnosticsJson` when opted in.
+    static QJsonObject collectDiagnostics(bool includeOperationContext = true);
+
+    /// Serialize diagnostics and enforce the byte-size cap.
+    static QString diagnosticsJsonString(const QJsonObject& diagnostics);
+
+    /// Clear in-memory state (tests).
+    static void resetForTests();
+};
+
+#endif

--- a/src/FeedbackDiagnostics_test.cpp
+++ b/src/FeedbackDiagnostics_test.cpp
@@ -1,0 +1,78 @@
+#include "FeedbackDiagnostics.h"
+
+#include <gtest/gtest.h>
+
+#include <QCoreApplication>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+class FeedbackDiagnosticsTest : public ::testing::Test {
+protected:
+    void SetUp() override { FeedbackDiagnostics::resetForTests(); }
+    void TearDown() override { FeedbackDiagnostics::resetForTests(); }
+};
+
+TEST_F(FeedbackDiagnosticsTest, RedactPathKeepsFilenameOnly)
+{
+    EXPECT_EQ(FeedbackDiagnostics::redactPath(QStringLiteral("/home/user/secret/models/hero.fbx")),
+              QStringLiteral("hero.fbx"));
+    EXPECT_EQ(FeedbackDiagnostics::redactPath(QStringLiteral("C:\\Users\\dev\\mesh.obj")),
+              QStringLiteral("mesh.obj"));
+}
+
+TEST_F(FeedbackDiagnosticsTest, RedactStringRemovesBearerTokensAndAbsolutePaths)
+{
+    const QString input =
+        QStringLiteral("Bearer abc.def.ghi failed on /home/user/model.fbx with token=secret");
+    const QString redacted = FeedbackDiagnostics::redactString(input);
+    EXPECT_FALSE(redacted.contains(QStringLiteral("Bearer abc")));
+    EXPECT_TRUE(redacted.contains(QStringLiteral("Bearer [redacted]")));
+    EXPECT_FALSE(redacted.contains(QStringLiteral("/home/user/model.fbx")));
+}
+
+TEST_F(FeedbackDiagnosticsTest, CollectDiagnosticsIncludesAllowedKeysOnly)
+{
+    FeedbackDiagnostics::recordRecentEvent(QStringLiteral("ui.action"), QStringLiteral("Test event"));
+    FeedbackDiagnostics::setOperationContext(QStringLiteral("import"),
+                                             QStringLiteral("fbx"),
+                                             QStringLiteral("E42"),
+                                             QStringLiteral("/tmp/bad.fbx broke"));
+
+    const QJsonObject diagnostics = FeedbackDiagnostics::collectDiagnostics(true);
+    EXPECT_TRUE(diagnostics.contains(QStringLiteral("appVersion")));
+    EXPECT_TRUE(diagnostics.contains(QStringLiteral("osName")));
+    EXPECT_TRUE(diagnostics.contains(QStringLiteral("architecture")));
+    EXPECT_TRUE(diagnostics.contains(QStringLiteral("locale")));
+    EXPECT_TRUE(diagnostics.contains(QStringLiteral("editorSessionId")));
+    EXPECT_TRUE(diagnostics.contains(QStringLiteral("cloudConnected")));
+    EXPECT_TRUE(diagnostics.contains(QStringLiteral("featureFlags")));
+    EXPECT_TRUE(diagnostics.contains(QStringLiteral("recentEvents")));
+
+    const QJsonObject lastOp = diagnostics.value(QStringLiteral("lastOperation")).toObject();
+    EXPECT_EQ(lastOp.value(QStringLiteral("operation")).toString(), QStringLiteral("import"));
+    EXPECT_EQ(lastOp.value(QStringLiteral("format")).toString(), QStringLiteral("fbx"));
+    EXPECT_FALSE(lastOp.value(QStringLiteral("errorMessage")).toString().contains(QStringLiteral("/tmp/")));
+}
+
+TEST_F(FeedbackDiagnosticsTest, DiagnosticsJsonStringIsSizeBounded)
+{
+    for (int i = 0; i < 100; ++i) {
+        FeedbackDiagnostics::recordRecentEvent(
+            QStringLiteral("ui.action"),
+            QStringLiteral("Event %1 with extra detail to grow payload size").arg(i));
+    }
+    const QString json = FeedbackDiagnostics::diagnosticsJsonString(
+        FeedbackDiagnostics::collectDiagnostics(true));
+    EXPECT_LE(json.toUtf8().size(), FeedbackDiagnostics::kMaxDiagnosticsJsonBytes);
+    QJsonParseError parseError{};
+    const QJsonDocument doc = QJsonDocument::fromJson(json.toUtf8(), &parseError);
+    EXPECT_EQ(parseError.error, QJsonParseError::NoError);
+}
+
+TEST_F(FeedbackDiagnosticsTest, EditorSessionIdIsStablePerProcess)
+{
+    const QString first = FeedbackDiagnostics::editorSessionId();
+    const QString second = FeedbackDiagnostics::editorSessionId();
+    EXPECT_FALSE(first.isEmpty());
+    EXPECT_EQ(first, second);
+}

--- a/src/FeedbackDialog.cpp
+++ b/src/FeedbackDialog.cpp
@@ -1,0 +1,359 @@
+#include "FeedbackDialog.h"
+
+#include "CloudCredentialStore.h"
+#include "FeedbackDiagnostics.h"
+#include "QtMeshCloudClient.h"
+#include "SentryReporter.h"
+
+#include <QApplication>
+#include <QCheckBox>
+#include <QClipboard>
+#include <QComboBox>
+#include <QDesktopServices>
+#include <QFormLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QMessageBox>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QSettings>
+#include <QUrl>
+#include <QVBoxLayout>
+
+#ifndef QTMESH_CLOUD_WEB_URL
+#define QTMESH_CLOUD_WEB_URL "https://qtmesh.dev"
+#endif
+
+namespace {
+
+QString feedbackWebsiteUrl()
+{
+    QString base = QStringLiteral(QTMESH_CLOUD_WEB_URL);
+    while (base.endsWith(QLatin1Char('/')))
+        base.chop(1);
+    return base + QStringLiteral("/#/feedback");
+}
+
+struct FeedbackTypeOption {
+    const char* apiValue;
+    const char* label;
+};
+
+constexpr FeedbackTypeOption kFeedbackTypes[] = {
+    {"bug", QT_TRANSLATE_NOOP("FeedbackDialog", "Bug report")},
+    {"feature_request", QT_TRANSLATE_NOOP("FeedbackDialog", "Feature request")},
+    {"general", QT_TRANSLATE_NOOP("FeedbackDialog", "General feedback")},
+    {"import_problem", QT_TRANSLATE_NOOP("FeedbackDialog", "Import problem")},
+    {"export_problem", QT_TRANSLATE_NOOP("FeedbackDialog", "Export problem")},
+};
+
+int typeIndexForApiValue(const QString& apiValue)
+{
+    for (int i = 0; i < int(sizeof(kFeedbackTypes) / sizeof(kFeedbackTypes[0])); ++i) {
+        if (apiValue == QLatin1String(kFeedbackTypes[i].apiValue))
+            return i;
+    }
+    return 0;
+}
+
+constexpr QLatin1StringView kSettingsIncludeDiagnostics{"Feedback/includeDiagnostics"};
+constexpr QLatin1StringView kSettingsContactAllowed{"Feedback/contactAllowed"};
+
+void loadFeedbackCheckboxPrefs(QCheckBox* diagnosticsCheck, QCheckBox* contactCheck)
+{
+    QSettings settings;
+    diagnosticsCheck->setChecked(settings.value(kSettingsIncludeDiagnostics, true).toBool());
+    contactCheck->setChecked(settings.value(kSettingsContactAllowed, true).toBool());
+}
+
+void saveFeedbackCheckboxPrefs(bool includeDiagnostics, bool contactAllowed)
+{
+    QSettings settings;
+    settings.setValue(kSettingsIncludeDiagnostics, includeDiagnostics);
+    settings.setValue(kSettingsContactAllowed, contactAllowed);
+}
+
+} // namespace
+
+FeedbackDialog::FeedbackDialog(QWidget* parent)
+    : QDialog(parent)
+{
+    setWindowTitle(tr("Send Feedback"));
+    setModal(true);
+    setMinimumWidth(480);
+    buildUi();
+    setSignedInAccountLabel({}, CloudCredentialStore::hasSession());
+    updateSubmitEnabled();
+}
+
+void FeedbackDialog::buildUi()
+{
+    auto* layout = new QVBoxLayout(this);
+
+    m_accountLabel = new QLabel(this);
+    m_accountLabel->setWordWrap(true);
+    layout->addWidget(m_accountLabel);
+
+    auto* form = new QFormLayout();
+    m_typeCombo = new QComboBox(this);
+    for (const FeedbackTypeOption& option : kFeedbackTypes)
+        m_typeCombo->addItem(tr(option.label), QString::fromLatin1(option.apiValue));
+    form->addRow(tr("Type:"), m_typeCombo);
+
+    m_ratingCombo = new QComboBox(this);
+    m_ratingCombo->addItem(tr("No rating"), QString());
+    m_ratingCombo->addItem(tr("Great"), QStringLiteral("great"));
+    m_ratingCombo->addItem(tr("Okay"), QStringLiteral("okay"));
+    m_ratingCombo->addItem(tr("Problem"), QStringLiteral("problem"));
+    form->addRow(tr("Rating (optional):"), m_ratingCombo);
+
+    m_messageEdit = new QPlainTextEdit(this);
+    m_messageEdit->setObjectName(QStringLiteral("feedbackMessageEdit"));
+    m_messageEdit->setPlaceholderText(
+        tr("Tell us what happened, what you expected, or what you'd like to see improved…"));
+    m_messageEdit->setTabChangesFocus(true);
+    form->addRow(tr("Message:"), m_messageEdit);
+    layout->addLayout(form);
+
+    m_diagnosticsCheck =
+        new QCheckBox(tr("Include anonymous diagnostics (version, OS, locale, recent non-sensitive events)"),
+                      this);
+    m_diagnosticsCheck->setObjectName(QStringLiteral("feedbackIncludeDiagnosticsCheck"));
+    m_contactCheck = new QCheckBox(tr("You may contact me about this feedback"), this);
+    m_contactCheck->setObjectName(QStringLiteral("feedbackContactAllowedCheck"));
+    loadFeedbackCheckboxPrefs(m_diagnosticsCheck, m_contactCheck);
+    layout->addWidget(m_diagnosticsCheck);
+    layout->addWidget(m_contactCheck);
+
+    connect(m_diagnosticsCheck, &QCheckBox::toggled, this, [this](bool checked) {
+        saveFeedbackCheckboxPrefs(checked, m_contactCheck->isChecked());
+    });
+    connect(m_contactCheck, &QCheckBox::toggled, this, [this](bool checked) {
+        saveFeedbackCheckboxPrefs(m_diagnosticsCheck->isChecked(), checked);
+    });
+
+    m_statusLabel = new QLabel(this);
+    m_statusLabel->setWordWrap(true);
+    m_statusLabel->hide();
+    layout->addWidget(m_statusLabel);
+
+    auto* buttons = new QHBoxLayout();
+    m_signInButton = new QPushButton(tr("Sign in to QtMesh Cloud…"), this);
+    m_signInButton->setObjectName(QStringLiteral("feedbackSignInButton"));
+    buttons->addWidget(m_signInButton);
+    buttons->addStretch();
+    auto* cancelButton = new QPushButton(tr("Cancel"), this);
+    buttons->addWidget(cancelButton);
+    m_sendButton = new QPushButton(tr("Send"), this);
+    m_sendButton->setDefault(true);
+    buttons->addWidget(m_sendButton);
+    layout->addLayout(buttons);
+
+    connect(cancelButton, &QPushButton::clicked, this, &QDialog::reject);
+    connect(m_signInButton, &QPushButton::clicked, this, [this]() {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("Feedback dialog: Sign in requested"));
+        if (signInRequested)
+            signInRequested();
+    });
+    connect(m_sendButton, &QPushButton::clicked, this, &FeedbackDialog::onSendClicked);
+    connect(m_typeCombo, &QComboBox::currentIndexChanged, this, &FeedbackDialog::updateSubmitEnabled);
+    connect(m_messageEdit, &QPlainTextEdit::textChanged, this, &FeedbackDialog::updateSubmitEnabled);
+}
+
+void FeedbackDialog::applyPrefill(const FeedbackPrefill& prefill)
+{
+    if (!prefill.type.isEmpty())
+        m_typeCombo->setCurrentIndex(typeIndexForApiValue(prefill.type));
+
+    if (!prefill.errorMessage.isEmpty() || !prefill.relatedFormat.isEmpty()) {
+        QString intro;
+        if (!prefill.relatedFormat.isEmpty()) {
+            intro = prefill.relatedOperation == QStringLiteral("export")
+                ? tr("Export failed for %1.").arg(prefill.relatedFormat)
+                : tr("Import failed for %1.").arg(prefill.relatedFormat);
+        }
+        if (!prefill.errorMessage.isEmpty()) {
+            if (!intro.isEmpty())
+                intro += QLatin1Char('\n');
+            intro += prefill.errorMessage;
+        }
+        if (!intro.isEmpty() && m_messageEdit->toPlainText().trimmed().isEmpty())
+            m_messageEdit->setPlainText(intro);
+    }
+
+    if (!prefill.relatedOperation.isEmpty())
+        m_relatedOperation = prefill.relatedOperation;
+    if (!prefill.relatedFormat.isEmpty())
+        m_relatedFormat = prefill.relatedFormat;
+
+    if (!prefill.relatedOperation.isEmpty() || !prefill.errorMessage.isEmpty()) {
+        FeedbackDiagnostics::setOperationContext(prefill.relatedOperation,
+                                                 prefill.relatedFormat,
+                                                 prefill.errorCode,
+                                                 prefill.errorMessage);
+    }
+}
+
+void FeedbackDialog::setSignedInAccountLabel(const QString& accountLabel, bool signedIn)
+{
+    m_signedIn = signedIn;
+    if (signedIn) {
+        const QString label = accountLabel.trimmed().isEmpty()
+            ? tr("Signed in to QtMesh Cloud")
+            : tr("Sending as %1").arg(accountLabel.trimmed());
+        m_accountLabel->setText(label);
+        m_signInButton->hide();
+    } else {
+        m_accountLabel->setText(
+            tr("Sign in to QtMesh Cloud to send feedback. Anonymous submissions are not available yet."));
+        m_signInButton->show();
+    }
+    updateSubmitEnabled();
+}
+
+QString FeedbackDialog::selectedType() const
+{
+    return m_typeCombo->currentData().toString();
+}
+
+QString FeedbackDialog::messageText() const
+{
+    return m_messageEdit->toPlainText();
+}
+
+bool FeedbackDialog::includeDiagnosticsChecked() const
+{
+    return m_diagnosticsCheck->isChecked();
+}
+
+bool FeedbackDialog::contactAllowedChecked() const
+{
+    return m_contactCheck->isChecked();
+}
+
+bool FeedbackDialog::canSubmit() const
+{
+    return m_signedIn && !selectedType().isEmpty() && !messageText().trimmed().isEmpty()
+        && messageText().size() <= kMaxMessageLength;
+}
+
+void FeedbackDialog::updateSubmitEnabled()
+{
+    const int length = messageText().size();
+    if (length > kMaxMessageLength) {
+        m_statusLabel->setText(tr("Message is too long (%1 / %2 characters).")
+                                   .arg(length)
+                                   .arg(kMaxMessageLength));
+        m_statusLabel->setStyleSheet(QStringLiteral("color: #c0392b;"));
+        m_statusLabel->show();
+    } else {
+        m_statusLabel->hide();
+    }
+    m_sendButton->setEnabled(canSubmit());
+}
+
+QString FeedbackDialog::selectedRatingApiValue() const
+{
+    return m_ratingCombo->currentData().toString();
+}
+
+QString FeedbackDialog::copyableFeedbackText() const
+{
+    return tr("Type: %1\nRating: %2\n\n%3")
+        .arg(m_typeCombo->currentText(),
+             m_ratingCombo->currentText(),
+             messageText().trimmed());
+}
+
+void FeedbackDialog::onSendClicked()
+{
+    if (!canSubmit()) {
+        if (!m_signedIn) {
+            QMessageBox::information(this, tr("Sign in required"),
+                                     tr("Sign in to QtMesh Cloud before sending feedback."));
+        }
+        return;
+    }
+
+    const CloudSession session = CloudCredentialStore::loadSession();
+    if (!session.hasToken()) {
+        setSignedInAccountLabel({}, false);
+        QMessageBox::information(this, tr("Sign in required"),
+                                 tr("Your QtMesh Cloud session is missing. Sign in and try again."));
+        return;
+    }
+
+    QtMeshCloudClient::FeedbackSubmission submission;
+    submission.type = selectedType();
+    submission.rating = selectedRatingApiValue();
+    submission.message = messageText().trimmed();
+    submission.relatedOperation = m_relatedOperation;
+    submission.relatedFormat = m_relatedFormat;
+    submission.includeDiagnostics = includeDiagnosticsChecked();
+    submission.contactAllowed = contactAllowedChecked();
+    if (submission.includeDiagnostics)
+        submission.diagnosticsJson = FeedbackDiagnostics::collectDiagnostics(true);
+
+    m_sendButton->setEnabled(false);
+    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                  QStringLiteral("Feedback dialog: Send clicked type=%1")
+                                      .arg(submission.type));
+
+    const auto result = QtMeshCloudClient::submitFeedback(session.token, submission);
+    m_sendButton->setEnabled(true);
+
+    if (result.ok) {
+        SentryReporter::addBreadcrumb(QStringLiteral("cloud.feedback"),
+                                      QStringLiteral("Feedback sent id=%1").arg(result.id));
+        QMessageBox::information(
+            this, tr("Thank you"),
+            tr("Thanks — your feedback was sent to the QtMesh team."));
+        accept();
+        return;
+    }
+
+    showSendFailure(result.userMessage.isEmpty() ? result.errorString : result.userMessage,
+                    result.httpStatus);
+}
+
+void FeedbackDialog::showSendFailure(const QString& userMessage, int httpStatus)
+{
+    Q_UNUSED(httpStatus);
+
+    const QString websiteUrl = feedbackWebsiteUrl();
+    QMessageBox failureBox(this);
+    failureBox.setIcon(QMessageBox::Warning);
+    failureBox.setWindowTitle(tr("Could not send feedback"));
+    failureBox.setText(userMessage);
+    failureBox.setInformativeText(
+        tr("Your message is still in this dialog.\n\n"
+           "You can send the same feedback on the QtMesh Cloud website while signed in:\n"
+           "%1\n\n"
+           "Use \"Copy Message\" to paste your text there, or \"Open Website\" to open the form.")
+            .arg(websiteUrl));
+    QPushButton* websiteButton = failureBox.addButton(tr("Open Website"), QMessageBox::ActionRole);
+    QPushButton* copyButton = failureBox.addButton(tr("Copy Message"), QMessageBox::ActionRole);
+    failureBox.addButton(QMessageBox::Ok);
+    failureBox.setDefaultButton(copyButton);
+    failureBox.exec();
+
+    if (failureBox.clickedButton() == websiteButton) {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("Feedback failure: Open Website"));
+        if (!QDesktopServices::openUrl(QUrl(websiteUrl))) {
+            QMessageBox::warning(this, tr("QtMesh Cloud"),
+                                 tr("Could not open %1 in your browser.").arg(websiteUrl));
+        }
+    } else if (failureBox.clickedButton() == copyButton && QApplication::clipboard()) {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("Feedback failure: Copy Message"));
+        QApplication::clipboard()->setText(copyableFeedbackText());
+    }
+}
+
+void FeedbackDialog::accept()
+{
+    saveFeedbackCheckboxPrefs(includeDiagnosticsChecked(), contactAllowedChecked());
+    QDialog::accept();
+}

--- a/src/FeedbackDialog.h
+++ b/src/FeedbackDialog.h
@@ -1,0 +1,63 @@
+#ifndef FEEDBACK_DIALOG_H
+#define FEEDBACK_DIALOG_H
+
+#include "FeedbackPrefill.h"
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QDialog>
+#include <QLabel>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <functional>
+
+/// Lightweight Help → Send Feedback dialog (#701).
+class FeedbackDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    static constexpr int kMaxMessageLength = 4000;
+
+    explicit FeedbackDialog(QWidget* parent = nullptr);
+
+    void applyPrefill(const FeedbackPrefill& prefill);
+    void setSignedInAccountLabel(const QString& accountLabel, bool signedIn);
+
+    /// Called when the user needs to sign in before sending (v1: no anonymous submit).
+    std::function<void()> signInRequested;
+
+    /// Exposed for unit tests.
+    QString selectedType() const;
+    QString messageText() const;
+    bool includeDiagnosticsChecked() const;
+    bool contactAllowedChecked() const;
+    bool canSubmit() const;
+
+public slots:
+    void accept() override;
+
+private slots:
+    void updateSubmitEnabled();
+    void onSendClicked();
+
+private:
+    void buildUi();
+    QString selectedRatingApiValue() const;
+    QString copyableFeedbackText() const;
+    void showSendFailure(const QString& userMessage, int httpStatus = 0);
+
+    QComboBox* m_typeCombo = nullptr;
+    QComboBox* m_ratingCombo = nullptr;
+    QPlainTextEdit* m_messageEdit = nullptr;
+    QCheckBox* m_diagnosticsCheck = nullptr;
+    QCheckBox* m_contactCheck = nullptr;
+    QLabel* m_accountLabel = nullptr;
+    QLabel* m_statusLabel = nullptr;
+    QPushButton* m_sendButton = nullptr;
+    QPushButton* m_signInButton = nullptr;
+    QString m_relatedOperation;
+    QString m_relatedFormat;
+    bool m_signedIn = false;
+};
+
+#endif

--- a/src/FeedbackDialog_test.cpp
+++ b/src/FeedbackDialog_test.cpp
@@ -1,0 +1,146 @@
+#include "FeedbackDialog.h"
+
+#include "CloudCredentialStore.h"
+
+#include <QApplication>
+#include <QCheckBox>
+#include <QCoreApplication>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QSettings>
+#include <gtest/gtest.h>
+
+class FeedbackDialogTest : public ::testing::Test {
+protected:
+    QString previousOrganizationName;
+    QString previousApplicationName;
+
+    void SetUp() override
+    {
+        previousOrganizationName = QCoreApplication::organizationName();
+        previousApplicationName = QCoreApplication::applicationName();
+        QCoreApplication::setOrganizationName(QStringLiteral("QtMeshEditorTests"));
+        QCoreApplication::setApplicationName(QStringLiteral("FeedbackDialogTest"));
+        QSettings().clear();
+        CloudCredentialStore::clearSession();
+    }
+
+    void TearDown() override
+    {
+        CloudCredentialStore::clearSession();
+        QSettings().clear();
+        QCoreApplication::setOrganizationName(previousOrganizationName);
+        QCoreApplication::setApplicationName(previousApplicationName);
+    }
+
+    static QPlainTextEdit* messageEdit(FeedbackDialog& dialog)
+    {
+        return dialog.findChild<QPlainTextEdit*>(QStringLiteral("feedbackMessageEdit"));
+    }
+};
+
+TEST_F(FeedbackDialogTest, RejectsEmptyMessageWhenSignedIn)
+{
+    FeedbackDialog dialog;
+    dialog.setSignedInAccountLabel(QStringLiteral("Dev User"), true);
+    EXPECT_FALSE(dialog.canSubmit());
+}
+
+TEST_F(FeedbackDialogTest, RejectsOverlongMessage)
+{
+    FeedbackDialog dialog;
+    dialog.setSignedInAccountLabel(QStringLiteral("Dev User"), true);
+    auto* edit = messageEdit(dialog);
+    ASSERT_NE(edit, nullptr);
+    edit->setPlainText(QString(FeedbackDialog::kMaxMessageLength + 1, QLatin1Char('x')));
+    QApplication::processEvents();
+    EXPECT_FALSE(dialog.canSubmit());
+}
+
+TEST_F(FeedbackDialogTest, LoggedOutCannotSubmitEvenWithMessage)
+{
+    FeedbackDialog dialog;
+    dialog.setSignedInAccountLabel({}, false);
+    auto* edit = messageEdit(dialog);
+    ASSERT_NE(edit, nullptr);
+    edit->setPlainText(QStringLiteral("Something broke"));
+    QApplication::processEvents();
+    EXPECT_FALSE(dialog.canSubmit());
+}
+
+TEST_F(FeedbackDialogTest, PrefillSetsImportProblemType)
+{
+    FeedbackDialog dialog;
+    FeedbackPrefill prefill;
+    prefill.type = QStringLiteral("import_problem");
+    prefill.relatedOperation = QStringLiteral("import");
+    prefill.relatedFormat = QStringLiteral("fbx");
+    prefill.errorMessage = QStringLiteral("Parse failed");
+    dialog.applyPrefill(prefill);
+    EXPECT_EQ(dialog.selectedType(), QStringLiteral("import_problem"));
+}
+
+TEST_F(FeedbackDialogTest, SignInRequestedCallbackFires)
+{
+    FeedbackDialog dialog;
+    dialog.setSignedInAccountLabel({}, false);
+    bool signInCalled = false;
+    dialog.signInRequested = [&signInCalled]() { signInCalled = true; };
+
+    auto* signInButton = dialog.findChild<QPushButton*>(QStringLiteral("feedbackSignInButton"));
+    ASSERT_NE(signInButton, nullptr);
+    signInButton->click();
+    QApplication::processEvents();
+    EXPECT_TRUE(signInCalled);
+}
+
+TEST_F(FeedbackDialogTest, SignedInWithMessageCanSubmit)
+{
+    FeedbackDialog dialog;
+    dialog.setSignedInAccountLabel(QStringLiteral("Dev User"), true);
+    auto* edit = messageEdit(dialog);
+    ASSERT_NE(edit, nullptr);
+    edit->setPlainText(QStringLiteral("Great editor, thanks!"));
+    QApplication::processEvents();
+    EXPECT_TRUE(dialog.canSubmit());
+}
+
+TEST_F(FeedbackDialogTest, CheckboxDefaultsAreCheckedWhenNoSavedPrefs)
+{
+    FeedbackDialog dialog;
+    EXPECT_TRUE(dialog.includeDiagnosticsChecked());
+    EXPECT_TRUE(dialog.contactAllowedChecked());
+}
+
+TEST_F(FeedbackDialogTest, RestoresCheckboxPrefsFromSettings)
+{
+    {
+        QSettings settings;
+        settings.setValue(QStringLiteral("Feedback/includeDiagnostics"), false);
+        settings.setValue(QStringLiteral("Feedback/contactAllowed"), true);
+    }
+    FeedbackDialog dialog;
+    EXPECT_FALSE(dialog.includeDiagnosticsChecked());
+    EXPECT_TRUE(dialog.contactAllowedChecked());
+}
+
+TEST_F(FeedbackDialogTest, PersistsCheckboxChangesToSettings)
+{
+    FeedbackDialog dialog;
+    auto* diagnostics =
+        dialog.findChild<QCheckBox*>(QStringLiteral("feedbackIncludeDiagnosticsCheck"));
+    auto* contact = dialog.findChild<QCheckBox*>(QStringLiteral("feedbackContactAllowedCheck"));
+    ASSERT_NE(diagnostics, nullptr);
+    ASSERT_NE(contact, nullptr);
+    diagnostics->setChecked(false);
+    contact->setChecked(false);
+    QApplication::processEvents();
+
+    QSettings settings;
+    EXPECT_FALSE(settings.value(QStringLiteral("Feedback/includeDiagnostics")).toBool());
+    EXPECT_FALSE(settings.value(QStringLiteral("Feedback/contactAllowed")).toBool());
+
+    FeedbackDialog dialogAgain;
+    EXPECT_FALSE(dialogAgain.includeDiagnosticsChecked());
+    EXPECT_FALSE(dialogAgain.contactAllowedChecked());
+}

--- a/src/FeedbackPrefill.h
+++ b/src/FeedbackPrefill.h
@@ -1,0 +1,15 @@
+#ifndef FEEDBACK_PREFILL_H
+#define FEEDBACK_PREFILL_H
+
+#include <QString>
+
+/// Optional values used to pre-populate the feedback dialog (e.g. after a failed import).
+struct FeedbackPrefill {
+    QString type;
+    QString relatedOperation;
+    QString relatedFormat;
+    QString errorCode;
+    QString errorMessage;
+};
+
+#endif

--- a/src/FeedbackReportHelper.cpp
+++ b/src/FeedbackReportHelper.cpp
@@ -1,0 +1,84 @@
+#include "FeedbackReportHelper.h"
+
+#include "FeedbackDiagnostics.h"
+#include "SentryReporter.h"
+
+#include <QAbstractButton>
+#include <QMessageBox>
+#include <QPushButton>
+
+namespace {
+
+FeedbackReportHelper::OpenFeedbackHandler g_openFeedbackHandler;
+
+} // namespace
+
+void FeedbackReportHelper::setOpenFeedbackHandler(OpenFeedbackHandler handler)
+{
+    g_openFeedbackHandler = std::move(handler);
+}
+
+bool FeedbackReportHelper::showFailureWithReportOption(QWidget* parent,
+                                                         const QString& title,
+                                                         const QString& text,
+                                                         const FeedbackPrefill& prefill)
+{
+    FeedbackDiagnostics::setOperationContext(prefill.relatedOperation,
+                                             prefill.relatedFormat,
+                                             prefill.errorCode,
+                                             prefill.errorMessage);
+
+    QMessageBox box(parent);
+    box.setIcon(QMessageBox::Warning);
+    box.setWindowTitle(title);
+    box.setText(text);
+    box.setStandardButtons(QMessageBox::Ok);
+    QPushButton* reportButton =
+        box.addButton(QObject::tr("Report Problem…"), QMessageBox::ActionRole);
+    if (auto* okButton = qobject_cast<QPushButton*>(box.button(QMessageBox::Ok)))
+        box.setDefaultButton(okButton);
+
+    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                  QStringLiteral("Import/export failure shown: %1").arg(title));
+
+    box.exec();
+    if (box.clickedButton() == reportButton) {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("Report Problem chosen after failure"));
+        if (g_openFeedbackHandler)
+            g_openFeedbackHandler(prefill);
+        return true;
+    }
+    return false;
+}
+
+FeedbackPrefill FeedbackReportHelper::importFailurePrefill(const QString& format,
+                                                           const QString& errorMessage,
+                                                           const QString& errorCode)
+{
+    FeedbackPrefill prefill;
+    prefill.type = QStringLiteral("import_problem");
+    prefill.relatedOperation = QStringLiteral("import");
+    prefill.relatedFormat = format;
+    prefill.errorCode = errorCode;
+    prefill.errorMessage = errorMessage;
+    return prefill;
+}
+
+FeedbackPrefill FeedbackReportHelper::exportFailurePrefill(const QString& format,
+                                                           const QString& errorMessage,
+                                                           const QString& errorCode)
+{
+    FeedbackPrefill prefill;
+    prefill.type = QStringLiteral("export_problem");
+    prefill.relatedOperation = QStringLiteral("export");
+    prefill.relatedFormat = format;
+    prefill.errorCode = errorCode;
+    prefill.errorMessage = errorMessage;
+    return prefill;
+}
+
+void FeedbackReportHelper::resetForTests()
+{
+    g_openFeedbackHandler = {};
+}

--- a/src/FeedbackReportHelper.h
+++ b/src/FeedbackReportHelper.h
@@ -1,0 +1,35 @@
+#ifndef FEEDBACK_REPORT_HELPER_H
+#define FEEDBACK_REPORT_HELPER_H
+
+#include "FeedbackPrefill.h"
+
+#include <functional>
+
+class QWidget;
+
+/// Shows import/export failures with an optional "Report Problem…" affordance (#701).
+class FeedbackReportHelper {
+public:
+    FeedbackReportHelper() = delete;
+
+    using OpenFeedbackHandler = std::function<void(const FeedbackPrefill&)>;
+
+    static void setOpenFeedbackHandler(OpenFeedbackHandler handler);
+
+    /// Warning dialog with OK + optional Report Problem. Returns true if report was chosen.
+    static bool showFailureWithReportOption(QWidget* parent,
+                                            const QString& title,
+                                            const QString& text,
+                                            const FeedbackPrefill& prefill);
+
+    static FeedbackPrefill importFailurePrefill(const QString& format,
+                                                const QString& errorMessage,
+                                                const QString& errorCode = QString());
+    static FeedbackPrefill exportFailurePrefill(const QString& format,
+                                                const QString& errorMessage,
+                                                const QString& errorCode = QString());
+
+    static void resetForTests();
+};
+
+#endif

--- a/src/MeshImporterExporter.cpp
+++ b/src/MeshImporterExporter.cpp
@@ -27,6 +27,7 @@ THE SOFTWARE.
 */
 
 #include "MeshImporterExporter.h"
+#include "FeedbackReportHelper.h"
 #include <assimp/Importer.hpp>
 #include <assimp/Exporter.hpp>
 #include <assimp/postprocess.h>
@@ -165,6 +166,15 @@ QString MeshImporterExporter::exportTextureName(const QString& originalName)
 }
 
 namespace {
+
+void showImportProblem(const QString& title,
+                       const QString& text,
+                       const QString& format,
+                       const QString& errorMessage = QString())
+{
+    FeedbackReportHelper::showFailureWithReportOption(
+        nullptr, title, text, FeedbackReportHelper::importFailurePrefill(format, errorMessage));
+}
 
 // Returns true when `tex` is safe to feed to `Ogre::Texture::convertToImage`.
 // Guards against the failure modes that caused the #681 SIGSEGV:
@@ -1785,11 +1795,11 @@ void MeshImporterExporter::importer(const QStringList &_uriList, unsigned int ad
                 const std::string meshName = (file.baseName() + QStringLiteral("_tmd")).toStdString();
                 Ogre::MeshPtr mesh = PS1TMD::importTmd(file.filePath(), meshName);
                 if (!mesh) {
-                    QMessageBox::warning(
-                        nullptr,
+                    showImportProblem(
                         QStringLiteral("PlayStation TMD"),
                         QStringLiteral("Could not import %1 — invalid file or unsupported primitive types.")
-                            .arg(file.fileName()));
+                            .arg(file.fileName()),
+                        QStringLiteral("tmd"));
                     continue;
                 }
 
@@ -1806,10 +1816,11 @@ void MeshImporterExporter::importer(const QStringList &_uriList, unsigned int ad
                 PS1RSD::RsdDescriptor rsd;
                 QString err;
                 if (!PS1RSD::parseRsdFile(file.filePath(), rsd, &err)) {
-                    QMessageBox::warning(
-                        nullptr,
+                    showImportProblem(
                         QStringLiteral("PlayStation RSD"),
-                        QStringLiteral("Could not parse %1: %2").arg(file.fileName(), err));
+                        QStringLiteral("Could not parse %1: %2").arg(file.fileName(), err),
+                        QStringLiteral("rsd"),
+                        err);
                     continue;
                 }
 
@@ -1955,10 +1966,10 @@ void MeshImporterExporter::importer(const QStringList &_uriList, unsigned int ad
                 const QString geomRel = rsd.plyPath;
                 const QString geomPath = resolve(geomRel);
                 if (geomPath.isEmpty() || !QFileInfo::exists(geomPath)) {
-                    QMessageBox::warning(
-                        nullptr,
+                    showImportProblem(
                         QStringLiteral("PlayStation RSD"),
-                        QStringLiteral("RSD does not reference an existing geometry file (PLY=...)."));
+                        QStringLiteral("RSD does not reference an existing geometry file (PLY=...)."),
+                        QStringLiteral("rsd"));
                     continue;
                 }
 
@@ -2047,10 +2058,10 @@ void MeshImporterExporter::importer(const QStringList &_uriList, unsigned int ad
                 }
 
                 if (!mesh) {
-                    QMessageBox::warning(
-                        nullptr,
+                    showImportProblem(
                         QStringLiteral("PlayStation RSD"),
-                        QStringLiteral("Could not import geometry referenced by %1").arg(file.fileName()));
+                        QStringLiteral("Could not import geometry referenced by %1").arg(file.fileName()),
+                        QStringLiteral("rsd"));
                     continue;
                 }
 
@@ -2146,12 +2157,12 @@ void MeshImporterExporter::importer(const QStringList &_uriList, unsigned int ad
                 const std::string meshName = (file.baseName() + QStringLiteral("_psyq_ply")).toStdString();
                 Ogre::MeshPtr mesh = PS1PLY::importPsyqPly(file.filePath(), meshName);
                 if (!mesh) {
-                    QMessageBox::warning(
-                        nullptr,
+                    showImportProblem(
                         QStringLiteral("PlayStation PLY"),
                         QStringLiteral("Could not import %1 — invalid Psy-Q PLY (expected @PLY header and "
                                        "face lines from the Psy-Q / RSD toolchain, not Stanford PLY).")
-                            .arg(file.fileName()));
+                            .arg(file.fileName()),
+                        QStringLiteral("ply"));
                     continue;
                 }
 
@@ -2234,12 +2245,12 @@ void MeshImporterExporter::importer(const QStringList &_uriList, unsigned int ad
                             outAnimOnlySkeletons->append(skel);
                     } else if (!file.suffix().compare(QStringLiteral("ply"), Qt::CaseInsensitive)) {
                         // Was not routed through PS1PLY (e.g. missing @PLY header) and Assimp failed.
-                        QMessageBox::warning(
-                            nullptr,
+                        showImportProblem(
                             QStringLiteral("Import PLY"),
                             QStringLiteral("Could not import %1. PlayStation Psy-Q PLY uses an @PLY header; "
                                            "Stanford PLY must start with \"ply\".")
-                                .arg(file.fileName()));
+                                .arg(file.fileName()),
+                            QStringLiteral("ply"));
                     }
                     continue;
                 }
@@ -2915,6 +2926,11 @@ int MeshImporterExporter::exporter(const Ogre::SceneNode *_sn, const QString &_u
                     .arg(formatId).arg(result).arg(exporter.GetErrorString());
                 Ogre::LogManager::getSingleton().logError(msg.toStdString());
                 SentryReporter::captureMessage(msg, "error");
+                FeedbackReportHelper::showFailureWithReportOption(
+                    nullptr,
+                    QObject::tr("Export failed"),
+                    msg,
+                    FeedbackReportHelper::exportFailurePrefill(_format, msg, QString::number(result)));
             }
             else
             {

--- a/src/QtMeshCloudClient.cpp
+++ b/src/QtMeshCloudClient.cpp
@@ -1,4 +1,5 @@
 #include "QtMeshCloudClient.h"
+#include "FeedbackDiagnostics.h"
 #include "SentryReporter.h"
 
 #include <QCoreApplication>
@@ -7,9 +8,11 @@
 #include <QFileInfo>
 #include <QJsonArray>
 #include <QJsonDocument>
+#include <QLocale>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
+#include <QSysInfo>
 #include <QThread>
 #include <QTimer>
 #include <QUrl>
@@ -1059,5 +1062,211 @@ QtMeshCloudClient::ManifestResult QtMeshCloudClient::fetchProjectManifest(const 
     out.ok = true;
     SentryReporter::addBreadcrumb(QStringLiteral("cloud.project"),
         QStringLiteral("QtMesh Cloud fetchProjectManifest: ok"));
+    return out;
+}
+
+QString QtMeshCloudClient::normalizeFeedbackType(const QString& type)
+{
+    const QString trimmed = type.trimmed();
+    if (trimmed == QStringLiteral("feature"))
+        return QStringLiteral("feature_request");
+    return trimmed;
+}
+
+QJsonObject QtMeshCloudClient::buildFeedbackPayload(const FeedbackSubmission& submission)
+{
+    QJsonObject body;
+    body.insert(QStringLiteral("type"), normalizeFeedbackType(submission.type));
+    if (!submission.rating.trimmed().isEmpty())
+        body.insert(QStringLiteral("rating"), submission.rating.trimmed());
+    body.insert(QStringLiteral("message"), submission.message.trimmed());
+
+    const QString appVersion = QCoreApplication::applicationVersion();
+    body.insert(QStringLiteral("appVersion"), appVersion.isEmpty() ? QStringLiteral("unknown") : appVersion);
+    body.insert(QStringLiteral("osName"), QSysInfo::productType());
+    body.insert(QStringLiteral("osVersion"), QSysInfo::productVersion());
+    body.insert(QStringLiteral("architecture"), QSysInfo::currentCpuArchitecture());
+    body.insert(QStringLiteral("locale"), QLocale::system().name());
+    body.insert(QStringLiteral("editorSessionId"), FeedbackDiagnostics::editorSessionId());
+
+    if (!submission.relatedOperation.trimmed().isEmpty())
+        body.insert(QStringLiteral("relatedOperation"), submission.relatedOperation.trimmed());
+    if (!submission.relatedFormat.trimmed().isEmpty())
+        body.insert(QStringLiteral("relatedFormat"), submission.relatedFormat.trimmed());
+
+    body.insert(QStringLiteral("includeDiagnostics"), submission.includeDiagnostics);
+    body.insert(QStringLiteral("contactAllowed"), submission.contactAllowed);
+
+    if (submission.includeDiagnostics) {
+        QJsonObject diagnostics = submission.diagnosticsJson;
+        if (diagnostics.isEmpty())
+            diagnostics = FeedbackDiagnostics::collectDiagnostics(true);
+        const QString diagnosticsString = FeedbackDiagnostics::diagnosticsJsonString(diagnostics);
+        if (!diagnosticsString.isEmpty()) {
+            QJsonParseError parseError{};
+            const QJsonDocument doc = QJsonDocument::fromJson(diagnosticsString.toUtf8(), &parseError);
+            if (parseError.error == QJsonParseError::NoError && doc.isObject())
+                body.insert(QStringLiteral("diagnosticsJson"), doc.object());
+            else
+                body.insert(QStringLiteral("diagnosticsJson"), diagnosticsString);
+        } else {
+            body.insert(QStringLiteral("diagnosticsJson"), QJsonObject());
+        }
+    }
+
+    return body;
+}
+
+QString QtMeshCloudClient::friendlyFeedbackError(int httpStatus,
+                                                 const QString& errorCode,
+                                                 const QString& fallback)
+{
+    if (httpStatus == 401 || errorCode == QStringLiteral("unauthorized")
+        || fallback.contains(QStringLiteral("Unauthorized"), Qt::CaseInsensitive))
+        return QStringLiteral("Your QtMesh Cloud session expired. Sign in again and retry.");
+    if (httpStatus == 413 || errorCode == QStringLiteral("payload_too_large")
+        || fallback.contains(QStringLiteral("Payload too large"), Qt::CaseInsensitive)
+        || fallback.contains(QStringLiteral("too large"), Qt::CaseInsensitive))
+        return QStringLiteral("Your feedback is too large. Shorten the message or turn off diagnostics.");
+    if (httpStatus == 429 || errorCode == QStringLiteral("rate_limited")
+        || fallback.contains(QStringLiteral("Too many feedback"), Qt::CaseInsensitive))
+        return QStringLiteral("Too many feedback submissions. Please wait a few minutes and try again.");
+    if (httpStatus == 400 || errorCode == QStringLiteral("validation_error")) {
+        if (fallback.contains(QStringLiteral("Invalid feedback type"), Qt::CaseInsensitive))
+            return QStringLiteral("This feedback category is not supported. Choose another type and try again.");
+        if (fallback.contains(QStringLiteral("Invalid rating"), Qt::CaseInsensitive))
+            return QStringLiteral("The selected rating is not supported. Choose another rating and try again.");
+        if (fallback.contains(QStringLiteral("Invalid related operation"), Qt::CaseInsensitive))
+            return QStringLiteral("The related workflow value was not accepted. Clear it and try again.");
+        if (fallback.contains(QStringLiteral("Message is required"), Qt::CaseInsensitive))
+            return QStringLiteral("Enter a message before sending feedback.");
+        if (fallback.contains(QStringLiteral("Invalid JSON"), Qt::CaseInsensitive))
+            return QStringLiteral("The feedback payload could not be sent. Try again or send it on the website.");
+        if (!fallback.isEmpty())
+            return QStringLiteral("The server could not accept this feedback: %1").arg(fallback);
+        return QStringLiteral("The feedback could not be accepted. Check the message and try again.");
+    }
+    if (!fallback.isEmpty())
+        return fallback;
+    if (httpStatus > 0)
+        return QStringLiteral("Could not send feedback (HTTP %1).").arg(httpStatus);
+    return QStringLiteral("Could not send feedback. Check your connection and try again.");
+}
+
+QtMeshCloudClient::FeedbackResult QtMeshCloudClient::submitFeedback(const QString& bearerToken,
+                                                                    const FeedbackSubmission& submission,
+                                                                    int timeoutMs)
+{
+    FeedbackResult out;
+    if (bearerToken.isEmpty()) {
+        out.errorString = QStringLiteral("missing bearer token");
+        out.userMessage = friendlyFeedbackError(401, QStringLiteral("unauthorized"), out.errorString);
+        return out;
+    }
+    if (submission.type.trimmed().isEmpty()) {
+        out.errorString = QStringLiteral("feedback type is required");
+        out.userMessage = friendlyFeedbackError(400, QStringLiteral("validation_error"), out.errorString);
+        return out;
+    }
+    const QString normalizedType = normalizeFeedbackType(submission.type);
+    if (!normalizedType.isEmpty()
+        && normalizedType != QStringLiteral("bug")
+        && normalizedType != QStringLiteral("feature_request")
+        && normalizedType != QStringLiteral("general")
+        && normalizedType != QStringLiteral("import_problem")
+        && normalizedType != QStringLiteral("export_problem")) {
+        out.errorString = QStringLiteral("unsupported feedback type: %1").arg(submission.type);
+        out.userMessage = friendlyFeedbackError(400, QStringLiteral("validation_error"),
+                                                QStringLiteral("Invalid feedback type"));
+        return out;
+    }
+    if (submission.message.trimmed().isEmpty()) {
+        out.errorString = QStringLiteral("message is required");
+        out.userMessage = friendlyFeedbackError(400, QStringLiteral("validation_error"), out.errorString);
+        return out;
+    }
+    if (submission.message.size() > kFeedbackMaxMessageLength) {
+        out.errorString = QStringLiteral("message exceeds maximum length");
+        out.userMessage = friendlyFeedbackError(413, QStringLiteral("payload_too_large"), out.errorString);
+        return out;
+    }
+
+    const QUrl url(apiBaseUrl() + QString(kFeedbackApiPath));
+    if (!url.isValid()) {
+        out.errorString = QStringLiteral("invalid API base URL");
+        out.userMessage = out.errorString;
+        return out;
+    }
+
+    const QJsonObject body = buildFeedbackPayload(submission);
+    const QByteArray payload = QJsonDocument(body).toJson(QJsonDocument::Compact);
+
+    QNetworkAccessManager nam;
+    QNetworkRequest req = authorizedJsonRequest(url, bearerToken, timeoutMs);
+    req.setHeader(QNetworkRequest::UserAgentHeader, QStringLiteral("qtmesheditor"));
+
+    SentryReporter::addBreadcrumb(QStringLiteral("cloud.feedback"),
+                                  QStringLiteral("QtMesh Cloud submitFeedback: start type=%1")
+                                      .arg(submission.type));
+
+    QNetworkReply* reply = nam.post(req, payload);
+    QEventLoop loop;
+    QObject::connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+    loop.exec();
+
+    out.httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    const QByteArray responseBody = reply->readAll();
+    const auto nerr = reply->error();
+    const QString transportErr = reply->errorString();
+    reply->deleteLater();
+
+    out.responseBodySnippet = trimSnippet(responseBody);
+
+    QJsonObject root;
+    QString parseError;
+    const bool parsed = parseJsonObjectBody(responseBody, root, parseError);
+    const QString errorCode = parsed ? jsonErrorCode(root) : QString();
+    const QString apiErrorText = parsed ? root.value(QStringLiteral("error")).toString() : QString();
+
+    // POST /v1/feedback — success is HTTP 201 with { ok, id, status, createdAt }.
+    if (nerr == QNetworkReply::NoError && out.httpStatus == 201 && parsed) {
+        out.id = root.value(QStringLiteral("id")).toString();
+        out.status = root.value(QStringLiteral("status")).toString();
+        const QJsonValue createdAtVal = root.value(QStringLiteral("createdAt"));
+        if (createdAtVal.isDouble())
+            out.createdAt = QString::number(static_cast<qint64>(createdAtVal.toDouble()));
+        else
+            out.createdAt = createdAtVal.toString();
+        const bool okFlag = root.contains(QStringLiteral("ok")) ? root.value(QStringLiteral("ok")).toBool()
+                                                                : true;
+        if (okFlag && !out.id.isEmpty()) {
+            out.ok = true;
+            SentryReporter::addBreadcrumb(QStringLiteral("cloud.feedback"),
+                                          QStringLiteral("QtMesh Cloud submitFeedback: ok id=%1 HTTP %2")
+                                              .arg(out.id)
+                                              .arg(out.httpStatus));
+            return out;
+        }
+    }
+
+    QString errMsg;
+    if (nerr != QNetworkReply::NoError)
+        errMsg = transportErr;
+    else if (!apiErrorText.isEmpty())
+        errMsg = apiErrorText;
+    else
+        errMsg = QStringLiteral("HTTP %1").arg(out.httpStatus);
+    if (!errorCode.isEmpty() && errorCode != apiErrorText)
+        errMsg = errorCode;
+    if (!out.responseBodySnippet.isEmpty() && !errMsg.contains(out.responseBodySnippet))
+        errMsg += QStringLiteral(" — ") + out.responseBodySnippet;
+
+    out.errorString = errMsg;
+    out.userMessage = friendlyFeedbackError(out.httpStatus, errorCode, errMsg);
+    SentryReporter::addBreadcrumb(QStringLiteral("cloud.feedback"),
+                                  QStringLiteral("QtMesh Cloud submitFeedback: failure HTTP %1 %2")
+                                      .arg(out.httpStatus)
+                                      .arg(errMsg),
+                                  QStringLiteral("warning"));
     return out;
 }

--- a/src/QtMeshCloudClient.h
+++ b/src/QtMeshCloudClient.h
@@ -205,6 +205,47 @@ public:
                                                const QString& ownerSlug,
                                                const QString& projectSlug,
                                                int timeoutMs = 30000);
+
+    struct FeedbackSubmission {
+        QString type;
+        QString rating;
+        QString message;
+        QString relatedOperation;
+        QString relatedFormat;
+        bool includeDiagnostics = false;
+        QJsonObject diagnosticsJson;
+        bool contactAllowed = false;
+    };
+
+    struct FeedbackResult {
+        bool ok = false;
+        int httpStatus = 0;
+        QString errorString;
+        QString userMessage;
+        QString responseBodySnippet;
+        QString id;
+        QString status;
+        QString createdAt;
+    };
+
+    static constexpr int kFeedbackMaxMessageLength = 4000;
+    static constexpr QLatin1StringView kFeedbackApiPath{"/v1/feedback"};
+
+    /// Normalize editor/API type strings (e.g. legacy `feature` → `feature_request`).
+    static QString normalizeFeedbackType(const QString& type);
+
+    /// Build POST /v1/feedback JSON body (also used by unit tests).
+    static QJsonObject buildFeedbackPayload(const FeedbackSubmission& submission);
+
+    /// Map API / transport failures to user-facing copy.
+    static QString friendlyFeedbackError(int httpStatus,
+                                         const QString& errorCode,
+                                         const QString& fallback);
+
+    /// POST /v1/feedback — authenticated in-app feedback (#701).
+    static FeedbackResult submitFeedback(const QString& bearerToken,
+                                         const FeedbackSubmission& submission,
+                                         int timeoutMs = 30000);
 };
 
 #endif

--- a/src/QtMeshCloudClient_test.cpp
+++ b/src/QtMeshCloudClient_test.cpp
@@ -2,6 +2,7 @@
 #include <QCoreApplication>
 #include <QJsonObject>
 #include "QtMeshCloudClient.h"
+#include "FeedbackDiagnostics.h"
 
 TEST(QtMeshCloudClientValidate, AcceptsMinimalValid)
 {
@@ -233,4 +234,102 @@ TEST(QtMeshCloudClientFetchManifest, MissingOwnerReturnsErrorImmediately)
                                                          QStringLiteral("project"), /*timeoutMs=*/100);
     EXPECT_FALSE(result.ok);
     EXPECT_TRUE(result.errorString.contains("owner", Qt::CaseInsensitive));
+}
+
+TEST(QtMeshCloudClientFeedbackPayload, IncludesRequiredFields)
+{
+    QtMeshCloudClient::FeedbackSubmission submission;
+    submission.type = QStringLiteral("feature_request");
+    submission.rating = QStringLiteral("great");
+    submission.message = QStringLiteral("Test message");
+    submission.relatedOperation = QStringLiteral("import");
+    submission.relatedFormat = QStringLiteral("fbx");
+    submission.includeDiagnostics = false;
+    submission.contactAllowed = true;
+
+    const QJsonObject body = QtMeshCloudClient::buildFeedbackPayload(submission);
+    EXPECT_EQ(body.value(QStringLiteral("type")).toString(), QStringLiteral("feature_request"));
+    EXPECT_EQ(body.value(QStringLiteral("rating")).toString(), QStringLiteral("great"));
+    EXPECT_EQ(body.value(QStringLiteral("message")).toString(), QStringLiteral("Test message"));
+    EXPECT_EQ(body.value(QStringLiteral("relatedOperation")).toString(), QStringLiteral("import"));
+    EXPECT_EQ(body.value(QStringLiteral("relatedFormat")).toString(), QStringLiteral("fbx"));
+    EXPECT_FALSE(body.value(QStringLiteral("includeDiagnostics")).toBool());
+    EXPECT_TRUE(body.value(QStringLiteral("contactAllowed")).toBool());
+    EXPECT_TRUE(body.contains(QStringLiteral("appVersion")));
+    EXPECT_TRUE(body.contains(QStringLiteral("editorSessionId")));
+    EXPECT_FALSE(body.contains(QStringLiteral("diagnosticsJson")));
+}
+
+TEST(QtMeshCloudClientFeedbackPayload, OmitsDiagnosticsWhenNotRequested)
+{
+    QtMeshCloudClient::FeedbackSubmission submission;
+    submission.type = QStringLiteral("general");
+    submission.message = QStringLiteral("Hello");
+    submission.includeDiagnostics = false;
+
+    const QJsonObject body = QtMeshCloudClient::buildFeedbackPayload(submission);
+    EXPECT_FALSE(body.contains(QStringLiteral("diagnosticsJson")));
+}
+
+TEST(QtMeshCloudClientFeedbackPayload, IncludesDiagnosticsWhenRequested)
+{
+    FeedbackDiagnostics::resetForTests();
+    QtMeshCloudClient::FeedbackSubmission submission;
+    submission.type = QStringLiteral("general");
+    submission.message = QStringLiteral("Hello");
+    submission.includeDiagnostics = true;
+
+    const QJsonObject body = QtMeshCloudClient::buildFeedbackPayload(submission);
+    EXPECT_TRUE(body.value(QStringLiteral("includeDiagnostics")).toBool());
+    EXPECT_TRUE(body.contains(QStringLiteral("diagnosticsJson")));
+    EXPECT_TRUE(body.value(QStringLiteral("diagnosticsJson")).isObject());
+    FeedbackDiagnostics::resetForTests();
+}
+
+TEST(QtMeshCloudClientFeedbackPayload, UsesV1FeedbackApiPath)
+{
+    EXPECT_EQ(QString(QtMeshCloudClient::kFeedbackApiPath), QStringLiteral("/v1/feedback"));
+}
+
+TEST(QtMeshCloudClientSubmitFeedback, MissingTokenReturnsErrorImmediately)
+{
+    QtMeshCloudClient::FeedbackSubmission submission;
+    submission.type = QStringLiteral("bug");
+    submission.message = QStringLiteral("Something failed");
+    auto result = QtMeshCloudClient::submitFeedback(QString(), submission, /*timeoutMs=*/100);
+    EXPECT_FALSE(result.ok);
+    EXPECT_TRUE(result.userMessage.contains(QStringLiteral("Sign in"), Qt::CaseInsensitive)
+                || result.userMessage.contains(QStringLiteral("session"), Qt::CaseInsensitive));
+}
+
+TEST(QtMeshCloudClientSubmitFeedback, MissingMessageReturnsValidationError)
+{
+    QtMeshCloudClient::FeedbackSubmission submission;
+    submission.type = QStringLiteral("bug");
+    auto result = QtMeshCloudClient::submitFeedback(QStringLiteral("token"), submission, /*timeoutMs=*/100);
+    EXPECT_FALSE(result.ok);
+    EXPECT_FALSE(result.userMessage.isEmpty());
+}
+
+TEST(QtMeshCloudClientFeedbackPayload, NormalizesLegacyFeatureType)
+{
+    QtMeshCloudClient::FeedbackSubmission submission;
+    submission.type = QStringLiteral("feature");
+    submission.message = QStringLiteral("Hello");
+    const QJsonObject body = QtMeshCloudClient::buildFeedbackPayload(submission);
+    EXPECT_EQ(body.value(QStringLiteral("type")).toString(), QStringLiteral("feature_request"));
+}
+
+TEST(QtMeshCloudClientFriendlyFeedbackError, MapsHttpStatuses)
+{
+    EXPECT_TRUE(QtMeshCloudClient::friendlyFeedbackError(404, QString(), QString())
+                    .contains(QStringLiteral("HTTP 404"), Qt::CaseInsensitive));
+    EXPECT_TRUE(QtMeshCloudClient::friendlyFeedbackError(429, QString(), QString())
+                    .contains(QStringLiteral("Too many"), Qt::CaseInsensitive));
+    EXPECT_TRUE(QtMeshCloudClient::friendlyFeedbackError(400, QString(), QStringLiteral("Message is required"))
+                    .contains(QStringLiteral("Enter a message"), Qt::CaseInsensitive));
+    EXPECT_TRUE(QtMeshCloudClient::friendlyFeedbackError(413, QString(), QString())
+                    .contains(QStringLiteral("too large"), Qt::CaseInsensitive));
+    EXPECT_TRUE(QtMeshCloudClient::friendlyFeedbackError(401, QString(), QString())
+                    .contains(QStringLiteral("Sign in"), Qt::CaseInsensitive));
 }

--- a/src/SentryReporter.cpp
+++ b/src/SentryReporter.cpp
@@ -1,4 +1,5 @@
 #include "SentryReporter.h"
+#include "FeedbackDiagnostics.h"
 #include "AppSettingsKeys.h"
 #include <QSettings>
 #include <QMessageBox>
@@ -104,6 +105,8 @@ void SentryReporter::setTag(const QString &key, const QString &value)
 void SentryReporter::addBreadcrumb(const QString &category, const QString &message,
                                    const QString &level)
 {
+    FeedbackDiagnostics::recordRecentEvent(category, message);
+
 #ifdef ENABLE_SENTRY
     if (!s_initialized) return;
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -41,6 +41,8 @@
 #include "AppConsoleLog.h"
 #include "AppSettingsKeys.h"
 #include "CloudAccountMenuButton.h"
+#include "FeedbackDialog.h"
+#include "FeedbackReportHelper.h"
 #include "CloudCredentialStore.h"
 #include "CloudUploadPlanner.h"
 #include "ui_mainwindow.h"
@@ -202,6 +204,10 @@ MainWindow::MainWindow(QWidget *parent) :
     manager->CreateEmptyScene();
 
     initToolBar();
+
+    FeedbackReportHelper::setOpenFeedbackHandler([this](const FeedbackPrefill& prefill) {
+        showSendFeedbackDialog(prefill);
+    });
 
     // Recent Files submenu in File menu
     m_recentFilesMenu = new QMenu(tr("Recent Files"), this); // NOSONAR — Qt parent manages lifetime
@@ -2231,6 +2237,15 @@ void MainWindow::initToolBar()
         widget->show();
     });
 
+    // Send Feedback (#701)
+    QAction* sendFeedbackAction = ui->menuHelp->addAction(tr("Send Feedback..."));
+    sendFeedbackAction->setObjectName(QStringLiteral("actionSendFeedback"));
+    connect(sendFeedbackAction, &QAction::triggered, this, [this]() {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("Help > Send Feedback"));
+        showSendFeedbackDialog({});
+    });
+
     // Crash reporting toggle in Help menu
     ui->menuHelp->addSeparator();
     QAction* crashReportAction = ui->menuHelp->addAction(tr("Send Crash Reports"));
@@ -2309,6 +2324,9 @@ void MainWindow::setupCloudAccountStatusControl()
                                  tr("Could not open QtMesh Cloud in your browser."));
         }
     });
+    connect(m_cloudAccountControl, &CloudAccountMenuButton::feedbackRequested, this, [this]() {
+        showSendFeedbackDialog({});
+    });
 
     // Push the account control to the bottom of the left objects toolbar (VS Code-style).
     auto* toolbarStretch = new QWidget(ui->objectsToolbar);
@@ -2326,6 +2344,27 @@ void MainWindow::updateCloudAuthActions()
 {
     if (m_cloudAccountControl)
         m_cloudAccountControl->refresh();
+}
+
+void MainWindow::showSendFeedbackDialog(const FeedbackPrefill& prefill)
+{
+    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                  QStringLiteral("Send Feedback dialog opened"));
+
+    FeedbackDialog dialog(this);
+    dialog.applyPrefill(prefill);
+
+    const auto refreshAccount = [&dialog]() {
+        dialog.setSignedInAccountLabel(storedCloudDisplayName(), CloudCredentialStore::hasSession());
+    };
+    refreshAccount();
+
+    dialog.signInRequested = [this, refreshAccount]() {
+        signInToQtMeshCloud();
+        refreshAccount();
+    };
+
+    dialog.exec();
 }
 
 void MainWindow::signInToQtMeshCloud()
@@ -3662,7 +3701,14 @@ void MainWindow::on_actionOpen_Scene_triggered()
 
     auto txn = SentryReporter::startTransaction("ui.import", "scene.import");
     try {
-        MeshImporterExporter::sceneImporter(fileName);
+        if (!MeshImporterExporter::sceneImporter(fileName)) {
+            FeedbackReportHelper::showFailureWithReportOption(
+                this, tr("Open Scene"), tr("Could not import scene file."),
+                FeedbackReportHelper::importFailurePrefill(
+                    QFileInfo(fileName).suffix(), tr("Could not import scene file.")));
+            SentryReporter::finishTransaction(txn);
+            return;
+        }
     } catch (...) {
         SentryReporter::finishTransaction(txn);
         throw;
@@ -3697,8 +3743,13 @@ void MainWindow::on_actionSave_Scene_triggered()
                 progressDialog.setValue(progress);
                 QApplication::processEvents();
             });
-        if (result != 0)
-            QMessageBox::warning(this, tr("Save Scene"), tr("Failed to save scene."));
+        if (result != 0) {
+            FeedbackReportHelper::showFailureWithReportOption(
+                this, tr("Save Scene"), tr("Failed to save scene."),
+                FeedbackReportHelper::exportFailurePrefill(
+                    QFileInfo(fileName).suffix(), tr("Failed to save scene."),
+                    QString::number(result)));
+        }
     } catch (...) {
         SentryReporter::finishTransaction(txn);
         throw;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -10,6 +10,7 @@
 #include <QNetworkAccessManager>
 
 #include "TransformOperator.h"
+#include "FeedbackPrefill.h"
 
 class LLMSettingsWidget;
 class MCPServer;
@@ -124,6 +125,7 @@ private slots:
     void signInToQtMeshCloud();
     void signOutOfQtMeshCloud();
     void uploadFilesToQtMeshCloud();
+    void showSendFeedbackDialog(const FeedbackPrefill& prefill = FeedbackPrefill{});
     bool startMCPServer(int port);
     void stopMCPServer();
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,6 +66,9 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/CloudCredentialStore.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/CloudUploadPlanner.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/CloudAccountMenuButton.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/FeedbackDiagnostics.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/FeedbackDialog.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/FeedbackReportHelper.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/RTShaderHelper.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/QMLMaterialHighlighter.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/ViewCube/ViewCubeController.cpp

--- a/website/src/hooks/useQtmeshActionRef.js
+++ b/website/src/hooks/useQtmeshActionRef.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 const QTMESH_RELEASES_LATEST_API = 'https://api.github.com/repos/fernandotonon/QtMeshEditor/releases/latest';
-const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.4.0';
+const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.4.1';
 const CACHE_KEY = 'qtmesh.actionRef.cache.v1';
 const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 


### PR DESCRIPTION
## Summary

- Adds **Help → Send Feedback** and cloud account menu entry for authenticated in-app feedback via `POST /v1/feedback` (types, rating, diagnostics, contact opt-in).
- **Report Problem…** on import/export failures pre-fills the dialog; checkbox prefs persist in `QSettings`; failed sends offer copy + open `https://qtmesh.dev/#/feedback`.
- Bumps version to **3.4.1** and fixes Docker publish: install **`libsecret-1-0`** so `libsecret-1.so.0` resolves for Linux cloud credential storage (fixes release job `docker-publish` ldd check).

## Test plan

- [ ] Sign in to QtMesh Cloud, send feedback from Help menu
- [ ] Toggle diagnostics/contact checkboxes, reopen dialog — prefs restored
- [ ] Trigger import failure → Report Problem → verify prefill
- [ ] `docker run --rm ghcr.io/fernandotonon/qtmesh:3.4.1 --help` after image publish
- [ ] UnitTests: `*Feedback*` suite on Linux CI

Closes #701

Made with [Cursor](https://cursor.com)