### PR TITLE
feat(updater): UpdaterController + GitHub release parsing (#441)

### DIFF
--- a/docs/AUTO_UPDATER_DESIGN.md
+++ b/docs/AUTO_UPDATER_DESIGN.md
@@ -126,8 +126,8 @@ Version comparison reuses `UpdateVersion::compare()` (#442) — normalises optio
 
 | Issue | Work |
 |-------|------|
-| [#441](https://github.com/fernandotonon/QtMeshEditor/issues/441) | `UpdaterController` + GitHub JSON |
-| [#442](https://github.com/fernandotonon/QtMeshEditor/issues/442) | Semver compare (partially done — `UpdateVersion`) |
+| [#441](https://github.com/fernandotonon/QtMeshEditor/issues/441) | `UpdaterController` + GitHub JSON — **in progress** |
+| [#442](https://github.com/fernandotonon/QtMeshEditor/issues/442) | Semver compare — **done** (`UpdateVersion`) |
 | [#443](https://github.com/fernandotonon/QtMeshEditor/issues/443) | Wire `InstallFlavor` into UX |
 | [#444–445](https://github.com/fernandotonon/QtMeshEditor/issues/444) | Download + verify pipeline |
 | [#446–448](https://github.com/fernandotonon/QtMeshEditor/issues/446) | Relauncher + per-platform install |
@@ -144,4 +144,7 @@ Version comparison reuses `UpdateVersion::compare()` (#442) — normalises optio
 | `src/updater/MinisignVerify.*` | minisign verify PoC (Linux) |
 | `cmake/Libsodium.cmake` | Static libsodium fetch/build |
 | `tests/fixtures/updater/*` | Signed README fixture + test pubkey |
-| `scripts/generate-updater-fixtures.sh` | Regenerate fixtures locally |
+| `src/updater/GitHubReleaseParser.*` | GitHub Releases JSON parsing (#441) |
+| `src/updater/UpdaterWorker.*` | Worker-thread HTTP for update checks (#441) |
+| `src/updater/UpdaterController.*` | QML singleton orchestrating checks (#441) |
+| `tests/fixtures/updater/github-releases-sample.json` | Canned releases API fixture |

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,6 +99,9 @@ TexturePaintBuffer.cpp
 UpdateVersion.cpp
 updater/InstallFlavor.cpp
 updater/MinisignVerify.cpp
+updater/GitHubReleaseParser.cpp
+updater/UpdaterWorker.cpp
+updater/UpdaterController.cpp
 TexturePaintController.cpp
 VertexColorBaker.cpp
 VATBaker.cpp
@@ -234,6 +237,9 @@ TexturePaintBuffer.h
 UpdateVersion.h
 updater/InstallFlavor.h
 updater/MinisignVerify.h
+updater/GitHubReleaseParser.h
+updater/UpdaterWorker.h
+updater/UpdaterController.h
 TexturePaintController.h
 VertexColorBaker.h
 ApplyAtlas.h

--- a/src/UpdateVersion.cpp
+++ b/src/UpdateVersion.cpp
@@ -3,58 +3,148 @@
 #include <QRegularExpression>
 #include <QString>
 #include <QVersionNumber>
+#include <optional>
 
 namespace UpdateVersion {
 
-QString normalize(const QString& raw)
+namespace {
+
+struct ParsedVersion {
+    QVersionNumber core;
+    QString prereleaseSuffix; // text after `-`, before `+`; empty for stable tags
+};
+
+QString stripLeadingVAndBuildMetadata(QString s)
 {
-    QString s = raw.trimmed();
-    if (s.isEmpty()) return {};
-
-    // Strip a single leading `v` / `V`. Common GitHub habit.
-    if (s.startsWith(QLatin1Char('v')) || s.startsWith(QLatin1Char('V')))
+    if (s.startsWith(QLatin1Char('v')) || s.startsWith(QLatin1Char('V'))) {
         s = s.mid(1);
+    }
 
-    // Cut off pre-release / build metadata. Semver lets us treat
-    // anything after `-` or `+` as a non-numeric suffix; for the
-    // purposes of "is there a newer stable release" we just drop it.
-    // Use qsizetype (the indexOf return type) end-to-end so a future
-    // very-long-string input doesn't silently truncate in a 32-bit
-    // signed int (Sonar flagged the previous int form).
-    const qsizetype dash = s.indexOf(QLatin1Char('-'));
     const qsizetype plus = s.indexOf(QLatin1Char('+'));
-    qsizetype cut = -1;
-    if (dash >= 0) cut = dash;
-    if (plus >= 0 && (cut < 0 || plus < cut)) cut = plus;
-    if (cut >= 0) s = s.left(cut);
-
-    // Require the result to look like one or more dot-separated
-    // numeric components, nothing else. This blocks "latest",
-    // "main", and the empty string from being treated as a version.
-    static const QRegularExpression rx(QStringLiteral("^\\d+(?:\\.\\d+)*$"));
-    if (!rx.match(s).hasMatch()) return {};
-
+    if (plus >= 0) {
+        s = s.left(plus);
+    }
     return s;
 }
 
-Comparison compare(const QString& localVersion, const QString& remoteTag)
+std::optional<ParsedVersion> parseReleaseOnly(const QString& raw)
 {
-    const QString local = normalize(localVersion);
-    const QString remote = normalize(remoteTag);
-    if (local.isEmpty() || remote.isEmpty())
-        return Comparison::Invalid;
+    QString s = stripLeadingVAndBuildMetadata(raw.trimmed());
+    if (s.isEmpty()) {
+        return std::nullopt;
+    }
 
-    bool okL = false, okR = false;
-    const QVersionNumber lv = QVersionNumber::fromString(local, /*suffixIndex=*/nullptr);
-    const QVersionNumber rv = QVersionNumber::fromString(remote, /*suffixIndex=*/nullptr);
-    okL = !lv.isNull();
-    okR = !rv.isNull();
-    if (!okL || !okR) return Comparison::Invalid;
+    const qsizetype dash = s.indexOf(QLatin1Char('-'));
+    if (dash >= 0) {
+        s = s.left(dash);
+    }
 
-    const int cmp = QVersionNumber::compare(lv, rv);
-    if (cmp <  0) return Comparison::Older;
-    if (cmp >  0) return Comparison::Newer;
+    static const QRegularExpression rx(QStringLiteral("^\\d+(?:\\.\\d+)*$"));
+    if (!rx.match(s).hasMatch()) {
+        return std::nullopt;
+    }
+
+    const QVersionNumber core = QVersionNumber::fromString(s);
+    if (core.isNull()) {
+        return std::nullopt;
+    }
+    return ParsedVersion{core, {}};
+}
+
+std::optional<ParsedVersion> parseWithPrerelease(const QString& raw)
+{
+    QString s = stripLeadingVAndBuildMetadata(raw.trimmed());
+    if (s.isEmpty()) {
+        return std::nullopt;
+    }
+
+    QString corePart = s;
+    QString suffix;
+    const qsizetype dash = s.indexOf(QLatin1Char('-'));
+    if (dash >= 0) {
+        corePart = s.left(dash);
+        suffix = s.mid(dash + 1);
+    }
+
+    static const QRegularExpression rx(QStringLiteral("^\\d+(?:\\.\\d+)*$"));
+    if (!rx.match(corePart).hasMatch()) {
+        return std::nullopt;
+    }
+
+    const QVersionNumber core = QVersionNumber::fromString(corePart);
+    if (core.isNull()) {
+        return std::nullopt;
+    }
+    return ParsedVersion{core, suffix};
+}
+
+Comparison compareParsed(const ParsedVersion& local, const ParsedVersion& remote)
+{
+    const int coreCmp = QVersionNumber::compare(local.core, remote.core);
+    if (coreCmp < 0) {
+        return Comparison::Older;
+    }
+    if (coreCmp > 0) {
+        return Comparison::Newer;
+    }
+
+    if (local.prereleaseSuffix.isEmpty() && remote.prereleaseSuffix.isEmpty()) {
+        return Comparison::Same;
+    }
+    if (local.prereleaseSuffix.isEmpty()) {
+        return Comparison::Newer;
+    }
+    if (remote.prereleaseSuffix.isEmpty()) {
+        return Comparison::Older;
+    }
+
+    const int suffixCmp =
+        QString::compare(local.prereleaseSuffix, remote.prereleaseSuffix, Qt::CaseInsensitive);
+    if (suffixCmp < 0) {
+        return Comparison::Older;
+    }
+    if (suffixCmp > 0) {
+        return Comparison::Newer;
+    }
     return Comparison::Same;
+}
+
+} // namespace
+
+QString normalize(const QString& raw)
+{
+    const auto parsed = parseReleaseOnly(raw);
+    if (!parsed) {
+        return {};
+    }
+
+    QString s = stripLeadingVAndBuildMetadata(raw.trimmed());
+    const qsizetype dash = s.indexOf(QLatin1Char('-'));
+    if (dash >= 0) {
+        s = s.left(dash);
+    }
+    return s;
+}
+
+Comparison compare(const QString& localVersion,
+                   const QString& remoteTag,
+                   const CompareMode mode)
+{
+    if (mode == CompareMode::ReleaseOnly) {
+        const auto local = parseReleaseOnly(localVersion);
+        const auto remote = parseReleaseOnly(remoteTag);
+        if (!local || !remote) {
+            return Comparison::Invalid;
+        }
+        return compareParsed(*local, *remote);
+    }
+
+    const auto local = parseWithPrerelease(localVersion);
+    const auto remote = parseWithPrerelease(remoteTag);
+    if (!local || !remote) {
+        return Comparison::Invalid;
+    }
+    return compareParsed(*local, *remote);
 }
 
 } // namespace UpdateVersion

--- a/src/UpdateVersion.h
+++ b/src/UpdateVersion.h
@@ -27,6 +27,11 @@ enum class Comparison {
     Invalid =  2,  ///< at least one input couldn't be parsed at all
 };
 
+enum class CompareMode {
+    ReleaseOnly,     ///< Ignore `-rc`/`-beta` suffixes (stable channel default)
+    WithPrerelease,  ///< Compare full semver including pre-release segment
+};
+
 /**
  * @brief Normalise a version-ish string into a canonical `X.Y.Z` form.
  *
@@ -50,7 +55,9 @@ QString normalize(const QString& raw);
  * treat Invalid as "do nothing" rather than "update available" — a
  * malformed release tag from the API shouldn't prompt the user.
  */
-Comparison compare(const QString& localVersion, const QString& remoteTag);
+Comparison compare(const QString& localVersion,
+                   const QString& remoteTag,
+                   CompareMode mode = CompareMode::ReleaseOnly);
 
 /// True iff `remoteTag` represents a version strictly newer than
 /// `localVersion`. Convenience wrapper used by the UI to decide

--- a/src/UpdateVersion_test.cpp
+++ b/src/UpdateVersion_test.cpp
@@ -77,6 +77,19 @@ TEST(UpdateVersion, CompareIgnoresPrereleaseSuffix)
     EXPECT_EQ(UpdateVersion::compare("3.2.0", "3.2.0-rc1"), Comparison::Same);
 }
 
+TEST(UpdateVersion, ComparePrereleaseSuffixWhenModeIncludesPrerelease)
+{
+    EXPECT_EQ(UpdateVersion::compare("3.6.0-beta.1", "3.6.0-beta.2",
+                                     UpdateVersion::CompareMode::WithPrerelease),
+              Comparison::Older);
+    EXPECT_EQ(UpdateVersion::compare("3.6.0-beta.2", "3.6.0-beta.1",
+                                     UpdateVersion::CompareMode::WithPrerelease),
+              Comparison::Newer);
+    EXPECT_EQ(UpdateVersion::compare("3.6.0-beta.1", "3.6.0-beta.1",
+                                     UpdateVersion::CompareMode::WithPrerelease),
+              Comparison::Same);
+}
+
 TEST(UpdateVersion, CompareInvalidWhenAnyInputUnparseable)
 {
     EXPECT_EQ(UpdateVersion::compare("", "3.2.0"),       Comparison::Invalid);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -28,7 +28,7 @@
 #include <QFileInfo>
 #include <QEvent>
 #include "SentryReporter.h"
-#include "UpdateVersion.h"
+#include "updater/UpdaterController.h"
 #include <QDialog>
 #include <QProgressDialog>
 #include <QThread>
@@ -4433,86 +4433,8 @@ void MainWindow::custom_Palette_Color_Selected(const QColor &color)
 // LCOV_EXCL_START — network request
 void MainWindow::on_actionVerify_Update_triggered()
 {
-    // Verify if the latest release on GitHub is equal to the current version
-    // If not, ask the user if he wants to update
-    // If yes, download the latest release and install it
-
-    auto networkManager = new QNetworkAccessManager(this);
-
-    // Send a GET request to the GitHub API to retrieve the latest release information
-    QNetworkRequest request(QUrl("https://api.github.com/repos/fernandotonon/QtMeshEditor/releases/latest"));
-    QNetworkReply* reply = networkManager->get(request);
-
-    // Connect the finished signal to a slot to handle the response
-    connect(reply, &QNetworkReply::finished, this, [=]() {
-        if (reply->error() == QNetworkReply::NoError) {
-            // Read the response data
-            QByteArray data = reply->readAll();
-
-            // Parse the JSON response
-            QJsonDocument doc = QJsonDocument::fromJson(data);
-            QJsonObject obj = doc.object();
-
-            // Compare the GitHub release tag against the running build
-            // through UpdateVersion: normalises a leading `v`, handles
-            // semver suffixes, and uses QVersionNumber so e.g. 3.10.0
-            // ranks above 3.2.0 (the old string-equality test got both
-            // of those wrong). Only prompt when the remote is strictly
-            // newer — Invalid / Same / Newer all stay quiet so a
-            // malformed API response doesn't permanently nag the user.
-            const QString latestVersion = obj.value("tag_name").toString();
-            const QString currentVersion = QApplication::applicationVersion();
-            const UpdateVersion::Comparison cmp =
-                UpdateVersion::compare(currentVersion, latestVersion);
-            if (cmp == UpdateVersion::Comparison::Older) {
-                SentryReporter::addBreadcrumb(
-                    "ui.action",
-                    QStringLiteral("Update available: %1 -> %2")
-                        .arg(currentVersion, latestVersion));
-                // Renamed from `reply` to dodge the outer-scope
-                // QNetworkReply* (Sonar flagged it as shadowing).
-                const QMessageBox::StandardButton userChoice =
-                    QMessageBox::question(
-                        nullptr, tr("Update"),
-                        tr("A new version is available (%1 → %2). Do you want to update?")
-                            .arg(currentVersion, latestVersion),
-                        QMessageBox::Yes | QMessageBox::No);
-                if (userChoice == QMessageBox::Yes) {
-                    SentryReporter::addBreadcrumb(
-                        "ui.action", "Open latest release page");
-                    QString downloadUrl = obj.value("html_url").toString();
-                    QDesktopServices::openUrl(QUrl(downloadUrl));
-                }
-            } else if (cmp == UpdateVersion::Comparison::Invalid) {
-                SentryReporter::addBreadcrumb(
-                    "ui.action", "Update check returned unparsable version data");
-                // Don't bother the user — log it and move on.
-                Ogre::LogManager::getSingleton().logMessage(
-                    "Update check: could not parse versions '"
-                    + currentVersion.toStdString() + "' / '"
-                    + latestVersion.toStdString() + "'");
-            } else {
-                SentryReporter::addBreadcrumb(
-                    "ui.action", "Already on latest release");
-                QMessageBox::information(
-                    nullptr, tr("Update"),
-                    tr("You're using the latest release."));
-            }
-        } else {
-            // Handle the error
-            Ogre::LogManager::getSingleton().logMessage(reply->errorString().toStdString());
-        }
-
-        // Clean up
-        networkManager->deleteLater();
-        reply->deleteLater();
-    });
-
-    // Connect the SSL errors signal to a slot to handle SSL errors
-    connect(networkManager, &QNetworkAccessManager::sslErrors, this, [=](QNetworkReply* reply, const QList<QSslError>& errors) {
-        // Ignore SSL errors
-        reply->ignoreSslErrors();
-    });
+    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"), QStringLiteral("Check for updates"));
+    UpdaterController::instance()->checkForUpdates();
 }
 // LCOV_EXCL_STOP
 

--- a/src/updater/GitHubReleaseParser.cpp
+++ b/src/updater/GitHubReleaseParser.cpp
@@ -1,0 +1,142 @@
+#include "GitHubReleaseParser.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonValue>
+
+namespace GitHubReleaseParser {
+
+namespace {
+
+ReleaseAsset parseAssetObject(const QJsonObject& obj)
+{
+    ReleaseAsset asset;
+    asset.name = obj.value(QStringLiteral("name")).toString();
+    asset.browserDownloadUrl = obj.value(QStringLiteral("browser_download_url")).toString();
+    asset.size = obj.value(QStringLiteral("size")).toDouble();
+    return asset;
+}
+
+bool releaseMatchesChannel(const ParsedRelease& release, Channel channel)
+{
+    switch (channel) {
+    case Channel::Stable:
+        return release.valid && !release.prerelease;
+    case Channel::Beta:
+        return release.valid && release.prerelease;
+    }
+    return false;
+}
+
+} // namespace
+
+ParsedRelease parseReleaseObject(const QJsonObject& obj)
+{
+    ParsedRelease release;
+    release.tagName = obj.value(QStringLiteral("tag_name")).toString();
+    release.name = obj.value(QStringLiteral("name")).toString();
+    release.body = obj.value(QStringLiteral("body")).toString();
+    release.htmlUrl = obj.value(QStringLiteral("html_url")).toString();
+    release.prerelease = obj.value(QStringLiteral("prerelease")).toBool(false);
+    release.publishedAt = obj.value(QStringLiteral("published_at")).toString();
+
+    const QJsonArray assets = obj.value(QStringLiteral("assets")).toArray();
+    for (const QJsonValue& value : assets) {
+        if (!value.isObject()) {
+            continue;
+        }
+        release.assets.append(parseAssetObject(value.toObject()));
+    }
+
+    release.valid = !release.tagName.isEmpty() && !release.htmlUrl.isEmpty();
+    return release;
+}
+
+CheckResult pickLatestForChannel(const QByteArray& releasesJson,
+                                 Channel channel,
+                                 const QString& localVersion)
+{
+    CheckResult result;
+
+    const QJsonDocument doc = QJsonDocument::fromJson(releasesJson);
+    if (!doc.isArray()) {
+        result.errorMessage = QStringLiteral("GitHub releases response is not a JSON array");
+        return result;
+    }
+
+    const QJsonArray releases = doc.array();
+    ParsedRelease chosen;
+    ParsedRelease stableFallback;
+
+    for (const QJsonValue& value : releases) {
+        if (!value.isObject()) {
+            continue;
+        }
+        const ParsedRelease parsed = parseReleaseObject(value.toObject());
+        if (!parsed.valid) {
+            continue;
+        }
+
+        if (channel == Channel::Stable && !parsed.prerelease) {
+            chosen = parsed;
+            break;
+        }
+
+        if (channel == Channel::Beta) {
+            if (parsed.prerelease && !chosen.valid) {
+                chosen = parsed;
+            }
+            if (!parsed.prerelease && !stableFallback.valid) {
+                stableFallback = parsed;
+            }
+        }
+    }
+
+    if (channel == Channel::Beta && !chosen.valid && stableFallback.valid) {
+        chosen = stableFallback;
+    }
+
+    if (!chosen.valid) {
+        result.errorMessage = QStringLiteral("No matching release found for channel");
+        return result;
+    }
+
+    result.parseOk = true;
+    result.release = chosen;
+    result.comparison = UpdateVersion::compare(localVersion, chosen.tagName);
+    return result;
+}
+
+QString channelToString(Channel channel)
+{
+    switch (channel) {
+    case Channel::Stable:
+        return QStringLiteral("stable");
+    case Channel::Beta:
+        return QStringLiteral("beta");
+    }
+    return QStringLiteral("stable");
+}
+
+Channel channelFromString(const QString& slug, bool* ok)
+{
+    const QString normalized = slug.trimmed().toLower();
+    if (normalized == QStringLiteral("stable") || normalized.isEmpty()) {
+        if (ok) {
+            *ok = true;
+        }
+        return Channel::Stable;
+    }
+    if (normalized == QStringLiteral("beta")) {
+        if (ok) {
+            *ok = true;
+        }
+        return Channel::Beta;
+    }
+    if (ok) {
+        *ok = false;
+    }
+    return Channel::Stable;
+}
+
+} // namespace GitHubReleaseParser

--- a/src/updater/GitHubReleaseParser.cpp
+++ b/src/updater/GitHubReleaseParser.cpp
@@ -103,7 +103,9 @@ CheckResult pickLatestForChannel(const QByteArray& releasesJson,
 
     result.parseOk = true;
     result.release = chosen;
-    result.comparison = UpdateVersion::compare(localVersion, chosen.tagName);
+    const auto compareMode = channel == Channel::Beta ? UpdateVersion::CompareMode::WithPrerelease
+                                                      : UpdateVersion::CompareMode::ReleaseOnly;
+    result.comparison = UpdateVersion::compare(localVersion, chosen.tagName, compareMode);
     return result;
 }
 

--- a/src/updater/GitHubReleaseParser.h
+++ b/src/updater/GitHubReleaseParser.h
@@ -1,0 +1,69 @@
+#ifndef GITHUBRELEASEPARSER_H
+#define GITHUBRELEASEPARSER_H
+
+#include "UpdateVersion.h"
+
+#include <QMetaType>
+#include <QJsonObject>
+#include <QList>
+#include <QString>
+
+/**
+ * @brief Pure-data parser for GitHub Releases API JSON (#441).
+ *
+ * Keeps network and UI out of the parsing path so unit tests can feed
+ * canned fixtures without a GL context or live HTTP.
+ */
+namespace GitHubReleaseParser {
+
+enum class Channel {
+    Stable,
+    Beta,
+};
+
+struct ReleaseAsset {
+    QString name;
+    QString browserDownloadUrl;
+    qint64 size = 0;
+};
+
+struct ParsedRelease {
+    QString tagName;
+    QString name;
+    QString body;
+    QString htmlUrl;
+    bool prerelease = false;
+    QString publishedAt;
+    QList<ReleaseAsset> assets;
+    bool valid = false;
+};
+
+struct CheckResult {
+    bool parseOk = false;
+    ParsedRelease release;
+    UpdateVersion::Comparison comparison = UpdateVersion::Comparison::Invalid;
+    QString errorMessage;
+};
+
+/// Parse one release object from the `/releases` array.
+ParsedRelease parseReleaseObject(const QJsonObject& obj);
+
+/**
+ * @brief Pick the newest release for @p channel and compare against @p localVersion.
+ *
+ * Stable channel skips `prerelease: true` entries. Beta channel prefers the
+ * first prerelease in API order (newest-first), falling back to the newest
+ * stable release when no prerelease exists.
+ */
+CheckResult pickLatestForChannel(const QByteArray& releasesJson,
+                                 Channel channel,
+                                 const QString& localVersion);
+
+QString channelToString(Channel channel);
+Channel channelFromString(const QString& slug, bool* ok = nullptr);
+
+} // namespace GitHubReleaseParser
+
+Q_DECLARE_METATYPE(GitHubReleaseParser::Channel)
+
+#endif // GITHUBRELEASEPARSER_H

--- a/src/updater/GitHubReleaseParser_test.cpp
+++ b/src/updater/GitHubReleaseParser_test.cpp
@@ -38,7 +38,7 @@ TEST(GitHubReleaseParser, ParsesReleaseFieldsAndAssets)
 
     const QJsonDocument doc = QJsonDocument::fromJson(json);
     ASSERT_TRUE(doc.isArray());
-    const auto release = GitHubReleaseParser::parseReleaseObject(doc.array().at(1).toObject());
+    const auto release = GitHubReleaseParser::parseReleaseObject(doc.array().at(2).toObject());
 
     EXPECT_TRUE(release.valid);
     EXPECT_EQ(release.tagName, QStringLiteral("3.5.3"));
@@ -80,8 +80,19 @@ TEST(GitHubReleaseParser, BetaChannelPrefersPrerelease)
         GitHubReleaseParser::pickLatestForChannel(json, Channel::Beta, QStringLiteral("3.5.3"));
 
     ASSERT_TRUE(result.parseOk);
-    EXPECT_EQ(result.release.tagName, QStringLiteral("3.6.0-beta.1"));
+    EXPECT_EQ(result.release.tagName, QStringLiteral("3.6.0-beta.2"));
     EXPECT_TRUE(result.release.prerelease);
+    EXPECT_EQ(result.comparison, Comparison::Older);
+}
+
+TEST(GitHubReleaseParser, BetaChannelDetectsPrereleaseBump)
+{
+    const QByteArray json = loadFixture("github-releases-sample.json");
+    const CheckResult result = GitHubReleaseParser::pickLatestForChannel(
+        json, Channel::Beta, QStringLiteral("3.6.0-beta.1"));
+
+    ASSERT_TRUE(result.parseOk);
+    EXPECT_EQ(result.release.tagName, QStringLiteral("3.6.0-beta.2"));
     EXPECT_EQ(result.comparison, Comparison::Older);
 }
 

--- a/src/updater/GitHubReleaseParser_test.cpp
+++ b/src/updater/GitHubReleaseParser_test.cpp
@@ -1,0 +1,95 @@
+#include <gtest/gtest.h>
+
+#include <QDir>
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QString>
+
+#include "GitHubReleaseParser.h"
+
+namespace {
+
+using GitHubReleaseParser::Channel;
+using GitHubReleaseParser::CheckResult;
+using UpdateVersion::Comparison;
+
+QString fixturePath(const char* name)
+{
+    return QDir(QStringLiteral(QTMESH_UT_SOURCE_ROOT))
+        .filePath(QStringLiteral("tests/fixtures/updater/%1").arg(QString::fromUtf8(name)));
+}
+
+QByteArray loadFixture(const char* name)
+{
+    QFile file(fixturePath(name));
+    if (!file.open(QIODevice::ReadOnly)) {
+        return {};
+    }
+    return file.readAll();
+}
+
+} // namespace
+
+TEST(GitHubReleaseParser, ParsesReleaseFieldsAndAssets)
+{
+    const QByteArray json = loadFixture("github-releases-sample.json");
+    ASSERT_FALSE(json.isEmpty());
+
+    const QJsonDocument doc = QJsonDocument::fromJson(json);
+    ASSERT_TRUE(doc.isArray());
+    const auto release = GitHubReleaseParser::parseReleaseObject(doc.array().at(1).toObject());
+
+    EXPECT_TRUE(release.valid);
+    EXPECT_EQ(release.tagName, QStringLiteral("3.5.3"));
+    EXPECT_EQ(release.name, QStringLiteral("3.5.3"));
+    EXPECT_EQ(release.body, QStringLiteral("Stable release notes."));
+    EXPECT_EQ(release.htmlUrl,
+              QStringLiteral("https://github.com/fernandotonon/QtMeshEditor/releases/tag/3.5.3"));
+    EXPECT_FALSE(release.prerelease);
+    ASSERT_EQ(release.assets.size(), 2);
+    EXPECT_EQ(release.assets.at(0).name,
+              QStringLiteral("QtMeshEditor-3.5.3-bin-Windows.zip"));
+}
+
+TEST(GitHubReleaseParser, StableChannelSkipsPrereleases)
+{
+    const QByteArray json = loadFixture("github-releases-sample.json");
+    const CheckResult result =
+        GitHubReleaseParser::pickLatestForChannel(json, Channel::Stable, QStringLiteral("3.5.2"));
+
+    ASSERT_TRUE(result.parseOk) << result.errorMessage.toStdString();
+    EXPECT_EQ(result.release.tagName, QStringLiteral("3.5.3"));
+    EXPECT_EQ(result.comparison, Comparison::Older);
+}
+
+TEST(GitHubReleaseParser, StableChannelReportsUpToDate)
+{
+    const QByteArray json = loadFixture("github-releases-sample.json");
+    const CheckResult result =
+        GitHubReleaseParser::pickLatestForChannel(json, Channel::Stable, QStringLiteral("3.5.3"));
+
+    ASSERT_TRUE(result.parseOk);
+    EXPECT_EQ(result.comparison, Comparison::Same);
+}
+
+TEST(GitHubReleaseParser, BetaChannelPrefersPrerelease)
+{
+    const QByteArray json = loadFixture("github-releases-sample.json");
+    const CheckResult result =
+        GitHubReleaseParser::pickLatestForChannel(json, Channel::Beta, QStringLiteral("3.5.3"));
+
+    ASSERT_TRUE(result.parseOk);
+    EXPECT_EQ(result.release.tagName, QStringLiteral("3.6.0-beta.1"));
+    EXPECT_TRUE(result.release.prerelease);
+    EXPECT_EQ(result.comparison, Comparison::Older);
+}
+
+TEST(GitHubReleaseParser, RejectsNonArrayPayload)
+{
+    const CheckResult result = GitHubReleaseParser::pickLatestForChannel(
+        QByteArray("{\"tag_name\":\"3.5.3\"}"), Channel::Stable, QStringLiteral("3.5.0"));
+
+    EXPECT_FALSE(result.parseOk);
+    EXPECT_FALSE(result.errorMessage.isEmpty());
+}

--- a/src/updater/UpdaterController.cpp
+++ b/src/updater/UpdaterController.cpp
@@ -1,0 +1,274 @@
+#include "UpdaterController.h"
+#include "UpdaterWorker.h"
+#include "SentryReporter.h"
+
+#include <QApplication>
+#include <QCoreApplication>
+#include <QDesktopServices>
+#include <QMessageBox>
+#include <QUrl>
+
+namespace {
+
+constexpr const char* kDefaultReleasesApi =
+    "https://api.github.com/repos/fernandotonon/QtMeshEditor/releases?per_page=20";
+
+} // namespace
+
+UpdaterController* UpdaterController::s_instance = nullptr;
+
+UpdaterController* UpdaterController::instance()
+{
+    if (!s_instance) {
+        s_instance = new UpdaterController();
+    }
+    return s_instance;
+}
+
+UpdaterController* UpdaterController::qmlInstance(QQmlEngine* engine, QJSEngine* scriptEngine)
+{
+    Q_UNUSED(engine)
+    Q_UNUSED(scriptEngine)
+    return instance();
+}
+
+UpdaterController::UpdaterController(QObject* parent)
+    : QObject(parent)
+{
+    qRegisterMetaType<GitHubReleaseParser::Channel>("GitHubReleaseParser::Channel");
+    refreshInstallFlavor();
+
+    m_workerThread = new QThread(this);
+    m_worker = new UpdaterWorker();
+    m_worker->moveToThread(m_workerThread);
+
+    connect(m_worker, &UpdaterWorker::checkFinished, this,
+            [this](const GitHubReleaseParser::CheckResult& result, const QString& networkError) {
+                if (!networkError.isEmpty()) {
+                    setState(State::Error);
+                    setError(networkError);
+                    SentryReporter::addBreadcrumb(
+                        QStringLiteral("updater.check.error"),
+                        networkError,
+                        QStringLiteral("error"));
+                    emit checkError(networkError);
+                    presentCheckOutcome();
+                    return;
+                }
+
+                applyCheckResult(result);
+                if (!result.parseOk) {
+                    setState(State::Error);
+                    setError(result.errorMessage);
+                    SentryReporter::addBreadcrumb(
+                        QStringLiteral("updater.check.error"),
+                        result.errorMessage,
+                        QStringLiteral("error"));
+                    emit checkError(result.errorMessage);
+                    presentCheckOutcome();
+                    return;
+                }
+
+                SentryReporter::addBreadcrumb(
+                    QStringLiteral("updater.check.success"),
+                    QStringLiteral("remote=%1 comparison=%2")
+                        .arg(result.release.tagName)
+                        .arg(static_cast<int>(result.comparison)));
+                presentCheckOutcome();
+            });
+
+    connect(m_workerThread, &QThread::finished, m_worker, &QObject::deleteLater);
+    m_workerThread->start();
+}
+
+UpdaterController::~UpdaterController()
+{
+    if (m_worker) {
+        QMetaObject::invokeMethod(m_worker, &UpdaterWorker::cancelActiveRequest,
+                                  Qt::BlockingQueuedConnection);
+    }
+    if (m_workerThread) {
+        m_workerThread->quit();
+        m_workerThread->wait();
+    }
+}
+
+void UpdaterController::refreshInstallFlavor()
+{
+    m_flavor = InstallFlavor::detect(QCoreApplication::applicationFilePath());
+    const QString slug = InstallFlavor::toSlug(m_flavor);
+    if (slug != m_installFlavor) {
+        m_installFlavor = slug;
+        emit installFlavorChanged();
+    }
+}
+
+void UpdaterController::setChannel(const QString& channel)
+{
+    bool ok = false;
+    const GitHubReleaseParser::Channel parsed = GitHubReleaseParser::channelFromString(channel, &ok);
+    const QString normalized =
+        GitHubReleaseParser::channelToString(ok ? parsed : GitHubReleaseParser::Channel::Stable);
+    if (normalized == m_channel) {
+        return;
+    }
+    m_channel = normalized;
+    emit channelChanged();
+}
+
+GitHubReleaseParser::Channel UpdaterController::activeChannel() const
+{
+    return GitHubReleaseParser::channelFromString(m_channel);
+}
+
+void UpdaterController::setState(State state)
+{
+    if (m_state == state) {
+        return;
+    }
+    m_state = state;
+    emit stateChanged();
+}
+
+void UpdaterController::setError(const QString& error)
+{
+    if (m_error == error) {
+        return;
+    }
+    m_error = error;
+    emit errorChanged();
+}
+
+void UpdaterController::applyCheckResult(const GitHubReleaseParser::CheckResult& result)
+{
+    m_lastComparison = result.comparison;
+    m_latestVersion = result.release.tagName;
+    m_latestUrl = result.release.htmlUrl;
+    m_changelog = result.release.body;
+    emit latestVersionChanged();
+    emit latestUrlChanged();
+    emit changelogChanged();
+
+    switch (result.comparison) {
+    case UpdateVersion::Comparison::Older:
+        setState(State::UpdateAvailable);
+        emit updateAvailable(m_localVersion, m_latestVersion);
+        break;
+    case UpdateVersion::Comparison::Same:
+    case UpdateVersion::Comparison::Newer:
+        setState(State::UpToDate);
+        emit noUpdate();
+        break;
+    case UpdateVersion::Comparison::Invalid:
+        setState(State::Error);
+        setError(QStringLiteral("Could not compare versions '%1' / '%2'")
+                     .arg(m_localVersion, m_latestVersion));
+        emit checkError(m_error);
+        break;
+    }
+}
+
+void UpdaterController::presentCheckOutcome()
+{
+    if (InstallFlavor::isPackageManagerManaged(m_flavor)) {
+        const QString hint = InstallFlavor::updateCommandHint(m_flavor);
+        QMessageBox::information(
+            nullptr,
+            tr("Update"),
+            tr("Updates for %1 installs are managed by your package manager.\n\nRun:\n%2")
+                .arg(InstallFlavor::displayName(m_flavor), hint));
+        setState(State::Idle);
+        return;
+    }
+
+    switch (m_state) {
+    case State::UpdateAvailable: {
+        const QMessageBox::StandardButton choice = QMessageBox::question(
+            nullptr,
+            tr("Update"),
+            tr("A new version is available (%1 → %2). Do you want to open the release page?")
+                .arg(m_localVersion, m_latestVersion),
+            QMessageBox::Yes | QMessageBox::No);
+        if (choice == QMessageBox::Yes) {
+            SentryReporter::addBreadcrumb(QStringLiteral("updater.check"),
+                                          QStringLiteral("Open release page"));
+            QDesktopServices::openUrl(QUrl(m_latestUrl));
+        }
+        setState(State::Idle);
+        break;
+    }
+    case State::UpToDate:
+        QMessageBox::information(nullptr, tr("Update"), tr("You're using the latest release."));
+        setState(State::Idle);
+        break;
+    case State::Error:
+        QMessageBox::warning(
+            nullptr,
+            tr("Update"),
+            tr("Could not check for updates.\n\n%1").arg(m_error));
+        setState(State::Idle);
+        break;
+    default:
+        break;
+    }
+}
+
+void UpdaterController::checkForUpdates()
+{
+    refreshInstallFlavor();
+    m_localVersion = QApplication::applicationVersion();
+    setError(QString());
+
+    if (InstallFlavor::isPackageManagerManaged(m_flavor)) {
+        SentryReporter::addBreadcrumb(
+            QStringLiteral("updater.check.start"),
+            QStringLiteral("package-manager flavor=%1").arg(m_installFlavor));
+        presentCheckOutcome();
+        return;
+    }
+
+    if (m_state == State::Checking) {
+        return;
+    }
+
+    SentryReporter::addBreadcrumb(
+        QStringLiteral("updater.check.start"),
+        QStringLiteral("channel=%1 local=%2").arg(m_channel, m_localVersion));
+    setState(State::Checking);
+
+    const QString localVersion = m_localVersion;
+    const auto channel = activeChannel();
+    QMetaObject::invokeMethod(
+        m_worker,
+        "checkForUpdates",
+        Qt::QueuedConnection,
+        Q_ARG(QString, QString::fromUtf8(kDefaultReleasesApi)),
+        Q_ARG(QString, localVersion),
+        Q_ARG(GitHubReleaseParser::Channel, channel));
+}
+
+void UpdaterController::downloadAndInstall()
+{
+    SentryReporter::addBreadcrumb(QStringLiteral("updater.download"),
+                                  QStringLiteral("downloadAndInstall not implemented yet"));
+    setError(tr("Automatic download and install is not available yet."));
+    setState(State::Error);
+    emit checkError(m_error);
+}
+
+void UpdaterController::cancel()
+{
+    if (m_worker) {
+        QMetaObject::invokeMethod(m_worker, &UpdaterWorker::cancelActiveRequest,
+                                  Qt::QueuedConnection);
+    }
+    if (m_state == State::Checking) {
+        setState(State::Idle);
+    }
+}
+
+void UpdaterController::dismiss()
+{
+    setState(State::Idle);
+    setError(QString());
+}

--- a/src/updater/UpdaterController.h
+++ b/src/updater/UpdaterController.h
@@ -1,0 +1,108 @@
+#ifndef UPDATERCONTROLLER_H
+#define UPDATERCONTROLLER_H
+
+#include "GitHubReleaseParser.h"
+#include "InstallFlavor.h"
+
+#include <QObject>
+#include <QQmlEngine>
+#include <QJSEngine>
+#include <QThread>
+
+/**
+ * @brief QML-facing singleton orchestrating update checks (#441).
+ *
+ * Mirrors the LLMManager / SDManager pattern: main-thread controller with
+ * a worker thread for HTTP. Download/install land in #444–448.
+ */
+class UpdaterController : public QObject
+{
+    Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
+
+    Q_PROPERTY(State state READ state NOTIFY stateChanged)
+    Q_PROPERTY(QString latestVersion READ latestVersion NOTIFY latestVersionChanged)
+    Q_PROPERTY(QString latestUrl READ latestUrl NOTIFY latestUrlChanged)
+    Q_PROPERTY(QString changelog READ changelog NOTIFY changelogChanged)
+    Q_PROPERTY(int progress READ progress NOTIFY progressChanged)
+    Q_PROPERTY(QString error READ error NOTIFY errorChanged)
+    Q_PROPERTY(QString channel READ channel WRITE setChannel NOTIFY channelChanged)
+    Q_PROPERTY(QString installFlavor READ installFlavor NOTIFY installFlavorChanged)
+
+public:
+    enum class State {
+        Idle = 0,
+        Checking,
+        UpdateAvailable,
+        UpToDate,
+        Error,
+        Downloading,
+        Verifying,
+        ReadyToInstall,
+    };
+    Q_ENUM(State)
+
+    static UpdaterController* instance();
+    static UpdaterController* qmlInstance(QQmlEngine* engine, QJSEngine* scriptEngine);
+
+    State state() const { return m_state; }
+    QString latestVersion() const { return m_latestVersion; }
+    QString latestUrl() const { return m_latestUrl; }
+    QString changelog() const { return m_changelog; }
+    int progress() const { return m_progress; }
+    QString error() const { return m_error; }
+    QString channel() const { return m_channel; }
+    QString installFlavor() const { return m_installFlavor; }
+
+    void setChannel(const QString& channel);
+
+    Q_INVOKABLE void checkForUpdates();
+    Q_INVOKABLE void downloadAndInstall();
+    Q_INVOKABLE void cancel();
+    Q_INVOKABLE void dismiss();
+
+signals:
+    void stateChanged();
+    void latestVersionChanged();
+    void latestUrlChanged();
+    void changelogChanged();
+    void progressChanged();
+    void errorChanged();
+    void channelChanged();
+    void installFlavorChanged();
+
+    void updateAvailable(const QString& currentVersion, const QString& latestVersion);
+    void noUpdate();
+    void checkError(const QString& message);
+
+private:
+    explicit UpdaterController(QObject* parent = nullptr);
+    ~UpdaterController() override;
+
+    void setState(State state);
+    void setError(const QString& error);
+    void applyCheckResult(const GitHubReleaseParser::CheckResult& result);
+    void presentCheckOutcome();
+    GitHubReleaseParser::Channel activeChannel() const;
+    void refreshInstallFlavor();
+
+    static UpdaterController* s_instance;
+
+    QThread* m_workerThread = nullptr;
+    class UpdaterWorker* m_worker = nullptr;
+
+    State m_state = State::Idle;
+    QString m_latestVersion;
+    QString m_latestUrl;
+    QString m_changelog;
+    int m_progress = 0;
+    QString m_error;
+    QString m_channel = QStringLiteral("stable");
+    QString m_installFlavor;
+    InstallFlavor::Flavor m_flavor = InstallFlavor::Flavor::Unknown;
+    UpdateVersion::Comparison m_lastComparison = UpdateVersion::Comparison::Invalid;
+    QString m_localVersion;
+};
+
+#endif // UPDATERCONTROLLER_H

--- a/src/updater/UpdaterWorker.cpp
+++ b/src/updater/UpdaterWorker.cpp
@@ -1,0 +1,74 @@
+#include "UpdaterWorker.h"
+
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QUrl>
+
+UpdaterWorker::UpdaterWorker(QObject* parent)
+    : QObject(parent)
+    , m_network(new QNetworkAccessManager(this))
+{
+}
+
+UpdaterWorker::~UpdaterWorker()
+{
+    cancelActiveRequest();
+}
+
+void UpdaterWorker::cancelActiveRequest()
+{
+    if (!m_activeReply) {
+        return;
+    }
+    m_activeReply->abort();
+    m_activeReply->deleteLater();
+    m_activeReply = nullptr;
+}
+
+void UpdaterWorker::checkForUpdates(const QString& apiUrl,
+                                    const QString& localVersion,
+                                    GitHubReleaseParser::Channel channel)
+{
+    cancelActiveRequest();
+
+    const QUrl url(apiUrl);
+    QNetworkRequest httpRequest(url);
+    httpRequest.setHeader(QNetworkRequest::UserAgentHeader,
+                          QStringLiteral("QtMeshEditor-Updater/1.0"));
+    httpRequest.setRawHeader("Accept", "application/vnd.github+json");
+
+    m_activeReply = m_network->get(httpRequest);
+    m_activeReply->setProperty("localVersion", localVersion);
+    m_activeReply->setProperty("channel", static_cast<int>(channel));
+    connect(m_activeReply, &QNetworkReply::finished, this, &UpdaterWorker::onReplyFinished);
+}
+
+void UpdaterWorker::onReplyFinished()
+{
+    QNetworkReply* reply = m_activeReply;
+    m_activeReply = nullptr;
+
+    if (!reply) {
+        return;
+    }
+
+    const QString localVersion = reply->property("localVersion").toString();
+    const auto channel =
+        static_cast<GitHubReleaseParser::Channel>(reply->property("channel").toInt());
+
+    GitHubReleaseParser::CheckResult result;
+    QString networkError;
+
+    if (reply->error() != QNetworkReply::NoError) {
+        networkError = reply->errorString();
+    } else {
+        result = GitHubReleaseParser::pickLatestForChannel(reply->readAll(), channel, localVersion);
+        if (!result.parseOk && result.errorMessage.isEmpty()) {
+            result.errorMessage = QStringLiteral("Failed to parse GitHub releases response");
+        }
+    }
+
+    reply->deleteLater();
+    emit checkFinished(result, networkError);
+}

--- a/src/updater/UpdaterWorker.cpp
+++ b/src/updater/UpdaterWorker.cpp
@@ -46,10 +46,20 @@ void UpdaterWorker::checkForUpdates(const QString& apiUrl,
 
 void UpdaterWorker::onReplyFinished()
 {
-    QNetworkReply* reply = m_activeReply;
+    auto* reply = qobject_cast<QNetworkReply*>(sender());
+    if (!reply) {
+        return;
+    }
+
+    if (reply != m_activeReply) {
+        reply->deleteLater();
+        return;
+    }
+
     m_activeReply = nullptr;
 
-    if (!reply) {
+    if (reply->error() == QNetworkReply::OperationCanceledError) {
+        reply->deleteLater();
         return;
     }
 

--- a/src/updater/UpdaterWorker.h
+++ b/src/updater/UpdaterWorker.h
@@ -1,0 +1,44 @@
+#ifndef UPDATERWORKER_H
+#define UPDATERWORKER_H
+
+#include "GitHubReleaseParser.h"
+
+#include <QObject>
+#include <QString>
+
+class QNetworkAccessManager;
+class QNetworkReply;
+
+/**
+ * @brief Worker-thread HTTP for the auto-updater (#441).
+ *
+ * Owns its QNetworkAccessManager on the worker thread so the main thread
+ * never blocks on GitHub API calls.
+ */
+class UpdaterWorker : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit UpdaterWorker(QObject* parent = nullptr);
+    ~UpdaterWorker() override;
+
+public slots:
+    void checkForUpdates(const QString& apiUrl,
+                         const QString& localVersion,
+                         GitHubReleaseParser::Channel channel);
+    void cancelActiveRequest();
+
+signals:
+    void checkFinished(const GitHubReleaseParser::CheckResult& result,
+                       const QString& networkError);
+
+private slots:
+    void onReplyFinished();
+
+private:
+    QNetworkAccessManager* m_network = nullptr;
+    QNetworkReply* m_activeReply = nullptr;
+};
+
+#endif // UPDATERWORKER_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -105,6 +105,10 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/PaintSelectionMask.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/TexturePaintBuffer.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/UpdateVersion.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/updater/InstallFlavor.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/updater/GitHubReleaseParser.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/updater/UpdaterWorker.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/updater/UpdaterController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/TexturePaintController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/VertexColorBaker.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/VATBaker.cpp

--- a/tests/fixtures/updater/github-releases-sample.json
+++ b/tests/fixtures/updater/github-releases-sample.json
@@ -1,5 +1,14 @@
 [
   {
+    "tag_name": "3.6.0-beta.2",
+    "name": "3.6.0-beta.2",
+    "body": "Second beta preview.",
+    "html_url": "https://github.com/fernandotonon/QtMeshEditor/releases/tag/3.6.0-beta.2",
+    "prerelease": true,
+    "published_at": "2026-06-16T18:00:00Z",
+    "assets": []
+  },
+  {
     "tag_name": "3.6.0-beta.1",
     "name": "3.6.0-beta.1",
     "body": "Beta preview with updater work.",

--- a/tests/fixtures/updater/github-releases-sample.json
+++ b/tests/fixtures/updater/github-releases-sample.json
@@ -1,0 +1,46 @@
+[
+  {
+    "tag_name": "3.6.0-beta.1",
+    "name": "3.6.0-beta.1",
+    "body": "Beta preview with updater work.",
+    "html_url": "https://github.com/fernandotonon/QtMeshEditor/releases/tag/3.6.0-beta.1",
+    "prerelease": true,
+    "published_at": "2026-06-16T12:00:00Z",
+    "assets": [
+      {
+        "name": "QtMeshEditor-3.6.0-beta.1-bin-Windows.zip",
+        "browser_download_url": "https://github.com/fernandotonon/QtMeshEditor/releases/download/3.6.0-beta.1/QtMeshEditor-3.6.0-beta.1-bin-Windows.zip",
+        "size": 120000000
+      }
+    ]
+  },
+  {
+    "tag_name": "3.5.3",
+    "name": "3.5.3",
+    "body": "Stable release notes.",
+    "html_url": "https://github.com/fernandotonon/QtMeshEditor/releases/tag/3.5.3",
+    "prerelease": false,
+    "published_at": "2026-06-15T19:38:57Z",
+    "assets": [
+      {
+        "name": "QtMeshEditor-3.5.3-bin-Windows.zip",
+        "browser_download_url": "https://github.com/fernandotonon/QtMeshEditor/releases/download/3.5.3/QtMeshEditor-3.5.3-bin-Windows.zip",
+        "size": 118000000
+      },
+      {
+        "name": "qtmesheditor_amd64.deb",
+        "browser_download_url": "https://github.com/fernandotonon/QtMeshEditor/releases/download/3.5.3/qtmesheditor_amd64.deb",
+        "size": 45000000
+      }
+    ]
+  },
+  {
+    "tag_name": "3.5.2",
+    "name": "3.5.2",
+    "body": "Older stable.",
+    "html_url": "https://github.com/fernandotonon/QtMeshEditor/releases/tag/3.5.2",
+    "prerelease": false,
+    "published_at": "2026-06-12T00:04:38Z",
+    "assets": []
+  }
+]


### PR DESCRIPTION
## Summary
- Adds `UpdaterController` QML singleton with worker-thread GitHub Releases API checks (#441)
- Introduces pure `GitHubReleaseParser` with stable/beta channel selection and fixture-backed unit tests
- Replaces inline `MainWindow::on_actionVerify_Update_triggered` network lambda with `UpdaterController::checkForUpdates()`
- Reuses existing `UpdateVersion` semver compare (#442)

## Technical Details
- `UpdaterWorker` owns `QNetworkAccessManager` on a worker thread; fetches `/releases?per_page=20`
- `UpdaterController` exposes state, channel, install flavor, latest version/url/changelog; emits `updateAvailable` / `noUpdate` / `checkError`
- Package-manager installs show `InstallFlavor::updateCommandHint()` without hitting GitHub
- Portable installs keep temporary `QMessageBox` UX until #449 (`UpdaterDialog` QML)
- `downloadAndInstall()` stubbed for #444
- Sentry breadcrumbs: `updater.check.start`, `updater.check.success`, `updater.check.error`

## Test plan
- [x] `./build_local/bin/UnitTests --gtest_filter="GitHubReleaseParser*:UpdateVersion*"` (16 tests pass)
- [x] `cmake --build build_local --target QtMeshEditor` succeeds
- [ ] CI unit-tests-linux green
- [ ] Manual: Help → Check for Updates on portable build (network)

Closes #441

Made with [Cursor](https://cursor.com)