### PR TITLE
feat(cloud): package editor assets for QtMesh Cloud upload (#684)

### DIFF
--- a/src/AppLaunchHandler.cpp
+++ b/src/AppLaunchHandler.cpp
@@ -25,6 +25,7 @@ bool isCliSubcommand(const QString& arg)
         QStringLiteral("optimize"), QStringLiteral("bake-vertex-colors"),
         QStringLiteral("vat"), QStringLiteral("uv"), QStringLiteral("retopo"),
         QStringLiteral("skin"), QStringLiteral("morph"), QStringLiteral("nodeanim"),
+        QStringLiteral("cloud"),
     };
     return kSubcommands.contains(arg);
 }

--- a/src/AssetScanController.cpp
+++ b/src/AssetScanController.cpp
@@ -264,7 +264,9 @@ struct ScanSubprocessOutcome {
     QByteArray jsonBytes;
 };
 
-static ScanSubprocessOutcome runScanSubprocessSync(const QString& rootPath, const QString& profileId)
+static ScanSubprocessOutcome runScanSubprocessSync(const QString& rootPath,
+                                                   const QString& profileId,
+                                                   const QString& includePattern)
 {
     ScanSubprocessOutcome outcome;
     const QString binary = AssetScanController::resolveCliBinaryForTest();
@@ -273,10 +275,13 @@ static ScanSubprocessOutcome runScanSubprocessSync(const QString& rootPath, cons
     if (baseName.contains(QStringLiteral("editor")))
         args << QStringLiteral("--cli");
     args << QStringLiteral("scan")
-         << QDir(rootPath).absolutePath()
-         << QStringLiteral("--target") << profileId
-         << QStringLiteral("--json")
+         << QDir(rootPath).absolutePath();
+    if (!profileId.isEmpty())
+        args << QStringLiteral("--target") << profileId;
+    args << QStringLiteral("--json")
          << QStringLiteral("--no-telemetry");
+    if (!includePattern.isEmpty())
+        args << QStringLiteral("--include") << includePattern;
 
     QProcess process;
     process.setProgram(binary);
@@ -312,6 +317,20 @@ static ScanSubprocessOutcome runScanSubprocessSync(const QString& rootPath, cons
 
     outcome.ok = true;
     return outcome;
+}
+
+QByteArray AssetScanController::runIsolatedScanJsonSync(const QString& rootPath,
+                                                          const QString& includePattern,
+                                                          QString* errorOut)
+{
+    const ScanSubprocessOutcome outcome =
+        runScanSubprocessSync(rootPath, QString(), includePattern);
+    if (!outcome.ok) {
+        if (errorOut)
+            *errorOut = outcome.message;
+        return {};
+    }
+    return outcome.jsonBytes;
 }
 
 void AssetScanController::scanFolder(const QString& rootPath)
@@ -355,7 +374,7 @@ void AssetScanController::scanFolder(const QString& rootPath)
     const QString profileId = m_selectedProfileId;
     auto outcome = std::make_shared<ScanSubprocessOutcome>();
     QThread* worker = QThread::create([absRoot, profileId, outcome]() {
-        *outcome = runScanSubprocessSync(absRoot, profileId);
+        *outcome = runScanSubprocessSync(absRoot, profileId, QString());
     });
 
     connect(worker, &QThread::finished, this, [this, worker, outcome]() {

--- a/src/AssetScanController.h
+++ b/src/AssetScanController.h
@@ -49,6 +49,12 @@ public:
     /// Resolve the CLI binary used for isolated subprocess scans (test seam).
     static QString resolveCliBinaryForTest();
 
+    /// Run `qtmesh scan` in a child process so the live editor scene is untouched.
+    /// When @p includePattern is non-empty, only matching files under @p rootPath are scanned.
+    static QByteArray runIsolatedScanJsonSync(const QString& rootPath,
+                                              const QString& includePattern = QString(),
+                                              QString* errorOut = nullptr);
+
     /// Parse `--json` scan stdout into summary + findings (test seam).
     static bool parseScanJsonReport(const QByteArray& jsonBytes,
                                     int* scanned, int* passed, int* warnings, int* errors,

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -1,4 +1,5 @@
 #include "CLIPipeline.h"
+#include "CloudCLIPipeline.h"
 #include "Manager.h"
 #include "MeshImporterExporter.h"
 #include "AnimationMerger.h"
@@ -750,6 +751,14 @@ void CLIPipeline::printUsage()
         "                                    animated lights — anything non-skeletal). Authoring on the CLI\n"
         "                                    side needs the C5 glTF/FBX exporter round-trip first.\n"
         "\n"
+        "  cloud login [--api-key <token>]   Sign in via device flow (prints URL + code) or store an API key.\n"
+        "  cloud logout                      Sign out and clear the saved session.\n"
+        "  cloud status [--json]             Show whether a QtMesh Cloud session is stored locally.\n"
+        "  cloud list [--json]               List cloud projects for the signed-in account.\n"
+        "  cloud upload <file> [--name <n>] [--no-scan] [--json]\n"
+        "                                    Package the asset + dependencies and upload to QtMesh Cloud.\n"
+        "  cloud delete <project-id>         Delete a cloud project by id.\n"
+        "\n"
         "Global options:\n"
         "  --help, -h            Show this help\n"
         "  --version, -v         Show version\n"
@@ -1290,6 +1299,7 @@ int CLIPipeline::run(int argc, char* argv[])
     else if (cmd == "skin") rc = cmdSkin(argc, argv);
     else if (cmd == "morph") rc = cmdMorph(argc, argv);
     else if (cmd == "nodeanim") rc = cmdNodeAnim(argc, argv);
+    else if (cmd == "cloud") rc = CloudCLIPipeline::run(argc, argv);
 
     if (rc < 0) {
         err() << "Error: Unknown command '" << cmd << "'" << Qt::endl;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -125,6 +125,13 @@ QtMeshCloudClient.cpp
 CloudCredentialStore.cpp
 CloudUploadPlanner.cpp
 CloudAccountMenuButton.cpp
+DependencyResolver.cpp
+ProjectPackager.cpp
+QtMeshCloudSession.cpp
+CloudUploadDialog.cpp
+CloudProjectsDialog.cpp
+CloudUploadProgress.cpp
+CloudCLIPipeline.cpp
 FeedbackDiagnostics.cpp
 FeedbackDialog.cpp
 FeedbackReportHelper.cpp
@@ -243,6 +250,13 @@ PlatformProfile.h
 QtMeshCloudClient.h
 CloudCredentialStore.h
 CloudUploadPlanner.h
+DependencyResolver.h
+ProjectPackager.h
+QtMeshCloudSession.h
+CloudUploadDialog.h
+CloudProjectsDialog.h
+CloudUploadProgress.h
+CloudCLIPipeline.h
 FeedbackPrefill.h
 FeedbackDiagnostics.h
 FeedbackDialog.h

--- a/src/CloudAccountMenuButton.cpp
+++ b/src/CloudAccountMenuButton.cpp
@@ -343,7 +343,7 @@ void CloudAccountMenuButton::refresh()
     updateHeader(display, signedIn);
 
     m_openProjectsAction->setEnabled(signedIn);
-    m_uploadAction->setEnabled(signedIn);
+    m_uploadAction->setEnabled(true);
 
     m_signInAction->setVisible(!signedIn);
     m_signInAction->setEnabled(!signedIn);
@@ -353,10 +353,16 @@ void CloudAccountMenuButton::refresh()
 
 void CloudAccountMenuButton::setUploadEnabled(bool enabled)
 {
-    if (m_uploadAction)
-        m_uploadAction->setEnabled(enabled && CloudCredentialStore::hasSession());
-    if (m_uploadAction && !enabled)
+    if (!m_uploadAction)
+        return;
+    if (!CloudCredentialStore::hasSession()) {
+        m_uploadAction->setEnabled(true);
+        m_uploadAction->setToolTip({});
+        return;
+    }
+    m_uploadAction->setEnabled(enabled);
+    if (!enabled)
         m_uploadAction->setToolTip(tr("Open a model first"));
-    else if (m_uploadAction)
+    else
         m_uploadAction->setToolTip({});
 }

--- a/src/CloudAccountMenuButton.cpp
+++ b/src/CloudAccountMenuButton.cpp
@@ -343,7 +343,10 @@ void CloudAccountMenuButton::refresh()
     updateHeader(display, signedIn);
 
     m_openProjectsAction->setEnabled(signedIn);
-    m_uploadAction->setEnabled(true);
+    if (signedIn)
+        setUploadEnabled(m_uploadAssetAvailable);
+    else if (m_uploadAction)
+        m_uploadAction->setEnabled(true);
 
     m_signInAction->setVisible(!signedIn);
     m_signInAction->setEnabled(!signedIn);
@@ -353,6 +356,7 @@ void CloudAccountMenuButton::refresh()
 
 void CloudAccountMenuButton::setUploadEnabled(bool enabled)
 {
+    m_uploadAssetAvailable = enabled;
     if (!m_uploadAction)
         return;
     if (!CloudCredentialStore::hasSession()) {

--- a/src/CloudAccountMenuButton.cpp
+++ b/src/CloudAccountMenuButton.cpp
@@ -262,7 +262,7 @@ void CloudAccountMenuButton::buildMenu()
         emit openProjectsRequested();
     });
 
-    m_uploadAction = m_menu->addAction(tr("Upload Files..."));
+    m_uploadAction = m_menu->addAction(tr("Upload to QtMesh Cloud..."));
     m_uploadAction->setObjectName(QStringLiteral("actionQtMeshCloudUploadFiles"));
     connect(m_uploadAction, &QAction::triggered, this, [this]() {
         SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
@@ -343,10 +343,20 @@ void CloudAccountMenuButton::refresh()
     updateHeader(display, signedIn);
 
     m_openProjectsAction->setEnabled(signedIn);
-    m_uploadAction->setEnabled(true);
+    m_uploadAction->setEnabled(signedIn);
 
     m_signInAction->setVisible(!signedIn);
     m_signInAction->setEnabled(!signedIn);
     m_signOutAction->setVisible(signedIn);
     m_signOutAction->setEnabled(signedIn);
+}
+
+void CloudAccountMenuButton::setUploadEnabled(bool enabled)
+{
+    if (m_uploadAction)
+        m_uploadAction->setEnabled(enabled && CloudCredentialStore::hasSession());
+    if (m_uploadAction && !enabled)
+        m_uploadAction->setToolTip(tr("Open a model first"));
+    else if (m_uploadAction)
+        m_uploadAction->setToolTip({});
 }

--- a/src/CloudAccountMenuButton.h
+++ b/src/CloudAccountMenuButton.h
@@ -24,6 +24,8 @@ public:
     /// Reads CloudCredentialStore / QSettings and updates button + menu visibility.
     void refresh();
 
+    void setUploadEnabled(bool enabled);
+
     /// Exposed for unit tests.
     static QString initialsFromDisplayName(const QString& displayName);
 

--- a/src/CloudAccountMenuButton.h
+++ b/src/CloudAccountMenuButton.h
@@ -56,6 +56,7 @@ private:
     QAction* m_uploadAction = nullptr;
     QAction* m_feedbackAction = nullptr;
     QAction* m_openProjectsAction = nullptr;
+    bool m_uploadAssetAvailable = false;
 };
 
 #endif

--- a/src/CloudCLIPipeline.cpp
+++ b/src/CloudCLIPipeline.cpp
@@ -6,6 +6,7 @@
 #include "QtMeshCloudClient.h"
 #include "ScanConfig.h"
 #include "ScanEngine.h"
+#include "SentryReporter.h"
 
 #include <QCoreApplication>
 #include <QFileInfo>
@@ -37,10 +38,39 @@ QString sessionToken(const QString& apiKeyFlag)
     return CloudCredentialStore::loadSession().token;
 }
 
+int cloudSubcommandIndex(int argc, char* argv[])
+{
+    for (int i = 1; i < argc; ++i) {
+        if (QString::fromUtf8(argv[i]) == QLatin1String("cloud"))
+            return i + 1;
+    }
+    return 2;
+}
+
+int cloudPayloadIndex(int argc, char* argv[])
+{
+    return cloudSubcommandIndex(argc, argv) + 1;
+}
+
+QString cloudSubcommand(int argc, char* argv[])
+{
+    const int index = cloudSubcommandIndex(argc, argv);
+    return index < argc ? QString::fromUtf8(argv[index]) : QString();
+}
+
+bool payloadHasJsonFlag(int argc, char* argv[])
+{
+    for (int i = cloudPayloadIndex(argc, argv); i < argc; ++i) {
+        if (QString::fromUtf8(argv[i]) == QLatin1String("--json"))
+            return true;
+    }
+    return false;
+}
+
 int cmdCloudLogin(int argc, char* argv[])
 {
     QString apiKey;
-    for (int i = 2; i < argc; ++i) {
+    for (int i = cloudPayloadIndex(argc, argv); i < argc; ++i) {
         const QString arg = QString::fromUtf8(argv[i]);
         if (arg == QLatin1String("--api-key") && i + 1 < argc)
             apiKey = QString::fromUtf8(argv[++i]);
@@ -100,6 +130,7 @@ int cmdCloudLogin(int argc, char* argv[])
 
 int cmdCloudLogout()
 {
+    CloudCredentialStore::migrateLegacySettingsIfNeeded();
     const QString token = CloudCredentialStore::loadSession().token;
     if (!token.isEmpty())
         QtMeshCloudClient::logout(token);
@@ -175,7 +206,7 @@ int cmdCloudList(bool jsonOutput)
 int cmdCloudDelete(int argc, char* argv[])
 {
     QString projectId;
-    for (int i = 2; i < argc; ++i) {
+    for (int i = cloudPayloadIndex(argc, argv); i < argc; ++i) {
         const QString arg = QString::fromUtf8(argv[i]);
         if (!arg.startsWith(QLatin1Char('-')) && projectId.isEmpty())
             projectId = arg;
@@ -205,7 +236,7 @@ int cmdCloudUpload(int argc, char* argv[])
     QString projectName;
     bool jsonOutput = false;
     bool runScan = true;
-    for (int i = 2; i < argc; ++i) {
+    for (int i = cloudPayloadIndex(argc, argv); i < argc; ++i) {
         const QString arg = QString::fromUtf8(argv[i]);
         if (arg == QLatin1String("--json")) {
             jsonOutput = true;
@@ -236,6 +267,9 @@ int cmdCloudUpload(int argc, char* argv[])
     if (projectName.isEmpty())
         projectName = QFileInfo(mainFile).completeBaseName();
 
+    SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
+                                  QStringLiteral("QtMesh Cloud CLI upload start"));
+
     PackageMetadata manifest = ProjectPackager::buildManifest(mainFile, {}, projectName);
     if (runScan) {
         ScanConfig config;
@@ -253,6 +287,9 @@ int cmdCloudUpload(int argc, char* argv[])
         project = QtMeshCloudClient::createProject(token, manifest.projectName, slug);
     }
     if (!project.ok) {
+        SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
+                                      QStringLiteral("QtMesh Cloud CLI upload failed: create project"),
+                                      QStringLiteral("error"));
         err() << "Error: " << project.errorString << Qt::endl;
         return 1;
     }
@@ -270,6 +307,9 @@ int cmdCloudUpload(int argc, char* argv[])
     const auto uploadUrls = QtMeshCloudClient::requestUploadUrls(
         token, project.ownerSlug, project.projectSlug, descriptors);
     if (!uploadUrls.ok) {
+        SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
+                                      QStringLiteral("QtMesh Cloud CLI upload failed: upload urls"),
+                                      QStringLiteral("error"));
         err() << "Error: " << uploadUrls.errorString << Qt::endl;
         return 1;
     }
@@ -281,6 +321,9 @@ int cmdCloudUpload(int argc, char* argv[])
         const auto result = QtMeshCloudClient::uploadFileContent(
             token, uploadUrls.uploads.at(i), descriptors.at(i).path, nullptr);
         if (!result.ok) {
+            SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
+                                          QStringLiteral("QtMesh Cloud CLI upload failed: file content"),
+                                          QStringLiteral("error"));
             err() << "Error: " << result.errorString << Qt::endl;
             return 1;
         }
@@ -296,11 +339,16 @@ int cmdCloudUpload(int argc, char* argv[])
     const auto completed = QtMeshCloudClient::completeUpload(
         token, project.ownerSlug, project.projectSlug, uploadedFileIds, mainFileId);
     if (!completed.ok) {
+        SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
+                                      QStringLiteral("QtMesh Cloud CLI upload failed: complete"),
+                                      QStringLiteral("error"));
         err() << "Error: " << completed.errorString << Qt::endl;
         return 1;
     }
 
     const QString projectUrl = project.projectUrl;
+    SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
+                                  QStringLiteral("QtMesh Cloud CLI upload completed"));
 
     if (jsonOutput) {
         QJsonObject obj;
@@ -321,20 +369,20 @@ int cmdCloudUpload(int argc, char* argv[])
 
 int CloudCLIPipeline::run(int argc, char* argv[])
 {
-    if (argc < 3) {
+    const QString sub = cloudSubcommand(argc, argv);
+    if (sub.isEmpty()) {
         err() << "Usage: qtmesh cloud <login|logout|status|list|upload|delete> ..." << Qt::endl;
         return 2;
     }
 
-    const QString sub = QString::fromUtf8(argv[2]);
     if (sub == QLatin1String("login"))
         return cmdCloudLogin(argc, argv);
     if (sub == QLatin1String("logout"))
         return cmdCloudLogout();
     if (sub == QLatin1String("status"))
-        return cmdCloudStatus(argc > 3 && QString::fromUtf8(argv[3]) == QLatin1String("--json"));
+        return cmdCloudStatus(payloadHasJsonFlag(argc, argv));
     if (sub == QLatin1String("list"))
-        return cmdCloudList(argc > 3 && QString::fromUtf8(argv[3]) == QLatin1String("--json"));
+        return cmdCloudList(payloadHasJsonFlag(argc, argv));
     if (sub == QLatin1String("delete"))
         return cmdCloudDelete(argc, argv);
     if (sub == QLatin1String("upload"))

--- a/src/CloudCLIPipeline.cpp
+++ b/src/CloudCLIPipeline.cpp
@@ -1,0 +1,345 @@
+#include "CloudCLIPipeline.h"
+
+#include "CloudCredentialStore.h"
+#include "CloudUploadPlanner.h"
+#include "ProjectPackager.h"
+#include "QtMeshCloudClient.h"
+#include "ScanConfig.h"
+#include "ScanEngine.h"
+
+#include <QCoreApplication>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QTextStream>
+#include <QThread>
+
+namespace {
+
+QTextStream& out()
+{
+    static QTextStream s(stdout);
+    return s;
+}
+
+QTextStream& err()
+{
+    static QTextStream s(stderr);
+    return s;
+}
+
+QString sessionToken(const QString& apiKeyFlag)
+{
+    if (!apiKeyFlag.trimmed().isEmpty())
+        return apiKeyFlag.trimmed();
+    CloudCredentialStore::migrateLegacySettingsIfNeeded();
+    return CloudCredentialStore::loadSession().token;
+}
+
+int cmdCloudLogin(int argc, char* argv[])
+{
+    QString apiKey;
+    for (int i = 2; i < argc; ++i) {
+        const QString arg = QString::fromUtf8(argv[i]);
+        if (arg == QLatin1String("--api-key") && i + 1 < argc)
+            apiKey = QString::fromUtf8(argv[++i]);
+    }
+
+    if (!apiKey.isEmpty()) {
+        CloudSession session;
+        session.token = apiKey;
+        if (!CloudCredentialStore::saveSession(session)) {
+            err() << "Error: could not persist API key securely." << Qt::endl;
+            return 1;
+        }
+        out() << "Saved API key to secure storage." << Qt::endl;
+        return 0;
+    }
+
+    const auto code = QtMeshCloudClient::requestDeviceCode();
+    if (!code.ok) {
+        err() << "Error: " << code.errorString << Qt::endl;
+        return 1;
+    }
+
+    out() << "Visit: " << code.verificationUriComplete << Qt::endl;
+    out() << "Code: " << code.userCode << Qt::endl;
+
+    int intervalMs = qMax(1, code.intervalSeconds) * 1000;
+    const int maxAttempts = qMax(1, code.expiresInSeconds / qMax(1, code.intervalSeconds) + 2);
+    for (int attempt = 0; attempt < maxAttempts; ++attempt) {
+        const auto token = QtMeshCloudClient::pollDeviceToken(code.deviceCode);
+        if (token.ok) {
+            CloudSession session;
+            session.token = token.token;
+            session.expiresAt = token.expiresAt;
+            session.email = token.user.value(QStringLiteral("email")).toString();
+            if (!CloudCredentialStore::saveSession(session)) {
+                err() << "Error: signed in but session could not be saved securely." << Qt::endl;
+                return 1;
+            }
+            out() << "Signed in as "
+                  << (session.email.isEmpty() ? QStringLiteral("(unknown)") : session.email)
+                  << Qt::endl;
+            return 0;
+        }
+        if (token.errorCode != QStringLiteral("authorization_pending")
+            && token.errorCode != QStringLiteral("slow_down")) {
+            err() << "Error: " << token.errorString << Qt::endl;
+            return 1;
+        }
+        if (token.errorCode == QStringLiteral("slow_down"))
+            intervalMs += 2000;
+        QThread::msleep(static_cast<unsigned long>(intervalMs));
+    }
+
+    err() << "Error: sign-in timed out." << Qt::endl;
+    return 1;
+}
+
+int cmdCloudLogout()
+{
+    const QString token = CloudCredentialStore::loadSession().token;
+    if (!token.isEmpty())
+        QtMeshCloudClient::logout(token);
+    CloudCredentialStore::clearSession();
+    out() << "Signed out." << Qt::endl;
+    return 0;
+}
+
+int cmdCloudStatus(bool jsonOutput)
+{
+    CloudCredentialStore::migrateLegacySettingsIfNeeded();
+    const bool signedIn = CloudCredentialStore::hasSession();
+    const CloudSession session = CloudCredentialStore::loadSession();
+
+    if (jsonOutput) {
+        QJsonObject obj;
+        obj.insert(QStringLiteral("connected"), signedIn);
+        if (signedIn)
+            obj.insert(QStringLiteral("email"), session.email);
+        out() << QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact)) << Qt::endl;
+        return 0;
+    }
+
+    if (!signedIn) {
+        out() << "Not connected to QtMesh Cloud." << Qt::endl;
+        return 0;
+    }
+    out() << "Connected to QtMesh Cloud";
+    if (!session.email.isEmpty())
+        out() << " as " << session.email;
+    out() << Qt::endl;
+    return 0;
+}
+
+int cmdCloudList(bool jsonOutput)
+{
+    const QString token = sessionToken({});
+    if (token.isEmpty()) {
+        err() << "Error: not signed in. Run `qtmesh cloud login` first." << Qt::endl;
+        return 1;
+    }
+    const auto result = QtMeshCloudClient::fetchProjects(token);
+    if (!result.ok) {
+        err() << "Error: " << result.errorString << Qt::endl;
+        return 1;
+    }
+
+    if (jsonOutput) {
+        QJsonArray projects;
+        for (const auto& project : result.projects) {
+            QJsonObject obj;
+            obj.insert(QStringLiteral("id"), project.id);
+            obj.insert(QStringLiteral("name"), project.name);
+            obj.insert(QStringLiteral("ownerSlug"), project.ownerSlug);
+            obj.insert(QStringLiteral("projectSlug"), project.projectSlug);
+            obj.insert(QStringLiteral("projectUrl"), project.projectUrl);
+            projects.append(obj);
+        }
+        QJsonObject root;
+        root.insert(QStringLiteral("projects"), projects);
+        out() << QString::fromUtf8(QJsonDocument(root).toJson(QJsonDocument::Compact)) << Qt::endl;
+        return 0;
+    }
+
+    for (const auto& project : result.projects) {
+        out() << project.id << '\t'
+              << project.ownerSlug << '/' << project.projectSlug << '\t'
+              << (project.name.isEmpty() ? project.projectSlug : project.name) << Qt::endl;
+    }
+    return 0;
+}
+
+int cmdCloudDelete(int argc, char* argv[])
+{
+    QString projectId;
+    for (int i = 2; i < argc; ++i) {
+        const QString arg = QString::fromUtf8(argv[i]);
+        if (!arg.startsWith(QLatin1Char('-')) && projectId.isEmpty())
+            projectId = arg;
+    }
+    if (projectId.isEmpty()) {
+        err() << "Usage: qtmesh cloud delete <project-id>" << Qt::endl;
+        return 2;
+    }
+
+    const QString token = sessionToken({});
+    if (token.isEmpty()) {
+        err() << "Error: not signed in." << Qt::endl;
+        return 1;
+    }
+    const auto result = QtMeshCloudClient::deleteProject(token, projectId);
+    if (!result.ok) {
+        err() << "Error: " << result.errorString << Qt::endl;
+        return 1;
+    }
+    out() << "Deleted project " << projectId << Qt::endl;
+    return 0;
+}
+
+int cmdCloudUpload(int argc, char* argv[])
+{
+    QString mainFile;
+    QString projectName;
+    bool jsonOutput = false;
+    bool runScan = true;
+    for (int i = 2; i < argc; ++i) {
+        const QString arg = QString::fromUtf8(argv[i]);
+        if (arg == QLatin1String("--json")) {
+            jsonOutput = true;
+        } else if (arg == QLatin1String("--no-scan")) {
+            runScan = false;
+        } else if (arg == QLatin1String("--name") && i + 1 < argc) {
+            projectName = QString::fromUtf8(argv[++i]);
+        } else if (!arg.startsWith(QLatin1Char('-')) && mainFile.isEmpty()) {
+            mainFile = arg;
+        }
+    }
+
+    if (mainFile.isEmpty()) {
+        err() << "Usage: qtmesh cloud upload <main-file> [--name <name>] [--no-scan] [--json]" << Qt::endl;
+        return 2;
+    }
+    if (!QFileInfo::exists(mainFile)) {
+        err() << "Error: file not found: " << mainFile << Qt::endl;
+        return 1;
+    }
+
+    const QString token = sessionToken({});
+    if (token.isEmpty()) {
+        err() << "Error: not signed in." << Qt::endl;
+        return 1;
+    }
+
+    if (projectName.isEmpty())
+        projectName = QFileInfo(mainFile).completeBaseName();
+
+    PackageMetadata manifest = ProjectPackager::buildManifest(mainFile, {}, projectName);
+    if (runScan) {
+        ScanConfig config;
+        config.roots = {QFileInfo(mainFile).absolutePath()};
+        config.includePatterns = {QFileInfo(mainFile).fileName()};
+        manifest.scanSummary = ScanEngine::scanReportToJsonObject(
+            ScanEngine::run(config, config.roots.first()));
+    }
+
+    QString slug = CloudUploadPlanner::makeProjectSlug(manifest.projectName);
+    auto project = QtMeshCloudClient::createProject(token, manifest.projectName, slug);
+    if (!project.ok && project.httpStatus == 409) {
+        slug = CloudUploadPlanner::makeProjectSlug(
+            QStringLiteral("%1-%2").arg(manifest.projectName, slug));
+        project = QtMeshCloudClient::createProject(token, manifest.projectName, slug);
+    }
+    if (!project.ok) {
+        err() << "Error: " << project.errorString << Qt::endl;
+        return 1;
+    }
+
+    QList<QtMeshCloudClient::AssetFileDescriptor> descriptors;
+    for (const PackageEntry& entry : manifest.files) {
+        QtMeshCloudClient::AssetFileDescriptor descriptor;
+        descriptor.path = entry.absolutePath.isEmpty() ? entry.relativePath : entry.absolutePath;
+        descriptor.uploadName = entry.relativePath;
+        descriptor.role = entry.role;
+        descriptor.sizeBytes = entry.size;
+        descriptors.append(descriptor);
+    }
+
+    const auto uploadUrls = QtMeshCloudClient::requestUploadUrls(
+        token, project.ownerSlug, project.projectSlug, descriptors);
+    if (!uploadUrls.ok) {
+        err() << "Error: " << uploadUrls.errorString << Qt::endl;
+        return 1;
+    }
+
+    QStringList uploadedFileIds;
+    QString mainFileId;
+    QString fallbackMainFileId;
+    for (int i = 0; i < uploadUrls.uploads.size(); ++i) {
+        const auto result = QtMeshCloudClient::uploadFileContent(
+            token, uploadUrls.uploads.at(i), descriptors.at(i).path, nullptr);
+        if (!result.ok) {
+            err() << "Error: " << result.errorString << Qt::endl;
+            return 1;
+        }
+        uploadedFileIds.append(uploadUrls.uploads.at(i).fileId);
+        if (fallbackMainFileId.isEmpty())
+            fallbackMainFileId = uploadUrls.uploads.at(i).fileId;
+        if (mainFileId.isEmpty() && descriptors.at(i).role == QLatin1String("main"))
+            mainFileId = uploadUrls.uploads.at(i).fileId;
+    }
+    if (mainFileId.isEmpty())
+        mainFileId = fallbackMainFileId;
+
+    const auto completed = QtMeshCloudClient::completeUpload(
+        token, project.ownerSlug, project.projectSlug, uploadedFileIds, mainFileId);
+    if (!completed.ok) {
+        err() << "Error: " << completed.errorString << Qt::endl;
+        return 1;
+    }
+
+    const QString projectUrl = project.projectUrl;
+
+    if (jsonOutput) {
+        QJsonObject obj;
+        obj.insert(QStringLiteral("ok"), true);
+        obj.insert(QStringLiteral("projectUrl"), projectUrl);
+        obj.insert(QStringLiteral("fileCount"), manifest.files.size());
+        out() << QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact)) << Qt::endl;
+    } else {
+        out() << "Uploaded " << manifest.files.size() << " file(s).";
+        if (!projectUrl.isEmpty())
+            out() << " " << projectUrl;
+        out() << Qt::endl;
+    }
+    return 0;
+}
+
+} // namespace
+
+int CloudCLIPipeline::run(int argc, char* argv[])
+{
+    if (argc < 3) {
+        err() << "Usage: qtmesh cloud <login|logout|status|list|upload|delete> ..." << Qt::endl;
+        return 2;
+    }
+
+    const QString sub = QString::fromUtf8(argv[2]);
+    if (sub == QLatin1String("login"))
+        return cmdCloudLogin(argc, argv);
+    if (sub == QLatin1String("logout"))
+        return cmdCloudLogout();
+    if (sub == QLatin1String("status"))
+        return cmdCloudStatus(argc > 3 && QString::fromUtf8(argv[3]) == QLatin1String("--json"));
+    if (sub == QLatin1String("list"))
+        return cmdCloudList(argc > 3 && QString::fromUtf8(argv[3]) == QLatin1String("--json"));
+    if (sub == QLatin1String("delete"))
+        return cmdCloudDelete(argc, argv);
+    if (sub == QLatin1String("upload"))
+        return cmdCloudUpload(argc, argv);
+
+    err() << "Error: unknown cloud subcommand '" << sub << "'" << Qt::endl;
+    return 2;
+}

--- a/src/CloudCLIPipeline.h
+++ b/src/CloudCLIPipeline.h
@@ -1,0 +1,11 @@
+#ifndef CLOUD_CLI_PIPELINE_H
+#define CLOUD_CLI_PIPELINE_H
+
+class CloudCLIPipeline {
+public:
+    CloudCLIPipeline() = delete;
+
+    static int run(int argc, char* argv[]);
+};
+
+#endif // CLOUD_CLI_PIPELINE_H

--- a/src/CloudProjectsDialog.cpp
+++ b/src/CloudProjectsDialog.cpp
@@ -1,5 +1,7 @@
 #include "CloudProjectsDialog.h"
 
+#include "SentryReporter.h"
+
 #include <QDesktopServices>
 #include <QHBoxLayout>
 #include <QLabel>
@@ -28,14 +30,21 @@ CloudProjectsDialog::CloudProjectsDialog(QWidget* parent)
     buttons->addWidget(m_openButton);
     layout->addLayout(buttons);
 
-    connect(closeButton, &QPushButton::clicked, this, &QDialog::reject);
+    connect(closeButton, &QPushButton::clicked, this, [this]() {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("Cloud projects dialog: Close"));
+        reject();
+    });
     connect(m_openButton, &QPushButton::clicked, this, [this]() {
         const QListWidgetItem* item = m_list->currentItem();
         if (!item)
             return;
         const QString url = item->data(Qt::UserRole + 1).toString();
-        if (!url.isEmpty())
-            QDesktopServices::openUrl(QUrl(url));
+        if (url.isEmpty())
+            return;
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("Cloud projects dialog: Open in Browser"));
+        QDesktopServices::openUrl(QUrl(url));
     });
     connect(m_list, &QListWidget::itemDoubleClicked, m_openButton, &QPushButton::click);
 }

--- a/src/CloudProjectsDialog.cpp
+++ b/src/CloudProjectsDialog.cpp
@@ -1,0 +1,58 @@
+#include "CloudProjectsDialog.h"
+
+#include <QDesktopServices>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QListWidget>
+#include <QPushButton>
+#include <QUrl>
+#include <QVBoxLayout>
+
+CloudProjectsDialog::CloudProjectsDialog(QWidget* parent)
+    : QDialog(parent)
+{
+    setWindowTitle(tr("My Cloud Projects"));
+    resize(560, 420);
+
+    auto* layout = new QVBoxLayout(this);
+    layout->addWidget(new QLabel(tr("Projects on QtMesh Cloud:"), this));
+
+    m_list = new QListWidget(this);
+    layout->addWidget(m_list, 1);
+
+    auto* buttons = new QHBoxLayout();
+    auto* closeButton = new QPushButton(tr("Close"), this);
+    m_openButton = new QPushButton(tr("Open in Browser"), this);
+    buttons->addStretch();
+    buttons->addWidget(closeButton);
+    buttons->addWidget(m_openButton);
+    layout->addLayout(buttons);
+
+    connect(closeButton, &QPushButton::clicked, this, &QDialog::reject);
+    connect(m_openButton, &QPushButton::clicked, this, [this]() {
+        const QListWidgetItem* item = m_list->currentItem();
+        if (!item)
+            return;
+        const QString url = item->data(Qt::UserRole + 1).toString();
+        if (!url.isEmpty())
+            QDesktopServices::openUrl(QUrl(url));
+    });
+    connect(m_list, &QListWidget::itemDoubleClicked, m_openButton, &QPushButton::click);
+}
+
+void CloudProjectsDialog::setProjects(const QList<QtMeshCloudClient::ProjectSummary>& projects)
+{
+    m_list->clear();
+    for (const auto& project : projects) {
+        const QString title = project.name.isEmpty() ? project.projectSlug : project.name;
+        const QString subtitle = QStringLiteral("%1/%2").arg(project.ownerSlug, project.projectSlug);
+        auto* item = new QListWidgetItem(
+            subtitle == title ? title : QStringLiteral("%1\n%2").arg(title, subtitle),
+            m_list);
+        item->setData(Qt::UserRole, project.id);
+        item->setData(Qt::UserRole + 1, project.projectUrl);
+        item->setToolTip(project.projectUrl);
+    }
+    if (m_list->count() > 0)
+        m_list->setCurrentRow(0);
+}

--- a/src/CloudProjectsDialog.h
+++ b/src/CloudProjectsDialog.h
@@ -1,0 +1,24 @@
+#ifndef CLOUD_PROJECTS_DIALOG_H
+#define CLOUD_PROJECTS_DIALOG_H
+
+#include "QtMeshCloudClient.h"
+
+#include <QDialog>
+
+class QListWidget;
+class QPushButton;
+
+class CloudProjectsDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit CloudProjectsDialog(QWidget* parent = nullptr);
+
+    void setProjects(const QList<QtMeshCloudClient::ProjectSummary>& projects);
+
+private:
+    QListWidget* m_list = nullptr;
+    QPushButton* m_openButton = nullptr;
+};
+
+#endif // CLOUD_PROJECTS_DIALOG_H

--- a/src/CloudUploadDialog.cpp
+++ b/src/CloudUploadDialog.cpp
@@ -1,0 +1,194 @@
+#include "CloudUploadDialog.h"
+
+#include "DependencyResolver.h"
+#include "ProjectPackager.h"
+
+#include <algorithm>
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QFileInfo>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QListWidget>
+#include <QPushButton>
+#include <QSet>
+#include <QVBoxLayout>
+
+CloudUploadDialog::CloudUploadDialog(QWidget* parent)
+    : QDialog(parent)
+{
+    setWindowTitle(tr("Upload to QtMesh Cloud"));
+    resize(640, 520);
+
+    auto* layout = new QVBoxLayout(this);
+
+    auto* accountLabel = new QLabel(this);
+    accountLabel->setObjectName(QStringLiteral("cloudUploadAccountLabel"));
+    accountLabel->setWordWrap(true);
+    layout->addWidget(accountLabel);
+
+    auto* projectLabel = new QLabel(tr("Project:"), this);
+    layout->addWidget(projectLabel);
+
+    m_projectCombo = new QComboBox(this);
+    m_projectCombo->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
+    layout->addWidget(m_projectCombo);
+
+    auto* depsLabel = new QLabel(tr("Files to upload:"), this);
+    layout->addWidget(depsLabel);
+
+    m_dependencyList = new QListWidget(this);
+    m_dependencyList->setSelectionMode(QAbstractItemView::NoSelection);
+    layout->addWidget(m_dependencyList, 1);
+
+    m_runScanCheck = new QCheckBox(tr("Run local scan before upload"), this);
+    m_runScanCheck->setChecked(true);
+    layout->addWidget(m_runScanCheck);
+
+    auto* buttons = new QHBoxLayout();
+    auto* cancelButton = new QPushButton(tr("Cancel"), this);
+    m_uploadButton = new QPushButton(tr("Upload"), this);
+    m_uploadButton->setDefault(true);
+    buttons->addStretch();
+    buttons->addWidget(cancelButton);
+    buttons->addWidget(m_uploadButton);
+    layout->addLayout(buttons);
+
+    connect(cancelButton, &QPushButton::clicked, this, &QDialog::reject);
+    connect(m_uploadButton, &QPushButton::clicked, this, &QDialog::accept);
+    connect(m_projectCombo, &QComboBox::currentIndexChanged, this, [this](int) {
+        m_uploadButton->setEnabled(hasSelectedProject());
+    });
+
+    m_uploadButton->setEnabled(false);
+}
+
+void CloudUploadDialog::setAccountLabel(const QString& accountLabel)
+{
+    if (auto* label = findChild<QLabel*>(QStringLiteral("cloudUploadAccountLabel")))
+        label->setText(tr("Destination account: %1").arg(accountLabel));
+}
+
+void CloudUploadDialog::setMainAssetPath(const QString& mainAssetPath)
+{
+    m_mainAssetPath = mainAssetPath;
+    rebuildDependencyList();
+}
+
+void CloudUploadDialog::setProjects(const QList<QtMeshCloudClient::ProjectSummary>& projects)
+{
+    m_projectCombo->clear();
+    for (const QtMeshCloudClient::ProjectSummary& project : projects) {
+        const QString title = project.name.isEmpty() ? project.projectSlug : project.name;
+        const QString subtitle =
+            QStringLiteral("%1/%2").arg(project.ownerSlug, project.projectSlug);
+        const QString label = subtitle == title
+                                  ? title
+                                  : QStringLiteral("%1 (%2)").arg(title, subtitle);
+        m_projectCombo->addItem(label);
+        const int index = m_projectCombo->count() - 1;
+        m_projectCombo->setItemData(index, project.id, Qt::UserRole);
+        m_projectCombo->setItemData(index, project.ownerSlug, Qt::UserRole + 1);
+        m_projectCombo->setItemData(index, project.projectSlug, Qt::UserRole + 2);
+        m_projectCombo->setItemData(index, project.name, Qt::UserRole + 3);
+        m_projectCombo->setItemData(index, project.projectUrl, Qt::UserRole + 4);
+    }
+    m_uploadButton->setEnabled(hasSelectedProject());
+}
+
+void CloudUploadDialog::setScanSummary(const QJsonObject& scanSummary)
+{
+    m_scanSummary = scanSummary;
+}
+
+void CloudUploadDialog::rebuildDependencyList()
+{
+    m_dependencyList->clear();
+    m_dependencies = DependencyResolver::detect(m_mainAssetPath);
+    for (const DependencyEntry& entry : m_dependencies) {
+        const QFileInfo info(entry.absolutePath);
+        QString label = info.fileName();
+        if (!entry.exists)
+            label += tr(" (missing)");
+        auto* item = new QListWidgetItem(label, m_dependencyList);
+        item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
+        item->setCheckState(entry.checkedByDefault ? Qt::Checked : Qt::Unchecked);
+        item->setData(Qt::UserRole, entry.absolutePath);
+        item->setToolTip(entry.referencedBy);
+        if (!entry.exists)
+            item->setForeground(Qt::darkYellow);
+    }
+}
+
+bool CloudUploadDialog::hasSelectedProject() const
+{
+    return m_projectCombo && m_projectCombo->currentIndex() >= 0;
+}
+
+QtMeshCloudClient::ProjectSummary CloudUploadDialog::selectedProject() const
+{
+    QtMeshCloudClient::ProjectSummary summary;
+    if (!hasSelectedProject())
+        return summary;
+
+    const int index = m_projectCombo->currentIndex();
+    summary.id = m_projectCombo->itemData(index, Qt::UserRole).toString();
+    summary.ownerSlug = m_projectCombo->itemData(index, Qt::UserRole + 1).toString();
+    summary.projectSlug = m_projectCombo->itemData(index, Qt::UserRole + 2).toString();
+    summary.name = m_projectCombo->itemData(index, Qt::UserRole + 3).toString();
+    summary.projectUrl = m_projectCombo->itemData(index, Qt::UserRole + 4).toString();
+    return summary;
+}
+
+QString CloudUploadDialog::projectName() const
+{
+    const QtMeshCloudClient::ProjectSummary project = selectedProject();
+    if (!project.name.isEmpty())
+        return project.name;
+    return project.projectSlug;
+}
+
+bool CloudUploadDialog::runLocalScanBeforeUpload() const
+{
+    return m_runScanCheck->isChecked();
+}
+
+QStringList CloudUploadDialog::selectedAbsolutePaths() const
+{
+    QStringList extras;
+    for (int row = 0; row < m_dependencyList->count(); ++row) {
+        QListWidgetItem* item = m_dependencyList->item(row);
+        if (item && item->checkState() == Qt::Checked)
+            extras.append(item->data(Qt::UserRole).toString());
+    }
+    return extras;
+}
+
+PackageMetadata CloudUploadDialog::manifest() const
+{
+    const QString mainCanonical = QFileInfo(m_mainAssetPath).absoluteFilePath();
+    QSet<QString> selected;
+    for (const QString& path : selectedAbsolutePaths())
+        selected.insert(QFileInfo(path).absoluteFilePath());
+
+    QStringList extras;
+    for (const QString& path : selected) {
+        if (path != mainCanonical)
+            extras.append(path);
+    }
+    PackageMetadata metadata =
+        ProjectPackager::buildManifest(m_mainAssetPath, extras, projectName());
+    metadata.files.erase(
+        std::remove_if(metadata.files.begin(), metadata.files.end(),
+                       [&](const PackageEntry& entry) {
+                           return !selected.contains(entry.absolutePath);
+                       }),
+        metadata.files.end());
+    metadata.totalSize = 0;
+    for (const PackageEntry& entry : metadata.files)
+        metadata.totalSize += entry.size;
+    if (!m_scanSummary.isEmpty())
+        metadata.scanSummary = m_scanSummary;
+    return metadata;
+}

--- a/src/CloudUploadDialog.cpp
+++ b/src/CloudUploadDialog.cpp
@@ -2,6 +2,7 @@
 
 #include "DependencyResolver.h"
 #include "ProjectPackager.h"
+#include "SentryReporter.h"
 
 #include <algorithm>
 
@@ -55,8 +56,16 @@ CloudUploadDialog::CloudUploadDialog(QWidget* parent)
     buttons->addWidget(m_uploadButton);
     layout->addLayout(buttons);
 
-    connect(cancelButton, &QPushButton::clicked, this, &QDialog::reject);
-    connect(m_uploadButton, &QPushButton::clicked, this, &QDialog::accept);
+    connect(cancelButton, &QPushButton::clicked, this, [this]() {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("Cloud upload dialog: Cancel"));
+        reject();
+    });
+    connect(m_uploadButton, &QPushButton::clicked, this, [this]() {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("Cloud upload dialog: Upload"));
+        accept();
+    });
     connect(m_projectCombo, &QComboBox::currentIndexChanged, this, [this](int) {
         m_uploadButton->setEnabled(hasSelectedProject());
     });
@@ -106,6 +115,9 @@ void CloudUploadDialog::rebuildDependencyList()
 {
     m_dependencyList->clear();
     m_dependencies = DependencyResolver::detect(m_mainAssetPath);
+    SentryReporter::addBreadcrumb(QStringLiteral("cloud.upload"),
+                                  QStringLiteral("Detected %1 cloud upload dependencies")
+                                      .arg(m_dependencies.size()));
     for (const DependencyEntry& entry : m_dependencies) {
         const QFileInfo info(entry.absolutePath);
         QString label = info.fileName();

--- a/src/CloudUploadDialog.h
+++ b/src/CloudUploadDialog.h
@@ -1,0 +1,46 @@
+#ifndef CLOUD_UPLOAD_DIALOG_H
+#define CLOUD_UPLOAD_DIALOG_H
+
+#include "DependencyResolver.h"
+#include "ProjectPackager.h"
+#include "QtMeshCloudClient.h"
+
+#include <QDialog>
+#include <QStringList>
+
+class QCheckBox;
+class QComboBox;
+class QListWidget;
+class QPushButton;
+
+class CloudUploadDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit CloudUploadDialog(QWidget* parent = nullptr);
+
+    void setAccountLabel(const QString& accountLabel);
+    void setMainAssetPath(const QString& mainAssetPath);
+    void setProjects(const QList<QtMeshCloudClient::ProjectSummary>& projects);
+    void setScanSummary(const QJsonObject& scanSummary);
+
+    bool hasSelectedProject() const;
+    QtMeshCloudClient::ProjectSummary selectedProject() const;
+    QString projectName() const;
+    PackageMetadata manifest() const;
+    bool runLocalScanBeforeUpload() const;
+
+private:
+    void rebuildDependencyList();
+    QStringList selectedAbsolutePaths() const;
+
+    QString m_mainAssetPath;
+    QComboBox* m_projectCombo = nullptr;
+    QListWidget* m_dependencyList = nullptr;
+    QCheckBox* m_runScanCheck = nullptr;
+    QPushButton* m_uploadButton = nullptr;
+    QVector<DependencyEntry> m_dependencies;
+    QJsonObject m_scanSummary;
+};
+
+#endif // CLOUD_UPLOAD_DIALOG_H

--- a/src/CloudUploadProgress.cpp
+++ b/src/CloudUploadProgress.cpp
@@ -1,5 +1,7 @@
 #include "CloudUploadProgress.h"
 
+#include "SentryReporter.h"
+
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QProgressBar>
@@ -21,7 +23,11 @@ CloudUploadProgress::CloudUploadProgress(QWidget* parent)
     layout->addWidget(m_bar);
     layout->addWidget(m_cancelButton);
 
-    connect(m_cancelButton, &QPushButton::clicked, this, &CloudUploadProgress::cancelRequested);
+    connect(m_cancelButton, &QPushButton::clicked, this, [this]() {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("Cloud upload progress: Cancel"));
+        emit cancelRequested();
+    });
     hide();
 }
 

--- a/src/CloudUploadProgress.cpp
+++ b/src/CloudUploadProgress.cpp
@@ -1,0 +1,57 @@
+#include "CloudUploadProgress.h"
+
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QProgressBar>
+#include <QPushButton>
+
+CloudUploadProgress::CloudUploadProgress(QWidget* parent)
+    : QWidget(parent)
+{
+    auto* layout = new QHBoxLayout(this);
+    layout->setContentsMargins(8, 2, 8, 2);
+
+    m_label = new QLabel(this);
+    m_bar = new QProgressBar(this);
+    m_bar->setTextVisible(false);
+    m_bar->setMaximumWidth(220);
+    m_cancelButton = new QPushButton(tr("Cancel"), this);
+
+    layout->addWidget(m_label, 1);
+    layout->addWidget(m_bar);
+    layout->addWidget(m_cancelButton);
+
+    connect(m_cancelButton, &QPushButton::clicked, this, &CloudUploadProgress::cancelRequested);
+    hide();
+}
+
+void CloudUploadProgress::start(const QString& label, int total)
+{
+    m_label->setText(label);
+    m_bar->setRange(0, qMax(1, total));
+    m_bar->setValue(0);
+    show();
+}
+
+void CloudUploadProgress::updateProgress(int current, int total, const QString& fileName)
+{
+    m_bar->setMaximum(qMax(1, total));
+    m_bar->setValue(current);
+    m_label->setText(tr("Uploading %1…").arg(fileName));
+}
+
+void CloudUploadProgress::finish(bool ok, const QString& message)
+{
+    m_label->setText(message);
+    m_bar->setValue(m_bar->maximum());
+    m_cancelButton->setEnabled(false);
+    if (!ok)
+        m_label->setStyleSheet(QStringLiteral("color: #ffb4b4;"));
+}
+
+void CloudUploadProgress::hideProgress()
+{
+    m_cancelButton->setEnabled(true);
+    m_label->setStyleSheet({});
+    hide();
+}

--- a/src/CloudUploadProgress.h
+++ b/src/CloudUploadProgress.h
@@ -1,0 +1,30 @@
+#ifndef CLOUD_UPLOAD_PROGRESS_H
+#define CLOUD_UPLOAD_PROGRESS_H
+
+#include <QWidget>
+
+class QLabel;
+class QProgressBar;
+class QPushButton;
+
+class CloudUploadProgress : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit CloudUploadProgress(QWidget* parent = nullptr);
+
+    void start(const QString& label, int total);
+    void updateProgress(int current, int total, const QString& fileName);
+    void finish(bool ok, const QString& message);
+    void hideProgress();
+
+signals:
+    void cancelRequested();
+
+private:
+    QLabel* m_label = nullptr;
+    QProgressBar* m_bar = nullptr;
+    QPushButton* m_cancelButton = nullptr;
+};
+
+#endif // CLOUD_UPLOAD_PROGRESS_H

