### PR TITLE
feat(updater): spike #440 — design doc, flavor detection, minisign verify

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -991,7 +991,7 @@ jobs:
             sudo apt-get update
             sudo apt-get install -y libxcb-cursor0 libxcb-xinerama0 libx11-dev xvfb \
                 mesa-utils libgl1-mesa-dri libegl-mesa0 libgbm1 libglx-mesa0 \
-                libsecret-1-dev libretro-beetle-psx
+                libsecret-1-dev libretro-beetle-psx libsodium-dev
             # Start Xvfb with GLX support for Ogre GL initialization
             Xvfb :99 -screen 0 1024x768x24 +extension GLX > /dev/null 2>&1 &
             sleep 3

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ ui_files/
 ui_*
 *.log
 *.cmake
+!cmake/Libsodium.cmake
 *.user
 *.qtc_clangd*
 _CPack_Packages/*
@@ -89,4 +90,5 @@ Twist Dance.fbx.skeleton
 #website
 website/dist/
 website/node_modules/
-docs/
+docs/*
+!docs/AUTO_UPDATER_DESIGN.md

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,8 @@ website/dist/
 website/node_modules/
 docs/*
 !docs/AUTO_UPDATER_DESIGN.md
+
+# minisign — never commit secret keys
+minisign.key
+*.minisig
+!tests/fixtures/**/*.minisig

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,6 +319,11 @@ endif()
 message(STATUS "xatlas enabled (auto UV unwrap)")
 
 ##############################################################
+#  libsodium — minisign signature verify (auto-updater spike #440)
+##############################################################
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Libsodium.cmake)
+
+##############################################################
 #  Sentry crash reporting and analytics
 ##############################################################
 option(ENABLE_SENTRY "Enable Sentry crash reporting and analytics" ON)

--- a/cmake/Libsodium.cmake
+++ b/cmake/Libsodium.cmake
@@ -1,7 +1,14 @@
 # Build a static libsodium for minisign verify (spike #440 / follow-up #445).
-# Windows MinGW is not wired yet — MinisignVerify returns Unsupported there.
+# Windows/macOS skip entirely — MinisignVerify returns Unsupported there.
 
 if(TARGET qtmesh_sodium)
+    return()
+endif()
+
+if(NOT (UNIX AND NOT APPLE))
+    message(STATUS "libsodium: skipped (minisign verify is Linux-only in spike #440)")
+    add_library(qtmesh_sodium INTERFACE)
+    target_compile_definitions(qtmesh_sodium INTERFACE QTMESH_MINISIGN_VERIFY=0)
     return()
 endif()
 
@@ -22,14 +29,6 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(qtmesh_libsodium_src)
 
 set(QTMESH_LIBSODIUM_PREFIX "${CMAKE_BINARY_DIR}/libsodium-install")
-
-if(NOT (UNIX AND NOT APPLE))
-    message(STATUS "libsodium: skipped (minisign verify is Linux-only in spike #440)")
-    add_library(qtmesh_sodium INTERFACE)
-    target_compile_definitions(qtmesh_sodium INTERFACE QTMESH_MINISIGN_VERIFY=0)
-    return()
-endif()
-
 set(QTMESH_LIBSODIUM_MARKER "${QTMESH_LIBSODIUM_PREFIX}/lib/libsodium.a")
 
 if(NOT EXISTS "${QTMESH_LIBSODIUM_MARKER}")

--- a/cmake/Libsodium.cmake
+++ b/cmake/Libsodium.cmake
@@ -1,0 +1,71 @@
+# Build a static libsodium for minisign verify (spike #440 / follow-up #445).
+# Windows MinGW is not wired yet — MinisignVerify returns Unsupported there.
+
+if(TARGET qtmesh_sodium)
+    return()
+endif()
+
+include(FetchContent)
+
+set(QTMESH_LIBSODIUM_URL
+    "https://download.libsodium.org/libsodium/releases/libsodium-1.0.20-stable.tar.gz"
+    CACHE STRING "libsodium source tarball for minisign verify")
+set(QTMESH_LIBSODIUM_SHA256
+    "b6b1d2a8802cd8bfa611638c0e9ce31d14ef324e16062c39a76854091cba6d7f"
+    CACHE STRING "SHA256 of libsodium tarball")
+
+FetchContent_Declare(
+    qtmesh_libsodium_src
+    URL ${QTMESH_LIBSODIUM_URL}
+    URL_HASH SHA256=${QTMESH_LIBSODIUM_SHA256}
+)
+FetchContent_MakeAvailable(qtmesh_libsodium_src)
+
+set(QTMESH_LIBSODIUM_PREFIX "${CMAKE_BINARY_DIR}/libsodium-install")
+
+if(NOT (UNIX AND NOT APPLE))
+    message(STATUS "libsodium: skipped (minisign verify is Linux-only in spike #440)")
+    add_library(qtmesh_sodium INTERFACE)
+    target_compile_definitions(qtmesh_sodium INTERFACE QTMESH_MINISIGN_VERIFY=0)
+    return()
+endif()
+
+set(QTMESH_LIBSODIUM_MARKER "${QTMESH_LIBSODIUM_PREFIX}/lib/libsodium.a")
+
+if(NOT EXISTS "${QTMESH_LIBSODIUM_MARKER}")
+    message(STATUS "libsodium: configuring and building static library (one-time)")
+    execute_process(
+        COMMAND "${qtmesh_libsodium_src_SOURCE_DIR}/configure"
+                "--prefix=${QTMESH_LIBSODIUM_PREFIX}"
+                "--enable-static"
+                "--disable-shared"
+        WORKING_DIRECTORY "${qtmesh_libsodium_src_SOURCE_DIR}"
+        RESULT_VARIABLE qtmesh_sodium_configure_result
+    )
+    if(NOT qtmesh_sodium_configure_result EQUAL 0)
+        message(FATAL_ERROR "libsodium configure failed (${qtmesh_sodium_configure_result})")
+    endif()
+    execute_process(
+        COMMAND make -j
+        WORKING_DIRECTORY "${qtmesh_libsodium_src_SOURCE_DIR}"
+        RESULT_VARIABLE qtmesh_sodium_build_result
+    )
+    if(NOT qtmesh_sodium_build_result EQUAL 0)
+        message(FATAL_ERROR "libsodium build failed (${qtmesh_sodium_build_result})")
+    endif()
+    execute_process(
+        COMMAND make install
+        WORKING_DIRECTORY "${qtmesh_libsodium_src_SOURCE_DIR}"
+        RESULT_VARIABLE qtmesh_sodium_install_result
+    )
+    if(NOT qtmesh_sodium_install_result EQUAL 0)
+        message(FATAL_ERROR "libsodium install failed (${qtmesh_sodium_install_result})")
+    endif()
+endif()
+
+add_library(qtmesh_sodium STATIC IMPORTED GLOBAL)
+set_target_properties(qtmesh_sodium PROPERTIES
+    IMPORTED_LOCATION "${QTMESH_LIBSODIUM_MARKER}"
+    INTERFACE_INCLUDE_DIRECTORIES "${QTMESH_LIBSODIUM_PREFIX}/include"
+    INTERFACE_COMPILE_DEFINITIONS "SODIUM_STATIC=1;QTMESH_MINISIGN_VERIFY=1"
+)

--- a/cmake/Libsodium.cmake
+++ b/cmake/Libsodium.cmake
@@ -1,5 +1,5 @@
-# Build a static libsodium for minisign verify (spike #440 / follow-up #445).
-# Windows/macOS skip entirely — MinisignVerify returns Unsupported there.
+# libsodium for minisign verify (spike #440 / follow-up #445).
+# Linux only — other platforms get a stub INTERFACE target.
 
 if(TARGET qtmesh_sodium)
     return()
