### PR TITLE
feat(scan): budget rules for triangles, bones, and textures (#365)

### DIFF
--- a/profiles/example-budget.json
+++ b/profiles/example-budget.json
@@ -1,0 +1,19 @@
+{
+  "id": "example-budget",
+  "displayName": "Example Budget",
+  "description": "Sample retro-style triangle, bone, texture, and draw-call budgets (issue #365).",
+  "extends": "example-texture-inspect",
+  "rules": {
+    "max_triangle_count": 50000,
+    "max_triangles_per_mesh": 20000,
+    "max_bones": 64,
+    "max_submesh_count": 8,
+    "max_draw_calls": 16,
+    "max_texture_dimension": 512,
+    "texture_not_power_of_two": true,
+    "allowed_texture_formats": ["png", "jpg"]
+  },
+  "metadata": {
+    "category": "example"
+  }
+}

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -603,6 +603,11 @@ void CLIPipeline::printUsage()
         "  --min-materials <n>       Override min_material_count (0 = no limit)\n"
         "  --max-vertices <n>        Override max_vertex_count (0 = no limit)\n"
         "  --min-vertices <n>        Override min_vertex_count (0 = no limit)\n"
+        "  --max-triangles <n>       Override max_triangle_count (0 = no limit)\n"
+        "  --max-triangles-per-mesh <n>  Override max_triangles_per_mesh (0 = no limit)\n"
+        "  --max-bones <n>           Override max_bones (0 = no limit)\n"
+        "  --max-submeshes <n>       Override max_submesh_count (0 = no limit)\n"
+        "  --max-draw-calls <n>      Override max_draw_calls (0 = no limit)\n"
         "  --max-acmr <n>            Override max_acmr (0 = no limit, e.g. 1.5)\n"
         "  --require-skeleton / --no-require-skeleton\n"
         "                            Override require_skeleton\n"
@@ -622,8 +627,17 @@ void CLIPipeline::printUsage()
         "  --require-animation-names <list> Required animation names/patterns CSV\n"
         "  --require-bone-names <list> Required bone names/patterns CSV\n"
         "\n"
-        "  Quality rules (config only — set in qtmesh.yml):\n"
+        "  Quality / budget rules (config or --target profile — set in qtmesh.yml):\n"
+        "    max_triangle_count: <n>           File-level triangle budget\n"
+        "    max_triangles_per_mesh: <n>       Per-mesh triangle ceiling\n"
+        "    max_bones: <n>                    Skeleton bone budget\n"
+        "    max_submesh_count: <n>            Submesh / material-split ceiling\n"
+        "    max_draw_calls: <n>               Estimated draw-call ceiling\n"
         "    max_texture_resolution: <px>      Largest texture edge ceiling (e.g. 2048)\n"
+        "    max_texture_dimension: <px>       Alias for max_texture_resolution\n"
+        "    texture_not_power_of_two: true     Warn on non-POT textures (needs inspect_textures)\n"
+        "    allowed_texture_formats: [png,jpg]  Texture extension allow-list\n"
+        "    disallowed_texture_formats: [tga]   Blocklisted texture extensions\n"
         "    require_uv_channels: <n>          Min UV sets per submesh (1=any, 2=lightmap)\n"
         "    detect_zero_weight_bones: true    Flag Mixamo-style unused bones (info)\n"
         "    detect_overlapping_uvs_pct: <n>   Warn at >= n% overlapping UV0 AABBs\n"
@@ -3826,6 +3840,11 @@ int CLIPipeline::cmdScan(int argc, char* argv[])
 
     int maxVerticesOverride = -1;
     int minVerticesOverride = -1;
+    int maxTrianglesOverride = -1;
+    int maxTrianglesPerMeshOverride = -1;
+    int maxBonesOverride = -1;
+    int maxSubmeshesOverride = -1;
+    int maxDrawCallsOverride = -1;
     double maxAcmrOverride = -1.0;
     int maxMeshesOverride = -1;
     int minMeshesOverride = -1;
@@ -3983,6 +4002,36 @@ int CLIPipeline::cmdScan(int argc, char* argv[])
         if (parseResult == ParseValueResult::Error) return 2;
         if (parseResult == ParseValueResult::Matched) {
             if (!parseNonNegativeDouble("--max-acmr", value, maxAcmrOverride)) return 2;
+            continue;
+        }
+        parseResult = parseValueArg(arg, "--max-triangles", i, value);
+        if (parseResult == ParseValueResult::Error) return 2;
+        if (parseResult == ParseValueResult::Matched) {
+            if (!parseNonNegativeInt("--max-triangles", value, maxTrianglesOverride)) return 2;
+            continue;
+        }
+        parseResult = parseValueArg(arg, "--max-triangles-per-mesh", i, value);
+        if (parseResult == ParseValueResult::Error) return 2;
+        if (parseResult == ParseValueResult::Matched) {
+            if (!parseNonNegativeInt("--max-triangles-per-mesh", value, maxTrianglesPerMeshOverride)) return 2;
+            continue;
+        }
+        parseResult = parseValueArg(arg, "--max-bones", i, value);
+        if (parseResult == ParseValueResult::Error) return 2;
+        if (parseResult == ParseValueResult::Matched) {
+            if (!parseNonNegativeInt("--max-bones", value, maxBonesOverride)) return 2;
+            continue;
+        }
+        parseResult = parseValueArg(arg, "--max-submeshes", i, value);
+        if (parseResult == ParseValueResult::Error) return 2;
+        if (parseResult == ParseValueResult::Matched) {
+            if (!parseNonNegativeInt("--max-submeshes", value, maxSubmeshesOverride)) return 2;
+            continue;
+        }
+        parseResult = parseValueArg(arg, "--max-draw-calls", i, value);
+        if (parseResult == ParseValueResult::Error) return 2;
+        if (parseResult == ParseValueResult::Matched) {
+            if (!parseNonNegativeInt("--max-draw-calls", value, maxDrawCallsOverride)) return 2;
             continue;
         }
         parseResult = parseValueArg(arg, "--max-meshes", i, value);
@@ -4201,6 +4250,11 @@ int CLIPipeline::cmdScan(int argc, char* argv[])
     if (minMaterialsOverride >= 0) config.minMaterialCount = minMaterialsOverride;
     if (maxVerticesOverride >= 0) config.maxVertexCount = maxVerticesOverride;
     if (minVerticesOverride >= 0) config.minVertexCount = minVerticesOverride;
+    if (maxTrianglesOverride >= 0) config.maxTriangleCount = maxTrianglesOverride;
+    if (maxTrianglesPerMeshOverride >= 0) config.maxTrianglesPerMesh = maxTrianglesPerMeshOverride;
+    if (maxBonesOverride >= 0) config.maxBoneCount = maxBonesOverride;
+    if (maxSubmeshesOverride >= 0) config.maxSubmeshCount = maxSubmeshesOverride;
+    if (maxDrawCallsOverride >= 0) config.maxDrawCalls = maxDrawCallsOverride;
     if (maxAcmrOverride >= 0.0)   config.maxAcmr        = maxAcmrOverride;
     if (maxAnimKeyframesOverride >= 0) config.maxAnimKeyframes = maxAnimKeyframesOverride;
     if (minAnimKeyframesOverride >= 0) config.minAnimKeyframes = minAnimKeyframesOverride;
@@ -4241,6 +4295,11 @@ int CLIPipeline::cmdScan(int argc, char* argv[])
     if (minMaterialsOverride >= 0)             cliRuleOverrides["min_material_count"] = config.minMaterialCount;
     if (maxVerticesOverride >= 0)              cliRuleOverrides["max_vertex_count"] = config.maxVertexCount;
     if (minVerticesOverride >= 0)              cliRuleOverrides["min_vertex_count"] = config.minVertexCount;
+    if (maxTrianglesOverride >= 0)             cliRuleOverrides["max_triangle_count"] = config.maxTriangleCount;
+    if (maxTrianglesPerMeshOverride >= 0)      cliRuleOverrides["max_triangles_per_mesh"] = config.maxTrianglesPerMesh;
+    if (maxBonesOverride >= 0)                 cliRuleOverrides["max_bones"] = config.maxBoneCount;
+    if (maxSubmeshesOverride >= 0)            cliRuleOverrides["max_submesh_count"] = config.maxSubmeshCount;
+    if (maxDrawCallsOverride >= 0)             cliRuleOverrides["max_draw_calls"] = config.maxDrawCalls;
     if (maxAnimKeyframesOverride >= 0)         cliRuleOverrides["max_anim_keyframes"] = config.maxAnimKeyframes;
     if (minAnimKeyframesOverride >= 0)         cliRuleOverrides["min_anim_keyframes"] = config.minAnimKeyframes;
     if (maxAnimDurationOverride >= 0.0)        cliRuleOverrides["max_anim_duration"] = config.maxAnimDuration;

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -4295,6 +4295,7 @@ int CLIPipeline::cmdScan(int argc, char* argv[])
     if (minMaterialsOverride >= 0)             cliRuleOverrides["min_material_count"] = config.minMaterialCount;
     if (maxVerticesOverride >= 0)              cliRuleOverrides["max_vertex_count"] = config.maxVertexCount;
     if (minVerticesOverride >= 0)              cliRuleOverrides["min_vertex_count"] = config.minVertexCount;
+    if (maxAcmrOverride >= 0.0)                cliRuleOverrides["max_acmr"] = config.maxAcmr;
     if (maxTrianglesOverride >= 0)             cliRuleOverrides["max_triangle_count"] = config.maxTriangleCount;
     if (maxTrianglesPerMeshOverride >= 0)      cliRuleOverrides["max_triangles_per_mesh"] = config.maxTrianglesPerMesh;
     if (maxBonesOverride >= 0)                 cliRuleOverrides["max_bones"] = config.maxBoneCount;

--- a/src/PlatformProfile.cpp
+++ b/src/PlatformProfile.cpp
@@ -141,6 +141,15 @@ QStringList PlatformProfileLoader::knownRuleKeys()
         QStringLiteral("detect_zero_weight_bones"),
         QStringLiteral("detect_overlapping_uvs_pct"),
         QStringLiteral("detect_non_manifold_edges_pct"),
+        QStringLiteral("max_triangle_count"),
+        QStringLiteral("max_triangles_per_mesh"),
+        QStringLiteral("max_bones"),
+        QStringLiteral("max_submesh_count"),
+        QStringLiteral("max_draw_calls"),
+        QStringLiteral("max_texture_dimension"),
+        QStringLiteral("texture_not_power_of_two"),
+        QStringLiteral("allowed_texture_formats"),
+        QStringLiteral("disallowed_texture_formats"),
     };
 }
 