--- a/src/DependencyResolver.cpp
+++ b/src/DependencyResolver.cpp
@@ -7,6 +7,7 @@
 #include <OgreMaterialManager.h>
 #include <OgrePass.h>
 #include <OgreResourceGroupManager.h>
+#include <OgreRoot.h>
 #include <OgreSubEntity.h>
 #include <OgreTechnique.h>
 #include <OgreTextureUnitState.h>
@@ -219,7 +220,7 @@ void collectRsdDependencies(const QString& rsdPath,
 
 QString locateTextureOnDisk(const Ogre::String& textureName, const Ogre::String& groupName)
 {
-    if (textureName.empty())
+    if (textureName.empty() || !Ogre::Root::getSingletonPtr())
         return {};
 
     const Ogre::StringVectorPtr locationsPtr =
@@ -293,10 +294,14 @@ QVector<DependencyEntry> DependencyResolver::detectFromLoadedScene(const QString
     QVector<DependencyEntry> out;
     QSet<QString> seen;
 
-    if (!Manager::getSingletonPtr())
+    Manager* manager = Manager::getSingletonPtr();
+    // Scene texture probing needs a live editor session. Unit tests may leave a
+    // headless Manager singleton around without a MainWindow or valid Ogre scene.
+    if (!manager || !manager->getMainWindow() || !manager->getRoot() || !manager->getSceneMgr())
         return out;
 
-    for (Ogre::Entity* entity : Manager::getSingleton()->getEntities()) {
+    try {
+    for (Ogre::Entity* entity : manager->getEntities()) {
         if (!entity || entity->getMovableType() != "Entity")
             continue;
 
@@ -328,6 +333,9 @@ QVector<DependencyEntry> DependencyResolver::detectFromLoadedScene(const QString
                 }
             }
         }
+    }
+    } catch (const Ogre::Exception&) {
+        return out;
     }
 
     return out;

--- a/src/DependencyResolver.cpp
+++ b/src/DependencyResolver.cpp
@@ -249,11 +249,31 @@ QVector<DependencyEntry> DependencyResolver::detectFromFiles(const QString& main
 
     const QString ext = mainInfo.suffix().toLower();
     if (ext == QLatin1String("obj")) {
-        const QString mtlPath = mainInfo.absolutePath() + QLatin1Char('/')
-            + mainInfo.completeBaseName() + QStringLiteral(".mtl");
-        if (QFileInfo::exists(mtlPath)) {
-            appendEntry(out, seen, mtlPath, QStringLiteral("material"), mainInfo.fileName());
-            collectMtlDependencies(mtlPath, out, seen);
+        bool foundMtl = false;
+        QFile objFile(mainInfo.absoluteFilePath());
+        if (objFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            while (!objFile.atEnd()) {
+                const QString line = QString::fromUtf8(objFile.readLine()).trimmed();
+                if (!line.startsWith(QLatin1String("mtllib "), Qt::CaseInsensitive))
+                    continue;
+                const QString mtlName = line.mid(7).trimmed();
+                if (mtlName.isEmpty())
+                    continue;
+                const QString mtlPath = QDir(mainInfo.absolutePath()).filePath(mtlName);
+                if (!QFileInfo::exists(mtlPath))
+                    continue;
+                foundMtl = true;
+                appendEntry(out, seen, mtlPath, QStringLiteral("material"), mainInfo.fileName());
+                collectMtlDependencies(mtlPath, out, seen);
+            }
+        }
+        if (!foundMtl) {
+            const QString mtlPath = mainInfo.absolutePath() + QLatin1Char('/')
+                + mainInfo.completeBaseName() + QStringLiteral(".mtl");
+            if (QFileInfo::exists(mtlPath)) {
+                appendEntry(out, seen, mtlPath, QStringLiteral("material"), mainInfo.fileName());
+                collectMtlDependencies(mtlPath, out, seen);
+            }
         }
     } else if (ext == QLatin1String("gltf")) {
         collectGltfDependencies(mainInfo.absoluteFilePath(), out, seen);

--- a/src/DependencyResolver.cpp
+++ b/src/DependencyResolver.cpp
@@ -1,0 +1,332 @@
+#include "DependencyResolver.h"
+
+#include "Manager.h"
+#include "PS1/PS1RSD.h"
+
+#include <OgreEntity.h>
+#include <OgreMaterialManager.h>
+#include <OgrePass.h>
+#include <OgreResourceGroupManager.h>
+#include <OgreSubEntity.h>
+#include <OgreTechnique.h>
+#include <OgreTextureUnitState.h>
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QRegularExpression>
+#include <QSet>
+#include <QStandardPaths>
+#include <QUrl>
+
+namespace {
+
+QString canonicalPath(const QString& path)
+{
+    const QFileInfo info(path);
+    if (!info.exists() && !info.isAbsolute())
+        return QFileInfo(path).absoluteFilePath();
+    return info.canonicalFilePath().isEmpty() ? info.absoluteFilePath() : info.canonicalFilePath();
+}
+
+QString roleForExtension(const QString& fileName)
+{
+    const QString ext = QFileInfo(fileName).suffix().toLower();
+    if (ext == QLatin1String("mesh") || ext == QLatin1String("obj") || ext == QLatin1String("fbx")
+        || ext == QLatin1String("gltf") || ext == QLatin1String("glb") || ext == QLatin1String("dae")
+        || ext == QLatin1String("collada") || ext == QLatin1String("stl") || ext == QLatin1String("tmd"))
+        return QStringLiteral("main");
+    if (ext == QLatin1String("skeleton") || ext == QLatin1String("skel"))
+        return QStringLiteral("skeleton");
+    if (ext == QLatin1String("anim") || ext == QLatin1String("animation"))
+        return QStringLiteral("animation");
+    if (ext == QLatin1String("material") || ext == QLatin1String("mat") || ext == QLatin1String("mtl"))
+        return QStringLiteral("material");
+    if (ext == QLatin1String("png") || ext == QLatin1String("jpg") || ext == QLatin1String("jpeg")
+        || ext == QLatin1String("tga") || ext == QLatin1String("bmp") || ext == QLatin1String("dds")
+        || ext == QLatin1String("tif") || ext == QLatin1String("tiff") || ext == QLatin1String("tim"))
+        return QStringLiteral("texture");
+    if (ext == QLatin1String("json") || ext == QLatin1String("yml") || ext == QLatin1String("yaml")
+        || ext == QLatin1String("xml"))
+        return QStringLiteral("metadata");
+    if (ext == QLatin1String("rsd"))
+        return QStringLiteral("main");
+    if (ext == QLatin1String("ply"))
+        return QStringLiteral("ps1-ply");
+    return QStringLiteral("other");
+}
+
+void appendEntry(QVector<DependencyEntry>& out,
+                 QSet<QString>& seen,
+                 const QString& absolutePath,
+                 const QString& role,
+                 const QString& referencedBy)
+{
+    if (absolutePath.trimmed().isEmpty())
+        return;
+
+    const QString key = canonicalPath(absolutePath);
+    if (seen.contains(key))
+        return;
+    seen.insert(key);
+
+    DependencyEntry entry;
+    entry.absolutePath = key;
+    entry.role = role;
+    entry.referencedBy = referencedBy;
+    entry.exists = QFileInfo::exists(key);
+    entry.checkedByDefault = entry.exists;
+    out.append(entry);
+}
+
+QString resolveRelativePath(const QString& baseDir, const QString& reference)
+{
+    QString ref = reference.trimmed();
+    if (ref.isEmpty())
+        return {};
+
+    if (ref.startsWith(QLatin1String("file://"), Qt::CaseInsensitive))
+        ref = QUrl(ref).toLocalFile();
+
+    const QFileInfo refInfo(ref);
+    if (refInfo.isAbsolute())
+        return refInfo.absoluteFilePath();
+
+    const QString joined = QDir(baseDir).filePath(ref);
+    return QFileInfo(joined).absoluteFilePath();
+}
+
+void collectMtlDependencies(const QString& mtlPath,
+                            QVector<DependencyEntry>& out,
+                            QSet<QString>& seen)
+{
+    QFile file(mtlPath);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+        return;
+
+    const QString baseDir = QFileInfo(mtlPath).absolutePath();
+    static const QRegularExpression mapLine(
+        QStringLiteral("^(map_[A-Za-z0-9_]+|bump|disp|decal)\\s+(.+)$"));
+    while (!file.atEnd()) {
+        const QString line = QString::fromUtf8(file.readLine()).trimmed();
+        const auto match = mapLine.match(line);
+        if (!match.hasMatch())
+            continue;
+        const QString textureRef = match.captured(2).trimmed();
+        const QString resolved = resolveRelativePath(baseDir, textureRef);
+        appendEntry(out, seen, resolved, QStringLiteral("texture"), QFileInfo(mtlPath).fileName());
+    }
+}
+
+void collectGltfDependencies(const QString& gltfPath,
+                             QVector<DependencyEntry>& out,
+                             QSet<QString>& seen)
+{
+    QFile file(gltfPath);
+    if (!file.open(QIODevice::ReadOnly))
+        return;
+
+    QJsonParseError err{};
+    const QJsonDocument doc = QJsonDocument::fromJson(file.readAll(), &err);
+    if (err.error != QJsonParseError::NoError || !doc.isObject())
+        return;
+
+    const QString baseDir = QFileInfo(gltfPath).absolutePath();
+    const QJsonObject root = doc.object();
+
+    const QJsonArray buffers = root.value(QStringLiteral("buffers")).toArray();
+    for (const QJsonValue& value : buffers) {
+        const QString uri = value.toObject().value(QStringLiteral("uri")).toString();
+        if (uri.startsWith(QStringLiteral("data:"), Qt::CaseInsensitive))
+            continue;
+        appendEntry(out, seen, resolveRelativePath(baseDir, uri), QStringLiteral("other"),
+                    QFileInfo(gltfPath).fileName());
+    }
+
+    const QJsonArray images = root.value(QStringLiteral("images")).toArray();
+    for (const QJsonValue& value : images) {
+        const QString uri = value.toObject().value(QStringLiteral("uri")).toString();
+        if (uri.startsWith(QStringLiteral("data:"), Qt::CaseInsensitive))
+            continue;
+        appendEntry(out, seen, resolveRelativePath(baseDir, uri), QStringLiteral("texture"),
+                    QFileInfo(gltfPath).fileName());
+    }
+}
+
+void collectColladaDependencies(const QString& daePath,
+                                QVector<DependencyEntry>& out,
+                                QSet<QString>& seen)
+{
+    QFile file(daePath);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+        return;
+
+    const QString baseDir = QFileInfo(daePath).absolutePath();
+    static const QRegularExpression imageInit(
+        QStringLiteral("<init_from>([^<]+)</init_from>"),
+        QRegularExpression::CaseInsensitiveOption);
+    const QString content = QString::fromUtf8(file.readAll());
+    auto it = imageInit.globalMatch(content);
+    while (it.hasNext()) {
+        const auto match = it.next();
+        appendEntry(out, seen, resolveRelativePath(baseDir, match.captured(1).trimmed()),
+                    QStringLiteral("texture"), QFileInfo(daePath).fileName());
+    }
+}
+
+void collectMeshSidecars(const QString& meshPath,
+                         QVector<DependencyEntry>& out,
+                         QSet<QString>& seen)
+{
+    const QFileInfo meshInfo(meshPath);
+    const QString base = meshInfo.absolutePath() + QLatin1Char('/') + meshInfo.completeBaseName();
+    const QStringList sidecars = {
+        base + QStringLiteral(".material"),
+        base + QStringLiteral(".skeleton"),
+        base + QStringLiteral(".skel"),
+    };
+    for (const QString& sidecar : sidecars) {
+        if (QFileInfo::exists(sidecar))
+            appendEntry(out, seen, sidecar, roleForExtension(sidecar), meshInfo.fileName());
+    }
+}
+
+void collectRsdDependencies(const QString& rsdPath,
+                            QVector<DependencyEntry>& out,
+                            QSet<QString>& seen)
+{
+    PS1RSD::RsdDescriptor descriptor;
+    QString err;
+    if (!PS1RSD::parseRsdFile(rsdPath, descriptor, &err))
+        return;
+
+    const QString baseDir = QFileInfo(rsdPath).absolutePath();
+    const auto addRef = [&](const QString& ref, const QString& role) {
+        if (ref.isEmpty())
+            return;
+        appendEntry(out, seen, resolveRelativePath(baseDir, ref), role, QFileInfo(rsdPath).fileName());
+    };
+
+    addRef(descriptor.plyPath, QStringLiteral("ps1-ply"));
+    addRef(descriptor.matPath, QStringLiteral("ps1-mat"));
+    addRef(descriptor.grpPath, QStringLiteral("metadata"));
+    for (const QString& texture : descriptor.textures)
+        addRef(texture, QStringLiteral("ps1-tim"));
+}
+
+QString locateTextureOnDisk(const Ogre::String& textureName, const Ogre::String& groupName)
+{
+    if (textureName.empty())
+        return {};
+
+    const Ogre::StringVectorPtr locationsPtr =
+        Ogre::ResourceGroupManager::getSingleton().findResourceLocation(groupName, textureName);
+    if (!locationsPtr)
+        return {};
+    for (const Ogre::String& location : *locationsPtr) {
+        const QString path = QString::fromStdString(location);
+        if (QFileInfo::exists(path))
+            return path;
+    }
+    return {};
+}
+
+} // namespace
+
+QVector<DependencyEntry> DependencyResolver::detectFromFiles(const QString& mainAssetPath)
+{
+    QVector<DependencyEntry> out;
+    QSet<QString> seen;
+
+    const QFileInfo mainInfo(mainAssetPath);
+    if (!mainInfo.exists())
+        return out;
+
+    appendEntry(out, seen, mainInfo.absoluteFilePath(), QStringLiteral("main"), QStringLiteral("main"));
+
+    const QString ext = mainInfo.suffix().toLower();
+    if (ext == QLatin1String("obj")) {
+        const QString mtlPath = mainInfo.absolutePath() + QLatin1Char('/')
+            + mainInfo.completeBaseName() + QStringLiteral(".mtl");
+        if (QFileInfo::exists(mtlPath)) {
+            appendEntry(out, seen, mtlPath, QStringLiteral("material"), mainInfo.fileName());
+            collectMtlDependencies(mtlPath, out, seen);
+        }
+    } else if (ext == QLatin1String("gltf")) {
+        collectGltfDependencies(mainInfo.absoluteFilePath(), out, seen);
+    } else if (ext == QLatin1String("dae") || ext == QLatin1String("collada")) {
+        collectColladaDependencies(mainInfo.absoluteFilePath(), out, seen);
+    } else if (ext == QLatin1String("mesh")) {
+        collectMeshSidecars(mainInfo.absoluteFilePath(), out, seen);
+    } else if (ext == QLatin1String("rsd")) {
+        collectRsdDependencies(mainInfo.absoluteFilePath(), out, seen);
+    }
+
+    return out;
+}
+
+QVector<DependencyEntry> DependencyResolver::detectFromLoadedScene(const QString& referencedBy)
+{
+    QVector<DependencyEntry> out;
+    QSet<QString> seen;
+
+    if (!Manager::getSingletonPtr())
+        return out;
+
+    for (Ogre::Entity* entity : Manager::getSingleton()->getEntities()) {
+        if (!entity || entity->getMovableType() != "Entity")
+            continue;
+
+        for (unsigned int sub = 0; sub < entity->getNumSubEntities(); ++sub) {
+            Ogre::SubEntity* subEntity = entity->getSubEntity(sub);
+            if (!subEntity)
+                continue;
+
+            Ogre::MaterialPtr material = subEntity->getMaterial();
+            if (!material)
+                continue;
+
+            for (Ogre::Technique* technique : material->getTechniques()) {
+                if (!technique)
+                    continue;
+                for (unsigned short passIndex = 0; passIndex < technique->getNumPasses(); ++passIndex) {
+                    Ogre::Pass* pass = technique->getPass(passIndex);
+                    if (!pass)
+                        continue;
+                    for (unsigned short tusIndex = 0; tusIndex < pass->getNumTextureUnitStates(); ++tusIndex) {
+                        Ogre::TextureUnitState* tus = pass->getTextureUnitState(tusIndex);
+                        if (!tus)
+                            continue;
+                        const QString texturePath = locateTextureOnDisk(
+                            tus->getTextureName(), material->getGroup());
+                        if (!texturePath.isEmpty())
+                            appendEntry(out, seen, texturePath, QStringLiteral("texture"), referencedBy);
+                    }
+                }
+            }
+        }
+    }
+
+    return out;
+}
+
+QVector<DependencyEntry> DependencyResolver::detect(const QString& mainAssetPath)
+{
+    QVector<DependencyEntry> out = detectFromFiles(mainAssetPath);
+    QSet<QString> seen;
+    for (const DependencyEntry& entry : out)
+        seen.insert(entry.absolutePath);
+
+    const QVector<DependencyEntry> sceneDeps =
+        detectFromLoadedScene(QFileInfo(mainAssetPath).fileName());
+    for (const DependencyEntry& entry : sceneDeps) {
+        if (!seen.contains(entry.absolutePath)) {
+            seen.insert(entry.absolutePath);
+            out.append(entry);
+        }
+    }
+    return out;
+}

--- a/src/DependencyResolver.h
+++ b/src/DependencyResolver.h
@@ -1,0 +1,30 @@
+#ifndef DEPENDENCY_RESOLVER_H
+#define DEPENDENCY_RESOLVER_H
+
+#include <QString>
+#include <QStringList>
+#include <QVector>
+
+struct DependencyEntry {
+    QString absolutePath;
+    QString role;
+    bool checkedByDefault = true;
+    bool exists = true;
+    QString referencedBy;
+};
+
+class DependencyResolver {
+public:
+    DependencyResolver() = delete;
+
+    /// Walk the main asset and any loaded scene materials; return deduped dependencies.
+    static QVector<DependencyEntry> detect(const QString& mainAssetPath);
+
+    /// File-format heuristics only (no Ogre scene walk). Used by unit tests.
+    static QVector<DependencyEntry> detectFromFiles(const QString& mainAssetPath);
+
+    /// Optional scene walk for textures/material sidecars when Ogre is initialized.
+    static QVector<DependencyEntry> detectFromLoadedScene(const QString& referencedBy);
+};
+
+#endif // DEPENDENCY_RESOLVER_H

--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -29,7 +29,6 @@
 #include "UvUnwrap.h"
 #include "AssetScanController.h"
 #include "CloudCredentialStore.h"
-#include "DependencyResolver.h"
 #include "ProjectPackager.h"
 #include "QtMeshCloudClient.h"
 #include "QtMeshCloudSession.h"

--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -27,7 +27,9 @@
 #include "VertexCacheOptimizer.h"
 #include "MeshDecimator.h"
 #include "UvUnwrap.h"
+#include "AssetScanController.h"
 #include "CloudCredentialStore.h"
+#include "DependencyResolver.h"
 #include "ProjectPackager.h"
 #include "QtMeshCloudClient.h"
 #include "QtMeshCloudSession.h"
@@ -674,8 +676,8 @@ QJsonObject MCPServer::callTool(const QString &name, const QJsonObject &args)
         txn = SentryReporter::startTransaction(QStringLiteral("mcp.%1").arg(name), "mcp.tool");
     }
 
-    // Lazily initialize Ogre/Manager on first tool call
-    if (!ensureOgreInitialized()) {
+    // Lazily initialize Ogre/Manager on first scene-dependent tool call
+    if (!name.startsWith(QStringLiteral("cloud_")) && !ensureOgreInitialized()) {
         if (txn) SentryReporter::finishTransaction(txn);
         return makeErrorResult("Error: Ogre 3D engine could not be initialized (no OpenGL available)");
     }
@@ -5070,6 +5072,7 @@ QJsonObject MCPServer::toolCloudLogin(const QJsonObject &args)
 QJsonObject MCPServer::toolCloudLogout(const QJsonObject & /*args*/)
 {
     SentryReporter::addBreadcrumb(QStringLiteral("ai.tool_call"), QStringLiteral("cloud_logout"));
+    CloudCredentialStore::migrateLegacySettingsIfNeeded();
     const QString token = CloudCredentialStore::loadSession().token;
     if (!token.isEmpty())
         QtMeshCloudClient::logout(token);
@@ -5116,6 +5119,7 @@ QJsonObject MCPServer::toolCloudDeleteProject(const QJsonObject &args)
     if (projectId.isEmpty())
         return makeErrorResult("Error: missing required 'project_id' argument");
 
+    CloudCredentialStore::migrateLegacySettingsIfNeeded();
     const QString token = CloudCredentialStore::loadSession().token;
     if (token.isEmpty())
         return makeErrorResult("Error: not signed in.");
@@ -5140,6 +5144,7 @@ QJsonObject MCPServer::toolCloudUpload(const QJsonObject &args)
     if (!QFileInfo::exists(filePath))
         return makeErrorResult(QString("Error: file not found: %1").arg(filePath));
 
+    CloudCredentialStore::migrateLegacySettingsIfNeeded();
     const QString token = CloudCredentialStore::loadSession().token;
     if (token.isEmpty())
         return makeErrorResult("Error: not signed in.");
@@ -5151,11 +5156,15 @@ QJsonObject MCPServer::toolCloudUpload(const QJsonObject &args)
     PackageMetadata manifest = ProjectPackager::buildManifest(filePath, {}, projectName);
     const bool runScan = !args.contains(QStringLiteral("scan")) || args.value(QStringLiteral("scan")).toBool(true);
     if (runScan) {
-        ScanConfig config;
-        config.roots = {QFileInfo(filePath).absolutePath()};
-        config.includePatterns = {QFileInfo(filePath).fileName()};
-        manifest.scanSummary = ScanEngine::scanReportToJsonObject(
-            ScanEngine::run(config, config.roots.first()));
+        QString scanError;
+        const QByteArray scanJson = AssetScanController::runIsolatedScanJsonSync(
+            QFileInfo(filePath).absolutePath(), QFileInfo(filePath).fileName(), &scanError);
+        if (!scanJson.isEmpty()) {
+            QJsonParseError parseError;
+            const QJsonDocument doc = QJsonDocument::fromJson(scanJson, &parseError);
+            if (parseError.error == QJsonParseError::NoError && doc.isObject())
+                manifest.scanSummary = doc.object();
+        }
     }
 
     QtMeshCloudSession session(token);

--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -27,12 +27,19 @@
 #include "VertexCacheOptimizer.h"
 #include "MeshDecimator.h"
 #include "UvUnwrap.h"
+#include "CloudCredentialStore.h"
+#include "ProjectPackager.h"
+#include "QtMeshCloudClient.h"
+#include "QtMeshCloudSession.h"
+#include "ScanConfig.h"
+#include "ScanEngine.h"
 #include "QuadRetopo.h"
 #include "SkinWeights.h"
 #include "MeshDepthRenderer.h"
 #ifdef ENABLE_STABLE_DIFFUSION
 #include "SDManager.h"
 #endif
+#include <QEventLoop>
 #include <QDebug>
 #include <QFile>
 #include <QDir>
@@ -623,7 +630,13 @@ const QMap<QString, MCPServer::ToolHandler>& MCPServer::toolHandlers()
         {QStringLiteral("mirror_pose"), &MCPServer::toolMirrorPose},
         {QStringLiteral("save_pose_library"), &MCPServer::toolSavePoseLibrary},
         {QStringLiteral("load_pose_library"), &MCPServer::toolLoadPoseLibrary},
-        {QStringLiteral("apply_pose_masked"), &MCPServer::toolApplyPoseMasked}
+        {QStringLiteral("apply_pose_masked"), &MCPServer::toolApplyPoseMasked},
+        {QStringLiteral("cloud_status"), &MCPServer::toolCloudStatus},
+        {QStringLiteral("cloud_login"), &MCPServer::toolCloudLogin},
+        {QStringLiteral("cloud_logout"), &MCPServer::toolCloudLogout},
+        {QStringLiteral("cloud_list_projects"), &MCPServer::toolCloudListProjects},
+        {QStringLiteral("cloud_delete_project"), &MCPServer::toolCloudDeleteProject},
+        {QStringLiteral("cloud_upload"), &MCPServer::toolCloudUpload}
     };
     return handlers;
 }
@@ -644,7 +657,8 @@ bool MCPServer::isHeavyTool(const QString &name)
         QStringLiteral("save_scene"),
         QStringLiteral("open_scene"),
         QStringLiteral("bake_vat"),
-        QStringLiteral("list_morph_targets")
+        QStringLiteral("list_morph_targets"),
+        QStringLiteral("cloud_upload")
     };
     return heavyTools.contains(name);
 }
@@ -5017,6 +5031,163 @@ QJsonObject MCPServer::toolApplyPoseMasked(const QJsonObject &args)
         QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Indented)));
 }
 
