### PR TITLE
Enable Windows MinGW minisign verify (#445)

### DIFF
--- a/cmake/Libsodium.cmake
+++ b/cmake/Libsodium.cmake
@@ -1,15 +1,67 @@
 # libsodium for minisign verify (#440 / #445).
-# Linux + macOS link static/system libsodium. Windows MinGW verify is deferred
-# (autotools/cmake build not wired in CI yet — download still runs, verify fails closed).
+# Linux + macOS: system pkg-config or autotools static build from source.
+# Windows MinGW: official prebuilt static libs (same 1.0.20-stable release).
 
 if(TARGET qtmesh_sodium)
     return()
 endif()
 
+function(qtmesh_sodium_add_imported_static lib_path include_dir)
+    add_library(qtmesh_sodium STATIC IMPORTED GLOBAL)
+    set_target_properties(qtmesh_sodium PROPERTIES
+        IMPORTED_LOCATION "${lib_path}"
+        INTERFACE_INCLUDE_DIRECTORIES "${include_dir}"
+        INTERFACE_COMPILE_DEFINITIONS "SODIUM_STATIC=1;QTMESH_MINISIGN_VERIFY=1"
+    )
+    if(WIN32)
+        set_property(TARGET qtmesh_sodium APPEND PROPERTY
+            IMPORTED_LINK_INTERFACE_LIBRARIES "advapi32;bcrypt")
+    endif()
+endfunction()
+
 if(WIN32)
-    message(STATUS "libsodium: Windows MinGW verify deferred (#445 follow-up)")
-    add_library(qtmesh_sodium INTERFACE)
-    target_compile_definitions(qtmesh_sodium INTERFACE QTMESH_MINISIGN_VERIFY=0)
+    if(NOT MINGW)
+        message(STATUS "libsodium: Windows MSVC minisign verify not wired — verify disabled")
+        add_library(qtmesh_sodium INTERFACE)
+        target_compile_definitions(qtmesh_sodium INTERFACE QTMESH_MINISIGN_VERIFY=0)
+        return()
+    endif()
+
+    include(FetchContent)
+
+    set(QTMESH_LIBSODIUM_MINGW_URL
+        "https://download.libsodium.org/libsodium/releases/libsodium-1.0.20-stable-mingw.tar.gz"
+        CACHE STRING "Prebuilt MinGW libsodium tarball for minisign verify")
+    set(QTMESH_LIBSODIUM_MINGW_SHA256
+        "19f7e5f814f62f5bfdf6ea2208244adbddb80e73362879ddb0e4844bc1f12c82"
+        CACHE STRING "SHA256 of MinGW libsodium tarball")
+
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set(QTMESH_LIBSODIUM_MINGW_ARCH "win64")
+    else()
+        set(QTMESH_LIBSODIUM_MINGW_ARCH "win32")
+    endif()
+
+    message(STATUS "libsodium: using prebuilt MinGW ${QTMESH_LIBSODIUM_MINGW_ARCH} package")
+
+    FetchContent_Declare(
+        qtmesh_libsodium_mingw
+        URL ${QTMESH_LIBSODIUM_MINGW_URL}
+        URL_HASH SHA256=${QTMESH_LIBSODIUM_MINGW_SHA256}
+    )
+    FetchContent_MakeAvailable(qtmesh_libsodium_mingw)
+
+    set(QTMESH_LIBSODIUM_MINGW_ROOT
+        "${qtmesh_libsodium_mingw_SOURCE_DIR}/libsodium-${QTMESH_LIBSODIUM_MINGW_ARCH}")
+    set(QTMESH_LIBSODIUM_MARKER "${QTMESH_LIBSODIUM_MINGW_ROOT}/lib/libsodium.a")
+
+    if(NOT EXISTS "${QTMESH_LIBSODIUM_MARKER}")
+        message(FATAL_ERROR "libsodium MinGW package missing ${QTMESH_LIBSODIUM_MARKER}")
+    endif()
+
+    qtmesh_sodium_add_imported_static(
+        "${QTMESH_LIBSODIUM_MARKER}"
+        "${QTMESH_LIBSODIUM_MINGW_ROOT}/include")
     return()
 endif()
 
@@ -87,9 +139,6 @@ if(NOT EXISTS "${QTMESH_LIBSODIUM_MARKER}")
     endif()
 endif()
 
-add_library(qtmesh_sodium STATIC IMPORTED GLOBAL)
-set_target_properties(qtmesh_sodium PROPERTIES
-    IMPORTED_LOCATION "${QTMESH_LIBSODIUM_MARKER}"
-    INTERFACE_INCLUDE_DIRECTORIES "${QTMESH_LIBSODIUM_PREFIX}/include"
-    INTERFACE_COMPILE_DEFINITIONS "SODIUM_STATIC=1;QTMESH_MINISIGN_VERIFY=1"
-)
+qtmesh_sodium_add_imported_static(
+    "${QTMESH_LIBSODIUM_MARKER}"
+    "${QTMESH_LIBSODIUM_PREFIX}/include")

--- a/docs/AUTO_UPDATER_DESIGN.md
+++ b/docs/AUTO_UPDATER_DESIGN.md
@@ -42,7 +42,7 @@ Production public key: `packaging/updater/minisign.pub` (embedded in `MinisignVe
 ### PoC status
 
 - `MinisignVerify::verifyFile()` implements minisign’s dual-signature check (file + trusted comment) via **libsodium** (same algorithms as the CLI).
-- **#445:** builds with `QTMESH_MINISIGN_VERIFY=1` on Linux and macOS (system pkg-config or static libsodium). Windows MinGW verify is deferred — downloads fail closed at the signature step until a follow-up wires libsodium there.
+- **#445:** builds with `QTMESH_MINISIGN_VERIFY=1` on Linux, macOS, and Windows MinGW (system pkg-config, autotools static build, or official prebuilt MinGW libs). Windows MSVC builds still fail closed at verify until wired.
 - Tests: `MinisignVerify_test` verifies good/tampered/bad-key against `tests/fixtures/updater/release-3.5.3-readme.md` (content from GitHub tag `3.5.3`).
 
 ---

--- a/src/updater/MinisignVerify.h
+++ b/src/updater/MinisignVerify.h
@@ -11,8 +11,9 @@
  * production public key is compiled in; CI signs artifacts with the matching
  * secret (see docs/AUTO_UPDATER_DESIGN.md).
  *
- * Linux builds link libsodium for verify when @c QTMESH_MINISIGN_VERIFY is set.
- * Builds without the backend return @ref Result::Unsupported.
+ * Linux, macOS, and Windows MinGW builds link libsodium when
+ * @c QTMESH_MINISIGN_VERIFY is set. Builds without the backend return
+ * @ref Result::Unsupported.
  */
 namespace MinisignVerify {
 


### PR DESCRIPTION
## Summary
- Wire libsodium on Windows MinGW by fetching the official `libsodium-1.0.20-stable-mingw.tar.gz` prebuilt static package (win32/win64) instead of disabling `QTMESH_MINISIGN_VERIFY`.
- Link `advapi32` + `bcrypt` for static sodium on Windows; MSVC builds still fail closed until wired separately.
- Update auto-updater design doc and `MinisignVerify.h` platform notes.

Fixes #445.

## Test plan
- [ ] `build-windows` CI job links `qtmesh_updater` with `QTMESH_MINISIGN_VERIFY=1`
- [ ] Linux/macOS configure paths unchanged (pkg-config or autotools static build)
- [ ] Windows portable update flow completes verify + install (manual smoke on next release)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Extended minisign signature verification support documentation to include Windows MinGW builds, in addition to Linux and macOS platforms.
  * Clarified signature verification backend behavior for builds without required dependencies.

* **Chores**
  * Refactored internal build configuration to improve libsodium static library target management.
  * Updated internal documentation regarding signature verification module linking across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->