--- a/src/PlatformProfile_test.cpp
+++ b/src/PlatformProfile_test.cpp
@@ -206,15 +206,28 @@ TEST(PlatformProfileLoaderTest, BuiltinExampleBudgetProfileLoadsRules)
         PlatformProfileLoader::load(QStringLiteral("example-budget"));
     ASSERT_TRUE(loaded.ok) << loaded.error.toStdString();
     EXPECT_EQ(loaded.profile.rules.value(QStringLiteral("max_triangle_count")).toInt(), 50000);
+    EXPECT_EQ(loaded.profile.rules.value(QStringLiteral("max_triangles_per_mesh")).toInt(), 20000);
     EXPECT_EQ(loaded.profile.rules.value(QStringLiteral("max_bones")).toInt(), 64);
+    EXPECT_EQ(loaded.profile.rules.value(QStringLiteral("max_submesh_count")).toInt(), 8);
+    EXPECT_EQ(loaded.profile.rules.value(QStringLiteral("max_draw_calls")).toInt(), 16);
+    EXPECT_EQ(loaded.profile.rules.value(QStringLiteral("max_texture_dimension")).toInt(), 512);
+    EXPECT_TRUE(loaded.profile.rules.value(QStringLiteral("texture_not_power_of_two")).toBool());
+    EXPECT_EQ(loaded.profile.rules.value(QStringLiteral("allowed_texture_formats")).toStringList(),
+              (QStringList{QStringLiteral("png"), QStringLiteral("jpg")}));
     EXPECT_TRUE(loaded.profile.metadata.value(QStringLiteral("inspect_textures")).toBool());
 
     ScanConfig config = ScanConfig::defaults();
     applyPlatformProfile(config, loaded.profile);
     EXPECT_EQ(config.maxTriangleCount, 50000);