+QJsonObject MCPServer::toolCloudStatus(const QJsonObject & /*args*/)
+{
+    SentryReporter::addBreadcrumb(QStringLiteral("ai.tool_call"), QStringLiteral("cloud_status"));
+    CloudCredentialStore::migrateLegacySettingsIfNeeded();
+    const bool connected = CloudCredentialStore::hasSession();
+    const CloudSession session = CloudCredentialStore::loadSession();
+
+    QJsonObject content;
+    content[QStringLiteral("connected")] = connected;
+    if (connected && !session.email.isEmpty())
+        content[QStringLiteral("email")] = session.email;
+    return makeSuccessResult(
+        QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Indented)));
+}
+
+QJsonObject MCPServer::toolCloudLogin(const QJsonObject &args)
+{
+    SentryReporter::addBreadcrumb(QStringLiteral("ai.tool_call"), QStringLiteral("cloud_login"));
+    const QString apiKey = args.value(QStringLiteral("api_key")).toString().trimmed();
+    if (apiKey.isEmpty())
+        return makeErrorResult(
+            "Error: cloud_login requires an 'api_key' argument. "
+            "Interactive device flow is only available via `qtmesh cloud login`.");
+
+    CloudSession session;
+    session.token = apiKey;
+    if (!CloudCredentialStore::saveSession(session))
+        return makeErrorResult("Error: could not persist API key securely.");
+
+    QJsonObject content;
+    content[QStringLiteral("ok")] = true;
+    content[QStringLiteral("message")] = QStringLiteral("Saved API key to secure storage.");
+    return makeSuccessResult(
+        QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Indented)));
+}
+
+QJsonObject MCPServer::toolCloudLogout(const QJsonObject & /*args*/)
+{
+    SentryReporter::addBreadcrumb(QStringLiteral("ai.tool_call"), QStringLiteral("cloud_logout"));
+    const QString token = CloudCredentialStore::loadSession().token;
+    if (!token.isEmpty())
+        QtMeshCloudClient::logout(token);
+    CloudCredentialStore::clearSession();
+
+    QJsonObject content;
+    content[QStringLiteral("ok")] = true;
+    return makeSuccessResult(
+        QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Indented)));
+}
+
+QJsonObject MCPServer::toolCloudListProjects(const QJsonObject & /*args*/)
+{
+    SentryReporter::addBreadcrumb(QStringLiteral("ai.tool_call"), QStringLiteral("cloud_list_projects"));
+    CloudCredentialStore::migrateLegacySettingsIfNeeded();
+    const QString token = CloudCredentialStore::loadSession().token;
+    if (token.isEmpty())
+        return makeErrorResult("Error: not signed in. Use cloud_login first.");
+
+    const auto result = QtMeshCloudClient::fetchProjects(token);
+    if (!result.ok)
+        return makeErrorResult(result.errorString);
+
+    QJsonArray projects;
+    for (const auto& project : result.projects) {
+        QJsonObject obj;
+        obj.insert(QStringLiteral("id"), project.id);
+        obj.insert(QStringLiteral("name"), project.name);
+        obj.insert(QStringLiteral("ownerSlug"), project.ownerSlug);
+        obj.insert(QStringLiteral("projectSlug"), project.projectSlug);
+        obj.insert(QStringLiteral("projectUrl"), project.projectUrl);
+        projects.append(obj);
+    }
+    QJsonObject content;
+    content.insert(QStringLiteral("projects"), projects);
+    return makeSuccessResult(
+        QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Indented)));
+}
+
+QJsonObject MCPServer::toolCloudDeleteProject(const QJsonObject &args)
+{
+    SentryReporter::addBreadcrumb(QStringLiteral("ai.tool_call"), QStringLiteral("cloud_delete_project"));
+    const QString projectId = args.value(QStringLiteral("project_id")).toString().trimmed();
+    if (projectId.isEmpty())
+        return makeErrorResult("Error: missing required 'project_id' argument");
+
+    const QString token = CloudCredentialStore::loadSession().token;
+    if (token.isEmpty())
+        return makeErrorResult("Error: not signed in.");
+
+    const auto result = QtMeshCloudClient::deleteProject(token, projectId);
+    if (!result.ok)
+        return makeErrorResult(result.errorString);
+
+    QJsonObject content;
+    content[QStringLiteral("ok")] = true;
+    content[QStringLiteral("project_id")] = projectId;
+    return makeSuccessResult(
+        QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Indented)));
+}
+
+QJsonObject MCPServer::toolCloudUpload(const QJsonObject &args)
+{
+    SentryReporter::addBreadcrumb(QStringLiteral("ai.tool_call"), QStringLiteral("cloud_upload"));
+    const QString filePath = args.value(QStringLiteral("file")).toString();
+    if (filePath.isEmpty())
+        return makeErrorResult("Error: missing required 'file' argument");
+    if (!QFileInfo::exists(filePath))
+        return makeErrorResult(QString("Error: file not found: %1").arg(filePath));
+
+    const QString token = CloudCredentialStore::loadSession().token;
+    if (token.isEmpty())
+        return makeErrorResult("Error: not signed in.");
+
+    QString projectName = args.value(QStringLiteral("name")).toString().trimmed();
+    if (projectName.isEmpty())
+        projectName = QFileInfo(filePath).completeBaseName();
+
+    PackageMetadata manifest = ProjectPackager::buildManifest(filePath, {}, projectName);
+    const bool runScan = !args.contains(QStringLiteral("scan")) || args.value(QStringLiteral("scan")).toBool(true);
+    if (runScan) {
+        ScanConfig config;
+        config.roots = {QFileInfo(filePath).absolutePath()};
+        config.includePatterns = {QFileInfo(filePath).fileName()};
+        manifest.scanSummary = ScanEngine::scanReportToJsonObject(
+            ScanEngine::run(config, config.roots.first()));
+    }
+
+    QtMeshCloudSession session(token);
+    QEventLoop loop;
+    QString projectUrl;
+    QString error;
+    connect(&session, &QtMeshCloudSession::uploadFinished, &loop,
+            [&](bool ok, const QString& err, const QString& url, const QString&) {
+                projectUrl = url;
+                error = err;
+                if (!ok && error.isEmpty())
+                    error = QStringLiteral("Upload failed");
+                loop.quit();
+            });
+    connect(&session, &QtMeshCloudSession::uploadCanceled, &loop, [&]() {
+        error = QStringLiteral("Upload canceled");
+        loop.quit();
+    });
+    session.uploadPackage(manifest);
+    loop.exec();
+
+    if (!error.isEmpty())
+        return makeErrorResult(error);
+
+    QJsonObject content;
+    content[QStringLiteral("ok")] = true;
+    content[QStringLiteral("projectUrl")] = projectUrl;
+    content[QStringLiteral("fileCount")] = manifest.files.size();
+    return makeSuccessResult(
+        QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Indented)));
+}
+
 QJsonArray MCPServer::buildToolsList()
 {
     QJsonArray tools;
@@ -6253,6 +6424,59 @@ QJsonArray MCPServer::buildToolsList()
             props,
             required
         );
