### PR TITLE
feat(scan): bundled retro validation profiles (ps1, n64, nds, dreamcast) (#366)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -795,7 +795,7 @@ jobs:
             rm -f ./pack-deb/usr/share/qtmesheditor/media/models/"Twist Dance.fbx"
             rm -f ./pack-deb/usr/share/qtmesheditor/media/models/"Rumba Dancing.fbx"
             rm -f ./pack-deb/usr/share/qtmesheditor/media/models/"Hip Hop Dancing.fbx"
-            cp -R ./bin/profiles/ ./pack-deb/usr/share/qtmesheditor/
+            cp -R ./bin/profiles ./pack-deb/usr/share/qtmesheditor/
             cp -R ./bin/platforms/ ./pack-deb/usr/share/qtmesheditor/
             if [ -d ./bin/tls ]; then
               cp -R ./bin/tls/ ./pack-deb/usr/share/qtmesheditor/tls/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -767,6 +767,7 @@ jobs:
             mkdir -p ./pack-deb/usr/share/qtmesheditor/
             mkdir -p ./pack-deb/usr/share/qtmesheditor/cfg/
             mkdir -p ./pack-deb/usr/share/qtmesheditor/media/
+            mkdir -p ./pack-deb/usr/share/qtmesheditor/profiles/
             mkdir -p ./pack-deb/usr/share/qtmesheditor/platforms/
             mkdir -p ./pack-deb/usr/lib/qtmesheditor/
             mkdir -p ./pack-deb/usr/share/doc/qtmesheditor/
@@ -794,6 +795,7 @@ jobs:
             rm -f ./pack-deb/usr/share/qtmesheditor/media/models/"Twist Dance.fbx"
             rm -f ./pack-deb/usr/share/qtmesheditor/media/models/"Rumba Dancing.fbx"
             rm -f ./pack-deb/usr/share/qtmesheditor/media/models/"Hip Hop Dancing.fbx"
+            cp -R ./bin/profiles/ ./pack-deb/usr/share/qtmesheditor/
             cp -R ./bin/platforms/ ./pack-deb/usr/share/qtmesheditor/
             if [ -d ./bin/tls ]; then
               cp -R ./bin/tls/ ./pack-deb/usr/share/qtmesheditor/tls/
@@ -1800,6 +1802,7 @@ jobs:
             sudo rm -f ${{github.workspace}}/bin/QtMeshEditor.app/Contents/MacOS/media/models/"Rumba Dancing.fbx"
             sudo rm -f ${{github.workspace}}/bin/QtMeshEditor.app/Contents/MacOS/media/models/"Hip Hop Dancing.fbx"
             sudo cp -R ${{github.workspace}}/bin/cfg ${{github.workspace}}/bin/QtMeshEditor.app/Contents/MacOS/cfg
+            sudo cp -R ${{github.workspace}}/bin/profiles ${{github.workspace}}/bin/QtMeshEditor.app/Contents/MacOS/profiles
             sudo cp -R ${{github.workspace}}/resources/icon.icns ${{github.workspace}}/bin/QtMeshEditor.app/Contents/MacOS/media
             sudo mkdir -p ${{github.workspace}}/bin/QtMeshEditor.app/Contents/Resources
 

--- a/profiles/dreamcast.json
+++ b/profiles/dreamcast.json
@@ -1,0 +1,24 @@
+{
+  "id": "dreamcast",
+  "displayName": "Sega Dreamcast (validation)",
+  "description": "Validation-only lint preset for Dreamcast-class workflows. PVR-oriented texture format allow-list placeholder (png/jpg/pvr) with triangle, bone, and draw-call budgets aligned with common homebrew targets. Does not export PVR-ready assets or guarantee KallistiOS/Hektic compliance — model export remains engine-specific.",
+  "rules": {
+    "max_triangle_count": 15000,
+    "max_triangles_per_mesh": 8000,
+    "max_vertex_count": 15000,
+    "max_bones": 64,
+    "max_submesh_count": 8,
+    "max_material_count": 12,
+    "max_draw_calls": 16,
+    "max_texture_dimension": 512,
+    "texture_not_power_of_two": true,
+    "allowed_texture_formats": ["png", "jpg", "pvr"],
+    "require_uv_channels": 1
+  },
+  "metadata": {
+    "inspect_textures": true,
+    "category": "retro",
+    "platform": "dreamcast",
+    "scope": "validation"
+  }
+}

--- a/profiles/n64.json
+++ b/profiles/n64.json
@@ -1,0 +1,24 @@
+{
+  "id": "n64",
+  "displayName": "Nintendo 64 (validation)",
+  "description": "Validation-only lint preset for N64-class pipelines. Warns on triangle, bone, submesh, draw-call, and texture budgets typical of N64 homebrew and preservation ports. Does not emit ROM-ready geometry or guarantee microcode compliance — defaults are tunable starting points, not certification.",
+  "rules": {
+    "max_triangle_count": 12000,
+    "max_triangles_per_mesh": 4000,
+    "max_vertex_count": 12000,
+    "max_bones": 32,
+    "max_submesh_count": 6,
+    "max_material_count": 8,
+    "max_draw_calls": 12,
+    "max_texture_dimension": 256,
+    "texture_not_power_of_two": true,
+    "allowed_texture_formats": ["png", "jpg"],
+    "require_uv_channels": 1
+  },
+  "metadata": {
+    "inspect_textures": true,
+    "category": "retro",
+    "platform": "n64",
+    "scope": "validation"
+  }
+}

--- a/profiles/nds.json
+++ b/profiles/nds.json
@@ -1,0 +1,24 @@
+{
+  "id": "nds",
+  "displayName": "Nintendo DS (validation)",
+  "description": "Validation-only lint preset for NDS-class demake and homebrew checks. Tight polygon and texture budgets with palette/texture size warnings suited to dual-screen handheld targets. Does not export NSBMD/NSBTX or validate proprietary SDK output — NSBMD/NSBTX feasibility is separate research.",
+  "rules": {
+    "max_triangle_count": 4000,
+    "max_triangles_per_mesh": 2000,
+    "max_vertex_count": 4000,
+    "max_bones": 16,
+    "max_submesh_count": 4,
+    "max_material_count": 4,
+    "max_draw_calls": 8,
+    "max_texture_dimension": 256,
+    "texture_not_power_of_two": true,
+    "allowed_texture_formats": ["png", "jpg"],
+    "require_uv_channels": 1
+  },
+  "metadata": {
+    "inspect_textures": true,
+    "category": "retro",
+    "platform": "nds",
+    "scope": "validation"
+  }
+}

--- a/profiles/ps1.json
+++ b/profiles/ps1.json
@@ -1,0 +1,24 @@
+{
+  "id": "ps1",
+  "displayName": "PlayStation 1 (validation)",
+  "description": "Validation-only lint preset for PS1-class homebrew and demake workflows. Applies conservative triangle, material, bone, and texture budgets plus power-of-two texture warnings. Does not export TIM/CLUT or guarantee hardware compliance — tune limits per title. TIM import is future work.",
+  "rules": {
+    "max_triangle_count": 5000,
+    "max_triangles_per_mesh": 2000,
+    "max_vertex_count": 5000,
+    "max_bones": 16,
+    "max_submesh_count": 4,
+    "max_material_count": 4,
+    "max_draw_calls": 8,
+    "max_texture_dimension": 256,
+    "texture_not_power_of_two": true,
+    "allowed_texture_formats": ["png", "jpg"],
+    "require_uv_channels": 1
+  },
+  "metadata": {
+    "inspect_textures": true,
+    "category": "retro",
+    "platform": "ps1",
+    "scope": "validation"
+  }
+}

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -582,7 +582,7 @@ void CLIPipeline::printUsage()
         "  material --list-presets         List the built-in preset names\n"
         "\n"
         "Scan options:\n"
-        "  --target <id>             Alias for --profile (CI-friendly). Built-in targets include: example-minimal, example-base\n"
+        "  --target <id>             Alias for --profile (CI-friendly). Built-in targets include: ps1, n64, nds, dreamcast, example-minimal\n"
         "  --profile <id>            Built-in platform profile (e.g. example-minimal) or path to .json\n"
         "  --list-profiles           List built-in platform profile ids and exit\n"
         "  --config <file>           Config file (default: qtmesh.yml, qtmesh.json)\n"

--- a/src/PlatformProfile.cpp
+++ b/src/PlatformProfile.cpp
@@ -101,6 +101,11 @@ QStringList candidateBuiltinProfileDirectories()
         dirs.append(QDir(appDir).filePath(QStringLiteral("../share/qtmesh/profiles")));
     }
 