+    EXPECT_EQ(config.maxTrianglesPerMesh, 20000);
     EXPECT_EQ(config.maxBoneCount, 64);
+    EXPECT_EQ(config.maxSubmeshCount, 8);
+    EXPECT_EQ(config.maxDrawCalls, 16);
+    EXPECT_EQ(config.maxTextureResolution, 512);
     EXPECT_TRUE(config.probeTextureFiles);
     EXPECT_TRUE(config.requireTexturePowerOfTwo);
+    EXPECT_EQ(config.allowedTextureFormats,
+              (QStringList{QStringLiteral("png"), QStringLiteral("jpg")}));
 }
 
 TEST(PlatformProfileLoaderTest, BuiltinExampleTextureInspectProfileEnablesProbe)

--- a/src/PlatformProfile_test.cpp
+++ b/src/PlatformProfile_test.cpp
@@ -200,6 +200,23 @@ TEST(ApplyPlatformProfileTest, MetadataInspectTexturesEnablesProbe)
     EXPECT_TRUE(config.probeTextureFiles);
 }
 
+TEST(PlatformProfileLoaderTest, BuiltinExampleBudgetProfileLoadsRules)
+{
+    const PlatformProfileLoadResult loaded =
+        PlatformProfileLoader::load(QStringLiteral("example-budget"));
+    ASSERT_TRUE(loaded.ok) << loaded.error.toStdString();
+    EXPECT_EQ(loaded.profile.rules.value(QStringLiteral("max_triangle_count")).toInt(), 50000);
+    EXPECT_EQ(loaded.profile.rules.value(QStringLiteral("max_bones")).toInt(), 64);
+    EXPECT_TRUE(loaded.profile.metadata.value(QStringLiteral("inspect_textures")).toBool());
+
+    ScanConfig config = ScanConfig::defaults();
+    applyPlatformProfile(config, loaded.profile);
+    EXPECT_EQ(config.maxTriangleCount, 50000);
+    EXPECT_EQ(config.maxBoneCount, 64);
+    EXPECT_TRUE(config.probeTextureFiles);
+    EXPECT_TRUE(config.requireTexturePowerOfTwo);
+}
+
 TEST(PlatformProfileLoaderTest, BuiltinExampleTextureInspectProfileEnablesProbe)
 {
     const PlatformProfileLoadResult loaded =

--- a/src/ScanConfig.cpp
+++ b/src/ScanConfig.cpp
@@ -306,8 +306,8 @@ void ScanConfig::applyRuleOverrides(const QVariantMap& r)
         allowedTextureFormats = r["allowed_texture_formats"].toStringList();
     if (r.contains("disallowed_texture_formats"))
         disallowedTextureFormats = r["disallowed_texture_formats"].toStringList();
-    // Alias for max_texture_resolution (issue #365 naming)
-    if (r.contains("max_texture_dimension"))
+    // Alias for max_texture_resolution (issue #365 naming); canonical key wins when both present.
+    if (r.contains("max_texture_dimension") && !r.contains("max_texture_resolution"))
         maxTextureResolution = r["max_texture_dimension"].toInt();
 }
 

--- a/src/ScanConfig.cpp
+++ b/src/ScanConfig.cpp
@@ -289,6 +289,26 @@ void ScanConfig::applyRuleOverrides(const QVariantMap& r)
         detectOverlappingUvsPct = r["detect_overlapping_uvs_pct"].toDouble();
     if (r.contains("detect_non_manifold_edges_pct"))
         detectNonManifoldEdgesPct = r["detect_non_manifold_edges_pct"].toDouble();
+    // Budget rules (#365)
+    if (r.contains("max_triangle_count"))
+        maxTriangleCount = r["max_triangle_count"].toInt();
+    if (r.contains("max_triangles_per_mesh"))
+        maxTrianglesPerMesh = r["max_triangles_per_mesh"].toInt();
+    if (r.contains("max_bones"))
+        maxBoneCount = r["max_bones"].toInt();
+    if (r.contains("max_submesh_count"))
+        maxSubmeshCount = r["max_submesh_count"].toInt();
+    if (r.contains("max_draw_calls"))
+        maxDrawCalls = r["max_draw_calls"].toInt();
+    if (r.contains("texture_not_power_of_two"))
+        requireTexturePowerOfTwo = r["texture_not_power_of_two"].toBool();
+    if (r.contains("allowed_texture_formats"))
+        allowedTextureFormats = r["allowed_texture_formats"].toStringList();
+    if (r.contains("disallowed_texture_formats"))
+        disallowedTextureFormats = r["disallowed_texture_formats"].toStringList();
+    // Alias for max_texture_resolution (issue #365 naming)
+    if (r.contains("max_texture_dimension"))
+        maxTextureResolution = r["max_texture_dimension"].toInt();
 }
 
 ScanConfig ScanConfig::withScopeOverrides(const QString& relativePath) const
