### PR TITLE
ci(updater): minisign release artifact signing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2050,26 +2050,61 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
+        set -euo pipefail
         VERSION="${{ github.ref_name }}"
+        REQUIRED=(
+          "QtMeshEditor-${VERSION}-bin-Windows.zip"
+          "QtMeshEditor-${VERSION}-setup-Windows.exe"
+          "qtmesheditor_amd64.deb"
+          "QtMeshEditor-${VERSION}-MacOS.dmg"
+        )
+        missing_required() {
+          local present
+          present=$(gh release view "$VERSION" --json assets --jq '.assets[].name')
+          local missing=()
+          for name in "${REQUIRED[@]}"; do
+            if ! printf '%s\n' "$present" | grep -Fxq "$name"; then
+              missing+=("$name")
+            fi
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            printf '%s\n' "${missing[@]}"
+            return 1
+          fi
+          return 0
+        }
         for i in 1 2 3 4 5 6 7 8 9 10; do
-          COUNT=$(gh release view "$VERSION" --json assets --jq '.assets | length')
-          echo "Release $VERSION has $COUNT asset(s) (attempt $i)"
-          if [ "$COUNT" -ge 3 ]; then
+          if missing=$(missing_required); then
+            echo "All required release assets present for $VERSION"
             exit 0
           fi
+          echo "Release $VERSION still missing (attempt $i):"
+          printf '  - %s\n' $missing
           sleep 30
         done
-        echo "::error::Timed out waiting for release assets"
+        echo "::error::Timed out waiting for required release assets"
         exit 1
 
     - name: Download release artifacts
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
+        set -euo pipefail
+        VERSION="${{ github.ref_name }}"
         mkdir -p release-assets
-        gh release download "${{ github.ref_name }}" --dir release-assets \
-          --pattern 'QtMeshEditor-*' \
-          --pattern 'qtmesheditor_*.deb'
+        REQUIRED=(
+          "QtMeshEditor-${VERSION}-bin-Windows.zip"
+          "QtMeshEditor-${VERSION}-setup-Windows.exe"
+          "qtmesheditor_amd64.deb"
+          "QtMeshEditor-${VERSION}-MacOS.dmg"
+        )
+        for name in "${REQUIRED[@]}"; do
+          gh release download "$VERSION" --dir release-assets --pattern "$name"
+          if [ ! -f "release-assets/$name" ]; then
+            echo "::error::Missing downloaded artifact: $name"
+            exit 1
+          fi
+        done
         ls -la release-assets/
 
     - name: Sign release artifacts
@@ -2085,6 +2120,13 @@ jobs:
         echo "$MINISIGN_SECRET_KEY" | base64 -d > /tmp/minisign.key
         chmod 600 /tmp/minisign.key
         cd release-assets
+        VERSION="${{ github.ref_name }}"
+        REQUIRED=(
+          "QtMeshEditor-${VERSION}-bin-Windows.zip"
+          "QtMeshEditor-${VERSION}-setup-Windows.exe"
+          "qtmesheditor_amd64.deb"
+          "QtMeshEditor-${VERSION}-MacOS.dmg"
+        )
         sign_file() {
           local f="$1"
           local trusted="timestamp:$(date +%s)	file:$(basename "$f")"
@@ -2095,17 +2137,14 @@ jobs:
             minisign -S -s /tmp/minisign.key -m "$f" -x "$f.minisig" -t "$trusted"
           fi
         }
