### PR TITLE
feat(updater): install + relauncher (#446–448)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -895,10 +895,9 @@ jobs:
     needs: [build-n-cache-assimp-linux, build-n-cache-ogre-linux]
     runs-on: ubuntu-latest
     # Hard cap on the whole job. The full sweep takes ~12 min normally
-    # (build + xvfb + ~25 suites + coverage + sonar). Cap at 45 so a
-    # hung suite or a deadlock surfaces in well under an hour instead
-    # of camping on the runner for GitHub's default 6-hour ceiling.
-    timeout-minutes: 45
+    # (build + xvfb + ~25 suites + coverage + sonar). Cap at 60 so a
+    # cold ccache build on a large PR still finishes under the limit.
+    timeout-minutes: 60
     permissions: read-all
     env: 
           LD_LIBRARY_PATH: gcc_64/lib/:/usr/local/lib/:/usr/local/lib/OGRE/:/usr/local/lib/pkgconfig/:/lib/x86_64-linux-gnu/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -986,9 +986,12 @@ jobs:
         create-symlink: true
 
     - name: Setup headless environment for Qt tests
+      env:
+        DEBIAN_FRONTEND: noninteractive
       run: |
             sudo apt-get update
-            sudo apt-get install -y libxcb-cursor0 libxcb-xinerama0 libx11-dev xvfb \
+            sudo apt-get install -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold \
+                libxcb-cursor0 libxcb-xinerama0 libx11-dev xvfb \
                 mesa-utils libgl1-mesa-dri libegl-mesa0 libgbm1 libglx-mesa0 \
                 libsecret-1-dev libretro-beetle-psx libsodium-dev
             # Start Xvfb with GLX support for Ogre GL initialization

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,6 +289,7 @@ option(ENABLE_AUTO_UPDATER "Enable in-app auto-updater UI and download path" ON)
 if(ENABLE_AUTO_UPDATER)
     add_definitions(-DENABLE_AUTO_UPDATER)
     message(STATUS "In-app auto-updater enabled")
+    add_subdirectory(src/updater/relauncher)
 endif()
 ##############################################################
 #  meshoptimizer — LOD generation, vertex-cache / overdraw /

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,7 +289,6 @@ option(ENABLE_AUTO_UPDATER "Enable in-app auto-updater UI and download path" ON)
 if(ENABLE_AUTO_UPDATER)
     add_definitions(-DENABLE_AUTO_UPDATER)
     message(STATUS "In-app auto-updater enabled")
-    add_subdirectory(src/updater/relauncher)
 endif()
 ##############################################################
 #  meshoptimizer — LOD generation, vertex-cache / overdraw /

--- a/qml/UpdaterDialog.qml
+++ b/qml/UpdaterDialog.qml
@@ -37,7 +37,8 @@ Window {
             if (event.key === Qt.Key_Escape) {
                 if (UpdaterController.state === UpdaterController.Checking
                     || UpdaterController.state === UpdaterController.Downloading
-                    || UpdaterController.state === UpdaterController.Verifying) {
+                    || UpdaterController.state === UpdaterController.Verifying
+                    || UpdaterController.state === UpdaterController.Installing) {
                     UpdaterController.cancel()
                 }
                 UpdaterController.dismiss()
@@ -100,6 +101,7 @@ Window {
                 case UpdaterController.Downloading: return "Downloading update…"
                 case UpdaterController.Verifying: return "Verifying download…"
                 case UpdaterController.ReadyToInstall: return "Ready to install"
+                case UpdaterController.Installing: return "Installing update…"
                 default: return "Software updates"
                 }
             }
@@ -119,6 +121,7 @@ Window {
             running: UpdaterController.state === UpdaterController.Checking
                      || UpdaterController.state === UpdaterController.Downloading
                      || UpdaterController.state === UpdaterController.Verifying
+                     || UpdaterController.state === UpdaterController.Installing
             visible: running
         }
 
@@ -272,7 +275,7 @@ Window {
             }
         }
 
-        // Ready to install (#444 — install step lands in #446–448)
+        // Ready to install (#446–448)
         ColumnLayout {
             Layout.fillWidth: true
             visible: UpdaterController.state === UpdaterController.ReadyToInstall
@@ -283,11 +286,33 @@ Window {
                 color: PropertiesPanelController.textColor
                 font.pixelSize: 12
                 text: "Update " + UpdaterController.latestVersion +
-                      " downloaded and verified. Automatic installation will be available in a future release."
+                      " downloaded and verified. Install now to replace this copy and restart."
             }
-            InspectorButton {
-                label: "Close"
-                onClicked: { UpdaterController.dismiss(); dialog.close() }
+            RowLayout {
+                spacing: 8
+                InspectorButton {
+                    label: "Install & restart"
+                    primary: true
+                    onClicked: UpdaterController.installUpdate()
+                }
+                InspectorButton {
+                    label: "Later"
+                    onClicked: { UpdaterController.dismiss(); dialog.close() }
+                }
+            }
+        }
+
+        // Installing
+        ColumnLayout {
+            Layout.fillWidth: true
+            visible: UpdaterController.state === UpdaterController.Installing
+            spacing: 8
+            Text {
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+                color: PropertiesPanelController.textColor
+                font.pixelSize: 12
+                text: "Preparing installation. The application will close and restart automatically."
             }
         }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,14 +98,6 @@ PaintBufferImageProvider.cpp
 PaintSelectionMask.cpp
 TexturePaintBuffer.cpp
 UpdateVersion.cpp
-updater/InstallFlavor.cpp
-updater/ArtifactResolver.cpp
-updater/UpdateVerifier.cpp
-updater/MinisignVerify.cpp
-updater/GitHubReleaseParser.cpp
-updater/UpdaterWorker.cpp
-updater/UpdaterController.cpp
-updater/UpdaterInstaller.cpp
 TexturePaintController.cpp
 VertexColorBaker.cpp
 VATBaker.cpp
@@ -240,14 +232,6 @@ PaintBufferImageProvider.h
 PaintSelectionMask.h
 TexturePaintBuffer.h
 UpdateVersion.h
-updater/InstallFlavor.h
-updater/ArtifactResolver.h
-updater/UpdateVerifier.h
-updater/MinisignVerify.h
-updater/GitHubReleaseParser.h
-updater/UpdaterWorker.h
-updater/UpdaterController.h
-updater/UpdaterInstaller.h
 TexturePaintController.h
 VertexColorBaker.h
 ApplyAtlas.h
@@ -299,6 +283,8 @@ ADD_SUBDIRECTORY("${CMAKE_CURRENT_SOURCE_DIR}/PS1")
 #file(GLOB UI_FILES ./ui_files/*.ui)
 # if we don't include this CMake will not include ui headers properly:
 include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${BUILD_INCLUDE_DIR} ${BUILD_UIH_DIR})
+
+add_subdirectory(updater)
 
 ##############################################################
 #  Processing ogre-procedural
@@ -555,6 +541,7 @@ Qt::QuickControls2
 meshoptimizer
 xatlas
 qtmesh_sodium
+qtmesh_updater
 )
 
 # One-time legacy secret-store read for migration (see CloudCredentialStore).
@@ -660,7 +647,7 @@ if(BUILD_TESTS)
     ${OGRE_LIBRARIES}
     ${ASSIMP_LIBRARIES}
     Qt::Widgets Qt::Core Qt::Gui Qt::Test Qt::Network Qt::Qml Qt::Quick Qt::QuickWidgets Qt::QuickControls2
-    meshoptimizer xatlas qtmesh_sodium)
+    meshoptimizer xatlas qtmesh_sodium qtmesh_updater)
 
     # CloudCredentialStore.cpp (compiled into the tests) does a one-time legacy
     # secret-store read in migrateLegacySettingsIfNeeded(), which

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -593,6 +593,16 @@ endif()
 
 if(ENABLE_AUTO_UPDATER AND TARGET qtmesh-relauncher)
     add_dependencies(${CMAKE_PROJECT_NAME} qtmesh-relauncher)