@@ -452,50 +472,9 @@ void ScanConfig::applyProjectConfig(ScanConfig& config, const QVariantMap& root)
     }
 
     // rules section
-    QVariantMap rules = root.value("rules").toMap();
-    if (!rules.isEmpty()) {
-        if (rules.contains("allowed_formats"))
-            config.allowedFormats = rules.value("allowed_formats").toStringList();
-        if (rules.contains("forbidden_extensions"))
-            config.forbiddenExtensions = rules.value("forbidden_extensions").toStringList();
-        config.maxFileSizeMb         = rules.value("max_file_size_mb",         config.maxFileSizeMb).toDouble();
-        config.minFileSizeMb         = rules.value("min_file_size_mb",         config.minFileSizeMb).toDouble();
-        config.maxMeshCount          = rules.value("max_mesh_count",           config.maxMeshCount).toInt();
-        config.minMeshCount          = rules.value("min_mesh_count",           config.minMeshCount).toInt();
-        config.maxMaterialCount      = rules.value("max_material_count",       config.maxMaterialCount).toInt();
-        config.minMaterialCount      = rules.value("min_material_count",       config.minMaterialCount).toInt();
-        config.maxVertexCount        = rules.value("max_vertex_count",         config.maxVertexCount).toInt();
-        config.minVertexCount        = rules.value("min_vertex_count",         config.minVertexCount).toInt();
-        config.maxAcmr               = rules.value("max_acmr",                 config.maxAcmr).toDouble();
-        config.requireSkeleton       = rules.value("require_skeleton",         config.requireSkeleton).toBool();
-        config.requireAnimations     = rules.value("require_animations",       config.requireAnimations).toBool();
-        config.allowEmbeddedTextures = rules.value("allow_embedded_textures",  config.allowEmbeddedTextures).toBool();
-        config.requireTexturesExist  = rules.value("require_textures_exist",   config.requireTexturesExist).toBool();
-        config.allowMissingMaterials = rules.value("allow_missing_materials",  config.allowMissingMaterials).toBool();
-        config.fileNameCase          = rules.value("file_name_case",           config.fileNameCase).toString();
-        config.maxAnimKeyframes      = rules.value("max_anim_keyframes",       config.maxAnimKeyframes).toInt();
-        config.minAnimKeyframes      = rules.value("min_anim_keyframes",       config.minAnimKeyframes).toInt();
-        config.maxAnimDuration       = rules.value("max_anim_duration",        config.maxAnimDuration).toDouble();
-        config.minAnimDuration       = rules.value("min_anim_duration",        config.minAnimDuration).toDouble();
-        if (rules.contains("require_animation_names"))
-            config.requireAnimationNames = rules.value("require_animation_names").toStringList();
-        if (rules.contains("require_bone_names"))
-            config.requireBoneNames = rules.value("require_bone_names").toStringList();
-        config.redundantKeyframesPctThreshold = rules.value(
-            "redundant_keyframes_pct", config.redundantKeyframesPctThreshold).toDouble();
-        config.redundantKeyframesTranslationTol = rules.value(
-            "redundant_keyframes_translation_tol", config.redundantKeyframesTranslationTol).toDouble();
-        config.redundantKeyframesRotationDegTol = rules.value(
-            "redundant_keyframes_rotation_deg_tol", config.redundantKeyframesRotationDegTol).toDouble();
-        config.redundantKeyframesScaleTol = rules.value(
-            "redundant_keyframes_scale_tol", config.redundantKeyframesScaleTol).toDouble();
-        // C4 quality rules
-        config.maxTextureResolution    = rules.value("max_texture_resolution",    config.maxTextureResolution).toInt();
-        config.requireUvChannels       = rules.value("require_uv_channels",       config.requireUvChannels).toInt();
-        config.detectZeroWeightBones   = rules.value("detect_zero_weight_bones",  config.detectZeroWeightBones).toBool();
-        config.detectOverlappingUvsPct = rules.value("detect_overlapping_uvs_pct",  config.detectOverlappingUvsPct).toDouble();
-        config.detectNonManifoldEdgesPct = rules.value("detect_non_manifold_edges_pct", config.detectNonManifoldEdgesPct).toDouble();
-    }
+    const QVariantMap rules = root.value("rules").toMap();
+    if (!rules.isEmpty())
+        config.applyRuleOverrides(rules);
 
     // scopes section — map of path patterns to rule override maps
     // Use _order key (if present) to preserve YAML declaration order,