+    }
+
+    // cloud_status / cloud_login / cloud_logout / cloud_list_projects / cloud_delete_project / cloud_upload
+    {
+        appendTool(
+            "cloud_status",
+            "Return whether a QtMesh Cloud session is stored locally (never includes the token).",
+            QJsonObject{},
+            QJsonArray{});
+        QJsonObject loginProps;
+        loginProps["api_key"] = QJsonObject{
+            {"type", "string"},
+            {"description", "Bearer token / API key to store in the OS keychain. Device flow is CLI-only."}};
+        appendTool(
+            "cloud_login",
+            "Store a QtMesh Cloud API key in secure local storage.",
+            loginProps,
+            QJsonArray{"api_key"});
+        appendTool(
+            "cloud_logout",
+            "Sign out of QtMesh Cloud and clear the locally stored session.",
+            QJsonObject{},
+            QJsonArray{});
+        appendTool(
+            "cloud_list_projects",
+            "List QtMesh Cloud projects for the signed-in account.",
+            QJsonObject{},
+            QJsonArray{});
+        QJsonObject deleteProps;
+        deleteProps["project_id"] = QJsonObject{
+            {"type", "string"},
+            {"description", "Cloud project id to delete."}};
+        appendTool(
+            "cloud_delete_project",
+            "Delete a QtMesh Cloud project by id.",
+            deleteProps,
+            QJsonArray{"project_id"});
+        QJsonObject uploadProps;
+        uploadProps["file"] = QJsonObject{
+            {"type", "string"},
+            {"description", "Main asset file to package and upload (dependencies are auto-detected)."}};
+        uploadProps["name"] = QJsonObject{
+            {"type", "string"},
+            {"description", "Optional cloud project display name (defaults to the file basename)."}};
+        uploadProps["scan"] = QJsonObject{
+            {"type", "boolean"},
+            {"description", "Run a local asset scan before upload and attach the report. Default true."}};
+        appendTool(
+            "cloud_upload",
+            "Package an asset plus detected dependencies and upload to QtMesh Cloud. "
+            "Returns the project URL on success.",
+            uploadProps,
+            QJsonArray{"file"});
     }
 
     // list_morph_targets