+    if(APPLE)
+        add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy
+                "${CMAKE_BINARY_DIR}/bin/qtmesh-relauncher"
+                "$<TARGET_BUNDLE_DIR:${CMAKE_PROJECT_NAME}>/Contents/MacOS/qtmesh-relauncher"
+            COMMAND ${CMAKE_COMMAND} -E chmod 755
+                "$<TARGET_BUNDLE_DIR:${CMAKE_PROJECT_NAME}>/Contents/MacOS/qtmesh-relauncher"
+            COMMENT "Copying qtmesh-relauncher into app bundle"
+        )
+    endif()
 endif()
 ENDIF()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -105,6 +105,7 @@ updater/MinisignVerify.cpp
 updater/GitHubReleaseParser.cpp
 updater/UpdaterWorker.cpp
 updater/UpdaterController.cpp
+updater/UpdaterInstaller.cpp
 TexturePaintController.cpp
 VertexColorBaker.cpp
 VATBaker.cpp
@@ -246,6 +247,7 @@ updater/MinisignVerify.h
 updater/GitHubReleaseParser.h
 updater/UpdaterWorker.h
 updater/UpdaterController.h
+updater/UpdaterInstaller.h
 TexturePaintController.h
 VertexColorBaker.h
 ApplyAtlas.h
@@ -587,6 +589,10 @@ endif()
 if(ENABLE_PS1_RIP AND TARGET Qt6::Gamepad)
     target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE HAVE_QT_GAMEPAD)
     target_link_libraries(${CMAKE_PROJECT_NAME} Qt6::Gamepad)
+endif()
+
+if(ENABLE_AUTO_UPDATER AND TARGET qtmesh-relauncher)
+    add_dependencies(${CMAKE_PROJECT_NAME} qtmesh-relauncher)
 endif()
 ENDIF()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -598,8 +598,6 @@ if(ENABLE_AUTO_UPDATER AND TARGET qtmesh-relauncher)
             COMMAND ${CMAKE_COMMAND} -E copy
                 "${CMAKE_BINARY_DIR}/bin/qtmesh-relauncher"
                 "$<TARGET_BUNDLE_DIR:${CMAKE_PROJECT_NAME}>/Contents/MacOS/qtmesh-relauncher"
-            COMMAND ${CMAKE_COMMAND} -E chmod 755
-                "$<TARGET_BUNDLE_DIR:${CMAKE_PROJECT_NAME}>/Contents/MacOS/qtmesh-relauncher"
             COMMENT "Copying qtmesh-relauncher into app bundle"
         )
     endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,7 +97,6 @@ TextureAtlasPacker.cpp
 PaintBufferImageProvider.cpp
 PaintSelectionMask.cpp
 TexturePaintBuffer.cpp
-UpdateVersion.cpp
 TexturePaintController.cpp
 VertexColorBaker.cpp
 VATBaker.cpp

--- a/src/updater/CMakeLists.txt
+++ b/src/updater/CMakeLists.txt
@@ -1,0 +1,36 @@
+set(QTMESH_UPDATER_SOURCES
+    InstallFlavor.cpp
+    ArtifactResolver.cpp
+    UpdateVerifier.cpp
+    MinisignVerify.cpp
+    GitHubReleaseParser.cpp
+    UpdaterWorker.cpp
+    UpdaterController.cpp
+    UpdaterInstaller.cpp
+)
+
+add_library(qtmesh_updater STATIC ${QTMESH_UPDATER_SOURCES})
+set_target_properties(qtmesh_updater PROPERTIES
+    AUTOMOC ON
+    POSITION_INDEPENDENT_CODE ON
+)
+target_include_directories(qtmesh_updater
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/..
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_link_libraries(qtmesh_updater
+    PUBLIC
+        Qt6::Core
+        Qt6::Network
+        Qt6::Qml
+        qtmesh_sodium
+)
+
+if(BUILD_TESTS)
+    target_compile_definitions(qtmesh_updater PRIVATE QTMESH_UNIT_TESTS)
+endif()
+
+if(ENABLE_AUTO_UPDATER AND BUILD_QT_MESH_EDITOR)
+    add_subdirectory(relauncher)
+endif()

--- a/src/updater/CMakeLists.txt
+++ b/src/updater/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(QTMESH_UPDATER_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/../UpdateVersion.cpp
     InstallFlavor.cpp
     ArtifactResolver.cpp
     UpdateVerifier.cpp

--- a/src/updater/UpdaterController.cpp
+++ b/src/updater/UpdaterController.cpp
@@ -1,5 +1,6 @@
 #include "UpdaterController.h"
 #include "ArtifactResolver.h"
+#include "UpdaterInstaller.h"
 #include "UpdaterWorker.h"
 #include "AppSettingsKeys.h"
 #include "SentryReporter.h"
@@ -34,6 +35,7 @@ QString stateToString(UpdaterController::State state)
     case UpdaterController::State::Downloading: return QStringLiteral("downloading");
     case UpdaterController::State::Verifying: return QStringLiteral("verifying");
     case UpdaterController::State::ReadyToInstall: return QStringLiteral("ready_to_install");
+    case UpdaterController::State::Installing: return QStringLiteral("installing");
     }
     return QStringLiteral("idle");
 }
@@ -367,6 +369,54 @@ void UpdaterController::downloadAndInstall()
     SentryReporter::addBreadcrumb(QStringLiteral("updater.download.start"),
                                   QStringLiteral("version=%1").arg(m_latestVersion));
     beginDownloadIfNeeded(true);
+}
+
+void UpdaterController::installUpdate()
+{
+    if (m_state != State::ReadyToInstall) {
+        return;
+    }
+
+    SentryReporter::addBreadcrumb(QStringLiteral("updater.install.start"),
+                                  QStringLiteral("version=%1").arg(m_latestVersion));
+    setError(QString());
+    setState(State::Installing);
+    logDialogStateBreadcrumb();
+
+    UpdaterInstaller::InstallContext context;
+    context.stagedArtifactPath = m_stagedArtifactPath;
+    context.releaseTag = m_latestVersion;
+    context.executablePath = QCoreApplication::applicationFilePath();
+    context.installRoot = UpdaterInstaller::resolveInstallRoot(context.executablePath);
+    context.parentPid = QCoreApplication::applicationPid();
+
+    const UpdaterInstaller::InstallPlan plan = UpdaterInstaller::prepareInstall(context);
+    if (!plan.ok) {
+        SentryReporter::addBreadcrumb(QStringLiteral("updater.install.error"),
+                                      plan.errorMessage,
+                                      QStringLiteral("error"));
+        setError(plan.errorMessage.isEmpty()
+                     ? tr("Could not prepare the update for installation.")
+                     : plan.errorMessage);
+        setState(State::Error);
+        logDialogStateBreadcrumb();
+        return;
+    }
+
+    if (!UpdaterInstaller::launchRelauncher(plan)) {
+        SentryReporter::addBreadcrumb(QStringLiteral("updater.install.error"),
+                                      QStringLiteral("relauncher missing or failed to start"),
+                                      QStringLiteral("error"));
+        setError(tr("Could not launch the update installer. "
+                    "Make sure qtmesh-relauncher is next to the application binary."));
+        setState(State::Error);
+        logDialogStateBreadcrumb();
+        return;
+    }
+
+    SentryReporter::addBreadcrumb(QStringLiteral("updater.install.relaunch"),
+                                  plan.manifestPath);
+    QApplication::quit();
 }
 
 void UpdaterController::beginDownloadIfNeeded(bool userInitiated)