--- a/src/ScanConfig.h
+++ b/src/ScanConfig.h
@@ -106,6 +106,16 @@ struct ScanConfig {
     // inspect (issue #364) — enabled via platform profile metadata `inspect_textures: true`
     bool probeTextureFiles = false;
 
+    // Budget rules (issue #365) — retro / platform profile triangle, bone, texture, draw-call limits.
+    int maxTriangleCount = 0;         // 0 = disabled; file-level tri count
+    int maxTrianglesPerMesh = 0;      // 0 = disabled; worst single mesh/entity
+    int maxBoneCount = 0;             // 0 = disabled
+    int maxSubmeshCount = 0;          // 0 = disabled; draw-call proxy (material splits)
+    int maxDrawCalls = 0;             // 0 = disabled; estimated SubEntity draw calls
+    bool requireTexturePowerOfTwo = false;
+    QStringList allowedTextureFormats;    // empty = any (e.g. png, jpg)
+    QStringList disallowedTextureFormats; // e.g. tga, bmp — checked when textureStats populated
+
     // scoped rules — path-specific overrides
     QList<ScanScope> scopes;
 

--- a/src/ScanConfig_test.cpp
+++ b/src/ScanConfig_test.cpp
@@ -503,6 +503,15 @@ TEST(ScanConfigApplyOverridesTest, ApplyRuleOverridesAffectsAllFields)
     r["detect_zero_weight_bones"]    = true;
     r["detect_overlapping_uvs_pct"]  = 2.0;
     r["detect_non_manifold_edges_pct"] = 0.5;
+    r["max_triangle_count"]            = 12000;
+    r["max_triangles_per_mesh"]        = 8000;
+    r["max_bones"]                     = 64;
+    r["max_submesh_count"]             = 8;
+    r["max_draw_calls"]                = 16;
+    r["texture_not_power_of_two"]      = true;
+    r["allowed_texture_formats"]       = QStringList{QStringLiteral("png")};
+    r["disallowed_texture_formats"]    = QStringList{QStringLiteral("tga")};
+    r["max_texture_dimension"]         = 1024;
 
     cfg.applyRuleOverrides(r);
     EXPECT_DOUBLE_EQ(cfg.maxFileSizeMb, 99.0);
@@ -532,11 +541,20 @@ TEST(ScanConfigApplyOverridesTest, ApplyRuleOverridesAffectsAllFields)
     EXPECT_DOUBLE_EQ(cfg.redundantKeyframesTranslationTol, 1e-2);
     EXPECT_DOUBLE_EQ(cfg.redundantKeyframesRotationDegTol, 0.5);
     EXPECT_DOUBLE_EQ(cfg.redundantKeyframesScaleTol, 1e-2);
-    EXPECT_EQ(cfg.maxTextureResolution, 2048);
     EXPECT_EQ(cfg.requireUvChannels, 1);
     EXPECT_TRUE(cfg.detectZeroWeightBones);
     EXPECT_DOUBLE_EQ(cfg.detectOverlappingUvsPct, 2.0);
     EXPECT_DOUBLE_EQ(cfg.detectNonManifoldEdgesPct, 0.5);
+    EXPECT_EQ(cfg.maxTriangleCount, 12000);
+    EXPECT_EQ(cfg.maxTrianglesPerMesh, 8000);
+    EXPECT_EQ(cfg.maxBoneCount, 64);
+    EXPECT_EQ(cfg.maxSubmeshCount, 8);
+    EXPECT_EQ(cfg.maxDrawCalls, 16);
+    EXPECT_TRUE(cfg.requireTexturePowerOfTwo);
+    EXPECT_EQ(cfg.allowedTextureFormats, (QStringList{QStringLiteral("png")}));
+    EXPECT_EQ(cfg.disallowedTextureFormats, (QStringList{QStringLiteral("tga")}));
+    // max_texture_dimension alias overrides max_texture_resolution when both are set.
+    EXPECT_EQ(cfg.maxTextureResolution, 1024);
 }
 
 TEST(ScanConfigApplyOverridesTest, ApplyRuleOverridesIgnoresUnknownKeys)

--- a/src/ScanConfig_test.cpp
+++ b/src/ScanConfig_test.cpp
@@ -553,7 +553,16 @@ TEST(ScanConfigApplyOverridesTest, ApplyRuleOverridesAffectsAllFields)
     EXPECT_TRUE(cfg.requireTexturePowerOfTwo);
     EXPECT_EQ(cfg.allowedTextureFormats, (QStringList{QStringLiteral("png")}));
     EXPECT_EQ(cfg.disallowedTextureFormats, (QStringList{QStringLiteral("tga")}));
-    // max_texture_dimension alias overrides max_texture_resolution when both are set.
+    // Canonical max_texture_resolution wins when both keys are in the same override set.
+    EXPECT_EQ(cfg.maxTextureResolution, 2048);
+}
+
+TEST(ScanConfigApplyOverridesTest, MaxTextureDimensionAliasUsedWhenCanonicalAbsent)
+{
+    ScanConfig cfg = ScanConfig::defaults();
+    QVariantMap r;
+    r["max_texture_dimension"] = 1024;
+    cfg.applyRuleOverrides(r);
     EXPECT_EQ(cfg.maxTextureResolution, 1024);
 }
 

