### PR TITLE
feat(texture): multi-view AI texture bake (front+back projection onto UV0)

### DIFF
--- a/qml/TexturePropertiesPanel.qml
+++ b/qml/TexturePropertiesPanel.qml
@@ -20,7 +20,11 @@ GroupBox {
         var useMesh = useMeshCheck.checked && MaterialEditorQML.hasSelectedMesh
         var w = sdWidthSpin.value
         var h = sdHeightSpin.value
-        if (useMesh) {
+        if (useMesh && multiViewCheck.checked) {
+            // Front+back projection bake onto the mesh's UV0 (slice 2).
+            MaterialEditorQML.generateMeshTextureMultiView(
+                sdPromptField.text, w, h, meshStrengthSlider.value, ["front", "back"])
+        } else if (useMesh) {
             MaterialEditorQML.generateMeshTextureFromPrompt(
                 sdPromptField.text, w, h, meshStrengthSlider.value)
         } else {
@@ -915,6 +919,22 @@ GroupBox {
                                     useMeshCheck.checked = false
                             }
                         }
+                    }
+                }
+
+                // Slice 2: multi-view bake. When on (and mesh conditioning is
+                // enabled), generate front + back images and projection-bake
+                // them onto the mesh's UV0 atlas instead of a single planar
+                // view. Only meaningful with "use selected mesh" checked.
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 8
+                    visible: useMeshCheck.checked && useMeshCheck.enabled
+                    ThemedCheckBox {
+                        id: multiViewCheck
+                        text: "Bake front + back (projects onto UV map)"
+                        enabled: !MaterialEditorQML.sdIsGenerating
+                        checked: false
                     }
                 }
 

--- a/src/AppSettingsKeys.h
+++ b/src/AppSettingsKeys.h
@@ -98,6 +98,15 @@ inline const QString& cloudUserSlug()
     return k;
 }
 
+/** @brief Set once the one-time pre-QSettings secret-store migration has been
+ *  attempted, so the OS keychain is never probed again (which would prompt on
+ *  every launch). */
+inline const QString& cloudLegacyMigrationDone()
+{
+    static const QString k(QStringLiteral("Cloud/legacyMigrationDone"));
+    return k;
+}
+
 /** @brief Last platform profile id used for Validation-mode asset folder scan (issue #370). */
 inline const QString& validationPlatformProfileId()
 {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,6 +91,7 @@ QuadRetopoController.cpp
 SkinWeights.cpp
 SkinWeightsController.cpp
 MeshDepthRenderer.cpp
+MultiViewTextureBaker.cpp
 TextureChannelPacker.cpp
 TextureAtlasPacker.cpp
 PaintBufferImageProvider.cpp
@@ -224,6 +225,7 @@ QuadRetopoController.h
 SkinWeights.h
 SkinWeightsController.h
 MeshDepthRenderer.h
+MultiViewTextureBaker.h
 TextureChannelPacker.h
 TextureAtlasPacker.h
 PaintBufferImageProvider.h

--- a/src/CloudCredentialStore.cpp
+++ b/src/CloudCredentialStore.cpp
@@ -192,17 +192,32 @@ void CloudCredentialStore::resetCacheForTesting()
 
 void CloudCredentialStore::migrateLegacySettingsIfNeeded()
 {
-    // If a session already lives in QSettings, we're done.
-    if (readFromSettings().hasToken())
-        return;
-
-    // Upgrade path: a user who signed in on a pre-QSettings build has their
-    // token in the OS secret store / legacy fallback file. Read it once and
-    // copy it into QSettings so they stay signed in instead of being silently
-    // logged out after the storage-backend change.
-    const CloudSession legacy = readLegacySecretStore();
-    if (legacy.hasToken() && writeToSettings(legacy)) {
-        g_sessionCache = legacy;
-        g_cacheValid = true;
+    // The OS secret store must be probed AT MOST ONCE, ever. Each probe is a
+    // SecItemCopyMatching (macOS Keychain) / CredRead (Windows) that can raise a
+    // confirmation prompt — re-probing on every launch (which happens when the
+    // user is signed out, since QSettings then has no token) is exactly the
+    // repeated-keychain-prompt bug we set out to kill. Persist a "done" flag the
+    // first time through and never touch the keychain again, signed in or not.
+    {
+        QSettings settings;
+        if (settings.value(AppSettingsKeys::cloudLegacyMigrationDone(), false).toBool())
+            return;
     }
+
+    // If a session already lives in QSettings there is nothing to migrate, but
+    // still mark the probe done so we don't keychain-probe on a later sign-out.
+    if (!readFromSettings().hasToken()) {
+        // One-time upgrade: a user who signed in on a pre-QSettings build has
+        // their token in the OS secret store / legacy fallback file. Carry it
+        // into QSettings so they stay signed in across the backend change.
+        const CloudSession legacy = readLegacySecretStore();
+        if (legacy.hasToken() && writeToSettings(legacy)) {
+            g_sessionCache = legacy;
+            g_cacheValid = true;
+        }
+    }
+
+    QSettings settings;
+    settings.setValue(AppSettingsKeys::cloudLegacyMigrationDone(), true);
+    settings.sync();
 }

--- a/src/CloudCredentialStore_test.cpp
+++ b/src/CloudCredentialStore_test.cpp
@@ -153,6 +153,12 @@ TEST_F(CloudCredentialStoreTest, MigratesLegacyFallbackFileIntoSettings)
 
 TEST_F(CloudCredentialStoreTest, LegacyMigrationProbesOnlyOnce)
 {
+    // Ensure a clean legacy precondition first — a leftover cloud_session.dat
+    // from another test/run would make the "nothing migrates" assertion below
+    // order-dependent.
+    const QString cfgDir = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
+    QFile::remove(cfgDir + QStringLiteral("/cloud_session.dat"));
+
     // First call: nothing in the legacy store, so nothing migrates — but the
     // probe must be marked done so the OS keychain is never touched again
     // (the repeated-prompt bug).

--- a/src/CloudCredentialStore_test.cpp
+++ b/src/CloudCredentialStore_test.cpp
@@ -151,6 +151,34 @@ TEST_F(CloudCredentialStoreTest, MigratesLegacyFallbackFileIntoSettings)
     QFile::remove(legacyPath);
 }
 
+TEST_F(CloudCredentialStoreTest, LegacyMigrationProbesOnlyOnce)
+{
+    // First call: nothing in the legacy store, so nothing migrates — but the
+    // probe must be marked done so the OS keychain is never touched again
+    // (the repeated-prompt bug).
+    CloudCredentialStore::migrateLegacySettingsIfNeeded();
+    {
+        QSettings settings;
+        EXPECT_TRUE(settings.value(AppSettingsKeys::cloudLegacyMigrationDone()).toBool());
+    }
+
+    // Now drop a legacy fallback file. A second migrate must IGNORE it (the
+    // done-flag short-circuits before any legacy read), so no session appears.
+    const QString dir = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
+    QDir().mkpath(dir);
+    const QString legacyPath = dir + QStringLiteral("/cloud_session.dat");
+    QFile f(legacyPath);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly | QIODevice::Truncate));
+    f.write(QByteArrayLiteral("{\"token\":\"should-be-ignored\",\"expiresAt\":1}"));
+    f.close();
+    CloudCredentialStore::resetCacheForTesting();
+
+    CloudCredentialStore::migrateLegacySettingsIfNeeded();
+    EXPECT_FALSE(CloudCredentialStore::hasSession());
+
+    QFile::remove(legacyPath);
+}
+
 TEST_F(CloudCredentialStoreTest, LoadSessionDropsEmailWhenTokenMissing)
 {
     // A stray email/expiry key without a token must not surface as a session.

--- a/src/MULTIVIEW_TEXTURE_BAKE_DESIGN.md
+++ b/src/MULTIVIEW_TEXTURE_BAKE_DESIGN.md
@@ -28,7 +28,7 @@ Decisions taken:
 
 ## Pipeline
 
-```
+```text
 selected Entity
   │
   ├─ 0. UV gate: UvUnwrap::infoForEntity → if !hasUv0 || uv0Coverage < THRESH
@@ -116,6 +116,7 @@ images, bake on the last completion. Same seed across views.
 - Sentry breadcrumb category `ai.assist.mesh_texture_multiview`.
 
 ## Risks & mitigations
+
 | Risk | Mitigation |
 |---|---|
 | Occlusion / back-facing bleed | facing weight `max(0,−n·viewDir)` + per-view depth occlusion test |

--- a/src/MULTIVIEW_TEXTURE_BAKE_DESIGN.md
+++ b/src/MULTIVIEW_TEXTURE_BAKE_DESIGN.md
@@ -1,0 +1,145 @@
+# Multi-View AI Texture Bake — Design
+
+**Status:** proposed · **Epic:** #397 (AI-assisted authoring) · follows issue #403 (depth-conditioned mesh texture)
+
+## Goal
+
+Generate a full diffuse texture for a mesh by ControlNet-generating images from
+several camera views (front + back to start, 4–6 later) and **projection-baking**
+them into the mesh's UV0 atlas — replacing today's crude planar bind that "is
+unreliable on RTSS-rendered PBR materials whose diffuse TUS is unnamed/numeric"
+(CLAUDE.md, issue #403 known limitation).
+
+## Why projection bake, not "UVs from the image"
+
+A generated 2D image has no intrinsic 3D correspondence. The only mapping back
+to the mesh is **the camera that produced the depth map** that conditioned the
+generation. So we do not derive UVs from the image; we keep the mesh's UV0 fixed
+and rasterize image → UV by re-projecting each triangle through that camera. This
+is the standard "project from view" / reprojection bake (Blender, Dream
+Textures, StableProjectorz).
+
+Decisions taken:
+- **Views:** ship front+back; the view list + blend are **data-driven** so 4–6
+  views is a config change, not a rewrite.
+- **UV handling:** **auto-unwrap when UV0 is missing or low-coverage**, else keep
+  existing UVs. This also fixes the #403 unreliability on raw/poorly-unwrapped
+  meshes (the bake writes into a real atlas instead of relying on a planar bind).
+
+## Pipeline
+
+```
+selected Entity
+  │
+  ├─ 0. UV gate: UvUnwrap::infoForEntity → if !hasUv0 || uv0Coverage < THRESH
+  │        run UvUnwrap (GUI-safe path), bake against the unwrapped copy.
+  │
+  ├─ 1. for each view V in viewList:                       (data-driven)
+  │        a. depth_V = MeshDepthRenderer::renderDepthMapView(entity, size, V)
+  │        b. image_V = SDManager::generateMeshTexture(prompt, depth_V, controlNet, …)
+  │           (same seed across views for style consistency)
+  │
+  ├─ 2. MultiViewTextureBaker::bake(entity/meshData, views[], images[], opts)
+  │        for each submesh triangle T (in UV0 space):
+  │          for each view V:
+  │            - project T's 3 world verts through camera_V → screen UVs
+  │            - facingWeight = max(0, −faceNormal · viewDir_V)   (cull back-faces)
+  │            - occlusion test: sample depth_V at the projected centroid;
+  │              skip if triangle is behind the recorded surface (± epsilon)
+  │            - if facingWeight > 0: rasterize T into the atlas
+  │              (VertexColorBaker::rasterizeTriangle pattern) but sample
+  │              image_V at the per-pixel projected screen UV instead of
+  │              interpolating a vertex colour; accumulate color*weight + weight
+  │        resolve: atlasPixel = Σ(color*weight) / Σ(weight)
+  │        dilate seams (VertexColorBaker::dilate) → fill UV-island gaps
+  │
+  └─ 3. export PNG → register resource → applyTextureToEntityDiffuse()
+         (existing RTSS rebind + PBR slot wiring)
+```
+
+## New / changed components
+
+### A. `MeshDepthRenderer` — add a view parameter (small change)
+Today the camera is hardcoded to the −Z front (MeshDepthRenderer.cpp:162). Add a
+view descriptor and a new overload; keep the existing `renderDepthMap` delegating
+to the front view so #403 is unchanged.
+
+```cpp
+struct DepthView {
+    Ogre::Vector3 dir;          // camera→target direction in WORLD space
+                                // front = (0,0,+1) looking toward −Z mesh face
+    const char*   name;         // "front", "back", "left", …  (for logs/files)
+};
+// returns the depth QImage AND the exact view/proj matrices used, so the
+// baker re-projects through the identical camera (no drift).
+struct DepthRenderResult { QImage depth; Ogre::Matrix4 view, proj; Ogre::Vector3 camPos; };
+static DepthRenderResult renderDepthMapView(Ogre::Entity*, int size, const DepthView&, QString* err=nullptr);
+```
+Built-in view table (data): `front (0,0,+1)`, `back (0,0,−1)`, then `left/right/top/bottom`
+for the 4–6 expansion. The bounding-sphere framing math is reused verbatim, only
+`camPos = center + dir.normalised()*dist` and the look-at change.
+
+### B. `MultiViewTextureBaker` (new — `src/MultiViewTextureBaker.h/.cpp`)
+Pure-data baker (no GL): inputs are the per-view images + their view/proj
+matrices + the mesh geometry (positions, normals, UV0, indices). Reuses:
+- `VertexColorBaker::rasterizeTriangle` / `dilate` (UV-space raster + seam fill)
+- the barycentric + projection math already in `TexturePaintController`
+  (`findMeshPointForUV`, `hitTestUV`) and `EditModeController::worldToScreen`.
+
+```cpp
+struct BakeView { QImage image; Ogre::Matrix4 viewProj; Ogre::Vector3 camDir; QImage depth; };
+struct BakeOptions { int resolution = 1024; int dilationPixels = 4;
+                     float facingPower = 1.0f; float occlusionEpsilon = 0.01f; };
+struct BakeReport { bool ok; int pixelsWritten; int trianglesProjected;
+                    QList<int> perViewTriangleCounts; QString error; };
+static BakeReport bake(const Ogre::Entity* entity,
+                       const QList<BakeView>& views,
+                       TexturePaintBuffer& out,
+                       const BakeOptions& opts);
+```
+Accumulation buffer holds `RGBA + weightSum`; final divide → straight color.
+Per-view facing weight gives a feathered front↔back blend with no hard seam.
+
+### C. `MaterialEditorQML` orchestration
+New `Q_INVOKABLE void generateMeshTextureMultiView(prompt, width, height,
+controlStrength, QStringList views)`. Drives steps 0–3; the existing
+single-view `generateMeshTextureFromPrompt` stays as the "front-only" fast path.
+Generation is async (SDWorker thread) → run views sequentially, accumulate
+images, bake on the last completion. Same seed across views.
+
+## UI / MCP surface
+- **Material Editor → AI panel:** a "Multi-view (front+back)" checkbox next to
+  the existing "Use selected mesh (depth-conditioned)" toggle, plus a small
+  view-count selector (2 / 4 / 6) once the data path is proven.
+- **MCP:** extend `generate_mesh_texture` with an optional `views: ["front","back"]`
+  array (defaults to `["front"]` = current behavior).
+- Sentry breadcrumb category `ai.assist.mesh_texture_multiview`.
+
+## Risks & mitigations
+| Risk | Mitigation |
+|---|---|
+| Occlusion / back-facing bleed | facing weight `max(0,−n·viewDir)` + per-view depth occlusion test |
+| Front/back style mismatch | same seed + prompt; (later) img2img-condition back on front |
+| Side seam with only 2 views | feathered facing blend + dilate; document that 4 views removes it |
+| Bad/missing UV0 | auto-unwrap gate (UvUnwrap) before bake |
+| Live skinned-mesh buffer mutation | bake reads geometry read-only; unwrap uses the GUI-safe `unwrapEntityToFile` snapshot/restore path |
+| RTSS apply unreliability (#403) | bake targets real UV0 atlas → `applyTextureToEntityDiffuse` binds a normal diffuse_map |
+
+## Test plan (headless, CI Linux+Xvfb; ASSERT_TRUE(tryInitOgre), no GTEST_SKIP)
+- `MultiViewTextureBaker` unit tests (pure data, no SD): synthetic 2-triangle
+  quad + 2 solid-color "images" from ±Z → assert front color on front face,
+  back color on back face, blended band in between; weight normalization;
+  dilation fills gaps; empty-view and no-UV0 guards.
+- `MeshDepthRenderer::renderDepthMapView` front vs back differ (non-identical
+  images) on robot.mesh; returned matrices project a known vert to the expected
+  screen quadrant.
+- UV gate: low-coverage mesh triggers unwrap; good-UV mesh does not.
+- SD-dependent end-to-end stays behind `#ifdef ENABLE_STABLE_DIFFUSION` and is
+  not unit-tested (no model in CI), matching the #403 pattern.
+
+## Phasing
+1. **Slice 1 (prototype):** `renderDepthMapView` + `MultiViewTextureBaker` +
+   front-only bake through real UV0 (validates reprojection math end-to-end).
+2. **Slice 2:** add back view + facing-weighted blend; the front+back deliverable.
+3. **Slice 3:** UV auto-unwrap gate; MCP `views` param; UI toggle.
+4. **Later:** 4–6 views (config only); optional img2img cross-view conditioning.

--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -821,6 +821,7 @@ bool Manager::isForbiddenNodeName(const QString &_name)
     return (_name.isEmpty() //Ogre 14 creates unnamed nodes with empty string (e.g. SpaceCamera nodes)
             ||_name=="TPCameraChildSceneNode" //TODO add a define for TPCameraChildSceneNode
             ||_name=="GridLine_node" //TODO add a define for GridLine_node
+            ||_name=="QtMeshDepthCameraNode" //offscreen depth-render camera (MeshDepthRenderer)
             ||_name==SELECTIONBOX_OBJECT_NAME
             ||_name==TRANSFORM_OBJECT_NAME
             ||_name.startsWith("Unnamed_")); //This is the cameras's nodes

--- a/src/MaterialEditorQML.cpp
+++ b/src/MaterialEditorQML.cpp
@@ -5,6 +5,8 @@
 #include "LLMManager.h"
 #include "SelectionSet.h"
 #include "MeshDepthRenderer.h"
+#include "MultiViewTextureBaker.h"
+#include "TexturePaintBuffer.h"
 #include <OgreEntity.h>
 #include <OgreSubEntity.h>
 #include <OgreMesh.h>
@@ -140,6 +142,10 @@ MaterialEditorQML::MaterialEditorQML(QObject *parent)
                 this, &MaterialEditorQML::hasSelectedMeshChanged);
     }
 }
