### PR TITLE
feat(texture): multi-view bake consistency — seed lock, color match, seam feather

### DIFF
--- a/src/MaterialEditorQML.cpp
+++ b/src/MaterialEditorQML.cpp
@@ -12,6 +12,7 @@
 #include <OgreMesh.h>
 #include <OgreTechnique.h>
 #include <QDir>
+#include <QRandomGenerator>
 #include <QRegularExpression>
 #include <QFileInfo>
 #include <QTextStream>
@@ -4019,6 +4020,7 @@ struct MaterialEditorQML::MultiViewBakeState {
     int width = 512;
     int height = 512;
     float controlStrength = 0.9f;
+    int64_t seed = -1;                             // ONE locked seed across views
     std::vector<MeshDepthRenderer::View> views;   // resolved camera views
     std::vector<MultiViewTextureBaker::View> baked; // accumulated image+matrices
     size_t current = 0;                            // index of the view being generated
@@ -4072,6 +4074,12 @@ void MaterialEditorQML::generateMeshTextureMultiView(const QString &prompt,
     st->height = height > 0 ? height : 512;
     st->controlStrength = static_cast<float>(std::clamp(controlStrength, 0.0, 1.0));
     st->controlNetPath = discoveredControlNetDepthPath();
+    // Lock ONE seed for every view so front/back share the same denoising
+    // trajectory — the cheapest, highest-leverage consistency win (otherwise
+    // each view draws fresh random noise and the styles diverge). Pick a fixed
+    // positive seed once; pass it to every generateMeshTexture call below.
+    st->seed = static_cast<int64_t>(
+        QRandomGenerator::global()->bounded(1, 2147483647));
 
     const QStringList viewNames = views.isEmpty()
         ? QStringList{ QStringLiteral("front"), QStringLiteral("back") } : views;
@@ -4143,7 +4151,7 @@ void MaterialEditorQML::startNextMultiViewGeneration()
     emit sdGenerationProgressChanged();
     SDManager::instance()->generateMeshTexture(
         s.prompt, rr.depth, s.controlNetPath, s.controlStrength,
-        QString(), s.width, s.height);
+        QString(), s.width, s.height, s.seed);  // same seed → consistent views
 #endif
 }
 

--- a/src/MultiViewTextureBaker.cpp
+++ b/src/MultiViewTextureBaker.cpp
@@ -69,6 +69,55 @@ Ogre::ColourValue sampleImage(const QImage& img, const Ogre::Vector2& uv)
     return top * (1 - ty) + bot * ty;
 }
 