+#ifdef Q_OS_LINUX
+    // Linux .deb/Docker layout: /usr/share/qtmesheditor/{qtmesheditor,profiles}
+    dirs.append(QStringLiteral("/usr/share/qtmesheditor/profiles"));
+#endif
+
     return dirs;
 }
 

--- a/src/PlatformProfile_test.cpp
+++ b/src/PlatformProfile_test.cpp
@@ -156,6 +156,16 @@ TEST(PlatformProfileLoaderTest, ListBuiltinIncludesExampleProfiles)
     EXPECT_TRUE(ids.contains(QStringLiteral("example-base")));
 }
 
+TEST(PlatformProfileLoaderTest, ListBuiltinIncludesRetroProfiles)
+{
+    const QStringList ids = PlatformProfileLoader::listBuiltinIds();
+    ASSERT_FALSE(ids.isEmpty());
+    EXPECT_TRUE(ids.contains(QStringLiteral("ps1")));
+    EXPECT_TRUE(ids.contains(QStringLiteral("n64")));
+    EXPECT_TRUE(ids.contains(QStringLiteral("nds")));
+    EXPECT_TRUE(ids.contains(QStringLiteral("dreamcast")));
+}
+
 TEST(PlatformProfileLoaderTest, BuiltinIdMismatchIsRejected)
 {
     QTemporaryDir temp;
@@ -240,4 +250,103 @@ TEST(PlatformProfileLoaderTest, BuiltinExampleTextureInspectProfileEnablesProbe)
     ScanConfig config = ScanConfig::defaults();
     applyPlatformProfile(config, loaded.profile);
     EXPECT_TRUE(config.probeTextureFiles);
+}
+
+namespace {
+
+struct RetroProfileSnapshot {
+    const char* id;
+    int maxTriangleCount;
+    int maxTrianglesPerMesh;
+    int maxVertexCount;
+    int maxBones;
+    int maxSubmeshCount;
+    int maxMaterialCount;
+    int maxDrawCalls;
+    int maxTextureResolution;
+    const char* const* allowedTextureFormats;
+    int allowedTextureFormatCount;
+};
+
+void expectRetroProfileLoadsAndApplies(const RetroProfileSnapshot& snap)
+{
+    const QString id = QString::fromLatin1(snap.id);
+    const PlatformProfileLoadResult loaded = PlatformProfileLoader::load(id);
+    ASSERT_TRUE(loaded.ok) << snap.id << ": " << loaded.error.toStdString();
+    EXPECT_EQ(loaded.profile.id, id);
+    EXPECT_FALSE(loaded.profile.description.isEmpty());
+    EXPECT_TRUE(loaded.profile.description.contains(QStringLiteral("Validation-only"),
+                                                    Qt::CaseInsensitive)
+                || loaded.profile.description.contains(QStringLiteral("validation-only")));
+    EXPECT_TRUE(loaded.profile.metadata.value(QStringLiteral("inspect_textures")).toBool());
+    EXPECT_EQ(loaded.profile.metadata.value(QStringLiteral("scope")).toString(),
+              QStringLiteral("validation"));
+
+    EXPECT_EQ(loaded.profile.rules.value(QStringLiteral("max_triangle_count")).toInt(),
+              snap.maxTriangleCount);
+    EXPECT_EQ(loaded.profile.rules.value(QStringLiteral("max_triangles_per_mesh")).toInt(),
+              snap.maxTrianglesPerMesh);
+    EXPECT_EQ(loaded.profile.rules.value(QStringLiteral("max_vertex_count")).toInt(),
+              snap.maxVertexCount);
+    EXPECT_EQ(loaded.profile.rules.value(QStringLiteral("max_bones")).toInt(), snap.maxBones);
+    EXPECT_EQ(loaded.profile.rules.value(QStringLiteral("max_submesh_count")).toInt(),
+              snap.maxSubmeshCount);
+    EXPECT_EQ(loaded.profile.rules.value(QStringLiteral("max_material_count")).toInt(),
+              snap.maxMaterialCount);
+    EXPECT_EQ(loaded.profile.rules.value(QStringLiteral("max_draw_calls")).toInt(),
+              snap.maxDrawCalls);
+    EXPECT_EQ(loaded.profile.rules.value(QStringLiteral("max_texture_dimension")).toInt(),
+              snap.maxTextureResolution);
+    EXPECT_TRUE(loaded.profile.rules.value(QStringLiteral("texture_not_power_of_two")).toBool());
+
+    QStringList expectedFormats;
+    for (int i = 0; i < snap.allowedTextureFormatCount; ++i)
+        expectedFormats.append(QString::fromLatin1(snap.allowedTextureFormats[i]));
+    EXPECT_EQ(loaded.profile.rules.value(QStringLiteral("allowed_texture_formats")).toStringList(),
+              expectedFormats);
+
+    ScanConfig config = ScanConfig::defaults();
+    applyPlatformProfile(config, loaded.profile);
+    EXPECT_EQ(config.maxTriangleCount, snap.maxTriangleCount);
+    EXPECT_EQ(config.maxTrianglesPerMesh, snap.maxTrianglesPerMesh);
+    EXPECT_EQ(config.maxVertexCount, snap.maxVertexCount);
+    EXPECT_EQ(config.maxBoneCount, snap.maxBones);
+    EXPECT_EQ(config.maxSubmeshCount, snap.maxSubmeshCount);
+    EXPECT_EQ(config.maxMaterialCount, snap.maxMaterialCount);
+    EXPECT_EQ(config.maxDrawCalls, snap.maxDrawCalls);
+    EXPECT_EQ(config.maxTextureResolution, snap.maxTextureResolution);
+    EXPECT_TRUE(config.probeTextureFiles);
+    EXPECT_TRUE(config.requireTexturePowerOfTwo);
+    EXPECT_EQ(config.allowedTextureFormats, expectedFormats);
+    EXPECT_EQ(config.requireUvChannels, 1);
+}
+
+} // namespace
+
+TEST(PlatformProfileLoaderTest, BuiltinPs1ProfileLoadsRules)
+{
+    static const char* kFormats[] = {"png", "jpg"};
+    expectRetroProfileLoadsAndApplies(
+        { "ps1", 5000, 2000, 5000, 16, 4, 4, 8, 256, kFormats, 2 });
+}
+
+TEST(PlatformProfileLoaderTest, BuiltinN64ProfileLoadsRules)
+{
+    static const char* kFormats[] = {"png", "jpg"};
+    expectRetroProfileLoadsAndApplies(
+        { "n64", 12000, 4000, 12000, 32, 6, 8, 12, 256, kFormats, 2 });
+}
+
+TEST(PlatformProfileLoaderTest, BuiltinNdsProfileLoadsRules)
+{
+    static const char* kFormats[] = {"png", "jpg"};
+    expectRetroProfileLoadsAndApplies(
+        { "nds", 4000, 2000, 4000, 16, 4, 4, 8, 256, kFormats, 2 });
+}
+
+TEST(PlatformProfileLoaderTest, BuiltinDreamcastProfileLoadsRules)
+{
+    static const char* kFormats[] = {"png", "jpg", "pvr"};
+    expectRetroProfileLoadsAndApplies(
+        { "dreamcast", 15000, 8000, 15000, 64, 8, 12, 16, 512, kFormats, 3 });
 }


