### PR TITLE
feat(scan): extend AssetInfo inspect for triangles and textures (#364)

### DIFF
--- a/profiles/example-texture-inspect.json
+++ b/profiles/example-texture-inspect.json
@@ -1,0 +1,10 @@
+{
+  "id": "example-texture-inspect",
+  "displayName": "Example Texture Inspect",
+  "description": "Enables filesystem texture probing during scan (issue #364).",
+  "extends": "example-base",
+  "metadata": {
+    "inspect_textures": true,
+    "category": "example"
+  }
+}

--- a/src/PlatformProfile.cpp
+++ b/src/PlatformProfile.cpp
@@ -396,6 +396,12 @@ void applyPlatformProfile(ScanConfig& config, const PlatformProfile& profile)
     if (!profile.scopes.isEmpty())
         appendProfileScopes(config, profile.scopes, &warnings);
 
+    const QVariantMap meta = profile.metadata;
+    if (meta.value(QStringLiteral("inspect_textures")).toBool()
+        || meta.value(QStringLiteral("inspectTextures")).toBool()) {
+        config.probeTextureFiles = true;
+    }
+
     for (const QString& w : warnings) {
         QTextStream(stderr) << "Warning: " << w << Qt::endl;
     }

--- a/src/PlatformProfile_test.cpp
+++ b/src/PlatformProfile_test.cpp
@@ -187,3 +187,27 @@ TEST(PlatformProfileLoaderTest, LoadByExplicitPath)
     ASSERT_TRUE(loaded.ok) << loaded.error.toStdString();
     EXPECT_EQ(loaded.profile.id, QStringLiteral("example-base"));
 }
+
+TEST(ApplyPlatformProfileTest, MetadataInspectTexturesEnablesProbe)
+{
+    ScanConfig config = ScanConfig::defaults();
+    EXPECT_FALSE(config.probeTextureFiles);
+
+    PlatformProfile profile;
+    profile.id = QStringLiteral("test-inspect");
+    profile.metadata.insert(QStringLiteral("inspect_textures"), true);
+    applyPlatformProfile(config, profile);
+    EXPECT_TRUE(config.probeTextureFiles);
+}
+
+TEST(PlatformProfileLoaderTest, BuiltinExampleTextureInspectProfileEnablesProbe)
+{
+    const PlatformProfileLoadResult loaded =
+        PlatformProfileLoader::load(QStringLiteral("example-texture-inspect"));
+    ASSERT_TRUE(loaded.ok) << loaded.error.toStdString();
+    EXPECT_TRUE(loaded.profile.metadata.value(QStringLiteral("inspect_textures")).toBool());
+
+    ScanConfig config = ScanConfig::defaults();
+    applyPlatformProfile(config, loaded.profile);
+    EXPECT_TRUE(config.probeTextureFiles);
+}

