### PR TITLE
Upload QtMesh Cloud scan reports after file complete

### DIFF
--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -777,6 +777,7 @@ void CLIPipeline::printUsage()
         "  cloud list [--json]               List cloud projects for the signed-in account.\n"
         "  cloud upload <file> [--name <n>] [--no-scan] [--json]\n"
         "                                    Package the asset + dependencies and upload to QtMesh Cloud.\n"
+        "                                    After files/complete, uploads the local scan report to the main file.\n"
         "  cloud delete <project-id>         Delete a cloud project by id.\n"
         "\n"
         "Global options:\n"

--- a/src/CloudCLIPipeline.cpp
+++ b/src/CloudCLIPipeline.cpp
@@ -346,6 +346,21 @@ int cmdCloudUpload(int argc, char* argv[])
         return 1;
     }
 
+    QString reportWarning;
+    if (!manifest.scanSummary.isEmpty() && !mainFileId.isEmpty()) {
+        const auto reportResult = QtMeshCloudClient::uploadFileReport(
+            token, project.ownerSlug, project.projectSlug, mainFileId, manifest.scanSummary);
+        if (!reportResult.ok) {
+            reportWarning = QStringLiteral("File uploaded, but analysis report upload failed.");
+            SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
+                                          QStringLiteral("QtMesh Cloud CLI report upload failed"),
+                                          QStringLiteral("warning"));
+            err() << "Warning: " << reportWarning << Qt::endl;
+            if (!reportResult.errorString.isEmpty())
+                err() << reportResult.errorString << Qt::endl;
+        }
+    }
+
     const QString projectUrl = project.projectUrl;
     SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
                                   QStringLiteral("QtMesh Cloud CLI upload completed"));
@@ -355,6 +370,8 @@ int cmdCloudUpload(int argc, char* argv[])
         obj.insert(QStringLiteral("ok"), true);
         obj.insert(QStringLiteral("projectUrl"), projectUrl);
         obj.insert(QStringLiteral("fileCount"), manifest.files.size());
+        if (!reportWarning.isEmpty())
+            obj.insert(QStringLiteral("reportWarning"), reportWarning);
         out() << QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact)) << Qt::endl;
     } else {
         out() << "Uploaded " << manifest.files.size() << " file(s).";

--- a/src/CloudUploadDialog.cpp
+++ b/src/CloudUploadDialog.cpp
@@ -166,6 +166,42 @@ bool CloudUploadDialog::runLocalScanBeforeUpload() const
     return m_runScanCheck->isChecked();
 }
 
+QStringList CloudUploadDialog::selectedAbsolutePathsForUpload() const
+{
+    return selectedAbsolutePaths();
+}
+
+PackageMetadata CloudUploadDialog::buildManifestForUpload(const QString& mainAssetPath,
+                                                          const QStringList& selectedAbsolutePaths,
+                                                          const QString& projectName,
+                                                          const QJsonObject& scanSummary)
+{
+    const QString mainCanonical = QFileInfo(mainAssetPath).absoluteFilePath();
+    QSet<QString> selected;
+    for (const QString& path : selectedAbsolutePaths)
+        selected.insert(QFileInfo(path).absoluteFilePath());
+
+    QStringList extras;
+    for (const QString& path : selected) {
+        if (path != mainCanonical)
+            extras.append(path);
+    }
+    PackageMetadata metadata =
+        ProjectPackager::buildManifest(mainAssetPath, extras, projectName);
+    metadata.files.erase(
+        std::remove_if(metadata.files.begin(), metadata.files.end(),
+                       [&](const PackageEntry& entry) {
+                           return !selected.contains(entry.absolutePath);
+                       }),
+        metadata.files.end());
+    metadata.totalSize = 0;
+    for (const PackageEntry& entry : metadata.files)
+        metadata.totalSize += entry.size;
+    if (!scanSummary.isEmpty())
+        metadata.scanSummary = scanSummary;
+    return metadata;
+}
+
 QStringList CloudUploadDialog::selectedAbsolutePaths() const
 {
     QStringList extras;
@@ -179,28 +215,6 @@ QStringList CloudUploadDialog::selectedAbsolutePaths() const
 
 PackageMetadata CloudUploadDialog::manifest() const
 {
-    const QString mainCanonical = QFileInfo(m_mainAssetPath).absoluteFilePath();
-    QSet<QString> selected;
-    for (const QString& path : selectedAbsolutePaths())
-        selected.insert(QFileInfo(path).absoluteFilePath());
-
-    QStringList extras;
-    for (const QString& path : selected) {
-        if (path != mainCanonical)
-            extras.append(path);
-    }
-    PackageMetadata metadata =
-        ProjectPackager::buildManifest(m_mainAssetPath, extras, projectName());
-    metadata.files.erase(
-        std::remove_if(metadata.files.begin(), metadata.files.end(),
-                       [&](const PackageEntry& entry) {
-                           return !selected.contains(entry.absolutePath);
-                       }),
-        metadata.files.end());
-    metadata.totalSize = 0;
-    for (const PackageEntry& entry : metadata.files)
-        metadata.totalSize += entry.size;
-    if (!m_scanSummary.isEmpty())
-        metadata.scanSummary = m_scanSummary;
-    return metadata;
+    return buildManifestForUpload(m_mainAssetPath, selectedAbsolutePaths(), projectName(),
+                                m_scanSummary);
 }

--- a/src/CloudUploadDialog.h
+++ b/src/CloudUploadDialog.h
@@ -27,8 +27,14 @@ public:
     bool hasSelectedProject() const;
     QtMeshCloudClient::ProjectSummary selectedProject() const;
     QString projectName() const;
+    QStringList selectedAbsolutePathsForUpload() const;
     PackageMetadata manifest() const;
     bool runLocalScanBeforeUpload() const;
+
+    static PackageMetadata buildManifestForUpload(const QString& mainAssetPath,
+                                                  const QStringList& selectedAbsolutePaths,
+                                                  const QString& projectName,
+                                                  const QJsonObject& scanSummary = QJsonObject());
 
 private:
     void rebuildDependencyList();

--- a/src/CloudUploadProgress.cpp
+++ b/src/CloudUploadProgress.cpp
@@ -43,7 +43,12 @@ void CloudUploadProgress::updateProgress(int current, int total, const QString& 
 {
     m_bar->setMaximum(qMax(1, total));
     m_bar->setValue(current);
-    m_label->setText(tr("Uploading %1…").arg(fileName));
+    if (fileName.isEmpty())
+        return;
+    if (fileName.endsWith(QChar(0x2026)) || fileName.endsWith(QLatin1Char('.')))
+        m_label->setText(fileName);
+    else
+        m_label->setText(tr("Uploading %1…").arg(fileName));
 }
 
 void CloudUploadProgress::finish(bool ok, const QString& message)

--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -5277,9 +5277,17 @@ QJsonObject MCPServer::toolCloudUpload(const QJsonObject &args)
 
     const bool runScan = !args.contains(QStringLiteral("scan")) || args.value(QStringLiteral("scan")).toBool(true);
 
+    const QString mainCanonical = QFileInfo(filePath).canonicalFilePath();
     QStringList selectedPaths;
-    for (const DependencyEntry& entry : DependencyResolver::detect(filePath))
-        selectedPaths.append(entry.absolutePath);
+    selectedPaths.append(mainCanonical);
+    for (const DependencyEntry& entry : DependencyResolver::detect(filePath)) {
+        if (!entry.exists || !entry.checkedByDefault)
+            continue;
+        const QString absolute = QFileInfo(entry.absolutePath).absoluteFilePath();
+        if (absolute == mainCanonical)
+            continue;
+        selectedPaths.append(absolute);
+    }
 
     CloudPackageUploadRequest request;
     request.mainAssetPath = filePath;
@@ -5294,7 +5302,7 @@ QJsonObject MCPServer::toolCloudUpload(const QJsonObject &args)
     QString error;
     QString reportWarning;
     bool uploadOk = false;
-    int uploadedFileCount = selectedPaths.size();
+    const int uploadedFileCount = selectedPaths.size();
     connect(&session, &QtMeshCloudSession::uploadFinished, &loop,
             [&](bool ok, const QString& err, const QString& url, const QString&) {
                 uploadOk = ok;
@@ -5310,6 +5318,16 @@ QJsonObject MCPServer::toolCloudUpload(const QJsonObject &args)
         error = QStringLiteral("Upload canceled");
         loop.quit();
     });
+    QTimer timeout;
+    timeout.setSingleShot(true);
+    timeout.setInterval(10 * 60 * 1000);
+    connect(&timeout, &QTimer::timeout, &loop, [&]() {
+        session.cancel();
+        uploadOk = false;
+        error = QStringLiteral("Upload timed out");
+        loop.quit();
+    });
+    timeout.start();
     session.uploadPackageFromAssets(request);
     loop.exec();
 

--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -29,6 +29,7 @@
 #include "UvUnwrap.h"
 #include "AssetScanController.h"
 #include "CloudCredentialStore.h"
+#include "DependencyResolver.h"
 #include "ProjectPackager.h"
 #include "QtMeshCloudClient.h"
 #include "QtMeshCloudSession.h"
@@ -5274,46 +5275,53 @@ QJsonObject MCPServer::toolCloudUpload(const QJsonObject &args)
     if (projectName.isEmpty())
         projectName = QFileInfo(filePath).completeBaseName();
 
-    PackageMetadata manifest = ProjectPackager::buildManifest(filePath, {}, projectName);
     const bool runScan = !args.contains(QStringLiteral("scan")) || args.value(QStringLiteral("scan")).toBool(true);
-    if (runScan) {
-        QString scanError;
-        const QByteArray scanJson = AssetScanController::runIsolatedScanJsonSync(
-            QFileInfo(filePath).absolutePath(), QFileInfo(filePath).fileName(), &scanError);
-        if (!scanJson.isEmpty()) {
-            QJsonParseError parseError;
-            const QJsonDocument doc = QJsonDocument::fromJson(scanJson, &parseError);
-            if (parseError.error == QJsonParseError::NoError && doc.isObject())
-                manifest.scanSummary = doc.object();
-        }
-    }
+
+    QStringList selectedPaths;
+    for (const DependencyEntry& entry : DependencyResolver::detect(filePath))
+        selectedPaths.append(entry.absolutePath);
+
+    CloudPackageUploadRequest request;
+    request.mainAssetPath = filePath;
+    request.selectedAbsolutePaths = selectedPaths;
+    request.projectName = projectName;
+    request.createNewProject = true;
+    request.runLocalScan = runScan;
 
     QtMeshCloudSession session(token);
     QEventLoop loop;
     QString projectUrl;
     QString error;
+    QString reportWarning;
+    bool uploadOk = false;
+    int uploadedFileCount = selectedPaths.size();
     connect(&session, &QtMeshCloudSession::uploadFinished, &loop,
             [&](bool ok, const QString& err, const QString& url, const QString&) {
+                uploadOk = ok;
                 projectUrl = url;
-                error = err;
-                if (!ok && error.isEmpty())
-                    error = QStringLiteral("Upload failed");
+                if (ok && !err.isEmpty())
+                    reportWarning = err;
+                else if (!ok)
+                    error = err.isEmpty() ? QStringLiteral("Upload failed") : err;
                 loop.quit();
             });
     connect(&session, &QtMeshCloudSession::uploadCanceled, &loop, [&]() {
+        uploadOk = false;
         error = QStringLiteral("Upload canceled");
         loop.quit();
     });
-    session.uploadPackage(manifest);
+    session.uploadPackageFromAssets(request);
     loop.exec();
 
-    if (!error.isEmpty())
+    if (!uploadOk)
         return makeErrorResult(error);
 
     QJsonObject content;
     content[QStringLiteral("ok")] = true;
     content[QStringLiteral("projectUrl")] = projectUrl;
-    content[QStringLiteral("fileCount")] = manifest.files.size();
+    content[QStringLiteral("fileCount")] = uploadedFileCount;
+    if (!reportWarning.isEmpty())
+        content[QStringLiteral("reportWarning")] = reportWarning;
     return makeSuccessResult(
         QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Indented)));
 }