--- a/src/updater/UpdaterController.h
+++ b/src/updater/UpdaterController.h
@@ -15,7 +15,8 @@
  * @brief QML-facing singleton orchestrating update checks (#441, #443, #449).
  *
  * Mirrors the LLMManager / SDManager pattern: main-thread controller with
- * a worker thread for HTTP. Install/relaunch land in #446–448.
+ * a worker thread for HTTP. Install/relaunch (#446–448) runs on the main thread
+ * via UpdaterInstaller before the app exits.
  */
 class UpdaterController : public QObject
 {
@@ -52,6 +53,7 @@ public:
         Downloading,
         Verifying,
         ReadyToInstall,
+        Installing,
     };
     Q_ENUM(State)
 
@@ -84,6 +86,7 @@ public:
     Q_INVOKABLE void requestCheckDialog();
     Q_INVOKABLE void confirmUnknownInstall();
     Q_INVOKABLE void downloadAndInstall();
+    Q_INVOKABLE void installUpdate();
     Q_INVOKABLE void cancel();
     Q_INVOKABLE void dismiss();
     Q_INVOKABLE void remindLater();

--- a/src/updater/UpdaterInstaller.cpp
+++ b/src/updater/UpdaterInstaller.cpp
@@ -78,21 +78,29 @@ bool extractArchive(const QString& artifactPath,
                     ArtifactKind kind,
                     QString* errorMessage)
 {
-    QDir().mkpath(destinationDir);
     QProcess process;
     QStringList args;
 
     switch (kind) {
     case ArtifactKind::Zip:
+        QDir().mkpath(destinationDir);
         args << QStringLiteral("-xf") << artifactPath << QStringLiteral("-C") << destinationDir;
         return runCommand(&process, QStringLiteral("tar"), args, 600000, errorMessage);
     case ArtifactKind::TarGz:
+        QDir().mkpath(destinationDir);
         args << QStringLiteral("-xzf") << artifactPath << QStringLiteral("-C") << destinationDir;
         return runCommand(&process, QStringLiteral("tar"), args, 600000, errorMessage);
     case ArtifactKind::TarXz:
+        QDir().mkpath(destinationDir);
         args << QStringLiteral("-xJf") << artifactPath << QStringLiteral("-C") << destinationDir;
         return runCommand(&process, QStringLiteral("tar"), args, 600000, errorMessage);
     case ArtifactKind::AppImage:
+        QDir().mkpath(QFileInfo(destinationDir).absolutePath());
+        if (QFileInfo::exists(destinationDir) && QFileInfo(destinationDir).isDir()) {
+            QDir(destinationDir).removeRecursively();
+        } else if (QFile::exists(destinationDir)) {
+            QFile::remove(destinationDir);
+        }
         if (!QFile::copy(artifactPath, destinationDir)) {
             if (errorMessage) {
                 *errorMessage = QStringLiteral("Could not stage AppImage payload");
@@ -323,8 +331,13 @@ InstallPlan prepareInstall(const InstallContext& context)
     QString oldDir;
 
 #if defined(Q_OS_WIN)
-    newDir = QDir(resolved.installRoot).filePath(QStringLiteral("_new"));
-    oldDir = QDir(resolved.installRoot).filePath(QStringLiteral("_old"));
+    {
+        QDir installParent(resolved.installRoot);
+        const QString installFolderName = QFileInfo(resolved.installRoot).fileName();
+        installParent.cdUp();
+        newDir = installParent.filePath(installFolderName + QStringLiteral("_new"));
+        oldDir = installParent.filePath(installFolderName + QStringLiteral("_old"));
+    }
     QDir(newDir).removeRecursively();
     QDir().mkpath(newDir);
     payloadDir = newDir;
@@ -347,7 +360,7 @@ InstallPlan prepareInstall(const InstallContext& context)
     }
 #elif defined(Q_OS_LINUX)
     if (plan.artifactKind == ArtifactKind::AppImage) {
-        payloadDir = QDir(workDir).filePath(stagedInfo.fileName());
+        payloadDir = QDir(workDir).filePath(QStringLiteral("payload/") + stagedInfo.fileName());
         if (!extractArchive(resolved.stagedArtifactPath, payloadDir, plan.artifactKind,
                             &extractError)) {
             plan.errorMessage = extractError;

--- a/src/updater/UpdaterInstaller.cpp
+++ b/src/updater/UpdaterInstaller.cpp
@@ -1,0 +1,402 @@
+#include "UpdaterInstaller.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QProcess>
+#include <QRegularExpression>
+#include <QStandardPaths>
+#include <QTextStream>
+
+namespace UpdaterInstaller {
+
+namespace {
+
+QString platformSlug()
+{
+#if defined(Q_OS_WIN)
+    return QStringLiteral("windows");
+#elif defined(Q_OS_MACOS)
+    return QStringLiteral("macos");
+#elif defined(Q_OS_LINUX)
+    return QStringLiteral("linux");
+#else
+    return QStringLiteral("unknown");
+#endif
+}
+
+QString artifactKindSlug(ArtifactKind kind)
+{
+    switch (kind) {
+    case ArtifactKind::Zip: return QStringLiteral("zip");
+    case ArtifactKind::TarGz: return QStringLiteral("tar_gz");
+    case ArtifactKind::TarXz: return QStringLiteral("tar_xz");
+    case ArtifactKind::Dmg: return QStringLiteral("dmg");
+    case ArtifactKind::AppImage: return QStringLiteral("app_image");
+    case ArtifactKind::Unknown: break;
+    }
+    return QStringLiteral("unknown");
+}
+
+bool runCommand(QProcess* process,
+                const QString& program,
+                const QStringList& arguments,
+                int timeoutMs,
+                QString* errorMessage)
+{
+    process->start(program, arguments);
+    if (!process->waitForStarted()) {
+        if (errorMessage) {
+            *errorMessage = QStringLiteral("Failed to start %1: %2")
+                                .arg(program, process->errorString());
+        }
+        return false;
+    }
+    if (!process->waitForFinished(timeoutMs)) {
+        process->kill();
+        process->waitForFinished(5000);
+        if (errorMessage) {
+            *errorMessage = QStringLiteral("%1 timed out").arg(program);
+        }
+        return false;
+    }
+    if (process->exitStatus() != QProcess::NormalExit || process->exitCode() != 0) {
+        if (errorMessage) {
+            *errorMessage = QStringLiteral("%1 failed (%2): %3")
+                                .arg(program)
+                                .arg(process->exitCode())
+                                .arg(QString::fromUtf8(process->readAllStandardError()));
+        }
+        return false;
+    }
+    return true;
+}
+
+bool extractArchive(const QString& artifactPath,
+                    const QString& destinationDir,
+                    ArtifactKind kind,
+                    QString* errorMessage)
+{
+    QDir().mkpath(destinationDir);
+    QProcess process;
+    QStringList args;
+
+    switch (kind) {
+    case ArtifactKind::Zip:
+        args << QStringLiteral("-xf") << artifactPath << QStringLiteral("-C") << destinationDir;
+        return runCommand(&process, QStringLiteral("tar"), args, 600000, errorMessage);
+    case ArtifactKind::TarGz:
+        args << QStringLiteral("-xzf") << artifactPath << QStringLiteral("-C") << destinationDir;
+        return runCommand(&process, QStringLiteral("tar"), args, 600000, errorMessage);
+    case ArtifactKind::TarXz:
+        args << QStringLiteral("-xJf") << artifactPath << QStringLiteral("-C") << destinationDir;
+        return runCommand(&process, QStringLiteral("tar"), args, 600000, errorMessage);
+    case ArtifactKind::AppImage:
+        if (!QFile::copy(artifactPath, destinationDir)) {
+            if (errorMessage) {
+                *errorMessage = QStringLiteral("Could not stage AppImage payload");
+            }
+            return false;
+        }
+        QFile::setPermissions(destinationDir,
+                              QFile::permissions(destinationDir) | QFile::ExeUser | QFile::ExeGroup
+                                  | QFile::ExeOther);
+        return true;
+    default:
+        if (errorMessage) {
+            *errorMessage = QStringLiteral("Unsupported artifact type for extraction");
+        }
+        return false;
+    }
+}
+
+#if defined(Q_OS_MACOS)
+
+bool extractDmg(const QString& dmgPath, const QString& payloadDir, QString* errorMessage)
+{
+    QDir().mkpath(payloadDir);
+    QProcess attach;
+    QStringList attachArgs;
+    attachArgs << QStringLiteral("attach") << dmgPath << QStringLiteral("-nobrowse")
+               << QStringLiteral("-readonly") << QStringLiteral("-plist");
+    if (!runCommand(&attach, QStringLiteral("hdiutil"), attachArgs, 120000, errorMessage)) {
+        return false;
+    }
+
+    const QString plistOutput = QString::fromUtf8(attach.readAllStandardOutput());
+    QRegularExpression mountRe(QStringLiteral("<key>mount-point</key>\\s*<string>([^<]+)</string>"));
+    const QRegularExpressionMatch match = mountRe.match(plistOutput);
+    if (!match.hasMatch()) {
+        if (errorMessage) {
+            *errorMessage = QStringLiteral("Could not determine DMG mount point");
+        }
+        return false;
+    }
+
+    const QString mountPoint = match.captured(1).trimmed();
+    const QString sourceApp = mountPoint + QStringLiteral("/QtMeshEditor.app");
+    if (!QFileInfo::exists(sourceApp)) {
+        if (errorMessage) {
+            *errorMessage = QStringLiteral("DMG does not contain QtMeshEditor.app");
+        }
+        QProcess detach;
+        runCommand(&detach, QStringLiteral("hdiutil"), {QStringLiteral("detach"), mountPoint}, 60000,
+                   nullptr);
+        return false;
+    }
+
+    QProcess copy;
+    const QString targetApp = QDir(payloadDir).filePath(QStringLiteral("QtMeshEditor.app"));
+    const bool copied =
+        runCommand(&copy,
+                   QStringLiteral("rsync"),
+                   {QStringLiteral("-a"), sourceApp + QStringLiteral("/"), targetApp + QStringLiteral("/")},
+                   600000,
+                   errorMessage);
+
+    QProcess detach;
+    runCommand(&detach, QStringLiteral("hdiutil"), {QStringLiteral("detach"), mountPoint}, 60000,
+               nullptr);
+    return copied;
+}
+
+#endif
+
+QString installRootFromExecutable(const QString& executablePath)
+{
+    const QFileInfo exeInfo(executablePath);
+#if defined(Q_OS_MACOS)
+    QString path = exeInfo.absoluteFilePath();
+    const int appIndex = path.indexOf(QStringLiteral(".app"), 0, Qt::CaseInsensitive);
+    if (appIndex >= 0) {
+        return path.left(appIndex + 4);
+    }
+    return exeInfo.absolutePath();
+#elif defined(Q_OS_WIN)
+    if (exeInfo.dir().dirName().compare(QStringLiteral("bin"), Qt::CaseInsensitive) == 0) {
+        return QFileInfo(exeInfo.absolutePath()).dir().absolutePath();
+    }
+    return exeInfo.absolutePath();
+#else
+    QString path = exeInfo.absoluteFilePath();
+    if (path.contains(QStringLiteral("/opt/QtMeshEditor"), Qt::CaseInsensitive)) {
+        return QStringLiteral("/opt/QtMeshEditor");
+    }
+    if (exeInfo.dir().dirName() == QStringLiteral("bin")) {
+        return QFileInfo(exeInfo.absolutePath()).dir().absolutePath();
+    }
+    return exeInfo.absolutePath();
+#endif
+}
+
+bool writeManifest(const InstallContext& context,
+                   const InstallPlan& plan,
+                   const QString& payloadDir,
+                   const QString& newDir,
+                   const QString& oldDir,
+                   QString* outManifestPath,
+                   QString* errorMessage)
+{
+    const QString manifestDir =
+        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
+        + QStringLiteral("/updater");
+    QDir().mkpath(manifestDir);
+    const QString manifestPath = QDir(manifestDir).filePath(QStringLiteral("install-manifest.txt"));
+
+    QFile manifestFile(manifestPath);
+    if (!manifestFile.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
+        if (errorMessage) {
+            *errorMessage = QStringLiteral("Cannot write install manifest");
+        }
+        return false;
+    }
+
+    QTextStream out(&manifestFile);
+    out << "parent_pid=" << context.parentPid << '\n';
+    out << "platform=" << platformSlug() << '\n';
+    out << "artifact_kind=" << artifactKindSlug(plan.artifactKind) << '\n';
+    out << "install_root=" << context.installRoot << '\n';
+    out << "executable_path=" << context.executablePath << '\n';
+    out << "payload_dir=" << payloadDir << '\n';
+    if (!newDir.isEmpty()) {
+        out << "new_dir=" << newDir << '\n';
+    }
+    if (!oldDir.isEmpty()) {
+        out << "old_dir=" << oldDir << '\n';
+    }
+    out << "release_tag=" << context.releaseTag << '\n';
+    manifestFile.close();
+    if (outManifestPath) {
+        *outManifestPath = manifestPath;
+    }
+    return true;
+}
+
+} // namespace
+
+ArtifactKind detectArtifactKind(const QString& fileName)
+{
+    const QString lower = fileName.toLower();
+    if (lower.endsWith(QStringLiteral(".zip"))) {
+        return ArtifactKind::Zip;
+    }
+    if (lower.endsWith(QStringLiteral(".tar.gz")) || lower.endsWith(QStringLiteral(".tgz"))) {
+        return ArtifactKind::TarGz;
+    }
+    if (lower.endsWith(QStringLiteral(".tar.xz"))) {
+        return ArtifactKind::TarXz;
+    }
+    if (lower.endsWith(QStringLiteral(".dmg"))) {
+        return ArtifactKind::Dmg;
+    }
+    if (lower.endsWith(QStringLiteral(".appimage"))) {
+        return ArtifactKind::AppImage;
+    }
+    return ArtifactKind::Unknown;
+}
+
+QString relauncherExecutablePath()
+{
+    const QFileInfo exe(QCoreApplication::applicationFilePath());
+#if defined(Q_OS_WIN)
+    return exe.dir().absoluteFilePath(QStringLiteral("qtmesh-relauncher.exe"));
+#else
+    return exe.dir().absoluteFilePath(QStringLiteral("qtmesh-relauncher"));
+#endif
+}
+
+bool isInstallLocationWritable(const InstallContext& context)
+{
+    if (context.installRoot.isEmpty()) {
+        return false;
+    }
+    const QFileInfo rootInfo(context.installRoot);
+    if (rootInfo.exists()) {
+        return rootInfo.isWritable();
+    }
+    return QFileInfo(rootInfo.absolutePath()).isWritable();
+}
+
+QString resolveInstallRoot(const QString& executablePath)
+{
+    const QString exe =
+        executablePath.isEmpty() ? QCoreApplication::applicationFilePath() : executablePath;
+    return installRootFromExecutable(exe);
+}
+
+InstallPlan prepareInstall(const InstallContext& context)
+{
+    InstallPlan plan;
+
+    InstallContext resolved = context;
+    if (resolved.executablePath.isEmpty()) {
+        resolved.executablePath = QCoreApplication::applicationFilePath();
+    }
+    if (resolved.installRoot.isEmpty()) {
+        resolved.installRoot = resolveInstallRoot(resolved.executablePath);
+    }
+
+    if (resolved.stagedArtifactPath.isEmpty()
+        || !QFileInfo::exists(resolved.stagedArtifactPath)) {
+        plan.errorMessage = QStringLiteral("Staged update artifact is missing");
+        return plan;
+    }
+
+    plan.artifactKind = detectArtifactKind(QFileInfo(resolved.stagedArtifactPath).fileName());
+    if (plan.artifactKind == ArtifactKind::Unknown) {
+        plan.errorMessage = QStringLiteral("Unsupported update artifact type");
+        return plan;
+    }
+
+    if (!isInstallLocationWritable(resolved)) {
+        plan.errorMessage =
+            QStringLiteral("Install location is not writable — use your package manager instead");
+        return plan;
+    }
+
+    QString extractError;
+    const QFileInfo stagedInfo(resolved.stagedArtifactPath);
+    const QString workDir = stagedInfo.absolutePath();
+    QString payloadDir;
+    QString newDir;
+    QString oldDir;
+
+#if defined(Q_OS_WIN)
+    newDir = QDir(resolved.installRoot).filePath(QStringLiteral("_new"));
+    oldDir = QDir(resolved.installRoot).filePath(QStringLiteral("_old"));
+    QDir(newDir).removeRecursively();
+    QDir().mkpath(newDir);
+    payloadDir = newDir;
+    if (!extractArchive(resolved.stagedArtifactPath, payloadDir, plan.artifactKind, &extractError)) {
+        plan.errorMessage = extractError;
+        return plan;
+    }
+#elif defined(Q_OS_MACOS)
+    payloadDir = QDir(workDir).filePath(QStringLiteral("payload"));
+    QDir(payloadDir).removeRecursively();
+    if (plan.artifactKind == ArtifactKind::Dmg) {
+        if (!extractDmg(resolved.stagedArtifactPath, payloadDir, &extractError)) {
+            plan.errorMessage = extractError;
+            return plan;
+        }
+    } else if (!extractArchive(resolved.stagedArtifactPath, payloadDir, plan.artifactKind,
+                               &extractError)) {
+        plan.errorMessage = extractError;
+        return plan;
+    }
+#elif defined(Q_OS_LINUX)
+    if (plan.artifactKind == ArtifactKind::AppImage) {
+        payloadDir = QDir(workDir).filePath(stagedInfo.fileName());
+        if (!extractArchive(resolved.stagedArtifactPath, payloadDir, plan.artifactKind,
+                            &extractError)) {
+            plan.errorMessage = extractError;
+            return plan;
+        }
+    } else {
+        payloadDir = QDir(workDir).filePath(QStringLiteral("payload"));
+        QDir(payloadDir).removeRecursively();
+        if (!extractArchive(resolved.stagedArtifactPath, payloadDir, plan.artifactKind,
+                            &extractError)) {
+            plan.errorMessage = extractError;
+            return plan;
+        }
+    }
+#else
+    plan.errorMessage = QStringLiteral("In-app install is not supported on this platform");
+    return plan;
+#endif
+
+    QString manifestError;
+    if (!writeManifest(resolved, plan, payloadDir, newDir, oldDir, &plan.manifestPath,
+                       &manifestError)) {
+        plan.errorMessage = manifestError;
+        return plan;
+    }
+
+    plan.ok = true;
+    return plan;
+}
+
+bool launchRelauncher(const InstallPlan& plan)
+{
+    if (!plan.ok || plan.manifestPath.isEmpty()) {
+        return false;
+    }
+
+    const QString relauncher = relauncherExecutablePath();
+    if (!QFileInfo::exists(relauncher)) {
+        return false;
+    }
+
+    return QProcess::startDetached(relauncher, {plan.manifestPath});
+}
+
+#ifdef QTMESH_UNIT_TESTS
+QString resolveInstallRootForTest(const QString& applicationFilePath)
+{
+    return resolveInstallRoot(applicationFilePath);
+}
+#endif
+
+} // namespace UpdaterInstaller

--- a/src/updater/UpdaterInstaller.h
+++ b/src/updater/UpdaterInstaller.h
@@ -1,0 +1,51 @@
+#ifndef UPDATERINSTALLER_H
+#define UPDATERINSTALLER_H
+
+#include <QString>
+
+/**
+ * @brief Platform install + relauncher orchestration (#446–448).
+ *
+ * Prepares a verified artifact for install, writes a manifest, and spawns the
+ * platform relauncher before the main app exits.
+ */
+namespace UpdaterInstaller {
+
+enum class ArtifactKind {
+    Unknown,
+    Zip,
+    TarGz,
+    TarXz,
+    Dmg,
+    AppImage,
+};
+
+struct InstallContext {
+    QString stagedArtifactPath;
+    QString releaseTag;
+    QString installRoot;
+    QString executablePath;
+    qint64 parentPid = 0;
+};
+
+struct InstallPlan {
+    bool ok = false;
+    QString errorMessage;
+    QString manifestPath;
+    ArtifactKind artifactKind = ArtifactKind::Unknown;
+};
+
+ArtifactKind detectArtifactKind(const QString& fileName);
+QString resolveInstallRoot(const QString& executablePath = QString());
+QString relauncherExecutablePath();
+InstallPlan prepareInstall(const InstallContext& context);
+bool launchRelauncher(const InstallPlan& plan);
+bool isInstallLocationWritable(const InstallContext& context);
+
+#ifdef QTMESH_UNIT_TESTS
+QString resolveInstallRootForTest(const QString& applicationFilePath);
+#endif
+
+} // namespace UpdaterInstaller
+
+#endif // UPDATERINSTALLER_H

--- a/src/updater/UpdaterInstaller_test.cpp
+++ b/src/updater/UpdaterInstaller_test.cpp
@@ -1,8 +1,9 @@
 #include <gtest/gtest.h>
 
 #include <QCoreApplication>
-#include <QTemporaryDir>
 #include <QFile>
+#include <QFileInfo>
+#include <QTemporaryDir>
 
 #include "UpdaterInstaller.h"
 
@@ -74,3 +75,34 @@ TEST(UpdaterInstaller, IsInstallLocationWritableUsesTempDir)
     context.installRoot = tempDir.path();
     EXPECT_TRUE(UpdaterInstaller::isInstallLocationWritable(context));
 }
+
+#if defined(Q_OS_LINUX)
+TEST(UpdaterInstaller, PrepareInstallStagesAppImagePayload)
+{
+    QTemporaryDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+
+    const QString stagedPath =
+        tempDir.filePath(QStringLiteral("QtMeshEditor-x86_64.AppImage"));
+    {
+        QFile staged(stagedPath);
+        ASSERT_TRUE(staged.open(QIODevice::WriteOnly));
+        staged.write("appimage-payload");
+    }
+
+    UpdaterInstaller::InstallContext context;
+    context.stagedArtifactPath = stagedPath;
+    context.releaseTag = QStringLiteral("9.9.9");
+    context.executablePath = tempDir.filePath(QStringLiteral("QtMeshEditor.AppImage"));
+    context.installRoot = tempDir.path();
+
+    const UpdaterInstaller::InstallPlan plan = UpdaterInstaller::prepareInstall(context);
+    ASSERT_TRUE(plan.ok) << plan.errorMessage.toStdString();
+    EXPECT_EQ(plan.artifactKind, UpdaterInstaller::ArtifactKind::AppImage);
+
+    const QString payloadPath =
+        tempDir.filePath(QStringLiteral("payload/QtMeshEditor-x86_64.AppImage"));
+    EXPECT_TRUE(QFileInfo::exists(payloadPath));
+    EXPECT_TRUE(QFileInfo(payloadPath).isExecutable());
+}
+#endif

--- a/src/updater/UpdaterInstaller_test.cpp
+++ b/src/updater/UpdaterInstaller_test.cpp
@@ -1,0 +1,76 @@
+#include <gtest/gtest.h>
+
+#include <QCoreApplication>
+#include <QTemporaryDir>
+#include <QFile>
+
+#include "UpdaterInstaller.h"
+
+TEST(UpdaterInstaller, DetectArtifactKindByExtension)
+{
+    EXPECT_EQ(UpdaterInstaller::detectArtifactKind(QStringLiteral("QtMeshEditor-bin-Windows.zip")),
+              UpdaterInstaller::ArtifactKind::Zip);
+    EXPECT_EQ(UpdaterInstaller::detectArtifactKind(QStringLiteral("release.tar.gz")),
+              UpdaterInstaller::ArtifactKind::TarGz);
+    EXPECT_EQ(UpdaterInstaller::detectArtifactKind(QStringLiteral("release.tgz")),
+              UpdaterInstaller::ArtifactKind::TarGz);
+    EXPECT_EQ(UpdaterInstaller::detectArtifactKind(QStringLiteral("release.tar.xz")),
+              UpdaterInstaller::ArtifactKind::TarXz);
+    EXPECT_EQ(UpdaterInstaller::detectArtifactKind(QStringLiteral("QtMeshEditor-MacOS.dmg")),
+              UpdaterInstaller::ArtifactKind::Dmg);
+    EXPECT_EQ(UpdaterInstaller::detectArtifactKind(QStringLiteral("QtMeshEditor-x86_64.AppImage")),
+              UpdaterInstaller::ArtifactKind::AppImage);
+    EXPECT_EQ(UpdaterInstaller::detectArtifactKind(QStringLiteral("readme.txt")),
+              UpdaterInstaller::ArtifactKind::Unknown);
+}
+
+TEST(UpdaterInstaller, ResolveInstallRootFromExecutablePath)
+{
+#if defined(Q_OS_MACOS)
+    const QString root = UpdaterInstaller::resolveInstallRootForTest(
+        QStringLiteral("/Applications/QtMeshEditor.app/Contents/MacOS/QtMeshEditor"));
+    EXPECT_EQ(root, QStringLiteral("/Applications/QtMeshEditor.app"));
+#elif defined(Q_OS_LINUX)
+    const QString optRoot = UpdaterInstaller::resolveInstallRootForTest(
+        QStringLiteral("/opt/QtMeshEditor/bin/QtMeshEditor"));
+    EXPECT_EQ(optRoot, QStringLiteral("/opt/QtMeshEditor"));
+
+    const QString localRoot = UpdaterInstaller::resolveInstallRootForTest(
+        QStringLiteral("/home/user/QtMeshEditor/bin/QtMeshEditor"));
+    EXPECT_EQ(localRoot, QStringLiteral("/home/user/QtMeshEditor"));
+#elif defined(Q_OS_WIN)
+    const QString root = UpdaterInstaller::resolveInstallRootForTest(
+        QStringLiteral("C:/QtMeshEditor/bin/QtMeshEditor.exe"));
+    EXPECT_EQ(root, QStringLiteral("C:/QtMeshEditor"));
+#endif
+}
+
+TEST(UpdaterInstaller, PrepareInstallFailsWhenArtifactMissing)
+{
+    UpdaterInstaller::InstallContext context;
+    context.stagedArtifactPath = QStringLiteral("/tmp/does-not-exist/QtMeshEditor.zip");
+    context.releaseTag = QStringLiteral("9.9.9");
+    context.executablePath = QCoreApplication::applicationFilePath();
+    context.installRoot = UpdaterInstaller::resolveInstallRoot(context.executablePath);
+
+    const UpdaterInstaller::InstallPlan plan = UpdaterInstaller::prepareInstall(context);
+    EXPECT_FALSE(plan.ok);
+    EXPECT_FALSE(plan.errorMessage.isEmpty());
+}
+
+TEST(UpdaterInstaller, IsInstallLocationWritableRejectsEmptyRoot)
+{
+    UpdaterInstaller::InstallContext context;
+    context.installRoot.clear();
+    EXPECT_FALSE(UpdaterInstaller::isInstallLocationWritable(context));
+}
+
+TEST(UpdaterInstaller, IsInstallLocationWritableUsesTempDir)
+{
+    QTemporaryDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+
+    UpdaterInstaller::InstallContext context;
+    context.installRoot = tempDir.path();
+    EXPECT_TRUE(UpdaterInstaller::isInstallLocationWritable(context));
+}

--- a/src/updater/relauncher/CMakeLists.txt
+++ b/src/updater/relauncher/CMakeLists.txt
@@ -1,0 +1,40 @@
+if(NOT ENABLE_AUTO_UPDATER)
+    return()
+endif()
+
+set(_QTMESH_RELAUNCHER_OUTPUT "${CMAKE_BINARY_DIR}/bin/qtmesh-relauncher")
+
+if(WIN32)
+    add_executable(qtmesh-relauncher windows/relauncher.c)
+    set_target_properties(qtmesh-relauncher PROPERTIES
+        OUTPUT_NAME qtmesh-relauncher
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+    )
+    target_link_libraries(qtmesh-relauncher PRIVATE kernel32)
+    install(TARGETS qtmesh-relauncher RUNTIME DESTINATION bin COMPONENT Runtime)
+else()
+    if(APPLE)
+        configure_file(
+            "${CMAKE_CURRENT_SOURCE_DIR}/macos/qtmesh-relauncher.sh"
+            "${_QTMESH_RELAUNCHER_OUTPUT}"
+            COPYONLY
+        )
+        install(PROGRAMS macos/qtmesh-relauncher.sh
+                DESTINATION MacOS COMPONENT Runtime
+                RENAME qtmesh-relauncher)
+    else()
+        configure_file(
+            "${CMAKE_CURRENT_SOURCE_DIR}/linux/qtmesh-relauncher.sh"
+            "${_QTMESH_RELAUNCHER_OUTPUT}"
+            COPYONLY
+        )
+        install(PROGRAMS linux/qtmesh-relauncher.sh
+                DESTINATION bin COMPONENT Runtime
+                RENAME qtmesh-relauncher)
+    endif()
+
+    file(CHMOD "${_QTMESH_RELAUNCHER_OUTPUT}"
+         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+
+    add_custom_target(qtmesh-relauncher ALL DEPENDS "${_QTMESH_RELAUNCHER_OUTPUT}")
+endif()

--- a/src/updater/relauncher/CMakeLists.txt
+++ b/src/updater/relauncher/CMakeLists.txt
@@ -10,7 +10,7 @@ if(WIN32)
         OUTPUT_NAME qtmesh-relauncher
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
     )
-    target_link_libraries(qtmesh-relauncher PRIVATE kernel32)
+    target_link_libraries(qtmesh-relauncher PRIVATE kernel32 shell32)
     install(TARGETS qtmesh-relauncher RUNTIME DESTINATION bin COMPONENT Runtime)
 else()
     if(APPLE)
@@ -20,7 +20,8 @@ else()
             COPYONLY
         )
         install(PROGRAMS macos/qtmesh-relauncher.sh
-                DESTINATION MacOS COMPONENT Runtime
+                DESTINATION "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/QtMeshEditor.app/Contents/MacOS"
+                COMPONENT Runtime
                 RENAME qtmesh-relauncher)
     else()
         configure_file(

--- a/src/updater/relauncher/linux/qtmesh-relauncher.sh
+++ b/src/updater/relauncher/linux/qtmesh-relauncher.sh
@@ -35,7 +35,7 @@ fi
 if [[ "$artifact_kind" == "app_image" ]]; then
   mv -f "$payload_dir" "$executable_path"
   chmod +x "$executable_path"
-  exec "$executable_path" "$@"
+  exec "$executable_path" "${@:2}"
 fi
 
 if ! command -v rsync >/dev/null 2>&1; then
@@ -44,4 +44,4 @@ if ! command -v rsync >/dev/null 2>&1; then
 fi
 
 rsync -a --delete "${payload_dir}/" "${install_root}/"
-exec "$executable_path" "$@"
+exec "$executable_path" "${@:2}"

--- a/src/updater/relauncher/linux/qtmesh-relauncher.sh
+++ b/src/updater/relauncher/linux/qtmesh-relauncher.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+manifest="${1:-}"
+if [[ -z "$manifest" || ! -f "$manifest" ]]; then
+  exit 1
+fi
+
+parent_pid=""
+install_root=""
+payload_dir=""
+executable_path=""
+artifact_kind=""
+
+while IFS='=' read -r key value; do
+  case "$key" in
+    parent_pid) parent_pid="$value" ;;
+    install_root) install_root="$value" ;;
+    payload_dir) payload_dir="$value" ;;
+    executable_path) executable_path="$value" ;;
+    artifact_kind) artifact_kind="$value" ;;
+  esac
+done < "$manifest"
+
+if [[ -z "$install_root" || -z "$executable_path" || -z "$payload_dir" ]]; then
+  exit 2
+fi
+
+if [[ -n "$parent_pid" ]]; then
+  while kill -0 "$parent_pid" 2>/dev/null; do
+    sleep 0.2
+  done
+fi
+
+if [[ "$artifact_kind" == "app_image" ]]; then
+  mv -f "$payload_dir" "$executable_path"
+  chmod +x "$executable_path"
+  exec "$executable_path" "$@"
+fi
+
+if ! command -v rsync >/dev/null 2>&1; then
+  echo "rsync is required for tarball installs" >&2
+  exit 3
+fi
+
+rsync -a --delete "${payload_dir}/" "${install_root}/"
+exec "$executable_path" "$@"

--- a/src/updater/relauncher/macos/qtmesh-relauncher.sh
+++ b/src/updater/relauncher/macos/qtmesh-relauncher.sh
@@ -36,10 +36,22 @@ if [[ ! -d "$source_app" ]]; then
   exit 3
 fi
 
+tmp_root="${install_root}.new.$$"
+bak_root="${install_root}.old.$$"
+rm -rf "$tmp_root" "$bak_root"
+
 if command -v rsync >/dev/null 2>&1; then
-  rsync -a --delete "${source_app}/" "${install_root}/"
+  rsync -a --delete "${source_app}/" "${tmp_root}/"
 else
-  ditto "${source_app}" "${install_root}"
+  ditto "${source_app}" "${tmp_root}"
+fi
+
+mv "$install_root" "$bak_root"
+if mv "$tmp_root" "$install_root"; then
+  rm -rf "$bak_root"
+else
+  mv "$bak_root" "$install_root"
+  exit 4
 fi
 
 open -n "$install_root"

--- a/src/updater/relauncher/macos/qtmesh-relauncher.sh
+++ b/src/updater/relauncher/macos/qtmesh-relauncher.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+manifest="${1:-}"
+if [[ -z "$manifest" || ! -f "$manifest" ]]; then
+  exit 1
+fi
+
+parent_pid=""
+install_root=""
+payload_dir=""
+executable_path=""
+
+while IFS='=' read -r key value; do
+  case "$key" in
+    parent_pid) parent_pid="$value" ;;
+    install_root) install_root="$value" ;;
+    payload_dir) payload_dir="$value" ;;
+    executable_path) executable_path="$value" ;;
+  esac
+done < "$manifest"
+
+if [[ -z "$install_root" || -z "$payload_dir" || -z "$executable_path" ]]; then
+  exit 2
+fi
+
+if [[ -n "$parent_pid" ]]; then
+  while kill -0 "$parent_pid" 2>/dev/null; do
+    sleep 0.2
+  done
+fi
+
+source_app="${payload_dir}/QtMeshEditor.app"
+if [[ ! -d "$source_app" ]]; then
+  echo "Payload app bundle missing: $source_app" >&2
+  exit 3
+fi
+
+if command -v rsync >/dev/null 2>&1; then
+  rsync -a --delete "${source_app}/" "${install_root}/"
+else
+  ditto "${source_app}" "${install_root}"
+fi
+
+open -n "$install_root"
+exit 0