--- a/src/ScanConfig.h
+++ b/src/ScanConfig.h
@@ -103,6 +103,9 @@ struct ScanConfig {
     // input; 1% is the conservative starting point.
     double detectNonManifoldEdgesPct = 0.0;
 
+    // inspect (issue #364) — enabled via platform profile metadata `inspect_textures: true`
+    bool probeTextureFiles = false;
+
     // scoped rules — path-specific overrides
     QList<ScanScope> scopes;
 

--- a/src/ScanEngine.cpp
+++ b/src/ScanEngine.cpp
@@ -6,6 +6,7 @@
 #include <QElapsedTimer>
 #include <QFile>
 #include <QFileInfo>
+#include <QImageReader>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -51,6 +52,190 @@
 #include <vector>
 
 namespace {
+
+static bool meshNameLooksLikeLod(const QString& name)
+{
+    static const QRegularExpression re(
+        QStringLiteral(R"((?:^|[_\-.])(?:lod|level_of_detail)(?:[_\-.]?\d*)?$)"),
+        QRegularExpression::CaseInsensitiveOption);
+    return re.match(name).hasMatch();
+}
+
+static void syncTriangleDerivedFields(AssetInfo& info)
+{
+    info.triangleCount = info.faceCount;
+}
+
+static void finalizeMeshStatsAggregates(AssetInfo& info)
+{
+    info.submeshCount = 0;
+    info.maxTrianglesPerMesh = 0;
+    for (const MeshStats& ms : info.meshStats) {
+        info.submeshCount += ms.submeshCount;
+        info.maxTrianglesPerMesh = std::max(info.maxTrianglesPerMesh, ms.triangleCount);
+    }
+}
+
+static void appendMeshStat(AssetInfo& info, const MeshStats& row)
+{
+    if (info.meshStats.size() >= AssetInfo::kMaxMeshStatsEntries)
+        return;
+    info.meshStats.append(row);
+}
+
+static void fillMeshStatsFromAssimpScene(const aiScene* scene, AssetInfo& info)
+{
+    if (!scene)
+        return;
+    info.lodMeshCount = 0;
+    for (unsigned i = 0; i < scene->mNumMeshes; ++i) {
+        const aiMesh* m = scene->mMeshes[i];
+        if (!m)
+            continue;
+        const QString name = QString::fromUtf8(m->mName.C_Str());
+        if (meshNameLooksLikeLod(name))
+            info.lodMeshCount++;
+
+        MeshStats row;
+        row.name = name.isEmpty() ? QStringLiteral("mesh_%1").arg(i) : name;
+        row.vertexCount = m->mNumVertices;
+        row.triangleCount = m->mNumFaces;
+        row.submeshCount = 1;
+        appendMeshStat(info, row);
+    }
+    finalizeMeshStatsAggregates(info);
+    info.estimatedDrawCalls = scene->mNumMeshes;
+}
+
+static void fillMeshStatsFromOgreMesh(const Ogre::MeshPtr& mesh, const QString& meshLabel,
+                                    AssetInfo& info)
+{
+    if (!mesh)
+        return;
+    MeshStats row;
+    row.name = meshLabel.isEmpty() ? QString::fromStdString(mesh->getName()) : meshLabel;
+    row.submeshCount = mesh->getNumSubMeshes();
+    const bool hasShared = mesh->sharedVertexData != nullptr;
+    if (hasShared && mesh->sharedVertexData)
+        row.vertexCount = mesh->sharedVertexData->vertexCount;
+
+    for (unsigned s = 0; s < mesh->getNumSubMeshes(); ++s) {
+        const Ogre::SubMesh* sm = mesh->getSubMesh(s);
+        if (!sm || !sm->indexData)
+            continue;
+        row.triangleCount += sm->indexData->indexCount / 3;
+        if (!hasShared) {
+            if (sm->vertexData)
+                row.vertexCount += sm->vertexData->vertexCount;
+        } else if (!sm->useSharedVertices && sm->vertexData) {
+            row.vertexCount += sm->vertexData->vertexCount;
+        }
+    }
+    if (meshNameLooksLikeLod(row.name))
+        info.lodMeshCount++;
+    appendMeshStat(info, row);
+    finalizeMeshStatsAggregates(info);
+}
+
+static void fillMeshStatsFromOgreEntities(const QList<Ogre::Entity*>& entities, AssetInfo& info)
+{
+    info.meshStats.clear();
+    info.lodMeshCount = 0;
+    unsigned int drawCalls = 0;
+    for (const Ogre::Entity* entity : entities) {
+        if (!entity)
+            continue;
+        drawCalls += entity->getNumSubEntities();
+        const Ogre::MeshPtr mesh = entity->getMesh();
+        if (!mesh)
+            continue;
+        fillMeshStatsFromOgreMesh(mesh, QString::fromStdString(entity->getName()), info);
+    }
+    info.estimatedDrawCalls = drawCalls;
+    if (info.meshStats.isEmpty())
+        finalizeMeshStatsAggregates(info);
+}
+
+static QString resolveTexturePath(const QString& assetFilePath, const QString& textureRef)
+{
+    if (textureRef.isEmpty())
+        return {};
+    const QFileInfo refFi(textureRef);
+    if (refFi.isAbsolute())
+        return refFi.absoluteFilePath();
+    const QFileInfo assetFi(assetFilePath);
+    const QString besideAsset = QDir(assetFi.absolutePath()).filePath(textureRef);
+    if (QFileInfo::exists(besideAsset))
+        return QFileInfo(besideAsset).absoluteFilePath();
+    return refFi.filePath();
+}
+
+static void probeReferencedTextures(AssetInfo& info, const AssetInspectOptions& options)
+{
+    if (!options.probeTextureFiles)
+        return;
+
+    info.textureStats.clear();
+    info.probedTextureMaxDimension = 0;
+    info.estimatedTextureVramBytes = 0;
+
+    std::set<QString> seen;
+    for (const QString& ref : info.texturePaths) {
+        if (ref.isEmpty() || seen.count(ref) != 0)
+            continue;
+        seen.insert(ref);
+        if (info.textureStats.size() >= AssetInfo::kMaxTextureStatsEntries)
+            break;
+
+        TextureRefStats ts;
+        ts.path = ref;
+        ts.resolvedPath = resolveTexturePath(info.filePath, ref);
+        const QFileInfo fi(ts.resolvedPath);
+        if (!fi.exists() || !fi.isFile()) {
+            ts.missing = true;
+            info.textureStats.append(ts);
+            continue;
+        }
+
+        ts.fileSizeBytes = fi.size();
+        ts.format = fi.suffix().toLower();
+
+        QImageReader reader(ts.resolvedPath);
+        const QSize dim = reader.size();
+        if (dim.isValid() && dim.width() > 0 && dim.height() > 0) {
+            ts.width = dim.width();
+            ts.height = dim.height();
+            const int maxDim = std::max(ts.width, ts.height);
+            info.probedTextureMaxDimension = std::max(info.probedTextureMaxDimension, maxDim);
+            // Estimate only: assumes uncompressed RGBA8 per texel (actual GPU format may differ).
+            info.estimatedTextureVramBytes += static_cast<qint64>(ts.width) * ts.height * 4;
+        }
+
+        info.textureStats.append(ts);
+    }
+
+    if (info.probedTextureMaxDimension > 0)
+        info.maxTextureDimension = std::max(info.maxTextureDimension, info.probedTextureMaxDimension);
+}
+
+static void copyAssetInspectExtensionFields(AssetInfo& dst, const AssetInfo& src)
+{
+    dst.triangleCount = src.triangleCount;
+    dst.submeshCount = src.submeshCount;
+    dst.maxTrianglesPerMesh = src.maxTrianglesPerMesh;
+    dst.meshStats = src.meshStats;
+    dst.textureStats = src.textureStats;
+    dst.probedTextureMaxDimension = src.probedTextureMaxDimension;
+    dst.estimatedTextureVramBytes = src.estimatedTextureVramBytes;
+    dst.estimatedDrawCalls = src.estimatedDrawCalls;
+    dst.lodMeshCount = src.lodMeshCount;
+}
+
+static void finalizeAssetInspect(AssetInfo& info, const AssetInspectOptions& options)
+{
+    syncTriangleDerivedFields(info);
+    probeReferencedTextures(info, options);
+}
 
 bool ensureOgreHeadlessQuiet()
 {
@@ -240,6 +425,11 @@ static void fillAssetInfoFromOgreMesh(AssetInfo& info, const Ogre::MeshPtr& mesh
                 info.materialNames.append(QString::fromStdString(mat));
         }
     }
+
+    info.meshStats.clear();
+    fillMeshStatsFromOgreMesh(mesh, {}, info);
+    syncTriangleDerivedFields(info);
+    info.estimatedDrawCalls = info.submeshCount;
 }
 
 #ifdef QTMESH_UNIT_TESTS
@@ -797,6 +987,9 @@ static bool fillAssetInfoFromAssimpFallback(const QString& filePath, AssetInfo& 
         mat->Get(AI_MATKEY_NAME, n);
         info.materialNames.append(QString::fromUtf8(n.C_Str()));
     }
+
+    fillMeshStatsFromAssimpScene(scene, info);
+    syncTriangleDerivedFields(info);
     return true;
 }
 