@@ -12,6 +12,21 @@ if(NOT (UNIX AND NOT APPLE))
     return()
 endif()
 
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND)
+    pkg_check_modules(QTMESH_LIBSODIUM libsodium)
+endif()
+
+if(QTMESH_LIBSODIUM_FOUND)
+    message(STATUS "libsodium: using system package (pkg-config)")
+    add_library(qtmesh_sodium INTERFACE)
+    target_include_directories(qtmesh_sodium SYSTEM INTERFACE ${QTMESH_LIBSODIUM_INCLUDE_DIRS})
+    target_link_libraries(qtmesh_sodium INTERFACE ${QTMESH_LIBSODIUM_LIBRARIES})
+    target_compile_options(qtmesh_sodium INTERFACE ${QTMESH_LIBSODIUM_CFLAGS_OTHER})
+    target_compile_definitions(qtmesh_sodium INTERFACE QTMESH_MINISIGN_VERIFY=1)
+    return()
+endif()
+
 include(FetchContent)
 
 set(QTMESH_LIBSODIUM_URL
@@ -20,6 +35,8 @@ set(QTMESH_LIBSODIUM_URL
 set(QTMESH_LIBSODIUM_SHA256
     "b6b1d2a8802cd8bfa611638c0e9ce31d14ef324e16062c39a76854091cba6d7f"
     CACHE STRING "SHA256 of libsodium tarball")
+
+message(STATUS "libsodium: system package not found — building static from source")
 
 FetchContent_Declare(
     qtmesh_libsodium_src

--- a/docs/AUTO_UPDATER_DESIGN.md
+++ b/docs/AUTO_UPDATER_DESIGN.md
@@ -1,0 +1,162 @@
+# Auto-updater architecture (spike #440)
+
+Parent epic: [#439](https://github.com/fernandotonon/QtMeshEditor/issues/439)
+
+This document locks the four architecturally consequential decisions before production updater code lands. Implementation PoC lives under `src/updater/` with unit tests and fixtures.
+
+## 1. Signature scheme
+
+### Decision: **minisign / Ed25519 (pre-hashed BLAKE2b-512)**
+
+| Option | Verdict |
+|--------|---------|
+| **minisign / Ed25519** | **Selected.** Single-purpose release signing; 32-byte pubkeys embed cleanly; `minisign` CLI is trivial in CI; signatures are sidecar `.minisig` files (no CMS overhead). |
+| GPG/PGP | Rejected. Heavy runtime (GnuPG or bundled libgcrypt), awkward key distribution, overkill for “is this GitHub artifact authentic?”. |
+| X.509 / codesign | Rejected for artifact signing. We already codesign/notarize *binaries* on macOS/Windows; X.509 adds PKI complexity without helping Linux portable tarballs/debs. |
+
+### Public key placement
+
+- **Production:** compile-time string in `MinisignVerify.cpp` (or generated header from `packaging/updater/minisign.pub.in` at configure time). Same pattern as Sentry DSN / embedded resource paths.
+- **Development / tests:** separate test keypair; only the `.pub` and `.minisig` fixtures are committed (`tests/fixtures/updater/`). Secret keys never enter git.
+
+### Key rotation
+
+1. Generate new keypair offline (`minisign -G`).
+2. Publish new `minisign.pub` in repo + release notes; keep **previous** pubkey in binary for one release cycle (`kPreviousPublicKeys[]`).
+3. CI signs with new secret (`MINISIGN_SECRET_KEY` GitHub Actions secret, base64-encoded key file).
+4. If secret compromised: revoke GitHub secret, publish advisory, push rotation release; package-manager channels (Homebrew/WinGet/Snap) bypass in-app verify and remain the recovery path.
+
+### CI signing (planned — follow-up PR)
+
+Extend `deploy.yml` after existing SHA-256 cask step:
+
+```yaml
+- name: Install minisign
+  run: sudo apt-get install -y minisign
+
+- name: Sign release artifacts
+  env:
+    MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
+  run: |
+    echo "$MINISIGN_SECRET_KEY" | base64 -d > /tmp/minisign.key
+    chmod 600 /tmp/minisign.key
+    for f in QtMeshEditor-*.zip QtMeshEditor-*.dmg qtmesheditor_*.deb; do
+      minisign -S -s /tmp/minisign.key -m "$f" -x "$f.minisig" \
+        -t "timestamp:$(date +%s)	file:$(basename "$f")"
+    done
+    rm -f /tmp/minisign.key
+
+- name: Upload signatures with release assets
+  uses: softprops/action-gh-release@v2
+  with:
+    files: "*.minisig"
+```
+
+Also publish `SHA256SUMS` + `SHA256SUMS.minisig` for manifest-driven downloads (#444).
+
+### PoC status
+
+- `MinisignVerify::verifyFile()` implements minisign’s dual-signature check (file + trusted comment) via **libsodium** (same algorithms as the CLI).
+- Linux-only in this spike; Windows/macOS return `Unsupported` until #445 wires cross-platform static libsodium.
+- Tests: `MinisignVerify_test` verifies good/tampered/bad-key against `tests/fixtures/updater/release-3.5.3-readme.md` (content from GitHub tag `3.5.3`).
+
+---
+
+## 2. Relauncher binary
+
+### Decision: **Separate CMake target, minimal native stub per platform**
+
+| Platform | Approach |
+|----------|----------|
+| **Windows** | Static `qtmesh-relauncher.exe` — **no Qt**, only `kernel32`: copy/move staged tree, `CreateProcess` new `QtMeshEditor.exe`, `WaitForSingleObject`, exit. Lives next to main binary. |
+| **macOS** | Small Mach-O CLI **or** `/bin/mv` + `/usr/bin/open` shell-out. **Preference:** tiny native relauncher (consistent logging, no shell injection, same Sentry breadcrumbs as Windows). |
+| **Linux portable** | **Shell script** `qtmesh-relauncher.sh` for spike/production MVP (AppImage/tarball installs already ship shell helpers). Optional static binary later if hardening is needed. |
+
+### Build integration
+
+```cmake
+add_subdirectory(src/updater/relauncher)  # #446–448
+```
+
+- Windows: MinGW static link, `-nostdlib` not required (keep MSVCRT).
+- Installed alongside `QtMeshEditor`; updater spawns relauncher **before** quitting so files are not locked (#439 epic risk table).
+
+### Flow
+
+```
+UpdaterController → stage to AppData/updater/staging/<tag>/ 
+                 → spawn relauncher(staging, installDir, exePath)
+                 → QApplication::quit()
+Relauncher       → atomic rename swap (Windows: move aside old, move in new)
+                 → start new process
+                 → exit 0 (or rollback on failure)
+```
+
+---
+
+## 3. Install-flavor detection
+
+### Decision: **`InstallFlavor::detect(applicationFilePath)`**
+
+Enum (`src/updater/InstallFlavor.h`):
+
+`Portable | Homebrew | WinGet | Snap | Flatpak | Debian | Docker | Unknown`
+
+Only **`Portable`** enables download/install. All others show `updateCommandHint()` (brew/winget/snap/apt/flatpak/docker).
+
+### Detection rules (canonical order)
+
+| Flavor | Signal |
+|--------|--------|
+| **Docker** | `/.dockerenv` exists (Linux). |
+| **Snap** | Path contains `/snap/qtmesheditor/` or `/snap/bin/qtmesheditor`. |
+| **Flatpak** | Path under `/var/lib/flatpak/` or `~/.local/share/flatpak/`. |
+| **Debian** | Binary in `/usr/bin` or `/bin` (apt `.deb` install). |
+| **Homebrew** | macOS: `/Applications/Homebrew/…`, `Caskroom/qtmesheditor/`, or `.app/Contents/Resources/.brew` sentinel. |
+| **WinGet** | Registry uninstall key `FernandoTonon.QtMeshEditor`, or path under `%APPDATA%\\Microsoft\\Windows\\Start Menu\\Programs\\WinGet`. |
+| **Portable** | macOS: `/Applications/QtMeshEditor.app`; Linux: `/opt/QtMeshEditor/`; Windows: zip layout / MSI registry `QtMeshEditor` without WinGet key. |
+| **Unknown** | CI trees, dev `build_local/`, ambiguous paths — **no self-update** (fail closed). |
+
+`ENABLE_AUTO_UPDATER=OFF` for snap/flatpak/deb/docker CI builds (#439) so the code path is absent in those artifacts.
+
+### PoC status
+
+- Implemented in `InstallFlavor.cpp` with platform unit tests asserting synthetic paths + CI-like `Unknown` on each OS.
+
+---
+
+## 4. Channel taxonomy
+
+| Channel | Source | Selection rule |
+|---------|--------|----------------|
+| **Stable** | GitHub Releases with `prerelease: false` | Default. Tag `X.Y.Z` (no `v` prefix per project policy). |
+| **Beta** | GitHub pre-releases | Tag pattern `X.Y.Z-beta.N` (semver pre-release). User opt-in in settings (#449). |
+| **Nightly** | `workflow_dispatch` artifacts | **Deferred (#452).** No GitHub Release entry — needs object storage manifest (`nightly.json` + signed SHA256 list). Spike records intent only. |
+
+Version comparison reuses `UpdateVersion::compare()` (#442) — normalises optional `v`, numeric `QVersionNumber`, strips `-beta`/`-rc` for stable channel comparisons.
+
+---
+
+## Follow-up issues
+
+| Issue | Work |
+|-------|------|
+| [#441](https://github.com/fernandotonon/QtMeshEditor/issues/441) | `UpdaterController` + GitHub JSON |
+| [#442](https://github.com/fernandotonon/QtMeshEditor/issues/442) | Semver compare (partially done — `UpdateVersion`) |
+| [#443](https://github.com/fernandotonon/QtMeshEditor/issues/443) | Wire `InstallFlavor` into UX |
+| [#444–445](https://github.com/fernandotonon/QtMeshEditor/issues/444) | Download + verify pipeline |
+| [#446–448](https://github.com/fernandotonon/QtMeshEditor/issues/446) | Relauncher + per-platform install |
+| **New PR** | `deploy.yml` minisign signing (section above) |
+
+---
+
+## Files added in this spike
+
+| Path | Purpose |
+|------|---------|
+| `docs/AUTO_UPDATER_DESIGN.md` | This document |
+| `src/updater/InstallFlavor.*` | Flavor detection PoC |
+| `src/updater/MinisignVerify.*` | minisign verify PoC (Linux) |
+| `cmake/Libsodium.cmake` | Static libsodium fetch/build |
+| `tests/fixtures/updater/*` | Signed README fixture + test pubkey |
+| `scripts/generate-updater-fixtures.sh` | Regenerate fixtures locally |

--- a/docs/AUTO_UPDATER_DESIGN.md
+++ b/docs/AUTO_UPDATER_DESIGN.md
@@ -16,7 +16,7 @@ This document locks the four architecturally consequential decisions before prod
 
 ### Public key placement
 
-- **Production:** compile-time string in `MinisignVerify.cpp` (or generated header from `packaging/updater/minisign.pub.in` at configure time). Same pattern as Sentry DSN / embedded resource paths.
+- **Production:** compile-time string `kProductionPublicKeyBase64` in `MinisignVerify.cpp`, kept in sync with `packaging/updater/minisign.pub` (human-readable copy for CI/docs).
 - **Development / tests:** separate test keypair; only the `.pub` and `.minisig` fixtures are committed (`tests/fixtures/updater/`). Secret keys never enter git.
 
 ### Key rotation

--- a/docs/AUTO_UPDATER_DESIGN.md
+++ b/docs/AUTO_UPDATER_DESIGN.md
@@ -28,6 +28,15 @@ This document locks the four architecturally consequential decisions before prod
 
 ### CI signing (planned — follow-up PR)
 
+**GitHub Actions secrets** (repo → Settings → Secrets and variables → Actions):
+
+| Secret | Required | Value |
+|--------|----------|-------|
+| `MINISIGN_SECRET_KEY` | Yes | `base64 -w0 ~/.minisign/minisign.key` (helper: `scripts/encode-minisign-secret-for-github.sh`) |
+| `MINISIGN_PASSWORD` | Only if the secret key is password-encrypted | The minisign key passphrase. CI passes it on stdin when signing. Prefer a dedicated `-W` (no password) release key stored only in this secret to avoid a second secret. |
+
+Production public key: `packaging/updater/minisign.pub` (embedded in `MinisignVerify::productionPublicKeyBase64()`).
+
 Extend `deploy.yml` after existing SHA-256 cask step:
 
 ```yaml
@@ -37,12 +46,21 @@ Extend `deploy.yml` after existing SHA-256 cask step:
 - name: Sign release artifacts
   env:
     MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
+    MINISIGN_PASSWORD: ${{ secrets.MINISIGN_PASSWORD }}
   run: |
     echo "$MINISIGN_SECRET_KEY" | base64 -d > /tmp/minisign.key
     chmod 600 /tmp/minisign.key
+    sign() {
+      if [[ -n "${MINISIGN_PASSWORD:-}" ]]; then
+        printf '%s\n' "$MINISIGN_PASSWORD" | minisign -S -s /tmp/minisign.key -m "$1" -x "$1.minisig" \
+          -t "timestamp:$(date +%s)	file:$(basename "$1")"
+      else
+        minisign -S -s /tmp/minisign.key -m "$1" -x "$1.minisig" \
+          -t "timestamp:$(date +%s)	file:$(basename "$1")"
+      fi
+    }
     for f in QtMeshEditor-*.zip QtMeshEditor-*.dmg qtmesheditor_*.deb; do
-      minisign -S -s /tmp/minisign.key -m "$f" -x "$f.minisig" \
-        -t "timestamp:$(date +%s)	file:$(basename "$f")"
+      sign "$f"
     done
     rm -f /tmp/minisign.key
 

--- a/packaging/updater/minisign.pub
+++ b/packaging/updater/minisign.pub
@@ -1,0 +1,2 @@
+untrusted comment: QtMeshEditor release signing (production)
+RWQYgVXaH+8eYME58t9l6roX1QIqFsW+/nYV216ymPtW8H6odA8aMGhJ

--- a/packaging/updater/minisign.pub.in
+++ b/packaging/updater/minisign.pub.in
@@ -1,0 +1,2 @@
+untrusted comment: QtMeshEditor release signing (production — replace at key rotation)
+@QTMESH_MINISIGN_PUBKEY@

--- a/packaging/updater/minisign.pub.in
+++ b/packaging/updater/minisign.pub.in
@@ -1,2 +1,0 @@
-untrusted comment: QtMeshEditor release signing (production — replace at key rotation)
-@QTMESH_MINISIGN_PUBKEY@

--- a/scripts/encode-minisign-secret-for-github.sh
+++ b/scripts/encode-minisign-secret-for-github.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Print base64 of a minisign secret key for the MINISIGN_SECRET_KEY GitHub Actions secret.
+# Usage: ./scripts/encode-minisign-secret-for-github.sh [path-to-minisign.key]
+# Default path: ~/.minisign/minisign.key
+set -euo pipefail
+
+KEY="${1:-$HOME/.minisign/minisign.key}"
+
+if [[ ! -f "$KEY" ]]; then
+  echo "Secret key not found: $KEY" >&2
+  exit 1
+fi
+
+echo "Copy the single line below into GitHub → Settings → Secrets → Actions → MINISIGN_SECRET_KEY"
+echo "(Do not commit this output or paste it in issues/PRs.)"
+echo
+base64 -w0 "$KEY"
+echo

--- a/scripts/encode-minisign-secret-for-github.sh
+++ b/scripts/encode-minisign-secret-for-github.sh
@@ -14,5 +14,5 @@ fi
 echo "Copy the single line below into GitHub → Settings → Secrets → Actions → MINISIGN_SECRET_KEY"
 echo "(Do not commit this output or paste it in issues/PRs.)"
 echo
-base64 -w0 "$KEY"
+base64 "$KEY" | tr -d '\n'
 echo

--- a/scripts/generate-updater-fixtures.sh
+++ b/scripts/generate-updater-fixtures.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Regenerate minisign test fixtures under tests/fixtures/updater/.
+# Requires: minisign, curl, libsodium (for the minisign binary).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FIXTURE_DIR="$ROOT/tests/fixtures/updater"
+RELEASE_TAG="${1:-3.5.3}"
+
+mkdir -p "$FIXTURE_DIR"
+cd "$FIXTURE_DIR"
+
+KEY="$FIXTURE_DIR/minisign-test.key"
+PUB="$FIXTURE_DIR/minisign-test.pub"
+
+if [[ ! -f "$KEY" ]]; then
+  minisign -G -f -W -s "$KEY" -p "$PUB"
+  echo "Generated new test keypair. Do NOT commit $KEY."
+fi
+
+README="$FIXTURE_DIR/release-${RELEASE_TAG}-readme.md"
+curl -fsSL "https://raw.githubusercontent.com/fernandotonon/QtMeshEditor/${RELEASE_TAG}/README.md" -o "$README"
+
+minisign -S -s "$KEY" -x "${README}.minisig" -m "$README" \
+  -c "spike fixture from release ${RELEASE_TAG} README" \
+  -t "timestamp:0	file:release-${RELEASE_TAG}-readme.md"
+
+echo "Fixtures updated. Commit:"
+echo "  ${PUB}"
+echo "  ${README}"
+echo "  ${README}.minisig"
+PUB_B64=$(grep -v '^untrusted' "$PUB" | grep -v '^#' | tr -d '\n\r')
+echo "Update kTestPublicKeyBase64 in MinisignVerify_test.cpp if the keypair changed:"
+echo "  ${PUB_B64}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,6 +97,8 @@ PaintBufferImageProvider.cpp
 PaintSelectionMask.cpp
 TexturePaintBuffer.cpp
 UpdateVersion.cpp
+updater/InstallFlavor.cpp
+updater/MinisignVerify.cpp
 TexturePaintController.cpp
 VertexColorBaker.cpp
 VATBaker.cpp
@@ -230,6 +232,8 @@ PaintBufferImageProvider.h
 PaintSelectionMask.h
 TexturePaintBuffer.h
 UpdateVersion.h
+updater/InstallFlavor.h
+updater/MinisignVerify.h
 TexturePaintController.h
 VertexColorBaker.h
 ApplyAtlas.h
@@ -536,6 +540,7 @@ Qt::QuickWidgets
 Qt::QuickControls2
 meshoptimizer
 xatlas
+qtmesh_sodium
 )
 
 # One-time legacy secret-store read for migration (see CloudCredentialStore).
@@ -625,7 +630,7 @@ if(BUILD_TESTS)
     ${OGRE_LIBRARIES}
     ${ASSIMP_LIBRARIES}
     Qt::Widgets Qt::Core Qt::Gui Qt::Test Qt::Network Qt::Qml Qt::Quick Qt::QuickWidgets Qt::QuickControls2
-    meshoptimizer xatlas)
+    meshoptimizer xatlas qtmesh_sodium)
 
     # CloudCredentialStore.cpp (compiled into the tests) does a one-time legacy
     # secret-store read in migrateLegacySettingsIfNeeded(), which

--- a/src/updater/InstallFlavor.cpp
+++ b/src/updater/InstallFlavor.cpp
@@ -108,9 +108,14 @@ Flavor detectWindows(const QString& path)
                L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\FernandoTonon.QtMeshEditor"))
         return Flavor::WinGet;
 
-    // Zip portable installs typically live under Downloads or a user-chosen folder.
-    if (pathContains(path, QLatin1String("\\QtMeshEditor\\"))
-        || path.endsWith(QStringLiteral("QtMeshEditor.exe"), Qt::CaseInsensitive))
+    // Zip portable installs use QtMeshEditor-<ver>-bin-Windows.zip layout: ...\QtMeshEditor\bin\...
+    // Reject CI/dev trees (...\build\...) even when the repo folder is named QtMeshEditor.
+    if (pathContains(path, QLatin1String("\\build\\"))
+        || pathContains(path, QLatin1String("/build/")))
+        return Flavor::Unknown;
+
+    if (pathContains(path, QLatin1String("\\QtMeshEditor\\bin\\"))
+        || pathContains(path, QLatin1String("/QtMeshEditor/bin/")))
         return Flavor::Portable;
 
     return Flavor::Unknown;

--- a/src/updater/InstallFlavor.cpp
+++ b/src/updater/InstallFlavor.cpp
@@ -1,0 +1,194 @@
+#include "InstallFlavor.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QStandardPaths>
+
+#ifdef Q_OS_WIN
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#endif
+
+namespace InstallFlavor {
+
+namespace {
+
+QString normalizedExePath(const QString& applicationFilePath)
+{
+    const QString raw = applicationFilePath.isEmpty()
+        ? QCoreApplication::applicationFilePath()
+        : applicationFilePath;
+    return QDir::cleanPath(QFileInfo(raw).absoluteFilePath());
+}
+
+bool pathContains(const QString& path, QLatin1String needle)
+{
+    return path.contains(needle, Qt::CaseInsensitive);
+}
+
+#ifdef Q_OS_LINUX
+Flavor detectLinux(const QString& path)
+{
+    if (QFile::exists(QStringLiteral("/.dockerenv")))
+        return Flavor::Docker;
+
+    if (pathContains(path, QLatin1String("/snap/qtmesheditor/"))
+        || path.startsWith(QStringLiteral("/snap/bin/qtmesheditor"), Qt::CaseInsensitive))
+        return Flavor::Snap;
+
+    if (pathContains(path, QLatin1String("/var/lib/flatpak/"))
+        || pathContains(path, QLatin1String("/.local/share/flatpak/")))
+        return Flavor::Flatpak;
+
+    const QFileInfo info(path);
+    const QString dir = info.absolutePath();
+    if (dir == QStringLiteral("/usr/bin") || dir == QStringLiteral("/bin"))
+        return Flavor::Debian;
+
+    if (pathContains(path, QLatin1String("/opt/QtMeshEditor"))
+        || pathContains(path, QLatin1String("/opt/qtmesheditor")))
+        return Flavor::Portable;
+
+    return Flavor::Unknown;
+}
+#endif
+
+#ifdef Q_OS_MACOS
+Flavor detectMacOS(const QString& path)
+{
+    // Homebrew cask installs under /Applications or /opt/homebrew/Caskroom/.
+    if (path.startsWith(QStringLiteral("/Applications/Homebrew/"), Qt::CaseInsensitive)
+        || pathContains(path, QLatin1String("/Caskroom/qtmesheditor/"))
+        || pathContains(path, QLatin1String("/opt/homebrew/Caskroom/qtmesheditor/")))
+        return Flavor::Homebrew;
+
+    // Sentinel some brew workflows drop inside the bundle (issue #440 spike).
+    if (path.contains(QStringLiteral(".app"), Qt::CaseInsensitive)) {
+        const int appIdx = path.indexOf(QStringLiteral(".app"), 0, Qt::CaseInsensitive);
+        const QString bundleRoot = path.left(appIdx + 4);
+        if (QFile::exists(bundleRoot + QStringLiteral("/Contents/Resources/.brew")))
+            return Flavor::Homebrew;
+    }
+
+    if (path.startsWith(QStringLiteral("/Applications/QtMeshEditor.app"), Qt::CaseInsensitive)
+        || pathContains(path, QLatin1String("/Applications/QtMeshEditor.app/")))
+        return Flavor::Portable;
+
+    return Flavor::Unknown;
+}
+#endif
+
+#ifdef Q_OS_WIN
+bool registryHasUninstallEntry(const wchar_t* subKey)
+{
+    HKEY key = nullptr;
+    const LONG opened =
+        RegOpenKeyExW(HKEY_LOCAL_MACHINE, subKey, 0, KEY_READ | KEY_WOW64_64KEY, &key);
+    if (opened != ERROR_SUCCESS)
+        return false;
+    RegCloseKey(key);
+    return true;
+}
+
+Flavor detectWindows(const QString& path)
+{
+    Q_UNUSED(path);
+
+    if (registryHasUninstallEntry(L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\QtMeshEditor"))
+        return Flavor::Portable; // MSI/custom installer — still self-managed, not WinGet
+
+    const QString startMenu = QStandardPaths::writableLocation(QStandardPaths::ApplicationsLocation);
+    if (pathContains(startMenu, QLatin1String("WinGet"))
+        || pathContains(path, QLatin1String("WindowsApps"))
+        || registryHasUninstallEntry(
+               L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\FernandoTonon.QtMeshEditor"))
+        return Flavor::WinGet;
+
+    // Zip portable installs typically live under Downloads or a user-chosen folder.
+    if (pathContains(path, QLatin1String("\\QtMeshEditor\\"))
+        || path.endsWith(QStringLiteral("QtMeshEditor.exe"), Qt::CaseInsensitive))
+        return Flavor::Portable;
+
+    return Flavor::Unknown;
+}
+#endif
+
+} // namespace
+
+QString toSlug(Flavor flavor)
+{
+    switch (flavor) {
+    case Flavor::Portable: return QStringLiteral("portable");
+    case Flavor::Homebrew: return QStringLiteral("homebrew");
+    case Flavor::WinGet: return QStringLiteral("winget");
+    case Flavor::Snap: return QStringLiteral("snap");
+    case Flavor::Flatpak: return QStringLiteral("flatpak");
+    case Flavor::Debian: return QStringLiteral("debian");
+    case Flavor::Docker: return QStringLiteral("docker");
+    case Flavor::Unknown: return QStringLiteral("unknown");
+    }
+    return QStringLiteral("unknown");
+}
+
+QString displayName(Flavor flavor)
+{
+    switch (flavor) {
+    case Flavor::Portable: return QStringLiteral("Portable");
+    case Flavor::Homebrew: return QStringLiteral("Homebrew");
+    case Flavor::WinGet: return QStringLiteral("WinGet");
+    case Flavor::Snap: return QStringLiteral("Snap");
+    case Flavor::Flatpak: return QStringLiteral("Flatpak");
+    case Flavor::Debian: return QStringLiteral("Debian package");
+    case Flavor::Docker: return QStringLiteral("Docker");
+    case Flavor::Unknown: return QStringLiteral("Unknown");
+    }
+    return QStringLiteral("Unknown");
+}
+
+bool isPackageManagerManaged(Flavor flavor)
+{
+    return flavor != Flavor::Portable && flavor != Flavor::Unknown;
+}
+
+QString updateCommandHint(Flavor flavor)
+{
+    switch (flavor) {
+    case Flavor::Homebrew:
+        return QStringLiteral("brew upgrade --cask qtmesheditor");
+    case Flavor::WinGet:
+        return QStringLiteral("winget upgrade FernandoTonon.QtMeshEditor");
+    case Flavor::Snap:
+        return QStringLiteral("sudo snap refresh qtmesheditor");
+    case Flavor::Flatpak:
+        return QStringLiteral("flatpak update io.github.fernandotonon.QtMeshEditor");
+    case Flavor::Debian:
+        return QStringLiteral("sudo apt update && sudo apt install qtmesheditor");
+    case Flavor::Docker:
+        return QStringLiteral("docker pull ghcr.io/fernandotonon/qtmesh");
+    case Flavor::Portable:
+    case Flavor::Unknown:
+        break;
+    }
+    return {};
+}
+
+Flavor detect(const QString& applicationFilePath)
+{
+    const QString path = normalizedExePath(applicationFilePath);
+#if defined(Q_OS_LINUX)
+    return detectLinux(path);
+#elif defined(Q_OS_MACOS)
+    return detectMacOS(path);
+#elif defined(Q_OS_WIN)
+    return detectWindows(path);
+#else
+    Q_UNUSED(path);
+    return Flavor::Unknown;
+#endif
+}
+
+} // namespace InstallFlavor

--- a/src/updater/InstallFlavor.cpp
+++ b/src/updater/InstallFlavor.cpp
@@ -33,9 +33,6 @@ bool pathContains(const QString& path, QLatin1String needle)
 #ifdef Q_OS_LINUX
 Flavor detectLinux(const QString& path)
 {
-    if (QFile::exists(QStringLiteral("/.dockerenv")))
-        return Flavor::Docker;
-
     if (pathContains(path, QLatin1String("/snap/qtmesheditor/"))
         || path.startsWith(QStringLiteral("/snap/bin/qtmesheditor"), Qt::CaseInsensitive))
         return Flavor::Snap;
@@ -52,6 +49,9 @@ Flavor detectLinux(const QString& path)
     if (pathContains(path, QLatin1String("/opt/QtMeshEditor"))
         || pathContains(path, QLatin1String("/opt/qtmesheditor")))
         return Flavor::Portable;
+
+    if (QFile::exists(QStringLiteral("/.dockerenv")))
+        return Flavor::Docker;
 
     return Flavor::Unknown;
 }

--- a/src/updater/InstallFlavor.h
+++ b/src/updater/InstallFlavor.h
@@ -1,0 +1,53 @@
+#ifndef INSTALLFLAVOR_H
+#define INSTALLFLAVOR_H
+
+#include <QString>
+
+/**
+ * @brief How the running binary was installed — gates the in-app auto-updater.
+ *
+ * Package-manager flavors must defer to their own update channel (brew, winget,
+ * snap, apt, flatpak, docker pull). Only @ref InstallFlavor::Portable receives
+ * download → verify → install → restart. See docs/AUTO_UPDATER_DESIGN.md (#440).
+ */
+namespace InstallFlavor {
+
+enum class Flavor {
+    Portable,   ///< Direct-download zip/dmg/tarball or /opt/QtMeshEditor portable tree
+    Homebrew,   ///< macOS Homebrew cask
+    WinGet,     ///< Windows WinGet package
+    Snap,       ///< Linux snap (qtmesheditor)
+    Flatpak,    ///< Linux Flatpak install
+    Debian,     ///< Linux .deb / apt install under /usr
+    Docker,     ///< Container image (/.dockerenv)
+    Unknown,    ///< Dev/CI build tree, ambiguous layout — no self-update
+};
+
+/// Canonical lowercase slug for Sentry breadcrumbs and settings keys.
+QString toSlug(Flavor flavor);
+
+/// User-facing label for the updater dialog.
+QString displayName(Flavor flavor);
+
+/// True for every flavor except @ref Flavor::Portable.
+bool isPackageManagerManaged(Flavor flavor);
+
+/**
+ * @brief One-line shell command the updater dialog shows instead of downloading.
+ *
+ * Empty for @ref Flavor::Portable and @ref Flavor::Unknown.
+ */
+QString updateCommandHint(Flavor flavor);
+
+/**
+ * @brief Detect install flavor from the application binary path.
+ *
+ * @p applicationFilePath is usually QCoreApplication::applicationFilePath().
+ * Normalised to absolute form internally. Pure function aside from optional
+ * registry / codesign probes on Windows and macOS.
+ */
+Flavor detect(const QString& applicationFilePath);
+
+} // namespace InstallFlavor
+
+#endif // INSTALLFLAVOR_H

--- a/src/updater/InstallFlavor_test.cpp
+++ b/src/updater/InstallFlavor_test.cpp
@@ -1,0 +1,79 @@
+#include <gtest/gtest.h>
+
+#include "InstallFlavor.h"
+
+#include <QString>
+
+using InstallFlavor::Flavor;
+
+TEST(InstallFlavor, SlugAndDisplayNamesAreStable)
+{
+    EXPECT_EQ(InstallFlavor::toSlug(Flavor::Portable), QStringLiteral("portable"));
+    EXPECT_EQ(InstallFlavor::displayName(Flavor::WinGet), QStringLiteral("WinGet"));
+}
+
+TEST(InstallFlavor, PackageManagerManagedExcludesPortableAndUnknown)
+{
+    EXPECT_FALSE(InstallFlavor::isPackageManagerManaged(Flavor::Portable));
+    EXPECT_FALSE(InstallFlavor::isPackageManagerManaged(Flavor::Unknown));
+    EXPECT_TRUE(InstallFlavor::isPackageManagerManaged(Flavor::Snap));
+    EXPECT_TRUE(InstallFlavor::isPackageManagerManaged(Flavor::Homebrew));
+}
+
+TEST(InstallFlavor, UpdateHintsMatchDocumentedCommands)
+{
+    EXPECT_EQ(InstallFlavor::updateCommandHint(Flavor::Homebrew),
+              QStringLiteral("brew upgrade --cask qtmesheditor"));
+    EXPECT_EQ(InstallFlavor::updateCommandHint(Flavor::WinGet),
+              QStringLiteral("winget upgrade FernandoTonon.QtMeshEditor"));
+    EXPECT_EQ(InstallFlavor::updateCommandHint(Flavor::Snap),
+              QStringLiteral("sudo snap refresh qtmesheditor"));
+    EXPECT_TRUE(InstallFlavor::updateCommandHint(Flavor::Portable).isEmpty());
+}
+
+#if defined(Q_OS_LINUX)
+TEST(InstallFlavor, LinuxDetectsSnapFlatpakDebianDockerPortable)
+{
+    EXPECT_EQ(InstallFlavor::detect(QStringLiteral("/snap/qtmesheditor/42/usr/bin/QtMeshEditor")),
+              Flavor::Snap);
+    EXPECT_EQ(InstallFlavor::detect(QStringLiteral("/var/lib/flatpak/app/io.github.app/x/active/files/bin/QtMeshEditor")),
+              Flavor::Flatpak);
+    EXPECT_EQ(InstallFlavor::detect(QStringLiteral("/usr/bin/QtMeshEditor")), Flavor::Debian);
+    EXPECT_EQ(InstallFlavor::detect(QStringLiteral("/opt/QtMeshEditor/bin/QtMeshEditor")),
+              Flavor::Portable);
+}
+
+TEST(InstallFlavor, LinuxCiBuildTreeIsUnknown)
+{
+    // GitHub Actions / local build trees are not package-manager installs.
+    const Flavor flavor = InstallFlavor::detect(
+        QStringLiteral("/home/runner/work/QtMeshEditor/build/bin/QtMeshEditor"));
+    EXPECT_EQ(flavor, Flavor::Unknown);
+}
+#elif defined(Q_OS_MACOS)
+TEST(InstallFlavor, MacDetectsHomebrewAndPortable)
+{
+    EXPECT_EQ(InstallFlavor::detect(QStringLiteral("/Applications/Homebrew/QtMeshEditor.app/Contents/MacOS/QtMeshEditor")),
+              Flavor::Homebrew);
+    EXPECT_EQ(InstallFlavor::detect(QStringLiteral("/Applications/QtMeshEditor.app/Contents/MacOS/QtMeshEditor")),
+              Flavor::Portable);
+}
+
+TEST(InstallFlavor, MacCiBuildTreeIsUnknown)
+{
+    EXPECT_EQ(InstallFlavor::detect(QStringLiteral("/Users/runner/work/QtMeshEditor/build/bin/QtMeshEditor")),
+              Flavor::Unknown);
+}
+#elif defined(Q_OS_WIN)
+TEST(InstallFlavor, WindowsPortableZipLayout)
+{
+    EXPECT_EQ(InstallFlavor::detect(QStringLiteral("C:/Tools/QtMeshEditor/bin/QtMeshEditor.exe")),
+              Flavor::Portable);
+}
+
+TEST(InstallFlavor, WindowsCiBuildTreeIsUnknown)
+{
+    EXPECT_EQ(InstallFlavor::detect(QStringLiteral("D:/a/QtMeshEditor/QtMeshEditor/build/bin/QtMeshEditor.exe")),
+              Flavor::Unknown);
+}
+#endif

--- a/src/updater/MinisignVerify.cpp
+++ b/src/updater/MinisignVerify.cpp
@@ -1,0 +1,174 @@
+#include "MinisignVerify.h"
+
+#include <QByteArray>
+#include <QFile>
+#include <QTextStream>
+
+#if defined(Q_OS_LINUX)
+#include <sodium.h>
+#endif
+
+namespace MinisignVerify {
+
+namespace {
+
+constexpr int kSigAlgBytes = 2;
+constexpr int kKeyNumBytes = 8;
+constexpr int kSigBytes = 64;
+constexpr int kPubKeyBytes = 32;
+constexpr int kSigStructBytes = kSigAlgBytes + kKeyNumBytes + kSigBytes;
+constexpr int kPubStructBytes = kSigAlgBytes + kKeyNumBytes + kPubKeyBytes;
+
+Outcome fail(Result result, const QString& message)
+{
+    Outcome out;
+    out.result = result;
+    out.errorMessage = message;
+    return out;
+}
+
+QByteArray decodeBase64(const QString& encoded)
+{
+    const QByteArray trimmed = encoded.trimmed().toLatin1();
+    return QByteArray::fromBase64(trimmed);
+}
+
+#if defined(Q_OS_LINUX)
+
+bool ensureSodiumInit()
+{
+    static bool ready = [] {
+        return sodium_init() >= 0;
+    }();
+    return ready;
+}
+
+Outcome verifyParsed(const QByteArray& message,
+                     const QByteArray& sigStruct,
+                     const QByteArray& globalSig,
+                     const QString& trustedComment,
+                     const QByteArray& pubStruct)
+{
+    if (!ensureSodiumInit())
+        return fail(Result::Unsupported, QStringLiteral("libsodium init failed"));
+
+    if (sigStruct.size() < kSigStructBytes || pubStruct.size() < kPubStructBytes)
+        return fail(Result::InvalidSignatureFile, QStringLiteral("signature or pubkey too short"));
+
+    if (sigStruct.mid(kSigAlgBytes, kKeyNumBytes) != pubStruct.mid(kSigAlgBytes, kKeyNumBytes))
+        return fail(Result::KeyIdMismatch, QStringLiteral("signature key id does not match public key"));
+
+    const auto sigAlg = sigStruct.left(kSigAlgBytes);
+    const bool hashed = sigAlg == QByteArray("ED", 2);
+    if (!hashed && sigAlg != QByteArray("Ed", 2))
+        return fail(Result::InvalidSignatureFile, QStringLiteral("unsupported signature algorithm"));
+
+    const QByteArray detachedSig = sigStruct.mid(kSigAlgBytes + kKeyNumBytes, kSigBytes);
+    const QByteArray publicKey = pubStruct.mid(kSigAlgBytes + kKeyNumBytes, kPubKeyBytes);
+
+    QByteArray payload = message;
+    if (hashed) {
+        payload.resize(crypto_generichash_BYTES_MAX);
+        if (crypto_generichash(reinterpret_cast<unsigned char*>(payload.data()),
+                               crypto_generichash_BYTES_MAX,
+                               reinterpret_cast<const unsigned char*>(message.constData()),
+                               static_cast<unsigned long long>(message.size()),
+                               nullptr,
+                               0) != 0)
+            return fail(Result::IoError, QStringLiteral("BLAKE2b digest failed"));
+    }
+
+    if (crypto_sign_verify_detached(reinterpret_cast<const unsigned char*>(detachedSig.constData()),
+                                    reinterpret_cast<const unsigned char*>(payload.constData()),
+                                    payload.size(),
+                                    reinterpret_cast<const unsigned char*>(publicKey.constData())) != 0)
+        return fail(Result::FileSignatureFailed, QStringLiteral("file signature invalid"));
+
+    const QByteArray trustedUtf8 = trustedComment.toUtf8();
+    QByteArray commentPayload;
+    commentPayload.reserve(kSigBytes + trustedUtf8.size());
+    commentPayload.append(detachedSig);
+    commentPayload.append(trustedUtf8);
+
+    if (globalSig.size() < kSigBytes
+        || crypto_sign_verify_detached(reinterpret_cast<const unsigned char*>(globalSig.constData()),
+                                       reinterpret_cast<const unsigned char*>(commentPayload.constData()),
+                                       commentPayload.size(),
+                                       reinterpret_cast<const unsigned char*>(publicKey.constData())) != 0)
+        return fail(Result::CommentSignatureFailed, QStringLiteral("trusted comment signature invalid"));
+
+    Outcome ok;
+    ok.result = Result::Ok;
+    ok.trustedComment = trustedComment;
+    return ok;
+}
+
+#endif // Q_OS_LINUX
+
+} // namespace
+
+QString resultToString(Result result)
+{
+    switch (result) {
+    case Result::Ok: return QStringLiteral("ok");
+    case Result::Unsupported: return QStringLiteral("unsupported");
+    case Result::IoError: return QStringLiteral("io_error");
+    case Result::InvalidPublicKey: return QStringLiteral("invalid_public_key");
+    case Result::InvalidSignatureFile: return QStringLiteral("invalid_signature_file");
+    case Result::KeyIdMismatch: return QStringLiteral("key_id_mismatch");
+    case Result::FileSignatureFailed: return QStringLiteral("file_signature_failed");
+    case Result::CommentSignatureFailed: return QStringLiteral("comment_signature_failed");
+    }
+    return QStringLiteral("unknown");
+}
+
+Outcome verifyFile(const QString& messageFile,
+                   const QString& signatureFile,
+                   const QString& publicKeyBase64)
+{
+#if !defined(Q_OS_LINUX)
+    Q_UNUSED(messageFile);
+    Q_UNUSED(signatureFile);
+    Q_UNUSED(publicKeyBase64);
+    return fail(Result::Unsupported,
+                QStringLiteral("minisign verify is only built on Linux in this spike"));
+#else
+    const QByteArray pubStruct = decodeBase64(publicKeyBase64);
+    if (pubStruct.size() < kPubStructBytes)
+        return fail(Result::InvalidPublicKey, QStringLiteral("could not decode public key"));
+
+    QFile messageFp(messageFile);
+    if (!messageFp.open(QIODevice::ReadOnly))
+        return fail(Result::IoError, QStringLiteral("cannot read message file"));
+
+    QFile sigFp(signatureFile);
+    if (!sigFp.open(QIODevice::ReadOnly | QIODevice::Text))
+        return fail(Result::IoError, QStringLiteral("cannot read signature file"));
+
+    QTextStream sigStream(&sigFp);
+    const QString untrustedLine = sigStream.readLine();
+    const QString sigLine = sigStream.readLine();
+    const QString trustedLine = sigStream.readLine();
+    const QString globalLine = sigStream.readLine();
+
+    if (untrustedLine.isEmpty() || sigLine.isEmpty() || trustedLine.isEmpty() || globalLine.isEmpty())
+        return fail(Result::InvalidSignatureFile, QStringLiteral("signature file is incomplete"));
+
+    if (!untrustedLine.startsWith(QStringLiteral("untrusted comment:")))
+        return fail(Result::InvalidSignatureFile, QStringLiteral("missing untrusted comment line"));
+
+    if (!trustedLine.startsWith(QStringLiteral("trusted comment:")))
+        return fail(Result::InvalidSignatureFile, QStringLiteral("missing trusted comment line"));
+
+    const QString trustedComment =
+        trustedLine.mid(QStringLiteral("trusted comment:").size()).trimmed();
+
+    const QByteArray sigStruct = decodeBase64(sigLine);
+    const QByteArray globalSig = decodeBase64(globalLine);
+    const QByteArray message = messageFp.readAll();
+
+    return verifyParsed(message, sigStruct, globalSig, trustedComment, pubStruct);
+#endif
+}
+
+} // namespace MinisignVerify

--- a/src/updater/MinisignVerify.cpp
+++ b/src/updater/MinisignVerify.cpp
@@ -12,6 +12,12 @@ namespace MinisignVerify {
 
 namespace {
 
+// packaging/updater/minisign.pub — rotate via docs/AUTO_UPDATER_DESIGN.md §1.
+constexpr const char kProductionPublicKeyBase64[] =
+    "RWQYgVXaH+8eYME58t9l6roX1QIqFsW+/nYV216ymPtW8H6odA8aMGhJ";
+
+} // namespace
+
 constexpr int kSigAlgBytes = 2;
 constexpr int kKeyNumBytes = 8;
 constexpr int kSigBytes = 64;
@@ -105,8 +111,6 @@ Outcome verifyParsed(const QByteArray& message,
 
 #endif // Q_OS_LINUX
 
-} // namespace
-
 QString resultToString(Result result)
 {
     switch (result) {
@@ -120,6 +124,16 @@ QString resultToString(Result result)
     case Result::CommentSignatureFailed: return QStringLiteral("comment_signature_failed");
     }
     return QStringLiteral("unknown");
+}
+
+QString productionPublicKeyBase64()
+{
+    return QString::fromUtf8(kProductionPublicKeyBase64);
+}
+
+Outcome verifyReleaseFile(const QString& messageFile, const QString& signatureFile)
+{
+    return verifyFile(messageFile, signatureFile, productionPublicKeyBase64());
 }
 
 Outcome verifyFile(const QString& messageFile,

--- a/src/updater/MinisignVerify.h
+++ b/src/updater/MinisignVerify.h
@@ -1,0 +1,52 @@
+#ifndef MINISIGNVERIFY_H
+#define MINISIGNVERIFY_H
+
+#include <QString>
+
+/**
+ * @brief Verify minisign (.minisig) detached signatures on release artifacts.
+ *
+ * Spike PoC for epic #439 / issue #440. Uses the same pre-hashed Ed25519
+ * format as the minisign CLI (BLAKE2b-512 digest + dual signatures). The
+ * production public key is compiled in; CI signs artifacts with the matching
+ * secret (see docs/AUTO_UPDATER_DESIGN.md).
+ *
+ * Linux builds link libsodium for verify. Other platforms return
+ * @ref Result::Unsupported until #445 lands cross-platform crypto.
+ */
+namespace MinisignVerify {
+
+enum class Result {
+    Ok,
+    Unsupported,       ///< Platform build without verify backend
+    IoError,
+    InvalidPublicKey,
+    InvalidSignatureFile,
+    KeyIdMismatch,
+    FileSignatureFailed,
+    CommentSignatureFailed,
+};
+
+struct Outcome {
+    Result result = Result::IoError;
+    QString trustedComment;
+    QString errorMessage;
+};
+
+/// Human-readable error for logging / UI.
+QString resultToString(Result result);
+
+/**
+ * @brief Verify @p messageFile against @p signatureFile using an embedded pubkey.
+ *
+ * @p publicKeyBase64 is the raw base64 body from a minisign .pub file (the
+ * line after the untrusted comment), or the `-P` string minisign prints after
+ * key generation.
+ */
+Outcome verifyFile(const QString& messageFile,
+                   const QString& signatureFile,
+                   const QString& publicKeyBase64);
+
+} // namespace MinisignVerify
+
+#endif // MINISIGNVERIFY_H

--- a/src/updater/MinisignVerify.h
+++ b/src/updater/MinisignVerify.h
@@ -36,6 +36,14 @@ struct Outcome {
 /// Human-readable error for logging / UI.
 QString resultToString(Result result);
 
+/// Base64 public key body for release artifact verification (`minisign -P` form).
+QString productionPublicKeyBase64();
+
+/**
+ * @brief Verify @p messageFile against @p signatureFile using the production pubkey.
+ */
+Outcome verifyReleaseFile(const QString& messageFile, const QString& signatureFile);
+
 /**
  * @brief Verify @p messageFile against @p signatureFile using an embedded pubkey.
  *

--- a/src/updater/MinisignVerify_test.cpp
+++ b/src/updater/MinisignVerify_test.cpp
@@ -66,6 +66,7 @@ TEST(MinisignVerify, RejectsWrongPublicKey)
         QStringLiteral("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="));
 
     EXPECT_NE(out.result, MinisignVerify::Result::Ok);
+    EXPECT_EQ(out.result, MinisignVerify::Result::InvalidPublicKey);
 }
 
 #else

--- a/src/updater/MinisignVerify_test.cpp
+++ b/src/updater/MinisignVerify_test.cpp
@@ -1,0 +1,83 @@
+#include <gtest/gtest.h>
+
+#include "MinisignVerify.h"
+
+#include <QDir>
+#include <QFile>
+#include <QTemporaryDir>
+#include <QString>
+
+namespace {
+
+QString fixturePath(const char* name)
+{
+    return QDir(QStringLiteral(QTMESH_UT_SOURCE_ROOT))
+        .filePath(QStringLiteral("tests/fixtures/updater/%1").arg(QString::fromUtf8(name)));
+}
+
+// Public half of tests/fixtures/updater/minisign-test.key (secret key is NOT committed).
+constexpr const char* kTestPublicKeyBase64 =
+    "RWT6vKVd359GZ2DxI4QZgc51byx/fJXWLFmbSby/kTnRsIZfwj5gkI2A";
+
+} // namespace
+
+#if defined(Q_OS_LINUX)
+
+TEST(MinisignVerify, AcceptsSignedReleaseReadmeFixture)
+{
+    const MinisignVerify::Outcome out = MinisignVerify::verifyFile(
+        fixturePath("release-3.5.3-readme.md"),
+        fixturePath("release-3.5.3-readme.md.minisig"),
+        QString::fromUtf8(kTestPublicKeyBase64));
+
+    ASSERT_EQ(out.result, MinisignVerify::Result::Ok) << out.errorMessage.toStdString();
+    EXPECT_FALSE(out.trustedComment.isEmpty());
+}
+
+TEST(MinisignVerify, RejectsTamperedPayload)
+{
+    QTemporaryDir temp;
+    ASSERT_TRUE(temp.isValid());
+
+    const QString tampered = temp.path() + QStringLiteral("/tampered.md");
+    ASSERT_TRUE(QFile::copy(fixturePath("release-3.5.3-readme.md"), tampered));
+
+    QFile file(tampered);
+    ASSERT_TRUE(file.open(QIODevice::ReadWrite));
+    file.seek(0);
+    const char first = file.read(1).at(0);
+    file.seek(0);
+    file.write(QByteArray(1, static_cast<char>(first ^ 0x01)));
+    file.close();
+
+    const MinisignVerify::Outcome out = MinisignVerify::verifyFile(
+        tampered,
+        fixturePath("release-3.5.3-readme.md.minisig"),
+        QString::fromUtf8(kTestPublicKeyBase64));
+
+    EXPECT_EQ(out.result, MinisignVerify::Result::FileSignatureFailed);
+}
+
+TEST(MinisignVerify, RejectsWrongPublicKey)
+{
+    const MinisignVerify::Outcome out = MinisignVerify::verifyFile(
+        fixturePath("release-3.5.3-readme.md"),
+        fixturePath("release-3.5.3-readme.md.minisig"),
+        QStringLiteral("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="));
+
+    EXPECT_NE(out.result, MinisignVerify::Result::Ok);
+}
+
+#else
+
+TEST(MinisignVerify, UnsupportedOnWindowsInSpike)
+{
+    const MinisignVerify::Outcome out = MinisignVerify::verifyFile(
+        fixturePath("release-3.5.3-readme.md"),
+        fixturePath("release-3.5.3-readme.md.minisig"),
+        QString::fromUtf8(kTestPublicKeyBase64));
+
+    EXPECT_EQ(out.result, MinisignVerify::Result::Unsupported);
+}
+
+#endif

--- a/tests/fixtures/updater/.gitignore
+++ b/tests/fixtures/updater/.gitignore
@@ -1,0 +1,2 @@
+# Never commit minisign secret keys — only .pub + signed fixtures belong in git.
+*.key

--- a/tests/fixtures/updater/minisign-test.pub
+++ b/tests/fixtures/updater/minisign-test.pub
@@ -1,0 +1,2 @@
+untrusted comment: minisign public key 67469FDF5DA5BCFA
+RWT6vKVd359GZ2DxI4QZgc51byx/fJXWLFmbSby/kTnRsIZfwj5gkI2A

--- a/tests/fixtures/updater/release-3.5.3-readme.md
+++ b/tests/fixtures/updater/release-3.5.3-readme.md
@@ -1,0 +1,325 @@
+
+# <img width=30 align="top" src="https://user-images.githubusercontent.com/996529/209745977-7b797223-46ce-4bce-aa70-707a88f2aaf2.png"> QtMeshEditor
+
+Automate your 3D asset pipeline — scan, validate, convert, fix, and merge 3D assets with GUI + CLI + CI/CD support.
+
+**Open 3D files from your OS** — after install, double-click `.fbx`, `.glb`, `.gltf`, `.obj`, `.dae`, `.stl`, `.ply`, `.mesh`, and PS1 `.rsd`/`.tmd` in Finder, Explorer, or your Linux file manager (or use **Open With**). QtMeshEditor loads the model in the running window; a second launch focuses the existing instance instead of spawning another process. Portable Windows ZIP users can run `bin/scripts/register-windows-file-associations.ps1` to register handlers without admin rights.
+
+[![GitHub stars](https://img.shields.io/github/stars/fernandotonon/QtMeshEditor.svg?style=social&label=Star&maxAge=2592000)](https://GitHub.com/fernandotonon/QtMeshEditor/stargazers) Star if you like it!
+
+[![Github All Releases](https://img.shields.io/github/downloads/fernandotonon/QtMeshEditor/total.svg)]()
+[![qtmesheditor](https://snapcraft.io/qtmesheditor/badge.svg)](https://snapcraft.io/qtmesheditor)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=fernandotonon_QtMeshEditor&metric=coverage)](https://sonarcloud.io/summary/new_code?id=fernandotonon_QtMeshEditor)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=fernandotonon_QtMeshEditor&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=fernandotonon_QtMeshEditor)
+[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=fernandotonon_QtMeshEditor&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=fernandotonon_QtMeshEditor)
+[![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=fernandotonon_QtMeshEditor&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=fernandotonon_QtMeshEditor)
+
+#### QtMesh Cloud Badges
+[![qtmesh status](https://api.qtmesh.dev/v1/u/u-28680b9c/p/qtmesheditor/badges/qtmesh-status.svg)](https://qtmesh.dev)
+[![qtmesh score](https://api.qtmesh.dev/v1/u/u-28680b9c/p/qtmesheditor/badges/qtmesh-score.svg)](https://qtmesh.dev)
+[![qtmesh errors](https://api.qtmesh.dev/v1/u/u-28680b9c/p/qtmesheditor/badges/qtmesh-errors.svg)](https://qtmesh.dev)
+[![qtmesh warnings](https://api.qtmesh.dev/v1/u/u-28680b9c/p/qtmesheditor/badges/qtmesh-warnings.svg)](https://qtmesh.dev)
+[![qtmesh models](https://api.qtmesh.dev/v1/u/u-28680b9c/p/qtmesheditor/badges/qtmesh-models.svg)](https://qtmesh.dev)
+[![qtmesh animations](https://api.qtmesh.dev/v1/u/u-28680b9c/p/qtmesheditor/badges/qtmesh-animations.svg)](https://qtmesh.dev)
+[![qtmesh skeletons](https://api.qtmesh.dev/v1/u/u-28680b9c/p/qtmesheditor/badges/qtmesh-skeletons.svg)](https://qtmesh.dev)
+[![qtmesh materials](https://api.qtmesh.dev/v1/u/u-28680b9c/p/qtmesheditor/badges/qtmesh-materials.svg)](https://qtmesh.dev)
+
+---
+
+### 🔌 CI/CD — GitHub Actions
+
+Available on the [GitHub Actions Marketplace](https://github.com/marketplace/actions/qtmesheditor).
+
+[![Latest action release](https://img.shields.io/github/v/release/fernandotonon/QtMeshEditor?label=latest%20action)](https://github.com/fernandotonon/QtMeshEditor/releases/latest)
+
+**Versioning**
+
+- **Always follow the latest GitHub release** — use the Marketplace floating tag `fernandotonon/QtMeshEditor@v1` (same pattern as the [Marketplace example](https://github.com/marketplace/actions/qtmesheditor)). The composite action defaults to `image-tag: latest`, so the Docker CLI tracks the newest published `ghcr.io/fernandotonon/qtmesh` image.
+- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.5.3**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
+
+Pinned workflow template (action + `ghcr.io` image aligned):
+
+```yaml
+name: QtMesh Scan
+
+on:
+  push:
+    branches: [ "master" ]
+
+jobs:
+  scan-assets-qtmesh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run QtMesh scan
+        uses: fernandotonon/QtMeshEditor@3.5.3
+        with:
+          command: scan
+          image-tag: "3.5.3"
+        env:
+          QTMESH_CLOUD_TOKEN: ${{ secrets.QTMESH_CLOUD_TOKEN }}
+```
+
+Floating ref (auto-updates when the `v1` tag moves on release):
+
+```yaml
+      - name: Run QtMesh scan
+        uses: fernandotonon/QtMeshEditor@v1
+        with:
+          command: scan
+```
+
+`QTMESH_CLOUD_TOKEN` is forwarded into the container and used by `scan` upload. GitHub Actions metadata (`GITHUB_*`) is also forwarded so uploads include `meta` fields (branch/commit/run and context used by QtMesh Cloud).
+
+To fail CI when upload fails, add `qtmesh-strict-upload: true` (or pass `--strict-upload` in `options`).
+
+Release tags are listed on the [releases page](https://github.com/fernandotonon/QtMeshEditor/releases/latest) (also referenced in QtMesh Cloud onboarding).
+
+<details>
+<summary>More CI examples</summary>
+
+```yaml
+# Validate a specific mesh
+- uses: fernandotonon/QtMeshEditor@3.5.3
+  with:
+    command: validate
+    input-file: ./models/character.fbx
+    image-tag: "3.5.3"
+
+# Convert FBX → glTF
+- uses: fernandotonon/QtMeshEditor@3.5.3
+  with:
+    command: convert
+    input-file: ./models/character.fbx
+    output-file: ./output/character.gltf2
+    image-tag: "3.5.3"
+
+# Resample Mixamo animations (200+ keyframes → 30)
+- uses: fernandotonon/QtMeshEditor@3.5.3
+  with:
+    command: anim
+    input-file: ./animations/dance.fbx
+    output-file: ./output/dance_optimized.fbx
+    options: --resample 30
+    image-tag: "3.5.3"
+
+# Get mesh info as JSON
+- uses: fernandotonon/QtMeshEditor@3.5.3
+  id: info
+  with:
+    command: info
+    input-file: ./models/character.fbx
+    options: --json
+    image-tag: "3.5.3"
+
+# Docker (alternative — :latest tracks newest image; pin :3.4.0 to match semver action ref)
+docker run --rm -v $(pwd):/workspace ghcr.io/fernandotonon/qtmesh:latest scan ./assets --fail-on error
+```
+
+</details>
+
+### ☁️ QtMesh Cloud Badges
+
+1. Sign in at [qtmesh.dev](https://qtmesh.dev) and create a project.
+2. Create a project token in QtMesh Cloud.
+3. Add the token as a GitHub secret named `QTMESH_CLOUD_TOKEN`.
+4. Run the scan command from Github Actions example above.
+
+Badge markdown (replace `<owner-slug>` and `<project-slug>`):
+
+```md
+[![qtmesh status](https://api.qtmesh.dev/v1/u/<owner-slug>/p/<project-slug>/badges/qtmesh-status.svg)](https://qtmesh.dev)
+[![qtmesh errors](https://api.qtmesh.dev/v1/u/<owner-slug>/p/<project-slug>/badges/qtmesh-errors.svg)](https://qtmesh.dev)
+[![qtmesh warnings](https://api.qtmesh.dev/v1/u/<owner-slug>/p/<project-slug>/badges/qtmesh-warnings.svg)](https://qtmesh.dev)
+```
+
+---
+
+### 🔧 CLI Pipeline (`qtmesh`)
+
+Same commands locally, in Docker, or in CI:
+
+```bash
+# Scan a directory for asset issues
+qtmesh scan ./assets --fail-on warning
+qtmesh scan ./assets --json --report report.json
+
+# Inspect a mesh
+qtmesh info model.fbx --json
+
+# Validate geometry
+qtmesh validate model.fbx
+
+# Convert between formats
+qtmesh convert model.fbx -o model.gltf2
+
+# Fix / optimize
+qtmesh fix model.fbx -o fixed.fbx --all
+
+# Animation tools
+qtmesh anim model.fbx --list
+qtmesh anim model.fbx --rename "Take 001" "Idle" -o renamed.fbx
+qtmesh anim model.fbx --resample 30 -o optimized.fbx
+qtmesh anim base.fbx --merge walk.fbx run.fbx -o merged.fbx
+
+# Export animation pose as static mesh (3D printing)
+qtmesh pose model.fbx --animation "Dance" --count 4 -o pose_%02d.stl
+
+# LOD generation
+qtmesh lod model.fbx --auto
+
+# Bake vertex colors → texture (with UV-seam dilation)
+qtmesh bake-vertex-colors model.fbx -o color_map.png --resolution 1024 --dilation 4
+
+# Auto UV unwrap (xatlas — same library Blender/Godot use)
+qtmesh uv model.fbx --unwrap -o unwrapped.glb               # overwrite UV0
+qtmesh uv model.fbx --unwrap --channel 1 -o lightmap.glb    # keep UV0, write UV1 (lightmap workflow)
+qtmesh uv model.fbx --info --json                           # report UV channels + coverage
+
+# Quad retopology (triangle-pairing — no new deps)
+qtmesh retopo model.fbx -o quads.glb                        # pair every viable triangle into quads
+qtmesh retopo model.fbx --target-faces 5000 -o lo.glb       # stop early once near target face count
+qtmesh retopo model.fbx --max-angle 15 -o conservative.glb  # tighter coplanarity gate
+
+# Compute skin weights (inverse-distance heuristic; mesh must have a skeleton)
+qtmesh skin model.fbx -o skinned.glb                        # default 4 influences, falloff 4
+qtmesh skin model.fbx --max-influences 8 --falloff 6 -o skinned.glb
+qtmesh skin model.fbx --skip-unweighted --merge -o filled.glb  # fill missing weights only
+```
+
+---
+
+### 🎨 Paint Tools
+
+ZBrush-style polypaint and BaseColor texture painting, with a 2D preview
+panel, multiple brush tools (paint, erase, fill, color picker, smudge),
+texture-slot picker per submesh, and a one-click bake that turns vertex
+colors into a UV-space texture.
+
+**Quick start (texture paint, GUI):**
+
+1. Switch to **Material Mode** (mode bar at the top).
+2. Select a mesh entity. The Inspector's **Texture Paint** section
+   shows a slot picker (every paintable TUS across submeshes) and a 256×256
+   live preview of the active texture.
+3. Click the **paint brush** button in the toolbar to enable painting. The
+   first click on the mesh auto-creates a paint session against the active
+   slot (or you can pre-create with *Create / Attach Texture*).
+4. Pick a tool from the row at the top of the panel: ✏ Paint, ⌫ Erase, ⧉ Fill,
+   ⊰ Pick (eyedropper), ∿ Smudge. Brush color/radius/strength/falloff comes
+   from the shared Paint Brush section above the toolbar's brush popup.
+5. Left-click-drag on **either** the 3D mesh or the 2D preview panel. Both
+   drive the same paint buffer; the 2D preview updates in real time and a
+   brush ring shows where the cursor maps on the 3D surface (and vice versa).
+6. *Save…* / *Load…* round-trips the buffer to disk as PNG (or any format
+   QImage can write).
+
+**Vertex paint (GUI):**
+
+Same flow, but vertex paint operates in **Edit Mode** instead. Press **Tab**
+on a selected mesh to enter Edit Mode, then tick *Vertex Color Preview* in
+the Edit Mode Tools section to see vertex colors live.
+
+**Bake Vertex Colors → Texture** rasterizes the active mesh's vertex colors
+into a UV-space PNG via barycentric interpolation, then dilates the result
+outward by N pixels to mask UV-seam bleed at MIP-map time.
+
+**Headless (CLI):**
+
+```bash
+qtmesh bake-vertex-colors model.fbx -o color_map.png --resolution 1024 --dilation 4
+```
+
+**Export.** Vertex colors are preserved on export to formats that support
+them (glTF preferred — verified round-trip).
+
+**Notes / limitations.**
+
+- Brush size is in local mesh units (shared with vertex paint). For texture
+  paint we divide by mesh bounding-box extent and clamp to a UV-friendly
+  range, so 0.25 produces a sensible stamp on both a unit cube and a
+  100-unit character.
+- Painting auto-rebinds every TUS named `albedo` or `diffuse_map` on the
+  active material — imported PBR materials alias the diffuse texture under
+  both, and rebinding only one would leave the other pointing at the
+  original.
+- Bake uses fan triangulation of n-gon faces; concave faces should be
+  pre-triangulated.
+
+---
+
+### ✨ Merge Mixamo Animations in Seconds
+
+Download animations from [Mixamo](https://www.mixamo.com), drop them into QtMeshEditor, and merge into a single file — export as glTF, FBX, Collada, OBJ, or Ogre Mesh.
+
+![Merge Animations Demo](https://github.com/user-attachments/assets/441f90c5-1968-4838-8001-4ca24856a501)
+
+### 🎬 More in Action
+
+Split View|Skeleton Animation Controls
+---|---
+![QtMeshEditor1 5 0](https://user-images.githubusercontent.com/996529/210196572-7b49da4c-c5db-406d-9ab4-7fa20bacb6ae.gif)|![QtMeshEditor1 6 0](https://user-images.githubusercontent.com/996529/218779819-0a61156d-c014-4ad1-aa8b-cee900c9da56.gif)
+**MCP tools (AI Agent Control)**|**Bone Weight Visualization**
+![MCP Demo](https://github.com/user-attachments/assets/ed3b7e9d-22ba-4e6e-a06c-868570db7a07)|![Bone Weights](https://github.com/user-attachments/assets/289403ac-8952-488c-bc65-0a768ab278e1)
+
+#### 🤖 AI-enhanced Material Editor
+
+![AI Materials](https://github.com/user-attachments/assets/c58978d7-7564-41f2-8c95-527ddf7ae78e)
+
+---
+
+### 🎮 Features
+
+- **Asset scanning** — ESLint for 3D assets: check naming, complexity, skeletons, formats
+- **40+ format support** — FBX, glTF, OBJ, Collada, STL, Ogre Mesh, and more
+- **Animation merge** — combine Mixamo clips into one file
+- **Animation resampling** — reduce keyframe density for game engines
+- **Pose export** — bake animation frames as static meshes (3D printing)
+- **LOD generation** — automatic level-of-detail mesh reduction
+- **Paint tools** — vertex paint, texture paint (BaseColor), bake vertex colors to texture with seam dilation
+- **Material editor** — visual editing with AI-assisted generation
+- **Skeleton inspection** — bone weights, debug overlays, animation preview
+- **Scene management** — duplicate (Ctrl+D), group (Ctrl+G), snap, pivot modes
+- **AI chat** — natural language scene editing via local LLMs
+- **MCP server** — 51 tools for AI agents (Claude, Cursor, etc.)
+- **REST API** — HTTP interface for external automation
+
+---
+
+### 📦 Install
+
+| Platform | Command |
+|----------|---------|
+| **Windows** | `winget install FernandoTonon.QtMeshEditor` |
+| **macOS** | `brew tap fernandotonon/qtmesheditor && brew trust fernandotonon/qtmesheditor && brew install qtmesheditor` |
+| **Linux** | `sudo snap install qtmesheditor` |
+| **Docker** | `docker run --rm ghcr.io/fernandotonon/qtmesh --help` |
+
+📥 [Download latest release](https://github.com/fernandotonon/QtMeshEditor/releases/latest) · 📖 [Website & docs](https://fernandotonon.github.io/QtMeshEditor/)
+
+---
+
+### 📋 Format Support
+
+| Format | Extension | Import | Export | Skeleton/Animation |
+|--------|-----------|--------|--------|--------------------|
+| FBX Binary | .fbx | ✅ | ✅ | ✅ |
+| glTF 2.0 | .gltf2 / .glb2 | ✅ | ✅ | ✅ |
+| Collada | .dae | ✅ | ✅ | ✅ |
+| OBJ | .obj | ✅ | ✅ | — |
+| STL | .stl | ✅ | ✅ | — |
+| Ogre Mesh | .mesh / .mesh.xml | ✅ | ✅ | ✅ |
+| PlayStation TMD | .tmd | ✅ | ✅ | — |
+| PlayStation RSD | .rsd | ✅ | ✅ | — |
+| 3DS | .3ds | ✅ | ✅ | — |
+| Stanford PLY | .ply | ✅ | ✅ | — |
+| Psy-Q PLY (PlayStation) | .ply | ✅ | ✅ | — |
+
+`.ply` is dispatched by content: **Stanford** (`ply` header) vs **Psy-Q** (`@PLY…` header). See [documentation/playstation-rsd-ply.md](documentation/playstation-rsd-ply.md).
+
+Import supports all formats provided by Assimp (40+).
+
+---
+
+📖 [Documentation](https://fernandotonon.github.io/QtMeshEditor/docs.html) · 🛠 [Build from source](https://github.com/fernandotonon/QtMeshEditor/wiki/How-to-build) · 🐛 [Report issues](https://github.com/fernandotonon/QtMeshEditor/issues) · 💬 [Contribute](https://github.com/fernandotonon/QtMeshEditor)

--- a/tests/fixtures/updater/release-3.5.3-readme.md.minisig
+++ b/tests/fixtures/updater/release-3.5.3-readme.md.minisig
@@ -1,0 +1,4 @@
+untrusted comment: spike fixture from release 3.5.3 README
+RUT6vKVd359GZ8q7WX3T2mecwoFKE55rHK65eeYGoGdNalMMund7TY4SRMEyZvrsWzmZiksMN8xEZoXGn4RyqezfGOjR4vbSSA4=
+trusted comment: timestamp:0	file:release-3.5.3-readme.md
+cz4xpCucKkkv4XI4VWXMEEBuuZWfsiGeqRZT7YGfNzenu+eiEeZXMtMk2TermpMmn6A3+rerAsY2j0G9CvnmBw==


### PR DESCRIPTION
## Summary
- Adds `docs/AUTO_UPDATER_DESIGN.md` locking decisions for epic #439: minisign/Ed25519 signatures, per-platform relauncher strategy, install-flavor detection, and stable/beta/nightly channel taxonomy.
- PoC implementation in `src/updater/`: `InstallFlavor::detect()` (all platforms) and `MinisignVerify` (Linux-only, libsodium) with unit tests and signed fixtures from release `3.5.3` README.
- Documents planned `deploy.yml` minisign signing steps for a follow-up PR (no CI changes in this PR).

Closes #440.

## GitHub secrets
**None required for this PR.** Tests use committed fixtures + a test-only public key.

For the follow-up CI signing PR, add:
- `MINISIGN_SECRET_KEY` — base64-encoded minisign secret key file (used only in release workflow)

## Test plan
- [x] `./build_local/bin/UnitTests --gtest_filter="InstallFlavor*:MinisignVerify*"` (8 tests pass on Linux)
- [ ] CI Linux unit tests (first configure builds static libsodium — may add ~30s)
- [ ] Windows/macOS CI builds (minisign verify returns `Unsupported`; no libsodium build)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added auto-updater installation flavor detection to tailor update handling across common deployment types.
  * Introduced release artifact signature verification using cryptography (Linux-supported) to secure downloaded updates.

* **Bug Fixes**
  * Hardened fixture and key handling to prevent accidental inclusion of sensitive signing material in the repository.

* **Documentation**
  * Added an in-depth design document covering the auto-updater signing, verification, and release workflow.

* **Tests**
  * Added automated coverage for signature verification and installation flavor detection.

* **Chores**
  * Updated build and CI setup to include required cryptography tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->