--- a/src/MCPServer.h
+++ b/src/MCPServer.h
@@ -286,6 +286,14 @@ private:
     /// the body pose.
     QJsonObject toolApplyPoseMasked(const QJsonObject &args);
 
+    /// Epic #684 slice H: QtMesh Cloud account + upload tools.
+    QJsonObject toolCloudStatus(const QJsonObject &args);
+    QJsonObject toolCloudLogin(const QJsonObject &args);
+    QJsonObject toolCloudLogout(const QJsonObject &args);
+    QJsonObject toolCloudListProjects(const QJsonObject &args);
+    QJsonObject toolCloudDeleteProject(const QJsonObject &args);
+    QJsonObject toolCloudUpload(const QJsonObject &args);
+
     // Animation
     struct NodeAnimation {
         Ogre::SceneNode* node;

--- a/src/ProjectPackager.cpp
+++ b/src/ProjectPackager.cpp
@@ -1,0 +1,254 @@
+#include "ProjectPackager.h"
+
+#include "DependencyResolver.h"
+#include "FeedbackDiagnostics.h"
+
+#include <QCryptographicHash>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QRegularExpression>
+#include <QSet>
+
+namespace {
+
+QString applicationVersion()
+{
+    return QString::fromUtf8(QTMESHEDITOR_VERSION);
+}
+
+QString sha256File(const QString& path)
+{
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly))
+        return {};
+
+    QCryptographicHash hash(QCryptographicHash::Sha256);
+    while (!file.atEnd())
+        hash.addData(file.read(1024 * 1024));
+    return QString::fromLatin1(hash.result().toHex());
+}
+
+QString commonRootDir(const QStringList& absolutePaths)
+{
+    if (absolutePaths.isEmpty())
+        return {};
+
+    QString common = QFileInfo(absolutePaths.first()).absolutePath();
+    for (const QString& path : absolutePaths) {
+        const QString dir = QFileInfo(path).absolutePath();
+        while (!dir.startsWith(common) && !common.isEmpty()) {
+            const int slash = common.lastIndexOf(QLatin1Char('/'));
+            if (slash < 0)
+                break;
+            common = common.left(slash);
+        }
+        if (common.isEmpty())
+            break;
+    }
+    return common;
+}
+
+QString makeRelativePath(const QString& rootDir, const QString& absolutePath, QSet<QString>& usedNames)
+{
+    QString relative;
+    if (!rootDir.isEmpty() && absolutePath.startsWith(rootDir)) {
+        relative = QDir(rootDir).relativeFilePath(absolutePath);
+    } else {
+        relative = QFileInfo(absolutePath).fileName();
+    }
+
+    relative = relative.replace(QLatin1Char('\\'), QLatin1Char('/'));
+    if (relative.isEmpty())
+        relative = QFileInfo(absolutePath).fileName();
+
+    QString candidate = relative;
+    int suffix = 1;
+    while (usedNames.contains(candidate)) {
+        const QFileInfo info(relative);
+        candidate = QStringLiteral("%1.%2%3")
+                        .arg(info.completeBaseName())
+                        .arg(suffix++, 3, 10, QLatin1Char('0'))
+                        .arg(info.suffix().isEmpty() ? QString() : QLatin1Char('.') + info.suffix());
+    }
+    usedNames.insert(candidate);
+    return candidate;
+}
+
+QStringList classifyAssetTypes(const PackageMetadata& metadata)
+{
+    QStringList types;
+    types << QStringLiteral("mesh");
+
+    bool hasTexture = false;
+    bool hasSkeleton = false;
+    bool hasAnimation = false;
+    int materialCount = 0;
+    bool ps1Style = false;
+
+    for (const PackageEntry& entry : metadata.files) {
+        if (entry.role == QLatin1String("texture"))
+            hasTexture = true;
+        if (entry.role == QLatin1String("skeleton"))
+            hasSkeleton = true;
+        if (entry.role == QLatin1String("animation"))
+            hasAnimation = true;
+        if (entry.role == QLatin1String("material"))
+            ++materialCount;
+        if (entry.role.startsWith(QLatin1String("ps1-")))
+            ps1Style = true;
+    }
+
+    if (hasSkeleton)
+        types << QStringLiteral("skinned");
+    if (hasAnimation)
+        types << QStringLiteral("animated");
+    if (materialCount > 1)
+        types << QStringLiteral("multi-material");
+    if (ps1Style || metadata.sourceFormat == QLatin1String("rsd")
+        || metadata.sourceFormat == QLatin1String("tmd")
+        || metadata.sourceFormat == QLatin1String("ply")
+        || metadata.sourceFormat == QLatin1String("mat"))
+        types << QStringLiteral("ps1-style");
+    if (metadata.totalSize > 100LL * 1024 * 1024)
+        types << QStringLiteral("large");
+    if (hasTexture)
+        types << QStringLiteral("textured");
+
+    return types;
+}
+
+bool containsSensitivePathFragment(const QString& value)
+{
+    if (value.isEmpty())
+        return false;
+
+    static const QRegularExpression unixHome(QStringLiteral("(?:^|/)(?:Users|home)/[^/]+"));
+    static const QRegularExpression windowsDrive(QStringLiteral("^[A-Za-z]:[\\\\/]"));
+    static const QRegularExpression absoluteUnix(QStringLiteral("^/"));
+    if (unixHome.match(value).hasMatch() || windowsDrive.match(value).hasMatch())
+        return true;
+    if (absoluteUnix.match(value).hasMatch() && value.count(QLatin1Char('/')) > 1)
+        return true;
+    return false;
+}
+
+void lintJsonValue(const QJsonValue& value, bool& bad)
+{
+    if (value.isString()) {
+        if (containsSensitivePathFragment(value.toString()))
+            bad = true;
+        return;
+    }
+    if (value.isObject()) {
+        for (auto it = value.toObject().begin(); it != value.toObject().end(); ++it)
+            lintJsonValue(it.value(), bad);
+        return;
+    }
+    if (value.isArray()) {
+        for (const QJsonValue& item : value.toArray())
+            lintJsonValue(item, bad);
+    }
+}
+
+} // namespace
+
+PackageMetadata ProjectPackager::buildManifest(const QString& mainAssetPath,
+                                               const QStringList& explicitExtras,
+                                               const QString& projectName)
+{
+    PackageMetadata metadata;
+    const QFileInfo mainInfo(mainAssetPath);
+    metadata.projectName = projectName.trimmed().isEmpty() ? mainInfo.completeBaseName() : projectName.trimmed();
+    metadata.sourceFormat = mainInfo.suffix().toLower();
+    metadata.qtMeshEditorVersion = applicationVersion();
+
+    QVector<DependencyEntry> dependencies = DependencyResolver::detect(mainAssetPath);
+    QSet<QString> included;
+    for (const DependencyEntry& entry : dependencies)
+        included.insert(entry.absolutePath);
+    for (const QString& extra : explicitExtras) {
+        const QString canonical = QFileInfo(extra).absoluteFilePath();
+        if (!included.contains(canonical)) {
+            DependencyEntry entry;
+            entry.absolutePath = canonical;
+            entry.role = QStringLiteral("other");
+            entry.exists = QFileInfo::exists(canonical);
+            entry.checkedByDefault = entry.exists;
+            entry.referencedBy = QStringLiteral("manual");
+            dependencies.append(entry);
+            included.insert(canonical);
+        }
+    }
+
+    QStringList absolutePaths;
+    for (const DependencyEntry& entry : dependencies)
+        absolutePaths.append(entry.absolutePath);
+
+    const QString rootDir = commonRootDir(absolutePaths);
+    QSet<QString> usedNames;
+    QString mainRelative;
+
+    for (const DependencyEntry& entry : dependencies) {
+        PackageEntry packageEntry;
+        packageEntry.relativePath = makeRelativePath(rootDir, entry.absolutePath, usedNames);
+        packageEntry.absolutePath = entry.absolutePath;
+        packageEntry.role = entry.role;
+        packageEntry.size = entry.exists ? QFileInfo(entry.absolutePath).size() : 0;
+        if (entry.exists)
+            packageEntry.sha256 = sha256File(entry.absolutePath);
+        metadata.files.append(packageEntry);
+        metadata.totalSize += packageEntry.size;
+
+        if (entry.role == QLatin1String("main"))
+            mainRelative = packageEntry.relativePath;
+    }
+
+    if (mainRelative.isEmpty() && !metadata.files.isEmpty())
+        mainRelative = metadata.files.first().relativePath;
+    metadata.mainFile = mainRelative;
+    metadata.detectedAssetTypes = classifyAssetTypes(metadata);
+    return metadata;
+}
+
+QJsonObject ProjectPackager::toJson(const PackageMetadata& metadata)
+{
+    QJsonObject root;
+    root.insert(QStringLiteral("manifestVersion"), metadata.manifestVersion);
+    root.insert(QStringLiteral("projectName"), metadata.projectName);
+    root.insert(QStringLiteral("sourceFormat"), metadata.sourceFormat);
+    root.insert(QStringLiteral("mainFile"), metadata.mainFile);
+    root.insert(QStringLiteral("totalSize"), metadata.totalSize);
+    root.insert(QStringLiteral("qtMeshEditorVersion"), metadata.qtMeshEditorVersion);
+
+    QJsonArray assetTypes;
+    for (const QString& type : metadata.detectedAssetTypes)
+        assetTypes.append(type);
+    root.insert(QStringLiteral("detectedAssetTypes"), assetTypes);
+
+    if (!metadata.scanSummary.isEmpty())
+        root.insert(QStringLiteral("scanSummary"), metadata.scanSummary);
+
+    QJsonArray files;
+    for (const PackageEntry& entry : metadata.files) {
+        QJsonObject fileObj;
+        fileObj.insert(QStringLiteral("relativePath"), entry.relativePath);
+        fileObj.insert(QStringLiteral("size"), entry.size);
+        fileObj.insert(QStringLiteral("role"), entry.role);
+        if (!entry.sha256.isEmpty())
+            fileObj.insert(QStringLiteral("sha256"), entry.sha256);
+        files.append(fileObj);
+    }
+    root.insert(QStringLiteral("files"), files);
+    return root;
+}
+
+bool ProjectPackager::jsonPassesPathSanitisationLint(const QJsonObject& json)
+{
+    bool bad = false;
+    lintJsonValue(json, bad);
+    return !bad;
+}

--- a/src/ProjectPackager.cpp
+++ b/src/ProjectPackager.cpp
@@ -177,7 +177,9 @@ PackageMetadata ProjectPackager::buildManifest(const QString& mainAssetPath,
     metadata.sourceFormat = mainInfo.suffix().toLower();
     metadata.qtMeshEditorVersion = applicationVersion();
 
-    QVector<DependencyEntry> dependencies = DependencyResolver::detect(mainAssetPath);
+    // File-based detection only. Callers that need live-scene textures (the upload
+    // dialog) discover them via DependencyResolver::detect() and pass explicitExtras.
+    QVector<DependencyEntry> dependencies = DependencyResolver::detectFromFiles(mainAssetPath);
     QSet<QString> included;
     for (const DependencyEntry& entry : dependencies)
         included.insert(entry.absolutePath);

--- a/src/ProjectPackager.cpp
+++ b/src/ProjectPackager.cpp
@@ -32,6 +32,17 @@ QString sha256File(const QString& path)
     return QString::fromLatin1(hash.result().toHex());
 }
 