### PR DESCRIPTION
## Summary
- Add bundled validation-only platform profiles: `ps1`, `n64`, `nds`, and `dreamcast` under `profiles/`.
- Each profile documents validation vs export scope in `description` and enables texture probing for budget rules from #365.
- Snapshot tests lock critical numeric limits and verify `applyPlatformProfile` maps rules into `ScanConfig`.

## Profile defaults (tunable starting points)

| Profile | Triangles | Tri/mesh | Bones | Texture max | Notes |
|---------|-----------|----------|-------|-------------|-------|
| ps1 | 5k | 2k | 16 | 256px | TIM/CLUT import deferred |
| n64 | 12k | 4k | 32 | 256px | ROM/microcode compliance not claimed |
| nds | 4k | 2k | 16 | 256px | NSBMD/NSBTX export deferred |
| dreamcast | 15k | 8k | 64 | 512px | PVR allow-list placeholder (`png/jpg/pvr`) |

## Test plan
- [x] `UnitTests --gtest_filter="PlatformProfile*"` — 16/16 pass locally
- [ ] CI green (linux unit tests + cross-platform builds)
- [ ] `qtmesh scan ./assets --target ps1` loads profile (manual smoke)

Closes #366


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation profiles for PS1, N64, NDS, and Dreamcast with platform-specific geometry and texture limits.

* **Documentation**
  * CLI help updated to list the new retro targets.

* **Tests**
  * Added tests to validate loading and application of the retro profiles.

* **Chores**
  * Packaged app now includes the profiles and installs them to the system profiles location on Linux.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->