+
+// Defaulted here (not in the header) so the std::unique_ptr<MultiViewBakeState>
+// pimpl is destroyed where MultiViewBakeState is a complete type.
+MaterialEditorQML::~MaterialEditorQML() = default;
 
 MaterialEditorQML* MaterialEditorQML::qmlInstance(QQmlEngine *engine, QJSEngine *scriptEngine)
 {
@@ -3999,6 +4005,212 @@ void MaterialEditorQML::generateMeshTextureFromPrompt(const QString &prompt,
 #endif
 }
 
+// --------------------------------------------------------------------------
+// Multi-view depth-conditioned generation + projection bake (slice 2).
+// --------------------------------------------------------------------------
+
+// In-flight state for a multi-view bake. One image is generated per view; the
+// per-view depth render also yields the exact camera matrices the baker needs.
+struct MaterialEditorQML::MultiViewBakeState {
+    QString entityName;
+    QString prompt;
+    QString controlNetPath;
+    int width = 512;
+    int height = 512;
+    float controlStrength = 0.9f;
+    std::vector<MeshDepthRenderer::View> views;   // resolved camera views
+    std::vector<MultiViewTextureBaker::View> baked; // accumulated image+matrices
+    size_t current = 0;                            // index of the view being generated
+};
+
+namespace {
+MeshDepthRenderer::View resolveDepthView(const QString& name)
+{
+    const QString n = name.trimmed().toLower();
+    if (n == "back")   return MeshDepthRenderer::back();
+    if (n == "left")   return MeshDepthRenderer::left();
+    if (n == "right")  return MeshDepthRenderer::right();
+    if (n == "top")    return MeshDepthRenderer::top();
+    if (n == "bottom") return MeshDepthRenderer::bottom();
+    return MeshDepthRenderer::front();
+}
+} // namespace
+
+void MaterialEditorQML::generateMeshTextureMultiView(const QString &prompt,
+                                                     int width, int height,
+                                                     double controlStrength,
+                                                     const QStringList &views)
+{
+    if (prompt.isEmpty()) {
+        emit sdGenerationError("Please enter a texture prompt");
+        return;
+    }
+#ifdef ENABLE_STABLE_DIFFUSION
+    SDManager *sdManager = SDManager::instance();
+    if (!sdManager->isModelLoaded()) {
+        emit sdGenerationError("No SD model loaded. Please download and load a model from AI Settings.");
+        return;
+    }
+    auto* sel = SelectionSet::getSingleton();
+    const auto entities = sel ? sel->getResolvedEntities() : QList<Ogre::Entity*>{};
+    if (entities.isEmpty() || !entities.first() || !entities.first()->getMesh()) {
+        emit sdGenerationError("No mesh selected. Select a mesh to condition on its shape.");
+        return;
+    }
+    if (m_multiViewBake) {
+        emit sdGenerationError("A multi-view bake is already in progress.");
+        return;
+    }
+    Ogre::Entity* entity = entities.first();
+
+    // LCOV_EXCL_START — requires a loaded SD model + a mesh
+    auto st = std::make_unique<MultiViewBakeState>();
+    st->entityName = QString::fromStdString(entity->getName());
+    st->prompt = prompt;
+    st->width = width > 0 ? width : 512;
+    st->height = height > 0 ? height : 512;
+    st->controlStrength = static_cast<float>(std::clamp(controlStrength, 0.0, 1.0));
+    st->controlNetPath = discoveredControlNetDepthPath();
+
+    const QStringList viewNames = views.isEmpty()
+        ? QStringList{ QStringLiteral("front"), QStringLiteral("back") } : views;
+    for (const QString& vn : viewNames)
+        st->views.push_back(resolveDepthView(vn));
+
+    if (st->controlNetPath.isEmpty()) {
+        emit sdGenerationNotice(
+            "No ControlNet depth model found — multi-view bake will follow the "
+            "prompt only (download \"ControlNet Depth (SD 1.5)\" for shape-aware results).");
+    }
+    SentryReporter::addBreadcrumb(QStringLiteral("ai.assist.mesh_texture_multiview"),
+        QStringLiteral("entity=%1 views=%2 size=%3")
+            .arg(st->entityName).arg(viewNames.join(',')).arg(std::max(st->width, st->height)));
+
+    m_multiViewBake = std::move(st);
+    startNextMultiViewGeneration();
+    // LCOV_EXCL_STOP
+#else
+    Q_UNUSED(width); Q_UNUSED(height); Q_UNUSED(controlStrength); Q_UNUSED(views);
+    emit sdGenerationError("Stable Diffusion support is not enabled. Rebuild with ENABLE_STABLE_DIFFUSION=ON");
+#endif
+}
+
+void MaterialEditorQML::startNextMultiViewGeneration()
+{
+#ifdef ENABLE_STABLE_DIFFUSION
+    if (!m_multiViewBake) return;
+    MultiViewBakeState& s = *m_multiViewBake;
+
+    // Resolve the entity afresh each step (selection could change; bail if gone).
+    Ogre::Entity* entity = nullptr;
+    if (Manager::getSingletonPtr()) {
+        for (Ogre::Entity* e : Manager::getSingleton()->getEntities()) {
+            if (e && e->getMovableType() == "Entity"
+                && e->getName() == s.entityName.toStdString()) { entity = e; break; }
+        }
+    }
+    if (!entity) {
+        emit sdGenerationError("Mesh for multi-view bake is no longer available.");
+        m_multiViewBake.reset();
+        emit sdIsGeneratingChanged();
+        return;
+    }
+
+    const int depthSize = std::max(s.width, s.height);
+    QString depthErr;
+    MeshDepthRenderer::RenderResult rr =
+        MeshDepthRenderer::renderDepthMapView(entity, depthSize, s.views[s.current], &depthErr);
+    if (rr.depth.isNull()) {
+        emit sdGenerationError(QStringLiteral("Depth render failed (%1 view): %2")
+            .arg(s.views[s.current].name, depthErr));
+        m_multiViewBake.reset();
+        emit sdIsGeneratingChanged();
+        return;
+    }
+
+    // Stash the camera matrices for this view now; the image arrives later in
+    // onSDGenerationCompleted and is paired with this entry by index.
+    MultiViewTextureBaker::View bv;
+    bv.viewProj = rr.projMatrix * rr.viewMatrix;
+    bv.camDirection = rr.camDirection;
+    s.baked.push_back(bv);  // image filled on completion
+
+    m_sdGenerationProgress = 0.0f;
+    emit sdGenerationProgressChanged();
+    SDManager::instance()->generateMeshTexture(
+        s.prompt, rr.depth, s.controlNetPath, s.controlStrength,
+        QString(), s.width, s.height);
+#endif
+}
+
+void MaterialEditorQML::finishMultiViewBake()
+{
+#ifdef ENABLE_STABLE_DIFFUSION
+    if (!m_multiViewBake) return;
+    // Move the state out so any early return fully clears the in-flight flag.
+    std::unique_ptr<MultiViewBakeState> s = std::move(m_multiViewBake);
+
+    Ogre::Entity* entity = nullptr;
+    if (Manager::getSingletonPtr()) {
+        for (Ogre::Entity* e : Manager::getSingleton()->getEntities()) {
+            if (e && e->getMovableType() == "Entity"
+                && e->getName() == s->entityName.toStdString()) { entity = e; break; }
+        }
+    }
+    if (!entity) { emit sdGenerationError("Mesh gone before bake."); emit sdIsGeneratingChanged(); return; }
+
+    QString geoErr;
+    std::vector<MultiViewTextureBaker::Triangle> tris =
+        MultiViewTextureBaker::fromEntity(entity, &geoErr);
+    if (tris.empty()) {
+        emit sdGenerationError(QStringLiteral("Bake failed: %1").arg(geoErr));
+        emit sdIsGeneratingChanged();
+        return;
+    }
+
+    MultiViewTextureBaker::Options opts;
+    opts.resolution = std::max(s->width, s->height);
+    TexturePaintBuffer out;
+    MultiViewTextureBaker::Report rep =
+        MultiViewTextureBaker::bake(tris, s->baked, out, opts);
+    if (!rep.ok || rep.pixelsWritten == 0) {
+        emit sdGenerationError(QStringLiteral("Bake produced no texels: %1")
+            .arg(rep.ok ? QStringLiteral("no view covered the mesh") : rep.error));
+        emit sdIsGeneratingChanged();
+        return;
+    }
+
+    // Save the baked atlas next to the generated textures and apply it.
+    const QString dataPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    const QString outDir = QDir(dataPath).filePath("generated_textures");
+    QDir().mkpath(outDir);
+    const QString outName = QStringLiteral("multiview_bake_%1.png").arg(s->entityName);
+    const QString outPath = QDir(outDir).filePath(outName);
+    if (!out.save(outPath.toStdString())) {
+        emit sdGenerationError("Failed to write baked texture.");
+        emit sdIsGeneratingChanged();
+        return;
+    }
+
+    if (isOgreAvailable() && Ogre::Root::getSingletonPtr()) {
+        try {
+            auto &rgm = Ogre::ResourceGroupManager::getSingleton();
+            rgm.addResourceLocation(outDir.toStdString(), "FileSystem",
+                                    Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+            rgm.initialiseResourceGroup(Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+        } catch (...) {}
+        applyTextureToEntityDiffuse(s->entityName, outName);
+    }
+    m_textureName = outName;
+    emit textureNameChanged();
+    emit sdTextureGenerated(outPath);
+    emit sdIsGeneratingChanged();
+    SentryReporter::addBreadcrumb(QStringLiteral("ai.assist.mesh_texture_multiview"),
+        QStringLiteral("baked %1 texels from %2 views (%3 dilated)")
+            .arg(rep.pixelsWritten).arg(s->baked.size()).arg(rep.pixelsDilated));
+#endif
+}
+
 void MaterialEditorQML::stopTextureGeneration()
 {
 #ifdef ENABLE_STABLE_DIFFUSION
@@ -4159,6 +4371,28 @@ void MaterialEditorQML::onSDGenerationCompleted(const QString &outputPath)
     QString dirPath = fileInfo.absolutePath();
     QString fileName = fileInfo.fileName();
 
+#ifdef ENABLE_STABLE_DIFFUSION
+    // Multi-view bake (slice 2): pair this completed image with the view whose
+    // depth/matrices we stashed in startNextMultiViewGeneration(), then either
+    // issue the next view or bake when all views are done.
+    if (m_multiViewBake) {
+        MultiViewBakeState& s = *m_multiViewBake;
+        if (s.current < s.baked.size()) {
+            QImage img(outputPath);
+            if (!img.isNull())
+                s.baked[s.current].image = img.convertToFormat(QImage::Format_RGB888);
+        }
+        emit sdTextureGenerated(outputPath);  // let the preview update per view
+        ++s.current;
+        if (s.current < s.views.size()) {
+            startNextMultiViewGeneration();   // next view
+        } else {
+            finishMultiViewBake();            // all views captured → bake + apply
+        }
+        return;
+    }
+#endif
+
     // Issue #403: if this was a mesh-aware generation, bind the
     // result to the selected entity's diffuse TUS directly (the
     // editor's "current pass" may not be the rendered material, which
@@ -4251,6 +4485,11 @@ void MaterialEditorQML::onSDGenerationError(const QString &error)
     // txt2img to complete would take the mesh-aware completion branch
     // and apply itself to this stale entity.
     m_sdMeshTextureEntity.clear();
+#ifdef ENABLE_STABLE_DIFFUSION
+    // Abort an in-flight multi-view bake on any generation error so it can't
+    // strand the in-progress flag or capture a later unrelated generation.
+    m_multiViewBake.reset();
+#endif
     m_sdGenerationProgress = 0.0f;
     emit sdGenerationProgressChanged();
     emit sdIsGeneratingChanged();

--- a/src/MaterialEditorQML.cpp
+++ b/src/MaterialEditorQML.cpp
@@ -12,6 +12,7 @@
 #include <OgreMesh.h>
 #include <OgreTechnique.h>
 #include <QDir>
+#include <QRegularExpression>
 #include <QFileInfo>
 #include <QTextStream>
 #include <set>
@@ -4082,6 +4083,9 @@ void MaterialEditorQML::generateMeshTextureMultiView(const QString &prompt,
             "No ControlNet depth model found — multi-view bake will follow the "
             "prompt only (download \"ControlNet Depth (SD 1.5)\" for shape-aware results).");
     }
+    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+        QStringLiteral("Multi-view mesh texture: entity=%1 views=%2 size=%3")
+            .arg(st->entityName).arg(viewNames.join(',')).arg(std::max(st->width, st->height)));
     SentryReporter::addBreadcrumb(QStringLiteral("ai.assist.mesh_texture_multiview"),
         QStringLiteral("entity=%1 views=%2 size=%3")
             .arg(st->entityName).arg(viewNames.join(',')).arg(std::max(st->width, st->height)));
@@ -4184,13 +4188,20 @@ void MaterialEditorQML::finishMultiViewBake()
     const QString dataPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
     const QString outDir = QDir(dataPath).filePath("generated_textures");
     QDir().mkpath(outDir);
-    const QString outName = QStringLiteral("multiview_bake_%1.png").arg(s->entityName);
+    // Sanitize the entity name into a filesystem-safe basename — imported names
+    // can carry '/', ':', spaces, etc. that would break out.save().
+    QString safeName = s->entityName;
+    safeName.replace(QRegularExpression(QStringLiteral("[^A-Za-z0-9._-]")), QStringLiteral("_"));
+    if (safeName.isEmpty()) safeName = QStringLiteral("entity");
+    const QString outName = QStringLiteral("multiview_bake_%1.png").arg(safeName);
     const QString outPath = QDir(outDir).filePath(outName);
     if (!out.save(outPath.toStdString())) {
         emit sdGenerationError("Failed to write baked texture.");
         emit sdIsGeneratingChanged();
         return;
     }
+    SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
+        QStringLiteral("Wrote multi-view baked texture %1").arg(outPath));
 
     if (isOgreAvailable() && Ogre::Root::getSingletonPtr()) {
         try {
@@ -4377,11 +4388,18 @@ void MaterialEditorQML::onSDGenerationCompleted(const QString &outputPath)
     // issue the next view or bake when all views are done.
     if (m_multiViewBake) {
         MultiViewBakeState& s = *m_multiViewBake;
-        if (s.current < s.baked.size()) {
-            QImage img(outputPath);
-            if (!img.isNull())
-                s.baked[s.current].image = img.convertToFormat(QImage::Format_RGB888);
+        QImage img(outputPath);
+        if (img.isNull() || s.current >= s.baked.size()) {
+            // A view image we can't load would bake invalid input later; abort
+            // the whole multi-view run now rather than fail late.
+            emit sdGenerationError(QStringLiteral("Multi-view bake aborted: could not "
+                "load the generated %1 view image.")
+                .arg(s.current < s.views.size() ? s.views[s.current].name : "?"));
+            m_multiViewBake.reset();
+            emit sdIsGeneratingChanged();
+            return;
         }
+        s.baked[s.current].image = img.convertToFormat(QImage::Format_RGB888);
         emit sdTextureGenerated(outputPath);  // let the preview update per view
         ++s.current;
         if (s.current < s.views.size()) {
@@ -4508,6 +4526,11 @@ void MaterialEditorQML::onSDGenerationError(const QString &error)
 void MaterialEditorQML::onSDGenerationStopped()
 {
     m_sdMeshTextureEntity.clear();
+#ifdef ENABLE_STABLE_DIFFUSION
+    // Abandon any in-flight multi-view bake so a later unrelated generation
+    // can't be captured into its stale per-view slots.
+    m_multiViewBake.reset();
+#endif
     m_sdGenerationProgress = 0.0f;
     emit sdGenerationProgressChanged();
     emit sdIsGeneratingChanged();

--- a/src/MaterialEditorQML.cpp
+++ b/src/MaterialEditorQML.cpp
@@ -4200,8 +4200,10 @@ void MaterialEditorQML::finishMultiViewBake()
         emit sdIsGeneratingChanged();
         return;
     }
+    // Log only the basename — outPath is under the app-data dir and would leak
+    // the local username/path into telemetry.
     SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
-        QStringLiteral("Wrote multi-view baked texture %1").arg(outPath));
+        QStringLiteral("Wrote multi-view baked texture %1").arg(outName));
 
     if (isOgreAvailable() && Ogre::Root::getSingletonPtr()) {
         try {

--- a/src/MaterialEditorQML.h
+++ b/src/MaterialEditorQML.h
@@ -5,6 +5,8 @@
 #include <QQmlEngine>
 #include <QColor>
 #include <QStringList>
+
+#include <memory>
 #include <QVariantMap>
 #include <QQuickItem>
 #include <QDir>
@@ -148,7 +150,9 @@ class MaterialEditorQML : public QObject
 
 public:
     explicit MaterialEditorQML(QObject *parent = nullptr);
-    virtual ~MaterialEditorQML() = default;
+    // Defined (defaulted) in the .cpp so std::unique_ptr<MultiViewBakeState>
+    // sees the complete type when destroying the pimpl.
+    ~MaterialEditorQML() override;
 
     // Property getters
     QString materialName() const { return m_materialName; }
@@ -550,6 +554,15 @@ public slots:
     Q_INVOKABLE void generateMeshTextureFromPrompt(const QString &prompt,
                                                    int width = 0, int height = 0,
                                                    double controlStrength = 0.9);
+    // Multi-view depth-conditioned generation (slice 2): generate one image per
+    // camera view (e.g. {"front","back"}) and projection-bake them onto the
+    // selected mesh's UV0 atlas, then apply the baked texture to its diffuse.
+    // Views run sequentially through the SD worker; the bake fires when the
+    // last view completes. `views` defaults to front+back when empty.
+    Q_INVOKABLE void generateMeshTextureMultiView(const QString &prompt,
+                                                  int width = 0, int height = 0,
+                                                  double controlStrength = 0.9,
+                                                  const QStringList &views = {});
     // True when a skinned/static mesh is selected — drives the
     // "use selected mesh" checkbox enabled state.
     Q_INVOKABLE bool hasSelectedMesh() const;
@@ -807,6 +820,17 @@ private:
     QString m_sdMeshTextureEntity;
     void applyTextureToEntityDiffuse(const QString& entityName,
                                      const QString& textureFileName);
+
+    // Multi-view bake (slice 2) in-flight state. When non-empty, each SD
+    // completion is captured into the per-view image list and the next view is
+    // issued; when the last view completes, MultiViewTextureBaker bakes the
+    // images onto the entity's UV0 and the result is applied to its diffuse.
+    // Stored separately from the single-view m_sdMeshTextureEntity path so the
+    // two never interfere. Implemented in the .cpp (sd-guarded).
+    struct MultiViewBakeState;
+    std::unique_ptr<MultiViewBakeState> m_multiViewBake;
+    void startNextMultiViewGeneration();   // issue depth+generate for the current view
+    void finishMultiViewBake();            // bake accumulated images + apply
 
     // Undo/Redo stacks
     QStringList m_undoStack;

--- a/src/MeshDepthRenderer.cpp
+++ b/src/MeshDepthRenderer.cpp
@@ -163,12 +163,13 @@ MeshDepthRenderer::RenderResult MeshDepthRenderer::renderDepthMapView(
     // Distance so the sphere fits in the 45° vertical FOV.
     const Ogre::Real fovY = st.camera->getFOVy().valueRadians();
     const Ogre::Real dist = radius / std::sin(fovY * 0.5f) * 1.15f;  // 15% margin
-    // The camera sits along `view.dir` from the centre, at framing distance.
-    // view.dir points FROM the camera TOWARD the centre, so the camera is at
-    // center - dir*dist. front = (0,0,-1) → camera on -Z (imported characters
-    // face -Z, so this captures the front), matching the pre-multiview default.
+    // `view.dir` is the direction the camera looks ALONG (toward the centre),
+    // so the camera is placed at center - dir*dist. front = (0,0,1) → camera on
+    // -Z (center - (0,0,1)*dist) looking toward +Z; imported characters face -Z
+    // so this captures the FRONT, matching the pre-multiview placement
+    // (camPos was center + (0,0,-dist)).
     Ogre::Vector3 dir = view.dir;
-    if (dir.isZeroLength()) dir = Ogre::Vector3(0, 0, -1);
+    if (dir.isZeroLength()) dir = Ogre::Vector3(0, 0, 1);
     dir.normalise();
     const Ogre::Vector3 camPos = center - dir * dist;
     st.cameraNode->setPosition(camPos);

--- a/src/MeshDepthRenderer.cpp
+++ b/src/MeshDepthRenderer.cpp
@@ -131,38 +131,52 @@ QImage readRenderTarget(int size)
 QImage MeshDepthRenderer::renderDepthMap(Ogre::Entity* entity, int size,
                                          QString* errorOut)
 {
+    // Back-compat: front view, image only.
+    return renderDepthMapView(entity, size, front(), errorOut).depth;
+}
+
+MeshDepthRenderer::RenderResult MeshDepthRenderer::renderDepthMapView(
+    Ogre::Entity* entity, int size, const View& view, QString* errorOut)
+{
+    RenderResult result;
     if (!entity) {
         if (errorOut) *errorOut = QStringLiteral("null entity");
-        return QImage();
+        return result;
     }
     size = std::clamp(size, 64, 2048);
     if (!ensureRenderTarget(size, errorOut))
-        return QImage();
+        return result;
 
     auto* sm = sceneMgr();
     DepthState& st = state();
 
     // Frame the camera on the entity's bounding sphere so the whole
     // mesh fills the view (matches how the generated texture is
-    // planar-projected back).
+    // projection-baked back).
     const Ogre::AxisAlignedBox aabb = entity->getWorldBoundingBox(true);
     const Ogre::Vector3 center = aabb.getCenter();
     const Ogre::Real radius = aabb.getHalfSize().length();
     if (radius <= 0.0f) {
         if (errorOut) *errorOut = QStringLiteral("entity has zero-size bounding box");
-        return QImage();
+        return result;
     }
     // Distance so the sphere fits in the 45° vertical FOV.
     const Ogre::Real fovY = st.camera->getFOVy().valueRadians();
     const Ogre::Real dist = radius / std::sin(fovY * 0.5f) * 1.15f;  // 15% margin
-    // Place the camera on the -Z side: imported characters (Mixamo et
-    // al.) face -Z, which is also the side the default editor camera
-    // looks at. Capturing from +Z gave the model's BACK; -Z gives the
-    // front.
-    const Ogre::Vector3 camPos = center + Ogre::Vector3(0, 0, -dist);
+    // The camera sits along `view.dir` from the centre, at framing distance.
+    // view.dir points FROM the camera TOWARD the centre, so the camera is at
+    // center - dir*dist. front = (0,0,-1) → camera on -Z (imported characters
+    // face -Z, so this captures the front), matching the pre-multiview default.
+    Ogre::Vector3 dir = view.dir;
+    if (dir.isZeroLength()) dir = Ogre::Vector3(0, 0, -1);
+    dir.normalise();
+    const Ogre::Vector3 camPos = center - dir * dist;
     st.cameraNode->setPosition(camPos);
-    // Ogre 14: orient the node, not the camera. Look from camPos
-    // toward the entity center.
+    // Orient via the view's up hint. Node::lookAt takes the up from the
+    // fixed-yaw axis, so set that to `up` first. Top/bottom views look parallel
+    // to the default +Y, which is degenerate, so those views supply a Z-up hint.
+    const Ogre::Vector3 up = view.up.isZeroLength() ? Ogre::Vector3::UNIT_Y : view.up;
+    st.cameraNode->setFixedYawAxis(true, up);
     st.cameraNode->lookAt(center, Ogre::Node::TS_WORLD,
                           Ogre::Vector3::NEGATIVE_UNIT_Z);
 
@@ -256,11 +270,20 @@ QImage MeshDepthRenderer::renderDepthMap(Ogre::Entity* entity, int size,
     st.renderTarget->update();
     QImage rgba = readRenderTarget(size);
 
+    // Capture the EXACT view/projection the frame was rendered with, so the
+    // multi-view baker re-projects mesh triangles through the identical camera.
+    // Read after update() so Ogre has finalised the auto-aspect projection.
+    result.viewMatrix = st.camera->getViewMatrix();
+    result.projMatrix = st.camera->getProjectionMatrix();
+    result.camPosition = camPos;
+    result.camDirection = dir;
+
     // Collapse to grayscale (the channels are equal already, but be
     // explicit so downstream code can rely on it). Restore runs as the
     // Restorer goes out of scope.
-    return rgba.convertToFormat(QImage::Format_Grayscale8)
+    result.depth = rgba.convertToFormat(QImage::Format_Grayscale8)
         .convertToFormat(QImage::Format_RGB888);
+    return result;
 }
 
 void MeshDepthRenderer::shutdown()

--- a/src/MeshDepthRenderer.h
+++ b/src/MeshDepthRenderer.h
@@ -35,25 +35,27 @@ namespace Ogre {
 // the live editor viewport camera instead; framing is the safe v1.)
 class MeshDepthRenderer {
 public:
-    // A camera view to capture from. `dir` is the WORLD-space direction
-    // pointing FROM the camera TOWARD the mesh centre, normalised by the
-    // renderer. front = (0,0,-1) because imported characters (Mixamo et al.)
-    // face -Z, so a camera on the -Z side looking toward +Z sees the front.
+    // A camera view to capture from. `dir` is the WORLD-space direction the
+    // camera looks ALONG (i.e. FROM the camera TOWARD the mesh centre),
+    // normalised by the renderer; the camera is placed at center - dir*dist.
+    // front = (0,0,1): imported characters (Mixamo et al.) face -Z, so the
+    // camera sits on the -Z side (center - (0,0,1)*dist) looking toward +Z and
+    // sees the front — matching the pre-multiview single-view placement.
     // `up` is the camera up-vector hint (defaults to +Y; use ±Z for top/bottom
     // views where the look direction is parallel to +Y).
     struct View {
-        Ogre::Vector3 dir = Ogre::Vector3(0, 0, -1);
+        Ogre::Vector3 dir = Ogre::Vector3(0, 0, 1);
         Ogre::Vector3 up  = Ogre::Vector3::UNIT_Y;
         const char*   name = "front";
     };
 
     // Built-in named views. front/back differ only in sign of Z.
-    static View front()  { return { Ogre::Vector3(0, 0, -1), Ogre::Vector3::UNIT_Y, "front"  }; }
-    static View back()   { return { Ogre::Vector3(0, 0,  1), Ogre::Vector3::UNIT_Y, "back"   }; }
-    static View left()   { return { Ogre::Vector3(-1, 0, 0), Ogre::Vector3::UNIT_Y, "left"   }; }
-    static View right()  { return { Ogre::Vector3( 1, 0, 0), Ogre::Vector3::UNIT_Y, "right"  }; }
-    static View top()    { return { Ogre::Vector3(0,  1, 0), Ogre::Vector3(0,0,1),  "top"    }; }
-    static View bottom() { return { Ogre::Vector3(0, -1, 0), Ogre::Vector3(0,0,1),  "bottom" }; }
+    static View front()  { return { Ogre::Vector3(0, 0,  1), Ogre::Vector3::UNIT_Y, "front"  }; }
+    static View back()   { return { Ogre::Vector3(0, 0, -1), Ogre::Vector3::UNIT_Y, "back"   }; }
+    static View left()   { return { Ogre::Vector3( 1, 0, 0), Ogre::Vector3::UNIT_Y, "left"   }; }
+    static View right()  { return { Ogre::Vector3(-1, 0, 0), Ogre::Vector3::UNIT_Y, "right"  }; }
+    static View top()    { return { Ogre::Vector3(0, -1, 0), Ogre::Vector3(0,0,1),  "top"    }; }
+    static View bottom() { return { Ogre::Vector3(0,  1, 0), Ogre::Vector3(0,0,1),  "bottom" }; }
 
     // Result of a view render: the grayscale depth image PLUS the exact
     // view/projection matrices and camera position used. The multi-view

--- a/src/MeshDepthRenderer.h
+++ b/src/MeshDepthRenderer.h
@@ -4,6 +4,9 @@
 #include <QImage>
 #include <QString>
 
+#include <OgreMatrix4.h>
+#include <OgreVector3.h>
+
 namespace Ogre {
     class Entity;
 }
@@ -32,10 +35,48 @@ namespace Ogre {
 // the live editor viewport camera instead; framing is the safe v1.)
 class MeshDepthRenderer {
 public:
-    // Render `entity`'s depth map at `size` x `size`. Returns a
-    // grayscale QImage on success, or a null QImage on failure
-    // (errorOut populated). Must be called on the main/render thread
-    // — it touches the Ogre scene manager.
+    // A camera view to capture from. `dir` is the WORLD-space direction
+    // pointing FROM the camera TOWARD the mesh centre, normalised by the
+    // renderer. front = (0,0,-1) because imported characters (Mixamo et al.)
+    // face -Z, so a camera on the -Z side looking toward +Z sees the front.
+    // `up` is the camera up-vector hint (defaults to +Y; use ±Z for top/bottom
+    // views where the look direction is parallel to +Y).
+    struct View {
+        Ogre::Vector3 dir = Ogre::Vector3(0, 0, -1);
+        Ogre::Vector3 up  = Ogre::Vector3::UNIT_Y;
+        const char*   name = "front";
+    };
+
+    // Built-in named views. front/back differ only in sign of Z.
+    static View front()  { return { Ogre::Vector3(0, 0, -1), Ogre::Vector3::UNIT_Y, "front"  }; }
+    static View back()   { return { Ogre::Vector3(0, 0,  1), Ogre::Vector3::UNIT_Y, "back"   }; }
+    static View left()   { return { Ogre::Vector3(-1, 0, 0), Ogre::Vector3::UNIT_Y, "left"   }; }
+    static View right()  { return { Ogre::Vector3( 1, 0, 0), Ogre::Vector3::UNIT_Y, "right"  }; }
+    static View top()    { return { Ogre::Vector3(0,  1, 0), Ogre::Vector3(0,0,1),  "top"    }; }
+    static View bottom() { return { Ogre::Vector3(0, -1, 0), Ogre::Vector3(0,0,1),  "bottom" }; }
+
+    // Result of a view render: the grayscale depth image PLUS the exact
+    // view/projection matrices and camera position used. The multi-view
+    // baker re-projects mesh triangles through THESE matrices so the bake
+    // aligns pixel-for-pixel with what ControlNet was conditioned on.
+    struct RenderResult {
+        QImage        depth;            // null on failure
+        Ogre::Matrix4 viewMatrix;
+        Ogre::Matrix4 projMatrix;
+        Ogre::Vector3 camPosition = Ogre::Vector3::ZERO;
+        Ogre::Vector3 camDirection = Ogre::Vector3::ZERO;  // normalised view dir
+    };
+
+    // Render `entity`'s depth map at `size` x `size` from `view`. Returns a
+    // RenderResult whose `.depth` is null on failure (errorOut populated).
+    // Must be called on the main/render thread — it touches the Ogre scene
+    // manager.
+    static RenderResult renderDepthMapView(Ogre::Entity* entity,
+                                           int size,
+                                           const View& view,
+                                           QString* errorOut = nullptr);
+
+    // Back-compat convenience: front-view depth image only (issue #403).
     static QImage renderDepthMap(Ogre::Entity* entity,
                                  int size,
                                  QString* errorOut = nullptr);

--- a/src/MultiViewTextureBaker.cpp
+++ b/src/MultiViewTextureBaker.cpp
@@ -258,10 +258,13 @@ MultiViewTextureBaker::fromEntity(Ogre::Entity* entity, QString* errorOut)
         if (errorOut) *errorOut = QStringLiteral("mesh has no triangles");
         return out;
     }
-    if (!sawUv && errorOut) {
-        // Not fatal here (caller decides) but flag it — a bake onto all-zero
-        // UVs collapses to one texel.
-        *errorOut = QStringLiteral("mesh has no usable UV0");
+    if (!sawUv) {
+        // No usable UV0 → a bake would collapse onto a single texel. Fail hard
+        // (return empty) so the caller aborts rather than producing garbage.
+        // The slice-3 UV-unwrap gate will handle this case by unwrapping first.
+        if (errorOut) *errorOut = QStringLiteral("mesh has no usable UV0 (run UV unwrap first)");
+        out.clear();
+        return out;
     }
     return out;
 }

--- a/src/MultiViewTextureBaker.cpp
+++ b/src/MultiViewTextureBaker.cpp
@@ -1,0 +1,200 @@
+#include "MultiViewTextureBaker.h"
+
+#include "VertexColorBaker.h"  // for dilate()
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+namespace {
+
+// Project a world point through view*proj (clip space) and return the
+// viewport UV in [0..1] (top-left origin, V down to match QImage). Sets
+// `behind` when the point is at/behind the camera (clip w <= 0). The depth
+// (NDC z) is returned for optional occlusion use later.
+struct Projected {
+    Ogre::Vector2 uv;   // [0..1], may be outside on off-screen verts
+    float ndcZ = 0.0f;
+    bool behind = false;
+};
+
+Projected projectToViewportUV(const Ogre::Vector3& worldP,
+                              const Ogre::Matrix4& viewProj)
+{
+    Projected out;
+    const Ogre::Vector4 clip = viewProj * Ogre::Vector4(worldP.x, worldP.y, worldP.z, 1.0f);
+    if (clip.w <= 1e-6f) {        // at or behind the camera plane
+        out.behind = true;
+        return out;
+    }
+    const float invW = 1.0f / clip.w;
+    const float ndcX = clip.x * invW;   // [-1..1]
+    const float ndcY = clip.y * invW;   // [-1..1], +Y up
+    out.ndcZ = clip.z * invW;
+    // NDC -> viewport UV. Flip Y so v=0 is the top of the image (QImage row 0).
+    out.uv = Ogre::Vector2(ndcX * 0.5f + 0.5f, 1.0f - (ndcY * 0.5f + 0.5f));
+    return out;
+}
+
+// Bilinear sample of a QImage at uv in [0..1] (top-left origin). Returns the
+// colour as ColourValue (0..1). Out-of-range uv is clamped to the edge.
+Ogre::ColourValue sampleImage(const QImage& img, const Ogre::Vector2& uv)
+{
+    const int w = img.width();
+    const int h = img.height();
+    if (w <= 0 || h <= 0) return Ogre::ColourValue(0, 0, 0, 1);
+    const float fx = std::clamp(uv.x, 0.0f, 1.0f) * (w - 1);
+    const float fy = std::clamp(uv.y, 0.0f, 1.0f) * (h - 1);
+    const int x0 = static_cast<int>(std::floor(fx));
+    const int y0 = static_cast<int>(std::floor(fy));
+    const int x1 = std::min(x0 + 1, w - 1);
+    const int y1 = std::min(y0 + 1, h - 1);
+    const float tx = fx - x0;
+    const float ty = fy - y0;
+    auto px = [&](int x, int y) {
+        const QRgb c = img.pixel(x, y);
+        return Ogre::ColourValue(qRed(c) / 255.0f, qGreen(c) / 255.0f,
+                                 qBlue(c) / 255.0f, qAlpha(c) / 255.0f);
+    };
+    const Ogre::ColourValue c00 = px(x0, y0), c10 = px(x1, y0);
+    const Ogre::ColourValue c01 = px(x0, y1), c11 = px(x1, y1);
+    const Ogre::ColourValue top = c00 * (1 - tx) + c10 * tx;
+    const Ogre::ColourValue bot = c01 * (1 - tx) + c11 * tx;
+    return top * (1 - ty) + bot * ty;
+}
+
+} // namespace
+
+MultiViewTextureBaker::Report MultiViewTextureBaker::bake(
+    const std::vector<Triangle>& tris,
+    const std::vector<View>& views,
+    TexturePaintBuffer& out)
+{
+    return bake(tris, views, out, Options{});
+}
+
+MultiViewTextureBaker::Report MultiViewTextureBaker::bake(
+    const std::vector<Triangle>& tris,
+    const std::vector<View>& views,
+    TexturePaintBuffer& out,
+    const Options& opts)
+{
+    Report rep;
+    if (tris.empty()) { rep.error = QStringLiteral("no triangles"); return rep; }
+    if (views.empty()) { rep.error = QStringLiteral("no views"); return rep; }
+    for (const View& v : views) {
+        if (v.image.isNull() || v.image.width() <= 0 || v.image.height() <= 0) {
+            rep.error = QStringLiteral("a view image is empty");
+            return rep;
+        }
+    }
+    const int res = std::clamp(opts.resolution, 16, 8192);
+    rep.perViewTriangleCount.assign(views.size(), 0);
+
+    // Weighted accumulation buffers (RGB * weight, and weight sum) per texel.
+    const size_t n = static_cast<size_t>(res) * res;
+    std::vector<float> accR(n, 0.0f), accG(n, 0.0f), accB(n, 0.0f), accW(n, 0.0f);
+
+    // Rasterize one triangle in UV0 space into the accumulators, sampling
+    // `img` at the per-texel barycentric-interpolated screen UV (s0,s1,s2),
+    // weighted by `weight`.
+    auto rasterTriIntoAcc = [&](const Ogre::Vector2& uv0, const Ogre::Vector2& uv1,
+                                const Ogre::Vector2& uv2,
+                                const Ogre::Vector2& s0, const Ogre::Vector2& s1,
+                                const Ogre::Vector2& s2,
+                                const QImage& img, float weight) -> int {
+        // UV -> pixel centre coords. V is top-left origin already.
+        auto toPix = [&](const Ogre::Vector2& uv) {
+            return Ogre::Vector2(uv.x * res, uv.y * res);
+        };
+        const Ogre::Vector2 a = toPix(uv0), b = toPix(uv1), c = toPix(uv2);
+        const float minXf = std::min({a.x, b.x, c.x});
+        const float maxXf = std::max({a.x, b.x, c.x});
+        const float minYf = std::min({a.y, b.y, c.y});
+        const float maxYf = std::max({a.y, b.y, c.y});
+        int x0 = std::max(0, static_cast<int>(std::floor(minXf)));
+        int x1 = std::min(res - 1, static_cast<int>(std::ceil(maxXf)));
+        int y0 = std::max(0, static_cast<int>(std::floor(minYf)));
+        int y1 = std::min(res - 1, static_cast<int>(std::ceil(maxYf)));
+        // Edge-function denominator (twice the signed area in pixel space).
+        const float denom = (b.y - c.y) * (a.x - c.x) + (c.x - b.x) * (a.y - c.y);
+        if (std::abs(denom) < 1e-9f) return 0;   // degenerate in UV space
+        const float invDen = 1.0f / denom;
+        int written = 0;
+        for (int py = y0; py <= y1; ++py) {
+            for (int px = x0; px <= x1; ++px) {
+                const float fx = px + 0.5f, fy = py + 0.5f;
+                // Barycentric coords w.r.t. UV-space triangle.
+                float l0 = ((b.y - c.y) * (fx - c.x) + (c.x - b.x) * (fy - c.y)) * invDen;
+                float l1 = ((c.y - a.y) * (fx - c.x) + (a.x - c.x) * (fy - c.y)) * invDen;
+                float l2 = 1.0f - l0 - l1;
+                const float eps = -1e-4f;
+                if (l0 < eps || l1 < eps || l2 < eps) continue;  // outside triangle
+                // Interpolated screen UV → sample the view image.
+                const Ogre::Vector2 suv = s0 * l0 + s1 * l1 + s2 * l2;
+                const Ogre::ColourValue col = sampleImage(img, suv);
+                const size_t idx = static_cast<size_t>(py) * res + px;
+                accR[idx] += col.r * weight;
+                accG[idx] += col.g * weight;
+                accB[idx] += col.b * weight;
+                accW[idx] += weight;
+                ++written;
+            }
+        }
+        return written;
+    };
+
+    for (const Triangle& t : tris) {
+        Ogre::Vector3 nrm = t.normal;
+        if (nrm.isZeroLength()) {
+            nrm = (t.p[1] - t.p[0]).crossProduct(t.p[2] - t.p[0]);
+        }
+        if (nrm.isZeroLength()) continue;   // degenerate triangle
+        nrm.normalise();
+
+        for (size_t vi = 0; vi < views.size(); ++vi) {
+            const View& v = views[vi];
+            // Facing weight: the surface normal pointing back toward the camera
+            // means -viewDir (camera looks ALONG camDirection into the scene).
+            float facing = -nrm.dotProduct(v.camDirection);
+            if (facing < opts.minFacing) continue;
+            facing = std::pow(facing, std::max(0.01f, opts.facingPower));
+
+            const Projected pa = projectToViewportUV(t.p[0], v.viewProj);
+            const Projected pb = projectToViewportUV(t.p[1], v.viewProj);
+            const Projected pc = projectToViewportUV(t.p[2], v.viewProj);
+            if (pa.behind || pb.behind || pc.behind) continue;  // clipped
+
+            const int w = rasterTriIntoAcc(t.uv[0], t.uv[1], t.uv[2],
+                                           pa.uv, pb.uv, pc.uv, v.image, facing);
+            if (w > 0) {
+                ++rep.trianglesProjected;
+                ++rep.perViewTriangleCount[vi];
+            }
+        }
+    }
+
+    // Resolve accumulators → RGBA8, build a coverage mask for dilation.
+    out.resize(res, res);
+    out.clear(opts.background);
+    std::vector<uint8_t> coverage(n, 0);
+    for (size_t i = 0; i < n; ++i) {
+        if (accW[i] <= 0.0f) continue;
+        const float inv = 1.0f / accW[i];
+        const int x = static_cast<int>(i % res);
+        const int y = static_cast<int>(i / res);
+        out.setPixel(x, y, Ogre::ColourValue(std::clamp(accR[i] * inv, 0.0f, 1.0f),
+                                             std::clamp(accG[i] * inv, 0.0f, 1.0f),
+                                             std::clamp(accB[i] * inv, 0.0f, 1.0f),
+                                             1.0f));
+        coverage[i] = 1;
+        ++rep.pixelsWritten;
+    }
+
+    if (opts.dilationPixels > 0 && rep.pixelsWritten > 0) {
+        rep.pixelsDilated = VertexColorBaker::dilate(out, coverage, opts.dilationPixels);
+    }
+
+    rep.ok = true;
+    return rep;
+}

--- a/src/MultiViewTextureBaker.cpp
+++ b/src/MultiViewTextureBaker.cpp
@@ -1,6 +1,12 @@
 #include "MultiViewTextureBaker.h"
 
 #include "VertexColorBaker.h"  // for dilate()
+#include "EditableMesh.h"
+
+#include <OgreEntity.h>
+#include <OgreNode.h>
+#include <OgreMatrix3.h>
+#include <OgreMatrix4.h>
 
 #include <algorithm>
 #include <cmath>
@@ -197,4 +203,65 @@ MultiViewTextureBaker::Report MultiViewTextureBaker::bake(
 
     rep.ok = true;
     return rep;
+}
+
+std::vector<MultiViewTextureBaker::Triangle>
+MultiViewTextureBaker::fromEntity(Ogre::Entity* entity, QString* errorOut)
+{
+    std::vector<Triangle> out;
+    if (!entity || !entity->getMesh()) {
+        if (errorOut) *errorOut = QStringLiteral("null entity/mesh");
+        return out;
+    }
+
+    EditableMesh em;
+    if (!em.loadFromEntity(entity)) {
+        if (errorOut) *errorOut = QStringLiteral("failed to read mesh geometry");
+        return out;
+    }
+
+    // World transform of the entity's parent node (positions to world, normals
+    // via the inverse-transpose to stay correct under non-uniform scale).
+    Ogre::Matrix4 world = Ogre::Matrix4::IDENTITY;
+    if (Ogre::Node* node = entity->getParentNode())
+        world = Ogre::Matrix4(node->_getFullTransform());  // derived world matrix
+    Ogre::Matrix3 world3;
+    world.extract3x3Matrix(world3);
+    Ogre::Matrix3 normalMat = world3.Inverse().Transpose();
+
+    bool sawUv = false;
+    for (const EditableSubMesh& sub : em.subMeshes()) {
+        for (const EditableTriangle& tri : sub.triangles) {
+            if (tri.indices[0] >= sub.vertices.size()
+                || tri.indices[1] >= sub.vertices.size()
+                || tri.indices[2] >= sub.vertices.size())
+                continue;
+            Triangle t;
+            for (int k = 0; k < 3; ++k) {
+                const EditableVertex& v = sub.vertices[tri.indices[k]];
+                t.p[k]  = world * v.position;       // world-space position
+                t.uv[k] = v.uv;
+                if (v.uv != Ogre::Vector2::ZERO) sawUv = true;
+            }
+            // World face normal from the geometry (robust even if per-vertex
+            // normals are absent); fall back to the transformed vertex normal.
+            Ogre::Vector3 fn = (t.p[1] - t.p[0]).crossProduct(t.p[2] - t.p[0]);
+            if (fn.isZeroLength()) {
+                fn = normalMat * sub.vertices[tri.indices[0]].normal;
+            }
+            t.normal = fn;
+            out.push_back(t);
+        }
+    }
+
+    if (out.empty()) {
+        if (errorOut) *errorOut = QStringLiteral("mesh has no triangles");
+        return out;
+    }
+    if (!sawUv && errorOut) {
+        // Not fatal here (caller decides) but flag it — a bake onto all-zero
+        // UVs collapses to one texel.
+        *errorOut = QStringLiteral("mesh has no usable UV0");
+    }
+    return out;
 }

--- a/src/MultiViewTextureBaker.h
+++ b/src/MultiViewTextureBaker.h
@@ -12,6 +12,8 @@
 
 #include <vector>
 
+namespace Ogre { class Entity; }
+
 /**
  * @brief Project per-view generated images onto a mesh's UV0 atlas (slice 1 of
  *        the multi-view AI texture bake — see MULTIVIEW_TEXTURE_BAKE_DESIGN.md).
@@ -84,6 +86,14 @@ public:
     static Report bake(const std::vector<Triangle>& tris,
                        const std::vector<View>& views,
                        TexturePaintBuffer& out);
+
+    /// Extract world-space triangles + UV0 from a live entity (positions and
+    /// normals transformed by the entity's parent-node derived world matrix).
+    /// Uses EditableMesh::loadFromEntity under the hood. Returns an empty
+    /// vector if the entity/mesh is null or has no UV0. The `errorOut` (if
+    /// given) is set on failure.
+    static std::vector<Triangle> fromEntity(Ogre::Entity* entity,
+                                            QString* errorOut = nullptr);
 };
 
 #endif // MULTIVIEWTEXTUREBAKER_H

--- a/src/MultiViewTextureBaker.h
+++ b/src/MultiViewTextureBaker.h
@@ -1,0 +1,89 @@
+#ifndef MULTIVIEWTEXTUREBAKER_H
+#define MULTIVIEWTEXTUREBAKER_H
+
+#include "TexturePaintBuffer.h"
+
+#include <QImage>
+#include <QString>
+
+#include <OgreMatrix4.h>
+#include <OgreVector2.h>
+#include <OgreVector3.h>
+
+#include <vector>
+
+/**
+ * @brief Project per-view generated images onto a mesh's UV0 atlas (slice 1 of
+ *        the multi-view AI texture bake — see MULTIVIEW_TEXTURE_BAKE_DESIGN.md).
+ *
+ * The mesh's UV0 layout is FIXED. For every triangle, each view's camera
+ * (view/projection matrix) projects the triangle's world-space vertices to
+ * screen space; the triangle is then rasterized in UV0 space, and each covered
+ * texel is coloured by sampling that view's image at the barycentric-
+ * interpolated screen position. Views are blended by a facing weight
+ * (max(0, -faceNormal . viewDir)^facingPower) so a front view dominates
+ * front-facing triangles and a back view the back, with a feathered seam.
+ *
+ * Pure data: inputs are plain geometry arrays + QImages + matrices. No Ogre
+ * scene-manager / GL state is touched, so the core is unit-testable headlessly.
+ * Build an instance from an Ogre::Entity via MultiViewTextureBaker::fromEntity()
+ * (defined in the .cpp) when wiring the live path.
+ */
+class MultiViewTextureBaker
+{
+public:
+    /// One mesh triangle in WORLD space + its UV0 coordinates. `normal` is the
+    /// world-space face normal (need not be normalised; the baker normalises).
+    struct Triangle {
+        Ogre::Vector3 p[3];     // world-space positions
+        Ogre::Vector2 uv[3];    // UV0 in [0..1]^2 (top-left origin, V down)
+        Ogre::Vector3 normal;   // world-space face normal
+    };
+
+    /// One generated view: the image plus the exact camera it was rendered
+    /// with (matrices from MeshDepthRenderer::RenderResult).
+    struct View {
+        QImage        image;        // RGB(A) generated texture for this view
+        Ogre::Matrix4 viewProj;     // projMatrix * viewMatrix (world -> clip)
+        Ogre::Vector3 camDirection; // normalised dir camera looks ALONG (into scene)
+    };
+
+    struct Options {
+        int   resolution     = 1024;  // output atlas size (square)
+        int   dilationPixels = 4;     // seam-dilation passes after raster
+        float facingPower    = 1.0f;  // exponent on the facing weight
+        /// Triangles whose facing weight to a view is below this are not
+        /// projected from that view (back-face / grazing rejection).
+        float minFacing      = 0.05f;
+        /// Background for texels no view covered (alpha 0 = transparent seam mask).
+        Ogre::ColourValue background = Ogre::ColourValue(1.0f, 1.0f, 1.0f, 0.0f);
+    };
+
+    struct Report {
+        bool ok = false;
+        QString error;
+        int pixelsWritten = 0;            // texels coloured by projection (pre-dilate)
+        int pixelsDilated = 0;            // texels filled by seam dilation
+        int trianglesProjected = 0;       // (triangle,view) pairs that contributed
+        std::vector<int> perViewTriangleCount;  // contributing tris per view
+    };
+
+    /**
+     * @brief Bake `views` onto `tris` (UV0 space) into `out`.
+     *
+     * `out` is resized to opts.resolution and filled with opts.background, then
+     * projection-painted and dilated. Returns a Report; on a usage error
+     * (no triangles / no views / empty images) ok=false and error is set.
+     */
+    static Report bake(const std::vector<Triangle>& tris,
+                       const std::vector<View>& views,
+                       TexturePaintBuffer& out,
+                       const Options& opts);
+
+    /// Convenience overload with default options.
+    static Report bake(const std::vector<Triangle>& tris,
+                       const std::vector<View>& views,
+                       TexturePaintBuffer& out);
+};
+
+#endif // MULTIVIEWTEXTUREBAKER_H

--- a/src/MultiViewTextureBaker_test.cpp
+++ b/src/MultiViewTextureBaker_test.cpp
@@ -1,0 +1,200 @@
+#include <gtest/gtest.h>
+
+#include "MultiViewTextureBaker.h"
+#include "TexturePaintBuffer.h"
+
+#include <QImage>
+
+#include <OgreMatrix4.h>
+#include <OgreVector2.h>
+#include <OgreVector3.h>
+
+#include <cmath>
+
+// Pure-data tests for the multi-view projection bake (slice 1). No Ogre scene
+// manager, no GL, no QApplication, no SD — the baker takes plain geometry +
+// QImages + matrices, so the reprojection math is fully verifiable headlessly.
+
+namespace {
+
+// Build view*proj for a camera at `eye` looking toward `target` with the given
+// up, perspective FOVy (radians), aspect 1, near/far. Mirrors what
+// MeshDepthRenderer captures (Ogre::Camera::getViewMatrix/getProjectionMatrix).
+Ogre::Matrix4 makeViewProj(const Ogre::Vector3& eye, const Ogre::Vector3& target,
+                           const Ogre::Vector3& up, float fovY, float aspect,
+                           float nearC, float farC)
+{
+    // View matrix (right-handed look-at, world -> camera).
+    Ogre::Vector3 zAxis = (eye - target);   // camera looks down -Z
+    zAxis.normalise();
+    Ogre::Vector3 xAxis = up.crossProduct(zAxis); xAxis.normalise();
+    Ogre::Vector3 yAxis = zAxis.crossProduct(xAxis);
+    Ogre::Matrix4 view = Ogre::Matrix4::IDENTITY;
+    view[0][0] = xAxis.x; view[0][1] = xAxis.y; view[0][2] = xAxis.z; view[0][3] = -xAxis.dotProduct(eye);
+    view[1][0] = yAxis.x; view[1][1] = yAxis.y; view[1][2] = yAxis.z; view[1][3] = -yAxis.dotProduct(eye);
+    view[2][0] = zAxis.x; view[2][1] = zAxis.y; view[2][2] = zAxis.z; view[2][3] = -zAxis.dotProduct(eye);
+
+    // Perspective projection (OpenGL-style, clip z in [-1,1]).
+    const float f = 1.0f / std::tan(fovY * 0.5f);
+    Ogre::Matrix4 proj = Ogre::Matrix4::ZERO;
+    proj[0][0] = f / aspect;
+    proj[1][1] = f;
+    proj[2][2] = (farC + nearC) / (nearC - farC);
+    proj[2][3] = (2.0f * farC * nearC) / (nearC - farC);
+    proj[3][2] = -1.0f;
+    return proj * view;
+}
+
+// A solid-colour image.
+QImage solid(int size, int r, int g, int b)
+{
+    QImage img(size, size, QImage::Format_RGB888);
+    img.fill(qRgb(r, g, b));
+    return img;
+}
+
+// Two triangles forming a quad in the Z=0 plane spanning [-1,1] in X/Y, with
+// UV0 covering the full [0..1] atlas. `frontFacing` chooses the winding/normal:
+// +Z normal (faces a +Z camera) or -Z normal.
+std::vector<MultiViewTextureBaker::Triangle> makeQuad(const Ogre::Vector3& normal)
+{
+    const Ogre::Vector3 bl(-1, -1, 0), br(1, -1, 0), tr(1, 1, 0), tl(-1, 1, 0);
+    // UVs: bl=(0,1) br=(1,1) tr=(1,0) tl=(0,0) (top-left origin, V down).
+    const Ogre::Vector2 ubl(0, 1), ubr(1, 1), utr(1, 0), utl(0, 0);
+    MultiViewTextureBaker::Triangle t0, t1;
+    t0.p[0] = bl; t0.p[1] = br; t0.p[2] = tr;
+    t0.uv[0] = ubl; t0.uv[1] = ubr; t0.uv[2] = utr; t0.normal = normal;
+    t1.p[0] = bl; t1.p[1] = tr; t1.p[2] = tl;
+    t1.uv[0] = ubl; t1.uv[1] = utr; t1.uv[2] = utl; t1.normal = normal;
+    return { t0, t1 };
+}
+
+MultiViewTextureBaker::View frontView(const QImage& img)
+{
+    MultiViewTextureBaker::View v;
+    v.image = img;
+    // Camera on +Z looking toward -Z (origin). camDirection points INTO scene.
+    v.viewProj = makeViewProj(Ogre::Vector3(0, 0, 4), Ogre::Vector3(0, 0, 0),
+                              Ogre::Vector3::UNIT_Y, 1.2f, 1.0f, 0.1f, 100.0f);
+    v.camDirection = Ogre::Vector3(0, 0, -1);
+    return v;
+}
+
+MultiViewTextureBaker::View backView(const QImage& img)
+{
+    MultiViewTextureBaker::View v;
+    v.image = img;
+    v.viewProj = makeViewProj(Ogre::Vector3(0, 0, -4), Ogre::Vector3(0, 0, 0),
+                              Ogre::Vector3::UNIT_Y, 1.2f, 1.0f, 0.1f, 100.0f);
+    v.camDirection = Ogre::Vector3(0, 0, 1);
+    return v;
+}
+
+// Read the bake's colour at a UV (top-left origin).
+Ogre::ColourValue at(const TexturePaintBuffer& buf, float u, float v)
+{
+    int x = std::clamp(static_cast<int>(u * buf.width()), 0, buf.width() - 1);
+    int y = std::clamp(static_cast<int>(v * buf.height()), 0, buf.height() - 1);
+    return buf.pixel(x, y);
+}
+
+} // namespace
+
+TEST(MultiViewTextureBakerTest, EmptyInputsAreRejected)
+{
+    TexturePaintBuffer out;
+    MultiViewTextureBaker::Options opts;
+    EXPECT_FALSE(MultiViewTextureBaker::bake({}, { frontView(solid(8, 255, 0, 0)) }, out, opts).ok);
+    EXPECT_FALSE(MultiViewTextureBaker::bake(makeQuad(Ogre::Vector3::UNIT_Z), {}, out, opts).ok);
+    // A view with a null image is rejected.
+    MultiViewTextureBaker::View bad; bad.camDirection = Ogre::Vector3(0,0,-1);
+    EXPECT_FALSE(MultiViewTextureBaker::bake(makeQuad(Ogre::Vector3::UNIT_Z), { bad }, out, opts).ok);
+}
+
+TEST(MultiViewTextureBakerTest, FrontViewPaintsFrontFacingQuad)
+{
+    // A quad whose normal faces +Z, lit only by the +Z (front) camera with a
+    // red image, should come out red across the whole atlas.
+    auto tris = makeQuad(Ogre::Vector3::UNIT_Z);
+    TexturePaintBuffer out;
+    MultiViewTextureBaker::Options opts;
+    opts.resolution = 64;
+    opts.dilationPixels = 2;
+    auto rep = MultiViewTextureBaker::bake(tris, { frontView(solid(16, 255, 0, 0)) }, out, opts);
+    ASSERT_TRUE(rep.ok) << rep.error.toStdString();
+    EXPECT_GT(rep.pixelsWritten, 0);
+    EXPECT_EQ(rep.trianglesProjected, 2);  // both tris faced the front camera
+    EXPECT_EQ(out.width(), 64);
+
+    const Ogre::ColourValue c = at(out, 0.5f, 0.5f);  // centre of atlas
+    EXPECT_NEAR(c.r, 1.0f, 0.02f);
+    EXPECT_NEAR(c.g, 0.0f, 0.02f);
+    EXPECT_NEAR(c.b, 0.0f, 0.02f);
+    EXPECT_NEAR(c.a, 1.0f, 0.02f);
+}
+
+TEST(MultiViewTextureBakerTest, BackCameraSkipsFrontFacingQuad)
+{
+    // The same +Z-facing quad seen ONLY by the back (-Z) camera: facing weight
+    // is negative, so nothing is painted (transparent background remains).
+    auto tris = makeQuad(Ogre::Vector3::UNIT_Z);
+    TexturePaintBuffer out;
+    MultiViewTextureBaker::Options opts;
+    opts.resolution = 64;
+    opts.dilationPixels = 0;
+    auto rep = MultiViewTextureBaker::bake(tris, { backView(solid(16, 0, 0, 255)) }, out, opts);
+    ASSERT_TRUE(rep.ok) << rep.error.toStdString();
+    EXPECT_EQ(rep.pixelsWritten, 0);
+    EXPECT_EQ(rep.trianglesProjected, 0);
+    EXPECT_NEAR(at(out, 0.5f, 0.5f).a, 0.0f, 0.02f);  // background, untouched
+}
+
+TEST(MultiViewTextureBakerTest, FrontAndBackBlendByFacing)
+{
+    // Front-facing quad with BOTH a red front view and a blue back view.
+    // Only the front camera faces the +Z normal, so red must win regardless of
+    // the blue back image being supplied.
+    auto tris = makeQuad(Ogre::Vector3::UNIT_Z);
+    TexturePaintBuffer out;
+    MultiViewTextureBaker::Options opts;
+    opts.resolution = 64;
+    opts.dilationPixels = 2;
+    std::vector<MultiViewTextureBaker::View> views = {
+        frontView(solid(16, 255, 0, 0)),
+        backView(solid(16, 0, 0, 255)),
+    };
+    auto rep = MultiViewTextureBaker::bake(tris, views, out, opts);
+    ASSERT_TRUE(rep.ok) << rep.error.toStdString();
+    ASSERT_EQ(rep.perViewTriangleCount.size(), 2u);
+    EXPECT_EQ(rep.perViewTriangleCount[0], 2);  // front contributed
+    EXPECT_EQ(rep.perViewTriangleCount[1], 0);  // back culled by facing
+
+    const Ogre::ColourValue c = at(out, 0.5f, 0.5f);
+    EXPECT_NEAR(c.r, 1.0f, 0.02f);
+    EXPECT_NEAR(c.b, 0.0f, 0.02f);
+}
+
+TEST(MultiViewTextureBakerTest, DilationFillsBackgroundNeighbours)
+{
+    // With a sub-region quad (UVs in [0.25..0.75]) the atlas has a wide
+    // background margin; dilation must flip some of those background texels.
+    MultiViewTextureBaker::Triangle t0, t1;
+    const Ogre::Vector3 bl(-1,-1,0), br(1,-1,0), tr(1,1,0), tl(-1,1,0);
+    t0.p[0]=bl; t0.p[1]=br; t0.p[2]=tr;
+    t0.uv[0]=Ogre::Vector2(0.25f,0.75f); t0.uv[1]=Ogre::Vector2(0.75f,0.75f); t0.uv[2]=Ogre::Vector2(0.75f,0.25f);
+    t0.normal=Ogre::Vector3::UNIT_Z;
+    t1.p[0]=bl; t1.p[1]=tr; t1.p[2]=tl;
+    t1.uv[0]=Ogre::Vector2(0.25f,0.75f); t1.uv[1]=Ogre::Vector2(0.75f,0.25f); t1.uv[2]=Ogre::Vector2(0.25f,0.25f);
+    t1.normal=Ogre::Vector3::UNIT_Z;
+
+    TexturePaintBuffer out;
+    MultiViewTextureBaker::Options opts;
+    opts.resolution = 64;
+    opts.dilationPixels = 3;
+    auto rep = MultiViewTextureBaker::bake({t0,t1}, { frontView(solid(16, 0, 255, 0)) }, out, opts);
+    ASSERT_TRUE(rep.ok) << rep.error.toStdString();
+    EXPECT_GT(rep.pixelsWritten, 0);
+    EXPECT_GT(rep.pixelsDilated, 0);  // some background texels got smeared
+    // Centre is inside the island → green.
+    EXPECT_NEAR(at(out, 0.5f, 0.5f).g, 1.0f, 0.02f);
+}


### PR DESCRIPTION
Generates a diffuse texture by ControlNet-generating images from multiple camera views (front + back to start) and **projection-baking** them onto the mesh's existing UV0 atlas — replacing the prior planar bind that was unreliable on RTSS/PBR materials (#403 known limitation). See `src/MULTIVIEW_TEXTURE_BAKE_DESIGN.md`.

Key idea: the UV layout stays fixed; each view's generated image is re-projected through the **exact camera that produced its depth map** and rasterized into UV0 (this is a bake, not "recompute UVs from the image").

## Slice 1 — reprojection foundation
- `MeshDepthRenderer::renderDepthMapView(entity, size, View)` returns the depth image **plus the exact view/projection matrices + camera dir** used. Built-in front/back/left/right/top/bottom views. `renderDepthMap()` stays as the front-view delegate so #403 is unchanged.
- `MultiViewTextureBaker` (pure-data): per triangle × view, facing-weight cull (`max(0,-n·viewDir)^p`), project to viewport UV, rasterize in UV0 space, sample the view image at the barycentric-interpolated screen UV, accumulate `color×weight`; resolve by weight + seam-dilate (reuses `VertexColorBaker::dilate` + `TexturePaintBuffer`).
- Unit tests: synthetic ±Z quad + solid images assert front paints, back-only is culled, front+back blends by facing, dilation fills margins, empty-input guards. (Math also validated locally via a standalone harness.)

## Slice 2 — front+back orchestration + UV0 bake
- `MultiViewTextureBaker::fromEntity()` extracts world-space triangles + UV0 from a live entity (world matrix on positions, inverse-transpose on normals).
- `MaterialEditorQML::generateMeshTextureMultiView(prompt,w,h,strength,views)`: a state machine that renders each view's depth+matrices, generates one image per view sequentially through the SD worker, and on the final completion bakes the accumulated images onto UV0 and applies the atlas to the entity's diffuse. `onSDGenerationError` aborts cleanly. Defaults to `{front, back}`. `ENABLE_STABLE_DIFFUSION`-guarded.
- QML: "Bake front + back (projects onto UV map)" sub-toggle under the existing "use selected mesh" checkbox.

## Incidental fixes found while building this
- **Keychain prompt regression**: `migrateLegacySettingsIfNeeded()` re-probed the OS secret store on every signed-out launch (SecItemCopyMatching → macOS prompt). Now gated behind a persisted `Cloud/legacyMigrationDone` flag → probes at most once, ever. Regression test added.
- **Scene tree**: hide the persistent offscreen `QtMeshDepthCameraNode` from the Inspector (added to `Manager::isForbiddenNodeName`).

## Testing
- App + UnitTests build clean (macOS); manually verified front+back bake produces a correct texture on the model.
- Pure-data baker covered by unit tests; SD-driven orchestration is `#ifdef`-guarded (no model in CI), matching #403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-view AI texture baking that projects front and back views onto the mesh UV0 atlas for improved coverage and consistency.
  * Added **“Bake front + back (projects onto UV map)”** option to the texture generation UI (shown when mesh conditioning is available).

* **Bug Fixes**
  * Reduced repeated legacy cloud credential prompts by recording a one-time migration completion flag and avoiding repeated legacy probing.

* **Other**
  * Improved filtering of a depth-related scene node during processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->