### PR TITLE
fix(release): ONNX Runtime bundling + Windows installer upload (3.8.1)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -558,7 +558,10 @@ jobs:
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-          file: QtMeshEditor-${{github.ref_name}}-setup-Windows.exe
+          # Inno Setup writes to packaging/windows/Output/ (its default OutputDir,
+          # next to the .iss) — the upload must point there, not the repo root,
+          # or the installer asset is never attached to the release.
+          file: packaging/windows/Output/QtMeshEditor-${{github.ref_name}}-setup-Windows.exe
           update_latest_release: true
           overwrite: false
           verbose: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 3.8.0 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 3.8.1 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Available on the [GitHub Actions Marketplace](https://github.com/marketplace/act
 **Versioning**
 
 - **Always follow the latest GitHub release** — use the Marketplace floating tag `fernandotonon/QtMeshEditor@v1` (same pattern as the [Marketplace example](https://github.com/marketplace/actions/qtmesheditor)). The composite action defaults to `image-tag: latest`, so the Docker CLI tracks the newest published `ghcr.io/fernandotonon/qtmesh` image.
-- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.8.0**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
+- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.8.1**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
 
 Pinned workflow template (action + `ghcr.io` image aligned):
 
@@ -53,10 +53,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run QtMesh scan
-        uses: fernandotonon/QtMeshEditor@3.8.0
+        uses: fernandotonon/QtMeshEditor@3.8.1
         with:
           command: scan
-          image-tag: "3.8.0"
+          image-tag: "3.8.1"
         env:
           QTMESH_CLOUD_TOKEN: ${{ secrets.QTMESH_CLOUD_TOKEN }}
 ```
@@ -81,37 +81,37 @@ Release tags are listed on the [releases page](https://github.com/fernandotonon/
 
 ```yaml
 # Validate a specific mesh
-- uses: fernandotonon/QtMeshEditor@3.8.0
+- uses: fernandotonon/QtMeshEditor@3.8.1
   with:
     command: validate
     input-file: ./models/character.fbx
-    image-tag: "3.8.0"
+    image-tag: "3.8.1"
 
 # Convert FBX → glTF
-- uses: fernandotonon/QtMeshEditor@3.8.0
+- uses: fernandotonon/QtMeshEditor@3.8.1
   with:
     command: convert
     input-file: ./models/character.fbx
     output-file: ./output/character.gltf2
-    image-tag: "3.8.0"
+    image-tag: "3.8.1"
 
 # Resample Mixamo animations (200+ keyframes → 30)
-- uses: fernandotonon/QtMeshEditor@3.8.0
+- uses: fernandotonon/QtMeshEditor@3.8.1
   with:
     command: anim
     input-file: ./animations/dance.fbx
     output-file: ./output/dance_optimized.fbx
     options: --resample 30
-    image-tag: "3.8.0"
+    image-tag: "3.8.1"
 
 # Get mesh info as JSON
-- uses: fernandotonon/QtMeshEditor@3.8.0
+- uses: fernandotonon/QtMeshEditor@3.8.1
   id: info
   with:
     command: info
     input-file: ./models/character.fbx
     options: --json
-    image-tag: "3.8.0"
+    image-tag: "3.8.1"
 
 # Docker (alternative — :latest tracks newest image; pin :3.4.0 to match semver action ref)
 docker run --rm -v $(pwd):/workspace ghcr.io/fernandotonon/qtmesh:latest scan ./assets --fail-on error

--- a/cmake/OnnxRuntime.cmake
+++ b/cmake/OnnxRuntime.cmake
@@ -70,6 +70,13 @@ endif()
 list(GET _ort_libs 0 QTMESH_ONNX_RUNTIME_LIB)
 set(QTMESH_ONNX_RUNTIME_LIB "${QTMESH_ONNX_RUNTIME_LIB}"
     CACHE FILEPATH "Path to the ONNX Runtime shared library to ship next to the binary" FORCE)
+# The lib dir holds the versioned shared lib PLUS its SONAME symlinks
+# (libonnxruntime.so.1 / libonnxruntime.so) that the loader actually requests
+# at runtime — copying only the resolved file leaves the binary unable to find
+# libonnxruntime.so.1. Expose the dir so the POST_BUILD copies the whole set.
+get_filename_component(QTMESH_ONNX_LIB_DIR "${QTMESH_ONNX_RUNTIME_LIB}" DIRECTORY)
+set(QTMESH_ONNX_LIB_DIR "${QTMESH_ONNX_LIB_DIR}"
+    CACHE PATH "Directory of the ONNX Runtime shared library + its SONAME symlinks" FORCE)
 
 add_library(qtmesh_onnx SHARED IMPORTED GLOBAL)
 set_target_properties(qtmesh_onnx PROPERTIES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -583,12 +583,20 @@ endif()
 # won't be found at runtime.
 if(ENABLE_ONNX)
     target_link_libraries(${CMAKE_PROJECT_NAME} qtmesh_onnx)
-    if(QTMESH_ONNX_RUNTIME_LIB)
-        add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                    "${QTMESH_ONNX_RUNTIME_LIB}"
-                    "$<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>"
-            COMMENT "Copying ONNX Runtime shared library next to QtMeshEditor")
+    if(QTMESH_ONNX_LIB_DIR)
+        # Copy the versioned lib AND its SONAME symlinks (libonnxruntime.so.1 /
+        # .so) — the loader requests the SONAME, not the resolved versioned name,
+        # so copying only one file breaks `.deb`/Docker packaging.
+        file(GLOB _ort_runtime_libs
+            "${QTMESH_ONNX_LIB_DIR}/libonnxruntime.so*"
+            "${QTMESH_ONNX_LIB_DIR}/libonnxruntime*.dylib"
+            "${QTMESH_ONNX_LIB_DIR}/onnxruntime.dll")
+        foreach(_ortlib ${_ort_runtime_libs})
+            add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                        "${_ortlib}" "$<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>"
+                COMMENT "Copying ONNX Runtime lib ${_ortlib} next to QtMeshEditor")
+        endforeach()
     endif()
 endif()
 
@@ -696,12 +704,17 @@ if(BUILD_TESTS)
     # Link ONNX Runtime for tests if enabled (#404)
     if(ENABLE_ONNX)
         target_link_libraries(UnitTests qtmesh_onnx)
-        if(QTMESH_ONNX_RUNTIME_LIB)
-            add_custom_command(TARGET UnitTests POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                        "${QTMESH_ONNX_RUNTIME_LIB}"
-                        "$<TARGET_FILE_DIR:UnitTests>"
-                COMMENT "Copying ONNX Runtime shared library next to UnitTests")
+        if(QTMESH_ONNX_LIB_DIR)
+            file(GLOB _ort_test_libs
+                "${QTMESH_ONNX_LIB_DIR}/libonnxruntime.so*"
+                "${QTMESH_ONNX_LIB_DIR}/libonnxruntime*.dylib"
+                "${QTMESH_ONNX_LIB_DIR}/onnxruntime.dll")
+            foreach(_ortlib ${_ort_test_libs})
+                add_custom_command(TARGET UnitTests POST_BUILD
+                    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                            "${_ortlib}" "$<TARGET_FILE_DIR:UnitTests>"
+                    COMMENT "Copying ONNX Runtime lib ${_ortlib} next to UnitTests")
+            endforeach()
         endif()
     endif()
 

--- a/website/src/hooks/useQtmeshActionRef.js
+++ b/website/src/hooks/useQtmeshActionRef.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 const QTMESH_RELEASES_LATEST_API = 'https://api.github.com/repos/fernandotonon/QtMeshEditor/releases/latest';
-const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.8.0';
+const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.8.1';
 const CACHE_KEY = 'qtmesh.actionRef.cache.v1';
 const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 


### PR DESCRIPTION
Hotfix for the **broken 3.8.0 release** — two independent release-pipeline bugs surfaced after 3.8.0 published.

## 1. Linux/Docker binary won't start — `libonnxruntime.so.1: cannot open shared object file`
Since #404 turned `ENABLE_ONNX` on for the Linux release, the binary links ONNX Runtime, but the POST_BUILD copied only the **resolved** versioned lib (`libonnxruntime.so.1.20.1`), not the **SONAME** the loader requests (`libonnxruntime.so.1`). So `./bin/*.so*` packaging never included a loadable name → the `.deb`/Docker binary aborts on startup. Caught by **both** `scan-assets-qtmesh` (PR #749) and `docker-publish`'s `ldd` check (3.8.0 release run).

**Fix:** `cmake/OnnxRuntime.cmake` exposes `QTMESH_ONNX_LIB_DIR`; the app + UnitTests POST_BUILD now glob-copy every `libonnxruntime.so*` / `.dylib` / `.dll` (versioned file **and** SONAME symlinks) next to the binary.

## 2. Windows installer never attached to releases
Inno Setup writes to `packaging/windows/Output/` (its default `OutputDir`), but the release upload globbed the repo root → `Can not find any file by QtMeshEditor-<v>-setup-Windows.exe`. This has failed **every release since ~3.5.x** (build + smoke tests pass; only the installer-upload step fails).

**Fix:** point the upload `file:` at `packaging/windows/Output/`.

## Release
Bumps to **3.8.1** (+ synced pinned doc refs). Merging + re-releasing publishes a working Linux `.deb`/Docker image and finally attaches the Windows installer.

Verified: macOS configure/build still works; on Linux the glob will now ship `libonnxruntime.so.1` (+ `.so`, `.so.1.20.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)