--- a/src/ScanEngine.cpp
+++ b/src/ScanEngine.cpp
@@ -1443,6 +1443,33 @@ QString ScanEngine::convertNameToCase(const QString& fileName, const QString& co
 // Rule evaluation
 // ---------------------------------------------------------------------------
 
+namespace {
+
+bool isPowerOfTwoDimension(int value)
+{
+    return value > 0 && (value & (value - 1)) == 0;
+}
+
+int effectiveTextureMaxDimension(const AssetInfo& asset)
+{
+    return std::max(asset.maxTextureDimension, asset.probedTextureMaxDimension);
+}
+
+bool textureFormatMatchesList(const QString& format, const QStringList& patterns)
+{
+    if (format.isEmpty())
+        return false;
+    for (const QString& pattern : patterns) {
+        if (pattern.isEmpty())
+            continue;
+        if (format.compare(pattern, Qt::CaseInsensitive) == 0)
+            return true;
+    }
+    return false;
+}
+
+} // namespace
+
 QList<Finding> ScanEngine::evaluateRules(const AssetInfo& asset, const ScanConfig& globalConfig)
 {
     // Apply scoped rule overrides for this asset's path
@@ -1524,6 +1551,42 @@ QList<Finding> ScanEngine::evaluateRules(const AssetInfo& asset, const ScanConfi
                          QString("%1 vertices is below minimum of %2")
                              .arg(asset.vertexCount).arg(config.minVertexCount)});
 
+    // ---- max_triangle_count / max_triangles_per_mesh ---- (issue #365)
+    if (config.maxTriangleCount > 0
+        && static_cast<int>(asset.triangleCount) > config.maxTriangleCount) {
+        findings.append({asset.relativePath, "max_triangle_count", Severity::Error,
+                         QString("%1 triangles exceeds limit of %2")
+                             .arg(asset.triangleCount).arg(config.maxTriangleCount)});
+    }
+    if (config.maxTrianglesPerMesh > 0
+        && static_cast<int>(asset.maxTrianglesPerMesh) > config.maxTrianglesPerMesh) {
+        findings.append({asset.relativePath, "max_triangles_per_mesh", Severity::Error,
+                         QString("Largest mesh has %1 triangles (limit %2)")
+                             .arg(asset.maxTrianglesPerMesh).arg(config.maxTrianglesPerMesh)});
+    }
+
+    // ---- max_bones ----
+    if (config.maxBoneCount > 0 && static_cast<int>(asset.boneCount) > config.maxBoneCount) {
+        findings.append({asset.relativePath, "max_bones", Severity::Error,
+                         QString("%1 bones exceeds limit of %2")
+                             .arg(asset.boneCount).arg(config.maxBoneCount)});
+    }
+
+    // ---- max_submesh_count / max_draw_calls ---- (draw-call proxies)
+    if (config.maxSubmeshCount > 0
+        && static_cast<int>(asset.submeshCount) > config.maxSubmeshCount) {
+        findings.append({asset.relativePath, "max_submesh_count", Severity::Warning,
+                         QString("%1 submeshes exceeds limit of %2 — merge materials or "
+                                 "combine meshes to cut draw calls")
+                             .arg(asset.submeshCount).arg(config.maxSubmeshCount)});
+    }
+    if (config.maxDrawCalls > 0
+        && static_cast<int>(asset.estimatedDrawCalls) > config.maxDrawCalls) {
+        findings.append({asset.relativePath, "max_draw_calls", Severity::Warning,
+                         QString("Estimated %1 draw calls exceeds limit of %2")
+                             .arg(asset.estimatedDrawCalls).arg(config.maxDrawCalls)});
+    }
+
     // ---- max_acmr ---- (Phase 6 slice C / C2)
     //
     // ACMR is measured on the same Ogre index buffer the editor's in-app
@@ -1568,14 +1631,75 @@ QList<Finding> ScanEngine::evaluateRules(const AssetInfo& asset, const ScanConfi
         }
     }
 
-    // ---- max_texture_resolution ---- (Phase 6 slice C4)
-    if (config.maxTextureResolution > 0
-        && asset.maxTextureDimension > config.maxTextureResolution) {
-        findings.append({asset.relativePath, "max_texture_resolution", Severity::Warning,
-            QString("Largest texture is %1px on its longest edge — exceeds limit of %2px. "
-                    "Downscale or pack with `qtmesh pack-textures` to reduce VRAM cost.")
-                .arg(asset.maxTextureDimension)
-                .arg(config.maxTextureResolution)});
+    // ---- max_texture_resolution / max_texture_dimension ---- (Phase 6 slice C4 + #365)
+    if (config.maxTextureResolution > 0) {
+        const int texMax = effectiveTextureMaxDimension(asset);
+        if (texMax > config.maxTextureResolution) {
+            findings.append({asset.relativePath, "max_texture_resolution", Severity::Warning,
+                QString("Largest texture is %1px on its longest edge — exceeds limit of %2px. "
+                        "Downscale or pack with `qtmesh pack-textures` to reduce VRAM cost.")
+                    .arg(texMax)
+                    .arg(config.maxTextureResolution)});
+        }
+    }
+
+    // ---- texture_not_power_of_two / texture format allow-list ---- (#365)
+    // Requires inspect_textures / probeTextureFiles so textureStats carry dimensions.
+    if (!asset.textureStats.isEmpty()) {
+        if (config.requireTexturePowerOfTwo) {
+            QStringList offenders;
+            for (const TextureRefStats& ts : asset.textureStats) {
+                if (ts.missing || ts.width <= 0 || ts.height <= 0)
+                    continue;
+                if (!isPowerOfTwoDimension(ts.width) || !isPowerOfTwoDimension(ts.height))
+                    offenders.append(QStringLiteral("%1 (%2×%3)")
+                                         .arg(ts.path)
+                                         .arg(ts.width)
+                                         .arg(ts.height));
+            }
+            if (!offenders.isEmpty()) {
+                const QStringList sample = offenders.mid(0, 3);
+                const QString suffix = offenders.size() > sample.size()
+                    ? QStringLiteral(" …+%1 more").arg(offenders.size() - sample.size())
+                    : QString();
+                findings.append({asset.relativePath, "texture_not_power_of_two", Severity::Warning,
+                    QString("Non power-of-two texture dimensions: %1%2. "
+                            "Resize to POT (e.g. 256, 512) for older GPU paths.")
+                        .arg(sample.join(QStringLiteral(", ")))
+                        .arg(suffix)});
+            }
+        }
+
+        if (!config.allowedTextureFormats.isEmpty()) {
+            QStringList offenders;
+            for (const TextureRefStats& ts : asset.textureStats) {
+                if (ts.missing || ts.format.isEmpty())
+                    continue;
+                if (!textureFormatMatchesList(ts.format, config.allowedTextureFormats))
+                    offenders.append(QStringLiteral("%1 (.%2)")
+                                         .arg(ts.path, ts.format));
+            }
+            if (!offenders.isEmpty()) {
+                findings.append({asset.relativePath, "texture_format_disallowed", Severity::Warning,
+                    QString("Texture format not in allow-list [%1]: %2")
+                        .arg(config.allowedTextureFormats.join(QStringLiteral(", ")),
+                             offenders.mid(0, 3).join(QStringLiteral(", ")))});
+            }
+        } else if (!config.disallowedTextureFormats.isEmpty()) {
+            QStringList offenders;
+            for (const TextureRefStats& ts : asset.textureStats) {
+                if (ts.missing || ts.format.isEmpty())
+                    continue;
+                if (textureFormatMatchesList(ts.format, config.disallowedTextureFormats))
+                    offenders.append(QStringLiteral("%1 (.%2)")
+                                         .arg(ts.path, ts.format));
+            }
+            if (!offenders.isEmpty()) {
+                findings.append({asset.relativePath, "texture_format_disallowed", Severity::Warning,
+                    QString("Disallowed texture format(s): %1")
+                        .arg(offenders.mid(0, 3).join(QStringLiteral(", ")))});
+            }
+        }
     }
 
     // ---- require_uv_channels ----
@@ -2467,6 +2591,14 @@ QString ScanEngine::formatSarif(const ScanResult& result, const QString& activeP
     ruleDescriptions["detect_zero_weight_bones"]  = "Skeleton has bones with no vertex weights (Mixamo bloat)";
     ruleDescriptions["detect_overlapping_uvs_pct"]    = "Triangles share overlapping UV0 regions (lightmap-unsafe)";
     ruleDescriptions["detect_non_manifold_edges_pct"] = "Mesh has non-manifold edges (booleans / printing will fail)";
+    ruleDescriptions["max_triangle_count"]            = "Asset exceeds maximum triangle count";
+    ruleDescriptions["max_triangles_per_mesh"]        = "Single mesh exceeds maximum triangle count";
+    ruleDescriptions["max_bones"]                   = "Skeleton exceeds maximum bone count";
+    ruleDescriptions["max_submesh_count"]           = "Asset exceeds maximum submesh count (draw-call proxy)";
+    ruleDescriptions["max_draw_calls"]                = "Estimated draw-call count exceeds limit";
+    ruleDescriptions["max_texture_dimension"]       = "Texture exceeds maximum dimension (alias of max_texture_resolution)";
+    ruleDescriptions["texture_not_power_of_two"]    = "Referenced texture dimensions are not power-of-two";
+    ruleDescriptions["texture_format_disallowed"]   = "Referenced texture uses a disallowed or non-allow-listed format";
 
     // Collect unique rules used in findings
     QSet<QString> usedRules;

--- a/src/ScanEngine_test.cpp
+++ b/src/ScanEngine_test.cpp
@@ -760,6 +760,195 @@ TEST(ScanEngineTest, EvaluateRules_C4Rules_AllDisabledByDefault)
     }
 }
 