--- a/src/updater/relauncher/windows/relauncher.c
+++ b/src/updater/relauncher/windows/relauncher.c
@@ -1,4 +1,5 @@
 #include <windows.h>
+#include <shellapi.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -54,14 +55,26 @@ static int parse_manifest(const char* path, InstallManifest* manifest)
 
     fclose(file);
     return manifest->installRoot[0] != '\0' && manifest->newDir[0] != '\0'
-        && manifest->executablePath[0] != '\0';
+        && manifest->oldDir[0] != '\0' && manifest->executablePath[0] != '\0';
 }
 
 static int remove_directory_tree(const char* path)
 {
-    char command[MAX_PATH * 2 + 32];
-    _snprintf(command, sizeof(command), "cmd /C rmdir /S /Q \"%s\"", path);
-    return system(command) == 0;
+    char from[MAX_PATH + 2] = {0};
+    const size_t length = strnlen(path, MAX_PATH);
+    if (length == 0 || length >= MAX_PATH) {
+        return 0;
+    }
+
+    memcpy(from, path, length);
+    from[length] = '\0';
+    from[length + 1] = '\0';
+
+    SHFILEOPSTRUCTA op = {0};
+    op.wFunc = FO_DELETE;
+    op.pFrom = from;
+    op.fFlags = FOF_NOCONFIRMATION | FOF_NOERRORUI | FOF_SILENT;
+    return SHFileOperationA(&op) == 0;
 }
 
 int main(int argc, char** argv)