@@ -881,6 +1074,9 @@ static bool inspectAssetViaOgre(const QString& filePath, AssetInfo& info,
     info.zeroWeightBoneNames  = zeroWeightBonesForEntities(entities);
     info.overlappingUvsRatio  = overlappingUvsRatioForEntities(entities);
     info.nonManifoldEdgesRatio = nonManifoldEdgesRatioForEntities(entities);
+
+    fillMeshStatsFromOgreEntities(entities, info);
+    syncTriangleDerivedFields(info);
 
     clearOgreSceneForScanImport();
     return true;
@@ -1043,7 +1239,8 @@ bool ScanEngine::isAssimpResultLoadFailure(const aiScene* scene, const char* ass
     return false;
 }
 
-AssetInfo ScanEngine::inspectAsset(const QString& filePath, const QString& scanRoot)
+AssetInfo ScanEngine::inspectAsset(const QString& filePath, const QString& scanRoot,
+                                   const AssetInspectOptions& options)
 {
     AssetInfo info;
     info.filePath = filePath;
@@ -1081,11 +1278,13 @@ AssetInfo ScanEngine::inspectAsset(const QString& filePath, const QString& scanR
         if (gext == QLatin1String("tmd")) {
             loadAndFillOgreInspect(
                 info, [geomPath](const std::string& mn) { return PS1TMD::importTmd(geomPath, mn); }, &detailErr);
+            finalizeAssetInspect(info, options);
             return info;
         }
         if (gext == QLatin1String("ply") && PS1PLY::isPsyqPlyFile(geomPath)) {
             loadAndFillOgreInspect(
                 info, [geomPath](const std::string& mn) { return PS1PLY::importPsyqPly(geomPath, mn); }, &detailErr);
+            finalizeAssetInspect(info, options);
             return info;
         }
         if (gext == QLatin1String("rsd")) {
@@ -1093,7 +1292,7 @@ AssetInfo ScanEngine::inspectAsset(const QString& filePath, const QString& scanR
             info.errorMessage = QStringLiteral("RSD references another RSD as geometry (not supported for scan)");
             return info;
         }
-        AssetInfo inner = ScanEngine::inspectAsset(geomPath, QFileInfo(geomPath).absolutePath());
+        AssetInfo inner = ScanEngine::inspectAsset(geomPath, QFileInfo(geomPath).absolutePath(), options);
         info.loadError = inner.loadError;
         info.errorMessage = inner.errorMessage;
         info.meshCount = inner.meshCount;
@@ -1122,6 +1321,7 @@ AssetInfo ScanEngine::inspectAsset(const QString& filePath, const QString& scanR
         info.zeroWeightBoneNames = inner.zeroWeightBoneNames;
         info.overlappingUvsRatio = inner.overlappingUvsRatio;
         info.nonManifoldEdgesRatio = inner.nonManifoldEdgesRatio;
+        copyAssetInspectExtensionFields(info, inner);
         info.filePath = filePath;
         info.relativePath = QDir(scanRoot).relativeFilePath(filePath);
         info.format = extLower;
@@ -1133,6 +1333,7 @@ AssetInfo ScanEngine::inspectAsset(const QString& filePath, const QString& scanR
         QString detailErr;
         loadAndFillOgreInspect(
             info, [filePath](const std::string& mn) { return PS1TMD::importTmd(filePath, mn); }, &detailErr);
+        finalizeAssetInspect(info, options);
         return info;
     }
 
@@ -1140,6 +1341,7 @@ AssetInfo ScanEngine::inspectAsset(const QString& filePath, const QString& scanR
         QString detailErr;
         loadAndFillOgreInspect(
             info, [filePath](const std::string& mn) { return PS1PLY::importPsyqPly(filePath, mn); }, &detailErr);
+        finalizeAssetInspect(info, options);
         return info;
     }
 
@@ -1162,6 +1364,7 @@ AssetInfo ScanEngine::inspectAsset(const QString& filePath, const QString& scanR
         return info;
     }
 
+    finalizeAssetInspect(info, options);
     return info;
 }
 
@@ -1805,7 +2008,9 @@ void ScanEngine::applyFixes(const ScanConfig& config, const QString& scanRoot, A
                             .arg(savedBytes / 1024)
                             .arg(QString::number(sizePct, 'f', 1));
             f.fixed = true;
-            asset = inspectAsset(asset.filePath, scanRoot);
+            AssetInspectOptions inspectOpts;
+            inspectOpts.probeTextureFiles = config.probeTextureFiles;
+            asset = inspectAsset(asset.filePath, scanRoot, inspectOpts);
         }
     }
 }
@@ -1840,8 +2045,11 @@ ScanResult ScanEngine::run(const ScanConfig& config, const QString& rootOverride
             QString("Scan start: %1").arg(scanRoot));
         QStringList files = enumerateFiles(config, scanRoot);
 
+        AssetInspectOptions inspectOpts;
+        inspectOpts.probeTextureFiles = config.probeTextureFiles;
+
         for (const auto& filePath : files) {
-            AssetInfo asset = inspectAsset(filePath, scanRoot);
+            AssetInfo asset = inspectAsset(filePath, scanRoot, inspectOpts);
             if (asset.loadError)
                 SentryReporter::addBreadcrumb("file.import",
                     QString("Load error: %1 — %2").arg(asset.relativePath, asset.errorMessage));
@@ -2058,6 +2266,15 @@ QJsonObject ScanEngine::scanReportToJsonObject(const ScanResult& result)
         ao["materialCount"]  = static_cast<int>(asset.materialCount);
         ao["vertexCount"]    = static_cast<int>(asset.vertexCount);
         ao["faceCount"]      = static_cast<int>(asset.faceCount);
+        ao["triangleCount"]  = static_cast<int>(asset.triangleCount);
+        if (asset.submeshCount > 0)
+            ao["submeshCount"] = static_cast<int>(asset.submeshCount);
+        if (asset.maxTrianglesPerMesh > 0)
+            ao["maxTrianglesPerMesh"] = static_cast<int>(asset.maxTrianglesPerMesh);
+        if (asset.estimatedDrawCalls > 0)
+            ao["estimatedDrawCalls"] = static_cast<int>(asset.estimatedDrawCalls);
+        if (asset.lodMeshCount > 0)
+            ao["lodMeshCount"] = static_cast<int>(asset.lodMeshCount);
         ao["animationCount"] = static_cast<int>(asset.animationCount);
         ao["hasSkeleton"]    = asset.hasSkeleton;
         ao["boneCount"]      = static_cast<int>(asset.boneCount);
@@ -2094,6 +2311,43 @@ QJsonObject ScanEngine::scanReportToJsonObject(const ScanResult& result)
         // so the JSON stays compact for assets the rule doesn't fire on.
         if (asset.maxTextureDimension > 0)
             ao["maxTextureDimension"] = asset.maxTextureDimension;
+        if (asset.probedTextureMaxDimension > 0)
+            ao["probedTextureMaxDimension"] = asset.probedTextureMaxDimension;
+        if (asset.estimatedTextureVramBytes > 0)
+            ao["estimatedTextureVramBytes"] = asset.estimatedTextureVramBytes;
+        if (!asset.meshStats.isEmpty()) {
+            QJsonArray meshes;
+            for (const MeshStats& ms : asset.meshStats) {
+                QJsonObject mo;
+                mo["name"] = ms.name;
+                mo["vertexCount"] = static_cast<int>(ms.vertexCount);
+                mo["triangleCount"] = static_cast<int>(ms.triangleCount);
+                mo["submeshCount"] = static_cast<int>(ms.submeshCount);
+                meshes.append(mo);
+            }
+            ao["meshStats"] = meshes;
+        }
+        if (!asset.textureStats.isEmpty()) {
+            QJsonArray textures;
+            for (const TextureRefStats& ts : asset.textureStats) {
+                QJsonObject to;
+                to["path"] = ts.path;
+                if (!ts.resolvedPath.isEmpty())
+                    to["resolvedPath"] = ts.resolvedPath;
+                if (ts.width > 0)
+                    to["width"] = ts.width;
+                if (ts.height > 0)
+                    to["height"] = ts.height;
+                if (ts.fileSizeBytes >= 0)
+                    to["fileSizeBytes"] = ts.fileSizeBytes;
+                if (!ts.format.isEmpty())
+                    to["format"] = ts.format;
+                if (ts.missing)
+                    to["missing"] = true;
+                textures.append(to);
+            }
+            ao["textureStats"] = textures;
+        }
         if (asset.minUvChannelCount > 0)
             ao["minUvChannelCount"]   = asset.minUvChannelCount;
         if (!asset.zeroWeightBoneNames.isEmpty()) {

--- a/src/ScanEngine.h
+++ b/src/ScanEngine.h
@@ -32,6 +32,31 @@ struct Finding {
     qint64 keysRemoved = 0;
 };
 
+/// Per-mesh geometry summary (issue #364). Only the first kMaxMeshStatsEntries meshes are stored.
+struct MeshStats {
+    QString name;
+    unsigned int vertexCount = 0;
+    unsigned int triangleCount = 0;
+    unsigned int submeshCount = 0;
+};
+
+/// Filesystem probe of one external texture reference (issue #364).
+struct TextureRefStats {
+    QString path;              // path as referenced in the asset
+    QString resolvedPath;      // absolute path when found on disk
+    int width = 0;
+    int height = 0;
+    qint64 fileSizeBytes = -1;
+    QString format;            // lowercase extension without dot
+    bool missing = false;
+};
+
+/// Options for inspectAsset (issue #364). Heavy texture probing is opt-in via profile metadata.
+struct AssetInspectOptions {
+    /// When true, stat() referenced texture files and read dimensions via QImageReader headers.
+    bool probeTextureFiles = false;
+};
+
 struct AssetInfo {
     QString filePath;       // absolute
     QString relativePath;   // relative to scan root
@@ -43,6 +68,14 @@ struct AssetInfo {
     unsigned int animationCount = 0;
     unsigned int vertexCount = 0;
     unsigned int faceCount = 0;
+    /// Triangulated triangle count (same as faceCount after Assimp triangulation / Ogre indices).
+    unsigned int triangleCount = 0;
+    /// Total submeshes across all meshes/entities in the asset.
+    unsigned int submeshCount = 0;
+    /// Largest triangle count among individual meshes/entities.
+    unsigned int maxTrianglesPerMesh = 0;
+    /// Capped per-mesh breakdown (see kMaxMeshStatsEntries).
+    QList<MeshStats> meshStats;
     unsigned int boneCount = 0;
     unsigned int textureRefCount = 0;
     bool hasSkeleton = false;
@@ -73,6 +106,16 @@ struct AssetInfo {
     // Maximum dimension (max(width, height)) of any texture bound through
     // any SubEntity's material. 0 when the asset has no bound textures.
     int maxTextureDimension = 0;
+    /// Per-texture filesystem probe (issue #364); filled when AssetInspectOptions::probeTextureFiles.
+    QList<TextureRefStats> textureStats;
+    /// Max(width,height) from textureStats probe (0 when not probed or no files found).
+    int probedTextureMaxDimension = 0;
+    /// Rough VRAM estimate from probed textures: sum(width*height*4) per file (RGBA32 heuristic).
+    qint64 estimatedTextureVramBytes = 0;
+    /// Draw-call proxy: Ogre SubEntity count or Assimp mesh count (one batch per submesh/mesh).
+    unsigned int estimatedDrawCalls = 0;
+    /// Meshes whose names look like LOD variants (_lod, LOD1, etc.).
+    unsigned int lodMeshCount = 0;
     // Per-submesh minimum UV-set count. Number of VES_TEXTURE_COORDINATES
     // elements in the vertex declaration of the *least*-equipped submesh.
     // 0 when no submeshes carry UVs at all (or the asset has no entities).
@@ -92,6 +135,11 @@ struct AssetInfo {
 
     bool loadError = false;
     QString errorMessage;
+
+    /// Maximum meshStats entries stored per asset (issue #364).
+    static constexpr int kMaxMeshStatsEntries = 16;
+    /// Maximum textureStats entries stored per asset.
+    static constexpr int kMaxTextureStatsEntries = 32;
 };
 
 struct ScanResult {
@@ -131,7 +179,10 @@ public:
 
     /// Inspect a single asset file (Assimp for most formats; PlayStation TMD / Psy-Q PLY / RSD
     /// use the same Ogre importers as the editor, with a headless render target when needed).
-    static AssetInfo inspectAsset(const QString& filePath, const QString& scanRoot);
+    /// Texture filesystem probes run only when @p options.probeTextureFiles is true (e.g. from
+    /// platform profile metadata `inspect_textures: true`).
+    static AssetInfo inspectAsset(const QString& filePath, const QString& scanRoot,
+                                  const AssetInspectOptions& options = {});
 
     /// After `Assimp::Importer::ReadFile`, whether the result would make `inspectAsset` set
     /// `loadError` (e.g. null scene, or no mesh and no animations). A scene may have

--- a/src/ScanEngine_test.cpp
+++ b/src/ScanEngine_test.cpp
@@ -14,6 +14,8 @@
 #include <QDateTime>
 #include <QDir>
 #include <QFile>
+#include <QImage>
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QTemporaryDir>
 #include <QTemporaryFile>
@@ -899,6 +901,62 @@ TEST(ScanEngineTest, FormatJson_Structure)
     EXPECT_EQ(fromObj, json);
 }
 
+TEST(ScanEngineTest, FormatJson_IncludesAssetInspectExtensionFields)
+{
+    ScanResult result;
+    AssetInfo asset;
+    asset.relativePath = QStringLiteral("hero.fbx");
+    asset.format = QStringLiteral("fbx");
+    asset.triangleCount = 1200;
+    asset.submeshCount = 3;
+    asset.maxTrianglesPerMesh = 800;
+    asset.estimatedDrawCalls = 3;
+    asset.lodMeshCount = 1;
+    asset.probedTextureMaxDimension = 512;
+    asset.estimatedTextureVramBytes = 524288;
+    asset.maxTextureDimension = 512;
+
+    MeshStats meshRow;
+    meshRow.name = QStringLiteral("body");
+    meshRow.vertexCount = 400;
+    meshRow.triangleCount = 800;
+    meshRow.submeshCount = 2;
+    asset.meshStats.append(meshRow);
+
+    TextureRefStats texRow;
+    texRow.path = QStringLiteral("albedo.png");
+    texRow.width = 512;
+    texRow.height = 256;
+    texRow.fileSizeBytes = 65536;
+    texRow.format = QStringLiteral("png");
+    asset.textureStats.append(texRow);
+
+    result.assets.append(asset);
+
+    const QJsonObject root = ScanEngine::scanReportToJsonObject(result);
+    ASSERT_TRUE(root.contains(QStringLiteral("assets")));
+    const QJsonArray assets = root[QStringLiteral("assets")].toArray();
+    ASSERT_EQ(assets.size(), 1);
+    const QJsonObject ao = assets.at(0).toObject();
+    EXPECT_EQ(ao[QStringLiteral("triangleCount")].toInt(), 1200);
+    EXPECT_EQ(ao[QStringLiteral("submeshCount")].toInt(), 3);
+    EXPECT_EQ(ao[QStringLiteral("maxTrianglesPerMesh")].toInt(), 800);
+    EXPECT_EQ(ao[QStringLiteral("estimatedDrawCalls")].toInt(), 3);
+    EXPECT_EQ(ao[QStringLiteral("lodMeshCount")].toInt(), 1);
+    EXPECT_EQ(ao[QStringLiteral("probedTextureMaxDimension")].toInt(), 512);
+    EXPECT_EQ(ao[QStringLiteral("estimatedTextureVramBytes")].toVariant().toLongLong(), 524288);
+
+    ASSERT_TRUE(ao.contains(QStringLiteral("meshStats")));
+    const QJsonArray meshes = ao[QStringLiteral("meshStats")].toArray();
+    ASSERT_EQ(meshes.size(), 1);
+    EXPECT_EQ(meshes.at(0).toObject()[QStringLiteral("name")].toString(), QStringLiteral("body"));
+
+    ASSERT_TRUE(ao.contains(QStringLiteral("textureStats")));
+    const QJsonArray textures = ao[QStringLiteral("textureStats")].toArray();
+    ASSERT_EQ(textures.size(), 1);
+    EXPECT_EQ(textures.at(0).toObject()[QStringLiteral("path")].toString(), QStringLiteral("albedo.png"));
+}
+
 TEST(ScanEngineTest, FormatJson_IncludesAnimationsBonesAndLoadError)
 {
     ScanResult result;
@@ -1699,6 +1757,79 @@ TEST(ScanEngineTest, InspectAsset_ObjParsesGeometryAndTextureReferences)
     EXPECT_GE(info.textureRefCount, 1u);
     EXPECT_TRUE(info.texturePaths.contains("texture.png"));
     EXPECT_FALSE(info.hasEmbeddedTextures);
+    EXPECT_EQ(info.triangleCount, info.faceCount);
+    EXPECT_GE(info.submeshCount, 1u);
+    EXPECT_EQ(info.maxTrianglesPerMesh, info.triangleCount);
+    EXPECT_FALSE(info.meshStats.isEmpty());
+    EXPECT_GE(info.estimatedDrawCalls, 1u);
+    EXPECT_TRUE(info.textureStats.isEmpty());
+    EXPECT_EQ(info.probedTextureMaxDimension, 0);
+}
+
+TEST(ScanEngineTest, InspectAsset_TextureProbePopulatesStatsWhenEnabled)
+{
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+
+    const QString texPath = QDir(tmpDir.path()).filePath("albedo.png");
+    {
+        QImage img(4, 8, QImage::Format_RGB32);
+        img.fill(Qt::red);
+        ASSERT_TRUE(img.save(texPath));
+    }
+
+    QFile mtl(QDir(tmpDir.path()).filePath("mesh.mtl"));
+    ASSERT_TRUE(mtl.open(QIODevice::WriteOnly | QIODevice::Text));
+    mtl.write("newmtl m\nmap_Kd albedo.png\n");
+    mtl.close();
+
+    QFile obj(QDir(tmpDir.path()).filePath("mesh.obj"));
+    ASSERT_TRUE(obj.open(QIODevice::WriteOnly | QIODevice::Text));
+    obj.write(
+        "mtllib mesh.mtl\n"
+        "usemtl m\n"
+        "v 0 0 0\nv 1 0 0\nv 0 1 0\n"
+        "f 1 2 3\n");
+    obj.close();
+
+    AssetInspectOptions opts;
+    opts.probeTextureFiles = true;
+    const AssetInfo info = ScanEngine::inspectAsset(obj.fileName(), tmpDir.path(), opts);
+    ASSERT_FALSE(info.loadError);
+    ASSERT_FALSE(info.textureStats.isEmpty());
+    EXPECT_FALSE(info.textureStats.first().missing);
+    EXPECT_EQ(info.textureStats.first().width, 4);
+    EXPECT_EQ(info.textureStats.first().height, 8);
+    EXPECT_EQ(info.probedTextureMaxDimension, 8);
+    EXPECT_GE(info.estimatedTextureVramBytes, 4 * 8 * 4);
+    EXPECT_GE(info.maxTextureDimension, 8);
+}
+
+TEST(ScanEngineTest, InspectAsset_TextureProbeSkippedByDefault)
+{
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+
+    const QString texPath = QDir(tmpDir.path()).filePath("albedo.png");
+    {
+        QImage img(2, 2, QImage::Format_RGB32);
+        img.fill(Qt::blue);
+        ASSERT_TRUE(img.save(texPath));
+    }
+
+    QFile mtl(QDir(tmpDir.path()).filePath("mesh.mtl"));
+    ASSERT_TRUE(mtl.open(QIODevice::WriteOnly | QIODevice::Text));
+    mtl.write("newmtl m\nmap_Kd albedo.png\n");
+    mtl.close();
+
+    const QString objPath = writeMinimalObj(tmpDir.path(), "mesh.obj");
+    ASSERT_FALSE(objPath.isEmpty());
+
+    const AssetInfo info = ScanEngine::inspectAsset(objPath, tmpDir.path());
+    ASSERT_FALSE(info.loadError);
+    EXPECT_TRUE(info.textureStats.isEmpty());
+    EXPECT_EQ(info.probedTextureMaxDimension, 0);
+    EXPECT_EQ(info.estimatedTextureVramBytes, 0);
 }
 
 TEST(ScanEngineTest, InspectAsset_AnimatedFixtureCollectsAnimationMetadata)

--- a/src/ScanEngine_test.cpp
+++ b/src/ScanEngine_test.cpp
@@ -1822,11 +1822,18 @@ TEST(ScanEngineTest, InspectAsset_TextureProbeSkippedByDefault)
     mtl.write("newmtl m\nmap_Kd albedo.png\n");
     mtl.close();
 
-    const QString objPath = writeMinimalObj(tmpDir.path(), "mesh.obj");
-    ASSERT_FALSE(objPath.isEmpty());
+    QFile obj(QDir(tmpDir.path()).filePath("mesh.obj"));
+    ASSERT_TRUE(obj.open(QIODevice::WriteOnly | QIODevice::Text));
+    obj.write(
+        "mtllib mesh.mtl\n"
+        "usemtl m\n"
+        "v 0 0 0\nv 1 0 0\nv 0 1 0\n"
+        "f 1 2 3\n");
+    obj.close();
 
-    const AssetInfo info = ScanEngine::inspectAsset(objPath, tmpDir.path());
+    const AssetInfo info = ScanEngine::inspectAsset(obj.fileName(), tmpDir.path());
     ASSERT_FALSE(info.loadError);
+    EXPECT_GE(info.textureRefCount, 1u);
     EXPECT_TRUE(info.textureStats.isEmpty());
     EXPECT_EQ(info.probedTextureMaxDimension, 0);
     EXPECT_EQ(info.estimatedTextureVramBytes, 0);


### PR DESCRIPTION
## Summary

- Extends `AssetInfo` / `inspectAsset` with triangle counts, per-mesh stats (capped), draw-call proxy, LOD mesh hints, and optional filesystem texture metadata (dimensions, file size, VRAM estimate).
- Texture probing is **opt-in** via platform profile metadata `inspect_textures: true` (or `--profile` / `--target example-texture-inspect`).
- JSON scan reports export the new fields for downstream platform-profile tooling.

## Test plan

- [x] `ScanEngineTest.InspectAsset_*` (geometry, texture probe on/off)
- [x] `ScanEngineTest.FormatJson_IncludesAssetInspectExtensionFields`
- [x] `ApplyPlatformProfileTest.MetadataInspectTexturesEnablesProbe`
- [x] `PlatformProfileLoaderTest.BuiltinExampleTextureInspectProfileEnablesProbe`
- [ ] CI Linux unit tests (Xvfb)

Closes #364


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Texture file inspection now available during asset scanning with configurable behavior.
  * Asset reports expanded with texture dimensions, VRAM estimates, draw-call counts, and mesh statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->