+// ---------------------------------------------------------------------------
+// Issue #365 — budget rule evaluator tests
+// ---------------------------------------------------------------------------
+
+static bool hasRule(const QList<Finding>& findings, const QString& ruleId)
+{
+    for (const auto& f : findings)
+        if (f.rule == ruleId)
+            return true;
+    return false;
+}
+
+TEST(ScanEngineTest, EvaluateRules_MaxTriangleCount)
+{
+    AssetInfo asset;
+    asset.relativePath = "hero.fbx";
+    asset.triangleCount = 5000;
+
+    ScanConfig config = ScanConfig::defaults();
+    config.maxTriangleCount = 4000;
+
+    const auto findings = ScanEngine::evaluateRules(asset, config);
+    EXPECT_TRUE(hasRule(findings, QStringLiteral("max_triangle_count")));
+}
+
+TEST(ScanEngineTest, EvaluateRules_MaxTrianglesPerMesh)
+{
+    AssetInfo asset;
+    asset.relativePath = "hero.fbx";
+    asset.maxTrianglesPerMesh = 3000;
+
+    ScanConfig config = ScanConfig::defaults();
+    config.maxTrianglesPerMesh = 2000;
+
+    const auto findings = ScanEngine::evaluateRules(asset, config);
+    EXPECT_TRUE(hasRule(findings, QStringLiteral("max_triangles_per_mesh")));
+}
+
+TEST(ScanEngineTest, EvaluateRules_MaxBones)
+{
+    AssetInfo asset;
+    asset.relativePath = "rig.fbx";
+    asset.boneCount = 120;
+
+    ScanConfig config = ScanConfig::defaults();
+    config.maxBoneCount = 64;
+
+    const auto findings = ScanEngine::evaluateRules(asset, config);
+    EXPECT_TRUE(hasRule(findings, QStringLiteral("max_bones")));
+}
+
+TEST(ScanEngineTest, EvaluateRules_MaxSubmeshCount)
+{
+    AssetInfo asset;
+    asset.relativePath = "props.fbx";
+    asset.submeshCount = 12;
+
+    ScanConfig config = ScanConfig::defaults();
+    config.maxSubmeshCount = 8;
+
+    const auto findings = ScanEngine::evaluateRules(asset, config);
+    EXPECT_TRUE(hasRule(findings, QStringLiteral("max_submesh_count")));
+}
+
+TEST(ScanEngineTest, EvaluateRules_MaxDrawCalls)
+{
+    AssetInfo asset;
+    asset.relativePath = "scene.fbx";
+    asset.estimatedDrawCalls = 40;
+
+    ScanConfig config = ScanConfig::defaults();
+    config.maxDrawCalls = 16;
+
+    const auto findings = ScanEngine::evaluateRules(asset, config);
+    EXPECT_TRUE(hasRule(findings, QStringLiteral("max_draw_calls")));
+}
+
+TEST(ScanEngineTest, EvaluateRules_MaxTextureResolutionUsesProbedDimension)
+{
+    AssetInfo asset;
+    asset.relativePath = "tex.fbx";
+    asset.maxTextureDimension = 512;
+    asset.probedTextureMaxDimension = 4096;
+
+    ScanConfig config = ScanConfig::defaults();
+    config.maxTextureResolution = 2048;
+
+    const auto findings = ScanEngine::evaluateRules(asset, config);
+    EXPECT_TRUE(hasRule(findings, QStringLiteral("max_texture_resolution")));
+}
+
+TEST(ScanEngineTest, EvaluateRules_TextureNotPowerOfTwo)
+{
+    AssetInfo asset;
+    asset.relativePath = "retro.fbx";
+
+    TextureRefStats bad;
+    bad.path = QStringLiteral("albedo.png");
+    bad.width = 300;
+    bad.height = 256;
+    bad.format = QStringLiteral("png");
+    asset.textureStats.append(bad);
+
+    ScanConfig config = ScanConfig::defaults();
+    config.requireTexturePowerOfTwo = true;
+
+    const auto findings = ScanEngine::evaluateRules(asset, config);
+    EXPECT_TRUE(hasRule(findings, QStringLiteral("texture_not_power_of_two")));
+}
+
+TEST(ScanEngineTest, EvaluateRules_TextureFormatDisallowed)
+{
+    AssetInfo asset;
+    asset.relativePath = "retro.fbx";
+
+    TextureRefStats tga;
+    tga.path = QStringLiteral("diffuse.tga");
+    tga.format = QStringLiteral("tga");
+    asset.textureStats.append(tga);
+
+    ScanConfig config = ScanConfig::defaults();
+    config.disallowedTextureFormats = {QStringLiteral("tga")};
+
+    const auto findings = ScanEngine::evaluateRules(asset, config);
+    EXPECT_TRUE(hasRule(findings, QStringLiteral("texture_format_disallowed")));
+}
+
+TEST(ScanEngineTest, EvaluateRules_AllowedTextureFormats)
+{
+    AssetInfo asset;
+    asset.relativePath = "retro.fbx";
+
+    TextureRefStats bmp;
+    bmp.path = QStringLiteral("mask.bmp");
+    bmp.format = QStringLiteral("bmp");
+    asset.textureStats.append(bmp);
+
+    ScanConfig config = ScanConfig::defaults();
+    config.allowedTextureFormats = {QStringLiteral("png"), QStringLiteral("jpg")};
+
+    const auto findings = ScanEngine::evaluateRules(asset, config);
+    EXPECT_TRUE(hasRule(findings, QStringLiteral("texture_format_disallowed")));
+}
+
+TEST(ScanEngineTest, EvaluateRules_BudgetRulesDisabledByDefault)
+{
+    AssetInfo asset;
+    asset.relativePath = "heavy.fbx";
+    asset.triangleCount = 999999;
+    asset.maxTrianglesPerMesh = 500000;
+    asset.boneCount = 500;
+    asset.submeshCount = 200;
+    asset.estimatedDrawCalls = 200;
+    asset.probedTextureMaxDimension = 8192;
+
+    TextureRefStats odd;
+    odd.path = QStringLiteral("x.png");
+    odd.width = 300;
+    odd.height = 300;
+    odd.format = QStringLiteral("bmp");
+    asset.textureStats.append(odd);
+
+    const auto findings = ScanEngine::evaluateRules(asset, ScanConfig::defaults());
+    for (const auto& f : findings) {
+        EXPECT_NE(f.rule, QStringLiteral("max_triangle_count"));
+        EXPECT_NE(f.rule, QStringLiteral("max_triangles_per_mesh"));
+        EXPECT_NE(f.rule, QStringLiteral("max_bones"));
+        EXPECT_NE(f.rule, QStringLiteral("max_submesh_count"));
+        EXPECT_NE(f.rule, QStringLiteral("max_draw_calls"));
+        EXPECT_NE(f.rule, QStringLiteral("texture_not_power_of_two"));
+        EXPECT_NE(f.rule, QStringLiteral("texture_format_disallowed"));
+    }
+}
+
+TEST(ScanEngineTest, FormatSarif_IncludesBudgetRuleDescriptions)
+{
+    ScanResult result;
+    Finding f;
+    f.file = QStringLiteral("hero.fbx");
+    f.rule = QStringLiteral("max_triangle_count");
+    f.severity = Severity::Error;
+    f.message = QStringLiteral("too many triangles");
+    result.findings.append(f);
+
+    const QString sarif = ScanEngine::formatSarif(result);
+    EXPECT_TRUE(sarif.contains(QStringLiteral("max_triangle_count")));
+    EXPECT_TRUE(sarif.contains(QStringLiteral("maximum triangle count")));
+}
+
 TEST(ScanEngineTest, EvaluateRules_MissingMaterials)
 {
     AssetInfo asset;


### PR DESCRIPTION
## Summary

- Adds actionable scan budget rules backed by #364 `AssetInfo` fields: `max_triangle_count`, `max_triangles_per_mesh`, `max_bones`, `max_submesh_count`, `max_draw_calls`, texture POT/format checks, and `max_texture_dimension` alias for texture size limits.
- Wires rules through `ScanConfig` / `evaluateRules`, SARIF descriptions, CLI overrides (`--max-triangles`, `--max-bones`, etc.), and built-in `example-budget` profile.
- Texture POT/format rules require probed `textureStats` (enable via profile metadata `inspect_textures: true` or `example-texture-inspect` / `example-budget`).

## Test plan

- [x] `ScanEngineTest.EvaluateRules_*` budget rule coverage (synthetic `AssetInfo`)
- [x] `ScanEngineTest.FormatSarif_IncludesBudgetRuleDescriptions`
- [x] `ScanConfigApplyOverridesTest.ApplyRuleOverridesAffectsAllFields`
- [x] `PlatformProfileLoaderTest.BuiltinExampleBudgetProfileLoadsRules`
- [ ] CI Linux unit tests

Closes #365


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added budget rules to constrain scans by triangle count, bone count, submesh count, and draw calls.
  * Added texture constraints: power-of-two requirement and format allow/disallow lists.
  * Introduced new CLI parameters (`--max-triangles`, `--max-bones`, `--max-submeshes`, `--max-draw-calls`) for budget overrides.
  * Added example budget profile demonstrating configuration of scan constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->