### PR TITLE
build(updater): disable auto-updater in package-manager builds (#439)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -749,6 +749,7 @@ jobs:
             sudo cmake -S . -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
             -DCMAKE_CXX_FLAGS="-g" -DCMAKE_C_FLAGS="-g" \
             -DENABLE_STABLE_DIFFUSION=ON \
+            -DENABLE_AUTO_UPDATER=OFF \
             -DASSIMP_DIR=/usr/local/lib/cmake/assimp-${{ env.ASSIMP_DIR_VERSION }} \
             -DASSIMP_INCLUDE_DIR=/usr/local/include/assimp \
             -DQt6_DIR=/home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/gcc_64/lib/cmake/Qt6 \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -991,10 +991,13 @@ jobs:
         DEBIAN_FRONTEND: noninteractive
       run: |
             sudo apt-get update
-            sudo apt-get install -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold \
+            # libretro PSX core is installed later via install-ps1-libretro-core.sh
+            # (buildbot download). Dropping libretro-beetle-psx here avoids apt
+            # stalls that have consumed the whole job timeout on GitHub runners.
+            timeout 600 sudo apt-get install -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold \
                 libxcb-cursor0 libxcb-xinerama0 libx11-dev xvfb \
                 mesa-utils libgl1-mesa-dri libegl-mesa0 libgbm1 libglx-mesa0 \
-                libsecret-1-dev libretro-beetle-psx libsodium-dev
+                libsecret-1-dev libsodium-dev
             # Start Xvfb with GLX support for Ogre GL initialization
             Xvfb :99 -screen 0 1024x768x24 +extension GLX > /dev/null 2>&1 &
             sleep 3

--- a/docs/AUTO_UPDATER_DESIGN.md
+++ b/docs/AUTO_UPDATER_DESIGN.md
@@ -102,7 +102,7 @@ Only **`Portable`** enables download/install. All others show `updateCommandHint
 | **Portable** | macOS: `/Applications/QtMeshEditor.app`; Linux: `/opt/QtMeshEditor/`; Windows: zip layout / MSI registry `QtMeshEditor` without WinGet key. |
 | **Unknown** | CI trees, dev `build_local/`, ambiguous paths — **no self-update** (fail closed). |
 
-`ENABLE_AUTO_UPDATER=OFF` for snap/flatpak/deb/docker CI builds (#439) so the code path is absent in those artifacts.
+`ENABLE_AUTO_UPDATER=OFF` for snap/flatpak/deb/docker CI builds (#439) so the code path is absent in those artifacts. **Wired:** `build-linux` passes `-DENABLE_AUTO_UPDATER=OFF` when producing `qtmesheditor_amd64.deb` (snap + Docker consume the same package).
 
 ### PoC status
 

--- a/docs/AUTO_UPDATER_DESIGN.md
+++ b/docs/AUTO_UPDATER_DESIGN.md
@@ -102,7 +102,7 @@ Only **`Portable`** enables download/install. All others show `updateCommandHint
 | **Portable** | macOS: `/Applications/QtMeshEditor.app`; Linux: `/opt/QtMeshEditor/`; Windows: zip layout / MSI registry `QtMeshEditor` without WinGet key. |
 | **Unknown** | CI trees, dev `build_local/`, ambiguous paths — **no self-update** (fail closed). |
 
-`ENABLE_AUTO_UPDATER=OFF` for snap/flatpak/deb/docker CI builds (#439) so the code path is absent in those artifacts. **Wired:** `build-linux` passes `-DENABLE_AUTO_UPDATER=OFF` when producing `qtmesheditor_amd64.deb` (snap + Docker consume the same package).
+`ENABLE_AUTO_UPDATER=OFF` for snap/flatpak/deb/docker CI builds (#439) so the code path is absent in those artifacts. **Wired:** `build-linux` passes `-DENABLE_AUTO_UPDATER=OFF` when producing `qtmesheditor_amd64.deb` (snap + Docker consume the same package). Package builds also remove **Help → Check for Updates** from the menu at runtime.
 
 ### PoC status
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -283,7 +283,9 @@ ADD_SUBDIRECTORY("${CMAKE_CURRENT_SOURCE_DIR}/PS1")
 # if we don't include this CMake will not include ui headers properly:
 include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${BUILD_INCLUDE_DIR} ${BUILD_UIH_DIR})
 
-add_subdirectory(updater)
+if(ENABLE_AUTO_UPDATER OR BUILD_TESTS)
+    add_subdirectory(updater)
+endif()
 
 ##############################################################
 #  Processing ogre-procedural
@@ -540,8 +542,11 @@ Qt::QuickControls2
 meshoptimizer
 xatlas
 qtmesh_sodium
-qtmesh_updater
 )
+
+if(ENABLE_AUTO_UPDATER)
+    target_link_libraries(${CMAKE_PROJECT_NAME} qtmesh_updater)
+endif()
 
 # One-time legacy secret-store read for migration (see CloudCredentialStore).
 if(APPLE)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2258,7 +2258,7 @@ void MainWindow::initToolBar()
 #ifdef ENABLE_AUTO_UPDATER
     ui->actionVerify_Update->setText(tr("Check for Updates..."));
 #else
-    ui->actionVerify_Update->setVisible(false);
+    ui->menuHelp->removeAction(ui->actionVerify_Update);
 #endif
 
     // Keyboard Shortcuts reference in Help menu


### PR DESCRIPTION
## Summary
- Pass `-DENABLE_AUTO_UPDATER=OFF` in the Linux `.deb` CI job so apt/snap/Docker channels ship without the in-app self-update code path.
- Gate `add_subdirectory(updater)` and app linkage on `ENABLE_AUTO_UPDATER OR BUILD_TESTS` so release `.deb` builds omit the updater library entirely while unit tests keep coverage.

## Epic context
Epic #439 MVP is nearly complete for **portable** releases (zip/dmg). Package-manager channels must not offer self-update — this closes that packaging gap before calling the feature shipped.

## Test plan
- [ ] CI `build-linux` produces `.deb` successfully
- [ ] CI `build-windows` / `build-macos` still build with updater ON (default)
- [ ] `unit-tests-linux` still passes (BUILD_TESTS keeps updater lib)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to support disabling the auto-updater feature in snap, flatpak, deb, and docker distributions.
  * Removed "Check for Updates" option from Help menu when auto-updater is disabled.

* **Documentation**
  * Clarified auto-updater feature behavior in build documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->