### PR TITLE
ci: pin exact Xcode 26.3 on macOS jobs (definitive libz.tbd fix)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ env:
   # build, fails with "No rule to make target '.../Xcode_26.5/...libz.tbd'"
   # (this broke the 3.9.1 macOS deploy). Bump this whenever the pinned Xcode
   # changes so the SDK is rebuilt against it. (xcode263 = under Pin step Xcode 26.3.)
-  MACOS_CACHE_VERSION: 'sdkpin1'
+  MACOS_CACHE_VERSION: 'xc263pin'
 
 jobs:
 #  send-slack-notification:
@@ -1574,11 +1574,20 @@ jobs:
     steps:
     - name: Pin newest stable Xcode (consistent SDK across all macOS jobs)
       run: |
-            # All three macOS jobs must use the SAME Xcode/SDK: the OGRE/Assimp
+            # All macOS jobs MUST use the SAME exact Xcode/SDK: the OGRE/Assimp
             # builds bake the active SDK's absolute libz.tbd path into their
-            # CMake export, and the consumer build links against it. Different
-            # default Xcodes per job → "No rule to make target '<SDK>/libz.tbd'".
-            DEV=$(ls -d /Applications/Xcode_*.app/Contents/Developer 2>/dev/null | sort -V | tail -1)
+            # CMake export, and the consumer links against it. The per-job runner
+            # images carry different *newest* Xcodes (one job got 26.5, another
+            # 26.3), so "sort -V | tail -1" (newest) made jobs disagree and the
+            # cached SDK's baked path failed to link → "No rule to make target
+            # '.../Xcode_XX/...libz.tbd'". Pin a SPECIFIC version present on all
+            # current images (26.3); fall back to newest only if it's absent.
+            PIN="/Applications/Xcode_26.3.app/Contents/Developer"
+            if [ -d "$PIN" ]; then
+                DEV="$PIN"
+            else
+                DEV=$(ls -d /Applications/Xcode_*.app/Contents/Developer 2>/dev/null | sort -V | tail -1)
+            fi
             if [ -z "$DEV" ]; then DEV="$(xcode-select -p)"; fi
             echo "Selected Xcode: $DEV"
             sudo xcode-select -s "$DEV"
@@ -1650,7 +1659,14 @@ jobs:
     steps:
     - name: Pin newest stable Xcode (consistent SDK across all macOS jobs)
       run: |
-            DEV=$(ls -d /Applications/Xcode_*.app/Contents/Developer 2>/dev/null | sort -V | tail -1)
+            # Pin a SPECIFIC Xcode present on all macos-latest images (26.3) so
+            # producers and consumer agree on the SDK; "newest" drifts per image.
+            PIN="/Applications/Xcode_26.3.app/Contents/Developer"
+            if [ -d "$PIN" ]; then
+                DEV="$PIN"
+            else
+                DEV=$(ls -d /Applications/Xcode_*.app/Contents/Developer 2>/dev/null | sort -V | tail -1)
+            fi
             if [ -z "$DEV" ]; then DEV="$(xcode-select -p)"; fi
             echo "Selected Xcode: $DEV"
             sudo xcode-select -s "$DEV"
@@ -1731,7 +1747,14 @@ jobs:
     steps:
     - name: Pin newest stable Xcode (consistent SDK across all macOS jobs)
       run: |
-            DEV=$(ls -d /Applications/Xcode_*.app/Contents/Developer 2>/dev/null | sort -V | tail -1)
+            # Pin a SPECIFIC Xcode present on all macos-latest images (26.3) so
+            # producers and consumer agree on the SDK; "newest" drifts per image.
+            PIN="/Applications/Xcode_26.3.app/Contents/Developer"
+            if [ -d "$PIN" ]; then
+                DEV="$PIN"
+            else
+                DEV=$(ls -d /Applications/Xcode_*.app/Contents/Developer 2>/dev/null | sort -V | tail -1)
+            fi
             if [ -z "$DEV" ]; then DEV="$(xcode-select -p)"; fi
             echo "Selected Xcode: $DEV"
             sudo xcode-select -s "$DEV"


### PR DESCRIPTION
**Definitive fix for the recurring macOS `libz.tbd` deploy failure.**

Root cause (peeled back over several attempts): the macOS jobs run on runner images whose *newest* Xcode differs (one job resolved 26.5, another 26.3). The OGRE/Assimp SDKs bake the active SDK's absolute `libz.tbd` path into their CMake export, so a producer that built under 26.5 cached an SDK the 26.3 consumer can't link (`No rule to make target '.../Xcode_26.5/...libz.tbd'`). `sort -V | tail -1` (newest) is non-deterministic across images; SDKROOT pinning helped the app's own ZLIB but the cached `Codec_Assimp`/ogre dylibs still carried the producer's path.

**Fix:** pin a SPECIFIC Xcode (26.3, present on all current `macos-latest` images) on all three macOS jobs, falling back to newest only if absent — so producers and consumer always agree on the SDK. Bump `MACOS_CACHE_VERSION` → `xc263pin` to discard the assimp+ogre caches that still carry a 26.5 path. (Keeps the SDKROOT pin + self-heal OGRE rebuild from the prior fixes as belt-and-suspenders.)

Needed to complete the **3.9.1 macOS deploy** (Windows + Linux already published; macOS artifact + Homebrew cask pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS CI/CD pipeline cache versioning to force rebuild when necessary.
  * Modified Xcode SDK selection logic to use pinned installation with fallback to automatic detection for improved build consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->