--- a/src/QtMeshCloudClient.cpp
+++ b/src/QtMeshCloudClient.cpp
@@ -1056,6 +1056,93 @@ QtMeshCloudClient::CompleteUploadResult QtMeshCloudClient::completeUpload(
     return out;
 }
 
+QtMeshCloudClient::UploadResult QtMeshCloudClient::uploadFileReport(
+    const QString& bearerToken,
+    const QString& ownerSlug,
+    const QString& projectSlug,
+    const QString& fileId,
+    const QJsonObject& report,
+    int timeoutMs)
+{
+    UploadResult out;
+    if (bearerToken.isEmpty()) {
+        out.errorString = QStringLiteral("missing bearer token");
+        return out;
+    }
+    if (ownerSlug.isEmpty() || projectSlug.isEmpty() || fileId.isEmpty()) {
+        out.errorString = QStringLiteral("owner slug, project slug, and fileId are required");
+        return out;
+    }
+    if (report.isEmpty()) {
+        out.errorString = QStringLiteral("report JSON is empty");
+        return out;
+    }
+
+    const QByteArray payload = QJsonDocument(report).toJson(QJsonDocument::Compact);
+    static constexpr int kMaxReportBytes = 5 * 1024 * 1024;
+    if (payload.size() > kMaxReportBytes) {
+        out.errorString = QStringLiteral("report exceeds 5 MB limit");
+        return out;
+    }
+
+    const QString path = ownerProjectPath(ownerSlug, projectSlug,
+                                          QStringLiteral("files/%1/report")
+                                              .arg(QString::fromUtf8(QUrl::toPercentEncoding(fileId))));
+    const QUrl url(apiBaseUrl() + path);
+    if (!url.isValid()) {
+        out.errorString = QStringLiteral("invalid API base URL");
+        return out;
+    }
+
+    QNetworkAccessManager nam;
+    QNetworkRequest req = authorizedJsonRequest(url, bearerToken, timeoutMs);
+
+    SentryReporter::addBreadcrumb(QStringLiteral("cloud.upload"),
+        QStringLiteral("QtMesh Cloud uploadFileReport: start fileId=%1 bytes=%2")
+            .arg(fileId, QString::number(payload.size())));
+
+    QNetworkReply* reply = nam.put(req, payload);
+    QEventLoop loop;
+    QObject::connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+    loop.exec();
+
+    out.httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    const QByteArray responseBody = reply->readAll();
+    const auto nerr = reply->error();
+    const QString transportErr = reply->errorString();
+    reply->deleteLater();
+
+    if (nerr != QNetworkReply::NoError || out.httpStatus < 200 || out.httpStatus >= 300) {
+        out.responseBodySnippet = trimSnippet(responseBody);
+        out.errorString = nerr != QNetworkReply::NoError ? transportErr : QStringLiteral("HTTP %1").arg(out.httpStatus);
+        if (!out.responseBodySnippet.isEmpty())
+            out.errorString += QStringLiteral(" — ") + out.responseBodySnippet;
+        SentryReporter::addBreadcrumb(QStringLiteral("cloud.upload"),
+            QStringLiteral("QtMesh Cloud uploadFileReport: failure HTTP %1").arg(out.httpStatus),
+            QStringLiteral("warning"));
+        return out;
+    }
+
+    QJsonObject root;
+    if (!parseJsonObjectBody(responseBody, root, out.errorString))
+        return out;
+    if (root.contains(QStringLiteral("ok")) && !root.value(QStringLiteral("ok")).toBool()) {
+        out.errorString = jsonErrorCode(root);
+        if (out.errorString.isEmpty())
+            out.errorString = QStringLiteral("report upload rejected");
+        out.responseBodySnippet = trimSnippet(responseBody);
+        SentryReporter::addBreadcrumb(QStringLiteral("cloud.upload"),
+            QStringLiteral("QtMesh Cloud uploadFileReport: rejected"),
+            QStringLiteral("warning"));
+        return out;
+    }
+
+    out.ok = true;
+    SentryReporter::addBreadcrumb(QStringLiteral("cloud.upload"),
+        QStringLiteral("QtMesh Cloud uploadFileReport: ok fileId=%1").arg(fileId));
+    return out;
+}
+
 QtMeshCloudClient::ManifestResult QtMeshCloudClient::fetchProjectManifest(const QString& bearerToken,
                                                                           const QString& ownerSlug,
                                                                           const QString& projectSlug,

--- a/src/QtMeshCloudClient.h
+++ b/src/QtMeshCloudClient.h
@@ -197,6 +197,15 @@ public:
                                                const QString& mainFileId = QString(),
                                                int timeoutMs = 30000);
 