+bool isDescendantPath(const QString& rootDir, const QString& absolutePath)
+{
+    const QString root = QDir(rootDir).absolutePath();
+    const QString path = QDir(absolutePath).absolutePath();
+    if (root.isEmpty() || path.isEmpty())
+        return false;
+    if (path == root)
+        return true;
+    return path.startsWith(root + QLatin1Char('/'));
+}
+
 QString commonRootDir(const QStringList& absolutePaths)
 {
     if (absolutePaths.isEmpty())
@@ -40,7 +51,7 @@ QString commonRootDir(const QStringList& absolutePaths)
     QString common = QFileInfo(absolutePaths.first()).absolutePath();
     for (const QString& path : absolutePaths) {
         const QString dir = QFileInfo(path).absolutePath();
-        while (!dir.startsWith(common) && !common.isEmpty()) {
+        while (!isDescendantPath(common, dir) && !common.isEmpty()) {
             const int slash = common.lastIndexOf(QLatin1Char('/'));
             if (slash < 0)
                 break;
@@ -55,7 +66,7 @@ QString commonRootDir(const QStringList& absolutePaths)
 QString makeRelativePath(const QString& rootDir, const QString& absolutePath, QSet<QString>& usedNames)
 {
     QString relative;
-    if (!rootDir.isEmpty() && absolutePath.startsWith(rootDir)) {
+    if (!rootDir.isEmpty() && isDescendantPath(rootDir, absolutePath)) {
         relative = QDir(rootDir).relativeFilePath(absolutePath);
     } else {
         relative = QFileInfo(absolutePath).fileName();

--- a/src/ProjectPackager.cpp
+++ b/src/ProjectPackager.cpp
@@ -155,12 +155,14 @@ void lintJsonValue(const QJsonValue& value, bool& bad)
         return;
     }
     if (value.isObject()) {
-        for (auto it = value.toObject().begin(); it != value.toObject().end(); ++it)
+        const QJsonObject object = value.toObject();
+        for (auto it = object.begin(); it != object.end(); ++it)
             lintJsonValue(it.value(), bad);
         return;
     }
     if (value.isArray()) {
-        for (const QJsonValue& item : value.toArray())
+        const QJsonArray array = value.toArray();
+        for (const QJsonValue& item : array)
             lintJsonValue(item, bad);
     }
 }

--- a/src/ProjectPackager.h
+++ b/src/ProjectPackager.h
@@ -1,0 +1,43 @@
+#ifndef PROJECT_PACKAGER_H
+#define PROJECT_PACKAGER_H
+
+#include <QJsonObject>
+#include <QString>
+#include <QStringList>
+#include <QVector>
+
+struct PackageEntry {
+    QString relativePath;
+    QString absolutePath;
+    qint64 size = 0;
+    QString sha256;
+    QString role;
+};
+
+struct PackageMetadata {
+    QString projectName;
+    QString sourceFormat;
+    QString mainFile;
+    qint64 totalSize = 0;
+    QStringList detectedAssetTypes;
+    QString qtMeshEditorVersion;
+    QJsonObject scanSummary;
+    QVector<PackageEntry> files;
+    int manifestVersion = 1;
+};
+
+class ProjectPackager {
+public:
+    ProjectPackager() = delete;
+
+    static PackageMetadata buildManifest(const QString& mainAssetPath,
+                                         const QStringList& explicitExtras,
+                                         const QString& projectName);
+
+    static QJsonObject toJson(const PackageMetadata& metadata);
+
+    /// Returns true when no absolute paths, usernames, or drive letters leak into JSON.
+    static bool jsonPassesPathSanitisationLint(const QJsonObject& json);
+};
+
+#endif // PROJECT_PACKAGER_H

--- a/src/ProjectPackager_test.cpp
+++ b/src/ProjectPackager_test.cpp
@@ -1,0 +1,121 @@
+#include "DependencyResolver.h"
+#include "ProjectPackager.h"
+
+#include <gtest/gtest.h>
+
+#include <QDir>
+#include <QFile>
+#include <QTemporaryDir>
+
+TEST(DependencyResolver, ObjMtlTextureDetection)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    const QString objPath = QDir(dir.path()).filePath(QStringLiteral("model.obj"));
+    const QString mtlPath = QDir(dir.path()).filePath(QStringLiteral("model.mtl"));
+    const QString texPath = QDir(dir.path()).filePath(QStringLiteral("albedo.png"));
+
+    QFile tex(texPath);
+    ASSERT_TRUE(tex.open(QIODevice::WriteOnly));
+    tex.write("png");
+    tex.close();
+
+    QFile mtl(mtlPath);
+    ASSERT_TRUE(mtl.open(QIODevice::WriteOnly | QIODevice::Text));
+    mtl.write("newmtl mat0\nmap_Kd albedo.png\n");
+    mtl.close();
+
+    QFile obj(objPath);
+    ASSERT_TRUE(obj.open(QIODevice::WriteOnly | QIODevice::Text));
+    obj.write("mtllib model.mtl\n");
+    obj.close();
+
+    const auto deps = DependencyResolver::detectFromFiles(objPath);
+    ASSERT_GE(deps.size(), 3);
+    bool hasMain = false;
+    bool hasTexture = false;
+    for (const DependencyEntry& entry : deps) {
+        if (entry.role == QLatin1String("main"))
+            hasMain = true;
+        if (entry.absolutePath.endsWith(QStringLiteral("albedo.png")))
+            hasTexture = true;
+    }
+    EXPECT_TRUE(hasMain);
+    EXPECT_TRUE(hasTexture);
+}
+
+TEST(DependencyResolver, RsdSidecarDetection)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    const QString rsdPath = QDir(dir.path()).filePath(QStringLiteral("stage.rsd"));
+    const QString timPath = QDir(dir.path()).filePath(QStringLiteral("wall.tim"));
+    QFile tim(timPath);
+    ASSERT_TRUE(tim.open(QIODevice::WriteOnly));
+    tim.write("tim");
+    tim.close();
+
+    QFile rsd(rsdPath);
+    ASSERT_TRUE(rsd.open(QIODevice::WriteOnly | QIODevice::Text));
+    rsd.write("@RSD940102\nPLY=STAGE.PLY\nMAT=STAGE.MAT\nNTEX=1\nTEX[0]=wall.tim\n");
+    rsd.close();
+
+    const auto deps = DependencyResolver::detectFromFiles(rsdPath);
+    bool hasTim = false;
+    for (const DependencyEntry& entry : deps) {
+        if (entry.absolutePath.endsWith(QStringLiteral("wall.tim")))
+            hasTim = true;
+    }
+    EXPECT_TRUE(hasTim);
+}
+
+TEST(ProjectPackager, SanitisedManifestJson)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    const QString secretRoot = QDir(dir.path()).filePath(QStringLiteral("Users/SECRET/models"));
+    QDir().mkpath(secretRoot);
+    const QString mainPath = QDir(secretRoot).filePath(QStringLiteral("hero.obj"));
+    const QString mtlPath = QDir(secretRoot).filePath(QStringLiteral("hero.mtl"));
+    const QString texPath = QDir(secretRoot).filePath(QStringLiteral("skin.png"));
+
+    for (const QString& path : {mainPath, mtlPath, texPath}) {
+        QFile file(path);
+        ASSERT_TRUE(file.open(QIODevice::WriteOnly));
+        file.write("x");
+        file.close();
+    }
+    QFile mtl(mtlPath);
+    ASSERT_TRUE(mtl.open(QIODevice::WriteOnly | QIODevice::Text));
+    mtl.write("map_Kd skin.png\n");
+    mtl.close();
+
+    const PackageMetadata metadata =
+        ProjectPackager::buildManifest(mainPath, {}, QStringLiteral("Hero Pack"));
+    const QJsonObject json = ProjectPackager::toJson(metadata);
+    const QString serialised = QString::fromUtf8(QJsonDocument(json).toJson(QJsonDocument::Compact));
+
+    EXPECT_FALSE(serialised.contains(QStringLiteral("SECRET")));
+    EXPECT_TRUE(ProjectPackager::jsonPassesPathSanitisationLint(json));
+    EXPECT_FALSE(metadata.mainFile.contains(QStringLiteral("/Users/")));
+    EXPECT_GE(metadata.files.size(), 2);
+}
+
+TEST(ProjectPackager, ComputesSha256)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString path = QDir(dir.path()).filePath(QStringLiteral("cube.mesh"));
+    QFile file(path);
+    ASSERT_TRUE(file.open(QIODevice::WriteOnly));
+    file.write("mesh-bytes");
+    file.close();
+
+    const PackageMetadata metadata = ProjectPackager::buildManifest(path, {}, QStringLiteral("Cube"));
+    ASSERT_EQ(metadata.files.size(), 1);
+    EXPECT_FALSE(metadata.files.first().sha256.isEmpty());
+    EXPECT_EQ(metadata.files.first().sha256.size(), 64);
+}

--- a/src/QtMeshCloudClient.cpp
+++ b/src/QtMeshCloudClient.cpp
@@ -630,6 +630,58 @@ QtMeshCloudClient::ProjectsListResult QtMeshCloudClient::fetchProjects(const QSt
     return out;
 }
 
+QtMeshCloudClient::UploadResult QtMeshCloudClient::deleteProject(const QString& bearerToken,
+                                                                 const QString& projectId,
+                                                                 int timeoutMs)
+{
+    UploadResult out;
+    if (bearerToken.isEmpty()) {
+        out.errorString = QStringLiteral("missing bearer token");
+        return out;
+    }
+    if (projectId.trimmed().isEmpty()) {
+        out.errorString = QStringLiteral("missing project id");
+        return out;
+    }
+
+    const QUrl url(apiBaseUrl()
+        + QStringLiteral("/v1/projects/")
+        + QString::fromUtf8(QUrl::toPercentEncoding(projectId.trimmed())));
+    if (!url.isValid()) {
+        out.errorString = QStringLiteral("invalid API base URL");
+        return out;
+    }
+
+    QNetworkAccessManager nam;
+    QNetworkRequest req(url);
+    req.setHeader(QNetworkRequest::UserAgentHeader, QStringLiteral("qtmesheditor"));
+    req.setRawHeader("Authorization", QByteArrayLiteral("Bearer ") + bearerToken.toUtf8());
+    req.setTransferTimeout(timeoutMs);
+
+    SentryReporter::addBreadcrumb(QStringLiteral("cloud.project"),
+                                  QStringLiteral("QtMesh Cloud deleteProject: start"));
+
+    QNetworkReply* reply = nam.deleteResource(req);
+    QEventLoop loop;
+    QObject::connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+    loop.exec();
+
+    out.httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    const QByteArray responseBody = reply->readAll();
+    const auto nerr = reply->error();
+    const QString transportErr = reply->errorString();
+    reply->deleteLater();
+
+    out.responseBodySnippet = trimSnippet(responseBody);
+    out.ok = nerr == QNetworkReply::NoError && out.httpStatus >= 200 && out.httpStatus < 300;
+    if (!out.ok) {
+        out.errorString = nerr != QNetworkReply::NoError ? transportErr : QStringLiteral("HTTP %1").arg(out.httpStatus);
+        if (!out.responseBodySnippet.isEmpty())
+            out.errorString += QStringLiteral(" — ") + out.responseBodySnippet;
+    }
+    return out;
+}
+
 QtMeshCloudClient::ProjectResult QtMeshCloudClient::createProject(const QString& bearerToken,
                                                                   const QString& name,
                                                                   const QString& slug,

--- a/src/QtMeshCloudClient.h
+++ b/src/QtMeshCloudClient.h
@@ -115,6 +115,11 @@ public:
     /// GET /v1/projects — lists cloud projects the authenticated user can access.
     static ProjectsListResult fetchProjects(const QString& bearerToken, int timeoutMs = 30000);
 
+    /// DELETE /v1/projects/{id} — removes a cloud project.
+    static UploadResult deleteProject(const QString& bearerToken,
+                                      const QString& projectId,
+                                      int timeoutMs = 30000);
+
     /// POST /v1/projects — creates a private cloud project owned by the authenticated user.
     static ProjectResult createProject(const QString& bearerToken,
                                        const QString& name,

--- a/src/QtMeshCloudSession.cpp
+++ b/src/QtMeshCloudSession.cpp
@@ -3,6 +3,8 @@
 #include "CloudUploadPlanner.h"
 #include "SentryReporter.h"
 
+#include <QPointer>
+#include <QCoreApplication>
 #include <QThread>
 
 QtMeshCloudSession::QtMeshCloudSession(const QString& bearerToken, QObject* parent)
@@ -19,14 +21,17 @@ void QtMeshCloudSession::cancel()
 void QtMeshCloudSession::listProjects()
 {
     const QString token = m_bearerToken;
-    QThread* worker = QThread::create([this, token]() {
+    QPointer<QtMeshCloudSession> self(this);
+    QThread* worker = QThread::create([self, token]() {
         const auto result = QtMeshCloudClient::fetchProjects(token);
-        QMetaObject::invokeMethod(this, [this, result]() {
+        QMetaObject::invokeMethod(qApp, [self, result]() {
+            if (!self)
+                return;
             if (!result.ok) {
-                emit projectsListed({}, result.errorString);
+                emit self->projectsListed({}, result.errorString);
                 return;
             }
-            emit projectsListed(result.projects, {});
+            emit self->projectsListed(result.projects, {});
         }, Qt::QueuedConnection);
     });
     connect(worker, &QThread::finished, worker, &QObject::deleteLater);
@@ -42,7 +47,8 @@ void QtMeshCloudSession::uploadPackage(const PackageMetadata& metadata,
     const QString token = m_bearerToken;
     const PackageMetadata package = metadata;
 
-    QThread* worker = QThread::create([this, token, package, ownerSlug, projectSlug, createNewProject]() {
+    QPointer<QtMeshCloudSession> self(this);
+    QThread* worker = QThread::create([self, token, package, ownerSlug, projectSlug, createNewProject, canceled = &m_canceled]() {
         QtMeshCloudClient::ProjectResult project;
         if (createNewProject) {
             QString slug = projectSlug.isEmpty()
@@ -58,15 +64,22 @@ void QtMeshCloudSession::uploadPackage(const PackageMetadata& metadata,
             project.ok = true;
             project.ownerSlug = ownerSlug;
             project.projectSlug = projectSlug;
+            project.projectUrl = QStringLiteral("https://qtmesh.dev/%1/%2")
+                                     .arg(project.ownerSlug, project.projectSlug);
         }
 
-        if (m_canceled.load()) {
-            QMetaObject::invokeMethod(this, [this]() { emit uploadCanceled(); }, Qt::QueuedConnection);
+        if (canceled->load()) {
+            QMetaObject::invokeMethod(qApp, [self]() {
+                if (self)
+                    emit self->uploadCanceled();
+            }, Qt::QueuedConnection);
             return;
         }
         if (!project.ok) {
-            QMetaObject::invokeMethod(this, [this, project]() {
-                emit uploadFinished(false, project.errorString, {}, {});
+            QMetaObject::invokeMethod(qApp, [self, project]() {
+                if (!self)
+                    return;
+                emit self->uploadFinished(false, project.errorString, {}, {});
             }, Qt::QueuedConnection);
             return;
         }
@@ -83,13 +96,18 @@ void QtMeshCloudSession::uploadPackage(const PackageMetadata& metadata,
 
         const auto uploadUrls = QtMeshCloudClient::requestUploadUrls(
             token, project.ownerSlug, project.projectSlug, descriptors);
-        if (m_canceled.load()) {
-            QMetaObject::invokeMethod(this, [this]() { emit uploadCanceled(); }, Qt::QueuedConnection);
+        if (canceled->load()) {
+            QMetaObject::invokeMethod(qApp, [self]() {
+                if (self)
+                    emit self->uploadCanceled();
+            }, Qt::QueuedConnection);
             return;
         }
         if (!uploadUrls.ok) {
-            QMetaObject::invokeMethod(this, [this, uploadUrls]() {
-                emit uploadFinished(false, uploadUrls.errorString, {}, {});
+            QMetaObject::invokeMethod(qApp, [self, uploadUrls]() {
+                if (!self)
+                    return;
+                emit self->uploadFinished(false, uploadUrls.errorString, {}, {});
             }, Qt::QueuedConnection);
             return;
         }
@@ -99,25 +117,35 @@ void QtMeshCloudSession::uploadPackage(const PackageMetadata& metadata,
         QString fallbackMainFileId;
         const int total = uploadUrls.uploads.size();
         for (int i = 0; i < total; ++i) {
-            if (m_canceled.load()) {
-                QMetaObject::invokeMethod(this, [this]() { emit uploadCanceled(); }, Qt::QueuedConnection);
+            if (canceled->load()) {
+                QMetaObject::invokeMethod(qApp, [self]() {
+                    if (self)
+                        emit self->uploadCanceled();
+                }, Qt::QueuedConnection);
                 return;
             }
 
             const QString label = descriptors.at(i).uploadName;
-            QMetaObject::invokeMethod(this, [this, i, total, label]() {
-                emit uploadProgress(i + 1, total + 1, label);
+            QMetaObject::invokeMethod(qApp, [self, i, total, label]() {
+                if (!self)
+                    return;
+                emit self->uploadProgress(i + 1, total + 1, label);
             }, Qt::QueuedConnection);
 
             const auto result = QtMeshCloudClient::uploadFileContent(
-                token, uploadUrls.uploads.at(i), descriptors.at(i).path, &m_canceled);
+                token, uploadUrls.uploads.at(i), descriptors.at(i).path, canceled);
             if (result.canceled) {
-                QMetaObject::invokeMethod(this, [this]() { emit uploadCanceled(); }, Qt::QueuedConnection);
+                QMetaObject::invokeMethod(qApp, [self]() {
+                    if (self)
+                        emit self->uploadCanceled();
+                }, Qt::QueuedConnection);
                 return;
             }
             if (!result.ok) {
-                QMetaObject::invokeMethod(this, [this, result]() {
-                    emit uploadFinished(false, result.errorString, {}, {});
+                QMetaObject::invokeMethod(qApp, [self, result]() {
+                    if (!self)
+                        return;
+                    emit self->uploadFinished(false, result.errorString, {}, {});
                 }, Qt::QueuedConnection);
                 return;
             }
@@ -131,19 +159,37 @@ void QtMeshCloudSession::uploadPackage(const PackageMetadata& metadata,
         if (mainFileId.isEmpty())
             mainFileId = fallbackMainFileId;
 
+        if (canceled->load()) {
+            QMetaObject::invokeMethod(qApp, [self]() {
+                if (self)
+                    emit self->uploadCanceled();
+            }, Qt::QueuedConnection);
+            return;
+        }
+
+        QMetaObject::invokeMethod(qApp, [self, total]() {
+            if (!self)
+                return;
+            emit self->uploadProgress(total + 1, total + 1, QString());
+        }, Qt::QueuedConnection);
+
         const auto completed = QtMeshCloudClient::completeUpload(
             token, project.ownerSlug, project.projectSlug, uploadedFileIds, mainFileId);
         if (!completed.ok) {
-            QMetaObject::invokeMethod(this, [this, completed]() {
-                emit uploadFinished(false, completed.errorString, {}, {});
+            QMetaObject::invokeMethod(qApp, [self, completed]() {
+                if (!self)
+                    return;
+                emit self->uploadFinished(false, completed.errorString, {}, {});
             }, Qt::QueuedConnection);
             return;
         }
 
         SentryReporter::addBreadcrumb(QStringLiteral("cloud.upload"),
                                       QStringLiteral("QtMesh Cloud package upload completed"));
-        QMetaObject::invokeMethod(this, [this, project, completed]() {
-            emit uploadFinished(true, {}, project.projectUrl, completed.scanStatus);
+        QMetaObject::invokeMethod(qApp, [self, project, completed]() {
+            if (!self)
+                return;
+            emit self->uploadFinished(true, {}, project.projectUrl, completed.scanStatus);
         }, Qt::QueuedConnection);
     });
 

--- a/src/QtMeshCloudSession.cpp
+++ b/src/QtMeshCloudSession.cpp
@@ -1,0 +1,152 @@
+#include "QtMeshCloudSession.h"
+
+#include "CloudUploadPlanner.h"
+#include "SentryReporter.h"
+
+#include <QThread>
+
+QtMeshCloudSession::QtMeshCloudSession(const QString& bearerToken, QObject* parent)
+    : QObject(parent)
+    , m_bearerToken(bearerToken)
+{
+}
+
+void QtMeshCloudSession::cancel()
+{
+    m_canceled.store(true);
+}
+
+void QtMeshCloudSession::listProjects()
+{
+    const QString token = m_bearerToken;
+    QThread* worker = QThread::create([this, token]() {
+        const auto result = QtMeshCloudClient::fetchProjects(token);
+        QMetaObject::invokeMethod(this, [this, result]() {
+            if (!result.ok) {
+                emit projectsListed({}, result.errorString);
+                return;
+            }
+            emit projectsListed(result.projects, {});
+        }, Qt::QueuedConnection);
+    });
+    connect(worker, &QThread::finished, worker, &QObject::deleteLater);
+    worker->start();
+}
+
+void QtMeshCloudSession::uploadPackage(const PackageMetadata& metadata,
+                                     const QString& ownerSlug,
+                                     const QString& projectSlug,
+                                     bool createNewProject)
+{
+    m_canceled.store(false);
+    const QString token = m_bearerToken;
+    const PackageMetadata package = metadata;
+
+    QThread* worker = QThread::create([this, token, package, ownerSlug, projectSlug, createNewProject]() {
+        QtMeshCloudClient::ProjectResult project;
+        if (createNewProject) {
+            QString slug = projectSlug.isEmpty()
+                ? CloudUploadPlanner::makeProjectSlug(package.projectName)
+                : projectSlug;
+            project = QtMeshCloudClient::createProject(token, package.projectName, slug);
+            if (!project.ok && project.httpStatus == 409) {
+                slug = CloudUploadPlanner::makeProjectSlug(
+                    QStringLiteral("%1-%2").arg(package.projectName, slug));
+                project = QtMeshCloudClient::createProject(token, package.projectName, slug);
+            }
+        } else {
+            project.ok = true;
+            project.ownerSlug = ownerSlug;
+            project.projectSlug = projectSlug;
+        }
+
+        if (m_canceled.load()) {
+            QMetaObject::invokeMethod(this, [this]() { emit uploadCanceled(); }, Qt::QueuedConnection);
+            return;
+        }
+        if (!project.ok) {
+            QMetaObject::invokeMethod(this, [this, project]() {
+                emit uploadFinished(false, project.errorString, {}, {});
+            }, Qt::QueuedConnection);
+            return;
+        }
+
+        QList<QtMeshCloudClient::AssetFileDescriptor> descriptors;
+        for (const PackageEntry& entry : package.files) {
+            QtMeshCloudClient::AssetFileDescriptor descriptor;
+            descriptor.path = entry.absolutePath.isEmpty() ? entry.relativePath : entry.absolutePath;
+            descriptor.uploadName = entry.relativePath;
+            descriptor.role = entry.role;
+            descriptor.sizeBytes = entry.size;
+            descriptors.append(descriptor);
+        }
+
+        const auto uploadUrls = QtMeshCloudClient::requestUploadUrls(
+            token, project.ownerSlug, project.projectSlug, descriptors);
+        if (m_canceled.load()) {
+            QMetaObject::invokeMethod(this, [this]() { emit uploadCanceled(); }, Qt::QueuedConnection);
+            return;
+        }
+        if (!uploadUrls.ok) {
+            QMetaObject::invokeMethod(this, [this, uploadUrls]() {
+                emit uploadFinished(false, uploadUrls.errorString, {}, {});
+            }, Qt::QueuedConnection);
+            return;
+        }
+
+        QStringList uploadedFileIds;
+        QString mainFileId;
+        QString fallbackMainFileId;
+        const int total = uploadUrls.uploads.size();
+        for (int i = 0; i < total; ++i) {
+            if (m_canceled.load()) {
+                QMetaObject::invokeMethod(this, [this]() { emit uploadCanceled(); }, Qt::QueuedConnection);
+                return;
+            }
+
+            const QString label = descriptors.at(i).uploadName;
+            QMetaObject::invokeMethod(this, [this, i, total, label]() {
+                emit uploadProgress(i + 1, total + 1, label);
+            }, Qt::QueuedConnection);
+
+            const auto result = QtMeshCloudClient::uploadFileContent(
+                token, uploadUrls.uploads.at(i), descriptors.at(i).path, &m_canceled);
+            if (result.canceled) {
+                QMetaObject::invokeMethod(this, [this]() { emit uploadCanceled(); }, Qt::QueuedConnection);
+                return;
+            }
+            if (!result.ok) {
+                QMetaObject::invokeMethod(this, [this, result]() {
+                    emit uploadFinished(false, result.errorString, {}, {});
+                }, Qt::QueuedConnection);
+                return;
+            }
+
+            uploadedFileIds.append(uploadUrls.uploads.at(i).fileId);
+            if (fallbackMainFileId.isEmpty())
+                fallbackMainFileId = uploadUrls.uploads.at(i).fileId;
+            if (mainFileId.isEmpty() && descriptors.at(i).role == QLatin1String("main"))
+                mainFileId = uploadUrls.uploads.at(i).fileId;
+        }
+        if (mainFileId.isEmpty())
+            mainFileId = fallbackMainFileId;
+
+        const auto completed = QtMeshCloudClient::completeUpload(
+            token, project.ownerSlug, project.projectSlug, uploadedFileIds, mainFileId);
+        if (!completed.ok) {
+            QMetaObject::invokeMethod(this, [this, completed]() {
+                emit uploadFinished(false, completed.errorString, {}, {});
+            }, Qt::QueuedConnection);
+            return;
+        }
+
+        SentryReporter::addBreadcrumb(QStringLiteral("cloud.upload"),
+                                      QStringLiteral("QtMesh Cloud package upload completed"));
+        QMetaObject::invokeMethod(this, [this, project, completed]() {
+            emit uploadFinished(true, {}, project.projectUrl, completed.scanStatus);
+        }, Qt::QueuedConnection);
+    });
+
+    connect(worker, &QThread::finished, worker, &QObject::deleteLater);
+    worker->start();
+}

--- a/src/QtMeshCloudSession.h
+++ b/src/QtMeshCloudSession.h
@@ -1,0 +1,44 @@
+#ifndef QTMESH_CLOUD_SESSION_H
+#define QTMESH_CLOUD_SESSION_H
+
+#include "ProjectPackager.h"
+#include "QtMeshCloudClient.h"
+
+#include <QObject>
+#include <atomic>
+
+/// Async, progress-reporting QtMesh Cloud upload session (Slice C / #687).
+class QtMeshCloudSession : public QObject {
+    Q_OBJECT
+
+public:
+    explicit QtMeshCloudSession(const QString& bearerToken, QObject* parent = nullptr);
+
+    QString bearerToken() const { return m_bearerToken; }
+
+    /// Lists projects for the authenticated user.
+    void listProjects();
+
+    /// Creates a project and uploads the manifest files.
+    void uploadPackage(const PackageMetadata& metadata,
+                       const QString& ownerSlug = QString(),
+                       const QString& projectSlug = QString(),
+                       bool createNewProject = true);
+
+    void cancel();
+
+signals:
+    void projectsListed(const QList<QtMeshCloudClient::ProjectSummary>& projects, const QString& error);
+    void uploadProgress(int current, int total, const QString& fileName);
+    void uploadFinished(bool ok,
+                        const QString& error,
+                        const QString& projectUrl,
+                        const QString& scanStatus);
+    void uploadCanceled();
+
+private:
+    QString m_bearerToken;
+    std::atomic_bool m_canceled{false};
+};
+
+#endif // QTMESH_CLOUD_SESSION_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -228,7 +228,11 @@ MainWindow::MainWindow(QWidget *parent) :
 
     m_cloudUploadMenuAction = new QAction(tr("Upload to QtMesh Cloud..."), this);
     m_cloudUploadMenuAction->setObjectName(QStringLiteral("actionUploadToQtMeshCloud"));
-    connect(m_cloudUploadMenuAction, &QAction::triggered, this, &MainWindow::uploadFilesToQtMeshCloud);
+    connect(m_cloudUploadMenuAction, &QAction::triggered, this, [this]() {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("File menu: Upload to QtMesh Cloud"));
+        uploadFilesToQtMeshCloud();
+    });
     ui->menuFile->insertAction(ui->actionExport_Selected, m_cloudUploadMenuAction);
 
     m_cloudUploadProgress = new CloudUploadProgress(this);
@@ -2580,10 +2584,25 @@ void MainWindow::signOutOfQtMeshCloud()
     settings.remove(AppSettingsKeys::cloudUserEmail());
     settings.remove(AppSettingsKeys::cloudUserSlug());
     settings.sync();
+    if (m_cloudSession) {
+        m_cloudSession->deleteLater();
+        m_cloudSession = nullptr;
+    }
     updateCloudAuthActions();
     SentryReporter::addBreadcrumb(QStringLiteral("cloud.auth"),
                                   QStringLiteral("QtMesh Cloud signed out"));
     QMessageBox::information(this, tr("QtMesh Cloud"), tr("Signed out of QtMesh Cloud."));
+}
+
+QtMeshCloudSession* MainWindow::cloudSessionForToken(const QString& token)
+{
+    if (m_cloudSession && m_cloudSession->bearerToken() != token) {
+        m_cloudSession->deleteLater();
+        m_cloudSession = nullptr;
+    }
+    if (!m_cloudSession)
+        m_cloudSession = new QtMeshCloudSession(token, this);
+    return m_cloudSession;
 }
 
 void MainWindow::showCloudProjectsDialog()
@@ -2607,19 +2626,19 @@ void MainWindow::showCloudProjectsDialog()
     progress.setMinimumDuration(0);
     progress.show();
 
-    if (!m_cloudSession)
-        m_cloudSession = new QtMeshCloudSession(token, this);
+    QtMeshCloudSession* session = cloudSessionForToken(token);
 
     QEventLoop loop;
     QList<QtMeshCloudClient::ProjectSummary> projects;
     QString error;
-    connect(m_cloudSession, &QtMeshCloudSession::projectsListed, this,
+    connect(session, &QtMeshCloudSession::projectsListed, this,
             [&](const QList<QtMeshCloudClient::ProjectSummary>& listed, const QString& err) {
                 projects = listed;
                 error = err;
                 loop.quit();
-            });
-    m_cloudSession->listProjects();
+            },
+            Qt::SingleShotConnection);
+    session->listProjects();
     loop.exec();
     progress.close();
 
@@ -2672,20 +2691,19 @@ void MainWindow::uploadFilesToQtMeshCloud()
     progress.setMinimumDuration(0);
     progress.show();
 
-    if (!m_cloudSession)
-        m_cloudSession = new QtMeshCloudSession(token, this);
+    QtMeshCloudSession* session = cloudSessionForToken(token);
 
     QEventLoop listLoop;
     QList<QtMeshCloudClient::ProjectSummary> projects;
     QString listError;
-    connect(m_cloudSession, &QtMeshCloudSession::projectsListed, this,
+    connect(session, &QtMeshCloudSession::projectsListed, this,
             [&](const QList<QtMeshCloudClient::ProjectSummary>& listed, const QString& err) {
                 projects = listed;
                 listError = err;
                 listLoop.quit();
             },
             Qt::SingleShotConnection);
-    m_cloudSession->listProjects();
+    session->listProjects();
     listLoop.exec();
     progress.close();
 
@@ -2762,24 +2780,22 @@ void MainWindow::uploadFilesToQtMeshCloud()
         }
     }
 
-    if (m_cloudSession)
-        m_cloudSession->deleteLater();
-    m_cloudSession = new QtMeshCloudSession(token, this);
+    session = cloudSessionForToken(token);
     m_cloudUploadProgress->start(tr("Uploading to QtMesh Cloud…"), manifest.files.size() + 1);
 
-    connect(m_cloudSession, &QtMeshCloudSession::uploadProgress, this,
+    connect(session, &QtMeshCloudSession::uploadProgress, this,
             [this](int current, int total, const QString& fileName) {
                 m_cloudUploadProgress->updateProgress(current, total, fileName);
             });
-    connect(m_cloudUploadProgress, &CloudUploadProgress::cancelRequested, m_cloudSession,
+    connect(m_cloudUploadProgress, &CloudUploadProgress::cancelRequested, session,
             &QtMeshCloudSession::cancel);
 
-    connect(m_cloudSession, &QtMeshCloudSession::uploadCanceled, this, [this]() {
+    connect(session, &QtMeshCloudSession::uploadCanceled, this, [this]() {
         m_cloudUploadProgress->finish(false, tr("Upload canceled"));
         QTimer::singleShot(3000, m_cloudUploadProgress, &CloudUploadProgress::hideProgress);
     });
 
-    connect(m_cloudSession, &QtMeshCloudSession::uploadFinished, this,
+    connect(session, &QtMeshCloudSession::uploadFinished, this,
             [this, fileCount = manifest.files.size()](bool ok, const QString& error,
                                                       const QString& projectUrl,
                                                       const QString& scanStatus) {
@@ -2816,7 +2832,7 @@ void MainWindow::uploadFilesToQtMeshCloud()
                 QTimer::singleShot(3000, m_cloudUploadProgress, &CloudUploadProgress::hideProgress);
             });
 
-    m_cloudSession->uploadPackage(manifest, selectedProject.ownerSlug, selectedProject.projectSlug,
+    session->uploadPackage(manifest, selectedProject.ownerSlug, selectedProject.projectSlug,
                                   false);
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -41,10 +41,16 @@
 #include "AppConsoleLog.h"
 #include "AppSettingsKeys.h"
 #include "CloudAccountMenuButton.h"
+#include "CloudCredentialStore.h"
+#include "CloudProjectsDialog.h"
+#include "CloudUploadDialog.h"
+#include "CloudUploadPlanner.h"
+#include "CloudUploadProgress.h"
 #include "FeedbackDialog.h"
 #include "FeedbackReportHelper.h"
-#include "CloudCredentialStore.h"
-#include "CloudUploadPlanner.h"
+#include "ProjectPackager.h"
+#include "QtMeshCloudClient.h"
+#include "QtMeshCloudSession.h"
 #include "ui_mainwindow.h"
 #include "OgreWidget.h"
 #include "QtInputManager.h"
@@ -168,13 +174,16 @@ void waitWithEvents(int milliseconds, QProgressDialog* progress)
     loop.exec();
 }
 
-struct CloudUploadWorkerOutcome {
-    bool ok = false;
-    bool canceled = false;
-    QString errorString;
-    QString scanStatus;
-    QStringList fileIds;
-};
+QString primaryCloudAssetPath()
+{
+    QSettings settings;
+    const QStringList recent = settings.value(QStringLiteral("RecentFiles/files")).toStringList();
+    for (const QString& path : recent) {
+        if (QFileInfo::exists(path))
+            return path;
+    }
+    return {};
+}
 
 } // namespace
 
@@ -216,6 +225,15 @@ MainWindow::MainWindow(QWidget *parent) :
     m_recentFilesMenu->setObjectName("recentFilesMenu");
     ui->menuFile->insertMenu(ui->actionExport_Selected, m_recentFilesMenu);
     ui->menuFile->insertSeparator(ui->actionExport_Selected);
+
+    m_cloudUploadMenuAction = new QAction(tr("Upload to QtMesh Cloud..."), this);
+    m_cloudUploadMenuAction->setObjectName(QStringLiteral("actionUploadToQtMeshCloud"));
+    connect(m_cloudUploadMenuAction, &QAction::triggered, this, &MainWindow::uploadFilesToQtMeshCloud);
+    ui->menuFile->insertAction(ui->actionExport_Selected, m_cloudUploadMenuAction);
+
+    m_cloudUploadProgress = new CloudUploadProgress(this);
+    statusBar()->addPermanentWidget(m_cloudUploadProgress, 1);
+
     updateRecentFilesMenu();
 
     ui->menuOp_es->insertAction(ui->actionChange_Ambient_Light, ui->actionMaterial_Editor);
@@ -2325,12 +2343,8 @@ void MainWindow::setupCloudAccountStatusControl()
             &MainWindow::signOutOfQtMeshCloud);
     connect(m_cloudAccountControl, &CloudAccountMenuButton::uploadFilesRequested, this,
             &MainWindow::uploadFilesToQtMeshCloud);
-    connect(m_cloudAccountControl, &CloudAccountMenuButton::openProjectsRequested, this, [this]() {
-        if (!QDesktopServices::openUrl(QUrl(QStringLiteral(QTMESH_CLOUD_WEB_URL)))) {
-            QMessageBox::warning(this, tr("QtMesh Cloud"),
-                                 tr("Could not open QtMesh Cloud in your browser."));
-        }
-    });
+    connect(m_cloudAccountControl, &CloudAccountMenuButton::openProjectsRequested, this,
+            &MainWindow::showCloudProjectsDialog);
     connect(m_cloudAccountControl, &CloudAccountMenuButton::feedbackRequested, this, [this]() {
         showSendFeedbackDialog({});
     });
@@ -2345,12 +2359,28 @@ void MainWindow::setupCloudAccountStatusControl()
     QAction* cloudAction = ui->objectsToolbar->addWidget(m_cloudAccountControl);
     cloudAction->setObjectName(QStringLiteral("modeAnyCloudAccountAction"));
     updateCloudAuthActions();
+    updateCloudUploadActionState();
 }
 
 void MainWindow::updateCloudAuthActions()
 {
     if (m_cloudAccountControl)
         m_cloudAccountControl->refresh();
+    updateCloudUploadActionState();
+}
+
+void MainWindow::updateCloudUploadActionState()
+{
+    const bool hasAsset = !primaryCloudAssetPath().isEmpty()
+        || !Manager::getSingleton()->getEntities().isEmpty();
+    if (m_cloudUploadMenuAction) {
+        m_cloudUploadMenuAction->setEnabled(hasAsset);
+        m_cloudUploadMenuAction->setToolTip(hasAsset
+            ? tr("Upload the current asset and its dependencies to QtMesh Cloud")
+            : tr("Open a model first"));
+    }
+    if (m_cloudAccountControl)
+        m_cloudAccountControl->setUploadEnabled(hasAsset);
 }
 
 void MainWindow::showSendFeedbackDialog(const FeedbackPrefill& prefill)
@@ -2556,14 +2586,14 @@ void MainWindow::signOutOfQtMeshCloud()
     QMessageBox::information(this, tr("QtMesh Cloud"), tr("Signed out of QtMesh Cloud."));
 }
 
-void MainWindow::uploadFilesToQtMeshCloud()
+void MainWindow::showCloudProjectsDialog()
 {
     CloudCredentialStore::migrateLegacySettingsIfNeeded();
     if (!CloudCredentialStore::hasSession()) {
         const int choice = QMessageBox::question(
             this,
-            tr("QtMesh Cloud Upload"),
-            tr("Sign in to QtMesh Cloud before uploading files?"));
+            tr("QtMesh Cloud"),
+            tr("Sign in to QtMesh Cloud to view your projects?"));
         if (choice != QMessageBox::Yes)
             return;
         signInToQtMeshCloud();
@@ -2571,273 +2601,223 @@ void MainWindow::uploadFilesToQtMeshCloud()
             return;
     }
 
-    const QStringList paths = QFileDialog::getOpenFileNames(
-        this,
-        tr("Upload Files to QtMesh Cloud"),
-        QString(),
-        tr("3D Assets (*.mesh *.obj *.fbx *.gltf *.glb *.dae *.collada *.stl *.tmd *.tim *.rsd *.ply *.mat *.mtl *.material *.skeleton *.skel *.anim *.animation *.png *.jpg *.jpeg *.tga *.bmp *.dds *.tif *.tiff *.json *.xml *.yml *.yaml);;All Files (*)"),
-        nullptr,
-        QFileDialog::DontUseNativeDialog | QFileDialog::HideNameFilterDetails);
-    if (paths.isEmpty())
+    const QString token = CloudCredentialStore::loadSession().token;
+    QProgressDialog progress(tr("Loading cloud projects..."), tr("Cancel"), 0, 0, this);
+    progress.setWindowModality(Qt::WindowModal);
+    progress.setMinimumDuration(0);
+    progress.show();
+
+    if (!m_cloudSession)
+        m_cloudSession = new QtMeshCloudSession(token, this);
+
+    QEventLoop loop;
+    QList<QtMeshCloudClient::ProjectSummary> projects;
+    QString error;
+    connect(m_cloudSession, &QtMeshCloudSession::projectsListed, this,
+            [&](const QList<QtMeshCloudClient::ProjectSummary>& listed, const QString& err) {
+                projects = listed;
+                error = err;
+                loop.quit();
+            });
+    m_cloudSession->listProjects();
+    loop.exec();
+    progress.close();
+
+    if (!error.isEmpty()) {
+        QMessageBox::warning(this, tr("QtMesh Cloud"),
+                             tr("Could not load your cloud projects.\n\n%1").arg(error));
         return;
+    }
+
+    CloudProjectsDialog dialog(this);
+    dialog.setProjects(projects);
+    dialog.exec();
+}
+
+void MainWindow::uploadFilesToQtMeshCloud()
+{
+    SentryReporter::addBreadcrumb(QStringLiteral("cloud.upload"),
+                                  QStringLiteral("QtMesh Cloud upload requested"));
+
+    CloudCredentialStore::migrateLegacySettingsIfNeeded();
+    if (!CloudCredentialStore::hasSession()) {
+        const int choice = QMessageBox::question(
+            this,
+            tr("QtMesh Cloud Upload"),
+            tr("Sign in to QtMesh Cloud before uploading?"));
+        if (choice != QMessageBox::Yes)
+            return;
+        signInToQtMeshCloud();
+        if (!CloudCredentialStore::hasSession())
+            return;
+    }
+
+    QString mainAssetPath = primaryCloudAssetPath();
+    if (mainAssetPath.isEmpty()) {
+        QMessageBox::information(this, tr("QtMesh Cloud Upload"),
+                                 tr("Open a model first, then upload it with its dependencies."));
+        return;
+    }
 
     const QString token = CloudCredentialStore::loadSession().token;
     if (token.isEmpty()) {
-        QMessageBox::warning(this, tr("QtMesh Cloud Upload"), tr("The saved QtMesh Cloud session is empty. Sign in again."));
+        QMessageBox::warning(this, tr("QtMesh Cloud Upload"),
+                             tr("The saved QtMesh Cloud session is empty. Sign in again."));
         updateCloudAuthActions();
         return;
     }
 
-    const QFileInfo firstFile(paths.first());
-    QString defaultProjectName = paths.size() == 1
-        ? firstFile.completeBaseName()
-        : QFileInfo(firstFile.absolutePath()).fileName();
-    if (defaultProjectName.trimmed().isEmpty())
-        defaultProjectName = tr("QtMesh Project");
-
-    QProgressDialog loadProjectsProgress(tr("Loading cloud projects..."), tr("Cancel"), 0, 0, this);
-    loadProjectsProgress.setWindowTitle(tr("QtMesh Cloud Upload"));
-    loadProjectsProgress.setWindowModality(Qt::WindowModal);
-    loadProjectsProgress.setMinimumDuration(0);
-    loadProjectsProgress.show();
-    const auto projectList = QtMeshCloudClient::fetchProjects(token);
-    loadProjectsProgress.close();
-    if (!projectList.ok) {
-        QMessageBox::warning(this, tr("QtMesh Cloud Upload"),
-                             tr("Could not load your cloud projects.\n\n%1").arg(projectList.errorString));
-        return;
-    }
-
-    QtMeshCloudClient::ProjectResult project;
-    bool createNewProject = projectList.projects.isEmpty();
-
-    if (!createNewProject) {
-        QDialog picker(this);
-        picker.setWindowTitle(tr("QtMesh Cloud Upload"));
-        auto* layout = new QVBoxLayout(&picker);
-        auto* label = new QLabel(tr("Select a project to upload files to:"), &picker);
-        layout->addWidget(label);
-
-        auto* list = new QListWidget(&picker);
-        list->setSelectionMode(QAbstractItemView::SingleSelection);
-        for (const auto& summary : projectList.projects) {
-            const QString title = summary.name.isEmpty() ? summary.projectSlug : summary.name;
-            const QString subtitle = QStringLiteral("%1/%2").arg(summary.ownerSlug, summary.projectSlug);
-            auto* item = new QListWidgetItem(
-                subtitle == title ? title : QStringLiteral("%1\n%2").arg(title, subtitle),
-                list);
-            item->setData(Qt::UserRole, summary.id);
-            item->setData(Qt::UserRole + 1, summary.ownerSlug);
-            item->setData(Qt::UserRole + 2, summary.projectSlug);
-            item->setData(Qt::UserRole + 3, summary.projectUrl);
-            item->setToolTip(subtitle);
-        }
-        list->setCurrentRow(0);
-        layout->addWidget(list);
-
-        auto* buttons = new QHBoxLayout();
-        auto* newProjectButton = new QPushButton(tr("New Project..."), &picker);
-        auto* uploadButton = new QPushButton(tr("Upload"), &picker);
-        auto* cancelButton = new QPushButton(tr("Cancel"), &picker);
-        buttons->addWidget(newProjectButton);
-        buttons->addStretch();
-        buttons->addWidget(cancelButton);
-        buttons->addWidget(uploadButton);
-        layout->addLayout(buttons);
-        uploadButton->setDefault(true);
-
-        connect(cancelButton, &QPushButton::clicked, &picker, &QDialog::reject);
-        connect(newProjectButton, &QPushButton::clicked, &picker, [&createNewProject, &picker]() {
-            createNewProject = true;
-            picker.accept();
-        });
-        connect(uploadButton, &QPushButton::clicked, &picker, &QDialog::accept);
-        connect(list, &QListWidget::itemDoubleClicked, &picker, &QDialog::accept);
-        picker.resize(480, 320);
-
-        if (picker.exec() != QDialog::Accepted)
-            return;
-
-        if (!createNewProject) {
-            const QListWidgetItem* item = list->currentItem();
-            if (!item) {
-                QMessageBox::warning(this, tr("QtMesh Cloud Upload"), tr("Select a project to upload to."));
-                return;
-            }
-            project.ok = true;
-            project.projectId = item->data(Qt::UserRole).toString();
-            project.ownerSlug = item->data(Qt::UserRole + 1).toString();
-            project.projectSlug = item->data(Qt::UserRole + 2).toString();
-            project.projectUrl = item->data(Qt::UserRole + 3).toString();
-        }
-    }
-
-    if (createNewProject) {
-        bool accepted = false;
-        const QString projectName = QInputDialog::getText(
-            this,
-            tr("QtMesh Cloud Upload"),
-            tr("Project name:"),
-            QLineEdit::Normal,
-            defaultProjectName,
-            &accepted).trimmed();
-        if (!accepted || projectName.isEmpty())
-            return;
-
-        QProgressDialog createProgress(tr("Creating cloud project..."), tr("Cancel"), 0, 0, this);
-        createProgress.setWindowTitle(tr("QtMesh Cloud Upload"));
-        createProgress.setWindowModality(Qt::WindowModal);
-        createProgress.setMinimumDuration(0);
-        createProgress.show();
-
-        QString slug = CloudUploadPlanner::makeProjectSlug(projectName);
-        project = QtMeshCloudClient::createProject(token, projectName, slug);
-        if (!project.ok && project.httpStatus == 409) {
-            slug = CloudUploadPlanner::makeProjectSlug(
-                QStringLiteral("%1-%2")
-                    .arg(projectName,
-                         QDateTime::currentDateTimeUtc().toString(QStringLiteral("yyyyMMddhhmmss"))));
-            project = QtMeshCloudClient::createProject(token, projectName, slug);
-        }
-        createProgress.close();
-        if (!project.ok) {
-            QMessageBox::warning(this, tr("QtMesh Cloud Upload"),
-                                 tr("Could not create the cloud project.\n\n%1").arg(project.errorString));
-            return;
-        }
-    }
-
-    QProgressDialog progress(tr("Preparing upload..."), tr("Cancel"), 0, paths.size() + 2, this);
-    progress.setWindowTitle(tr("QtMesh Cloud Upload"));
+    QProgressDialog progress(tr("Loading cloud projects..."), tr("Cancel"), 0, 0, this);
     progress.setWindowModality(Qt::WindowModal);
     progress.setMinimumDuration(0);
-    progress.setValue(0);
     progress.show();
 
-    const auto descriptors = CloudUploadPlanner::buildAssetFileDescriptors(paths);
-    progress.setLabelText(tr("Requesting upload URLs..."));
-    auto uploadUrls = QtMeshCloudClient::requestUploadUrls(
-        token,
-        project.ownerSlug,
-        project.projectSlug,
-        descriptors);
-    progress.setValue(1);
-    if (progress.wasCanceled())
-        return;
-    if (!uploadUrls.ok) {
-        QMessageBox::warning(this, tr("QtMesh Cloud Upload"),
-                             tr("Could not prepare file uploads.\n\n%1").arg(uploadUrls.errorString));
-        return;
-    }
+    if (!m_cloudSession)
+        m_cloudSession = new QtMeshCloudSession(token, this);
 
-    std::atomic_bool canceled{false};
-    connect(&progress, &QProgressDialog::canceled, this, [&canceled]() {
-        canceled.store(true);
-    });
-
-    CloudUploadWorkerOutcome outcome;
-    const QString ownerSlug = project.ownerSlug;
-    const QString projectSlug = project.projectSlug;
-    const auto uploads = uploadUrls.uploads;
-    QThread* worker = QThread::create([token, ownerSlug, projectSlug, descriptors, uploads, &progress, &outcome, &canceled]() {
-        QStringList uploadedFileIds;
-        QString mainFileId;
-        QString fallbackMainFileId;
-        for (int i = 0; i < uploads.size(); ++i) {
-            if (canceled.load()) {
-                outcome.canceled = true;
-                return;
-            }
-
-            const QString label = QObject::tr("Uploading %1...").arg(descriptors.at(i).uploadName);
-            QMetaObject::invokeMethod(&progress, [label, i, &progress]() {
-                progress.setLabelText(label);
-                progress.setValue(i + 1);
-            }, Qt::QueuedConnection);
-
-            const auto result = QtMeshCloudClient::uploadFileContent(
-                token,
-                uploads.at(i),
-                descriptors.at(i).path,
-                &canceled);
-            if (result.canceled) {
-                outcome.canceled = true;
-                return;
-            }
-            if (!result.ok) {
-                outcome.errorString = result.errorString;
-                return;
-            }
-            uploadedFileIds.append(uploads.at(i).fileId);
-            if (fallbackMainFileId.isEmpty())
-                fallbackMainFileId = uploads.at(i).fileId;
-            if (mainFileId.isEmpty() && descriptors.at(i).role == QLatin1String("model"))
-                mainFileId = uploads.at(i).fileId;
-        }
-        if (mainFileId.isEmpty())
-            mainFileId = fallbackMainFileId;
-
-        if (canceled.load()) {
-            outcome.canceled = true;
-            return;
-        }
-
-        QMetaObject::invokeMethod(&progress, [&progress, uploads]() {
-            progress.setLabelText(QObject::tr("Finalizing upload..."));
-            progress.setValue(uploads.size() + 1);
-        }, Qt::QueuedConnection);
-
-        const auto completed = QtMeshCloudClient::completeUpload(
-            token,
-            ownerSlug,
-            projectSlug,
-            uploadedFileIds,
-            mainFileId);
-        if (!completed.ok) {
-            outcome.errorString = completed.errorString;
-            return;
-        }
-        outcome.ok = true;
-        outcome.scanStatus = completed.scanStatus;
-        outcome.fileIds = completed.fileIds;
-    });
-
-    QEventLoop loop;
-    connect(worker, &QThread::finished, &loop, &QEventLoop::quit);
-    connect(worker, &QThread::finished, worker, &QObject::deleteLater);
-    worker->start();
-    loop.exec();
-
-    progress.setValue(paths.size() + 2);
+    QEventLoop listLoop;
+    QList<QtMeshCloudClient::ProjectSummary> projects;
+    QString listError;
+    connect(m_cloudSession, &QtMeshCloudSession::projectsListed, this,
+            [&](const QList<QtMeshCloudClient::ProjectSummary>& listed, const QString& err) {
+                projects = listed;
+                listError = err;
+                listLoop.quit();
+            },
+            Qt::SingleShotConnection);
+    m_cloudSession->listProjects();
+    listLoop.exec();
     progress.close();
 
-    if (outcome.canceled || canceled.load())
-        return;
-    if (!outcome.ok) {
+    if (!listError.isEmpty()) {
         QMessageBox::warning(this, tr("QtMesh Cloud Upload"),
-                             tr("Upload failed.\n\n%1").arg(outcome.errorString));
+                             tr("Could not load your cloud projects.\n\n%1").arg(listError));
+        return;
+    }
+    if (projects.isEmpty()) {
+        QMessageBox::information(
+            this, tr("QtMesh Cloud Upload"),
+            tr("You do not have any cloud projects yet. Create a project on QtMesh Cloud first, "
+               "then upload files into it."));
         return;
     }
 
-    statusBar()->showMessage(
-        tr("Uploaded %1 file(s) to QtMesh Cloud.").arg(outcome.fileIds.isEmpty() ? paths.size() : outcome.fileIds.size()),
-        5000);
-    SentryReporter::addBreadcrumb(QStringLiteral("cloud.upload"),
-                                  QStringLiteral("QtMesh Cloud project upload completed"));
+    CloudUploadDialog dialog(this);
+    dialog.setAccountLabel(storedCloudDisplayName());
+    dialog.setProjects(projects);
+    dialog.setMainAssetPath(mainAssetPath);
 
-    QMessageBox done(this);
-    done.setIcon(QMessageBox::Information);
-    done.setWindowTitle(tr("QtMesh Cloud Upload"));
-    done.setText(tr("Uploaded %1 file(s) to QtMesh Cloud.").arg(outcome.fileIds.isEmpty() ? paths.size() : outcome.fileIds.size()));
-    if (!outcome.scanStatus.isEmpty())
-        done.setInformativeText(tr("Scan status: %1").arg(outcome.scanStatus));
-    QPushButton* openProjectButton = nullptr;
-    if (!project.projectUrl.isEmpty())
-        openProjectButton = done.addButton(tr("Open Project"), QMessageBox::AcceptRole);
-    done.addButton(QMessageBox::Ok);
-    done.exec();
-    if (openProjectButton && done.clickedButton() == openProjectButton)
-        QDesktopServices::openUrl(QUrl(project.projectUrl));
+    if (dialog.exec() != QDialog::Accepted)
+        return;
+
+    if (!dialog.hasSelectedProject()) {
+        QMessageBox::warning(this, tr("QtMesh Cloud Upload"), tr("Select a cloud project."));
+        return;
+    }
+
+    const QtMeshCloudClient::ProjectSummary selectedProject = dialog.selectedProject();
+
+    if (dialog.runLocalScanBeforeUpload()) {
+        QProgressDialog scanProgress(tr("Running local scan..."), QString(), 0, 0, this);
+        scanProgress.setWindowModality(Qt::WindowModal);
+        scanProgress.setMinimumDuration(0);
+        scanProgress.show();
+
+        const QFileInfo mainAssetInfo(mainAssetPath);
+        QString scanError;
+        const QByteArray scanJson = AssetScanController::runIsolatedScanJsonSync(
+            mainAssetInfo.absolutePath(), mainAssetInfo.fileName(), &scanError);
+        scanProgress.close();
+
+        if (scanJson.isEmpty()) {
+            QMessageBox::warning(this, tr("QtMesh Cloud Upload"),
+                                 tr("Local scan failed; continuing without scan summary.\n\n%1")
+                                     .arg(scanError));
+        } else {
+            QJsonParseError parseError;
+            const QJsonDocument doc = QJsonDocument::fromJson(scanJson, &parseError);
+            if (parseError.error != QJsonParseError::NoError || !doc.isObject()) {
+                QMessageBox::warning(
+                    this, tr("QtMesh Cloud Upload"),
+                    tr("Local scan returned invalid JSON; continuing without scan summary.\n\n%1")
+                        .arg(parseError.errorString()));
+            } else {
+                dialog.setScanSummary(doc.object());
+            }
+        }
+    }
+
+    PackageMetadata manifest = dialog.manifest();
+    if (manifest.files.isEmpty()) {
+        QMessageBox::warning(this, tr("QtMesh Cloud Upload"),
+                             tr("Select at least one file to upload."));
+        return;
+    }
+
+    for (const PackageEntry& entry : manifest.files) {
+        if (!QFileInfo::exists(entry.absolutePath)) {
+            QMessageBox::warning(this, tr("QtMesh Cloud Upload"),
+                                 tr("Missing file: %1").arg(QFileInfo(entry.absolutePath).fileName()));
+            return;
+        }
+    }
+
+    if (m_cloudSession)
+        m_cloudSession->deleteLater();
+    m_cloudSession = new QtMeshCloudSession(token, this);
+    m_cloudUploadProgress->start(tr("Uploading to QtMesh Cloud…"), manifest.files.size() + 1);
+
+    connect(m_cloudSession, &QtMeshCloudSession::uploadProgress, this,
+            [this](int current, int total, const QString& fileName) {
+                m_cloudUploadProgress->updateProgress(current, total, fileName);
+            });
+    connect(m_cloudUploadProgress, &CloudUploadProgress::cancelRequested, m_cloudSession,
+            &QtMeshCloudSession::cancel);
+
+    connect(m_cloudSession, &QtMeshCloudSession::uploadCanceled, this, [this]() {
+        m_cloudUploadProgress->finish(false, tr("Upload canceled"));
+        QTimer::singleShot(3000, m_cloudUploadProgress, &CloudUploadProgress::hideProgress);
+    });
+
+    connect(m_cloudSession, &QtMeshCloudSession::uploadFinished, this,
+            [this, fileCount = manifest.files.size()](bool ok, const QString& error,
+                                                      const QString& projectUrl,
+                                                      const QString& scanStatus) {
+                if (!ok) {
+                    m_cloudUploadProgress->finish(false, tr("Upload failed"));
+                    QMessageBox::warning(this, tr("QtMesh Cloud Upload"),
+                                         tr("Upload failed.\n\n%1").arg(error));
+                    QTimer::singleShot(3000, m_cloudUploadProgress, &CloudUploadProgress::hideProgress);
+                    return;
+                }
+
+                m_cloudUploadProgress->finish(true, tr("Upload complete"));
+                statusBar()->showMessage(tr("Uploaded %1 file(s) to QtMesh Cloud.").arg(fileCount), 5000);
+
+                QMessageBox done(this);
+                done.setIcon(QMessageBox::Information);
+                done.setWindowTitle(tr("QtMesh Cloud Upload"));
+                done.setText(tr("Uploaded %1 file(s) to QtMesh Cloud.").arg(fileCount));
+                if (!scanStatus.isEmpty())
+                    done.setInformativeText(tr("Scan status: %1").arg(scanStatus));
+                QPushButton* openButton = nullptr;
+                QPushButton* copyButton = nullptr;
+                if (!projectUrl.isEmpty()) {
+                    openButton = done.addButton(tr("Open in Browser"), QMessageBox::AcceptRole);
+                    copyButton = done.addButton(tr("Copy Link"), QMessageBox::ActionRole);
+                }
+                done.addButton(QMessageBox::Ok);
+                done.exec();
+                if (openButton && done.clickedButton() == openButton)
+                    QDesktopServices::openUrl(QUrl(projectUrl));
+                if (copyButton && done.clickedButton() == copyButton && QApplication::clipboard())
+                    QApplication::clipboard()->setText(projectUrl);
+
+                QTimer::singleShot(3000, m_cloudUploadProgress, &CloudUploadProgress::hideProgress);
+            });
+
+    m_cloudSession->uploadPackage(manifest, selectedProject.ownerSlug, selectedProject.projectSlug,
+                                  false);
 }
 
 void MainWindow::setPlaying(bool playing)
@@ -3633,6 +3613,7 @@ void MainWindow::loadFile(const QString& filePath)
         MeshImporterExporter::sceneImporter(filePath);
     else
         mUriList.append(filePath);
+    updateCloudUploadActionState();
 }
 
 void MainWindow::openLaunchFiles(const QStringList& paths)

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -130,6 +130,7 @@ private slots:
     void signOutOfQtMeshCloud();
     void uploadFilesToQtMeshCloud();
     void showCloudProjectsDialog();
+    QtMeshCloudSession* cloudSessionForToken(const QString& token);
     void showSendFeedbackDialog(const FeedbackPrefill& prefill = FeedbackPrefill{});
     bool startMCPServer(int port);
     void stopMCPServer();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -29,6 +29,8 @@ class QToolBar;
 class QAction;
 class QToolButton;
 class CloudAccountMenuButton;
+class CloudUploadProgress;
+class QtMeshCloudSession;
 class OgreWidget;
 
 namespace Ui {
@@ -127,6 +129,7 @@ private slots:
     void signInToQtMeshCloud();
     void signOutOfQtMeshCloud();
     void uploadFilesToQtMeshCloud();
+    void showCloudProjectsDialog();
     void showSendFeedbackDialog(const FeedbackPrefill& prefill = FeedbackPrefill{});
     bool startMCPServer(int port);
     void stopMCPServer();
@@ -197,6 +200,11 @@ private:
     QToolBar* m_topBarStretch = nullptr;
     QQuickWidget* m_modeBar = nullptr;
     CloudAccountMenuButton* m_cloudAccountControl = nullptr;
+    CloudUploadProgress* m_cloudUploadProgress = nullptr;
+    QtMeshCloudSession* m_cloudSession = nullptr;
+    QAction* m_cloudUploadMenuAction = nullptr;
+
+    void updateCloudUploadActionState();
 
     /// View menu entries for bottom tabbed docks — checked state follows user
     /// preference, not QDockWidget::isVisible() (inactive tabs would otherwise

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -65,6 +65,13 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/QtMeshCloudClient.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/CloudCredentialStore.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/CloudUploadPlanner.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/CloudCLIPipeline.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/CloudProjectsDialog.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/CloudUploadDialog.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/CloudUploadProgress.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/DependencyResolver.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/ProjectPackager.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/QtMeshCloudSession.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/CloudAccountMenuButton.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/FeedbackDiagnostics.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/FeedbackDialog.cpp
@@ -516,6 +523,12 @@ if(BUILD_TESTS)
             "${CMAKE_CURRENT_SOURCE_DIR}/../src/CloudAccountMenuButton_test.cpp"
         )
     endif()
+
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../src/ProjectPackager_test.cpp")
+        create_test_executable(ProjectPackager_test
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/ProjectPackager_test.cpp"
+        )
+    endif()
     
     # 4. QML Component Test Runner (existing) - special handling for CI
     create_test_executable_no_autotest(MaterialEditorQML_qml_test_runner
@@ -555,6 +568,9 @@ if(BUILD_TESTS)
 
     if(TARGET CloudAccountMenuButton_test)
         gtest_discover_tests(CloudAccountMenuButton_test DISCOVERY_MODE PRE_TEST)
+    endif()
+    if(TARGET ProjectPackager_test)
+        gtest_discover_tests(ProjectPackager_test DISCOVERY_MODE PRE_TEST)
     endif()
     
     if(TARGET MaterialEditorQML_qml_test_runner)


### PR DESCRIPTION
## Summary
- Upload the open model and its detected dependencies to an existing QtMesh Cloud project via File → Upload to QtMesh Cloud and the account menu.
- Add dependency resolution, project packaging/manifest generation, in-app project listing, upload progress UI, and `qtmesh cloud` / MCP cloud tools.
- Run optional pre-upload scans in an isolated CLI subprocess so the live editor scene is not cleared.

## Test plan
- [ ] Sign in to QtMesh Cloud and confirm File → Upload shows a project dropdown populated from `/v1/projects`.
- [ ] Upload an open FBX with sidecar textures/materials and verify only selected dependencies are sent.
- [ ] With "Run local scan before upload" enabled, confirm the viewport scene remains intact after upload.
- [ ] Run `qtmesh cloud upload model.fbx` headlessly against a signed-in session.
- [ ] Exercise MCP `cloud_list_projects`, `cloud_upload`, and `cloud_delete_project`.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * QtMesh Cloud integration across UI, CLI, and MCP: sign-in/out, project listing, deletion, and uploads.
  * New cloud upload workflow with a project picker, dependency detection, manifest generation, optional local scan, and cancellable progress UI with completion actions.
  * CLI: added `cloud` subcommands (`login/logout/status/list/delete/upload`) and updated command routing/help.
  * Asset scanning now supports an optional include filter for subprocess scans.
* **Tests**
  * Added unit tests for dependency detection and manifest generation, including JSON path-sanitisation lint and SHA-256 output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->