-        shopt -s nullglob
-        FILES=(QtMeshEditor-* qtmesheditor_*.deb)
-        if [ ${#FILES[@]} -eq 0 ]; then
-          echo "::error::No release artifacts found to sign"
-          exit 1
-        fi
-        for f in "${FILES[@]}"; do
-          [[ "$f" == *.minisig ]] && continue
+        for f in "${REQUIRED[@]}"; do
+          if [ ! -f "$f" ]; then
+            echo "::error::Required artifact missing before signing: $f"
+            exit 1
+          fi
           sign_file "$f"
         done
-        sha256sum "${FILES[@]}" | LC_ALL=C sort -k2 > SHA256SUMS
+        sha256sum "${REQUIRED[@]}" | LC_ALL=C sort -k2 > SHA256SUMS
         sign_file SHA256SUMS
         rm -f /tmp/minisign.key
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2040,8 +2040,12 @@ jobs:
     needs: [build-windows, build-linux, build-macos]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
+    env:
+      RELEASE_TAG: ${{ github.ref_name }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
 
     - name: Install minisign
       run: sudo apt-get update && sudo apt-get install -y minisign
@@ -2051,7 +2055,7 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
-        VERSION="${{ github.ref_name }}"
+        VERSION="${RELEASE_TAG}"
         REQUIRED=(
           "QtMeshEditor-${VERSION}-bin-Windows.zip"
           "QtMeshEditor-${VERSION}-setup-Windows.exe"
@@ -2090,7 +2094,7 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
-        VERSION="${{ github.ref_name }}"
+        VERSION="${RELEASE_TAG}"
         mkdir -p release-assets
         REQUIRED=(
           "QtMeshEditor-${VERSION}-bin-Windows.zip"
@@ -2120,7 +2124,7 @@ jobs:
         echo "$MINISIGN_SECRET_KEY" | base64 -d > /tmp/minisign.key
         chmod 600 /tmp/minisign.key
         cd release-assets
-        VERSION="${{ github.ref_name }}"
+        VERSION="${RELEASE_TAG}"
         REQUIRED=(
           "QtMeshEditor-${VERSION}-bin-Windows.zip"
           "QtMeshEditor-${VERSION}-setup-Windows.exe"
@@ -2162,7 +2166,7 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        gh release upload "${{ github.ref_name }}" \
+        gh release upload "${RELEASE_TAG}" \
           release-assets/*.minisig \
           release-assets/SHA256SUMS \
           packaging/updater/minisign.pub \
@@ -2176,6 +2180,8 @@ jobs:
     needs: build-macos
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
+    env:
+      RELEASE_TAG: ${{ github.ref_name }}
     steps:
     - name: Wait for DMG to be available
       run: |
@@ -2184,7 +2190,7 @@ jobs:
 
     - name: Download DMG from release
       run: |
-        VERSION="${{ github.ref_name }}"
+        VERSION="${RELEASE_TAG}"
         DMG_URL="https://github.com/fernandotonon/QtMeshEditor/releases/download/${VERSION}/QtMeshEditor-${VERSION}-MacOS.dmg"
         echo "Downloading DMG from: $DMG_URL"
 
@@ -2225,7 +2231,7 @@ jobs:
 
     - name: Generate Cask file from canonical template
       run: |
-        VERSION="${{ github.ref_name }}"
+        VERSION="${RELEASE_TAG}"
         SHA256="${{ steps.sha256.outputs.sha256 }}"
         CASK_FILE="homebrew-qtmesheditor/Casks/qtmesheditor.rb"
         TEMPLATE="qtmesheditor-src/packaging/macos/qtmesheditor.rb.in"
@@ -2250,7 +2256,7 @@ jobs:
       run: |
         cd homebrew-qtmesheditor
         git add Casks/qtmesheditor.rb
-        git commit -m "Update QtMeshEditor to ${{ github.ref_name }}" || echo "No changes to commit"
+        git commit -m "Update QtMeshEditor to ${RELEASE_TAG}" || echo "No changes to commit"
         git push
 
 ####################################################################

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2033,6 +2033,103 @@ jobs:
         echo "Sentry release $VERSION created and finalized"
 
 ####################################################################
+# Sign release artifacts (minisign / Ed25519) — epic #439 spike follow-up
+####################################################################
+
+ sign-release-artifacts:
+    needs: [build-windows, build-linux, build-macos]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install minisign
+      run: sudo apt-get update && sudo apt-get install -y minisign
+
+    - name: Wait for release assets to appear
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        VERSION="${{ github.ref_name }}"
+        for i in 1 2 3 4 5 6 7 8 9 10; do
+          COUNT=$(gh release view "$VERSION" --json assets --jq '.assets | length')
+          echo "Release $VERSION has $COUNT asset(s) (attempt $i)"
+          if [ "$COUNT" -ge 3 ]; then
+            exit 0
+          fi
+          sleep 30
+        done
+        echo "::error::Timed out waiting for release assets"
+        exit 1
+
+    - name: Download release artifacts
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        mkdir -p release-assets
+        gh release download "${{ github.ref_name }}" --dir release-assets \
+          --pattern 'QtMeshEditor-*' \
+          --pattern 'qtmesheditor_*.deb'
+        ls -la release-assets/
+
+    - name: Sign release artifacts
+      env:
+        MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
+        MINISIGN_PASSWORD: ${{ secrets.MINISIGN_PASSWORD }}
+      run: |
+        set -euo pipefail
+        if [ -z "${MINISIGN_SECRET_KEY:-}" ]; then
+          echo "::error::MINISIGN_SECRET_KEY secret is not configured"
+          exit 1
+        fi
+        echo "$MINISIGN_SECRET_KEY" | base64 -d > /tmp/minisign.key
+        chmod 600 /tmp/minisign.key
+        cd release-assets
+        sign_file() {
+          local f="$1"
+          local trusted="timestamp:$(date +%s)	file:$(basename "$f")"
+          if [ -n "${MINISIGN_PASSWORD:-}" ]; then
+            printf '%s\n' "$MINISIGN_PASSWORD" | minisign -S -s /tmp/minisign.key \
+              -m "$f" -x "$f.minisig" -t "$trusted"
+          else
+            minisign -S -s /tmp/minisign.key -m "$f" -x "$f.minisig" -t "$trusted"
+          fi
+        }
+        shopt -s nullglob
+        FILES=(QtMeshEditor-* qtmesheditor_*.deb)
+        if [ ${#FILES[@]} -eq 0 ]; then
+          echo "::error::No release artifacts found to sign"
+          exit 1
+        fi
+        for f in "${FILES[@]}"; do
+          [[ "$f" == *.minisig ]] && continue
+          sign_file "$f"
+        done
+        sha256sum "${FILES[@]}" | LC_ALL=C sort -k2 > SHA256SUMS
+        sign_file SHA256SUMS
+        rm -f /tmp/minisign.key
+
+    - name: Verify signatures (smoke test)
+      run: |
+        set -euo pipefail
+        PUB=$(grep -v '^untrusted' packaging/updater/minisign.pub | grep -v '^#' | tr -d '\n\r')
+        cd release-assets
+        for sig in *.minisig; do
+          base="${sig%.minisig}"
+          minisign -V -m "$base" -x "$sig" -P "$PUB" -q
+        done
+
+    - name: Upload signatures and checksum manifest
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh release upload "${{ github.ref_name }}" \
+          release-assets/*.minisig \
+          release-assets/SHA256SUMS \
+          packaging/updater/minisign.pub \
+          --clobber
+
+####################################################################
 # Update Homebrew Cask after macOS release
 ####################################################################
 

--- a/docs/AUTO_UPDATER_DESIGN.md
+++ b/docs/AUTO_UPDATER_DESIGN.md
@@ -28,7 +28,7 @@ This document locks the four architecturally consequential decisions before prod
 
 ### CI signing
 
-Implemented in `.github/workflows/deploy.yml` as the `sign-release-artifacts` job (runs on `release: published`). Downloads zip/dmg/deb assets, writes `SHA256SUMS`, signs each artifact + manifest with minisign, verifies with `packaging/updater/minisign.pub`, and uploads `*.minisig` + `SHA256SUMS` + `minisign.pub` to the GitHub Release.
+Implemented in `.github/workflows/deploy.yml` as the `sign-release-artifacts` job (runs on `release: published`). Waits until all four required assets are on the release (`*-bin-Windows.zip`, `*-setup-Windows.exe`, `qtmesheditor_amd64.deb`, `*-MacOS.dmg`), downloads each by exact filename, writes `SHA256SUMS`, signs each artifact + manifest with minisign, verifies with `packaging/updater/minisign.pub`, and uploads `*.minisig` + `SHA256SUMS` + `minisign.pub` to the GitHub Release.
 
 **GitHub Actions secrets** (repo → Settings → Secrets and variables → Actions):
 

--- a/docs/AUTO_UPDATER_DESIGN.md
+++ b/docs/AUTO_UPDATER_DESIGN.md
@@ -26,51 +26,18 @@ This document locks the four architecturally consequential decisions before prod
 3. CI signs with new secret (`MINISIGN_SECRET_KEY` GitHub Actions secret, base64-encoded key file).
 4. If secret compromised: revoke GitHub secret, publish advisory, push rotation release; package-manager channels (Homebrew/WinGet/Snap) bypass in-app verify and remain the recovery path.
 
-### CI signing (planned — follow-up PR)
+### CI signing
+
+Implemented in `.github/workflows/deploy.yml` as the `sign-release-artifacts` job (runs on `release: published`). Downloads zip/dmg/deb assets, writes `SHA256SUMS`, signs each artifact + manifest with minisign, verifies with `packaging/updater/minisign.pub`, and uploads `*.minisig` + `SHA256SUMS` + `minisign.pub` to the GitHub Release.
 
 **GitHub Actions secrets** (repo → Settings → Secrets and variables → Actions):
 
 | Secret | Required | Value |
 |--------|----------|-------|
 | `MINISIGN_SECRET_KEY` | Yes | `base64 -w0 ~/.minisign/minisign.key` (helper: `scripts/encode-minisign-secret-for-github.sh`) |
-| `MINISIGN_PASSWORD` | Only if the secret key is password-encrypted | The minisign key passphrase. CI passes it on stdin when signing. Prefer a dedicated `-W` (no password) release key stored only in this secret to avoid a second secret. |
+| `MINISIGN_PASSWORD` | Only if the secret key is password-encrypted | The minisign key passphrase. CI passes it on stdin when signing. |
 
 Production public key: `packaging/updater/minisign.pub` (embedded in `MinisignVerify::productionPublicKeyBase64()`).
-
-Extend `deploy.yml` after existing SHA-256 cask step:
-
-```yaml
-- name: Install minisign
-  run: sudo apt-get install -y minisign
-
-- name: Sign release artifacts
-  env:
-    MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
-    MINISIGN_PASSWORD: ${{ secrets.MINISIGN_PASSWORD }}
-  run: |
-    echo "$MINISIGN_SECRET_KEY" | base64 -d > /tmp/minisign.key
-    chmod 600 /tmp/minisign.key
-    sign() {
-      if [[ -n "${MINISIGN_PASSWORD:-}" ]]; then
-        printf '%s\n' "$MINISIGN_PASSWORD" | minisign -S -s /tmp/minisign.key -m "$1" -x "$1.minisig" \
-          -t "timestamp:$(date +%s)	file:$(basename "$1")"
-      else
-        minisign -S -s /tmp/minisign.key -m "$1" -x "$1.minisig" \
-          -t "timestamp:$(date +%s)	file:$(basename "$1")"
-      fi
-    }
-    for f in QtMeshEditor-*.zip QtMeshEditor-*.dmg qtmesheditor_*.deb; do
-      sign "$f"
-    done
-    rm -f /tmp/minisign.key
-
-- name: Upload signatures with release assets
-  uses: softprops/action-gh-release@v2
-  with:
-    files: "*.minisig"
-```
-
-Also publish `SHA256SUMS` + `SHA256SUMS.minisig` for manifest-driven downloads (#444).
 
 ### PoC status
 


### PR DESCRIPTION
## Summary
- Adds `sign-release-artifacts` job to `deploy.yml` (runs on `release: published` after platform builds finish).
- Downloads release zip/dmg/deb, writes `SHA256SUMS`, signs each file + manifest with minisign, smoke-verifies with `packaging/updater/minisign.pub`, uploads `*.minisig` + `SHA256SUMS` + pubkey.
- Updates `docs/AUTO_UPDATER_DESIGN.md` to document the live CI path.

Follow-up to #722 / spike #440. Requires `MINISIGN_SECRET_KEY` (+ `MINISIGN_PASSWORD` for encrypted keys) — already configured.

## Test plan
- [ ] Merge and verify on next GitHub Release publish
- [ ] Confirm release assets include `.minisig`, `SHA256SUMS`, `SHA256SUMS.minisig`, `minisign.pub`
- [ ] `minisign -Vm <asset> -x <asset>.minisig -P <pubkey>` succeeds locally


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release artifacts are now cryptographically signed, enabling users to verify authenticity and integrity of downloads.
  * SHA256 checksums are automatically generated and signed for each release.

* **Documentation**
  * Updated design documentation to reflect the implemented release signing workflow and verification process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->