+    /// PUT /v1/u/:owner/p/:project/files/:fileId/report — scan report after files/complete.
+    /// Body is the JSON from `ScanEngine::scanReportToJsonObject()` (max 5 MB).
+    static UploadResult uploadFileReport(const QString& bearerToken,
+                                         const QString& ownerSlug,
+                                         const QString& projectSlug,
+                                         const QString& fileId,
+                                         const QJsonObject& report,
+                                         int timeoutMs = 30000);
+
     struct ManifestResult {
         bool ok = false;
         int httpStatus = 0;

--- a/src/QtMeshCloudClient_test.cpp
+++ b/src/QtMeshCloudClient_test.cpp
@@ -1,8 +1,170 @@
 #include <gtest/gtest.h>
 #include <QCoreApplication>
+#include <QElapsedTimer>
+#include <QHostAddress>
+#include <QJsonArray>
+#include <QJsonDocument>
 #include <QJsonObject>
+#include <QMap>
+#include <QTcpServer>
+#include <QTcpSocket>
+#include <QThread>
+#include <QUrl>
+#include <memory>
 #include "QtMeshCloudClient.h"
 #include "FeedbackDiagnostics.h"
+
+namespace {
+
+struct ParsedHttpRequest {
+    QString method;
+    QString path;
+    QMap<QString, QString> headers;
+    QByteArray body;
+};
+
+QString headerValue(const QMap<QString, QString>& headers, const QString& name)
+{
+    for (auto it = headers.constBegin(); it != headers.constEnd(); ++it) {
+        if (it.key().compare(name, Qt::CaseInsensitive) == 0)
+            return it.value();
+    }
+    return {};
+}
+
+ParsedHttpRequest parseHttpRequest(const QByteArray& raw)
+{
+    ParsedHttpRequest req;
+    const int headerEnd = raw.indexOf("\r\n\r\n");
+    const QByteArray headerBlock = headerEnd >= 0 ? raw.left(headerEnd) : raw;
+    req.body = headerEnd >= 0 ? raw.mid(headerEnd + 4) : QByteArray{};
+
+    const QList<QByteArray> lines = headerBlock.split('\n');
+    if (!lines.isEmpty()) {
+        const QString requestLine = QString::fromUtf8(lines.first()).trimmed();
+        req.method = requestLine.section(QLatin1Char(' '), 0, 0);
+        req.path = requestLine.section(QLatin1Char(' '), 1, 1);
+    }
+    for (int i = 1; i < lines.size(); ++i) {
+        const QString line = QString::fromUtf8(lines.at(i)).trimmed();
+        const int colon = line.indexOf(QLatin1Char(':'));
+        if (colon <= 0)
+            continue;
+        const QString key = line.left(colon).trimmed();
+        const QString value = line.mid(colon + 1).trimmed();
+        req.headers.insert(key, value);
+    }
+    return req;
+}
+
+void writeHttpResponse(QTcpSocket* socket, int status, const QByteArray& body,
+                       const char* statusText = "OK")
+{
+    QByteArray response;
+    response += "HTTP/1.1 ";
+    response += QByteArray::number(status);
+    response += ' ';
+    response += statusText;
+    response += "\r\nContent-Type: application/json\r\n";
+    response += "Content-Length: ";
+    response += QByteArray::number(body.size());
+    response += "\r\nConnection: close\r\n\r\n";
+    response += body;
+    socket->write(response);
+    socket->flush();
+    socket->waitForBytesWritten(2000);
+    socket->disconnectFromHost();
+}
+
+struct CloudReportHttpMock {
+    QTcpServer server;
+    bool uploadCompleteCalled = false;
+    bool rejectReportBeforeComplete = true;
+    int reportStatus = 200;
+    QString lastMethod;
+    QString lastPath;
+    QString lastAuthHeader;
+    QString lastContentType;
+    QByteArray lastReportBody;
+    QStringList requestOrder;
+
+    bool listen()
+    {
+        QObject::connect(&server, &QTcpServer::newConnection, [this]() {
+            QTcpSocket* socket = server.nextPendingConnection();
+            auto buffer = std::make_shared<QByteArray>();
+            QObject::connect(socket, &QTcpSocket::readyRead, socket, [this, socket, buffer]() {
+                buffer->append(socket->readAll());
+                const int headerEnd = buffer->indexOf("\r\n\r\n");
+                if (headerEnd < 0)
+                    return;
+
+                const ParsedHttpRequest req = parseHttpRequest(*buffer);
+                const int contentLength = headerValue(req.headers, QStringLiteral("Content-Length")).toInt();
+                if (buffer->size() < headerEnd + 4 + contentLength)
+                    return;
+
+                lastMethod = req.method;
+                lastPath = req.path;
+                lastAuthHeader = headerValue(req.headers, QStringLiteral("Authorization"));
+                lastContentType = headerValue(req.headers, QStringLiteral("Content-Type"));
+
+                if (req.method == QStringLiteral("POST")
+                    && req.path.contains(QStringLiteral("/files/complete"))) {
+                    uploadCompleteCalled = true;
+                    requestOrder.append(QStringLiteral("complete"));
+                    writeHttpResponse(socket, 200,
+                                      QByteArray(R"({"ok":true,"scanStatus":"warning","files":[]})"));
+                    return;
+                }
+
+                if (req.method == QStringLiteral("PUT") && req.path.contains(QStringLiteral("/report"))) {
+                    requestOrder.append(QStringLiteral("report"));
+                    lastReportBody = req.body;
+                    if (rejectReportBeforeComplete && !uploadCompleteCalled) {
+                        writeHttpResponse(socket, 400, QByteArray(R"({"error":"file incomplete"})"),
+                                          "Bad Request");
+                        return;
+                    }
+                    if (reportStatus >= 400) {
+                        writeHttpResponse(socket, reportStatus, QByteArray(R"({"error":"server error"})"),
+                                          "Error");
+                        return;
+                    }
+                    writeHttpResponse(
+                        socket, 200,
+                        QByteArray(
+                            R"({"ok":true,"file":{"id":"file-main","scanSummary":{"status":"warning"}}})"));
+                    return;
+                }
+
+                writeHttpResponse(socket, 404, QByteArray(R"({"error":"not found"})"), "Not Found");
+            });
+        });
+        return server.listen(QHostAddress::LocalHost);
+    }
+
+    quint16 port() const { return server.serverPort(); }
+
+    QString baseUrl() const
+    {
+        return QStringLiteral("http://127.0.0.1:%1").arg(server.serverPort());
+    }
+};
+
+QJsonObject sampleScanReport()
+{
+    QJsonObject report;
+    report.insert(QStringLiteral("version"), QStringLiteral("3.0.0"));
+    QJsonObject summary;
+    summary.insert(QStringLiteral("scanned"), 1);
+    summary.insert(QStringLiteral("warnings"), 0);
+    summary.insert(QStringLiteral("errors"), 0);
+    report.insert(QStringLiteral("summary"), summary);
+    return report;
+}
+
+} // namespace
 
 TEST(QtMeshCloudClientValidate, AcceptsMinimalValid)
 {
@@ -226,6 +388,121 @@ TEST(QtMeshCloudClientCompleteUpload, MissingFileIdsReturnsErrorImmediately)
                                                    QStringLiteral("project"), {}, QString(), /*timeoutMs=*/100);
     EXPECT_FALSE(result.ok);
     EXPECT_TRUE(result.errorString.contains("fileIds", Qt::CaseInsensitive));
+}
+
+TEST(QtMeshCloudClientUploadFileReport, MissingTokenReturnsErrorImmediately)
+{
+    auto result = QtMeshCloudClient::uploadFileReport(QString(), QStringLiteral("me"),
+                                                      QStringLiteral("project"), QStringLiteral("file-1"),
+                                                      sampleScanReport(), /*timeoutMs=*/100);
+    EXPECT_FALSE(result.ok);
+    EXPECT_TRUE(result.errorString.contains("missing bearer token", Qt::CaseInsensitive));
+}
+
+TEST(QtMeshCloudClientUploadFileReport, MissingOwnerProjectOrFileIdReturnsErrorImmediately)
+{
+    const QJsonObject report = sampleScanReport();
+    auto missingOwner = QtMeshCloudClient::uploadFileReport(QStringLiteral("token"), QString(),
+                                                            QStringLiteral("project"), QStringLiteral("file-1"),
+                                                            report, /*timeoutMs=*/100);
+    EXPECT_FALSE(missingOwner.ok);
+    EXPECT_TRUE(missingOwner.errorString.contains("owner slug", Qt::CaseInsensitive));
+
+    auto missingFileId = QtMeshCloudClient::uploadFileReport(QStringLiteral("token"),
+                                                             QStringLiteral("me"), QStringLiteral("project"),
+                                                             QString(), report, /*timeoutMs=*/100);
+    EXPECT_FALSE(missingFileId.ok);
+    EXPECT_TRUE(missingFileId.errorString.contains("fileId", Qt::CaseInsensitive));
+}
+
+TEST(QtMeshCloudClientUploadFileReport, EmptyReportReturnsErrorImmediately)
+{
+    auto result = QtMeshCloudClient::uploadFileReport(QStringLiteral("token"), QStringLiteral("me"),
+                                                      QStringLiteral("project"), QStringLiteral("file-1"),
+                                                      QJsonObject{}, /*timeoutMs=*/100);
+    EXPECT_FALSE(result.ok);
+    EXPECT_TRUE(result.errorString.contains("empty", Qt::CaseInsensitive));
+}
+
+class QtMeshCloudClientUploadFileReportHttpTest : public QtMeshCloudClientApiBaseUrlTest {
+protected:
+    void SetUp() override
+    {
+        QtMeshCloudClientApiBaseUrlTest::SetUp();
+        ASSERT_TRUE(m_mock.listen());
+        qputenv("QTMESH_API_BASE", m_mock.baseUrl().toUtf8());
+    }
+
+    CloudReportHttpMock m_mock;
+};
+
+TEST_F(QtMeshCloudClientUploadFileReportHttpTest, UsesPutWithAuthAndJsonHeaders)
+{
+    m_mock.uploadCompleteCalled = true;
+    m_mock.rejectReportBeforeComplete = false;
+
+    const QJsonObject report = sampleScanReport();
+    const auto result = QtMeshCloudClient::uploadFileReport(
+        QStringLiteral("session-token"), QStringLiteral("owner slug"), QStringLiteral("proj/slug"),
+        QStringLiteral("file-main"), report, /*timeoutMs=*/5000);
+
+    EXPECT_TRUE(result.ok);
+    EXPECT_EQ(m_mock.lastMethod, QStringLiteral("PUT"));
+    EXPECT_TRUE(m_mock.lastPath.contains(QStringLiteral("/v1/u/owner%20slug/p/proj%2Fslug/files/file-main/report")));
+    EXPECT_EQ(m_mock.lastAuthHeader, QStringLiteral("Bearer session-token"));
+    EXPECT_TRUE(m_mock.lastContentType.contains(QStringLiteral("application/json")));
+    EXPECT_FALSE(m_mock.lastReportBody.isEmpty());
+    const QJsonDocument sent = QJsonDocument::fromJson(m_mock.lastReportBody);
+    ASSERT_TRUE(sent.isObject());
+    EXPECT_EQ(sent.object().value(QStringLiteral("version")).toString(), QStringLiteral("3.0.0"));
+}
+
+TEST_F(QtMeshCloudClientUploadFileReportHttpTest, PropagatesHttpFailure)
+{
+    m_mock.uploadCompleteCalled = true;
+    m_mock.rejectReportBeforeComplete = false;
+    m_mock.reportStatus = 413;
+
+    const auto result = QtMeshCloudClient::uploadFileReport(
+        QStringLiteral("token"), QStringLiteral("me"), QStringLiteral("project"),
+        QStringLiteral("file-1"), sampleScanReport(), /*timeoutMs=*/5000);
+
+    EXPECT_FALSE(result.ok);
+    EXPECT_EQ(result.httpStatus, 413);
+    EXPECT_FALSE(result.errorString.isEmpty());
+    EXPECT_FALSE(result.responseBodySnippet.isEmpty());
+}
+
+TEST_F(QtMeshCloudClientUploadFileReportHttpTest, ReportRejectedBeforeCompleteUpload)
+{
+    m_mock.uploadCompleteCalled = false;
+    m_mock.rejectReportBeforeComplete = true;
+
+    const auto result = QtMeshCloudClient::uploadFileReport(
+        QStringLiteral("token"), QStringLiteral("me"), QStringLiteral("project"),
+        QStringLiteral("file-1"), sampleScanReport(), /*timeoutMs=*/5000);
+
+    EXPECT_FALSE(result.ok);
+    EXPECT_EQ(result.httpStatus, 400);
+}
+
+TEST_F(QtMeshCloudClientUploadFileReportHttpTest, CompleteUploadMustPrecedeReportUpload)
+{
+    m_mock.rejectReportBeforeComplete = true;
+
+    const auto completed = QtMeshCloudClient::completeUpload(
+        QStringLiteral("token"), QStringLiteral("me"), QStringLiteral("project"),
+        QStringList{QStringLiteral("file-1")}, QStringLiteral("file-1"), /*timeoutMs=*/5000);
+    ASSERT_TRUE(completed.ok);
+
+    const auto report = QtMeshCloudClient::uploadFileReport(
+        QStringLiteral("token"), QStringLiteral("me"), QStringLiteral("project"),
+        QStringLiteral("file-1"), sampleScanReport(), /*timeoutMs=*/5000);
+
+    EXPECT_TRUE(report.ok);
+    ASSERT_EQ(m_mock.requestOrder.size(), 2);
+    EXPECT_EQ(m_mock.requestOrder.at(0), QStringLiteral("complete"));
+    EXPECT_EQ(m_mock.requestOrder.at(1), QStringLiteral("report"));
 }
 
 TEST(QtMeshCloudClientFetchManifest, MissingOwnerReturnsErrorImmediately)

--- a/src/QtMeshCloudSession.cpp
+++ b/src/QtMeshCloudSession.cpp
@@ -1,11 +1,72 @@
 #include "QtMeshCloudSession.h"
 
+#include "AssetScanController.h"
+#include "CloudUploadDialog.h"
 #include "CloudUploadPlanner.h"
 #include "SentryReporter.h"
 
+#include <QJsonDocument>
+#include <QJsonParseError>
 #include <QPointer>
 #include <QCoreApplication>
+#include <QFileInfo>
 #include <QThread>
+
+namespace {
+
+void invokeUploadProgress(QtMeshCloudSession* self, int current, int total, const QString& label)
+{
+    if (!self)
+        return;
+    QMetaObject::invokeMethod(qApp,
+                              [self, current, total, label]() {
+                                  if (self)
+                                      emit self->uploadProgress(current, total, label);
+                              },
+                              Qt::QueuedConnection);
+}
+
+void invokeUploadFinished(QtMeshCloudSession* self,
+                          bool ok,
+                          const QString& error,
+                          const QString& projectUrl,
+                          const QString& scanStatus)
+{
+    if (!self)
+        return;
+    QMetaObject::invokeMethod(qApp,
+                              [self, ok, error, projectUrl, scanStatus]() {
+                                  if (self)
+                                      emit self->uploadFinished(ok, error, projectUrl, scanStatus);
+                              },
+                              Qt::QueuedConnection);
+}
+
+void invokeUploadCanceled(QtMeshCloudSession* self)
+{
+    if (!self)
+        return;
+    QMetaObject::invokeMethod(qApp,
+                              [self]() {
+                                  if (self)
+                                      emit self->uploadCanceled();
+                              },
+                              Qt::QueuedConnection);
+}
+
+void invokePrepareWarning(QtMeshCloudSession* self, const QString& warning)
+{
+    if (!self || warning.isEmpty())
+        return;
+    QMetaObject::invokeMethod(qApp,
+                              [self, warning]() {
+                                  if (self)
+                                      emit self->uploadPrepareWarning(warning);
+                              },
+                              Qt::QueuedConnection);
+}
+
+} // namespace
 
 QtMeshCloudSession::QtMeshCloudSession(const QString& bearerToken, QObject* parent)
     : QObject(parent)
