### PR TITLE
fix(material): embedded-texture preview + crash on rapid texture switch + live material lists

### DIFF
--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -3288,6 +3288,15 @@ Rectangle {
                 function onMaterialNameChanged() { materialToolCol.refreshMaterialList() }
             }
 
+            // Also refresh when the scene's material set may have changed —
+            // a model load or selection change — so newly-loaded materials
+            // appear without needing the manual Refresh button.
+            Connections {
+                target: PropertiesPanelController.sceneTreeModel
+                ignoreUnknownSignals: true
+                function onMaterialsChanged() { materialToolCol.refreshMaterialList() }
+            }
+
             // ── Material Library header: New / Import / Refresh ──
 
             Text {

--- a/qml/SceneTreeNode.qml
+++ b/qml/SceneTreeNode.qml
@@ -214,6 +214,11 @@ Column {
                         onClicked: {
                             matSelector.dropdownOpen = !matSelector.dropdownOpen
                             if (matSelector.dropdownOpen) {
+                                // Fetch the current list lazily, on open, so we
+                                // don't fan out availableMaterials() across every
+                                // node when materialsChanged fires.
+                                if (treeModel)
+                                    matFilter.allMaterials = treeModel.availableMaterials()
                                 matFilter.text = ""
                                 matFilter.forceActiveFocus()
                             }
@@ -294,7 +299,14 @@ Column {
                         target: treeModel
                         ignoreUnknownSignals: true
                         function onMaterialsChanged() {
-                            matFilter.allMaterials = treeModel ? treeModel.availableMaterials() : []
+                            // Only the open submesh dropdown needs a fresh list;
+                            // refetching on every node would fan out one signal
+                            // into one availableMaterials() call per tree node
+                            // and stall large scenes. Closed dropdowns re-fetch
+                            // lazily when opened (matSelector click handler).
+                            if (!treeModel || !matSelector.visible || !matSelector.dropdownOpen)
+                                return
+                            matFilter.allMaterials = treeModel.availableMaterials()
                         }
                     }
                     property var filtered: {

--- a/qml/SceneTreeNode.qml
+++ b/qml/SceneTreeNode.qml
@@ -287,6 +287,16 @@ Column {
                     verticalAlignment: TextInput.AlignVCenter
 
                     property var allMaterials: treeModel ? treeModel.availableMaterials() : []
+                    // Re-fetch the material list whenever it may have changed
+                    // (model load / node + entity created / selection change),
+                    // so the dropdown always offers an up-to-date set.
+                    Connections {
+                        target: treeModel
+                        ignoreUnknownSignals: true
+                        function onMaterialsChanged() {
+                            matFilter.allMaterials = treeModel ? treeModel.availableMaterials() : []
+                        }
+                    }
                     property var filtered: {
                         var query = text.toLowerCase()
                         if (query.length === 0) return allMaterials

--- a/qml/TexturePropertiesPanel.qml
+++ b/qml/TexturePropertiesPanel.qml
@@ -206,10 +206,19 @@ GroupBox {
                     width: Math.min(parent.width - 20, sourceSize.width)
                     height: Math.min(parent.height - 20, sourceSize.height)
                     fillMode: Image.PreserveAspectFit
-                    source: MaterialEditorQML.getTexturePreviewPath() !== "" ? MaterialEditorQML.getTexturePreviewPath() + "?v=0" : ""
-                    
+                    // Driven imperatively via reloadPreview() — NOT a binding.
+                    // A `source:` binding on getTexturePreviewPath() re-evaluates
+                    // the getter twice per change (once for the !=="" test, once
+                    // for the value); combined with reloadPreview() that re-ran
+                    // the GPU readback + preview-PNG rewrite several times per
+                    // switch and crashed under rapid switching. The getter is now
+                    // memoized C++-side, and we call it once here.
+                    source: ""
+
                     // Cache-bust counter for forcing image reload
                     property int cacheBuster: 0
+
+                    Component.onCompleted: reloadPreview()
 
                     function reloadPreview() {
                         var path = MaterialEditorQML.getTexturePreviewPath()

--- a/qml/TexturePropertiesPanel.qml
+++ b/qml/TexturePropertiesPanel.qml
@@ -224,9 +224,15 @@ GroupBox {
                         var path = MaterialEditorQML.getTexturePreviewPath()
                         if (path !== "") {
                             cacheBuster++
+                            texturePreview.visible = true
                             texturePreview.source = path + "?v=" + cacheBuster
                         } else {
+                            // No resolvable preview — clearing source leaves
+                            // status at Image.Null (no statusChanged for Error),
+                            // so explicitly fall back to the placeholder here.
                             texturePreview.source = ""
+                            texturePreview.visible = false
+                            placeholderText.visible = true
                         }
                     }
 
@@ -243,8 +249,8 @@ GroupBox {
                     }
 
                     onStatusChanged: {
-                        if (status === Image.Error) {
-                            // If the constructed path fails, show placeholder
+                        if (status === Image.Null || status === Image.Error) {
+                            // Null (empty source) or a failed load → placeholder.
                             texturePreview.visible = false
                             placeholderText.visible = true
                         } else if (status === Image.Ready) {

--- a/src/MaterialEditorQML.cpp
+++ b/src/MaterialEditorQML.cpp
@@ -1096,6 +1096,9 @@ void MaterialEditorQML::setTextureName(const QString &name)
         m_textureName = name;
 
         if (!name.isEmpty() && name != "*Select a texture*") {
+            SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                QStringLiteral("Set material texture: %1").arg(name));
+
             // The on-screen mesh renders via RTSS (the viewport uses the
             // MSN_SHADERGEN material scheme). RTSS resolves the TUS texture by
             // name against the MATERIAL's resource group (+ AUTODETECT). If the
@@ -1112,9 +1115,13 @@ void MaterialEditorQML::setTextureName(const QString &name)
             // Technique/Pass/TUS objects and the cached m_texUnitMap pointer
             // dangles — dereferencing it crashed inside
             // TextureUnitState::retrieveTexture()/Pass::getResourceGroup().
-            // Re-running updateTextureUnitList() re-captures live pointers via
-            // the same name-keyed lookup the selection uses (which correctly
-            // tracks the authored technique even after RTSS augments the list).
+            // Re-running these re-captures live pointers via the same
+            // name-keyed lookup the selection uses (which correctly tracks the
+            // authored technique even after RTSS augments the list).
+            // updateTechniqueList() must run first: updateTextureUnitList()
+            // reads m_passMap via getCurrentPass(), and a prior recompile may
+            // have left that map referencing freed Pass objects.
+            updateTechniqueList(); // rebuilds m_techMap + the selected pass map
             updateTextureUnitList();
             Ogre::TextureUnitState* textureUnit = getCurrentTextureUnit();
             if (textureUnit) {
@@ -1128,10 +1135,19 @@ void MaterialEditorQML::setTextureName(const QString &name)
                         if (Ogre::Technique* tech = getCurrentTechnique()) {
                             while (tech->getNumPasses() > 1)
                                 tech->removePass(1);
+                            // removePass() invalidated any cached pass beyond 0;
+                            // reset the selection to the surviving pass and
+                            // refresh the maps before touching it via the cache,
+                            // then apply alpha-reject directly to pass 0 (PS1
+                            // .tim uses color 0x0000 for transparent texels — see
+                            // PS1TIM::loadTimToOgreImage).
+                            m_selectedPassIndex = 0;
+                            updatePassList();
+                            updateTextureUnitList();
+                            if (tech->getNumPasses() > 0)
+                                tech->getPass(0)->setAlphaRejectSettings(
+                                    Ogre::CMPF_GREATER_EQUAL, 1);
                         }
-                        // PS1 .tim often uses color 0x0000 for transparent texels (see PS1TIM::loadTimToOgreImage).
-                        if (Ogre::Pass* pass = getCurrentPass())
-                            pass->setAlphaRejectSettings(Ogre::CMPF_GREATER_EQUAL, 1);
                     }
                 }
 
@@ -1984,6 +2000,21 @@ QStringList MaterialEditorQML::getAvailableTextures() const
     return textures;
 }
 
+namespace {
+// A texture name from an imported asset can carry subdirectories or "..".
+// Reduce it to a single safe filename so a preview can never escape the
+// texture_previews dir or fail because a nested dir wasn't created.
+QString safePreviewBaseName(const QString& texName)
+{
+    QString base = QFileInfo(texName).fileName(); // strip any directory part
+    base.replace(QRegularExpression(QStringLiteral("[^A-Za-z0-9._-]")),
+                 QStringLiteral("_"));
+    if (base.isEmpty())
+        base = QStringLiteral("texture");
+    return base;
+}
+} // namespace
+
 QString MaterialEditorQML::getTexturePreviewPath() const
 {
     const QString texName = m_textureName;
@@ -1993,27 +2024,34 @@ QString MaterialEditorQML::getTexturePreviewPath() const
 
     // Memoize: the QML Image `source` binding evaluates this getter twice per
     // change and reloadPreview() calls it once more, so a single texture switch
-    // invokes us 3×. Resolving touches the GPU (convertToImage locks the
-    // hardware buffer) and disk (remove + save the preview PNG) — re-running
-    // that on every call raced the renderer / the QML Image still loading the
-    // file, and crashed under rapid back-and-forth switching. Once resolved,
-    // the path is stable for a given texture name, so cache it; the cache is
-    // cleared when a texture is (re)applied (see clearTexturePreviewCache()).
-    auto cached = m_previewPathCache.constFind(texName);
+    // invokes us 3×. Resolving touches disk (decode + save the preview PNG), so
+    // re-running it on every call raced the QML Image still loading the file.
+    // Key the cache by the material's resource GROUP as well as the texture
+    // name: FBX imports can load the same basename (e.g. diffuse.png) into
+    // different per-asset groups, and a name-only key would serve the previous
+    // asset's preview after switching materials.
+    const QString groupKey = QString::fromStdString(
+        m_ogreMaterial ? m_ogreMaterial->getGroup()
+                       : std::string(Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME));
+    const QString cacheKey = groupKey + QLatin1Char('\n') + texName;
+    auto cached = m_previewPathCache.constFind(cacheKey);
     if (cached != m_previewPathCache.constEnd()) {
         return cached.value();
     }
-    // Refuse to recurse: convertToImage() inside computeTexturePreviewPath()
-    // can pump the event loop and re-enter this getter; a nested second
-    // GPU-buffer readback is exactly what crashed. Return empty (uncached) so
-    // the outer call still resolves and caches the real path.
+    // Refuse to recurse: if computeTexturePreviewPath() ever pumps the event
+    // loop it could re-enter this getter. Return empty (uncached) so the outer
+    // call still resolves and caches the real path.
     if (m_resolvingPreview) {
         return "";
     }
     m_resolvingPreview = true;
     const QString resolved = computeTexturePreviewPath(texName);
     m_resolvingPreview = false;
-    m_previewPathCache.insert(texName, resolved);
+    // Only cache real resolutions — a transient miss (texture not yet loaded)
+    // must not stick until the next explicit invalidation.
+    if (!resolved.isEmpty()) {
+        m_previewPathCache.insert(cacheKey, resolved);
+    }
     return resolved;
 }
 
@@ -2043,10 +2081,28 @@ QString MaterialEditorQML::computeTexturePreviewPath(const QString &texName) con
                 // Check origin (absolute path)
                 QString origin = QString::fromStdString(texPtr->getOrigin());
                 if (!origin.isEmpty() && QFileInfo::exists(origin)) {
-                    // QML Image cannot display .tim; for those, generate a PNG preview.
+                    // QML Image cannot display .tim; for those, generate a PNG
+                    // preview via the CPU-side PS1TIM decoder (NOT convertToImage,
+                    // which faults on these GPU-only buffers).
                     const QString ext = QFileInfo(origin).suffix().toLower();
                     if (ext != "tim") {
                         return QUrl::fromLocalFile(QFileInfo(origin).absoluteFilePath()).toString();
+                    }
+                    Ogre::Image timImg;
+                    if (PS1TIM::loadTimToOgreImage(origin, timImg)) {
+                        const QString dataPath = QStandardPaths::writableLocation(
+                            QStandardPaths::AppDataLocation);
+                        const QString outDir = QDir(dataPath).filePath("texture_previews");
+                        QDir().mkpath(outDir);
+                        const QString outPath = QDir(outDir).filePath(
+                            safePreviewBaseName(texName) + "_tim.png");
+                        QFile::remove(outPath);
+                        try {
+                            timImg.save(outPath.toStdString());
+                        } catch (...) {}
+                        if (QFileInfo::exists(outPath))
+                            return QUrl::fromLocalFile(
+                                QFileInfo(outPath).absoluteFilePath()).toString();
                     }
                 }
 
@@ -2071,8 +2127,8 @@ QString MaterialEditorQML::computeTexturePreviewPath(const QString &texName) con
                                 QStandardPaths::AppDataLocation);
                             const QString outDir = QDir(dataPath).filePath("texture_previews");
                             QDir().mkpath(outDir);
-                            const QString outPath =
-                                QDir(outDir).filePath(texName + "_embedded.png");
+                            const QString outPath = QDir(outDir).filePath(
+                                safePreviewBaseName(texName) + "_embedded.png");
                             QFile::remove(outPath);
                             if (qimg.save(outPath, "PNG")
                                 && QFileInfo::exists(outPath)) {
@@ -4504,9 +4560,9 @@ void MaterialEditorQML::onSDGenerationCompleted(const QString &outputPath)
     QString fileName = fileInfo.fileName();
 
     // A freshly generated image may reuse a texture name whose preview path is
-    // already memoized — drop the stale entry so the preview re-resolves to the
-    // new pixels rather than the previous file.
-    m_previewPathCache.remove(fileName);
+    // already memoized — clear the (group-keyed) cache so the preview
+    // re-resolves to the new pixels rather than a previous file.
+    m_previewPathCache.clear();
 
 #ifdef ENABLE_STABLE_DIFFUSION
     // Multi-view bake (slice 2): pair this completed image with the view whose

--- a/src/MaterialEditorQML.cpp
+++ b/src/MaterialEditorQML.cpp
@@ -1092,95 +1092,91 @@ void MaterialEditorQML::ensureTextureInMaterialGroup(const QString& textureName)
 
 void MaterialEditorQML::setTextureName(const QString &name)
 {
-    if (m_textureName != name) {
-        m_textureName = name;
+    if (m_textureName == name)
+        return;
+    m_textureName = name;
 
-        if (!name.isEmpty() && name != "*Select a texture*") {
-            SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
-                QStringLiteral("Set material texture: %1").arg(name));
+    if (!name.isEmpty() && name != "*Select a texture*") {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+            QStringLiteral("Set material texture: %1").arg(name));
 
-            // The on-screen mesh renders via RTSS (the viewport uses the
-            // MSN_SHADERGEN material scheme). RTSS resolves the TUS texture by
-            // name against the MATERIAL's resource group (+ AUTODETECT). If the
-            // texture was loaded into a DIFFERENT group than the material, the
-            // lookup misses and RTSS renders the yellow/black placeholder —
-            // even though the editor preview (which reads the file straight off
-            // disk) looks correct. Make the texture resolvable from the
-            // material's own group before binding it.
-            ensureTextureInMaterialGroup(name);
+        // The on-screen mesh renders via RTSS (the viewport uses the
+        // MSN_SHADERGEN material scheme). RTSS resolves the TUS texture by name
+        // against the MATERIAL's resource group (+ AUTODETECT). If the texture
+        // was loaded into a DIFFERENT group than the material, the lookup
+        // misses and RTSS renders the yellow/black placeholder. Make the
+        // texture resolvable from the material's own group before binding it.
+        ensureTextureInMaterialGroup(name);
 
-            // Rebuild the cached technique/pass/TUS pointers BEFORE using them.
-            // An earlier apply (or ensureTextureInMaterialGroup) can recompile
-            // the material, after which Ogre has destroyed+rebuilt its
-            // Technique/Pass/TUS objects and the cached m_texUnitMap pointer
-            // dangles — dereferencing it crashed inside
-            // TextureUnitState::retrieveTexture()/Pass::getResourceGroup().
-            // Re-running these re-captures live pointers via the same
-            // name-keyed lookup the selection uses (which correctly tracks the
-            // authored technique even after RTSS augments the list).
-            // updateTechniqueList() must run first: updateTextureUnitList()
-            // reads m_passMap via getCurrentPass(), and a prior recompile may
-            // have left that map referencing freed Pass objects.
-            updateTechniqueList(); // rebuilds m_techMap + the selected pass map
-            updateTextureUnitList();
-            Ogre::TextureUnitState* textureUnit = getCurrentTextureUnit();
-            if (textureUnit) {
-                // Only set non-empty, valid texture names to avoid OGRE crashes
-                textureUnit->setTextureName(name.toStdString());
-
-                // If this is a per-import PS1 TMD material, default to unlit single-pass once an image is present.
-                if (m_ogreMaterial) {
-                    const std::string matName = m_ogreMaterial->getName();
-                    if (matName.rfind("TMD/", 0) == 0) {
-                        if (Ogre::Technique* tech = getCurrentTechnique()) {
-                            while (tech->getNumPasses() > 1)
-                                tech->removePass(1);
-                            // removePass() invalidated any cached pass beyond 0;
-                            // reset the selection to the surviving pass and
-                            // refresh the maps before touching it via the cache,
-                            // then apply alpha-reject directly to pass 0 (PS1
-                            // .tim uses color 0x0000 for transparent texels — see
-                            // PS1TIM::loadTimToOgreImage).
-                            m_selectedPassIndex = 0;
-                            updatePassList();
-                            updateTextureUnitList();
-                            if (tech->getNumPasses() > 0)
-                                tech->getPass(0)->setAlphaRejectSettings(
-                                    Ogre::CMPF_GREATER_EQUAL, 1);
-                        }
-                    }
-                }
-
-                // The viewport renders this material through RTSS (the
-                // MSN_SHADERGEN scheme). Rebinding the TUS texture above does
-                // NOT update the already-generated shader/technique — RTSS keeps
-                // serving the cached program built against the PREVIOUS texture,
-                // so after a few switches the surface went blank and lighting
-                // glitched (FFP↔generated technique desync). Force RTSS to
-                // regenerate this material's shaders against the new binding.
-                if (m_ogreMaterial) {
-                    if (auto* shaderGen =
-                            Ogre::RTShader::ShaderGenerator::getSingletonPtr()) {
-                        const Ogre::String scheme =
-                            Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME;
-                        try {
-                            shaderGen->invalidateMaterial(scheme,
-                                m_ogreMaterial->getName(), m_ogreMaterial->getGroup());
-                            shaderGen->validateMaterial(scheme,
-                                m_ogreMaterial->getName(), m_ogreMaterial->getGroup());
-                        } catch (...) {
-                            // Best-effort: a missing generated technique just
-                            // means RTSS will rebuild it lazily on next render.
-                        }
-                    }
-                    m_ogreMaterial->compile();
-                }
-                updateMaterialText();
-            }
+        // Rebuild the cached technique/pass/TUS pointers BEFORE using them. An
+        // earlier apply (or ensureTextureInMaterialGroup) can recompile the
+        // material, after which Ogre has destroyed+rebuilt its
+        // Technique/Pass/TUS objects and the cached m_texUnitMap pointer
+        // dangles — dereferencing it crashed in
+        // TextureUnitState::retrieveTexture()/Pass::getResourceGroup().
+        // updateTechniqueList() must run first: updateTextureUnitList() reads
+        // m_passMap via getCurrentPass(), which a prior recompile may have left
+        // referencing freed Pass objects.
+        updateTechniqueList(); // rebuilds m_techMap + the selected pass map
+        updateTextureUnitList();
+        if (Ogre::TextureUnitState* textureUnit = getCurrentTextureUnit()) {
+            // Only set non-empty, valid texture names to avoid OGRE crashes.
+            textureUnit->setTextureName(name.toStdString());
+            collapseTmdMaterialToSinglePass();
+            regenerateRtssShaders();
+            updateMaterialText();
         }
-
-        emit textureNameChanged();
     }
+
+    emit textureNameChanged();
+}
+
+void MaterialEditorQML::collapseTmdMaterialToSinglePass()
+{
+    // Per-import PS1 TMD materials default to unlit single-pass once an image
+    // is present.
+    if (!m_ogreMaterial || m_ogreMaterial->getName().rfind("TMD/", 0) != 0)
+        return;
+    Ogre::Technique* tech = getCurrentTechnique();
+    if (!tech)
+        return;
+    while (tech->getNumPasses() > 1)
+        tech->removePass(1);
+    // removePass() invalidated any cached pass beyond 0; reset the selection to
+    // the surviving pass and refresh the maps before touching it via the cache,
+    // then apply alpha-reject directly to pass 0 (PS1 .tim uses color 0x0000
+    // for transparent texels — see PS1TIM::loadTimToOgreImage).
+    m_selectedPassIndex = 0;
+    updatePassList();
+    updateTextureUnitList();
+    if (tech->getNumPasses() > 0)
+        tech->getPass(0)->setAlphaRejectSettings(Ogre::CMPF_GREATER_EQUAL, 1);
+}
+
+void MaterialEditorQML::regenerateRtssShaders()
+{
+    // The viewport renders this material through RTSS (the MSN_SHADERGEN
+    // scheme). Rebinding a TUS texture does NOT update the already-generated
+    // shader — RTSS keeps serving the program built against the PREVIOUS
+    // texture, so after a few switches the surface went blank and lighting
+    // glitched (FFP↔generated technique desync). Force RTSS to regenerate this
+    // material's shaders against the new binding.
+    if (!m_ogreMaterial)
+        return;
+    if (auto* shaderGen = Ogre::RTShader::ShaderGenerator::getSingletonPtr()) {
+        const Ogre::String scheme =
+            Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME;
+        try {
+            shaderGen->invalidateMaterial(scheme,
+                m_ogreMaterial->getName(), m_ogreMaterial->getGroup());
+            shaderGen->validateMaterial(scheme,
+                m_ogreMaterial->getName(), m_ogreMaterial->getGroup());
+        } catch (const Ogre::Exception&) {
+            // Best-effort: a missing generated technique just means RTSS will
+            // rebuild it lazily on next render.
+        }
+    }
+    m_ogreMaterial->compile();
 }
 
 void MaterialEditorQML::setScrollAnimUSpeed(double speed)
@@ -2013,6 +2009,117 @@ QString safePreviewBaseName(const QString& texName)
         base = QStringLiteral("texture");
     return base;
 }
+
+QString fileUrl(const QString& path)
+{
+    return QUrl::fromLocalFile(QFileInfo(path).absoluteFilePath()).toString();
+}
+
+// Writable <AppData>/texture_previews/<safeBase><suffix>, with the dir created
+// and any stale file removed. Empty if AppData can't be resolved.
+QString previewOutPath(const QString& texName, const QString& suffix)
+{
+    const QString dataPath =
+        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    if (dataPath.isEmpty())
+        return {};
+    const QString outDir = QDir(dataPath).filePath(QStringLiteral("texture_previews"));
+    QDir().mkpath(outDir);
+    const QString outPath =
+        QDir(outDir).filePath(safePreviewBaseName(texName) + suffix);
+    QFile::remove(outPath);
+    return outPath;
+}
+
+// Locate an already-loaded Ogre texture by name across ALL resource groups
+// (getByName only searches the default group; FBX imports use per-asset groups).
+Ogre::TexturePtr findLoadedTexture(const std::string& name)
+{
+    auto texPtr = Ogre::TextureManager::getSingleton().getByName(name);
+    if (texPtr)
+        return texPtr;
+    auto it = Ogre::TextureManager::getSingleton().getResourceIterator();
+    while (it.hasMoreElements()) {
+        const Ogre::ResourcePtr r = it.getNext();
+        if (r && r->getName() == name)
+            return Ogre::static_pointer_cast<Ogre::Texture>(r);
+    }
+    return {};
+}
+
+// .tim can't be shown by QML — decode CPU-side (PS1TIM, NOT convertToImage which
+// faults on GPU-only buffers) and write a PNG preview. Empty on failure.
+QString timPreviewUrl(const QString& origin, const QString& texName)
+{
+    Ogre::Image timImg;
+    if (!PS1TIM::loadTimToOgreImage(origin, timImg))
+        return {};
+    const QString outPath = previewOutPath(texName, QStringLiteral("_tim.png"));
+    if (outPath.isEmpty())
+        return {};
+    try {
+        timImg.save(outPath.toStdString());
+    } catch (const Ogre::Exception&) {
+        return {};
+    }
+    return QFileInfo::exists(outPath) ? fileUrl(outPath) : QString();
+}
+
+// Embedded-FBX textures (e.g. Boss_diffuse.png inside Rumba Dancing.fbx, #508)
+// have no on-disk origin and live only in the GPU buffer convertToImage can't
+// read back. Decode the bytes stashed at import (EmbeddedTextureCache) to a PNG.
+QString embeddedPreviewUrl(const QString& texName)
+{
+    const std::vector<uint8_t> bytes =
+        EmbeddedTextureCache::retrieve(texName.toStdString());
+    if (bytes.empty())
+        return {};
+    QImage qimg;
+    if (!qimg.loadFromData(bytes.data(), static_cast<int>(bytes.size())))
+        return {};
+    const QString outPath = previewOutPath(texName, QStringLiteral("_embedded.png"));
+    if (outPath.isEmpty())
+        return {};
+    if (qimg.save(outPath, "PNG") && QFileInfo::exists(outPath))
+        return fileUrl(outPath);
+    return {};
+}
+
+// Resolve a preview from an already-loaded Ogre texture: its on-disk origin
+// (PNG-decoding .tim), the embedded-byte cache, or its resource-group dir.
+QString previewUrlFromOgreTexture(const Ogre::TexturePtr& texPtr,
+                                  const QString& texName)
+{
+    const QString origin = QString::fromStdString(texPtr->getOrigin());
+    if (!origin.isEmpty() && QFileInfo::exists(origin)) {
+        if (QFileInfo(origin).suffix().toLower() != QStringLiteral("tim"))
+            return fileUrl(origin);
+        const QString timUrl = timPreviewUrl(origin, texName);
+        if (!timUrl.isEmpty())
+            return timUrl;
+    }
+
+    const QString embedded = embeddedPreviewUrl(texName);
+    if (!embedded.isEmpty())
+        return embedded;
+
+    // The resource group name is often the directory the model loaded from.
+    // (We deliberately never call convertToImage() — see embeddedPreviewUrl;
+    // on loadImage/loadRawData textures it faults with an uncatchable
+    // EXC_BAD_ACCESS, which is the crash this whole path was rewritten to fix.)
+    const QString group = QString::fromStdString(texPtr->getGroup());
+    if (!group.isEmpty()) {
+        const QString groupPath = group + "/" + texName;
+        if (QFileInfo::exists(groupPath))
+            return fileUrl(groupPath);
+        if (!origin.isEmpty()) {
+            const QString combined = group + "/" + origin;
+            if (QFileInfo::exists(combined))
+                return fileUrl(combined);
+        }
+    }
+    return {};
+}
 } // namespace
 
 QString MaterialEditorQML::getTexturePreviewPath() const
@@ -2034,8 +2141,8 @@ QString MaterialEditorQML::getTexturePreviewPath() const
         m_ogreMaterial ? m_ogreMaterial->getGroup()
                        : std::string(Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME));
     const QString cacheKey = groupKey + QLatin1Char('\n') + texName;
-    auto cached = m_previewPathCache.constFind(cacheKey);
-    if (cached != m_previewPathCache.constEnd()) {
+    if (auto cached = m_previewPathCache.constFind(cacheKey);
+        cached != m_previewPathCache.constEnd()) {
         return cached.value();
     }
     // Refuse to recurse: if computeTexturePreviewPath() ever pumps the event
@@ -2057,140 +2164,40 @@ QString MaterialEditorQML::getTexturePreviewPath() const
 
 QString MaterialEditorQML::computeTexturePreviewPath(const QString &texName) const
 {
-
-    // 1. Ask Ogre where the texture was actually loaded from (most accurate)
+    // 1. Ask Ogre where the texture was actually loaded from (most accurate).
     if (isOgreAvailable()) {
         try {
-            // getByName(name) only searches the DEFAULT resource group. Imported
-            // FBX textures are frequently loaded into a per-asset group (named
-            // after the import directory), so the no-group lookup misses them
-            // and the preview came up blank even though the texture is loaded.
-            // Fall back to a group-agnostic scan of the resource map by name.
-            auto texPtr = Ogre::TextureManager::getSingleton().getByName(texName.toStdString());
-            if (!texPtr) {
-                auto it = Ogre::TextureManager::getSingleton().getResourceIterator();
-                while (it.hasMoreElements()) {
-                    Ogre::ResourcePtr r = it.getNext();
-                    if (r && r->getName() == texName.toStdString()) {
-                        texPtr = Ogre::static_pointer_cast<Ogre::Texture>(r);
-                        break;
-                    }
-                }
+            if (auto texPtr = findLoadedTexture(texName.toStdString())) {
+                const QString url = previewUrlFromOgreTexture(texPtr, texName);
+                if (!url.isEmpty())
+                    return url;
             }
-            if (texPtr) {
-                // Check origin (absolute path)
-                QString origin = QString::fromStdString(texPtr->getOrigin());
-                if (!origin.isEmpty() && QFileInfo::exists(origin)) {
-                    // QML Image cannot display .tim; for those, generate a PNG
-                    // preview via the CPU-side PS1TIM decoder (NOT convertToImage,
-                    // which faults on these GPU-only buffers).
-                    const QString ext = QFileInfo(origin).suffix().toLower();
-                    if (ext != "tim") {
-                        return QUrl::fromLocalFile(QFileInfo(origin).absoluteFilePath()).toString();
-                    }
-                    Ogre::Image timImg;
-                    if (PS1TIM::loadTimToOgreImage(origin, timImg)) {
-                        const QString dataPath = QStandardPaths::writableLocation(
-                            QStandardPaths::AppDataLocation);
-                        const QString outDir = QDir(dataPath).filePath("texture_previews");
-                        QDir().mkpath(outDir);
-                        const QString outPath = QDir(outDir).filePath(
-                            safePreviewBaseName(texName) + "_tim.png");
-                        QFile::remove(outPath);
-                        try {
-                            timImg.save(outPath.toStdString());
-                        } catch (...) {}
-                        if (QFileInfo::exists(outPath))
-                            return QUrl::fromLocalFile(
-                                QFileInfo(outPath).absoluteFilePath()).toString();
-                    }
-                }
-
-                // Embedded-FBX textures (Boss_diffuse.png inside Rumba
-                // Dancing.fbx, #508) have no on-disk origin and are loaded into
-                // Ogre via loadImage/loadRawData, where convertToImage() below
-                // often can't read the buffer back — so the preview was blank.
-                // The original bytes were stashed at import in
-                // EmbeddedTextureCache; decode those (most reliable source)
-                // into a PNG preview. Try this BEFORE convertToImage.
-                {
-                    const std::vector<uint8_t> bytes =
-                        EmbeddedTextureCache::retrieve(texName.toStdString());
-                    if (!bytes.empty()) {
-                        // Decode with QImage first (handles PNG/JPG/BMP/…); the
-                        // cache holds the original compressed payload for the
-                        // common mHeight==0 case.
-                        QImage qimg;
-                        if (qimg.loadFromData(bytes.data(),
-                                              static_cast<int>(bytes.size()))) {
-                            const QString dataPath = QStandardPaths::writableLocation(
-                                QStandardPaths::AppDataLocation);
-                            const QString outDir = QDir(dataPath).filePath("texture_previews");
-                            QDir().mkpath(outDir);
-                            const QString outPath = QDir(outDir).filePath(
-                                safePreviewBaseName(texName) + "_embedded.png");
-                            QFile::remove(outPath);
-                            if (qimg.save(outPath, "PNG")
-                                && QFileInfo::exists(outPath)) {
-                                return QUrl::fromLocalFile(
-                                    QFileInfo(outPath).absoluteFilePath()).toString();
-                            }
-                        }
-                    }
-                }
-
-                // NOTE: we deliberately do NOT call texPtr->convertToImage()
-                // here. For textures loaded via loadImage/loadRawData (embedded
-                // FBX, generated, raw-decoded) the GPU buffer often can't be
-                // read back, and convertToImage() then dereferences a null
-                // internal buffer and faults with EXC_BAD_ACCESS — a HARDWARE
-                // fault that a C++ try/catch CANNOT intercept, so it crashed the
-                // app (reliably reproduced by switching back to an embedded
-                // texture). The embedded-cache branch above already covers the
-                // case convertToImage() was meant to handle; anything not
-                // resolved by then falls through to the on-disk searches below.
-
-                // The resource group name is often the directory the model was loaded from
-                QString group = QString::fromStdString(texPtr->getGroup());
-                if (!group.isEmpty()) {
-                    // Group name IS the directory path for imported models
-                    QString groupPath = group + "/" + texName;
-                    if (QFileInfo::exists(groupPath)) {
-                        return QUrl::fromLocalFile(QFileInfo(groupPath).absoluteFilePath()).toString();
-                    }
-                    // Also try origin relative to group
-                    if (!origin.isEmpty()) {
-                        QString combined = group + "/" + origin;
-                        if (QFileInfo::exists(combined)) {
-                            return QUrl::fromLocalFile(QFileInfo(combined).absoluteFilePath()).toString();
-                        }
-                    }
-                }
-            }
-        } catch (...) {}
-    }
-
-    // 2. Check generated textures directory
-    QString dataPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    QString genTexPath = QDir(dataPath).filePath("generated_textures/" + texName);
-    if (QFileInfo::exists(genTexPath)) {
-        return QUrl::fromLocalFile(QFileInfo(genTexPath).absoluteFilePath()).toString();
-    }
-
-    // 3. Try common texture locations
-    QStringList possiblePaths = {
-        QString("media/materials/textures/%1").arg(texName),
-        QString("../media/materials/textures/%1").arg(texName),
-        QString("../../media/materials/textures/%1").arg(texName)
-    };
-    for (const QString &path : possiblePaths) {
-        QFileInfo fileInfo(path);
-        if (fileInfo.exists() && fileInfo.isFile()) {
-            return QUrl::fromLocalFile(fileInfo.absoluteFilePath()).toString();
+        } catch (const Ogre::Exception&) {
+            // Fall through to the on-disk searches below.
         }
     }
 
-    // Return empty if texture file not found (may only exist in GPU memory)
+    // 2. Check the generated-textures directory.
+    const QString dataPath =
+        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    const QString genTexPath =
+        QDir(dataPath).filePath("generated_textures/" + texName);
+    if (QFileInfo::exists(genTexPath))
+        return fileUrl(genTexPath);
+
+    // 3. Try common on-disk texture locations.
+    const QStringList possiblePaths = {
+        QStringLiteral("media/materials/textures/%1").arg(texName),
+        QStringLiteral("../media/materials/textures/%1").arg(texName),
+        QStringLiteral("../../media/materials/textures/%1").arg(texName)
+    };
+    for (const QString &path : possiblePaths) {
+        const QFileInfo fileInfo(path);
+        if (fileInfo.exists() && fileInfo.isFile())
+            return fileUrl(path);
+    }
+
+    // Not found on disk (may only exist in GPU memory).
     return "";
 }
 

--- a/src/MaterialEditorQML.cpp
+++ b/src/MaterialEditorQML.cpp
@@ -7,6 +7,7 @@
 #include "MeshDepthRenderer.h"
 #include "MultiViewTextureBaker.h"
 #include "TexturePaintBuffer.h"
+#include "EmbeddedTextureCache.h"
 #include <OgreEntity.h>
 #include <OgreSubEntity.h>
 #include <OgreMesh.h>
@@ -1093,9 +1094,8 @@ void MaterialEditorQML::setTextureName(const QString &name)
 {
     if (m_textureName != name) {
         m_textureName = name;
-        
-        Ogre::TextureUnitState* textureUnit = getCurrentTextureUnit();
-        if (textureUnit && !name.isEmpty() && name != "*Select a texture*") {
+
+        if (!name.isEmpty() && name != "*Select a texture*") {
             // The on-screen mesh renders via RTSS (the viewport uses the
             // MSN_SHADERGEN material scheme). RTSS resolves the TUS texture by
             // name against the MATERIAL's resource group (+ AUTODETECT). If the
@@ -1105,25 +1105,64 @@ void MaterialEditorQML::setTextureName(const QString &name)
             // disk) looks correct. Make the texture resolvable from the
             // material's own group before binding it.
             ensureTextureInMaterialGroup(name);
-            // Only set non-empty, valid texture names to avoid OGRE crashes
-            textureUnit->setTextureName(name.toStdString());
 
-            // If this is a per-import PS1 TMD material, default to unlit single-pass once an image is present.
-            if (m_ogreMaterial) {
-                const std::string matName = m_ogreMaterial->getName();
-                if (matName.rfind("TMD/", 0) == 0) {
-                    if (Ogre::Technique* tech = getCurrentTechnique()) {
-                        while (tech->getNumPasses() > 1)
-                            tech->removePass(1);
+            // Rebuild the cached technique/pass/TUS pointers BEFORE using them.
+            // An earlier apply (or ensureTextureInMaterialGroup) can recompile
+            // the material, after which Ogre has destroyed+rebuilt its
+            // Technique/Pass/TUS objects and the cached m_texUnitMap pointer
+            // dangles — dereferencing it crashed inside
+            // TextureUnitState::retrieveTexture()/Pass::getResourceGroup().
+            // Re-running updateTextureUnitList() re-captures live pointers via
+            // the same name-keyed lookup the selection uses (which correctly
+            // tracks the authored technique even after RTSS augments the list).
+            updateTextureUnitList();
+            Ogre::TextureUnitState* textureUnit = getCurrentTextureUnit();
+            if (textureUnit) {
+                // Only set non-empty, valid texture names to avoid OGRE crashes
+                textureUnit->setTextureName(name.toStdString());
+
+                // If this is a per-import PS1 TMD material, default to unlit single-pass once an image is present.
+                if (m_ogreMaterial) {
+                    const std::string matName = m_ogreMaterial->getName();
+                    if (matName.rfind("TMD/", 0) == 0) {
+                        if (Ogre::Technique* tech = getCurrentTechnique()) {
+                            while (tech->getNumPasses() > 1)
+                                tech->removePass(1);
+                        }
+                        // PS1 .tim often uses color 0x0000 for transparent texels (see PS1TIM::loadTimToOgreImage).
+                        if (Ogre::Pass* pass = getCurrentPass())
+                            pass->setAlphaRejectSettings(Ogre::CMPF_GREATER_EQUAL, 1);
                     }
-                    // PS1 .tim often uses color 0x0000 for transparent texels (see PS1TIM::loadTimToOgreImage).
-                    if (Ogre::Pass* pass = getCurrentPass())
-                        pass->setAlphaRejectSettings(Ogre::CMPF_GREATER_EQUAL, 1);
                 }
+
+                // The viewport renders this material through RTSS (the
+                // MSN_SHADERGEN scheme). Rebinding the TUS texture above does
+                // NOT update the already-generated shader/technique — RTSS keeps
+                // serving the cached program built against the PREVIOUS texture,
+                // so after a few switches the surface went blank and lighting
+                // glitched (FFP↔generated technique desync). Force RTSS to
+                // regenerate this material's shaders against the new binding.
+                if (m_ogreMaterial) {
+                    if (auto* shaderGen =
+                            Ogre::RTShader::ShaderGenerator::getSingletonPtr()) {
+                        const Ogre::String scheme =
+                            Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME;
+                        try {
+                            shaderGen->invalidateMaterial(scheme,
+                                m_ogreMaterial->getName(), m_ogreMaterial->getGroup());
+                            shaderGen->validateMaterial(scheme,
+                                m_ogreMaterial->getName(), m_ogreMaterial->getGroup());
+                        } catch (...) {
+                            // Best-effort: a missing generated technique just
+                            // means RTSS will rebuild it lazily on next render.
+                        }
+                    }
+                    m_ogreMaterial->compile();
+                }
+                updateMaterialText();
             }
-            updateMaterialText();
         }
-        
+
         emit textureNameChanged();
     }
 }
@@ -1947,15 +1986,59 @@ QStringList MaterialEditorQML::getAvailableTextures() const
 
 QString MaterialEditorQML::getTexturePreviewPath() const
 {
-    QString texName = m_textureName;
+    const QString texName = m_textureName;
     if (texName.isEmpty() || texName == "*Select a texture*" || texName.trimmed().isEmpty()) {
         return "";
     }
 
+    // Memoize: the QML Image `source` binding evaluates this getter twice per
+    // change and reloadPreview() calls it once more, so a single texture switch
+    // invokes us 3×. Resolving touches the GPU (convertToImage locks the
+    // hardware buffer) and disk (remove + save the preview PNG) — re-running
+    // that on every call raced the renderer / the QML Image still loading the
+    // file, and crashed under rapid back-and-forth switching. Once resolved,
+    // the path is stable for a given texture name, so cache it; the cache is
+    // cleared when a texture is (re)applied (see clearTexturePreviewCache()).
+    auto cached = m_previewPathCache.constFind(texName);
+    if (cached != m_previewPathCache.constEnd()) {
+        return cached.value();
+    }
+    // Refuse to recurse: convertToImage() inside computeTexturePreviewPath()
+    // can pump the event loop and re-enter this getter; a nested second
+    // GPU-buffer readback is exactly what crashed. Return empty (uncached) so
+    // the outer call still resolves and caches the real path.
+    if (m_resolvingPreview) {
+        return "";
+    }
+    m_resolvingPreview = true;
+    const QString resolved = computeTexturePreviewPath(texName);
+    m_resolvingPreview = false;
+    m_previewPathCache.insert(texName, resolved);
+    return resolved;
+}
+
+QString MaterialEditorQML::computeTexturePreviewPath(const QString &texName) const
+{
+
     // 1. Ask Ogre where the texture was actually loaded from (most accurate)
     if (isOgreAvailable()) {
         try {
+            // getByName(name) only searches the DEFAULT resource group. Imported
+            // FBX textures are frequently loaded into a per-asset group (named
+            // after the import directory), so the no-group lookup misses them
+            // and the preview came up blank even though the texture is loaded.
+            // Fall back to a group-agnostic scan of the resource map by name.
             auto texPtr = Ogre::TextureManager::getSingleton().getByName(texName.toStdString());
+            if (!texPtr) {
+                auto it = Ogre::TextureManager::getSingleton().getResourceIterator();
+                while (it.hasMoreElements()) {
+                    Ogre::ResourcePtr r = it.getNext();
+                    if (r && r->getName() == texName.toStdString()) {
+                        texPtr = Ogre::static_pointer_cast<Ogre::Texture>(r);
+                        break;
+                    }
+                }
+            }
             if (texPtr) {
                 // Check origin (absolute path)
                 QString origin = QString::fromStdString(texPtr->getOrigin());
@@ -1967,21 +2050,49 @@ QString MaterialEditorQML::getTexturePreviewPath() const
                     }
                 }
 
-                // If we can't return a directly viewable file (e.g., .tim), generate a PNG preview from the GPU texture.
-                try {
-                    Ogre::Image img;
-                    texPtr->convertToImage(img, true);
-                    const QString dataPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-                    const QString outDir = QDir(dataPath).filePath("texture_previews");
-                    QDir().mkpath(outDir);
-                    const QString outPath = QDir(outDir).filePath(texName + ".png");
-                    QFile::remove(outPath); // ensure stale previews don't linger
-                    img.save(outPath.toStdString());
-                    if (QFileInfo::exists(outPath)) {
-                        return QUrl::fromLocalFile(QFileInfo(outPath).absoluteFilePath()).toString();
+                // Embedded-FBX textures (Boss_diffuse.png inside Rumba
+                // Dancing.fbx, #508) have no on-disk origin and are loaded into
+                // Ogre via loadImage/loadRawData, where convertToImage() below
+                // often can't read the buffer back — so the preview was blank.
+                // The original bytes were stashed at import in
+                // EmbeddedTextureCache; decode those (most reliable source)
+                // into a PNG preview. Try this BEFORE convertToImage.
+                {
+                    const std::vector<uint8_t> bytes =
+                        EmbeddedTextureCache::retrieve(texName.toStdString());
+                    if (!bytes.empty()) {
+                        // Decode with QImage first (handles PNG/JPG/BMP/…); the
+                        // cache holds the original compressed payload for the
+                        // common mHeight==0 case.
+                        QImage qimg;
+                        if (qimg.loadFromData(bytes.data(),
+                                              static_cast<int>(bytes.size()))) {
+                            const QString dataPath = QStandardPaths::writableLocation(
+                                QStandardPaths::AppDataLocation);
+                            const QString outDir = QDir(dataPath).filePath("texture_previews");
+                            QDir().mkpath(outDir);
+                            const QString outPath =
+                                QDir(outDir).filePath(texName + "_embedded.png");
+                            QFile::remove(outPath);
+                            if (qimg.save(outPath, "PNG")
+                                && QFileInfo::exists(outPath)) {
+                                return QUrl::fromLocalFile(
+                                    QFileInfo(outPath).absoluteFilePath()).toString();
+                            }
+                        }
                     }
-                } catch (...) {
                 }
+
+                // NOTE: we deliberately do NOT call texPtr->convertToImage()
+                // here. For textures loaded via loadImage/loadRawData (embedded
+                // FBX, generated, raw-decoded) the GPU buffer often can't be
+                // read back, and convertToImage() then dereferences a null
+                // internal buffer and faults with EXC_BAD_ACCESS — a HARDWARE
+                // fault that a C++ try/catch CANNOT intercept, so it crashed the
+                // app (reliably reproduced by switching back to an embedded
+                // texture). The embedded-cache branch above already covers the
+                // case convertToImage() was meant to handle; anything not
+                // resolved by then falls through to the on-disk searches below.
 
                 // The resource group name is often the directory the model was loaded from
                 QString group = QString::fromStdString(texPtr->getGroup());
@@ -4391,6 +4502,11 @@ void MaterialEditorQML::onSDGenerationCompleted(const QString &outputPath)
     QFileInfo fileInfo(outputPath);
     QString dirPath = fileInfo.absolutePath();
     QString fileName = fileInfo.fileName();
+
+    // A freshly generated image may reuse a texture name whose preview path is
+    // already memoized — drop the stale entry so the preview re-resolves to the
+    // new pixels rather than the previous file.
+    m_previewPathCache.remove(fileName);
 
 #ifdef ENABLE_STABLE_DIFFUSION
     // Multi-view bake (slice 2): pair this completed image with the view whose

--- a/src/MaterialEditorQML.h
+++ b/src/MaterialEditorQML.h
@@ -5,6 +5,7 @@
 #include <QQmlEngine>
 #include <QColor>
 #include <QStringList>
+#include <QHash>
 
 #include <memory>
 #include <QVariantMap>
@@ -363,6 +364,9 @@ public slots:
     QStringList getBlendFactorNames() const;
     QStringList getAvailableTextures() const;
     QString getTexturePreviewPath() const;
+    // Drop any memoized preview paths (call when a texture is applied/changed so
+    // a regenerated image is re-resolved instead of serving a stale cached PNG).
+    void clearTexturePreviewCache() { m_previewPathCache.clear(); }
 
     // Export the currently-shown texture (the preview image) to a
     // user-chosen file. Lets the user save a generated texture even
@@ -702,6 +706,9 @@ private:
     Ogre::TextureUnitState* getCurrentTextureUnit() const;
     Ogre::Technique* getCurrentTechnique() const;
     bool isOgreAvailable() const;
+    // Uncached resolution of a texture's preview path (the body behind the
+    // memoizing getTexturePreviewPath()). Does the Ogre/disk work.
+    QString computeTexturePreviewPath(const QString &texName) const;
     /**
      * Make a texture name resolvable from the current material's resource
      * group so the RTSS-rendered mesh can sample it (otherwise the on-screen
@@ -747,6 +754,18 @@ private:
     
     // Texture properties
     QString m_textureName = "*Select a texture*";
+    // Memoizes getTexturePreviewPath() results keyed by texture name. The QML
+    // Image `source` binding evaluates the getter twice per change and
+    // reloadPreview() calls it again, so without a cache rapid texture
+    // switching re-runs convertToImage() (locks the GPU buffer) + rewrites the
+    // same preview PNG on every call — a re-entrant GPU-buffer / file race that
+    // crashed on macOS. Cache the resolved path so repeat lookups are cheap and
+    // touch neither Ogre nor disk. Mutable: the getter is const.
+    mutable QHash<QString, QString> m_previewPathCache;
+    // Re-entrancy guard for computeTexturePreviewPath(): convertToImage() can
+    // pump the event loop, which could re-enter the getter and run a second
+    // GPU-buffer readback nested inside the first. Refuse to recurse.
+    mutable bool m_resolvingPreview = false;
     double m_scrollAnimUSpeed = 0.0;
     double m_scrollAnimVSpeed = 0.0;
     

--- a/src/MaterialEditorQML.h
+++ b/src/MaterialEditorQML.h
@@ -709,6 +709,11 @@ private:
     // Uncached resolution of a texture's preview path (the body behind the
     // memoizing getTexturePreviewPath()). Does the Ogre/disk work.
     QString computeTexturePreviewPath(const QString &texName) const;
+    // setTextureName() post-bind steps, split out to keep that method flat:
+    // collapse a PS1 TMD material to a single unlit pass, and force RTSS to
+    // regenerate this material's shaders against the freshly bound texture.
+    void collapseTmdMaterialToSinglePass();
+    void regenerateRtssShaders();
     /**
      * Make a texture name resolvable from the current material's resource
      * group so the RTSS-rendered mesh can sample it (otherwise the on-screen

--- a/src/SceneTreeModel.cpp
+++ b/src/SceneTreeModel.cpp
@@ -76,6 +76,10 @@ SceneTreeModel::SceneTreeModel(QObject* parent)
     connect(Manager::getSingleton(), &Manager::sceneNodeDestroyed, this, scheduleRebuild);
     connect(Manager::getSingleton(), &Manager::entityCreated, this, scheduleRebuild);
     connect(SelectionSet::getSingleton(), &SelectionSet::selectionChanged, this, &SceneTreeModel::updateSelection);
+    // The user wants the material picker to refresh on selection change too, so
+    // a freshly-selected entity's materials are immediately offered.
+    connect(SelectionSet::getSingleton(), &SelectionSet::selectionChanged,
+            this, &SceneTreeModel::materialsChanged);
 }
 
 SceneTreeModel::~SceneTreeModel()
@@ -95,6 +99,9 @@ void SceneTreeModel::rebuild()
     buildChildren(rootNode, mRootItem);
 
     endResetModel();
+    // A rebuild follows model loads / node + entity creation, any of which can
+    // introduce new materials — tell QML pickers to refresh their lists.
+    emit materialsChanged();
 }
 
 void SceneTreeModel::buildChildren(Ogre::SceneNode* sceneNode, SceneTreeItem* parentItem)

--- a/src/SceneTreeModel.h
+++ b/src/SceneTreeModel.h
@@ -79,6 +79,11 @@ public slots:
 
 signals:
     void selectionUpdated();
+    // Emitted whenever the set of available materials may have changed — on
+    // scene rebuild (model load / node or entity created) and on selection
+    // change — so QML material pickers (the scene-tree submesh dropdown) can
+    // re-fetch availableMaterials() instead of caching a stale list.
+    void materialsChanged();
 
 private:
     void buildChildren(Ogre::SceneNode* sceneNode, SceneTreeItem* parentItem);


### PR DESCRIPTION
## Summary

Fixes the Material Editor texture-preview blanking, a crash when rapidly switching texture images, and stale Inspector material lists.

### Preview resolution (`getTexturePreviewPath`)
- **Group-agnostic lookup.** FBX imports load textures into a per-asset resource group; `getByName(name)` only searches the default group, so valid textures previewed blank. Now falls back to a group-agnostic scan of the resource map.
- **Embedded-FBX textures.** Decode the original bytes from `EmbeddedTextureCache` (textures with no on-disk origin, e.g. `Boss_diffuse.png` inside Rumba Dancing.fbx).
- **Removed the `convertToImage()` GPU-readback fallback.** For textures loaded via `loadImage`/`loadRawData` the GPU buffer can't be read back and `convertToImage` dereferenced a null internal buffer → `EXC_BAD_ACCESS`. That is a **hardware fault a C++ `try/catch` cannot intercept**, so it crashed the app reliably when switching back to an embedded texture.
- **Memoization + re-entrancy guard.** The QML `Image.source` binding evaluated the getter twice per change and `reloadPreview()` called it again (3× per switch), each doing GPU + disk work. The preview is now driven imperatively and the resolved path is cached per texture name (invalidated when a generated image reuses a name).

### Apply path (`setTextureName`)
- **Dangling-TUS crash.** A prior apply/recompile destroyed+rebuilt Ogre's Technique/Pass/TUS objects, leaving the cached `TextureUnitState*` orphaned; the next switch dereferenced a TUS with a null parent Pass and crashed in `TextureUnitState::retrieveTexture()` → `Pass::getResourceGroup()`. Now re-captures live pointers via `updateTextureUnitList()` before use.
- **RTSS stale-shader.** The viewport renders via the `MSN_SHADERGEN` scheme; rebinding the TUS texture did not update the already-generated shader, so after a few switches the surface blanked and lighting glitched. Now `invalidateMaterial` + `validateMaterial` in the RTSS scheme and `compile()` so the program regenerates against the new binding.

### Inspector material lists
- `SceneTreeModel::materialsChanged()` emitted on rebuild (model load / node+entity created) and on selection change. The submesh material dropdown and material library list re-fetch instead of caching a stale set.

## Testing
- Built locally on macOS arm64 (`QtMeshEditor` target, `ENABLE_STABLE_DIFFUSION=ON`).
- Verified with lldb that the two crash sites (`convertToImage` and `retrieveTexture`/`getResourceGroup`) no longer fault under rapid back-and-forth texture switching, including repeatedly returning to the embedded FBX texture.

## Known follow-up
- The bound texture is still occasionally dropped after several rapid switches (renders untextured but no crash, lighting stable). Tracked separately — not a regression introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Material lists and selection controls now automatically refresh when scene materials change
  * Texture previews display correctly and update dynamically when textures are modified or regenerated
  * Improved stability when recompiling materials to prevent crashes from outdated internal state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->