### PR TITLE
Add updater download and verification (#444, #445)

### DIFF
--- a/cmake/Libsodium.cmake
+++ b/cmake/Libsodium.cmake
@@ -30,6 +30,12 @@ if(UNIX AND NOT APPLE)
 endif()
 
 include(FetchContent)
+include(ProcessorCount)
+
+ProcessorCount(QTMESH_LIBSODIUM_JOBS)
+if(NOT QTMESH_LIBSODIUM_JOBS OR QTMESH_LIBSODIUM_JOBS LESS 1)
+    set(QTMESH_LIBSODIUM_JOBS 1)
+endif()
 
 set(QTMESH_LIBSODIUM_URL
     "https://download.libsodium.org/libsodium/releases/libsodium-1.0.20-stable.tar.gz"
@@ -64,7 +70,7 @@ if(NOT EXISTS "${QTMESH_LIBSODIUM_MARKER}")
         message(FATAL_ERROR "libsodium configure failed (${qtmesh_sodium_configure_result})")
     endif()
     execute_process(
-        COMMAND make -j
+        COMMAND make -j${QTMESH_LIBSODIUM_JOBS}
         WORKING_DIRECTORY "${qtmesh_libsodium_src_SOURCE_DIR}"
         RESULT_VARIABLE qtmesh_sodium_build_result
     )

--- a/cmake/Libsodium.cmake
+++ b/cmake/Libsodium.cmake
@@ -1,30 +1,32 @@
-# libsodium for minisign verify (spike #440 / follow-up #445).
-# Linux only — other platforms get a stub INTERFACE target.
+# libsodium for minisign verify (#440 / #445).
+# Linux + macOS link static/system libsodium. Windows MinGW verify is deferred
+# (autotools/cmake build not wired in CI yet — download still runs, verify fails closed).
 
 if(TARGET qtmesh_sodium)
     return()
 endif()
 
-if(NOT (UNIX AND NOT APPLE))
-    message(STATUS "libsodium: skipped (minisign verify is Linux-only in spike #440)")
+if(WIN32)
+    message(STATUS "libsodium: Windows MinGW verify deferred (#445 follow-up)")
     add_library(qtmesh_sodium INTERFACE)
     target_compile_definitions(qtmesh_sodium INTERFACE QTMESH_MINISIGN_VERIFY=0)
     return()
 endif()
 
-find_package(PkgConfig QUIET)
-if(PkgConfig_FOUND)
-    pkg_check_modules(QTMESH_LIBSODIUM libsodium)
-endif()
-
-if(QTMESH_LIBSODIUM_FOUND)
-    message(STATUS "libsodium: using system package (pkg-config)")
-    add_library(qtmesh_sodium INTERFACE)
-    target_include_directories(qtmesh_sodium SYSTEM INTERFACE ${QTMESH_LIBSODIUM_INCLUDE_DIRS})
-    target_link_libraries(qtmesh_sodium INTERFACE ${QTMESH_LIBSODIUM_LIBRARIES})
-    target_compile_options(qtmesh_sodium INTERFACE ${QTMESH_LIBSODIUM_CFLAGS_OTHER})
-    target_compile_definitions(qtmesh_sodium INTERFACE QTMESH_MINISIGN_VERIFY=1)
-    return()
+if(UNIX AND NOT APPLE)
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(QTMESH_LIBSODIUM libsodium)
+    endif()
+    if(QTMESH_LIBSODIUM_FOUND)
+        message(STATUS "libsodium: using system package (pkg-config)")
+        add_library(qtmesh_sodium INTERFACE)
+        target_include_directories(qtmesh_sodium SYSTEM INTERFACE ${QTMESH_LIBSODIUM_INCLUDE_DIRS})
+        target_link_libraries(qtmesh_sodium INTERFACE ${QTMESH_LIBSODIUM_LIBRARIES})
+        target_compile_options(qtmesh_sodium INTERFACE ${QTMESH_LIBSODIUM_CFLAGS_OTHER})
+        target_compile_definitions(qtmesh_sodium INTERFACE QTMESH_MINISIGN_VERIFY=1)
+        return()
+    endif()
 endif()
 
 include(FetchContent)
@@ -36,7 +38,7 @@ set(QTMESH_LIBSODIUM_SHA256
     "b6b1d2a8802cd8bfa611638c0e9ce31d14ef324e16062c39a76854091cba6d7f"
     CACHE STRING "SHA256 of libsodium tarball")
 
-message(STATUS "libsodium: system package not found — building static from source")
+message(STATUS "libsodium: building static from source")
 
 FetchContent_Declare(
     qtmesh_libsodium_src

--- a/docs/AUTO_UPDATER_DESIGN.md
+++ b/docs/AUTO_UPDATER_DESIGN.md
@@ -43,6 +43,7 @@ Production public key: `packaging/updater/minisign.pub` (embedded in `MinisignVe
 
 - `MinisignVerify::verifyFile()` implements minisign’s dual-signature check (file + trusted comment) via **libsodium** (same algorithms as the CLI).
 - Linux-only in this spike; Windows/macOS return `Unsupported` until #445 wires cross-platform static libsodium.
+- **#445:** `MinisignVerify` builds wherever `QTMESH_MINISIGN_VERIFY=1` (Linux + macOS via libsodium). Windows MinGW verify is deferred — downloads fail closed at the signature step until a follow-up wires libsodium there.
 - Tests: `MinisignVerify_test` verifies good/tampered/bad-key against `tests/fixtures/updater/release-3.5.3-readme.md` (content from GitHub tag `3.5.3`).
 
 ---
@@ -129,7 +130,7 @@ Version comparison reuses `UpdateVersion::compare()` (#442) — normalises optio
 | [#441](https://github.com/fernandotonon/QtMeshEditor/issues/441) | `UpdaterController` + GitHub JSON — **in progress** |
 | [#442](https://github.com/fernandotonon/QtMeshEditor/issues/442) | Semver compare — **done** (`UpdateVersion`) |
 | [#443](https://github.com/fernandotonon/QtMeshEditor/issues/443) | Wire `InstallFlavor` into UX |
-| [#444–445](https://github.com/fernandotonon/QtMeshEditor/issues/444) | Download + verify pipeline |
+| [#444–445](https://github.com/fernandotonon/QtMeshEditor/issues/444) | Download + verify pipeline — **in progress** |
 | [#446–448](https://github.com/fernandotonon/QtMeshEditor/issues/446) | Relauncher + per-platform install |
 | **New PR** | `deploy.yml` minisign signing (section above) |
 

--- a/docs/AUTO_UPDATER_DESIGN.md
+++ b/docs/AUTO_UPDATER_DESIGN.md
@@ -42,8 +42,7 @@ Production public key: `packaging/updater/minisign.pub` (embedded in `MinisignVe
 ### PoC status
 
 - `MinisignVerify::verifyFile()` implements minisign’s dual-signature check (file + trusted comment) via **libsodium** (same algorithms as the CLI).
-- Linux-only in this spike; Windows/macOS return `Unsupported` until #445 wires cross-platform static libsodium.
-- **#445:** `MinisignVerify` builds wherever `QTMESH_MINISIGN_VERIFY=1` (Linux + macOS via libsodium). Windows MinGW verify is deferred — downloads fail closed at the signature step until a follow-up wires libsodium there.
+- **#445:** builds with `QTMESH_MINISIGN_VERIFY=1` on Linux and macOS (system pkg-config or static libsodium). Windows MinGW verify is deferred — downloads fail closed at the signature step until a follow-up wires libsodium there.
 - Tests: `MinisignVerify_test` verifies good/tampered/bad-key against `tests/fixtures/updater/release-3.5.3-readme.md` (content from GitHub tag `3.5.3`).
 
 ---

--- a/qml/UpdaterDialog.qml
+++ b/qml/UpdaterDialog.qml
@@ -236,7 +236,6 @@ Window {
                 }
                 InspectorButton {
                     label: "Download & install"
-                    buttonEnabled: false
                     onClicked: UpdaterController.downloadAndInstall()
                 }
             }
@@ -266,6 +265,25 @@ Window {
                 text: UpdaterController.latestVersion.length > 0
                       ? "You already have the latest release (" + UpdaterController.latestVersion + ")."
                       : "You already have the latest release."
+            }
+            InspectorButton {
+                label: "Close"
+                onClicked: { UpdaterController.dismiss(); dialog.close() }
+            }
+        }
+
+        // Ready to install (#444 — install step lands in #446–448)
+        ColumnLayout {
+            Layout.fillWidth: true
+            visible: UpdaterController.state === UpdaterController.ReadyToInstall
+            spacing: 8
+            Text {
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+                color: PropertiesPanelController.textColor
+                font.pixelSize: 12
+                text: "Update " + UpdaterController.latestVersion +
+                      " downloaded and verified. Automatic installation will be available in a future release."
             }
             InspectorButton {
                 label: "Close"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,6 +99,8 @@ PaintSelectionMask.cpp
 TexturePaintBuffer.cpp
 UpdateVersion.cpp
 updater/InstallFlavor.cpp
+updater/ArtifactResolver.cpp
+updater/UpdateVerifier.cpp
 updater/MinisignVerify.cpp
 updater/GitHubReleaseParser.cpp
 updater/UpdaterWorker.cpp
@@ -238,6 +240,8 @@ PaintSelectionMask.h
 TexturePaintBuffer.h
 UpdateVersion.h
 updater/InstallFlavor.h
+updater/ArtifactResolver.h
+updater/UpdateVerifier.h
 updater/MinisignVerify.h
 updater/GitHubReleaseParser.h
 updater/UpdaterWorker.h

--- a/src/updater/ArtifactResolver.cpp
+++ b/src/updater/ArtifactResolver.cpp
@@ -1,0 +1,110 @@
+#include "ArtifactResolver.h"
+
+#include <QRegularExpression>
+
+namespace ArtifactResolver {
+
+namespace {
+
+const GitHubReleaseParser::ReleaseAsset* findAssetByName(
+    const QList<GitHubReleaseParser::ReleaseAsset>& assets,
+    const QRegularExpression& pattern)
+{
+    for (const GitHubReleaseParser::ReleaseAsset& asset : assets) {
+        if (pattern.match(asset.name).hasMatch()) {
+            return &asset;
+        }
+    }
+    return nullptr;
+}
+
+const GitHubReleaseParser::ReleaseAsset* findAssetExact(
+    const QList<GitHubReleaseParser::ReleaseAsset>& assets,
+    const QString& name)
+{
+    for (const GitHubReleaseParser::ReleaseAsset& asset : assets) {
+        if (asset.name.compare(name, Qt::CaseInsensitive) == 0) {
+            return &asset;
+        }
+    }
+    return nullptr;
+}
+
+QRegularExpression primaryArtifactPattern()
+{
+#if defined(Q_OS_WIN)
+    return QRegularExpression(QStringLiteral("^.+-bin-Windows\\.zip$"),
+                              QRegularExpression::CaseInsensitiveOption);
+#elif defined(Q_OS_MACOS)
+    return QRegularExpression(QStringLiteral("^.+-MacOS\\.dmg$"),
+                              QRegularExpression::CaseInsensitiveOption);
+#elif defined(Q_OS_LINUX)
+    return QRegularExpression(
+        QStringLiteral("^.+(-linux|_linux)[-_].+\\.(AppImage|tar\\.gz|tar\\.xz)$"),
+        QRegularExpression::CaseInsensitiveOption);
+#else
+    return QRegularExpression();
+#endif
+}
+
+} // namespace
+
+ResolvedArtifact resolveForCurrentPlatform(
+    const QList<GitHubReleaseParser::ReleaseAsset>& assets,
+    InstallFlavor::Flavor flavor)
+{
+    ResolvedArtifact result;
+
+    if (!InstallFlavor::isPackageManagerManaged(flavor) && flavor != InstallFlavor::Flavor::Portable
+        && flavor != InstallFlavor::Flavor::Unknown) {
+        result.errorMessage = QStringLiteral("In-app download is only supported for portable installs");
+        return result;
+    }
+
+    const QRegularExpression pattern = primaryArtifactPattern();
+#if !defined(Q_OS_WIN) && !defined(Q_OS_MACOS) && !defined(Q_OS_LINUX)
+    result.errorMessage = QStringLiteral("Auto-update downloads are not supported on this platform");
+    return result;
+#endif
+
+    if (!pattern.isValid()) {
+        result.errorMessage = QStringLiteral("Auto-update downloads are not supported on this platform");
+        return result;
+    }
+
+    const GitHubReleaseParser::ReleaseAsset* primary = findAssetByName(assets, pattern);
+    if (!primary) {
+#if defined(Q_OS_LINUX)
+        result.errorMessage =
+            QStringLiteral("No portable Linux update package found in this release "
+                           "(expected AppImage or .tar.gz; .deb installs use apt)");
+#else
+        result.errorMessage = QStringLiteral("No update package found for this platform in the release");
+#endif
+        return result;
+    }
+
+    result.fileName = primary->name;
+    result.downloadUrl = primary->browserDownloadUrl;
+
+    const QString signatureName = primary->name + QStringLiteral(".minisig");
+    if (const GitHubReleaseParser::ReleaseAsset* sig = findAssetExact(assets, signatureName)) {
+        result.signatureFileName = sig->name;
+        result.signatureUrl = sig->browserDownloadUrl;
+    } else {
+        result.errorMessage =
+            QStringLiteral("Release is missing signature sidecar: %1").arg(signatureName);
+        return result;
+    }
+
+    if (const GitHubReleaseParser::ReleaseAsset* sums =
+            findAssetExact(assets, QStringLiteral("SHA256SUMS"))) {
+        result.sha256SumsFileName = sums->name;
+        result.sha256SumsUrl = sums->browserDownloadUrl;
+    }
+
+    result.ok = true;
+    return result;
+}
+
+} // namespace ArtifactResolver

--- a/src/updater/ArtifactResolver.cpp
+++ b/src/updater/ArtifactResolver.cpp
@@ -55,8 +55,7 @@ ResolvedArtifact resolveForCurrentPlatform(
 {
     ResolvedArtifact result;
 
-    if (!InstallFlavor::isPackageManagerManaged(flavor) && flavor != InstallFlavor::Flavor::Portable
-        && flavor != InstallFlavor::Flavor::Unknown) {
+    if (flavor != InstallFlavor::Flavor::Portable && flavor != InstallFlavor::Flavor::Unknown) {
         result.errorMessage = QStringLiteral("In-app download is only supported for portable installs");
         return result;
     }

--- a/src/updater/ArtifactResolver.h
+++ b/src/updater/ArtifactResolver.h
@@ -1,0 +1,39 @@
+#ifndef ARTIFACTRESOLVER_H
+#define ARTIFACTRESOLVER_H
+
+#include "GitHubReleaseParser.h"
+#include "InstallFlavor.h"
+
+#include <QList>
+#include <QString>
+
+/**
+ * @brief Pick the release artifact matching the running platform (#444).
+ *
+ * Pure-data resolver — no network. Only @ref InstallFlavor::Portable receives
+ * an artifact; package-managed flavors should never call this.
+ */
+namespace ArtifactResolver {
+
+struct ResolvedArtifact {
+    bool ok = false;
+    QString fileName;
+    QString downloadUrl;
+    QString signatureFileName;
+    QString signatureUrl;
+    QString sha256SumsFileName;
+    QString sha256SumsUrl;
+    QString errorMessage;
+};
+
+/**
+ * @brief Resolve the portable update artifact for the current OS/arch.
+ *
+ * @p assets is the `assets[]` array from the chosen GitHub release.
+ */
+ResolvedArtifact resolveForCurrentPlatform(const QList<GitHubReleaseParser::ReleaseAsset>& assets,
+                                           InstallFlavor::Flavor flavor);
+
+} // namespace ArtifactResolver
+
+#endif // ARTIFACTRESOLVER_H

--- a/src/updater/ArtifactResolver_test.cpp
+++ b/src/updater/ArtifactResolver_test.cpp
@@ -87,6 +87,20 @@ TEST(ArtifactResolver, PicksLinuxTarballWithSignature)
 
 #endif
 
+TEST(ArtifactResolver, RejectsPackageManagedFlavor)
+{
+    QList<ReleaseAsset> assets = {
+        makeAsset(QStringLiteral("QtMeshEditor-3.5.3-bin-Windows.zip")),
+        makeAsset(QStringLiteral("QtMeshEditor-3.5.3-bin-Windows.zip.minisig")),
+    };
+
+    const ArtifactResolver::ResolvedArtifact resolved =
+        ArtifactResolver::resolveForCurrentPlatform(assets, InstallFlavor::Flavor::Homebrew);
+
+    EXPECT_FALSE(resolved.ok);
+    EXPECT_TRUE(resolved.errorMessage.contains(QStringLiteral("portable")));
+}
+
 TEST(ArtifactResolver, RequiresSignatureSidecar)
 {
     QList<ReleaseAsset> assets;

--- a/src/updater/ArtifactResolver_test.cpp
+++ b/src/updater/ArtifactResolver_test.cpp
@@ -1,0 +1,106 @@
+#include <gtest/gtest.h>
+
+#include "ArtifactResolver.h"
+
+using GitHubReleaseParser::ReleaseAsset;
+
+namespace {
+
+ReleaseAsset makeAsset(const QString& name, const QString& url = QString())
+{
+    ReleaseAsset asset;
+    asset.name = name;
+    asset.browserDownloadUrl = url.isEmpty()
+        ? QStringLiteral("https://example.com/%1").arg(name)
+        : url;
+    asset.size = 1024;
+    return asset;
+}
+
+} // namespace
+
+#if defined(Q_OS_WIN)
+
+TEST(ArtifactResolver, PicksWindowsZipWithSignature)
+{
+    QList<ReleaseAsset> assets = {
+        makeAsset(QStringLiteral("qtmesheditor_amd64.deb")),
+        makeAsset(QStringLiteral("QtMeshEditor-3.5.3-bin-Windows.zip")),
+        makeAsset(QStringLiteral("QtMeshEditor-3.5.3-bin-Windows.zip.minisig")),
+        makeAsset(QStringLiteral("SHA256SUMS")),
+    };
+
+    const ArtifactResolver::ResolvedArtifact resolved =
+        ArtifactResolver::resolveForCurrentPlatform(assets, InstallFlavor::Flavor::Portable);
+
+    ASSERT_TRUE(resolved.ok) << resolved.errorMessage.toStdString();
+    EXPECT_EQ(resolved.fileName, QStringLiteral("QtMeshEditor-3.5.3-bin-Windows.zip"));
+    EXPECT_FALSE(resolved.signatureUrl.isEmpty());
+    EXPECT_FALSE(resolved.sha256SumsUrl.isEmpty());
+}
+
+#elif defined(Q_OS_MACOS)
+
+TEST(ArtifactResolver, PicksMacDmgWithSignature)
+{
+    QList<ReleaseAsset> assets = {
+        makeAsset(QStringLiteral("QtMeshEditor-3.5.3-MacOS.dmg")),
+        makeAsset(QStringLiteral("QtMeshEditor-3.5.3-MacOS.dmg.minisig")),
+    };
+
+    const ArtifactResolver::ResolvedArtifact resolved =
+        ArtifactResolver::resolveForCurrentPlatform(assets, InstallFlavor::Flavor::Portable);
+
+    ASSERT_TRUE(resolved.ok) << resolved.errorMessage.toStdString();
+    EXPECT_EQ(resolved.fileName, QStringLiteral("QtMeshEditor-3.5.3-MacOS.dmg"));
+}
+
+#elif defined(Q_OS_LINUX)
+
+TEST(ArtifactResolver, RejectsDebOnlyReleaseForPortableLinux)
+{
+    QList<ReleaseAsset> assets = {
+        makeAsset(QStringLiteral("qtmesheditor_amd64.deb")),
+        makeAsset(QStringLiteral("qtmesheditor_amd64.deb.minisig")),
+    };
+
+    const ArtifactResolver::ResolvedArtifact resolved =
+        ArtifactResolver::resolveForCurrentPlatform(assets, InstallFlavor::Flavor::Portable);
+
+    EXPECT_FALSE(resolved.ok);
+    EXPECT_FALSE(resolved.errorMessage.isEmpty());
+}
+
+TEST(ArtifactResolver, PicksLinuxTarballWithSignature)
+{
+    QList<ReleaseAsset> assets = {
+        makeAsset(QStringLiteral("QtMeshEditor-3.5.3-linux-x86_64.tar.gz")),
+        makeAsset(QStringLiteral("QtMeshEditor-3.5.3-linux-x86_64.tar.gz.minisig")),
+    };
+
+    const ArtifactResolver::ResolvedArtifact resolved =
+        ArtifactResolver::resolveForCurrentPlatform(assets, InstallFlavor::Flavor::Portable);
+
+    ASSERT_TRUE(resolved.ok) << resolved.errorMessage.toStdString();
+    EXPECT_TRUE(resolved.fileName.contains(QStringLiteral("linux")));
+}
+
+#endif
+
+TEST(ArtifactResolver, RequiresSignatureSidecar)
+{
+    QList<ReleaseAsset> assets;
+#if defined(Q_OS_WIN)
+    assets.append(makeAsset(QStringLiteral("QtMeshEditor-3.5.3-bin-Windows.zip")));
+#elif defined(Q_OS_MACOS)
+    assets.append(makeAsset(QStringLiteral("QtMeshEditor-3.5.3-MacOS.dmg")));
+#else
+    assets.append(makeAsset(QStringLiteral("QtMeshEditor-3.5.3-linux-x86_64.tar.gz")));
+#endif
+
+    const ArtifactResolver::ResolvedArtifact resolved =
+        ArtifactResolver::resolveForCurrentPlatform(assets, InstallFlavor::Flavor::Portable);
+
+    EXPECT_FALSE(resolved.ok);
+    EXPECT_TRUE(resolved.errorMessage.contains(QStringLiteral("minisig")));
+}

--- a/src/updater/MinisignVerify.cpp
+++ b/src/updater/MinisignVerify.cpp
@@ -4,7 +4,7 @@
 #include <QFile>
 #include <QTextStream>
 
-#if defined(Q_OS_LINUX)
+#if defined(QTMESH_MINISIGN_VERIFY) && QTMESH_MINISIGN_VERIFY
 #include <sodium.h>
 #endif
 
@@ -39,7 +39,7 @@ QByteArray decodeBase64(const QString& encoded)
     return QByteArray::fromBase64(trimmed);
 }
 
-#if defined(Q_OS_LINUX)
+#if defined(QTMESH_MINISIGN_VERIFY) && QTMESH_MINISIGN_VERIFY
 
 bool ensureSodiumInit()
 {
@@ -109,7 +109,7 @@ Outcome verifyParsed(const QByteArray& message,
     return ok;
 }
 
-#endif // Q_OS_LINUX
+#endif // QTMESH_MINISIGN_VERIFY
 
 QString resultToString(Result result)
 {
@@ -140,12 +140,12 @@ Outcome verifyFile(const QString& messageFile,
                    const QString& signatureFile,
                    const QString& publicKeyBase64)
 {
-#if !defined(Q_OS_LINUX)
+#if !defined(QTMESH_MINISIGN_VERIFY) || !QTMESH_MINISIGN_VERIFY
     Q_UNUSED(messageFile);
     Q_UNUSED(signatureFile);
     Q_UNUSED(publicKeyBase64);
     return fail(Result::Unsupported,
-                QStringLiteral("minisign verify is only built on Linux in this spike"));
+                QStringLiteral("minisign verify is not available in this build"));
 #else
     const QByteArray pubStruct = decodeBase64(publicKeyBase64);
     if (pubStruct.size() < kPubStructBytes)

--- a/src/updater/MinisignVerify.h
+++ b/src/updater/MinisignVerify.h
@@ -11,8 +11,8 @@
  * production public key is compiled in; CI signs artifacts with the matching
  * secret (see docs/AUTO_UPDATER_DESIGN.md).
  *
- * Linux builds link libsodium for verify. Other platforms return
- * @ref Result::Unsupported until #445 lands cross-platform crypto.
+ * Linux builds link libsodium for verify when @c QTMESH_MINISIGN_VERIFY is set.
+ * Builds without the backend return @ref Result::Unsupported.
  */
 namespace MinisignVerify {
 

--- a/src/updater/MinisignVerify_test.cpp
+++ b/src/updater/MinisignVerify_test.cpp
@@ -21,7 +21,7 @@ constexpr const char* kTestPublicKeyBase64 =
 
 } // namespace
 
-#if defined(Q_OS_LINUX)
+#if defined(QTMESH_MINISIGN_VERIFY) && QTMESH_MINISIGN_VERIFY
 
 TEST(MinisignVerify, AcceptsSignedReleaseReadmeFixture)
 {
@@ -71,7 +71,7 @@ TEST(MinisignVerify, RejectsWrongPublicKey)
 
 #else
 
-TEST(MinisignVerify, UnsupportedOnWindowsInSpike)
+TEST(MinisignVerify, UnsupportedWhenVerifyBackendDisabled)
 {
     const MinisignVerify::Outcome out = MinisignVerify::verifyFile(
         fixturePath("release-3.5.3-readme.md"),

--- a/src/updater/UpdateVerifier.cpp
+++ b/src/updater/UpdateVerifier.cpp
@@ -1,0 +1,145 @@
+#include "UpdateVerifier.h"
+
+#include <QCryptographicHash>
+#include <QFile>
+#include <QRegularExpression>
+#include <QTextStream>
+
+namespace UpdateVerifier {
+
+namespace {
+
+QString readManifestHashForFile(const QString& manifestPath, const QString& fileName, QString* error)
+{
+    QFile manifest(manifestPath);
+    if (!manifest.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        if (error) {
+            *error = QStringLiteral("Cannot read SHA256SUMS manifest");
+        }
+        return {};
+    }
+
+    QTextStream stream(&manifest);
+    while (!stream.atEnd()) {
+        const QString line = stream.readLine().trimmed();
+        if (line.isEmpty()) {
+            continue;
+        }
+        const int spaceIdx = line.indexOf(QStringLiteral("  "));
+        if (spaceIdx <= 0) {
+            continue;
+        }
+        const QString hash = line.left(spaceIdx).trimmed();
+        const QString name = line.mid(spaceIdx + 2).trimmed();
+        if (name.compare(fileName, Qt::CaseInsensitive) == 0) {
+            return hash;
+        }
+    }
+
+    if (error) {
+        *error = QStringLiteral("SHA256SUMS does not list %1").arg(fileName);
+    }
+    return {};
+}
+
+} // namespace
+
+QString sha256HexOfFile(const QString& filePath, QString* errorMessage)
+{
+    QFile file(filePath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        if (errorMessage) {
+            *errorMessage = QStringLiteral("Cannot read file for SHA-256: %1").arg(filePath);
+        }
+        return {};
+    }
+
+    QCryptographicHash hash(QCryptographicHash::Sha256);
+    if (!hash.addData(&file)) {
+        if (errorMessage) {
+            *errorMessage = QStringLiteral("SHA-256 read failed: %1").arg(filePath);
+        }
+        return {};
+    }
+
+    return QString::fromLatin1(hash.result().toHex());
+}
+
+bool verifySha256Hex(const QString& filePath,
+                     const QString& expectedHex,
+                     QString* errorMessage)
+{
+    const QString actual = sha256HexOfFile(filePath, errorMessage);
+    if (actual.isEmpty()) {
+        return false;
+    }
+    if (actual.compare(expectedHex.trimmed(), Qt::CaseInsensitive) != 0) {
+        if (errorMessage) {
+            *errorMessage = QStringLiteral("SHA-256 mismatch for %1").arg(filePath);
+        }
+        return false;
+    }
+    return true;
+}
+
+Outcome verifySha256FromManifest(const QString& filePath,
+                                 const QString& manifestPath,
+                                 const QString& fileName)
+{
+    Outcome out;
+    QString lookupError;
+    const QString expected = readManifestHashForFile(manifestPath, fileName, &lookupError);
+    if (expected.isEmpty()) {
+        out.failedStage = QStringLiteral("sha256");
+        out.errorMessage = lookupError;
+        return out;
+    }
+
+    QString verifyError;
+    if (!verifySha256Hex(filePath, expected, &verifyError)) {
+        out.failedStage = QStringLiteral("sha256");
+        out.errorMessage = verifyError;
+        return out;
+    }
+
+    out.ok = true;
+    return out;
+}
+
+Outcome verifyDownloadedArtifact(const QString& artifactPath,
+                                 const QString& signaturePath,
+                                 const QString& manifestPath,
+                                 const QString& fileName)
+{
+    Outcome out;
+
+    if (!manifestPath.isEmpty()) {
+        const Outcome shaOutcome =
+            verifySha256FromManifest(artifactPath, manifestPath, fileName);
+        if (!shaOutcome.ok) {
+            return shaOutcome;
+        }
+    }
+
+#if defined(QTMESH_MINISIGN_VERIFY) && QTMESH_MINISIGN_VERIFY
+    const MinisignVerify::Outcome sigOutcome =
+        MinisignVerify::verifyReleaseFile(artifactPath, signaturePath);
+    if (sigOutcome.result != MinisignVerify::Result::Ok) {
+        out.failedStage = QStringLiteral("minisign");
+        out.errorMessage = sigOutcome.errorMessage.isEmpty()
+            ? MinisignVerify::resultToString(sigOutcome.result)
+            : sigOutcome.errorMessage;
+        return out;
+    }
+#else
+    Q_UNUSED(signaturePath);
+    out.failedStage = QStringLiteral("minisign");
+    out.errorMessage = QStringLiteral("Signature verification is not available in this build");
+    return out;
+#endif
+
+    out.ok = true;
+    return out;
+}
+
+} // namespace UpdateVerifier

--- a/src/updater/UpdateVerifier.h
+++ b/src/updater/UpdateVerifier.h
@@ -1,0 +1,50 @@
+#ifndef UPDATEVERIFIER_H
+#define UPDATEVERIFIER_H
+
+#include "MinisignVerify.h"
+
+#include <QString>
+
+/**
+ * @brief SHA-256 + minisign verification for downloaded update artifacts (#445).
+ */
+namespace UpdateVerifier {
+
+struct Outcome {
+    bool ok = false;
+    QString errorMessage;
+    /// @c sha256, @c minisign, or empty on success.
+    QString failedStage;
+};
+
+/// Compute lowercase hex SHA-256 of @p filePath.
+QString sha256HexOfFile(const QString& filePath, QString* errorMessage = nullptr);
+
+/// Compare @p filePath digest to @p expectedHex (case-insensitive).
+bool verifySha256Hex(const QString& filePath,
+                     const QString& expectedHex,
+                     QString* errorMessage = nullptr);
+
+/**
+ * @brief Look up @p fileName in a GNU @c sha256sum manifest and verify the file.
+ *
+ * Manifest lines: @c "<hex>  <filename>" (two spaces before name, per CI).
+ */
+Outcome verifySha256FromManifest(const QString& filePath,
+                                 const QString& manifestPath,
+                                 const QString& fileName);
+
+/**
+ * @brief Full verify pipeline: optional SHA256SUMS entry + minisign signature.
+ *
+ * When @p manifestPath is empty, SHA-256 manifest check is skipped. Minisign
+ * verification is always required when compiled with @c QTMESH_MINISIGN_VERIFY.
+ */
+Outcome verifyDownloadedArtifact(const QString& artifactPath,
+                                 const QString& signaturePath,
+                                 const QString& manifestPath,
+                                 const QString& fileName);
+
+} // namespace UpdateVerifier
+
+#endif // UPDATEVERIFIER_H

--- a/src/updater/UpdateVerifier_test.cpp
+++ b/src/updater/UpdateVerifier_test.cpp
@@ -1,0 +1,59 @@
+#include <gtest/gtest.h>
+
+#include "UpdateVerifier.h"
+
+#include <QDir>
+#include <QFile>
+#include <QTemporaryDir>
+#include <QString>
+
+namespace {
+
+QString fixturePath(const char* name)
+{
+    return QDir(QStringLiteral(QTMESH_UT_SOURCE_ROOT))
+        .filePath(QStringLiteral("tests/fixtures/updater/%1").arg(QString::fromUtf8(name)));
+}
+
+} // namespace
+
+TEST(UpdateVerifier, ComputesSha256Hex)
+{
+    const QString path = fixturePath("release-3.5.3-readme.md");
+    QString error;
+    const QString digest = UpdateVerifier::sha256HexOfFile(path, &error);
+    ASSERT_FALSE(digest.isEmpty()) << error.toStdString();
+    EXPECT_EQ(digest.size(), 64);
+    EXPECT_TRUE(UpdateVerifier::verifySha256Hex(path, digest, &error));
+}
+
+TEST(UpdateVerifier, RejectsSha256Mismatch)
+{
+    const QString path = fixturePath("release-3.5.3-readme.md");
+    QString error;
+    EXPECT_FALSE(UpdateVerifier::verifySha256Hex(path, QStringLiteral("00"), &error));
+    EXPECT_FALSE(error.isEmpty());
+}
+
+TEST(UpdateVerifier, ReadsSha256ManifestEntry)
+{
+    QTemporaryDir temp;
+    ASSERT_TRUE(temp.isValid());
+
+    const QString artifact = temp.path() + QStringLiteral("/payload.bin");
+    ASSERT_TRUE(QFile::copy(fixturePath("release-3.5.3-readme.md"), artifact));
+
+    const QString manifest = temp.path() + QStringLiteral("/SHA256SUMS");
+    QFile manifestFile(manifest);
+    ASSERT_TRUE(manifestFile.open(QIODevice::WriteOnly | QIODevice::Text));
+
+    QString error;
+    const QString digest = UpdateVerifier::sha256HexOfFile(artifact, &error);
+    ASSERT_FALSE(digest.isEmpty()) << error.toStdString();
+    manifestFile.write(QStringLiteral("%1  payload.bin\n").arg(digest).toUtf8());
+    manifestFile.close();
+
+    const UpdateVerifier::Outcome out =
+        UpdateVerifier::verifySha256FromManifest(artifact, manifest, QStringLiteral("payload.bin"));
+    EXPECT_TRUE(out.ok) << out.errorMessage.toStdString();
+}

--- a/src/updater/UpdaterController.cpp
+++ b/src/updater/UpdaterController.cpp
@@ -1,4 +1,5 @@
 #include "UpdaterController.h"
+#include "ArtifactResolver.h"
 #include "UpdaterWorker.h"
 #include "AppSettingsKeys.h"
 #include "SentryReporter.h"
@@ -8,8 +9,11 @@
 #include <QCoreApplication>
 #include <QDateTime>
 #include <QDesktopServices>
+#include <QDir>
+#include <QElapsedTimer>
 #include <QGuiApplication>
 #include <QSettings>
+#include <QStandardPaths>
 #include <QUrl>
 
 namespace {
@@ -63,6 +67,10 @@ UpdaterController::UpdaterController(QObject* parent)
     : QObject(parent)
 {
     qRegisterMetaType<GitHubReleaseParser::Channel>("GitHubReleaseParser::Channel");
+    qRegisterMetaType<DownloadRequest>("DownloadRequest");
+    qRegisterMetaType<DownloadOutcome>("DownloadOutcome");
+    qRegisterMetaType<VerifyRequest>("VerifyRequest");
+    qRegisterMetaType<VerifyOutcome>("VerifyOutcome");
     loadSettings();
     refreshInstallFlavor();
 
@@ -106,6 +114,29 @@ UpdaterController::UpdaterController(QObject* parent)
                         .arg(static_cast<int>(result.comparison)));
                 logDialogStateBreadcrumb();
             });
+
+    connect(m_worker, &UpdaterWorker::downloadProgress, this,
+            [this](qint64 received, qint64 total) {
+                if (total <= 0) {
+                    return;
+                }
+                if (!m_progressThrottle.isValid()) {
+                    m_progressThrottle.start();
+                }
+                const qint64 nowMs = m_progressThrottle.elapsed();
+                const int percent =
+                    static_cast<int>((received * 100LL) / total);
+                const int clamped = qBound(0, percent, 100);
+                if (clamped >= 100 || nowMs - m_lastProgressEmitMs >= 100) {
+                    m_lastProgressEmitMs = nowMs;
+                    setProgressPercent(clamped);
+                }
+            });
+
+    connect(m_worker, &UpdaterWorker::downloadFinished, this,
+            &UpdaterController::handleDownloadFinished);
+    connect(m_worker, &UpdaterWorker::verifyFinished, this,
+            &UpdaterController::handleVerifyFinished);
 
     m_workerThread->start();
 }
@@ -243,6 +274,7 @@ void UpdaterController::applyCheckResult(const GitHubReleaseParser::CheckResult&
     m_latestUrl = result.release.htmlUrl;
     m_changelog = result.release.body;
     m_publishedAt = result.release.publishedAt;
+    m_releaseAssets = result.release.assets;
     emit latestVersionChanged();
     emit latestUrlChanged();
     emit changelogChanged();
@@ -257,6 +289,7 @@ void UpdaterController::applyCheckResult(const GitHubReleaseParser::CheckResult&
         }
         setState(State::UpdateAvailable);
         emit updateAvailable(m_currentVersion, m_latestVersion);
+        beginDownloadIfNeeded(false);
         break;
     case UpdateVersion::Comparison::Same:
     case UpdateVersion::Comparison::Newer:
@@ -331,12 +364,141 @@ void UpdaterController::confirmUnknownInstall()
 
 void UpdaterController::downloadAndInstall()
 {
-    SentryReporter::addBreadcrumb(QStringLiteral("updater.download"),
-                                  QStringLiteral("downloadAndInstall not implemented yet"));
-    setError(tr("Automatic download and install is not available yet."));
-    setState(State::Error);
-    emit checkError(m_error);
+    SentryReporter::addBreadcrumb(QStringLiteral("updater.download.start"),
+                                  QStringLiteral("version=%1").arg(m_latestVersion));
+    beginDownloadIfNeeded(true);
+}
+
+void UpdaterController::beginDownloadIfNeeded(bool userInitiated)
+{
+    if (m_state != State::UpdateAvailable) {
+        return;
+    }
+    if (!userInitiated && !m_autoDownload) {
+        return;
+    }
+    if (InstallFlavor::isPackageManagerManaged(m_flavor)) {
+        setError(tr("Updates for this install are managed by %1.")
+                     .arg(InstallFlavor::displayName(m_flavor)));
+        setState(State::Error);
+        return;
+    }
+    startDownloadJob();
+}
+
+void UpdaterController::startDownloadJob()
+{
+    const ArtifactResolver::ResolvedArtifact artifact =
+        ArtifactResolver::resolveForCurrentPlatform(m_releaseAssets, m_flavor);
+    if (!artifact.ok) {
+        setError(artifact.errorMessage);
+        setState(State::Error);
+        SentryReporter::addBreadcrumb(QStringLiteral("updater.download.error"),
+                                    artifact.errorMessage,
+                                    QStringLiteral("error"));
+        logDialogStateBreadcrumb();
+        return;
+    }
+
+    const QString stagingRoot =
+        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
+        + QStringLiteral("/updater/staging/")
+        + m_latestVersion;
+    QDir().mkpath(stagingRoot);
+
+    DownloadRequest request;
+    request.fileName = artifact.fileName;
+    request.artifactUrl = artifact.downloadUrl;
+    request.artifactPartPath =
+        QDir(stagingRoot).filePath(artifact.fileName + QStringLiteral(".part"));
+    request.artifactFinalPath = QDir(stagingRoot).filePath(artifact.fileName);
+    request.signatureUrl = artifact.signatureUrl;
+    request.signaturePath = QDir(stagingRoot).filePath(artifact.signatureFileName);
+    if (!artifact.sha256SumsUrl.isEmpty()) {
+        request.sha256SumsUrl = artifact.sha256SumsUrl;
+        request.sha256SumsPath = QDir(stagingRoot).filePath(artifact.sha256SumsFileName);
+    }
+
+    m_stagedArtifactPath = request.artifactFinalPath;
+    setError(QString());
+    setProgressPercent(0);
+    m_lastProgressEmitMs = 0;
+    setState(State::Downloading);
     logDialogStateBreadcrumb();
+
+    QMetaObject::invokeMethod(m_worker,
+                              "downloadUpdate",
+                              Qt::QueuedConnection,
+                              Q_ARG(DownloadRequest, request));
+}
+
+void UpdaterController::handleDownloadFinished(const DownloadOutcome& outcome)
+{
+    if (outcome.cancelled) {
+        SentryReporter::addBreadcrumb(QStringLiteral("updater.download.cancel"),
+                                    outcome.fileName);
+        setState(State::UpdateAvailable);
+        setProgressPercent(0);
+        logDialogStateBreadcrumb();
+        return;
+    }
+
+    if (!outcome.ok) {
+        SentryReporter::addBreadcrumb(QStringLiteral("updater.download.error"),
+                                      outcome.errorMessage,
+                                      QStringLiteral("error"));
+        setError(outcome.errorMessage);
+        setState(State::Error);
+        logDialogStateBreadcrumb();
+        return;
+    }
+
+    SentryReporter::addBreadcrumb(QStringLiteral("updater.download.complete"),
+                                  outcome.fileName);
+    setProgressPercent(100);
+    setState(State::Verifying);
+    logDialogStateBreadcrumb();
+
+    VerifyRequest verifyRequest;
+    verifyRequest.artifactPath = outcome.artifactPath;
+    verifyRequest.signaturePath = outcome.signaturePath;
+    verifyRequest.sha256SumsPath = outcome.sha256SumsPath;
+    verifyRequest.fileName = outcome.fileName;
+
+    QMetaObject::invokeMethod(m_worker,
+                              "verifyDownload",
+                              Qt::QueuedConnection,
+                              Q_ARG(VerifyRequest, verifyRequest));
+}
+
+void UpdaterController::handleVerifyFinished(const VerifyOutcome& outcome)
+{
+    if (!outcome.ok) {
+        SentryReporter::addBreadcrumb(
+            QStringLiteral("updater.verify.failure"),
+            QStringLiteral("%1: %2").arg(outcome.failedStage, outcome.errorMessage),
+            QStringLiteral("error"));
+        setError(outcome.errorMessage.isEmpty()
+                     ? tr("Download verification failed.")
+                     : outcome.errorMessage);
+        setState(State::Error);
+        logDialogStateBreadcrumb();
+        return;
+    }
+
+    SentryReporter::addBreadcrumb(QStringLiteral("updater.verify.success"), m_latestVersion);
+    setState(State::ReadyToInstall);
+    logDialogStateBreadcrumb();
+}
+
+void UpdaterController::setProgressPercent(int percent)
+{
+    const int clamped = qBound(0, percent, 100);
+    if (m_progress == clamped) {
+        return;
+    }
+    m_progress = clamped;
+    emit progressChanged();
 }
 
 void UpdaterController::cancel()
@@ -345,8 +507,14 @@ void UpdaterController::cancel()
         QMetaObject::invokeMethod(m_worker, &UpdaterWorker::cancelActiveRequest,
                                   Qt::QueuedConnection);
     }
-    if (m_state == State::Checking || m_state == State::Downloading) {
-        setState(State::Idle);
+    if (m_state == State::Checking || m_state == State::Downloading
+        || m_state == State::Verifying) {
+        if (m_state == State::Downloading) {
+            setState(State::UpdateAvailable);
+        } else {
+            setState(State::Idle);
+        }
+        setProgressPercent(0);
         logDialogStateBreadcrumb();
     }
 }

--- a/src/updater/UpdaterController.h
+++ b/src/updater/UpdaterController.h
@@ -3,8 +3,10 @@
 
 #include "GitHubReleaseParser.h"
 #include "InstallFlavor.h"
+#include "UpdaterWorker.h"
 
-#include <QObject>
+#include <QElapsedTimer>
+#include <QList>
 #include <QQmlEngine>
 #include <QJSEngine>
 #include <QThread>
@@ -13,7 +15,7 @@
  * @brief QML-facing singleton orchestrating update checks (#441, #443, #449).
  *
  * Mirrors the LLMManager / SDManager pattern: main-thread controller with
- * a worker thread for HTTP. Download/install land in #444–448.
+ * a worker thread for HTTP. Install/relaunch land in #446–448.
  */
 class UpdaterController : public QObject
 {
@@ -120,6 +122,11 @@ private:
     void setState(State state);
     void setError(const QString& error);
     void applyCheckResult(const GitHubReleaseParser::CheckResult& result);
+    void beginDownloadIfNeeded(bool userInitiated);
+    void startDownloadJob();
+    void handleDownloadFinished(const DownloadOutcome& outcome);
+    void handleVerifyFinished(const VerifyOutcome& outcome);
+    void setProgressPercent(int percent);
     GitHubReleaseParser::Channel activeChannel() const;
     void refreshInstallFlavor();
     void loadSettings();
@@ -149,6 +156,10 @@ private:
     bool m_checkOnStartup = true;
     bool m_autoDownload = false;
     QString m_lastCheckedAt;
+    QList<GitHubReleaseParser::ReleaseAsset> m_releaseAssets;
+    QString m_stagedArtifactPath;
+    qint64 m_lastProgressEmitMs = 0;
+    QElapsedTimer m_progressThrottle;
 };
 
 #endif // UPDATERCONTROLLER_H

--- a/src/updater/UpdaterWorker.cpp
+++ b/src/updater/UpdaterWorker.cpp
@@ -36,17 +36,28 @@ UpdaterWorker::UpdaterWorker(QObject* parent)
 UpdaterWorker::~UpdaterWorker()
 {
     cancelActiveRequest();
+    closeDownloadPartFile();
+}
+
+void UpdaterWorker::closeDownloadPartFile()
+{
+    if (!m_downloadPartFile) {
+        return;
+    }
+    m_downloadPartFile->close();
+    delete m_downloadPartFile;
+    m_downloadPartFile = nullptr;
 }
 
 void UpdaterWorker::cancelActiveRequest()
 {
-    if (!m_activeReply) {
-        m_activeJob = ActiveJob::None;
-        return;
+    m_cancelRequested = true;
+    if (m_activeReply) {
+        m_activeReply->abort();
+        m_activeReply->deleteLater();
+        m_activeReply = nullptr;
     }
-    m_activeReply->abort();
-    m_activeReply->deleteLater();
-    m_activeReply = nullptr;
+    closeDownloadPartFile();
     m_activeJob = ActiveJob::None;
 }
 
@@ -55,6 +66,7 @@ void UpdaterWorker::checkForUpdates(const QString& apiUrl,
                                     GitHubReleaseParser::Channel channel)
 {
     cancelActiveRequest();
+    m_cancelRequested = false;
 
     const QUrl url(apiUrl);
     QNetworkRequest httpRequest(url);
@@ -110,6 +122,7 @@ void UpdaterWorker::onCheckReplyFinished()
 void UpdaterWorker::downloadUpdate(const DownloadRequest& request)
 {
     cancelActiveRequest();
+    m_cancelRequested = false;
     m_downloadRequest = request;
     m_downloadAttempt = 0;
     m_activeJob = ActiveJob::Download;
@@ -121,28 +134,38 @@ void UpdaterWorker::startArtifactDownloadAttempt(int attemptIndex)
     m_downloadAttempt = attemptIndex;
 
     const auto beginDownload = [this]() {
-        if (m_activeJob != ActiveJob::Download) {
+        if (m_activeJob != ActiveJob::Download || m_cancelRequested) {
             return;
         }
 
-    qint64 existingSize = 0;
-    if (QFile::exists(m_downloadRequest.artifactPartPath)) {
-        existingSize = QFileInfo(m_downloadRequest.artifactPartPath).size();
-    }
+        closeDownloadPartFile();
 
-    QNetworkRequest httpRequest = makeRequest(QUrl(m_downloadRequest.artifactUrl));
-    if (existingSize > 0) {
-        httpRequest.setRawHeader("Range",
-                                 QByteArray("bytes=" + QByteArray::number(existingSize) + '-'));
-    }
+        qint64 existingSize = 0;
+        if (QFile::exists(m_downloadRequest.artifactPartPath)) {
+            existingSize = QFileInfo(m_downloadRequest.artifactPartPath).size();
+        }
 
-    m_activeReply = m_network->get(httpRequest);
-    connect(m_activeReply, &QNetworkReply::downloadProgress, this, &UpdaterWorker::onDownloadProgress);
-    connect(m_activeReply, &QNetworkReply::finished, this, &UpdaterWorker::onDownloadReplyFinished);
+        m_downloadPartFile = new QFile(m_downloadRequest.artifactPartPath);
+        QIODevice::OpenMode mode = QIODevice::WriteOnly;
+        if (existingSize > 0) {
+            mode |= QIODevice::Append;
+        }
+        if (!m_downloadPartFile->open(mode)) {
+            finishDownloadWithError(QStringLiteral("Cannot write download to disk"));
+            return;
+        }
 
-    if (existingSize > 0) {
+        QNetworkRequest httpRequest = makeRequest(QUrl(m_downloadRequest.artifactUrl));
+        if (existingSize > 0) {
+            httpRequest.setRawHeader("Range",
+                                     QByteArray("bytes=" + QByteArray::number(existingSize) + '-'));
+        }
+
+        m_activeReply = m_network->get(httpRequest);
         m_activeReply->setProperty("resumeOffset", existingSize);
-    }
+        connect(m_activeReply, &QNetworkReply::downloadProgress, this, &UpdaterWorker::onDownloadProgress);
+        connect(m_activeReply, &QNetworkReply::readyRead, this, &UpdaterWorker::onDownloadReadyRead);
+        connect(m_activeReply, &QNetworkReply::finished, this, &UpdaterWorker::onDownloadReplyFinished);
     };
 
     if (attemptIndex > 0) {
@@ -164,8 +187,23 @@ void UpdaterWorker::onDownloadProgress(qint64 received, qint64 total)
     emit downloadProgress(combinedReceived, combinedTotal);
 }
 
+void UpdaterWorker::onDownloadReadyRead()
+{
+    if (!m_activeReply || !m_downloadPartFile) {
+        return;
+    }
+    const QByteArray chunk = m_activeReply->readAll();
+    if (chunk.isEmpty()) {
+        return;
+    }
+    if (m_downloadPartFile->write(chunk) != chunk.size()) {
+        m_activeReply->abort();
+    }
+}
+
 void UpdaterWorker::finishDownloadWithError(const QString& message, bool cancelled)
 {
+    closeDownloadPartFile();
     DownloadOutcome outcome;
     outcome.cancelled = cancelled;
     outcome.errorMessage = message;
@@ -179,6 +217,13 @@ bool UpdaterWorker::downloadUrlBlocking(const QString& url,
                                         bool resume,
                                         QString* errorMessage)
 {
+    if (m_cancelRequested || m_activeJob != ActiveJob::Download) {
+        if (errorMessage) {
+            *errorMessage = QStringLiteral("Download cancelled");
+        }
+        return false;
+    }
+
     qint64 existingSize = 0;
     if (resume && QFile::exists(destPath)) {
         existingSize = QFileInfo(destPath).size();
@@ -191,17 +236,51 @@ bool UpdaterWorker::downloadUrlBlocking(const QString& url,
     }
 
     QNetworkReply* reply = m_network->get(httpRequest);
+    m_activeReply = reply;
+
+    QFile out(destPath);
+    QIODevice::OpenMode mode = QIODevice::WriteOnly;
+    if (existingSize > 0) {
+        mode |= QIODevice::Append;
+    }
+    if (!out.open(mode)) {
+        m_activeReply = nullptr;
+        reply->deleteLater();
+        if (errorMessage) {
+            *errorMessage = QStringLiteral("Cannot write %1").arg(destPath);
+        }
+        return false;
+    }
+
     QEventLoop loop;
+    connect(reply, &QNetworkReply::readyRead, &loop, [&]() {
+        if (m_cancelRequested) {
+            reply->abort();
+            return;
+        }
+        const QByteArray chunk = reply->readAll();
+        if (!chunk.isEmpty() && out.write(chunk) != chunk.size()) {
+            reply->abort();
+        }
+    });
     connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
     loop.exec();
 
-    const bool wasCancelled = reply->error() == QNetworkReply::OperationCanceledError;
-    const bool ok = reply->error() == QNetworkReply::NoError;
-    const QByteArray payload = reply->readAll();
+    const QByteArray tail = reply->readAll();
+    if (!tail.isEmpty()) {
+        out.write(tail);
+    }
+    out.close();
+
+    const bool cancelled = m_cancelRequested
+        || m_activeJob != ActiveJob::Download
+        || reply->error() == QNetworkReply::OperationCanceledError;
+    const bool ok = !cancelled && reply->error() == QNetworkReply::NoError;
     const QString errorString = reply->errorString();
+    m_activeReply = nullptr;
     reply->deleteLater();
 
-    if (wasCancelled) {
+    if (cancelled) {
         if (errorMessage) {
             *errorMessage = QStringLiteral("Download cancelled");
         }
@@ -215,23 +294,6 @@ bool UpdaterWorker::downloadUrlBlocking(const QString& url,
         return false;
     }
 
-    QIODevice::OpenMode mode = QIODevice::WriteOnly;
-    if (existingSize > 0) {
-        mode |= QIODevice::Append;
-    }
-    QFile out(destPath);
-    if (!out.open(mode)) {
-        if (errorMessage) {
-            *errorMessage = QStringLiteral("Cannot write %1").arg(destPath);
-        }
-        return false;
-    }
-    if (out.write(payload) != payload.size()) {
-        if (errorMessage) {
-            *errorMessage = QStringLiteral("Write failed for %1").arg(destPath);
-        }
-        return false;
-    }
     return true;
 }
 
@@ -246,8 +308,9 @@ void UpdaterWorker::onDownloadReplyFinished()
     }
 
     m_activeReply = nullptr;
+    onDownloadReadyRead();
 
-    if (reply->error() == QNetworkReply::OperationCanceledError) {
+    if (reply->error() == QNetworkReply::OperationCanceledError || m_cancelRequested) {
         reply->deleteLater();
         finishDownloadWithError(QStringLiteral("Download cancelled"), true);
         return;
@@ -255,11 +318,12 @@ void UpdaterWorker::onDownloadReplyFinished()
 
     const qint64 resumeOffset = reply->property("resumeOffset").toLongLong();
     const bool append = resumeOffset > 0;
-    const QByteArray payload = reply->readAll();
     const bool httpOk = reply->error() == QNetworkReply::NoError;
     const int httpStatus =
         reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
     reply->deleteLater();
+
+    closeDownloadPartFile();
 
     if (!httpOk) {
         if (m_downloadAttempt + 1 < kMaxDownloadAttempts) {
@@ -277,20 +341,11 @@ void UpdaterWorker::onDownloadReplyFinished()
         return;
     }
 
-    QIODevice::OpenMode mode = QIODevice::WriteOnly;
-    if (append) {
-        mode |= QIODevice::Append;
-    }
-    QFile partFile(m_downloadRequest.artifactPartPath);
-    if (!partFile.open(mode)) {
-        finishDownloadWithError(QStringLiteral("Cannot write download to disk"));
+    if (append && httpStatus == 200) {
+        QFile::remove(m_downloadRequest.artifactPartPath);
+        startArtifactDownloadAttempt(0);
         return;
     }
-    if (partFile.write(payload) != payload.size()) {
-        finishDownloadWithError(QStringLiteral("Download write failed"));
-        return;
-    }
-    partFile.close();
 
     if (QFile::exists(m_downloadRequest.artifactFinalPath)) {
         QFile::remove(m_downloadRequest.artifactFinalPath);
@@ -300,12 +355,17 @@ void UpdaterWorker::onDownloadReplyFinished()
         return;
     }
 
+    if (m_cancelRequested || m_activeJob != ActiveJob::Download) {
+        finishDownloadWithError(QStringLiteral("Download cancelled"), true);
+        return;
+    }
+
     QString sidecarError;
     if (!downloadUrlBlocking(m_downloadRequest.signatureUrl,
                              m_downloadRequest.signaturePath,
                              false,
                              &sidecarError)) {
-        finishDownloadWithError(sidecarError);
+        finishDownloadWithError(sidecarError, sidecarError.contains(QStringLiteral("cancelled")));
         return;
     }
 
@@ -314,9 +374,15 @@ void UpdaterWorker::onDownloadReplyFinished()
                                  m_downloadRequest.sha256SumsPath,
                                  false,
                                  &sidecarError)) {
-            finishDownloadWithError(sidecarError);
+            finishDownloadWithError(sidecarError,
+                                    sidecarError.contains(QStringLiteral("cancelled")));
             return;
         }
+    }
+
+    if (m_cancelRequested || m_activeJob != ActiveJob::Download) {
+        finishDownloadWithError(QStringLiteral("Download cancelled"), true);
+        return;
     }
 
     DownloadOutcome outcome;

--- a/src/updater/UpdaterWorker.cpp
+++ b/src/updater/UpdaterWorker.cpp
@@ -1,14 +1,36 @@
 #include "UpdaterWorker.h"
+#include "UpdateVerifier.h"
 
+#include <QEventLoop>
+#include <QFile>
+#include <QFileInfo>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
+#include <QTimer>
 #include <QUrl>
+
+namespace {
+
+QNetworkRequest makeRequest(const QUrl& url)
+{
+    QNetworkRequest httpRequest(url);
+    httpRequest.setHeader(QNetworkRequest::UserAgentHeader,
+                          QStringLiteral("QtMeshEditor-Updater/1.0"));
+    httpRequest.setRawHeader("Accept", "*/*");
+    return httpRequest;
+}
+
+} // namespace
 
 UpdaterWorker::UpdaterWorker(QObject* parent)
     : QObject(parent)
     , m_network(new QNetworkAccessManager(this))
 {
+    qRegisterMetaType<DownloadRequest>("DownloadRequest");
+    qRegisterMetaType<DownloadOutcome>("DownloadOutcome");
+    qRegisterMetaType<VerifyRequest>("VerifyRequest");
+    qRegisterMetaType<VerifyOutcome>("VerifyOutcome");
 }
 
 UpdaterWorker::~UpdaterWorker()
@@ -19,11 +41,13 @@ UpdaterWorker::~UpdaterWorker()
 void UpdaterWorker::cancelActiveRequest()
 {
     if (!m_activeReply) {
+        m_activeJob = ActiveJob::None;
         return;
     }
     m_activeReply->abort();
     m_activeReply->deleteLater();
     m_activeReply = nullptr;
+    m_activeJob = ActiveJob::None;
 }
 
 void UpdaterWorker::checkForUpdates(const QString& apiUrl,
@@ -38,25 +62,25 @@ void UpdaterWorker::checkForUpdates(const QString& apiUrl,
                           QStringLiteral("QtMeshEditor-Updater/1.0"));
     httpRequest.setRawHeader("Accept", "application/vnd.github+json");
 
+    m_activeJob = ActiveJob::Check;
     m_activeReply = m_network->get(httpRequest);
     m_activeReply->setProperty("localVersion", localVersion);
     m_activeReply->setProperty("channel", static_cast<int>(channel));
-    connect(m_activeReply, &QNetworkReply::finished, this, &UpdaterWorker::onReplyFinished);
+    connect(m_activeReply, &QNetworkReply::finished, this, &UpdaterWorker::onCheckReplyFinished);
 }
 
-void UpdaterWorker::onReplyFinished()
+void UpdaterWorker::onCheckReplyFinished()
 {
     auto* reply = qobject_cast<QNetworkReply*>(sender());
-    if (!reply) {
-        return;
-    }
-
-    if (reply != m_activeReply) {
-        reply->deleteLater();
+    if (!reply || reply != m_activeReply) {
+        if (reply) {
+            reply->deleteLater();
+        }
         return;
     }
 
     m_activeReply = nullptr;
+    m_activeJob = ActiveJob::None;
 
     if (reply->error() == QNetworkReply::OperationCanceledError) {
         reply->deleteLater();
@@ -81,4 +105,240 @@ void UpdaterWorker::onReplyFinished()
 
     reply->deleteLater();
     emit checkFinished(result, networkError);
+}
+
+void UpdaterWorker::downloadUpdate(const DownloadRequest& request)
+{
+    cancelActiveRequest();
+    m_downloadRequest = request;
+    m_downloadAttempt = 0;
+    m_activeJob = ActiveJob::Download;
+    startArtifactDownloadAttempt(0);
+}
+
+void UpdaterWorker::startArtifactDownloadAttempt(int attemptIndex)
+{
+    m_downloadAttempt = attemptIndex;
+
+    const auto beginDownload = [this]() {
+        if (m_activeJob != ActiveJob::Download) {
+            return;
+        }
+
+    qint64 existingSize = 0;
+    if (QFile::exists(m_downloadRequest.artifactPartPath)) {
+        existingSize = QFileInfo(m_downloadRequest.artifactPartPath).size();
+    }
+
+    QNetworkRequest httpRequest = makeRequest(QUrl(m_downloadRequest.artifactUrl));
+    if (existingSize > 0) {
+        httpRequest.setRawHeader("Range",
+                                 QByteArray("bytes=" + QByteArray::number(existingSize) + '-'));
+    }
+
+    m_activeReply = m_network->get(httpRequest);
+    connect(m_activeReply, &QNetworkReply::downloadProgress, this, &UpdaterWorker::onDownloadProgress);
+    connect(m_activeReply, &QNetworkReply::finished, this, &UpdaterWorker::onDownloadReplyFinished);
+
+    if (existingSize > 0) {
+        m_activeReply->setProperty("resumeOffset", existingSize);
+    }
+    };
+
+    if (attemptIndex > 0) {
+        const int delayMs = kRetryDelaysMs[qMin(attemptIndex, kMaxDownloadAttempts - 1)];
+        QTimer::singleShot(delayMs, this, beginDownload);
+    } else {
+        beginDownload();
+    }
+}
+
+void UpdaterWorker::onDownloadProgress(qint64 received, qint64 total)
+{
+    if (m_activeJob != ActiveJob::Download || !m_activeReply) {
+        return;
+    }
+    const qint64 resumeOffset = m_activeReply->property("resumeOffset").toLongLong();
+    const qint64 combinedReceived = received + resumeOffset;
+    const qint64 combinedTotal = total > 0 ? total + resumeOffset : total;
+    emit downloadProgress(combinedReceived, combinedTotal);
+}
+
+void UpdaterWorker::finishDownloadWithError(const QString& message, bool cancelled)
+{
+    DownloadOutcome outcome;
+    outcome.cancelled = cancelled;
+    outcome.errorMessage = message;
+    outcome.fileName = m_downloadRequest.fileName;
+    m_activeJob = ActiveJob::None;
+    emit downloadFinished(outcome);
+}
+
+bool UpdaterWorker::downloadUrlBlocking(const QString& url,
+                                        const QString& destPath,
+                                        bool resume,
+                                        QString* errorMessage)
+{
+    qint64 existingSize = 0;
+    if (resume && QFile::exists(destPath)) {
+        existingSize = QFileInfo(destPath).size();
+    }
+
+    QNetworkRequest httpRequest = makeRequest(QUrl(url));
+    if (existingSize > 0) {
+        httpRequest.setRawHeader("Range",
+                                 QByteArray("bytes=" + QByteArray::number(existingSize) + '-'));
+    }
+
+    QNetworkReply* reply = m_network->get(httpRequest);
+    QEventLoop loop;
+    connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+    loop.exec();
+
+    const bool wasCancelled = reply->error() == QNetworkReply::OperationCanceledError;
+    const bool ok = reply->error() == QNetworkReply::NoError;
+    const QByteArray payload = reply->readAll();
+    const QString errorString = reply->errorString();
+    reply->deleteLater();
+
+    if (wasCancelled) {
+        if (errorMessage) {
+            *errorMessage = QStringLiteral("Download cancelled");
+        }
+        return false;
+    }
+
+    if (!ok) {
+        if (errorMessage) {
+            *errorMessage = errorString;
+        }
+        return false;
+    }
+
+    QIODevice::OpenMode mode = QIODevice::WriteOnly;
+    if (existingSize > 0) {
+        mode |= QIODevice::Append;
+    }
+    QFile out(destPath);
+    if (!out.open(mode)) {
+        if (errorMessage) {
+            *errorMessage = QStringLiteral("Cannot write %1").arg(destPath);
+        }
+        return false;
+    }
+    if (out.write(payload) != payload.size()) {
+        if (errorMessage) {
+            *errorMessage = QStringLiteral("Write failed for %1").arg(destPath);
+        }
+        return false;
+    }
+    return true;
+}
+
+void UpdaterWorker::onDownloadReplyFinished()
+{
+    auto* reply = qobject_cast<QNetworkReply*>(sender());
+    if (!reply || reply != m_activeReply) {
+        if (reply) {
+            reply->deleteLater();
+        }
+        return;
+    }
+
+    m_activeReply = nullptr;
+
+    if (reply->error() == QNetworkReply::OperationCanceledError) {
+        reply->deleteLater();
+        finishDownloadWithError(QStringLiteral("Download cancelled"), true);
+        return;
+    }
+
+    const qint64 resumeOffset = reply->property("resumeOffset").toLongLong();
+    const bool append = resumeOffset > 0;
+    const QByteArray payload = reply->readAll();
+    const bool httpOk = reply->error() == QNetworkReply::NoError;
+    const int httpStatus =
+        reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    reply->deleteLater();
+
+    if (!httpOk) {
+        if (m_downloadAttempt + 1 < kMaxDownloadAttempts) {
+            startArtifactDownloadAttempt(m_downloadAttempt + 1);
+            return;
+        }
+        finishDownloadWithError(QStringLiteral("Download failed after %1 attempts")
+                                    .arg(kMaxDownloadAttempts));
+        return;
+    }
+
+    if (httpStatus == 416 && append) {
+        QFile::remove(m_downloadRequest.artifactPartPath);
+        startArtifactDownloadAttempt(0);
+        return;
+    }
+
+    QIODevice::OpenMode mode = QIODevice::WriteOnly;
+    if (append) {
+        mode |= QIODevice::Append;
+    }
+    QFile partFile(m_downloadRequest.artifactPartPath);
+    if (!partFile.open(mode)) {
+        finishDownloadWithError(QStringLiteral("Cannot write download to disk"));
+        return;
+    }
+    if (partFile.write(payload) != payload.size()) {
+        finishDownloadWithError(QStringLiteral("Download write failed"));
+        return;
+    }
+    partFile.close();
+
+    if (QFile::exists(m_downloadRequest.artifactFinalPath)) {
+        QFile::remove(m_downloadRequest.artifactFinalPath);
+    }
+    if (!QFile::rename(m_downloadRequest.artifactPartPath, m_downloadRequest.artifactFinalPath)) {
+        finishDownloadWithError(QStringLiteral("Could not finalize downloaded file"));
+        return;
+    }
+
+    QString sidecarError;
+    if (!downloadUrlBlocking(m_downloadRequest.signatureUrl,
+                             m_downloadRequest.signaturePath,
+                             false,
+                             &sidecarError)) {
+        finishDownloadWithError(sidecarError);
+        return;
+    }
+
+    if (!m_downloadRequest.sha256SumsUrl.isEmpty()) {
+        if (!downloadUrlBlocking(m_downloadRequest.sha256SumsUrl,
+                                 m_downloadRequest.sha256SumsPath,
+                                 false,
+                                 &sidecarError)) {
+            finishDownloadWithError(sidecarError);
+            return;
+        }
+    }
+
+    DownloadOutcome outcome;
+    outcome.ok = true;
+    outcome.artifactPath = m_downloadRequest.artifactFinalPath;
+    outcome.signaturePath = m_downloadRequest.signaturePath;
+    outcome.sha256SumsPath = m_downloadRequest.sha256SumsPath;
+    outcome.fileName = m_downloadRequest.fileName;
+    m_activeJob = ActiveJob::None;
+    emit downloadFinished(outcome);
+}
+
+void UpdaterWorker::verifyDownload(const VerifyRequest& request)
+{
+    VerifyOutcome outcome;
+    const UpdateVerifier::Outcome verify = UpdateVerifier::verifyDownloadedArtifact(
+        request.artifactPath,
+        request.signaturePath,
+        request.sha256SumsPath,
+        request.fileName);
+    outcome.ok = verify.ok;
+    outcome.errorMessage = verify.errorMessage;
+    outcome.failedStage = verify.failedStage;
+    emit verifyFinished(outcome);
 }

--- a/src/updater/UpdaterWorker.h
+++ b/src/updater/UpdaterWorker.h
@@ -9,6 +9,7 @@
 
 class QNetworkAccessManager;
 class QNetworkReply;
+class QFile;
 
 struct DownloadRequest {
     QString artifactUrl;
@@ -81,6 +82,7 @@ signals:
 private slots:
     void onCheckReplyFinished();
     void onDownloadProgress(qint64 received, qint64 total);
+    void onDownloadReadyRead();
     void onDownloadReplyFinished();
 
 private:
@@ -96,10 +98,13 @@ private:
                              QString* errorMessage);
     void finishDownloadWithError(const QString& message, bool cancelled = false);
     void startArtifactDownloadAttempt(int attemptIndex);
+    void closeDownloadPartFile();
 
     QNetworkAccessManager* m_network = nullptr;
     QNetworkReply* m_activeReply = nullptr;
+    QFile* m_downloadPartFile = nullptr;
     ActiveJob m_activeJob = ActiveJob::None;
+    bool m_cancelRequested = false;
     DownloadRequest m_downloadRequest;
     int m_downloadAttempt = 0;
     static constexpr int kMaxDownloadAttempts = 3;

--- a/src/updater/UpdaterWorker.h
+++ b/src/updater/UpdaterWorker.h
@@ -3,17 +3,57 @@
 
 #include "GitHubReleaseParser.h"
 
+#include <QMetaType>
 #include <QObject>
 #include <QString>
 
 class QNetworkAccessManager;
 class QNetworkReply;
 
+struct DownloadRequest {
+    QString artifactUrl;
+    QString artifactPartPath;
+    QString artifactFinalPath;
+    QString signatureUrl;
+    QString signaturePath;
+    QString sha256SumsUrl;
+    QString sha256SumsPath;
+    QString fileName;
+};
+
+struct DownloadOutcome {
+    bool ok = false;
+    bool cancelled = false;
+    QString errorMessage;
+    QString artifactPath;
+    QString signaturePath;
+    QString sha256SumsPath;
+    QString fileName;
+};
+
+struct VerifyRequest {
+    QString artifactPath;
+    QString signaturePath;
+    QString sha256SumsPath;
+    QString fileName;
+};
+
+struct VerifyOutcome {
+    bool ok = false;
+    QString errorMessage;
+    QString failedStage;
+};
+
+Q_DECLARE_METATYPE(DownloadRequest)
+Q_DECLARE_METATYPE(DownloadOutcome)
+Q_DECLARE_METATYPE(VerifyRequest)
+Q_DECLARE_METATYPE(VerifyOutcome)
+
 /**
- * @brief Worker-thread HTTP for the auto-updater (#441).
+ * @brief Worker-thread HTTP for the auto-updater (#441, #444, #445).
  *
  * Owns its QNetworkAccessManager on the worker thread so the main thread
- * never blocks on GitHub API calls.
+ * never blocks on GitHub API or artifact download calls.
  */
 class UpdaterWorker : public QObject
 {
@@ -27,18 +67,43 @@ public slots:
     void checkForUpdates(const QString& apiUrl,
                          const QString& localVersion,
                          GitHubReleaseParser::Channel channel);
+    void downloadUpdate(const DownloadRequest& request);
+    void verifyDownload(const VerifyRequest& request);
     void cancelActiveRequest();
 
 signals:
     void checkFinished(const GitHubReleaseParser::CheckResult& result,
                        const QString& networkError);
+    void downloadProgress(qint64 received, qint64 total);
+    void downloadFinished(const DownloadOutcome& outcome);
+    void verifyFinished(const VerifyOutcome& outcome);
 
 private slots:
-    void onReplyFinished();
+    void onCheckReplyFinished();
+    void onDownloadProgress(qint64 received, qint64 total);
+    void onDownloadReplyFinished();
 
 private:
+    enum class ActiveJob {
+        None,
+        Check,
+        Download,
+    };
+
+    bool downloadUrlBlocking(const QString& url,
+                             const QString& destPath,
+                             bool resume,
+                             QString* errorMessage);
+    void finishDownloadWithError(const QString& message, bool cancelled = false);
+    void startArtifactDownloadAttempt(int attemptIndex);
+
     QNetworkAccessManager* m_network = nullptr;
     QNetworkReply* m_activeReply = nullptr;
+    ActiveJob m_activeJob = ActiveJob::None;
+    DownloadRequest m_downloadRequest;
+    int m_downloadAttempt = 0;
+    static constexpr int kMaxDownloadAttempts = 3;
+    static constexpr int kRetryDelaysMs[kMaxDownloadAttempts] = {0, 5000, 15000};
 };
 
 #endif // UPDATERWORKER_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -106,6 +106,9 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/TexturePaintBuffer.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/UpdateVersion.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/updater/InstallFlavor.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/updater/ArtifactResolver.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/updater/UpdateVerifier.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/updater/MinisignVerify.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/updater/GitHubReleaseParser.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/updater/UpdaterWorker.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/updater/UpdaterController.cpp
@@ -419,6 +422,7 @@ if(BUILD_TESTS)
         Qt::QuickControls2
         meshoptimizer
         xatlas
+        qtmesh_sodium
     )
 
     # Add llama.cpp libraries if local LLM is enabled


### PR DESCRIPTION
## Summary
- Implements resumable artifact download with progress, cancel, and retry (Range resume + `.part` staging under AppData).
- Adds `ArtifactResolver` (platform-specific release asset pick) and `UpdateVerifier` (SHA-256 manifest + minisign signature).
- Wires `UpdaterController::downloadAndInstall()`, auto-download when enabled, and dialog UI through `ReadyToInstall` (install step remains #446–448).

## Test plan
- [x] `UnitTests --gtest_filter="ArtifactResolver*:UpdateVerifier*:MinisignVerify*:UpdaterController*"` passes locally on Linux
- [ ] CI `unit-tests-linux` green
- [ ] CI `build-windows` / `build-macos` green (Windows verify backend still stubbed — fail-closed at signature step)
- [ ] Manual: Help → Check for Updates → Download & install on a portable build when a signed release asset exists


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * “Download & install” is now functional from the update prompt.
  * Added a “Ready to install” step after the update is downloaded and verified.
  * Auto-download can begin automatically when enabled.
* **Improvements**
  * Update downloads now include integrity checks (SHA-256 plus signature verification when available) before installation.
  * Downloading is more robust with resume/retry behavior.
* **Chores**
  * Refreshed cross-platform update build configuration and updater documentation for verification behavior.
* **Tests**
  * Added unit tests for artifact selection and verification logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->