@@ -39,16 +100,88 @@ void QtMeshCloudSession::listProjects()
 }
 
 void QtMeshCloudSession::uploadPackage(const PackageMetadata& metadata,
-                                     const QString& ownerSlug,
-                                     const QString& projectSlug,
-                                     bool createNewProject)
+                                       const QString& ownerSlug,
+                                       const QString& projectSlug,
+                                       bool createNewProject)
+{
+    m_canceled.store(false);
+    startUploadWorker(metadata, ownerSlug, projectSlug, createNewProject);
+}
+
+void QtMeshCloudSession::uploadPackageFromAssets(const CloudPackageUploadRequest& request)
 {
     m_canceled.store(false);
     const QString token = m_bearerToken;
-    const PackageMetadata package = metadata;
-
+    const CloudPackageUploadRequest req = request;
     QPointer<QtMeshCloudSession> self(this);
-    QThread* worker = QThread::create([self, token, package, ownerSlug, projectSlug, createNewProject, canceled = &m_canceled]() {
+
+    QThread* worker = QThread::create([self, token, req, canceled = &m_canceled]() {
+        if (canceled->load()) {
+            invokeUploadCanceled(self.data());
+            return;
+        }
+
+        invokeUploadProgress(self.data(), 0, 1, QStringLiteral("Preparing package…"));
+
+        QJsonObject scanSummary;
+        if (req.runLocalScan) {
+            invokeUploadProgress(self.data(), 0, 1, QStringLiteral("Scanning assets…"));
+            const QFileInfo mainAssetInfo(req.mainAssetPath);
+            QString scanError;
+            const QByteArray scanJson = AssetScanController::runIsolatedScanJsonSync(
+                mainAssetInfo.absolutePath(), mainAssetInfo.fileName(), &scanError);
+            if (scanJson.isEmpty()) {
+                invokePrepareWarning(
+                    self.data(),
+                    scanError.isEmpty()
+                        ? QStringLiteral("Local scan failed; continuing without scan summary.")
+                        : QStringLiteral("Local scan failed; continuing without scan summary.\n\n%1")
+                              .arg(scanError));
+            } else {
+                QJsonParseError parseError;
+                const QJsonDocument doc = QJsonDocument::fromJson(scanJson, &parseError);
+                if (parseError.error != QJsonParseError::NoError || !doc.isObject()) {
+                    invokePrepareWarning(
+                        self.data(),
+                        QStringLiteral("Local scan returned invalid JSON; continuing without scan summary.\n\n%1")
+                            .arg(parseError.errorString()));
+                } else {
+                    scanSummary = doc.object();
+                }
+            }
+        }
+
+        if (canceled->load()) {
+            invokeUploadCanceled(self.data());
+            return;
+        }
+
+        const PackageMetadata package = CloudUploadDialog::buildManifestForUpload(
+            req.mainAssetPath, req.selectedAbsolutePaths, req.projectName, scanSummary);
+        if (package.files.isEmpty()) {
+            invokeUploadFinished(self.data(), false,
+                                 QStringLiteral("Select at least one file to upload."), {}, {});
+            return;
+        }
+
+        for (const PackageEntry& entry : package.files) {
+            if (!QFileInfo::exists(entry.absolutePath)) {
+                invokeUploadFinished(self.data(), false,
+                                     QStringLiteral("Missing file: %1")
+                                         .arg(QFileInfo(entry.absolutePath).fileName()),
+                                     {}, {});
+                return;
+            }
+        }
+
+        if (!self)
+            return;
+
+        // Continue upload on this worker thread (scan/manifest prep must not block the GUI).
+        const bool createNewProject = req.createNewProject;
+        const QString ownerSlug = req.ownerSlug;
+        const QString projectSlug = req.projectSlug;
+
         QtMeshCloudClient::ProjectResult project;
         if (createNewProject) {
             QString slug = projectSlug.isEmpty()
@@ -69,18 +202,11 @@ void QtMeshCloudSession::uploadPackage(const PackageMetadata& metadata,
         }
 
         if (canceled->load()) {
-            QMetaObject::invokeMethod(qApp, [self]() {
-                if (self)
-                    emit self->uploadCanceled();
-            }, Qt::QueuedConnection);
+            invokeUploadCanceled(self.data());
             return;
         }
         if (!project.ok) {
-            QMetaObject::invokeMethod(qApp, [self, project]() {
-                if (!self)
-                    return;
-                emit self->uploadFinished(false, project.errorString, {}, {});
-            }, Qt::QueuedConnection);
+            invokeUploadFinished(self.data(), false, project.errorString, {}, {});
             return;
         }
 
@@ -97,18 +223,11 @@ void QtMeshCloudSession::uploadPackage(const PackageMetadata& metadata,
         const auto uploadUrls = QtMeshCloudClient::requestUploadUrls(
             token, project.ownerSlug, project.projectSlug, descriptors);
         if (canceled->load()) {
-            QMetaObject::invokeMethod(qApp, [self]() {
-                if (self)
-                    emit self->uploadCanceled();
-            }, Qt::QueuedConnection);
+            invokeUploadCanceled(self.data());
             return;
         }
         if (!uploadUrls.ok) {
-            QMetaObject::invokeMethod(qApp, [self, uploadUrls]() {
-                if (!self)
-                    return;
-                emit self->uploadFinished(false, uploadUrls.errorString, {}, {});
-            }, Qt::QueuedConnection);
+            invokeUploadFinished(self.data(), false, uploadUrls.errorString, {}, {});
             return;
         }
 
@@ -118,35 +237,20 @@ void QtMeshCloudSession::uploadPackage(const PackageMetadata& metadata,
         const int total = uploadUrls.uploads.size();
         for (int i = 0; i < total; ++i) {
             if (canceled->load()) {
-                QMetaObject::invokeMethod(qApp, [self]() {
-                    if (self)
-                        emit self->uploadCanceled();
-                }, Qt::QueuedConnection);
+                invokeUploadCanceled(self.data());
                 return;
             }
 
-            const QString label = descriptors.at(i).uploadName;
-            QMetaObject::invokeMethod(qApp, [self, i, total, label]() {
-                if (!self)
-                    return;
-                emit self->uploadProgress(i + 1, total + 1, label);
-            }, Qt::QueuedConnection);
+            invokeUploadProgress(self.data(), i + 1, total + 1, descriptors.at(i).uploadName);
 
             const auto result = QtMeshCloudClient::uploadFileContent(
                 token, uploadUrls.uploads.at(i), descriptors.at(i).path, canceled);
             if (result.canceled) {
-                QMetaObject::invokeMethod(qApp, [self]() {
-                    if (self)
-                        emit self->uploadCanceled();
-                }, Qt::QueuedConnection);
+                invokeUploadCanceled(self.data());
                 return;
             }
             if (!result.ok) {
-                QMetaObject::invokeMethod(qApp, [self, result]() {
-                    if (!self)
-                        return;
-                    emit self->uploadFinished(false, result.errorString, {}, {});
-                }, Qt::QueuedConnection);
+                invokeUploadFinished(self.data(), false, result.errorString, {}, {});
                 return;
             }
 
@@ -160,37 +264,169 @@ void QtMeshCloudSession::uploadPackage(const PackageMetadata& metadata,
             mainFileId = fallbackMainFileId;
 
         if (canceled->load()) {
-            QMetaObject::invokeMethod(qApp, [self]() {
-                if (self)
-                    emit self->uploadCanceled();
-            }, Qt::QueuedConnection);
+            invokeUploadCanceled(self.data());
             return;
         }
 
-        QMetaObject::invokeMethod(qApp, [self, total]() {
-            if (!self)
-                return;
-            emit self->uploadProgress(total + 1, total + 1, QString());
-        }, Qt::QueuedConnection);
+        invokeUploadProgress(self.data(), total + 1, total + 1, QString());
 
         const auto completed = QtMeshCloudClient::completeUpload(
             token, project.ownerSlug, project.projectSlug, uploadedFileIds, mainFileId);
         if (!completed.ok) {
-            QMetaObject::invokeMethod(qApp, [self, completed]() {
-                if (!self)
-                    return;
-                emit self->uploadFinished(false, completed.errorString, {}, {});
-            }, Qt::QueuedConnection);
+            invokeUploadFinished(self.data(), false, completed.errorString, {}, {});
             return;
+        }
+
+        QString reportWarning;
+        if (!package.scanSummary.isEmpty() && !mainFileId.isEmpty()) {
+            const auto reportResult = QtMeshCloudClient::uploadFileReport(
+                token, project.ownerSlug, project.projectSlug, mainFileId, package.scanSummary);
+            if (!reportResult.ok) {
+                reportWarning = QStringLiteral("File uploaded, but analysis report upload failed.");
+                if (!reportResult.errorString.isEmpty())
+                    reportWarning += QStringLiteral("\n\n") + reportResult.errorString;
+                SentryReporter::addBreadcrumb(QStringLiteral("cloud.upload"),
+                                              reportWarning,
+                                              QStringLiteral("warning"));
+            }
         }
 
         SentryReporter::addBreadcrumb(QStringLiteral("cloud.upload"),
                                       QStringLiteral("QtMesh Cloud package upload completed"));
-        QMetaObject::invokeMethod(qApp, [self, project, completed]() {
-            if (!self)
+        invokeUploadFinished(self.data(), true, reportWarning, project.projectUrl, completed.scanStatus);
+    });
+
+    connect(worker, &QThread::finished, worker, &QObject::deleteLater);
+    worker->start();
+}
+
+void QtMeshCloudSession::startUploadWorker(const PackageMetadata& package,
+                                           const QString& ownerSlug,
+                                           const QString& projectSlug,
+                                           bool createNewProject)
+{
+    const QString token = m_bearerToken;
+    QPointer<QtMeshCloudSession> self(this);
+
+    QThread* worker = QThread::create([self, token, package, ownerSlug, projectSlug, createNewProject,
+                                       canceled = &m_canceled]() {
+        if (canceled->load()) {
+            invokeUploadCanceled(self.data());
+            return;
+        }
+
+        QtMeshCloudClient::ProjectResult project;
+        if (createNewProject) {
+            QString slug = projectSlug.isEmpty()
+                ? CloudUploadPlanner::makeProjectSlug(package.projectName)
+                : projectSlug;
+            project = QtMeshCloudClient::createProject(token, package.projectName, slug);
+            if (!project.ok && project.httpStatus == 409) {
+                slug = CloudUploadPlanner::makeProjectSlug(
+                    QStringLiteral("%1-%2").arg(package.projectName, slug));
+                project = QtMeshCloudClient::createProject(token, package.projectName, slug);
+            }
+        } else {
+            project.ok = true;
+            project.ownerSlug = ownerSlug;
+            project.projectSlug = projectSlug;
+            project.projectUrl = QStringLiteral("https://qtmesh.dev/%1/%2")
+                                     .arg(project.ownerSlug, project.projectSlug);
+        }
+
+        if (canceled->load()) {
+            invokeUploadCanceled(self.data());
+            return;
+        }
+        if (!project.ok) {
+            invokeUploadFinished(self.data(), false, project.errorString, {}, {});
+            return;
+        }
+
+        QList<QtMeshCloudClient::AssetFileDescriptor> descriptors;
+        for (const PackageEntry& entry : package.files) {
+            QtMeshCloudClient::AssetFileDescriptor descriptor;
+            descriptor.path = entry.absolutePath.isEmpty() ? entry.relativePath : entry.absolutePath;
+            descriptor.uploadName = entry.relativePath;
+            descriptor.role = entry.role;
+            descriptor.sizeBytes = entry.size;
+            descriptors.append(descriptor);
+        }
+
+        const auto uploadUrls = QtMeshCloudClient::requestUploadUrls(
+            token, project.ownerSlug, project.projectSlug, descriptors);
+        if (canceled->load()) {
+            invokeUploadCanceled(self.data());
+            return;
+        }
+        if (!uploadUrls.ok) {
+            invokeUploadFinished(self.data(), false, uploadUrls.errorString, {}, {});
+            return;
+        }
+
+        QStringList uploadedFileIds;
+        QString mainFileId;
+        QString fallbackMainFileId;
+        const int total = uploadUrls.uploads.size();
+        for (int i = 0; i < total; ++i) {
+            if (canceled->load()) {
+                invokeUploadCanceled(self.data());
                 return;
-            emit self->uploadFinished(true, {}, project.projectUrl, completed.scanStatus);
-        }, Qt::QueuedConnection);
+            }
+
+            invokeUploadProgress(self.data(), i + 1, total + 1, descriptors.at(i).uploadName);
+
+            const auto result = QtMeshCloudClient::uploadFileContent(
+                token, uploadUrls.uploads.at(i), descriptors.at(i).path, canceled);
+            if (result.canceled) {
+                invokeUploadCanceled(self.data());
+                return;
+            }
+            if (!result.ok) {
+                invokeUploadFinished(self.data(), false, result.errorString, {}, {});
+                return;
+            }
+
+            uploadedFileIds.append(uploadUrls.uploads.at(i).fileId);
+            if (fallbackMainFileId.isEmpty())
+                fallbackMainFileId = uploadUrls.uploads.at(i).fileId;
+            if (mainFileId.isEmpty() && descriptors.at(i).role == QLatin1String("main"))
+                mainFileId = uploadUrls.uploads.at(i).fileId;
+        }
+        if (mainFileId.isEmpty())
+            mainFileId = fallbackMainFileId;
+
+        if (canceled->load()) {
+            invokeUploadCanceled(self.data());
+            return;
+        }
+
+        invokeUploadProgress(self.data(), total + 1, total + 1, QString());
+
+        const auto completed = QtMeshCloudClient::completeUpload(
+            token, project.ownerSlug, project.projectSlug, uploadedFileIds, mainFileId);
+        if (!completed.ok) {
+            invokeUploadFinished(self.data(), false, completed.errorString, {}, {});
+            return;
+        }
+
+        QString reportWarning;
+        if (!package.scanSummary.isEmpty() && !mainFileId.isEmpty()) {
+            const auto reportResult = QtMeshCloudClient::uploadFileReport(
+                token, project.ownerSlug, project.projectSlug, mainFileId, package.scanSummary);
+            if (!reportResult.ok) {
+                reportWarning = QStringLiteral("File uploaded, but analysis report upload failed.");
+                if (!reportResult.errorString.isEmpty())
+                    reportWarning += QStringLiteral("\n\n") + reportResult.errorString;
+                SentryReporter::addBreadcrumb(QStringLiteral("cloud.upload"),
+                                              reportWarning,
+                                              QStringLiteral("warning"));
+            }
+        }
+
+        SentryReporter::addBreadcrumb(QStringLiteral("cloud.upload"),
+                                      QStringLiteral("QtMesh Cloud package upload completed"));
+        invokeUploadFinished(self.data(), true, reportWarning, project.projectUrl, completed.scanStatus);
     });
 
     connect(worker, &QThread::finished, worker, &QObject::deleteLater);

--- a/src/QtMeshCloudSession.cpp
+++ b/src/QtMeshCloudSession.cpp
@@ -14,7 +14,10 @@
 
 namespace {
 
-void invokeUploadProgress(QtMeshCloudSession* self, int current, int total, const QString& label)
+void invokeUploadProgress(const QPointer<QtMeshCloudSession>& self,
+                          int current,
+                          int total,
+                          const QString& label)
 {
     if (!self)
         return;
@@ -26,7 +29,7 @@ void invokeUploadProgress(QtMeshCloudSession* self, int current, int total, cons
                               Qt::QueuedConnection);
 }
 
-void invokeUploadFinished(QtMeshCloudSession* self,
+void invokeUploadFinished(const QPointer<QtMeshCloudSession>& self,
                           bool ok,
                           const QString& error,
                           const QString& projectUrl,
@@ -42,7 +45,7 @@ void invokeUploadFinished(QtMeshCloudSession* self,
                               Qt::QueuedConnection);
 }
 
-void invokeUploadCanceled(QtMeshCloudSession* self)
+void invokeUploadCanceled(const QPointer<QtMeshCloudSession>& self)
 {
     if (!self)
         return;
@@ -54,7 +57,7 @@ void invokeUploadCanceled(QtMeshCloudSession* self)
                               Qt::QueuedConnection);
 }
 
-void invokePrepareWarning(QtMeshCloudSession* self, const QString& warning)
+void invokePrepareWarning(const QPointer<QtMeshCloudSession>& self, const QString& warning)
 {
     if (!self || warning.isEmpty())
         return;
@@ -117,22 +120,22 @@ void QtMeshCloudSession::uploadPackageFromAssets(const CloudPackageUploadRequest
 
     QThread* worker = QThread::create([self, token, req, canceled = &m_canceled]() {
         if (canceled->load()) {
-            invokeUploadCanceled(self.data());
+            invokeUploadCanceled(self);
             return;
         }
 
-        invokeUploadProgress(self.data(), 0, 1, QStringLiteral("Preparing package…"));
+        invokeUploadProgress(self, 0, 1, QStringLiteral("Preparing package…"));
 
         QJsonObject scanSummary;
         if (req.runLocalScan) {
-            invokeUploadProgress(self.data(), 0, 1, QStringLiteral("Scanning assets…"));
+            invokeUploadProgress(self, 0, 1, QStringLiteral("Scanning assets…"));
             const QFileInfo mainAssetInfo(req.mainAssetPath);
             QString scanError;
             const QByteArray scanJson = AssetScanController::runIsolatedScanJsonSync(
                 mainAssetInfo.absolutePath(), mainAssetInfo.fileName(), &scanError);
             if (scanJson.isEmpty()) {
                 invokePrepareWarning(
-                    self.data(),
+                    self,
                     scanError.isEmpty()
                         ? QStringLiteral("Local scan failed; continuing without scan summary.")
                         : QStringLiteral("Local scan failed; continuing without scan summary.\n\n%1")
@@ -142,7 +145,7 @@ void QtMeshCloudSession::uploadPackageFromAssets(const CloudPackageUploadRequest
                 const QJsonDocument doc = QJsonDocument::fromJson(scanJson, &parseError);
                 if (parseError.error != QJsonParseError::NoError || !doc.isObject()) {
                     invokePrepareWarning(
-                        self.data(),
+                        self,
                         QStringLiteral("Local scan returned invalid JSON; continuing without scan summary.\n\n%1")
                             .arg(parseError.errorString()));
                 } else {
@@ -152,21 +155,21 @@ void QtMeshCloudSession::uploadPackageFromAssets(const CloudPackageUploadRequest
         }
 
         if (canceled->load()) {
-            invokeUploadCanceled(self.data());
+            invokeUploadCanceled(self);
             return;
         }
 
         const PackageMetadata package = CloudUploadDialog::buildManifestForUpload(
             req.mainAssetPath, req.selectedAbsolutePaths, req.projectName, scanSummary);
         if (package.files.isEmpty()) {
-            invokeUploadFinished(self.data(), false,
+            invokeUploadFinished(self, false,
                                  QStringLiteral("Select at least one file to upload."), {}, {});
             return;
         }
 
         for (const PackageEntry& entry : package.files) {
             if (!QFileInfo::exists(entry.absolutePath)) {
-                invokeUploadFinished(self.data(), false,
+                invokeUploadFinished(self, false,
                                      QStringLiteral("Missing file: %1")
                                          .arg(QFileInfo(entry.absolutePath).fileName()),
                                      {}, {});
@@ -202,11 +205,11 @@ void QtMeshCloudSession::uploadPackageFromAssets(const CloudPackageUploadRequest
         }
 
         if (canceled->load()) {
-            invokeUploadCanceled(self.data());
+            invokeUploadCanceled(self);
             return;
         }
         if (!project.ok) {
-            invokeUploadFinished(self.data(), false, project.errorString, {}, {});
+            invokeUploadFinished(self, false, project.errorString, {}, {});
             return;
         }
 
@@ -223,11 +226,11 @@ void QtMeshCloudSession::uploadPackageFromAssets(const CloudPackageUploadRequest
         const auto uploadUrls = QtMeshCloudClient::requestUploadUrls(
             token, project.ownerSlug, project.projectSlug, descriptors);
         if (canceled->load()) {
-            invokeUploadCanceled(self.data());
+            invokeUploadCanceled(self);
             return;
         }
         if (!uploadUrls.ok) {
-            invokeUploadFinished(self.data(), false, uploadUrls.errorString, {}, {});
+            invokeUploadFinished(self, false, uploadUrls.errorString, {}, {});
             return;
         }
 
@@ -237,20 +240,20 @@ void QtMeshCloudSession::uploadPackageFromAssets(const CloudPackageUploadRequest
         const int total = uploadUrls.uploads.size();
         for (int i = 0; i < total; ++i) {
             if (canceled->load()) {
-                invokeUploadCanceled(self.data());
+                invokeUploadCanceled(self);
                 return;
             }
 
-            invokeUploadProgress(self.data(), i + 1, total + 1, descriptors.at(i).uploadName);
+            invokeUploadProgress(self, i + 1, total + 1, descriptors.at(i).uploadName);
 
             const auto result = QtMeshCloudClient::uploadFileContent(
                 token, uploadUrls.uploads.at(i), descriptors.at(i).path, canceled);
             if (result.canceled) {
-                invokeUploadCanceled(self.data());
+                invokeUploadCanceled(self);
                 return;
             }
             if (!result.ok) {
-                invokeUploadFinished(self.data(), false, result.errorString, {}, {});
+                invokeUploadFinished(self, false, result.errorString, {}, {});
                 return;
             }
 
@@ -264,16 +267,16 @@ void QtMeshCloudSession::uploadPackageFromAssets(const CloudPackageUploadRequest
             mainFileId = fallbackMainFileId;
 
         if (canceled->load()) {
-            invokeUploadCanceled(self.data());
+            invokeUploadCanceled(self);
             return;
         }
 
-        invokeUploadProgress(self.data(), total + 1, total + 1, QString());
+        invokeUploadProgress(self, total + 1, total + 1, QString());
 
         const auto completed = QtMeshCloudClient::completeUpload(
             token, project.ownerSlug, project.projectSlug, uploadedFileIds, mainFileId);
         if (!completed.ok) {
-            invokeUploadFinished(self.data(), false, completed.errorString, {}, {});
+            invokeUploadFinished(self, false, completed.errorString, {}, {});
             return;
         }
 
@@ -293,7 +296,7 @@ void QtMeshCloudSession::uploadPackageFromAssets(const CloudPackageUploadRequest
 
         SentryReporter::addBreadcrumb(QStringLiteral("cloud.upload"),
                                       QStringLiteral("QtMesh Cloud package upload completed"));
-        invokeUploadFinished(self.data(), true, reportWarning, project.projectUrl, completed.scanStatus);
+        invokeUploadFinished(self, true, reportWarning, project.projectUrl, completed.scanStatus);
     });
 
     connect(worker, &QThread::finished, worker, &QObject::deleteLater);
@@ -311,7 +314,7 @@ void QtMeshCloudSession::startUploadWorker(const PackageMetadata& package,
     QThread* worker = QThread::create([self, token, package, ownerSlug, projectSlug, createNewProject,
                                        canceled = &m_canceled]() {
         if (canceled->load()) {
-            invokeUploadCanceled(self.data());
+            invokeUploadCanceled(self);
             return;
         }
 
@@ -335,11 +338,11 @@ void QtMeshCloudSession::startUploadWorker(const PackageMetadata& package,
         }
 
         if (canceled->load()) {
-            invokeUploadCanceled(self.data());
+            invokeUploadCanceled(self);
             return;
         }
         if (!project.ok) {
-            invokeUploadFinished(self.data(), false, project.errorString, {}, {});
+            invokeUploadFinished(self, false, project.errorString, {}, {});
             return;
         }
 
@@ -356,11 +359,11 @@ void QtMeshCloudSession::startUploadWorker(const PackageMetadata& package,
         const auto uploadUrls = QtMeshCloudClient::requestUploadUrls(
             token, project.ownerSlug, project.projectSlug, descriptors);
         if (canceled->load()) {
-            invokeUploadCanceled(self.data());
+            invokeUploadCanceled(self);
             return;
         }
         if (!uploadUrls.ok) {
-            invokeUploadFinished(self.data(), false, uploadUrls.errorString, {}, {});
+            invokeUploadFinished(self, false, uploadUrls.errorString, {}, {});
             return;
         }
 
@@ -370,20 +373,20 @@ void QtMeshCloudSession::startUploadWorker(const PackageMetadata& package,
         const int total = uploadUrls.uploads.size();
         for (int i = 0; i < total; ++i) {
             if (canceled->load()) {
-                invokeUploadCanceled(self.data());
+                invokeUploadCanceled(self);
                 return;
             }
 
-            invokeUploadProgress(self.data(), i + 1, total + 1, descriptors.at(i).uploadName);
+            invokeUploadProgress(self, i + 1, total + 1, descriptors.at(i).uploadName);
 
             const auto result = QtMeshCloudClient::uploadFileContent(
                 token, uploadUrls.uploads.at(i), descriptors.at(i).path, canceled);
             if (result.canceled) {
-                invokeUploadCanceled(self.data());
+                invokeUploadCanceled(self);
                 return;
             }
             if (!result.ok) {
-                invokeUploadFinished(self.data(), false, result.errorString, {}, {});
+                invokeUploadFinished(self, false, result.errorString, {}, {});
                 return;
             }
 
@@ -397,16 +400,16 @@ void QtMeshCloudSession::startUploadWorker(const PackageMetadata& package,
             mainFileId = fallbackMainFileId;
 
         if (canceled->load()) {
-            invokeUploadCanceled(self.data());
+            invokeUploadCanceled(self);
             return;
         }
 
-        invokeUploadProgress(self.data(), total + 1, total + 1, QString());
+        invokeUploadProgress(self, total + 1, total + 1, QString());
 
         const auto completed = QtMeshCloudClient::completeUpload(
             token, project.ownerSlug, project.projectSlug, uploadedFileIds, mainFileId);
         if (!completed.ok) {
-            invokeUploadFinished(self.data(), false, completed.errorString, {}, {});
+            invokeUploadFinished(self, false, completed.errorString, {}, {});
             return;
         }
 
@@ -426,7 +429,7 @@ void QtMeshCloudSession::startUploadWorker(const PackageMetadata& package,
 
         SentryReporter::addBreadcrumb(QStringLiteral("cloud.upload"),
                                       QStringLiteral("QtMesh Cloud package upload completed"));
-        invokeUploadFinished(self.data(), true, reportWarning, project.projectUrl, completed.scanStatus);
+        invokeUploadFinished(self, true, reportWarning, project.projectUrl, completed.scanStatus);
     });
 
     connect(worker, &QThread::finished, worker, &QObject::deleteLater);

--- a/src/QtMeshCloudSession.cpp
+++ b/src/QtMeshCloudSession.cpp
@@ -80,6 +80,8 @@ QtMeshCloudSession::QtMeshCloudSession(const QString& bearerToken, QObject* pare
 void QtMeshCloudSession::cancel()
 {
     m_canceled.store(true);
+    if (m_uploadCancelFlag)
+        m_uploadCancelFlag->store(true);
 }
 
 void QtMeshCloudSession::listProjects()
@@ -107,18 +109,21 @@ void QtMeshCloudSession::uploadPackage(const PackageMetadata& metadata,
                                        const QString& projectSlug,
                                        bool createNewProject)
 {
+    m_uploadCancelFlag = std::make_shared<std::atomic_bool>(false);
     m_canceled.store(false);
     startUploadWorker(metadata, ownerSlug, projectSlug, createNewProject);
 }
 
 void QtMeshCloudSession::uploadPackageFromAssets(const CloudPackageUploadRequest& request)
 {
+    m_uploadCancelFlag = std::make_shared<std::atomic_bool>(false);
     m_canceled.store(false);
     const QString token = m_bearerToken;
     const CloudPackageUploadRequest req = request;
     QPointer<QtMeshCloudSession> self(this);
+    const std::shared_ptr<std::atomic_bool> canceled = m_uploadCancelFlag;
 
-    QThread* worker = QThread::create([self, token, req, canceled = &m_canceled]() {
+    QThread* worker = QThread::create([self, token, req, canceled]() {
         if (canceled->load()) {
             invokeUploadCanceled(self);
             return;
@@ -247,7 +252,7 @@ void QtMeshCloudSession::uploadPackageFromAssets(const CloudPackageUploadRequest
             invokeUploadProgress(self, i + 1, total + 1, descriptors.at(i).uploadName);
 
             const auto result = QtMeshCloudClient::uploadFileContent(
-                token, uploadUrls.uploads.at(i), descriptors.at(i).path, canceled);
+                token, uploadUrls.uploads.at(i), descriptors.at(i).path, canceled.get());
             if (result.canceled) {
                 invokeUploadCanceled(self);
                 return;
@@ -288,13 +293,13 @@ void QtMeshCloudSession::uploadPackageFromAssets(const CloudPackageUploadRequest
                 reportWarning = QStringLiteral("File uploaded, but analysis report upload failed.");
                 if (!reportResult.errorString.isEmpty())
                     reportWarning += QStringLiteral("\n\n") + reportResult.errorString;
-                SentryReporter::addBreadcrumb(QStringLiteral("cloud.upload"),
+                SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
                                               reportWarning,
                                               QStringLiteral("warning"));
             }
         }
 
-        SentryReporter::addBreadcrumb(QStringLiteral("cloud.upload"),
+        SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
                                       QStringLiteral("QtMesh Cloud package upload completed"));
         invokeUploadFinished(self, true, reportWarning, project.projectUrl, completed.scanStatus);
     });
@@ -310,9 +315,10 @@ void QtMeshCloudSession::startUploadWorker(const PackageMetadata& package,
 {
     const QString token = m_bearerToken;
     QPointer<QtMeshCloudSession> self(this);
+    const std::shared_ptr<std::atomic_bool> canceled = m_uploadCancelFlag;
 
     QThread* worker = QThread::create([self, token, package, ownerSlug, projectSlug, createNewProject,
-                                       canceled = &m_canceled]() {
+                                       canceled]() {
         if (canceled->load()) {
             invokeUploadCanceled(self);
             return;
@@ -380,7 +386,7 @@ void QtMeshCloudSession::startUploadWorker(const PackageMetadata& package,
             invokeUploadProgress(self, i + 1, total + 1, descriptors.at(i).uploadName);
 
             const auto result = QtMeshCloudClient::uploadFileContent(
-                token, uploadUrls.uploads.at(i), descriptors.at(i).path, canceled);
+                token, uploadUrls.uploads.at(i), descriptors.at(i).path, canceled.get());
             if (result.canceled) {
                 invokeUploadCanceled(self);
                 return;
@@ -421,13 +427,13 @@ void QtMeshCloudSession::startUploadWorker(const PackageMetadata& package,
                 reportWarning = QStringLiteral("File uploaded, but analysis report upload failed.");
                 if (!reportResult.errorString.isEmpty())
                     reportWarning += QStringLiteral("\n\n") + reportResult.errorString;
-                SentryReporter::addBreadcrumb(QStringLiteral("cloud.upload"),
+                SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
                                               reportWarning,
                                               QStringLiteral("warning"));
             }
         }
 
-        SentryReporter::addBreadcrumb(QStringLiteral("cloud.upload"),
+        SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
                                       QStringLiteral("QtMesh Cloud package upload completed"));
         invokeUploadFinished(self, true, reportWarning, project.projectUrl, completed.scanStatus);
     });

--- a/src/QtMeshCloudSession.h
+++ b/src/QtMeshCloudSession.h
@@ -7,6 +7,16 @@
 #include <QObject>
 #include <atomic>
 
+struct CloudPackageUploadRequest {
+    QString mainAssetPath;
+    QStringList selectedAbsolutePaths;
+    QString projectName;
+    QString ownerSlug;
+    QString projectSlug;
+    bool createNewProject = false;
+    bool runLocalScan = false;
+};
+
 /// Async, progress-reporting QtMesh Cloud upload session (Slice C / #687).
 class QtMeshCloudSession : public QObject {
     Q_OBJECT
@@ -25,11 +35,17 @@ public:
                        const QString& projectSlug = QString(),
                        bool createNewProject = true);
 
+    /// Scans (optional), builds the manifest, and uploads on a worker thread.
+    void uploadPackageFromAssets(const CloudPackageUploadRequest& request);
+
     void cancel();
 
 signals:
     void projectsListed(const QList<QtMeshCloudClient::ProjectSummary>& projects, const QString& error);
     void uploadProgress(int current, int total, const QString& fileName);
+    /// Non-fatal prep issues (e.g. scan failed) surfaced before/during upload.
+    void uploadPrepareWarning(const QString& warning);
+    /// When ok is true, error may carry a non-fatal report-upload warning.
     void uploadFinished(bool ok,
                         const QString& error,
                         const QString& projectUrl,
@@ -37,6 +53,11 @@ signals:
     void uploadCanceled();
 
 private:
+    void startUploadWorker(const PackageMetadata& package,
+                           const QString& ownerSlug,
+                           const QString& projectSlug,
+                           bool createNewProject);
+
     QString m_bearerToken;
     std::atomic_bool m_canceled{false};
 };

--- a/src/QtMeshCloudSession.h
+++ b/src/QtMeshCloudSession.h
@@ -6,6 +6,7 @@
 
 #include <QObject>
 #include <atomic>
+#include <memory>
 
 struct CloudPackageUploadRequest {
     QString mainAssetPath;
@@ -60,6 +61,7 @@ private:
 
     QString m_bearerToken;
     std::atomic_bool m_canceled{false};
+    std::shared_ptr<std::atomic_bool> m_uploadCancelFlag;
 };
 
 #endif // QTMESH_CLOUD_SESSION_H

--- a/src/QtMeshCloudSession_test.cpp
+++ b/src/QtMeshCloudSession_test.cpp
@@ -15,6 +15,7 @@
 #include <QTcpServer>
 #include <QTcpSocket>
 #include <QTemporaryDir>
+#include <QTimer>
 #include <memory>
 
 namespace {
@@ -210,9 +211,14 @@ TEST_F(QtMeshCloudSessionUploadReportTest, ReportFailureDoesNotFailBinaryUpload)
             });
 
     session.uploadPackage(manifest);
+    QTimer watchdog;
+    watchdog.setSingleShot(true);
+    watchdog.setInterval(30000);
+    QObject::connect(&watchdog, &QTimer::timeout, &loop, &QEventLoop::quit);
+    watchdog.start();
     loop.exec();
 
-    EXPECT_TRUE(uploadOk);
+    ASSERT_TRUE(uploadOk) << "uploadFinished never fired (timeout or failure)";
     EXPECT_TRUE(m_mock->completeCalled());
     EXPECT_TRUE(m_mock->reportCalled());
     EXPECT_TRUE(uploadError.contains(QStringLiteral("analysis report upload failed"),

--- a/src/QtMeshCloudSession_test.cpp
+++ b/src/QtMeshCloudSession_test.cpp
@@ -1,0 +1,220 @@
+#include <gtest/gtest.h>
+
+#include "ProjectPackager.h"
+#include "QtMeshCloudSession.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QEventLoop>
+#include <QFile>
+#include <QHostAddress>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QObject>
+#include <QTcpServer>
+#include <QTcpSocket>
+#include <QTemporaryDir>
+#include <memory>
+
+namespace {
+
+struct ParsedHttpRequest {
+    QString method;
+    QString path;
+    QByteArray body;
+};
+
+ParsedHttpRequest parseHttpRequest(const QByteArray& raw)
+{
+    ParsedHttpRequest req;
+    const int headerEnd = raw.indexOf("\r\n\r\n");
+    const QByteArray headerBlock = headerEnd >= 0 ? raw.left(headerEnd) : raw;
+    req.body = headerEnd >= 0 ? raw.mid(headerEnd + 4) : QByteArray{};
+
+    const QList<QByteArray> lines = headerBlock.split('\n');
+    if (!lines.isEmpty()) {
+        const QString requestLine = QString::fromUtf8(lines.first()).trimmed();
+        req.method = requestLine.section(QLatin1Char(' '), 0, 0);
+        req.path = requestLine.section(QLatin1Char(' '), 1, 1);
+    }
+    return req;
+}
+
+void writeHttpResponse(QTcpSocket* socket, int status, const QByteArray& body)
+{
+    QByteArray response;
+    response += "HTTP/1.1 ";
+    response += QByteArray::number(status);
+    response += status == 200 ? " OK\r\n" : " Error\r\n";
+    response += "Content-Type: application/json\r\nContent-Length: ";
+    response += QByteArray::number(body.size());
+    response += "\r\nConnection: close\r\n\r\n";
+    response += body;
+    socket->write(response);
+    socket->flush();
+    socket->waitForBytesWritten(2000);
+    socket->disconnectFromHost();
+}
+
+class CloudUploadFlowMock {
+public:
+    bool listen()
+    {
+        if (!m_server.listen(QHostAddress::LocalHost))
+            return false;
+        m_baseUrl = QStringLiteral("http://127.0.0.1:%1").arg(m_server.serverPort());
+
+        QObject::connect(&m_server, &QTcpServer::newConnection, [this]() {
+            QTcpSocket* socket = m_server.nextPendingConnection();
+            QObject::connect(socket, &QTcpSocket::readyRead, socket, [this, socket]() {
+                const ParsedHttpRequest req = parseHttpRequest(socket->readAll());
+
+                if (req.method == QStringLiteral("POST") && req.path == QStringLiteral("/v1/projects")) {
+                    writeHttpResponse(
+                        socket, 200,
+                        QByteArray(
+                            R"({"project":{"id":"proj-1","ownerSlug":"testowner","slug":"testproj"}})"));
+                    return;
+                }
+
+                if (req.method == QStringLiteral("POST")
+                    && req.path.endsWith(QStringLiteral("/files/upload-urls"))) {
+                    QJsonObject upload;
+                    upload.insert(QStringLiteral("id"), QStringLiteral("file-main"));
+                    upload.insert(QStringLiteral("uploadUrl"),
+                                  QStringLiteral("%1/binary/file-main").arg(m_baseUrl));
+                    upload.insert(QStringLiteral("sanitizedName"), QStringLiteral("model.obj"));
+                    upload.insert(QStringLiteral("role"), QStringLiteral("main"));
+
+                    QJsonObject root;
+                    root.insert(QStringLiteral("uploadMethod"), QStringLiteral("PUT"));
+                    root.insert(QStringLiteral("uploads"), QJsonArray{upload});
+                    writeHttpResponse(socket, 200, QJsonDocument(root).toJson(QJsonDocument::Compact));
+                    return;
+                }
+
+                if (req.method == QStringLiteral("PUT")
+                    && req.path.startsWith(QStringLiteral("/binary/"))) {
+                    writeHttpResponse(socket, 200, QByteArray(R"({"ok":true})"));
+                    return;
+                }
+
+                if (req.method == QStringLiteral("POST")
+                    && req.path.endsWith(QStringLiteral("/files/complete"))) {
+                    m_completeCalled = true;
+                    writeHttpResponse(
+                        socket, 200,
+                        QByteArray(R"({"ok":true,"scanStatus":"warning","files":[{"id":"file-main"}]})"));
+                    return;
+                }
+
+                if (req.method == QStringLiteral("PUT")
+                    && req.path.contains(QStringLiteral("/files/file-main/report"))) {
+                    m_reportCalled = true;
+                    if (m_failReport) {
+                        writeHttpResponse(socket, 500, QByteArray(R"({"error":"report failed"})"));
+                        return;
+                    }
+                    writeHttpResponse(socket, 200, QByteArray(R"({"ok":true,"file":{"id":"file-main"}})"));
+                    return;
+                }
+
+                writeHttpResponse(socket, 404, QByteArray(R"({"error":"not found"})"));
+            });
+        });
+        return true;
+    }
+
+    quint16 port() const { return m_server.serverPort(); }
+
+    QString baseUrl() const { return m_baseUrl; }
+
+    bool completeCalled() const { return m_completeCalled; }
+    bool reportCalled() const { return m_reportCalled; }
+
+    bool m_failReport = false;
+
+private:
+    QTcpServer m_server;
+    QString m_baseUrl;
+    bool m_completeCalled = false;
+    bool m_reportCalled = false;
+};
+
+QJsonObject minimalScanReport()
+{
+    QJsonObject report;
+    report.insert(QStringLiteral("version"), QStringLiteral("3.0.0"));
+    QJsonObject summary;
+    summary.insert(QStringLiteral("scanned"), 1);
+    report.insert(QStringLiteral("summary"), summary);
+    return report;
+}
+
+} // namespace
+
+class QtMeshCloudSessionUploadReportTest : public ::testing::Test {
+protected:
+    void SetUp() override
+    {
+        m_hadApiBase = qEnvironmentVariableIsSet("QTMESH_API_BASE");
+        if (m_hadApiBase)
+            m_originalApiBase = qgetenv("QTMESH_API_BASE");
+
+        m_mock = std::make_unique<CloudUploadFlowMock>();
+        ASSERT_TRUE(m_mock->listen());
+        qputenv("QTMESH_API_BASE", m_mock->baseUrl().toUtf8());
+    }
+
+    void TearDown() override
+    {
+        if (m_hadApiBase)
+            qputenv("QTMESH_API_BASE", m_originalApiBase);
+        else
+            qunsetenv("QTMESH_API_BASE");
+    }
+
+    std::unique_ptr<CloudUploadFlowMock> m_mock;
+    QByteArray m_originalApiBase;
+    bool m_hadApiBase = false;
+};
+
+TEST_F(QtMeshCloudSessionUploadReportTest, ReportFailureDoesNotFailBinaryUpload)
+{
+    ASSERT_NE(QCoreApplication::instance(), nullptr);
+
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString modelPath = QDir(dir.path()).filePath(QStringLiteral("model.obj"));
+    QFile model(modelPath);
+    ASSERT_TRUE(model.open(QIODevice::WriteOnly));
+    model.write("v 0 0 0\n");
+    model.close();
+
+    PackageMetadata manifest = ProjectPackager::buildManifest(modelPath, {}, QStringLiteral("Test"));
+    manifest.scanSummary = minimalScanReport();
+    ASSERT_FALSE(manifest.files.isEmpty());
+
+    m_mock->m_failReport = true;
+
+    QtMeshCloudSession session(QStringLiteral("session-token"));
+    QEventLoop loop;
+    bool uploadOk = false;
+    QString uploadError;
+    QObject::connect(&session, &QtMeshCloudSession::uploadFinished, &loop,
+            [&](bool ok, const QString& error, const QString&, const QString&) {
+                uploadOk = ok;
+                uploadError = error;
+                loop.quit();
+            });
+
+    session.uploadPackage(manifest);
+    loop.exec();
+
+    EXPECT_TRUE(uploadOk);
+    EXPECT_TRUE(m_mock->completeCalled());
+    EXPECT_TRUE(m_mock->reportCalled());
+    EXPECT_TRUE(uploadError.contains(QStringLiteral("analysis report upload failed"),
+                                     Qt::CaseInsensitive));
+}

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2732,7 +2732,7 @@ void MainWindow::uploadFilesToQtMeshCloud()
             return;
     }
 
-    QString mainAssetPath = primaryCloudAssetPath();
+    const QString mainAssetPath = primaryCloudAssetPath();
     if (mainAssetPath.isEmpty()) {
         QMessageBox::information(this, tr("QtMesh Cloud Upload"),
                                  tr("Open a model first, then upload it with its dependencies."));
@@ -2747,106 +2747,88 @@ void MainWindow::uploadFilesToQtMeshCloud()
         return;
     }
 
-    QProgressDialog progress(tr("Loading cloud projects..."), tr("Cancel"), 0, 0, this);
-    progress.setWindowModality(Qt::WindowModal);
-    progress.setMinimumDuration(0);
-    progress.show();
+    statusBar()->showMessage(tr("Loading cloud projects…"), 0);
+    m_cloudUploadProgress->start(tr("Loading cloud projects…"), 1);
 
     QtMeshCloudSession* session = cloudSessionForToken(token);
-
-    QEventLoop listLoop;
-    QList<QtMeshCloudClient::ProjectSummary> projects;
-    QString listError;
+    QPointer<MainWindow> self(this);
     connect(session, &QtMeshCloudSession::projectsListed, this,
-            [&](const QList<QtMeshCloudClient::ProjectSummary>& listed, const QString& err) {
-                projects = listed;
-                listError = err;
-                listLoop.quit();
+            [self, token, mainAssetPath](const QList<QtMeshCloudClient::ProjectSummary>& projects,
+                                         const QString& listError) {
+                if (!self)
+                    return;
+
+                self->m_cloudUploadProgress->hideProgress();
+                self->statusBar()->clearMessage();
+
+                if (!listError.isEmpty()) {
+                    QMessageBox::warning(self, self->tr("QtMesh Cloud Upload"),
+                                         self->tr("Could not load your cloud projects.\n\n%1")
+                                             .arg(listError));
+                    return;
+                }
+                if (projects.isEmpty()) {
+                    QMessageBox::information(
+                        self, self->tr("QtMesh Cloud Upload"),
+                        self->tr("You do not have any cloud projects yet. Create a project on "
+                                 "QtMesh Cloud first, then upload files into it."));
+                    return;
+                }
+
+                CloudUploadDialog dialog(self);
+                dialog.setAccountLabel(storedCloudDisplayName());
+                dialog.setProjects(projects);
+                dialog.setMainAssetPath(mainAssetPath);
+
+                if (dialog.exec() != QDialog::Accepted)
+                    return;
+
+                if (!dialog.hasSelectedProject()) {
+                    QMessageBox::warning(self, self->tr("QtMesh Cloud Upload"),
+                                         self->tr("Select a cloud project."));
+                    return;
+                }
+
+                const QtMeshCloudClient::ProjectSummary selectedProject = dialog.selectedProject();
+
+                CloudPackageUploadRequest request;
+                request.mainAssetPath = mainAssetPath;
+                request.selectedAbsolutePaths = dialog.selectedAbsolutePathsForUpload();
+                request.projectName = dialog.projectName();
+                request.ownerSlug = selectedProject.ownerSlug;
+                request.projectSlug = selectedProject.projectSlug;
+                request.createNewProject = false;
+                request.runLocalScan = dialog.runLocalScanBeforeUpload();
+
+                self->startCloudPackageUpload(self->cloudSessionForToken(token), request);
             },
             Qt::SingleShotConnection);
+
     session->listProjects();
-    listLoop.exec();
-    progress.close();
+}
 
-    if (!listError.isEmpty()) {
-        QMessageBox::warning(this, tr("QtMesh Cloud Upload"),
-                             tr("Could not load your cloud projects.\n\n%1").arg(listError));
-        return;
-    }
-    if (projects.isEmpty()) {
-        QMessageBox::information(
-            this, tr("QtMesh Cloud Upload"),
-            tr("You do not have any cloud projects yet. Create a project on QtMesh Cloud first, "
-               "then upload files into it."));
-        return;
-    }
-
-    CloudUploadDialog dialog(this);
-    dialog.setAccountLabel(storedCloudDisplayName());
-    dialog.setProjects(projects);
-    dialog.setMainAssetPath(mainAssetPath);
-
-    if (dialog.exec() != QDialog::Accepted)
+void MainWindow::startCloudPackageUpload(QtMeshCloudSession* session,
+                                         const CloudPackageUploadRequest& request)
+{
+    if (!session)
         return;
 
-    if (!dialog.hasSelectedProject()) {
-        QMessageBox::warning(this, tr("QtMesh Cloud Upload"), tr("Select a cloud project."));
-        return;
-    }
+    disconnect(session, &QtMeshCloudSession::uploadProgress, this, nullptr);
+    disconnect(session, &QtMeshCloudSession::uploadFinished, this, nullptr);
+    disconnect(session, &QtMeshCloudSession::uploadCanceled, this, nullptr);
+    disconnect(session, &QtMeshCloudSession::uploadPrepareWarning, this, nullptr);
+    disconnect(m_cloudUploadProgress, &CloudUploadProgress::cancelRequested, session, nullptr);
 
-    const QtMeshCloudClient::ProjectSummary selectedProject = dialog.selectedProject();
-
-    if (dialog.runLocalScanBeforeUpload()) {
-        QProgressDialog scanProgress(tr("Running local scan..."), QString(), 0, 0, this);
-        scanProgress.setWindowModality(Qt::WindowModal);
-        scanProgress.setMinimumDuration(0);
-        scanProgress.show();
-
-        const QFileInfo mainAssetInfo(mainAssetPath);
-        QString scanError;
-        const QByteArray scanJson = AssetScanController::runIsolatedScanJsonSync(
-            mainAssetInfo.absolutePath(), mainAssetInfo.fileName(), &scanError);
-        scanProgress.close();
-
-        if (scanJson.isEmpty()) {
-            QMessageBox::warning(this, tr("QtMesh Cloud Upload"),
-                                 tr("Local scan failed; continuing without scan summary.\n\n%1")
-                                     .arg(scanError));
-        } else {
-            QJsonParseError parseError;
-            const QJsonDocument doc = QJsonDocument::fromJson(scanJson, &parseError);
-            if (parseError.error != QJsonParseError::NoError || !doc.isObject()) {
-                QMessageBox::warning(
-                    this, tr("QtMesh Cloud Upload"),
-                    tr("Local scan returned invalid JSON; continuing without scan summary.\n\n%1")
-                        .arg(parseError.errorString()));
-            } else {
-                dialog.setScanSummary(doc.object());
-            }
-        }
-    }
-
-    PackageMetadata manifest = dialog.manifest();
-    if (manifest.files.isEmpty()) {
-        QMessageBox::warning(this, tr("QtMesh Cloud Upload"),
-                             tr("Select at least one file to upload."));
-        return;
-    }
-
-    for (const PackageEntry& entry : manifest.files) {
-        if (!QFileInfo::exists(entry.absolutePath)) {
-            QMessageBox::warning(this, tr("QtMesh Cloud Upload"),
-                                 tr("Missing file: %1").arg(QFileInfo(entry.absolutePath).fileName()));
-            return;
-        }
-    }
-
-    session = cloudSessionForToken(token);
-    m_cloudUploadProgress->start(tr("Uploading to QtMesh Cloud…"), manifest.files.size() + 1);
+    m_cloudUploadProgress->start(tr("Preparing QtMesh Cloud upload…"), 1);
 
     connect(session, &QtMeshCloudSession::uploadProgress, this,
             [this](int current, int total, const QString& fileName) {
                 m_cloudUploadProgress->updateProgress(current, total, fileName);
+            });
+    connect(session, &QtMeshCloudSession::uploadPrepareWarning, this,
+            [this](const QString& warning) {
+                if (!warning.isEmpty())
+                    statusBar()->showMessage(warning, 8000);
             });
     connect(m_cloudUploadProgress, &CloudUploadProgress::cancelRequested, session,
             &QtMeshCloudSession::cancel);
@@ -2854,12 +2836,11 @@ void MainWindow::uploadFilesToQtMeshCloud()
     connect(session, &QtMeshCloudSession::uploadCanceled, this, [this]() {
         m_cloudUploadProgress->finish(false, tr("Upload canceled"));
         QTimer::singleShot(3000, m_cloudUploadProgress, &CloudUploadProgress::hideProgress);
-    });
+    }, Qt::SingleShotConnection);
 
     connect(session, &QtMeshCloudSession::uploadFinished, this,
-            [this, fileCount = manifest.files.size()](bool ok, const QString& error,
-                                                      const QString& projectUrl,
-                                                      const QString& scanStatus) {
+            [this](bool ok, const QString& error, const QString& projectUrl,
+                   const QString& scanStatus) {
                 if (!ok) {
                     m_cloudUploadProgress->finish(false, tr("Upload failed"));
                     QMessageBox::warning(this, tr("QtMesh Cloud Upload"),
@@ -2869,14 +2850,23 @@ void MainWindow::uploadFilesToQtMeshCloud()
                 }
 
                 m_cloudUploadProgress->finish(true, tr("Upload complete"));
-                statusBar()->showMessage(tr("Uploaded %1 file(s) to QtMesh Cloud.").arg(fileCount), 5000);
+                statusBar()->showMessage(tr("Uploaded to QtMesh Cloud."), 5000);
 
                 QMessageBox done(this);
-                done.setIcon(QMessageBox::Information);
+                if (!error.isEmpty()) {
+                    done.setIcon(QMessageBox::Warning);
+                } else {
+                    done.setIcon(QMessageBox::Information);
+                }
                 done.setWindowTitle(tr("QtMesh Cloud Upload"));
-                done.setText(tr("Uploaded %1 file(s) to QtMesh Cloud.").arg(fileCount));
-                if (!scanStatus.isEmpty())
-                    done.setInformativeText(tr("Scan status: %1").arg(scanStatus));
+                done.setText(tr("Upload to QtMesh Cloud completed."));
+                QString infoText;
+                if (!error.isEmpty())
+                    infoText = error;
+                else if (!scanStatus.isEmpty())
+                    infoText = tr("Scan status: %1").arg(scanStatus);
+                if (!infoText.isEmpty())
+                    done.setInformativeText(infoText);
                 QPushButton* openButton = nullptr;
                 QPushButton* copyButton = nullptr;
                 if (!projectUrl.isEmpty()) {
@@ -2891,10 +2881,10 @@ void MainWindow::uploadFilesToQtMeshCloud()
                     QApplication::clipboard()->setText(projectUrl);
 
                 QTimer::singleShot(3000, m_cloudUploadProgress, &CloudUploadProgress::hideProgress);
-            });
+            },
+            Qt::SingleShotConnection);
 
-    session->uploadPackage(manifest, selectedProject.ownerSlug, selectedProject.projectSlug,
-                                  false);
+    session->uploadPackageFromAssets(request);
 }
 
 void MainWindow::setPlaying(bool playing)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2747,10 +2747,17 @@ void MainWindow::uploadFilesToQtMeshCloud()
         return;
     }
 
+    if (m_cloudUploadListingInFlight) {
+        statusBar()->showMessage(tr("Cloud upload already in progress…"), 3000);
+        return;
+    }
+    m_cloudUploadListingInFlight = true;
+
     statusBar()->showMessage(tr("Loading cloud projects…"), 0);
     m_cloudUploadProgress->start(tr("Loading cloud projects…"), 1);
 
     QtMeshCloudSession* session = cloudSessionForToken(token);
+    disconnect(session, &QtMeshCloudSession::projectsListed, this, nullptr);
     QPointer<MainWindow> self(this);
     connect(session, &QtMeshCloudSession::projectsListed, this,
             [self, token, mainAssetPath](const QList<QtMeshCloudClient::ProjectSummary>& projects,
@@ -2758,6 +2765,7 @@ void MainWindow::uploadFilesToQtMeshCloud()
                 if (!self)
                     return;
 
+                self->m_cloudUploadListingInFlight = false;
                 self->m_cloudUploadProgress->hideProgress();
                 self->statusBar()->clearMessage();
 
@@ -2772,6 +2780,21 @@ void MainWindow::uploadFilesToQtMeshCloud()
                         self, self->tr("QtMesh Cloud Upload"),
                         self->tr("You do not have any cloud projects yet. Create a project on "
                                  "QtMesh Cloud first, then upload files into it."));
+                    return;
+                }
+
+                if (!CloudCredentialStore::hasSession()) {
+                    QMessageBox::warning(self, self->tr("QtMesh Cloud Upload"),
+                                         self->tr("Your QtMesh Cloud session expired. Sign in again."));
+                    self->updateCloudAuthActions();
+                    return;
+                }
+                const QString currentToken = CloudCredentialStore::loadSession().token;
+                if (currentToken.isEmpty() || currentToken != token) {
+                    QMessageBox::warning(self, self->tr("QtMesh Cloud Upload"),
+                                         self->tr("Your QtMesh Cloud session changed while loading "
+                                                  "projects. Sign in again and retry."));
+                    self->updateCloudAuthActions();
                     return;
                 }
 
@@ -2800,7 +2823,7 @@ void MainWindow::uploadFilesToQtMeshCloud()
                 request.createNewProject = false;
                 request.runLocalScan = dialog.runLocalScanBeforeUpload();
 
-                self->startCloudPackageUpload(self->cloudSessionForToken(token), request);
+                self->startCloudPackageUpload(self->cloudSessionForToken(currentToken), request);
             },
             Qt::SingleShotConnection);
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -32,6 +32,7 @@ class QToolButton;
 class CloudAccountMenuButton;
 class CloudUploadProgress;
 class QtMeshCloudSession;
+struct CloudPackageUploadRequest;
 class OgreWidget;
 
 namespace Ui {
@@ -207,6 +208,8 @@ private:
     QAction* m_cloudUploadMenuAction = nullptr;
 
     void updateCloudUploadActionState();
+    void startCloudPackageUpload(QtMeshCloudSession* session,
+                                 const CloudPackageUploadRequest& request);
 
     /// View menu entries for bottom tabbed docks — checked state follows user
     /// preference, not QDockWidget::isVisible() (inactive tabs would otherwise

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -206,6 +206,7 @@ private:
     CloudUploadProgress* m_cloudUploadProgress = nullptr;
     QtMeshCloudSession* m_cloudSession = nullptr;
     QAction* m_cloudUploadMenuAction = nullptr;
+    bool m_cloudUploadListingInFlight = false;
 
     void updateCloudUploadActionState();
     void startCloudPackageUpload(QtMeshCloudSession* session,


### PR DESCRIPTION
## Summary
- Add `QtMeshCloudClient::uploadFileReport()` (PUT `/v1/u/{owner}/p/{project}/files/{fileId}/report`) and call it after `completeUpload` in the GUI session, CLI `cloud upload`, and MCP `cloud_upload` tool.
- Attach the aggregate local scan JSON (`ScanEngine::scanReportToJsonObject` format) to `mainFileId` only; report upload failure is non-fatal with a user-visible warning.
- Move scan, manifest SHA256 prep, and project listing off the GUI thread via `uploadPackageFromAssets()` so the editor stays responsive during upload.

## Test plan
- [x] `UnitTests --gtest_filter="QtMeshCloudClient*:QtMeshCloudSession*:CloudUpload*"` (64 tests)
- [x] New HTTP mock tests for `uploadFileReport` (PUT path, auth, ordering after complete)
- [x] `QtMeshCloudSessionUploadReportTest.ReportFailureDoesNotFailBinaryUpload`
- [ ] Manual: upload asset with local scan enabled; confirm website shows report and app stays responsive


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cloud uploads now automatically upload analysis reports after file transfer when available.
  * Enhanced cloud upload workflow with improved dependency detection and project configuration.

* **Bug Fixes**
  * Improved upload progress display handling for better feedback.

* **Documentation**
  * Updated help text for the cloud upload command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->