### PR TITLE
Add updater dialog and preferences (#443, #449)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,6 +282,15 @@ if(ENABLE_PS1_RIP)
     add_subdirectory(plugins/ps1core_stub)
 endif()
 ##############################################################
+#  In-app auto-updater (portable Windows/macOS/Linux tarballs)
+##############################################################
+option(ENABLE_AUTO_UPDATER "Enable in-app auto-updater UI and download path" ON)
+
+if(ENABLE_AUTO_UPDATER)
+    add_definitions(-DENABLE_AUTO_UPDATER)
+    message(STATUS "In-app auto-updater enabled")
+endif()
+##############################################################
 #  meshoptimizer — LOD generation, vertex-cache / overdraw /
 #  fetch optimization, vertex remap dedupe. MIT, header-light,
 #  ~200 KB. First consumer is `qtmesh lod --algo meshopt`

--- a/qml/PreferencesDialog.qml
+++ b/qml/PreferencesDialog.qml
@@ -23,6 +23,12 @@ Rectangle {
     property color inputBgColor: palette.base
 
     property int currentTab: 0
+    readonly property var tabLabels: {
+        var tabs = ["General", "Appearance", "Viewport"]
+        if (PropertiesPanelController.autoUpdaterEnabled)
+            tabs.push("Updates")
+        return tabs
+    }
 
     // Helper to read a setting with default
     function readSetting(key, defaultVal) {
@@ -73,7 +79,7 @@ Rectangle {
                 spacing: 2
 
                 Repeater {
-                    model: ["General", "Appearance", "Viewport"]
+                    model: root.tabLabels
 
                     Rectangle {
                         Layout.fillWidth: true
@@ -500,6 +506,16 @@ Rectangle {
                                     onEditingFinished: writeSetting("Viewport/farClip", parseFloat(text) || 10000)
                                 }
                             }
+                        }
+                    }
+
+                    Loader {
+                        width: parent.width - 32
+                        active: PropertiesPanelController.autoUpdaterEnabled && currentTab === 3
+                        source: "qrc:/UpdaterDialog/UpdaterSettingsPanel.qml"
+                        onLoaded: {
+                            if (item)
+                                item.currentTab = Qt.binding(function() { return currentTab })
                         }
                     }
 

--- a/qml/UpdaterDialog.qml
+++ b/qml/UpdaterDialog.qml
@@ -35,6 +35,11 @@ Window {
         focus: true
         Keys.onPressed: function(event) {
             if (event.key === Qt.Key_Escape) {
+                if (UpdaterController.state === UpdaterController.Checking
+                    || UpdaterController.state === UpdaterController.Downloading
+                    || UpdaterController.state === UpdaterController.Verifying) {
+                    UpdaterController.cancel()
+                }
                 UpdaterController.dismiss()
                 dialog.close()
                 event.accepted = true

--- a/qml/UpdaterDialog.qml
+++ b/qml/UpdaterDialog.qml
@@ -1,0 +1,297 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
+import PropertiesPanel 1.0
+import Updater 1.0
+
+Window {
+    id: dialog
+    title: "Check for Updates"
+    width: 560
+    height: 520
+    minimumWidth: 480
+    minimumHeight: 420
+    flags: Qt.Dialog
+    modality: Qt.ApplicationModal
+    color: PropertiesPanelController.panelColor
+
+    property bool autoCheck: true
+
+    function open(runCheck) {
+        if (runCheck !== undefined)
+            dialog.autoCheck = runCheck
+        dialog.show()
+        dialog.raise()
+        dialog.requestActivate()
+        keyCapture.forceActiveFocus()
+        if (dialog.autoCheck)
+            UpdaterController.checkForUpdates()
+    }
+
+    Item {
+        id: keyCapture
+        anchors.fill: parent
+        focus: true
+        Keys.onPressed: function(event) {
+            if (event.key === Qt.Key_Escape) {
+                UpdaterController.dismiss()
+                dialog.close()
+                event.accepted = true
+            }
+        }
+    }
+
+    component InspectorButton: Rectangle {
+        id: btn
+        property string label: ""
+        property bool buttonEnabled: true
+        property bool primary: false
+        signal clicked()
+        height: 28
+        radius: 3
+        color: !buttonEnabled ? Qt.darker(PropertiesPanelController.controlBgColor, 1.2)
+             : btnMouse.containsMouse ? Qt.lighter(primary ? PropertiesPanelController.highlightColor
+                                                          : PropertiesPanelController.controlBgColor, 1.15)
+             : (primary ? PropertiesPanelController.highlightColor
+                        : PropertiesPanelController.controlBgColor)
+        border.color: PropertiesPanelController.borderColor
+        border.width: 1
+        Text {
+            anchors.centerIn: parent
+            text: btn.label
+            color: primary ? "white" : PropertiesPanelController.textColor
+            font.pixelSize: 12
+        }
+        MouseArea {
+            id: btnMouse
+            anchors.fill: parent
+            hoverEnabled: true
+            enabled: btn.buttonEnabled
+            cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+            onClicked: btn.clicked()
+        }
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 16
+        spacing: 12
+
+        Text {
+            Layout.fillWidth: true
+            wrapMode: Text.WordWrap
+            font.pixelSize: 16
+            font.bold: true
+            color: PropertiesPanelController.textColor
+            text: {
+                switch (UpdaterController.state) {
+                case UpdaterController.Checking: return "Checking for updates…"
+                case UpdaterController.UnknownInstall: return "Unrecognized install layout"
+                case UpdaterController.PackageManaged: return "Updates via " + UpdaterController.flavorDisplayName
+                case UpdaterController.UpdateAvailable: return "Update available"
+                case UpdaterController.UpToDate: return "You're up to date"
+                case UpdaterController.Error: return "Update check failed"
+                case UpdaterController.Downloading: return "Downloading update…"
+                case UpdaterController.Verifying: return "Verifying download…"
+                case UpdaterController.ReadyToInstall: return "Ready to install"
+                default: return "Software updates"
+                }
+            }
+        }
+
+        Text {
+            Layout.fillWidth: true
+            visible: UpdaterController.currentVersion.length > 0
+                     && UpdaterController.state !== UpdaterController.PackageManaged
+            text: "Current version: " + UpdaterController.currentVersion
+            color: Qt.darker(PropertiesPanelController.textColor, 1.35)
+            font.pixelSize: 11
+        }
+
+        BusyIndicator {
+            Layout.alignment: Qt.AlignHCenter
+            running: UpdaterController.state === UpdaterController.Checking
+                     || UpdaterController.state === UpdaterController.Downloading
+                     || UpdaterController.state === UpdaterController.Verifying
+            visible: running
+        }
+
+        // Unknown portable install confirmation (#443)
+        ColumnLayout {
+            Layout.fillWidth: true
+            visible: UpdaterController.state === UpdaterController.UnknownInstall
+            spacing: 8
+            Text {
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+                color: PropertiesPanelController.textColor
+                font.pixelSize: 12
+                text: "This install path doesn't match a known portable or package-manager layout. " +
+                      "In-app updates are only supported for direct-download installs. Continue anyway?"
+            }
+            RowLayout {
+                spacing: 8
+                InspectorButton {
+                    label: "Continue"
+                    primary: true
+                    onClicked: UpdaterController.confirmUnknownInstall()
+                }
+                InspectorButton {
+                    label: "Cancel"
+                    onClicked: { UpdaterController.dismiss(); dialog.close() }
+                }
+            }
+        }
+
+        // Package-manager guidance (#443)
+        ColumnLayout {
+            Layout.fillWidth: true
+            visible: UpdaterController.state === UpdaterController.PackageManaged
+            spacing: 8
+            Text {
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+                color: PropertiesPanelController.textColor
+                font.pixelSize: 12
+                text: "Your copy was installed via " + UpdaterController.flavorDisplayName +
+                      ". Use your package manager to update:"
+            }
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: commandField.implicitHeight + 12
+                color: PropertiesPanelController.inputColor
+                border.color: PropertiesPanelController.borderColor
+                radius: 3
+                Text {
+                    id: commandField
+                    anchors.fill: parent
+                    anchors.margins: 6
+                    wrapMode: Text.Wrap
+                    font.family: "monospace"
+                    font.pixelSize: 11
+                    color: PropertiesPanelController.textColor
+                    text: UpdaterController.updateCommandHint
+                }
+            }
+            RowLayout {
+                spacing: 8
+                InspectorButton {
+                    label: "Copy command"
+                    buttonEnabled: UpdaterController.updateCommandHint.length > 0
+                    onClicked: UpdaterController.copyUpdateCommand()
+                }
+                InspectorButton {
+                    label: "Close"
+                    onClicked: { UpdaterController.dismiss(); dialog.close() }
+                }
+            }
+        }
+
+        // Update available
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            visible: UpdaterController.state === UpdaterController.UpdateAvailable
+            spacing: 8
+            Text {
+                Layout.fillWidth: true
+                color: PropertiesPanelController.textColor
+                font.pixelSize: 12
+                text: UpdaterController.latestVersion +
+                      (UpdaterController.publishedAt.length > 0
+                       ? "  ·  published " + UpdaterController.publishedAt.substring(0, 10)
+                       : "")
+            }
+            ScrollView {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                clip: true
+                TextArea {
+                    readOnly: true
+                    wrapMode: TextArea.Wrap
+                    textFormat: TextEdit.MarkdownText
+                    text: UpdaterController.changelog.length > 0
+                          ? UpdaterController.changelog
+                          : "_No release notes provided._"
+                    color: PropertiesPanelController.textColor
+                    background: Rectangle {
+                        color: PropertiesPanelController.inputColor
+                        border.color: PropertiesPanelController.borderColor
+                        radius: 3
+                    }
+                }
+            }
+            RowLayout {
+                spacing: 8
+                InspectorButton {
+                    label: "Open release page"
+                    primary: true
+                    onClicked: UpdaterController.openReleasePage()
+                }
+                InspectorButton {
+                    label: "Download & install"
+                    buttonEnabled: false
+                    onClicked: UpdaterController.downloadAndInstall()
+                }
+            }
+            RowLayout {
+                spacing: 8
+                InspectorButton {
+                    label: "Remind me later"
+                    onClicked: { UpdaterController.remindLater(); dialog.close() }
+                }
+                InspectorButton {
+                    label: "Skip this version"
+                    onClicked: { UpdaterController.skipThisVersion(); dialog.close() }
+                }
+            }
+        }
+
+        // Up to date
+        ColumnLayout {
+            Layout.fillWidth: true
+            visible: UpdaterController.state === UpdaterController.UpToDate
+            spacing: 8
+            Text {
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+                color: PropertiesPanelController.textColor
+                font.pixelSize: 12
+                text: UpdaterController.latestVersion.length > 0
+                      ? "You already have the latest release (" + UpdaterController.latestVersion + ")."
+                      : "You already have the latest release."
+            }
+            InspectorButton {
+                label: "Close"
+                onClicked: { UpdaterController.dismiss(); dialog.close() }
+            }
+        }
+
+        // Error
+        ColumnLayout {
+            Layout.fillWidth: true
+            visible: UpdaterController.state === UpdaterController.Error
+            spacing: 8
+            Text {
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+                color: "#cc4444"
+                font.pixelSize: 12
+                text: UpdaterController.error
+            }
+            InspectorButton {
+                label: "Close"
+                onClicked: { UpdaterController.dismiss(); dialog.close() }
+            }
+        }
+
+        ProgressBar {
+            Layout.fillWidth: true
+            visible: UpdaterController.state === UpdaterController.Downloading
+            from: 0
+            to: 100
+            value: UpdaterController.progress
+        }
+    }
+}

--- a/qml/UpdaterSettingsPanel.qml
+++ b/qml/UpdaterSettingsPanel.qml
@@ -60,6 +60,7 @@ Column {
     }
 
     CheckBox {
+        id: startupCheck
         width: parent.width
         text: "Check for updates on startup"
         checked: UpdaterController.checkOnStartup
@@ -68,30 +69,31 @@ Column {
         indicator: Rectangle {
             implicitWidth: 14
             implicitHeight: 14
-            x: control.leftPadding
+            x: startupCheck.leftPadding
             y: parent.height / 2 - height / 2
             radius: 2
             border.color: borderColor
             border.width: 1
-            color: control.checked ? highlightColor : "transparent"
+            color: startupCheck.checked ? highlightColor : "transparent"
             Text {
                 anchors.centerIn: parent
-                visible: control.checked
+                visible: startupCheck.checked
                 text: "\u2713"
                 color: "white"
                 font.pixelSize: 10
             }
         }
         contentItem: Text {
-            text: control.text
-            font: control.font
+            text: startupCheck.text
+            font: startupCheck.font
             color: textColor
             verticalAlignment: Text.AlignVCenter
-            leftPadding: control.indicator.width + control.spacing
+            leftPadding: startupCheck.indicator.width + startupCheck.spacing
         }
     }
 
     CheckBox {
+        id: autoDownloadCheck
         width: parent.width
         text: "Auto-download in background (opt-in)"
         checked: UpdaterController.autoDownload
@@ -100,26 +102,26 @@ Column {
         indicator: Rectangle {
             implicitWidth: 14
             implicitHeight: 14
-            x: control.leftPadding
+            x: autoDownloadCheck.leftPadding
             y: parent.height / 2 - height / 2
             radius: 2
             border.color: borderColor
             border.width: 1
-            color: control.checked ? highlightColor : "transparent"
+            color: autoDownloadCheck.checked ? highlightColor : "transparent"
             Text {
                 anchors.centerIn: parent
-                visible: control.checked
+                visible: autoDownloadCheck.checked
                 text: "\u2713"
                 color: "white"
                 font.pixelSize: 10
             }
         }
         contentItem: Text {
-            text: control.text
-            font: control.font
+            text: autoDownloadCheck.text
+            font: autoDownloadCheck.font
             color: textColor
             verticalAlignment: Text.AlignVCenter
-            leftPadding: control.indicator.width + control.spacing
+            leftPadding: autoDownloadCheck.indicator.width + autoDownloadCheck.spacing
         }
     }
 

--- a/qml/UpdaterSettingsPanel.qml
+++ b/qml/UpdaterSettingsPanel.qml
@@ -1,0 +1,141 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import PropertiesPanel 1.0
+import Updater 1.0
+
+Column {
+    id: updatesRoot
+    width: parent ? parent.width : 400
+    spacing: 12
+    property int currentTab: 3
+    visible: currentTab === 3
+    property color textColor: PropertiesPanelController.textColor
+    property color dimTextColor: Qt.darker(PropertiesPanelController.textColor, 1.35)
+    property color borderColor: PropertiesPanelController.borderColor
+    property color highlightColor: PropertiesPanelController.highlightColor
+    property color inputBgColor: PropertiesPanelController.inputColor
+
+    Text {
+        width: parent.width
+        text: "Updates"
+        font.pixelSize: 12
+        font.bold: true
+        color: textColor
+    }
+
+    Text {
+        width: parent.width
+        wrapMode: Text.WordWrap
+        font.pixelSize: 11
+        color: dimTextColor
+        text: "Install flavor: " + UpdaterController.flavorDisplayName +
+              (UpdaterController.isPackageManaged
+               ? " — in-app download is disabled; use your package manager."
+               : "")
+    }
+
+    Column {
+        width: parent.width
+        spacing: 4
+        Text { text: "Channel"; font.pixelSize: 12; font.bold: true; color: textColor }
+        Row {
+            spacing: 6
+            Repeater {
+                model: ["stable", "beta"]
+                Rectangle {
+                    width: 72; height: 26; radius: 3
+                    border.color: borderColor; border.width: 1
+                    color: UpdaterController.channel === modelData ? highlightColor
+                         : channelMouse.containsMouse ? Qt.lighter(inputBgColor, 1.1) : inputBgColor
+                    Text {
+                        anchors.centerIn: parent
+                        text: modelData
+                        font.pixelSize: 11
+                        color: UpdaterController.channel === modelData ? "white" : textColor
+                    }
+                    MouseArea {
+                        id: channelMouse
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: UpdaterController.channel = modelData
+                    }
+                }
+            }
+        }
+    }
+
+    Row {
+        spacing: 6
+        width: parent.width
+        property bool enabled: UpdaterController.checkOnStartup
+        Rectangle {
+            width: 14; height: 14; anchors.verticalCenter: parent.verticalCenter
+            border.color: borderColor; border.width: 1; radius: 2
+            color: parent.enabled ? highlightColor : "transparent"
+            Text { anchors.centerIn: parent; text: parent.parent.enabled ? "\u2713" : ""; color: "white"; font.pixelSize: 10 }
+            MouseArea {
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+                onClicked: UpdaterController.checkOnStartup = !parent.parent.enabled
+            }
+        }
+        Text {
+            text: "Check for updates on startup"
+            font.pixelSize: 12
+            color: textColor
+            anchors.verticalCenter: parent.verticalCenter
+        }
+    }
+
+    Row {
+        spacing: 6
+        width: parent.width
+        property bool enabled: UpdaterController.autoDownload
+        Rectangle {
+            width: 14; height: 14; anchors.verticalCenter: parent.verticalCenter
+            border.color: borderColor; border.width: 1; radius: 2
+            color: parent.enabled ? highlightColor : "transparent"
+            Text { anchors.centerIn: parent; text: parent.parent.enabled ? "\u2713" : ""; color: "white"; font.pixelSize: 10 }
+            MouseArea {
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+                onClicked: UpdaterController.autoDownload = !parent.parent.enabled
+            }
+        }
+        Text {
+            text: "Auto-download in background (opt-in)"
+            font.pixelSize: 12
+            color: textColor
+            anchors.verticalCenter: parent.verticalCenter
+        }
+    }
+
+    Text {
+        width: parent.width
+        font.pixelSize: 11
+        color: dimTextColor
+        text: UpdaterController.lastCheckedAt.length > 0
+              ? "Last checked: " + UpdaterController.lastCheckedAt
+              : "Last checked: never"
+    }
+
+    Rectangle {
+        width: 120; height: 28; radius: 3
+        color: checkMouse.containsMouse ? Qt.lighter(highlightColor, 1.1) : highlightColor
+        Text {
+            anchors.centerIn: parent
+            text: "Check now"
+            color: "white"
+            font.pixelSize: 12
+        }
+        MouseArea {
+            id: checkMouse
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            onClicked: UpdaterController.requestCheckDialog()
+        }
+    }
+}

--- a/qml/UpdaterSettingsPanel.qml
+++ b/qml/UpdaterSettingsPanel.qml
@@ -39,76 +39,87 @@ Column {
         width: parent.width
         spacing: 4
         Text { text: "Channel"; font.pixelSize: 12; font.bold: true; color: textColor }
+        ButtonGroup { id: channelGroup }
         Row {
             spacing: 6
             Repeater {
                 model: ["stable", "beta"]
-                Rectangle {
-                    width: 72; height: 26; radius: 3
-                    border.color: borderColor; border.width: 1
-                    color: UpdaterController.channel === modelData ? highlightColor
-                         : channelMouse.containsMouse ? Qt.lighter(inputBgColor, 1.1) : inputBgColor
-                    Text {
-                        anchors.centerIn: parent
-                        text: modelData
-                        font.pixelSize: 11
-                        color: UpdaterController.channel === modelData ? "white" : textColor
-                    }
-                    MouseArea {
-                        id: channelMouse
-                        anchors.fill: parent
-                        hoverEnabled: true
-                        cursorShape: Qt.PointingHandCursor
-                        onClicked: UpdaterController.channel = modelData
-                    }
+                Button {
+                    ButtonGroup.group: channelGroup
+                    checkable: true
+                    checked: UpdaterController.channel === modelData
+                    text: modelData
+                    implicitHeight: 26
+                    implicitWidth: 72
+                    onClicked: UpdaterController.channel = modelData
+                    palette.button: checked ? highlightColor : inputBgColor
+                    palette.buttonText: checked ? "white" : textColor
                 }
             }
         }
     }
 
-    Row {
-        spacing: 6
+    CheckBox {
         width: parent.width
-        property bool enabled: UpdaterController.checkOnStartup
-        Rectangle {
-            width: 14; height: 14; anchors.verticalCenter: parent.verticalCenter
-            border.color: borderColor; border.width: 1; radius: 2
-            color: parent.enabled ? highlightColor : "transparent"
-            Text { anchors.centerIn: parent; text: parent.parent.enabled ? "\u2713" : ""; color: "white"; font.pixelSize: 10 }
-            MouseArea {
-                anchors.fill: parent
-                cursorShape: Qt.PointingHandCursor
-                onClicked: UpdaterController.checkOnStartup = !parent.parent.enabled
+        text: "Check for updates on startup"
+        checked: UpdaterController.checkOnStartup
+        onToggled: UpdaterController.checkOnStartup = checked
+        font.pixelSize: 12
+        indicator: Rectangle {
+            implicitWidth: 14
+            implicitHeight: 14
+            x: control.leftPadding
+            y: parent.height / 2 - height / 2
+            radius: 2
+            border.color: borderColor
+            border.width: 1
+            color: control.checked ? highlightColor : "transparent"
+            Text {
+                anchors.centerIn: parent
+                visible: control.checked
+                text: "\u2713"
+                color: "white"
+                font.pixelSize: 10
             }
         }
-        Text {
-            text: "Check for updates on startup"
-            font.pixelSize: 12
+        contentItem: Text {
+            text: control.text
+            font: control.font
             color: textColor
-            anchors.verticalCenter: parent.verticalCenter
+            verticalAlignment: Text.AlignVCenter
+            leftPadding: control.indicator.width + control.spacing
         }
     }
 
-    Row {
-        spacing: 6
+    CheckBox {
         width: parent.width
-        property bool enabled: UpdaterController.autoDownload
-        Rectangle {
-            width: 14; height: 14; anchors.verticalCenter: parent.verticalCenter
-            border.color: borderColor; border.width: 1; radius: 2
-            color: parent.enabled ? highlightColor : "transparent"
-            Text { anchors.centerIn: parent; text: parent.parent.enabled ? "\u2713" : ""; color: "white"; font.pixelSize: 10 }
-            MouseArea {
-                anchors.fill: parent
-                cursorShape: Qt.PointingHandCursor
-                onClicked: UpdaterController.autoDownload = !parent.parent.enabled
+        text: "Auto-download in background (opt-in)"
+        checked: UpdaterController.autoDownload
+        onToggled: UpdaterController.autoDownload = checked
+        font.pixelSize: 12
+        indicator: Rectangle {
+            implicitWidth: 14
+            implicitHeight: 14
+            x: control.leftPadding
+            y: parent.height / 2 - height / 2
+            radius: 2
+            border.color: borderColor
+            border.width: 1
+            color: control.checked ? highlightColor : "transparent"
+            Text {
+                anchors.centerIn: parent
+                visible: control.checked
+                text: "\u2713"
+                color: "white"
+                font.pixelSize: 10
             }
         }
-        Text {
-            text: "Auto-download in background (opt-in)"
-            font.pixelSize: 12
+        contentItem: Text {
+            text: control.text
+            font: control.font
             color: textColor
-            anchors.verticalCenter: parent.verticalCenter
+            verticalAlignment: Text.AlignVCenter
+            leftPadding: control.indicator.width + control.spacing
         }
     }
 
@@ -121,21 +132,13 @@ Column {
               : "Last checked: never"
     }
 
-    Rectangle {
-        width: 120; height: 28; radius: 3
-        color: checkMouse.containsMouse ? Qt.lighter(highlightColor, 1.1) : highlightColor
-        Text {
-            anchors.centerIn: parent
-            text: "Check now"
-            color: "white"
-            font.pixelSize: 12
-        }
-        MouseArea {
-            id: checkMouse
-            anchors.fill: parent
-            hoverEnabled: true
-            cursorShape: Qt.PointingHandCursor
-            onClicked: UpdaterController.requestCheckDialog()
-        }
+    Button {
+        text: "Check now"
+        implicitHeight: 28
+        implicitWidth: 120
+        onClicked: UpdaterController.requestCheckDialog()
+        palette.button: highlightColor
+        palette.buttonText: "white"
+        font.pixelSize: 12
     }
 }

--- a/src/AppSettingsKeys.h
+++ b/src/AppSettingsKeys.h
@@ -121,6 +121,36 @@ inline const QString& validationPlatformProfilePickerVersion()
     return k;
 }
 
+inline const QString& updaterChannel()
+{
+    static const QString k(QStringLiteral("Updater/channel"));
+    return k;
+}
+
+inline const QString& updaterCheckOnStartup()
+{
+    static const QString k(QStringLiteral("Updater/checkOnStartup"));
+    return k;
+}
+
+inline const QString& updaterAutoDownload()
+{
+    static const QString k(QStringLiteral("Updater/autoDownload"));
+    return k;
+}
+
+inline const QString& updaterLastCheckedAt()
+{
+    static const QString k(QStringLiteral("Updater/lastCheckedAt"));
+    return k;
+}
+
+inline const QString& updaterSkippedVersion()
+{
+    static const QString k(QStringLiteral("Updater/skippedVersion"));
+    return k;
+}
+
 } // namespace AppSettingsKeys
 
 #endif // APP_SETTINGS_KEYS_H

--- a/src/PropertiesPanelController.cpp
+++ b/src/PropertiesPanelController.cpp
@@ -155,6 +155,15 @@ QColor PropertiesPanelController::highlightColor() const
     return QApplication::palette().color(QPalette::Highlight);
 }
 
+bool PropertiesPanelController::autoUpdaterEnabled() const
+{
+#ifdef ENABLE_AUTO_UPDATER
+    return true;
+#else
+    return false;
+#endif
+}
+
 // Transform accessors
 double PropertiesPanelController::posX() const { return mPosX; }
 double PropertiesPanelController::posY() const { return mPosY; }

--- a/src/PropertiesPanelController.h
+++ b/src/PropertiesPanelController.h
@@ -23,6 +23,7 @@ class PropertiesPanelController : public QObject
     Q_PROPERTY(QColor inputColor READ inputColor NOTIFY themeChanged)
     Q_PROPERTY(QColor controlBgColor READ controlBgColor NOTIFY themeChanged)
     Q_PROPERTY(QColor highlightColor READ highlightColor NOTIFY themeChanged)
+    Q_PROPERTY(bool autoUpdaterEnabled READ autoUpdaterEnabled CONSTANT)
 
     // Transform properties
     Q_PROPERTY(double posX READ posX WRITE setPosX NOTIFY transformChanged)
@@ -98,6 +99,7 @@ public:
     QColor inputColor() const;
     QColor controlBgColor() const;
     QColor highlightColor() const;
+    bool autoUpdaterEnabled() const;
 
     // Transform accessors
     double posX() const;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -679,11 +679,13 @@ void MainWindow::initToolBar()
 #ifdef ENABLE_AUTO_UPDATER
         connect(UpdaterController::instance(), &UpdaterController::showDialogRequested,
                 this, &MainWindow::showUpdaterDialog);
+#ifndef QTMESH_UNIT_TESTS
         if (UpdaterController::instance()->checkOnStartup()) {
             QTimer::singleShot(3000, this, []() {
                 UpdaterController::instance()->checkForUpdates();
             });
         }
+#endif
 #endif
 
         m_propertiesPanel->setSource(QUrl("qrc:/PropertiesPanel/PropertiesPanel.qml"));

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -679,6 +679,11 @@ void MainWindow::initToolBar()
 #ifdef ENABLE_AUTO_UPDATER
         connect(UpdaterController::instance(), &UpdaterController::showDialogRequested,
                 this, &MainWindow::showUpdaterDialog);
+        if (UpdaterController::instance()->checkOnStartup()) {
+            QTimer::singleShot(3000, this, []() {
+                UpdaterController::instance()->checkForUpdates();
+            });
+        }
 #endif
 
         m_propertiesPanel->setSource(QUrl("qrc:/PropertiesPanel/PropertiesPanel.qml"));

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -28,7 +28,9 @@
 #include <QFileInfo>
 #include <QEvent>
 #include "SentryReporter.h"
+#ifdef ENABLE_AUTO_UPDATER
 #include "updater/UpdaterController.h"
+#endif
 #include <QDialog>
 #include <QProgressDialog>
 #include <QThread>
@@ -603,6 +605,13 @@ void MainWindow::initToolBar()
             [](QQmlEngine* engine, QJSEngine*) -> QObject* {
                 return SkinWeightsController::qmlInstance(engine, nullptr);
             });
+#ifdef ENABLE_AUTO_UPDATER
+        qmlRegisterSingletonType<UpdaterController>(
+            "Updater", 1, 0, "UpdaterController",
+            [](QQmlEngine* engine, QJSEngine*) -> QObject* {
+                return UpdaterController::qmlInstance(engine, nullptr);
+            });
+#endif
         // Open the LOD export directory picker from MainWindow so the dialog has a
         // proper parent widget — QFileDialog invoked from a QML context doesn't
         // reliably appear on macOS without a valid parent QWidget.
@@ -666,6 +675,11 @@ void MainWindow::initToolBar()
         // thumbnail during a paint stroke.
         m_propertiesPanel->engine()->addImageProvider(
             QStringLiteral("paintbuffer"), new PaintBufferImageProvider());
+
+#ifdef ENABLE_AUTO_UPDATER
+        connect(UpdaterController::instance(), &UpdaterController::showDialogRequested,
+                this, &MainWindow::showUpdaterDialog);
+#endif
 
         m_propertiesPanel->setSource(QUrl("qrc:/PropertiesPanel/PropertiesPanel.qml"));
         if (auto* root = m_propertiesPanel->rootObject()) {
@@ -2232,6 +2246,12 @@ void MainWindow::initToolBar()
 
     QAction* mcpSettingsAction = aiMenu->addAction(tr("MCP Server Settings..."));
     connect(mcpSettingsAction, &QAction::triggered, this, &MainWindow::showMCPSettings);
+
+#ifdef ENABLE_AUTO_UPDATER
+    ui->actionVerify_Update->setText(tr("Check for Updates..."));
+#else
+    ui->actionVerify_Update->setVisible(false);
+#endif
 
     // Keyboard Shortcuts reference in Help menu
     QAction* shortcutsAction = ui->menuHelp->addAction(tr("Keyboard Shortcuts"));
@@ -4430,12 +4450,79 @@ void MainWindow::custom_Palette_Color_Selected(const QColor &color)
 }
 // LCOV_EXCL_STOP
 
-// LCOV_EXCL_START — network request
+// LCOV_EXCL_START — updater dialog
+#ifdef ENABLE_AUTO_UPDATER
+void MainWindow::showUpdaterDialog(bool runCheck)
+{
+    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                  QStringLiteral("Help > Check for Updates"));
+
+    if (m_updaterWindow) {
+        if (auto* window = qobject_cast<QQuickWindow*>(m_updaterWindow)) {
+            QMetaObject::invokeMethod(window, "open", Q_ARG(QVariant, runCheck));
+            window->show();
+            window->raise();
+            window->requestActivate();
+        }
+        return;
+    }
+
+    auto* engine = new QQmlApplicationEngine(this);
+    m_updaterEngine = engine;
+    engine->addImportPath(QLibraryInfo::path(QLibraryInfo::QmlImportsPath));
+
+    qmlRegisterSingletonType<PropertiesPanelController>(
+        "PropertiesPanel", 1, 0, "PropertiesPanelController",
+        [](QQmlEngine* eng, QJSEngine*) -> QObject* {
+            return PropertiesPanelController::qmlInstance(eng, nullptr);
+        });
+    qmlRegisterSingletonType<UpdaterController>(
+        "Updater", 1, 0, "UpdaterController",
+        [](QQmlEngine* eng, QJSEngine*) -> QObject* {
+            return UpdaterController::qmlInstance(eng, nullptr);
+        });
+
+    connect(engine, &QQmlApplicationEngine::objectCreated, this,
+            [this, engine, runCheck](QObject* obj, const QUrl&) {
+                if (!obj) {
+                    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                                  QStringLiteral("Updater dialog: QML load failed"));
+                    engine->deleteLater();
+                    m_updaterEngine = nullptr;
+                    return;
+                }
+
+                m_updaterWindow = obj;
+                if (auto* window = qobject_cast<QQuickWindow*>(obj)) {
+                    QQuickWindow::setGraphicsApi(QSGRendererInterface::Software);
+                    connect(window, &QQuickWindow::visibleChanged, this,
+                            [this, window, engine](bool visible) {
+                                if (visible || m_updaterWindow != window) {
+                                    return;
+                                }
+                                m_updaterWindow = nullptr;
+                                m_updaterEngine = nullptr;
+                                engine->deleteLater();
+                            });
+                    QMetaObject::invokeMethod(window, "open", Q_ARG(QVariant, runCheck));
+                    window->show();
+                    window->raise();
+                    window->requestActivate();
+                }
+            });
+
+    engine->load(QUrl(QStringLiteral("qrc:/UpdaterDialog/UpdaterDialog.qml")));
+}
+
 void MainWindow::on_actionVerify_Update_triggered()
 {
-    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"), QStringLiteral("Check for updates"));
-    UpdaterController::instance()->checkForUpdates();
+    showUpdaterDialog(true);
 }
+#else
+void MainWindow::on_actionVerify_Update_triggered()
+{
+}
+#endif
 // LCOV_EXCL_STOP
 
 // LCOV_EXCL_START — dialogs and server lifecycle

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -23,6 +23,7 @@ class EditorModeController;
 class WelcomeScreenController;
 class AssetBrowserController;
 class QQuickWidget;
+class QQmlApplicationEngine;
 class QPlainTextEdit;
 class QLabel;
 class QToolBar;
@@ -238,6 +239,12 @@ private:
     void updateToolRailForMode();
     void setupCloudAccountStatusControl();
     void updateCloudAuthActions();
+
+#ifdef ENABLE_AUTO_UPDATER
+    void showUpdaterDialog(bool runCheck = true);
+    QObject* m_updaterWindow = nullptr;
+    QQmlApplicationEngine* m_updaterEngine = nullptr;
+#endif
 };
 
 #endif // MAINWINDOW_H

--- a/src/qml_resources.qrc
+++ b/src/qml_resources.qrc
@@ -54,6 +54,10 @@
   <qresource prefix="/ShortcutReference">
     <file alias="ShortcutReference.qml">../qml/ShortcutReference.qml</file>
   </qresource>
+  <qresource prefix="/UpdaterDialog">
+    <file alias="UpdaterDialog.qml">../qml/UpdaterDialog.qml</file>
+    <file alias="UpdaterSettingsPanel.qml">../qml/UpdaterSettingsPanel.qml</file>
+  </qresource>
   <qresource prefix="/PreferencesDialog">
     <file alias="PreferencesDialog.qml">../qml/PreferencesDialog.qml</file>
   </qresource>

--- a/src/updater/UpdaterController.cpp
+++ b/src/updater/UpdaterController.cpp
@@ -128,7 +128,12 @@ UpdaterController::~UpdaterController()
 void UpdaterController::loadSettings()
 {
     QSettings settings;
-    setChannel(settings.value(AppSettingsKeys::updaterChannel(), QStringLiteral("stable")).toString());
+    bool channelOk = false;
+    const GitHubReleaseParser::Channel parsed = GitHubReleaseParser::channelFromString(
+        settings.value(AppSettingsKeys::updaterChannel(), QStringLiteral("stable")).toString(),
+        &channelOk);
+    m_channel = GitHubReleaseParser::channelToString(
+        channelOk ? parsed : GitHubReleaseParser::Channel::Stable);
     m_checkOnStartup = settings.value(AppSettingsKeys::updaterCheckOnStartup(), true).toBool();
     m_autoDownload = settings.value(AppSettingsKeys::updaterAutoDownload(), false).toBool();
     m_lastCheckedAt = settings.value(AppSettingsKeys::updaterLastCheckedAt()).toString();
@@ -269,6 +274,8 @@ void UpdaterController::applyCheckResult(const GitHubReleaseParser::CheckResult&
 
 void UpdaterController::requestCheckDialog()
 {
+    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                  QStringLiteral("Updater settings: Check now"));
     emit showDialogRequested(true);
 }
 

--- a/src/updater/UpdaterController.cpp
+++ b/src/updater/UpdaterController.cpp
@@ -1,17 +1,38 @@
 #include "UpdaterController.h"
 #include "UpdaterWorker.h"
+#include "AppSettingsKeys.h"
 #include "SentryReporter.h"
 
 #include <QApplication>
+#include <QClipboard>
 #include <QCoreApplication>
+#include <QDateTime>
 #include <QDesktopServices>
-#include <QMessageBox>
+#include <QGuiApplication>
+#include <QSettings>
 #include <QUrl>
 
 namespace {
 
 constexpr const char* kDefaultReleasesApi =
     "https://api.github.com/repos/fernandotonon/QtMeshEditor/releases?per_page=20";
+
+QString stateToString(UpdaterController::State state)
+{
+    switch (state) {
+    case UpdaterController::State::Idle: return QStringLiteral("idle");
+    case UpdaterController::State::Checking: return QStringLiteral("checking");
+    case UpdaterController::State::UnknownInstall: return QStringLiteral("unknown_install");
+    case UpdaterController::State::PackageManaged: return QStringLiteral("package_managed");
+    case UpdaterController::State::UpdateAvailable: return QStringLiteral("update_available");
+    case UpdaterController::State::UpToDate: return QStringLiteral("up_to_date");
+    case UpdaterController::State::Error: return QStringLiteral("error");
+    case UpdaterController::State::Downloading: return QStringLiteral("downloading");
+    case UpdaterController::State::Verifying: return QStringLiteral("verifying");
+    case UpdaterController::State::ReadyToInstall: return QStringLiteral("ready_to_install");
+    }
+    return QStringLiteral("idle");
+}
 
 } // namespace
 
@@ -32,10 +53,17 @@ UpdaterController* UpdaterController::qmlInstance(QQmlEngine* engine, QJSEngine*
     return instance();
 }
 
+void UpdaterController::kill()
+{
+    delete s_instance;
+    s_instance = nullptr;
+}
+
 UpdaterController::UpdaterController(QObject* parent)
     : QObject(parent)
 {
     qRegisterMetaType<GitHubReleaseParser::Channel>("GitHubReleaseParser::Channel");
+    loadSettings();
     refreshInstallFlavor();
 
     m_workerThread = new QThread(this);
@@ -44,6 +72,8 @@ UpdaterController::UpdaterController(QObject* parent)
 
     connect(m_worker, &UpdaterWorker::checkFinished, this,
             [this](const GitHubReleaseParser::CheckResult& result, const QString& networkError) {
+                recordLastChecked();
+
                 if (!networkError.isEmpty()) {
                     setState(State::Error);
                     setError(networkError);
@@ -52,11 +82,10 @@ UpdaterController::UpdaterController(QObject* parent)
                         networkError,
                         QStringLiteral("error"));
                     emit checkError(networkError);
-                    presentCheckOutcome();
+                    logDialogStateBreadcrumb();
                     return;
                 }
 
-                applyCheckResult(result);
                 if (!result.parseOk) {
                     setState(State::Error);
                     setError(result.errorMessage);
@@ -65,32 +94,66 @@ UpdaterController::UpdaterController(QObject* parent)
                         result.errorMessage,
                         QStringLiteral("error"));
                     emit checkError(result.errorMessage);
-                    presentCheckOutcome();
+                    logDialogStateBreadcrumb();
                     return;
                 }
 
+                applyCheckResult(result);
                 SentryReporter::addBreadcrumb(
                     QStringLiteral("updater.check.success"),
                     QStringLiteral("remote=%1 comparison=%2")
                         .arg(result.release.tagName)
                         .arg(static_cast<int>(result.comparison)));
-                presentCheckOutcome();
+                logDialogStateBreadcrumb();
             });
 
-    connect(m_workerThread, &QThread::finished, m_worker, &QObject::deleteLater);
     m_workerThread->start();
 }
 
 UpdaterController::~UpdaterController()
 {
-    if (m_worker) {
-        QMetaObject::invokeMethod(m_worker, &UpdaterWorker::cancelActiveRequest,
-                                  Qt::BlockingQueuedConnection);
+    if (m_worker && m_workerThread) {
+        if (m_workerThread->isRunning()) {
+            QMetaObject::invokeMethod(m_worker, &UpdaterWorker::cancelActiveRequest,
+                                      Qt::BlockingQueuedConnection);
+            m_workerThread->quit();
+            m_workerThread->wait();
+        }
+        m_worker->moveToThread(QThread::currentThread());
+        delete m_worker;
+        m_worker = nullptr;
     }
-    if (m_workerThread) {
-        m_workerThread->quit();
-        m_workerThread->wait();
-    }
+}
+
+void UpdaterController::loadSettings()
+{
+    QSettings settings;
+    setChannel(settings.value(AppSettingsKeys::updaterChannel(), QStringLiteral("stable")).toString());
+    m_checkOnStartup = settings.value(AppSettingsKeys::updaterCheckOnStartup(), true).toBool();
+    m_autoDownload = settings.value(AppSettingsKeys::updaterAutoDownload(), false).toBool();
+    m_lastCheckedAt = settings.value(AppSettingsKeys::updaterLastCheckedAt()).toString();
+}
+
+void UpdaterController::saveSettings()
+{
+    QSettings settings;
+    settings.setValue(AppSettingsKeys::updaterChannel(), m_channel);
+    settings.setValue(AppSettingsKeys::updaterCheckOnStartup(), m_checkOnStartup);
+    settings.setValue(AppSettingsKeys::updaterAutoDownload(), m_autoDownload);
+    settings.setValue(AppSettingsKeys::updaterLastCheckedAt(), m_lastCheckedAt);
+}
+
+void UpdaterController::recordLastChecked()
+{
+    m_lastCheckedAt = QDateTime::currentDateTimeUtc().toString(Qt::ISODate);
+    saveSettings();
+    emit lastCheckedAtChanged();
+}
+
+bool UpdaterController::isVersionSkipped(const QString& tag) const
+{
+    QSettings settings;
+    return settings.value(AppSettingsKeys::updaterSkippedVersion()).toString() == tag;
 }
 
 void UpdaterController::refreshInstallFlavor()
@@ -101,6 +164,7 @@ void UpdaterController::refreshInstallFlavor()
         m_installFlavor = slug;
         emit installFlavorChanged();
     }
+    SentryReporter::addBreadcrumb(QStringLiteral("updater.flavor.detected"), slug);
 }
 
 void UpdaterController::setChannel(const QString& channel)
@@ -113,7 +177,28 @@ void UpdaterController::setChannel(const QString& channel)
         return;
     }
     m_channel = normalized;
+    saveSettings();
     emit channelChanged();
+}
+
+void UpdaterController::setCheckOnStartup(bool value)
+{
+    if (m_checkOnStartup == value) {
+        return;
+    }
+    m_checkOnStartup = value;
+    saveSettings();
+    emit checkOnStartupChanged();
+}
+
+void UpdaterController::setAutoDownload(bool value)
+{
+    if (m_autoDownload == value) {
+        return;
+    }
+    m_autoDownload = value;
+    saveSettings();
+    emit autoDownloadChanged();
 }
 
 GitHubReleaseParser::Channel UpdaterController::activeChannel() const
@@ -139,20 +224,34 @@ void UpdaterController::setError(const QString& error)
     emit errorChanged();
 }
 
+void UpdaterController::logDialogStateBreadcrumb()
+{
+    SentryReporter::addBreadcrumb(
+        QStringLiteral("updater.dialog.state"),
+        stateToString(m_state));
+}
+
 void UpdaterController::applyCheckResult(const GitHubReleaseParser::CheckResult& result)
 {
     m_lastComparison = result.comparison;
     m_latestVersion = result.release.tagName;
     m_latestUrl = result.release.htmlUrl;
     m_changelog = result.release.body;
+    m_publishedAt = result.release.publishedAt;
     emit latestVersionChanged();
     emit latestUrlChanged();
     emit changelogChanged();
+    emit publishedAtChanged();
 
     switch (result.comparison) {
     case UpdateVersion::Comparison::Older:
+        if (isVersionSkipped(m_latestVersion)) {
+            setState(State::UpToDate);
+            emit noUpdate();
+            return;
+        }
         setState(State::UpdateAvailable);
-        emit updateAvailable(m_localVersion, m_latestVersion);
+        emit updateAvailable(m_currentVersion, m_latestVersion);
         break;
     case UpdateVersion::Comparison::Same:
     case UpdateVersion::Comparison::Newer:
@@ -162,68 +261,36 @@ void UpdaterController::applyCheckResult(const GitHubReleaseParser::CheckResult&
     case UpdateVersion::Comparison::Invalid:
         setState(State::Error);
         setError(QStringLiteral("Could not compare versions '%1' / '%2'")
-                     .arg(m_localVersion, m_latestVersion));
+                     .arg(m_currentVersion, m_latestVersion));
         emit checkError(m_error);
         break;
     }
 }
 
-void UpdaterController::presentCheckOutcome()
+void UpdaterController::requestCheckDialog()
 {
-    if (InstallFlavor::isPackageManagerManaged(m_flavor)) {
-        const QString hint = InstallFlavor::updateCommandHint(m_flavor);
-        QMessageBox::information(
-            nullptr,
-            tr("Update"),
-            tr("Updates for %1 installs are managed by your package manager.\n\nRun:\n%2")
-                .arg(InstallFlavor::displayName(m_flavor), hint));
-        setState(State::Idle);
-        return;
-    }
-
-    switch (m_state) {
-    case State::UpdateAvailable: {
-        const QMessageBox::StandardButton choice = QMessageBox::question(
-            nullptr,
-            tr("Update"),
-            tr("A new version is available (%1 → %2). Do you want to open the release page?")
-                .arg(m_localVersion, m_latestVersion),
-            QMessageBox::Yes | QMessageBox::No);
-        if (choice == QMessageBox::Yes) {
-            SentryReporter::addBreadcrumb(QStringLiteral("updater.check"),
-                                          QStringLiteral("Open release page"));
-            QDesktopServices::openUrl(QUrl(m_latestUrl));
-        }
-        setState(State::Idle);
-        break;
-    }
-    case State::UpToDate:
-        QMessageBox::information(nullptr, tr("Update"), tr("You're using the latest release."));
-        setState(State::Idle);
-        break;
-    case State::Error:
-        QMessageBox::warning(
-            nullptr,
-            tr("Update"),
-            tr("Could not check for updates.\n\n%1").arg(m_error));
-        setState(State::Idle);
-        break;
-    default:
-        break;
-    }
+    emit showDialogRequested(true);
 }
 
 void UpdaterController::checkForUpdates()
 {
     refreshInstallFlavor();
-    m_localVersion = QApplication::applicationVersion();
+    m_currentVersion = QApplication::applicationVersion();
+    emit currentVersionChanged();
     setError(QString());
 
     if (InstallFlavor::isPackageManagerManaged(m_flavor)) {
         SentryReporter::addBreadcrumb(
             QStringLiteral("updater.check.start"),
             QStringLiteral("package-manager flavor=%1").arg(m_installFlavor));
-        presentCheckOutcome();
+        setState(State::PackageManaged);
+        logDialogStateBreadcrumb();
+        return;
+    }
+
+    if (m_flavor == InstallFlavor::Flavor::Unknown && !m_unknownInstallConfirmed) {
+        setState(State::UnknownInstall);
+        logDialogStateBreadcrumb();
         return;
     }
 
@@ -233,10 +300,10 @@ void UpdaterController::checkForUpdates()
 
     SentryReporter::addBreadcrumb(
         QStringLiteral("updater.check.start"),
-        QStringLiteral("channel=%1 local=%2").arg(m_channel, m_localVersion));
+        QStringLiteral("channel=%1 local=%2").arg(m_channel, m_currentVersion));
     setState(State::Checking);
 
-    const QString localVersion = m_localVersion;
+    const QString localVersion = m_currentVersion;
     const auto channel = activeChannel();
     QMetaObject::invokeMethod(
         m_worker,
@@ -247,6 +314,14 @@ void UpdaterController::checkForUpdates()
         Q_ARG(GitHubReleaseParser::Channel, channel));
 }
 
+void UpdaterController::confirmUnknownInstall()
+{
+    m_unknownInstallConfirmed = true;
+    SentryReporter::addBreadcrumb(QStringLiteral("updater.dialog.action"),
+                                  QStringLiteral("confirm_unknown_install"));
+    checkForUpdates();
+}
+
 void UpdaterController::downloadAndInstall()
 {
     SentryReporter::addBreadcrumb(QStringLiteral("updater.download"),
@@ -254,6 +329,7 @@ void UpdaterController::downloadAndInstall()
     setError(tr("Automatic download and install is not available yet."));
     setState(State::Error);
     emit checkError(m_error);
+    logDialogStateBreadcrumb();
 }
 
 void UpdaterController::cancel()
@@ -262,8 +338,9 @@ void UpdaterController::cancel()
         QMetaObject::invokeMethod(m_worker, &UpdaterWorker::cancelActiveRequest,
                                   Qt::QueuedConnection);
     }
-    if (m_state == State::Checking) {
+    if (m_state == State::Checking || m_state == State::Downloading) {
         setState(State::Idle);
+        logDialogStateBreadcrumb();
     }
 }
 
@@ -271,4 +348,60 @@ void UpdaterController::dismiss()
 {
     setState(State::Idle);
     setError(QString());
+    logDialogStateBreadcrumb();
 }
+
+void UpdaterController::remindLater()
+{
+    SentryReporter::addBreadcrumb(QStringLiteral("updater.dialog.action"),
+                                  QStringLiteral("remind_later"));
+    dismiss();
+}
+
+void UpdaterController::skipThisVersion()
+{
+    if (m_latestVersion.isEmpty()) {
+        dismiss();
+        return;
+    }
+    QSettings settings;
+    settings.setValue(AppSettingsKeys::updaterSkippedVersion(), m_latestVersion);
+    SentryReporter::addBreadcrumb(QStringLiteral("updater.dialog.action"),
+                                  QStringLiteral("skip_version=%1").arg(m_latestVersion));
+    setState(State::UpToDate);
+    logDialogStateBreadcrumb();
+}
+
+void UpdaterController::openReleasePage()
+{
+    if (m_latestUrl.isEmpty()) {
+        return;
+    }
+    SentryReporter::addBreadcrumb(QStringLiteral("updater.dialog.action"),
+                                  QStringLiteral("open_release_page"));
+    QDesktopServices::openUrl(QUrl(m_latestUrl));
+}
+
+void UpdaterController::copyUpdateCommand()
+{
+    const QString hint = updateCommandHint();
+    if (hint.isEmpty()) {
+        return;
+    }
+    if (QGuiApplication::clipboard()) {
+        QGuiApplication::clipboard()->setText(hint);
+    }
+    SentryReporter::addBreadcrumb(QStringLiteral("updater.dialog.action"),
+                                  QStringLiteral("copy_update_command"));
+}
+
+#ifdef QTMESH_UNIT_TESTS
+void UpdaterController::setLatestVersionForTest(const QString& tag)
+{
+    if (m_latestVersion == tag) {
+        return;
+    }
+    m_latestVersion = tag;
+    emit latestVersionChanged();
+}
+#endif

--- a/src/updater/UpdaterController.h
+++ b/src/updater/UpdaterController.h
@@ -10,7 +10,7 @@
 #include <QThread>
 
 /**
- * @brief QML-facing singleton orchestrating update checks (#441).
+ * @brief QML-facing singleton orchestrating update checks (#441, #443, #449).
  *
  * Mirrors the LLMManager / SDManager pattern: main-thread controller with
  * a worker thread for HTTP. Download/install land in #444–448.
@@ -22,18 +22,28 @@ class UpdaterController : public QObject
     QML_SINGLETON
 
     Q_PROPERTY(State state READ state NOTIFY stateChanged)
+    Q_PROPERTY(QString currentVersion READ currentVersion NOTIFY currentVersionChanged)
     Q_PROPERTY(QString latestVersion READ latestVersion NOTIFY latestVersionChanged)
     Q_PROPERTY(QString latestUrl READ latestUrl NOTIFY latestUrlChanged)
     Q_PROPERTY(QString changelog READ changelog NOTIFY changelogChanged)
+    Q_PROPERTY(QString publishedAt READ publishedAt NOTIFY publishedAtChanged)
     Q_PROPERTY(int progress READ progress NOTIFY progressChanged)
     Q_PROPERTY(QString error READ error NOTIFY errorChanged)
     Q_PROPERTY(QString channel READ channel WRITE setChannel NOTIFY channelChanged)
     Q_PROPERTY(QString installFlavor READ installFlavor NOTIFY installFlavorChanged)
+    Q_PROPERTY(QString flavorDisplayName READ flavorDisplayName NOTIFY installFlavorChanged)
+    Q_PROPERTY(QString updateCommandHint READ updateCommandHint NOTIFY installFlavorChanged)
+    Q_PROPERTY(bool isPackageManaged READ isPackageManaged NOTIFY installFlavorChanged)
+    Q_PROPERTY(bool checkOnStartup READ checkOnStartup WRITE setCheckOnStartup NOTIFY checkOnStartupChanged)
+    Q_PROPERTY(bool autoDownload READ autoDownload WRITE setAutoDownload NOTIFY autoDownloadChanged)
+    Q_PROPERTY(QString lastCheckedAt READ lastCheckedAt NOTIFY lastCheckedAtChanged)
 
 public:
     enum class State {
         Idle = 0,
         Checking,
+        UnknownInstall,
+        PackageManaged,
         UpdateAvailable,
         UpToDate,
         Error,
@@ -45,32 +55,59 @@ public:
 
     static UpdaterController* instance();
     static UpdaterController* qmlInstance(QQmlEngine* engine, QJSEngine* scriptEngine);
+    static void kill();
 
     State state() const { return m_state; }
+    QString currentVersion() const { return m_currentVersion; }
     QString latestVersion() const { return m_latestVersion; }
     QString latestUrl() const { return m_latestUrl; }
     QString changelog() const { return m_changelog; }
+    QString publishedAt() const { return m_publishedAt; }
     int progress() const { return m_progress; }
     QString error() const { return m_error; }
     QString channel() const { return m_channel; }
     QString installFlavor() const { return m_installFlavor; }
+    QString flavorDisplayName() const { return InstallFlavor::displayName(m_flavor); }
+    QString updateCommandHint() const { return InstallFlavor::updateCommandHint(m_flavor); }
+    bool isPackageManaged() const { return InstallFlavor::isPackageManagerManaged(m_flavor); }
+    bool checkOnStartup() const { return m_checkOnStartup; }
+    bool autoDownload() const { return m_autoDownload; }
+    QString lastCheckedAt() const { return m_lastCheckedAt; }
 
     void setChannel(const QString& channel);
+    void setCheckOnStartup(bool value);
+    void setAutoDownload(bool value);
 
     Q_INVOKABLE void checkForUpdates();
+    Q_INVOKABLE void requestCheckDialog();
+    Q_INVOKABLE void confirmUnknownInstall();
     Q_INVOKABLE void downloadAndInstall();
     Q_INVOKABLE void cancel();
     Q_INVOKABLE void dismiss();
+    Q_INVOKABLE void remindLater();
+    Q_INVOKABLE void skipThisVersion();
+    Q_INVOKABLE void openReleasePage();
+    Q_INVOKABLE void copyUpdateCommand();
+
+#ifdef QTMESH_UNIT_TESTS
+    void setLatestVersionForTest(const QString& tag);
+#endif
 
 signals:
     void stateChanged();
+    void currentVersionChanged();
     void latestVersionChanged();
     void latestUrlChanged();
     void changelogChanged();
+    void publishedAtChanged();
     void progressChanged();
     void errorChanged();
     void channelChanged();
     void installFlavorChanged();
+    void checkOnStartupChanged();
+    void autoDownloadChanged();
+    void lastCheckedAtChanged();
+    void showDialogRequested(bool runCheck);
 
     void updateAvailable(const QString& currentVersion, const QString& latestVersion);
     void noUpdate();
@@ -83,9 +120,13 @@ private:
     void setState(State state);
     void setError(const QString& error);
     void applyCheckResult(const GitHubReleaseParser::CheckResult& result);
-    void presentCheckOutcome();
     GitHubReleaseParser::Channel activeChannel() const;
     void refreshInstallFlavor();
+    void loadSettings();
+    void saveSettings();
+    void recordLastChecked();
+    bool isVersionSkipped(const QString& tag) const;
+    void logDialogStateBreadcrumb();
 
     static UpdaterController* s_instance;
 
@@ -93,16 +134,21 @@ private:
     class UpdaterWorker* m_worker = nullptr;
 
     State m_state = State::Idle;
+    QString m_currentVersion;
     QString m_latestVersion;
     QString m_latestUrl;
     QString m_changelog;
+    QString m_publishedAt;
     int m_progress = 0;
     QString m_error;
     QString m_channel = QStringLiteral("stable");
     QString m_installFlavor;
     InstallFlavor::Flavor m_flavor = InstallFlavor::Flavor::Unknown;
     UpdateVersion::Comparison m_lastComparison = UpdateVersion::Comparison::Invalid;
-    QString m_localVersion;
+    bool m_unknownInstallConfirmed = false;
+    bool m_checkOnStartup = true;
+    bool m_autoDownload = false;
+    QString m_lastCheckedAt;
 };
 
 #endif // UPDATERCONTROLLER_H

--- a/src/updater/UpdaterController_test.cpp
+++ b/src/updater/UpdaterController_test.cpp
@@ -1,0 +1,66 @@
+#include <gtest/gtest.h>
+
+#include <QSettings>
+
+#include "AppSettingsKeys.h"
+#include "UpdaterController.h"
+
+namespace {
+
+class UpdaterControllerTestEnv : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        QSettings settings;
+        settings.remove(AppSettingsKeys::updaterChannel());
+        settings.remove(AppSettingsKeys::updaterCheckOnStartup());
+        settings.remove(AppSettingsKeys::updaterAutoDownload());
+        settings.remove(AppSettingsKeys::updaterSkippedVersion());
+    }
+
+    void TearDown() override
+    {
+        // Leave singleton alive — explicit kill() during QApplication teardown
+        // can race Qt widget cleanup on some platforms.
+    }
+};
+
+} // namespace
+
+TEST_F(UpdaterControllerTestEnv, ChannelDefaultsToStableAndPersists)
+{
+    UpdaterController* controller = UpdaterController::instance();
+    ASSERT_NE(controller, nullptr);
+    EXPECT_EQ(controller->channel(), QStringLiteral("stable"));
+
+    controller->setChannel(QStringLiteral("beta"));
+    EXPECT_EQ(controller->channel(), QStringLiteral("beta"));
+
+    QSettings settings;
+    EXPECT_EQ(settings.value(AppSettingsKeys::updaterChannel()).toString(),
+              QStringLiteral("beta"));
+}
+
+TEST_F(UpdaterControllerTestEnv, StartupAndAutoDownloadSettingsPersist)
+{
+    UpdaterController* controller = UpdaterController::instance();
+    controller->setCheckOnStartup(false);
+    controller->setAutoDownload(true);
+
+    QSettings settings;
+    EXPECT_FALSE(settings.value(AppSettingsKeys::updaterCheckOnStartup(), true).toBool());
+    EXPECT_TRUE(settings.value(AppSettingsKeys::updaterAutoDownload(), false).toBool());
+}
+
+TEST_F(UpdaterControllerTestEnv, SkipVersionWritesSettingsKey)
+{
+    UpdaterController* controller = UpdaterController::instance();
+    controller->setLatestVersionForTest(QStringLiteral("3.5.4-beta.1"));
+    controller->skipThisVersion();
+
+    QSettings settings;
+    EXPECT_EQ(settings.value(AppSettingsKeys::updaterSkippedVersion()).toString(),
+              QStringLiteral("3.5.4-beta.1"));
+    EXPECT_EQ(controller->state(), UpdaterController::State::UpToDate);
+}

--- a/src/updater/UpdaterController_test.cpp
+++ b/src/updater/UpdaterController_test.cpp
@@ -12,6 +12,7 @@ class UpdaterControllerTestEnv : public ::testing::Test
 protected:
     void SetUp() override
     {
+        UpdaterController::kill();
         QSettings settings;
         settings.remove(AppSettingsKeys::updaterChannel());
         settings.remove(AppSettingsKeys::updaterCheckOnStartup());
@@ -63,4 +64,17 @@ TEST_F(UpdaterControllerTestEnv, SkipVersionWritesSettingsKey)
     EXPECT_EQ(settings.value(AppSettingsKeys::updaterSkippedVersion()).toString(),
               QStringLiteral("3.5.4-beta.1"));
     EXPECT_EQ(controller->state(), UpdaterController::State::UpToDate);
+}
+
+TEST_F(UpdaterControllerTestEnv, LoadSettingsDoesNotResetOtherPreferences)
+{
+    QSettings settings;
+    settings.setValue(AppSettingsKeys::updaterChannel(), QStringLiteral("beta"));
+    settings.setValue(AppSettingsKeys::updaterCheckOnStartup(), false);
+    settings.setValue(AppSettingsKeys::updaterAutoDownload(), true);
+
+    UpdaterController* controller = UpdaterController::instance();
+    EXPECT_EQ(controller->channel(), QStringLiteral("beta"));
+    EXPECT_FALSE(controller->checkOnStartup());
+    EXPECT_TRUE(controller->autoDownload());
 }


### PR DESCRIPTION
## Summary
- Adds `UpdaterDialog.qml` with state-driven UX for unknown install confirmation, package-manager guidance, update available (release notes + actions), up-to-date, and error states — replacing the old `QMessageBox` flow.
- Adds Preferences → **Updates** tab (`UpdaterSettingsPanel.qml`) with stable/beta channel, check-on-startup, auto-download opt-in, and **Check now** (opens the dialog).
- Introduces `ENABLE_AUTO_UPDATER` (default ON) to omit in-app updater UI from package-managed builds; wires Help → **Check for Updates…** through `MainWindow::showUpdaterDialog()`.

## Test plan
- [x] `./build_local/bin/UnitTests --gtest_filter="UpdaterController*:GitHubReleaseParser*:UpdateVersion*"` (21 tests pass)
- [ ] Help → Check for Updates… opens dialog and runs GitHub check (portable/dev install)
- [ ] Homebrew/Snap/Debian install shows package-manager command panel (no download)
- [ ] Edit → Preferences → Updates tab: channel/toggles persist; **Check now** opens dialog
- [ ] Skip this version / Remind me later dismiss dialog; skipped version treated as up-to-date on next check

Closes #443, #449

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-app auto-updater with a full “Check for Updates” dialog (includes update progress, changelog preview, release page access, and last-checked info).
  * Added an “Updates” section in Preferences with stable/beta selection, check-on-startup, and auto-download options; the tab and updater UI appear only when supported.
  * Supports skipping versions and copying the suggested update command.
* **Bug Fixes**
  * Improved updater state handling, error messaging, and persistence of updater preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->