@@ -84,9 +97,7 @@ int main(int argc, char** argv)
         }
     }
 
-    if (manifest.oldDir[0] != '\0') {
-        remove_directory_tree(manifest.oldDir);
-    }
+    remove_directory_tree(manifest.oldDir);
 
     if (!MoveFileExA(manifest.installRoot, manifest.oldDir, MOVEFILE_WRITE_THROUGH)) {
         return 3;
@@ -112,7 +123,10 @@ int main(int argc, char** argv)
                         manifest.installRoot,
                         &startupInfo,
                         &processInfo)) {
-        MoveFileExA(manifest.oldDir, manifest.installRoot, MOVEFILE_WRITE_THROUGH);
+        remove_directory_tree(manifest.installRoot);
+        if (!MoveFileExA(manifest.oldDir, manifest.installRoot, MOVEFILE_WRITE_THROUGH)) {
+            return 6;
+        }
         return 5;
     }
 

--- a/src/updater/relauncher/windows/relauncher.c
+++ b/src/updater/relauncher/windows/relauncher.c
@@ -1,0 +1,123 @@
+#include <windows.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+    DWORD parentPid;
+    char installRoot[MAX_PATH];
+    char newDir[MAX_PATH];
+    char oldDir[MAX_PATH];
+    char executablePath[MAX_PATH];
+} InstallManifest;
+
+static void trim(char* value)
+{
+    if (!value) {
+        return;
+    }
+    size_t len = strlen(value);
+    while (len > 0 && (value[len - 1] == '\r' || value[len - 1] == '\n' || value[len - 1] == ' ')) {
+        value[--len] = '\0';
+    }
+}
+
+static int parse_manifest(const char* path, InstallManifest* manifest)
+{
+    FILE* file = fopen(path, "r");
+    if (!file) {
+        return 0;
+    }
+
+    char line[1024];
+    while (fgets(line, sizeof(line), file)) {
+        char* equals = strchr(line, '=');
+        if (!equals) {
+            continue;
+        }
+        *equals = '\0';
+        char* key = line;
+        char* value = equals + 1;
+        trim(value);
+        if (strcmp(key, "parent_pid") == 0) {
+            manifest->parentPid = (DWORD)strtoul(value, NULL, 10);
+        } else if (strcmp(key, "install_root") == 0) {
+            strncpy(manifest->installRoot, value, sizeof(manifest->installRoot) - 1);
+        } else if (strcmp(key, "new_dir") == 0) {
+            strncpy(manifest->newDir, value, sizeof(manifest->newDir) - 1);
+        } else if (strcmp(key, "old_dir") == 0) {
+            strncpy(manifest->oldDir, value, sizeof(manifest->oldDir) - 1);
+        } else if (strcmp(key, "executable_path") == 0) {
+            strncpy(manifest->executablePath, value, sizeof(manifest->executablePath) - 1);
+        }
+    }
+
+    fclose(file);
+    return manifest->installRoot[0] != '\0' && manifest->newDir[0] != '\0'
+        && manifest->executablePath[0] != '\0';
+}
+
+static int remove_directory_tree(const char* path)
+{
+    char command[MAX_PATH * 2 + 32];
+    _snprintf(command, sizeof(command), "cmd /C rmdir /S /Q \"%s\"", path);
+    return system(command) == 0;
+}
+
+int main(int argc, char** argv)
+{
+    if (argc < 2) {
+        return 1;
+    }
+
+    InstallManifest manifest;
+    ZeroMemory(&manifest, sizeof(manifest));
+    if (!parse_manifest(argv[1], &manifest)) {
+        return 2;
+    }
+
+    if (manifest.parentPid != 0) {
+        HANDLE process = OpenProcess(SYNCHRONIZE, FALSE, manifest.parentPid);
+        if (process) {
+            WaitForSingleObject(process, INFINITE);
+            CloseHandle(process);
+        }
+    }
+
+    if (manifest.oldDir[0] != '\0') {
+        remove_directory_tree(manifest.oldDir);
+    }
+
+    if (!MoveFileExA(manifest.installRoot, manifest.oldDir, MOVEFILE_WRITE_THROUGH)) {
+        return 3;
+    }
+    if (!MoveFileExA(manifest.newDir, manifest.installRoot, MOVEFILE_WRITE_THROUGH)) {
+        MoveFileExA(manifest.oldDir, manifest.installRoot, MOVEFILE_WRITE_THROUGH);
+        return 4;
+    }
+
+    STARTUPINFOA startupInfo;
+    PROCESS_INFORMATION processInfo;
+    ZeroMemory(&startupInfo, sizeof(startupInfo));
+    ZeroMemory(&processInfo, sizeof(processInfo));
+    startupInfo.cb = sizeof(startupInfo);
+
+    if (!CreateProcessA(manifest.executablePath,
+                        NULL,
+                        NULL,
+                        NULL,
+                        FALSE,
+                        0,
+                        NULL,
+                        manifest.installRoot,
+                        &startupInfo,
+                        &processInfo)) {
+        MoveFileExA(manifest.oldDir, manifest.installRoot, MOVEFILE_WRITE_THROUGH);
+        return 5;
+    }
+
+    CloseHandle(processInfo.hThread);
+    CloseHandle(processInfo.hProcess);
+    remove_directory_tree(manifest.oldDir);
+    return 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -104,7 +104,6 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/PaintBufferImageProvider.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/PaintSelectionMask.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/TexturePaintBuffer.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/../src/UpdateVersion.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/TexturePaintController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/VertexColorBaker.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/VATBaker.cpp
@@ -395,12 +394,19 @@ if(BUILD_TESTS)
         SET(OGRE_Codec_Assimp_LIBRARY_REL ${OGRE_PLUGIN_DIR}/libCodec_Assimp.dll.a)
     endif()
 
-    # Common libraries for all test executables
-    set(COMMON_TEST_LIBRARIES
-        gtest
-        gtest_main
-        gmock
-        gmock_main
+    # Shared static lib: compile MaterialEditor test support sources once instead
+    # of rebuilding them for every *_test executable (CI build-wrapper budget).
+    set(TEST_SUPPORT_INCLUDES
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src
+        ${BUILD_INCLUDE_DIR}
+        ${BUILD_UIH_DIR}
+        ${OGRE_PROCEDURAL_LIB_DIR}include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/OgreXML
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/Assimp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/FBX
+    )
+
+    set(TEST_SUPPORT_LIBRARIES
         ${OGRE_Codec_Assimp_LIBRARY_REL}
         ${OGRE_LIBRARIES}
         ${ASSIMP_LIBRARIES}
@@ -419,44 +425,64 @@ if(BUILD_TESTS)
         qtmesh_updater
     )
 
-    # Add llama.cpp libraries if local LLM is enabled
     if(ENABLE_LOCAL_LLM)
-        list(APPEND COMMON_TEST_LIBRARIES llama ggml)
+        list(APPEND TEST_SUPPORT_LIBRARIES llama ggml)
     endif()
 
-    # Link Sentry for tests if enabled (SentryReporter is part of TEST_SRC_FILES).
     if(ENABLE_SENTRY)
-        list(APPEND COMMON_TEST_LIBRARIES sentry)
+        list(APPEND TEST_SUPPORT_LIBRARIES sentry)
     endif()
+
+    add_library(qtmesh_test_common STATIC ${TEST_SRC_FILES} ${TEST_HEADER_FILES})
+    set_target_properties(qtmesh_test_common PROPERTIES
+        AUTOMOC ON
+        POSITION_INDEPENDENT_CODE ON
+    )
+    target_include_directories(qtmesh_test_common PRIVATE ${TEST_SUPPORT_INCLUDES})
+    target_compile_definitions(qtmesh_test_common PRIVATE
+        BATCH_EXPORTER_TEST_SEAM
+        QTMESH_UNIT_TESTS
+        "QTMESH_UT_SOURCE_ROOT=\"${CMAKE_SOURCE_DIR}\"")
+    target_link_libraries(qtmesh_test_common PUBLIC ${TEST_SUPPORT_LIBRARIES})
+
+    if(APPLE)
+        target_link_libraries(qtmesh_test_common PUBLIC "-framework Security")
+    elseif(WIN32)
+        target_link_libraries(qtmesh_test_common PUBLIC advapi32)
+    endif()
+
+    if(ENABLE_PS1_RIP)
+        add_dependencies(qtmesh_test_common qtmesh_ps1core_stub)
+        if(TARGET qtmesh_ps1core_libretro)
+            add_dependencies(qtmesh_test_common qtmesh_ps1core_libretro)
+        endif()
+        if(TARGET Qt6::Gamepad)
+            target_compile_definitions(qtmesh_test_common PRIVATE HAVE_QT_GAMEPAD)
+            target_link_libraries(qtmesh_test_common PUBLIC Qt6::Gamepad)
+        endif()
+    endif()
+
+    ADD_DEPENDENCIES(qtmesh_test_common ui)
+
+    set(COMMON_TEST_LIBRARIES
+        gtest
+        gtest_main
+        gmock
+        gmock_main
+        qtmesh_test_common
+    )
     
     # Helper function to create test executables
     function(create_test_executable target_name test_source_file)
         add_executable(${target_name} 
             ${test_source_file}
-            ${TEST_HEADER_FILES}
-            ${TEST_SRC_FILES}
             ${TEST_RESOURCE_SRCS}
             ${TEST_QML_RESOURCE_SRCS}
         )
         
-        target_include_directories(${target_name} PRIVATE
-            ${CMAKE_CURRENT_SOURCE_DIR}/../src
-            ${BUILD_INCLUDE_DIR}
-            ${BUILD_UIH_DIR}
-            ${OGRE_PROCEDURAL_LIB_DIR}include
-            ${CMAKE_CURRENT_SOURCE_DIR}/../src/OgreXML
-            ${CMAKE_CURRENT_SOURCE_DIR}/../src/Assimp
-            ${CMAKE_CURRENT_SOURCE_DIR}/../src/FBX
-        )
+        target_include_directories(${target_name} PRIVATE ${TEST_SUPPORT_INCLUDES})
         
         target_link_libraries(${target_name} ${COMMON_TEST_LIBRARIES})
-
-        if(ENABLE_PS1_RIP)
-            add_dependencies(${target_name} qtmesh_ps1core_stub)
-            if(TARGET qtmesh_ps1core_libretro)
-                add_dependencies(${target_name} qtmesh_ps1core_libretro)
-            endif()
-        endif()
         
         # Add dependency on UI generation
         ADD_DEPENDENCIES(${target_name} ui)
@@ -469,30 +495,13 @@ if(BUILD_TESTS)
     function(create_test_executable_no_autotest target_name test_source_file)
         add_executable(${target_name} 
             ${test_source_file}
-            ${TEST_HEADER_FILES}
-            ${TEST_SRC_FILES}
             ${TEST_RESOURCE_SRCS}
             ${TEST_QML_RESOURCE_SRCS}
         )
         
-        target_include_directories(${target_name} PRIVATE
-            ${CMAKE_CURRENT_SOURCE_DIR}/../src
-            ${BUILD_INCLUDE_DIR}
-            ${BUILD_UIH_DIR}
-            ${OGRE_PROCEDURAL_LIB_DIR}include
-            ${CMAKE_CURRENT_SOURCE_DIR}/../src/OgreXML
-            ${CMAKE_CURRENT_SOURCE_DIR}/../src/Assimp
-            ${CMAKE_CURRENT_SOURCE_DIR}/../src/FBX
-        )
+        target_include_directories(${target_name} PRIVATE ${TEST_SUPPORT_INCLUDES})
         
         target_link_libraries(${target_name} ${COMMON_TEST_LIBRARIES})
-
-        if(ENABLE_PS1_RIP)
-            add_dependencies(${target_name} qtmesh_ps1core_stub)
-            if(TARGET qtmesh_ps1core_libretro)
-                add_dependencies(${target_name} qtmesh_ps1core_libretro)
-            endif()
-        endif()
         
         # Add dependency on UI generation
         ADD_DEPENDENCIES(${target_name} ui)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -112,6 +112,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/updater/GitHubReleaseParser.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/updater/UpdaterWorker.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/updater/UpdaterController.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/updater/UpdaterInstaller.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/TexturePaintController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/VertexColorBaker.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/VATBaker.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -105,14 +105,6 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/PaintSelectionMask.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/TexturePaintBuffer.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/UpdateVersion.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/../src/updater/InstallFlavor.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/../src/updater/ArtifactResolver.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/../src/updater/UpdateVerifier.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/../src/updater/MinisignVerify.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/../src/updater/GitHubReleaseParser.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/../src/updater/UpdaterWorker.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/../src/updater/UpdaterController.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/../src/updater/UpdaterInstaller.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/TexturePaintController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/VertexColorBaker.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/VATBaker.cpp
@@ -424,6 +416,7 @@ if(BUILD_TESTS)
         meshoptimizer
         xatlas
         qtmesh_sodium
+        qtmesh_updater
     )
 
     # Add llama.cpp libraries if local LLM is enabled


### PR DESCRIPTION
## Summary
- Add `UpdaterInstaller` to extract verified release artifacts, write an install manifest, and spawn the platform relauncher before the app exits.
- Build and ship `qtmesh-relauncher` for Windows (static C), Linux, and macOS (shell scripts staged next to the main binary).
- Wire `UpdaterController::installUpdate()` and update `UpdaterDialog.qml` with **Install & restart** once download verification succeeds.

Closes #446, #447, #448.

## Test plan
- [x] `./build_local/bin/UnitTests --gtest_filter="UpdaterInstaller*:UpdaterController*"`
- [ ] Portable Linux: download + verify + install tarball update end-to-end
- [ ] Windows CI: `qtmesh-relauncher.exe` builds and links
- [ ] macOS: DMG payload extraction + relauncher script permissions in bundle


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added update installation with automatic app restart. Users can choose **Install & restart** to apply updates and close/relaunch the app automatically.
  * Improved installer feedback by showing an **Installing update…** message and a busy indicator while installation is in progress.

* **Bug Fixes**
  * Updated the update dialog dismissal behavior so **Esc** can be used during the **Installing** phase (not just earlier stages).

* **UI/UX Improvements**
  * Refined the **Ready to install** step copy and button layout, adding **Later** alongside **Install & restart**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->