+// Per-channel mean of a view image over reasonably-opaque, non-near-white
+// pixels (near-white is usually the generator's empty background, which would
+// skew the target). Returns mean RGB in 0..1.
+Ogre::Vector3 imageMeanRGB(const QImage& img)
+{
+    double sr = 0, sg = 0, sb = 0; long count = 0;
+    const int w = img.width(), h = img.height();
+    // Sample on a grid (cap work on large images) — mean is stable from a subset.
+    const int step = std::max(1, (w * h) / (256 * 256));
+    long idx = 0;
+    for (int y = 0; y < h; ++y) {
+        for (int x = 0; x < w; ++x, ++idx) {
+            if (idx % step) continue;
+            const QRgb c = img.pixel(x, y);
+            if (qAlpha(c) < 8) continue;
+            if (qRed(c) > 247 && qGreen(c) > 247 && qBlue(c) > 247) continue; // bg
+            sr += qRed(c); sg += qGreen(c); sb += qBlue(c); ++count;
+        }
+    }
+    if (count == 0) return Ogre::Vector3(0.5f, 0.5f, 0.5f);
+    return Ogre::Vector3(float(sr / count) / 255.0f,
+                         float(sg / count) / 255.0f,
+                         float(sb / count) / 255.0f);
+}
+
+// Shift `img`'s per-channel mean toward `target` (mean-matching). A gentle
+// additive correction — robust and avoids the contrast over-stretch a full
+// mean+std match can cause on flat textures.
+QImage colorMatched(const QImage& img, const Ogre::Vector3& target)
+{
+    const Ogre::Vector3 m = imageMeanRGB(img);
+    const float dr = (target.x - m.x) * 255.0f;
+    const float dg = (target.y - m.y) * 255.0f;
+    const float db = (target.z - m.z) * 255.0f;
+    if (std::abs(dr) < 1.0f && std::abs(dg) < 1.0f && std::abs(db) < 1.0f)
+        return img;  // already close — skip the copy
+    QImage outImg = img.convertToFormat(QImage::Format_RGB888);
+    for (int y = 0; y < outImg.height(); ++y) {
+        uchar* line = outImg.scanLine(y);
+        for (int x = 0; x < outImg.width(); ++x) {
+            uchar* p = line + x * 3;
+            p[0] = static_cast<uchar>(std::clamp(p[0] + dr, 0.0f, 255.0f));
+            p[1] = static_cast<uchar>(std::clamp(p[1] + dg, 0.0f, 255.0f));
+            p[2] = static_cast<uchar>(std::clamp(p[2] + db, 0.0f, 255.0f));
+        }
+    }
+    return outImg;
+}
+
 } // namespace
 
 MultiViewTextureBaker::Report MultiViewTextureBaker::bake(
@@ -96,6 +145,20 @@ MultiViewTextureBaker::Report MultiViewTextureBaker::bake(
     }
     const int res = std::clamp(opts.resolution, 16, 8192);
     rep.perViewTriangleCount.assign(views.size(), 0);
+
+    // Color-match later views to the first view's mean so independent diffusion
+    // runs (front vs back) don't show a global hue/brightness jump at the seam.
+    // Work on a local copy; the first view is the reference (unchanged).
+    std::vector<View> matched;
+    const std::vector<View>* useViews = &views;
+    if (opts.colorMatchToFirstView && views.size() > 1) {
+        const Ogre::Vector3 target = imageMeanRGB(views[0].image);
+        matched = views;
+        for (size_t i = 1; i < matched.size(); ++i)
+            matched[i].image = colorMatched(matched[i].image, target);
+        useViews = &matched;
+    }
+    const std::vector<View>& V = *useViews;
 
     // Weighted accumulation buffers (RGB * weight, and weight sum) per texel.
     const size_t n = static_cast<size_t>(res) * res;
@@ -158,8 +221,8 @@ MultiViewTextureBaker::Report MultiViewTextureBaker::bake(
         if (nrm.isZeroLength()) continue;   // degenerate triangle
         nrm.normalise();
 
-        for (size_t vi = 0; vi < views.size(); ++vi) {
-            const View& v = views[vi];
+        for (size_t vi = 0; vi < V.size(); ++vi) {
+            const View& v = V[vi];
             // Facing weight: the surface normal pointing back toward the camera
             // means -viewDir (camera looks ALONG camDirection into the scene).
             float facing = -nrm.dotProduct(v.camDirection);

--- a/src/MultiViewTextureBaker.h
+++ b/src/MultiViewTextureBaker.h
@@ -53,10 +53,17 @@ public:
     struct Options {
         int   resolution     = 1024;  // output atlas size (square)
         int   dilationPixels = 4;     // seam-dilation passes after raster
-        float facingPower    = 1.0f;  // exponent on the facing weight
+        /// Exponent on the per-view facing weight. LOWER = wider, softer
+        /// front↔back cross-fade band near the silhouette (less visible seam);
+        /// higher = each view dominates its facing hemisphere more sharply.
+        float facingPower    = 0.5f;
         /// Triangles whose facing weight to a view is below this are not
         /// projected from that view (back-face / grazing rejection).
         float minFacing      = 0.05f;
+        /// Match the per-channel mean of every view image to the FIRST view
+        /// before baking, so independent diffusion runs (front/back) don't
+        /// produce a global hue/brightness mismatch across the seam.
+        bool  colorMatchToFirstView = true;
         /// Background for texels no view covered (alpha 0 = transparent seam mask).
         Ogre::ColourValue background = Ogre::ColourValue(1.0f, 1.0f, 1.0f, 0.0f);
     };

--- a/src/MultiViewTextureBaker_test.cpp
+++ b/src/MultiViewTextureBaker_test.cpp
@@ -198,3 +198,37 @@ TEST(MultiViewTextureBakerTest, DilationFillsBackgroundNeighbours)
     // Centre is inside the island → green.
     EXPECT_NEAR(at(out, 0.5f, 0.5f).g, 1.0f, 0.02f);
 }
+
+TEST(MultiViewTextureBakerTest, ColorMatchShiftsLaterViewTowardFirst)
+{
+    // Two cameras that BOTH face the +Z quad (front at +Z, and a second one
+    // slightly off +Z so its facing weight is also positive). The first view is
+    // mid-grey; the second is dark. With colorMatchToFirstView on, the second
+    // image's mean is lifted toward the first, so the blended result is brighter
+    // than it would be with the dark second image left as-is.
+    auto tris = makeQuad(Ogre::Vector3::UNIT_Z);
+
+    MultiViewTextureBaker::View v0 = frontView(solid(16, 130, 130, 130)); // grey
+    MultiViewTextureBaker::View v1;                                        // dark
+    v1.image = solid(16, 20, 20, 20);
+    v1.viewProj = makeViewProj(Ogre::Vector3(0.6f, 0, 4), Ogre::Vector3(0, 0, 0),
+                               Ogre::Vector3::UNIT_Y, 1.2f, 1.0f, 0.1f, 100.0f);
+    v1.camDirection = Ogre::Vector3(-0.15f, 0, -1).normalisedCopy();
+
+    auto bakeWith = [&](bool match) {
+        TexturePaintBuffer out;
+        MultiViewTextureBaker::Options opts;
+        opts.resolution = 32;
+        opts.dilationPixels = 0;
+        opts.colorMatchToFirstView = match;
+        auto rep = MultiViewTextureBaker::bake(tris, { v0, v1 }, out, opts);
+        EXPECT_TRUE(rep.ok) << rep.error.toStdString();
+        return at(out, 0.5f, 0.5f).r;
+    };
+
+    const float matched = bakeWith(true);
+    const float unmatched = bakeWith(false);
+    // Matching lifts the dark second view toward the grey first view, so the
+    // blended centre is brighter than without matching.
+    EXPECT_GT(matched, unmatched);
+}

--- a/src/SDManager.cpp
+++ b/src/SDManager.cpp
@@ -452,7 +452,8 @@ void SDManager::generateMeshTexture(const QString &prompt,
                                     float controlStrength,
                                     const QString &outputFileName,
                                     int width,
-                                    int height)
+                                    int height,
+                                    int64_t seed)
 {
     if (!isModelLoaded()) {
         emit generationError("No SD model loaded. Please load a model first.");
@@ -486,6 +487,10 @@ void SDManager::generateMeshTexture(const QString &prompt,
     }
     genSettings.controlNetPath  = controlNetPath;
     genSettings.controlStrength = controlStrength;
+    // A non-negative seed locks generation determinism for this call (used by
+    // the multi-view bake to share one seed across views); -1 keeps the stored
+    // seed (which is itself -1 = random by default).
+    if (seed >= 0) genSettings.seed = seed;
     // Honor the caller's requested generation size (the depth map is
     // captured at this resolution too); fall back to the stored SD
     // settings when a non-positive value is passed.

--- a/src/SDManager.h
+++ b/src/SDManager.h
@@ -118,13 +118,18 @@ public slots:
     // rendered depth map) via a ControlNet model at `controlNetPath`.
     // When controlImage is null or controlNetPath empty, behaves
     // like a plain generateTexture. `controlStrength` is 0..1.
+    // `seed` >= 0 overrides the stored random seed for this call — used by the
+    // multi-view bake to lock ONE seed across all views so front/back share the
+    // same denoising trajectory (much closer hue/lighting/style). -1 keeps the
+    // stored seed (random when that is also -1).
     void generateMeshTexture(const QString &prompt,
                              const QImage &controlImage,
                              const QString &controlNetPath,
                              float controlStrength,
                              const QString &outputFileName = QString(),
                              int width = 0,
-                             int height = 0);
+                             int height = 0,
+                             int64_t seed = -1);
 
     Q_INVOKABLE void stopGeneration();
     Q_INVOKABLE void tryAutoLoadModel();


### PR DESCRIPTION
Follow-up to the multi-view AI texture bake (#729). Makes the per-view images read as one coherent texture instead of independent diffusion runs, so front/back don't show a style/colour jump at the silhouette seam.

## Changes
- **Seed lock:** `generateMeshTextureMultiView` picks ONE positive seed and passes it to every view's generation, so all views share the same denoising trajectory (closest hue/lighting/style). `SDManager::generateMeshTexture` gains an optional `seed` arg (`>=0` overrides the stored/random seed; `-1` = unchanged) — the single-view path is unaffected.
- **Color match:** `MultiViewTextureBaker` shifts each later view's per-channel mean to the FIRST view's mean before baking (`Options::colorMatchToFirstView`, default on). Mean is computed over non-background, non-near-white pixels; correction is a gentle additive shift (avoids the contrast over-stretch of a full mean+std match). Kills the global hue/brightness mismatch across the seam.
- **Wider seam feather:** default `Options::facingPower` lowered 1.0 → 0.5 so front and back cross-fade over a band near the silhouette rather than switching hard.

## Why seed+color+feather (not `ref_images` yet)
The literal "back uses front as context" is sd.cpp's reference-image path (`ref_images[]`). The field exists in the build but isn't wired, and its payoff depends on an empirical model test. This trio is the safe, high-leverage fix with zero sd.cpp risk; `ref_images` is scoped as a follow-up if style drift remains.

## Testing
- App + UnitTests build clean.
- New unit test asserts the color-match shifts a darker later view toward the first view's brightness.
- Color-match mean-shift validated standalone (dark back image mean lifted exactly to the front mean).
- SD-driven generation stays `#ifdef ENABLE_STABLE_DIFFUSION`-guarded (no model in CI), matching #403/#729.

🤖 Generated with [Claude Code](https://claude.com/claude-code)