### PR TITLE
UV Editor: UV component selection (issue #460)

### DIFF
--- a/qml/UVEditorPanel.qml
+++ b/qml/UVEditorPanel.qml
@@ -4,7 +4,7 @@ import QtQuick.Layouts
 import PropertiesPanel 1.0
 import ThemeManager 1.0
 
-// Read-only UV layout viewer (issue #459). Software Canvas2D — no GL.
+// UV layout viewer with component selection (issues #459 / #460).
 Rectangle {
     id: root
     color: ThemeManager.panelColor
@@ -17,6 +17,21 @@ Rectangle {
 
     property var triCache: []
     property int cachedRevision: -1
+    property int cachedSelectionRevision: -1
+    property var selVertCache: []
+    property var selEdgeCache: []
+    property var selFaceCache: []
+    property var ctxIslandCache: []
+
+    property bool draggingSelect: false
+    property real dragStartX: 0
+    property real dragStartY: 0
+    property real dragEndX: 0
+    property real dragEndY: 0
+
+    readonly property int modNone: 0
+    readonly property int modShift: 0x02000000
+    readonly property int modCtrl: 0x04000000
 
     function uvToScreen(u, v) {
         return Qt.point(
@@ -33,11 +48,30 @@ Rectangle {
     }
 
     function rebuildTriangleCache() {
-        if (UVEditorController.meshRevision === cachedRevision)
+        if (UVEditorController.meshRevision === cachedRevision
+                && UVEditorController.selectionRevision === cachedSelectionRevision)
             return
         cachedRevision = UVEditorController.meshRevision
+        cachedSelectionRevision = UVEditorController.selectionRevision
         triCache = UVEditorController.triangles()
+        selVertCache = UVEditorController.selectionVertices()
+        selEdgeCache = UVEditorController.selectionEdges()
+        selFaceCache = UVEditorController.selectionFaces()
+        ctxIslandCache = UVEditorController.contextIslandFaces()
         viewCanvas.requestPaint()
+    }
+
+    function pickRadiusUv() {
+        return 8.0 / Math.max(1, root.zoom)
+    }
+
+    function eventModifiers(event) {
+        let m = modNone
+        if (event.modifiers & Qt.ShiftModifier)
+            m |= modShift
+        if (event.modifiers & Qt.ControlModifier)
+            m |= modCtrl
+        return m
     }
 
     function resetView() {
@@ -77,6 +111,8 @@ Rectangle {
         }
         function onFitToViewRequested() { root.fitToView() }
         function onShowTextureBackgroundChanged() { viewCanvas.requestPaint() }
+        function onUvSelectionChanged() { root.rebuildTriangleCache() }
+        function onSelectionModeChanged() { viewCanvas.requestPaint() }
     }
 
     Component.onCompleted: {
@@ -90,6 +126,15 @@ Rectangle {
             event.accepted = true
         } else if (event.key === Qt.Key_Home) {
             resetView()
+            event.accepted = true
+        } else if (event.key === Qt.Key_1) {
+            UVEditorController.selectionMode = 0
+            event.accepted = true
+        } else if (event.key === Qt.Key_2) {
+            UVEditorController.selectionMode = 1
+            event.accepted = true
+        } else if (event.key === Qt.Key_3) {
+            UVEditorController.selectionMode = 2
             event.accepted = true
         }
     }
@@ -117,6 +162,73 @@ Rectangle {
                       : ""
                 color: ThemeManager.disabledTextColor
                 font.pixelSize: 10
+            }
+
+            Row {
+                spacing: 2
+                Repeater {
+                    model: [
+                        { label: "V", mode: 0, tip: "UV Vertex (1)" },
+                        { label: "E", mode: 1, tip: "UV Edge (2)" },
+                        { label: "F", mode: 2, tip: "UV Face (3)" }
+                    ]
+                    delegate: Rectangle {
+                        width: 20; height: 18; radius: 3
+                        color: UVEditorController.selectionMode === modelData.mode
+                            ? ThemeManager.highlightColor
+                            : ThemeManager.inputColor
+                        border.color: ThemeManager.borderColor
+                        border.width: 1
+                        ToolTip.visible: modeMa.containsMouse
+                        ToolTip.text: modelData.tip
+                        Text {
+                            anchors.centerIn: parent
+                            text: modelData.label
+                            color: ThemeManager.textColor
+                            font.pixelSize: 10
+                            font.bold: UVEditorController.selectionMode === modelData.mode
+                        }
+                        MouseArea {
+                            id: modeMa
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: UVEditorController.selectionMode = modelData.mode
+                        }
+                    }
+                }
+            }
+
+            Row {
+                spacing: 4
+                anchors.verticalCenter: parent.verticalCenter
+                Rectangle {
+                    width: 18; height: 18; radius: 3
+                    color: UVEditorController.selectionSyncEnabled
+                        ? ThemeManager.highlightColor
+                        : ThemeManager.inputColor
+                    border.color: ThemeManager.borderColor
+                    border.width: 1
+                    anchors.verticalCenter: parent.verticalCenter
+                    Text {
+                        anchors.centerIn: parent
+                        text: UVEditorController.selectionSyncEnabled ? "\u2713" : ""
+                        color: ThemeManager.textColor
+                        font.pixelSize: 10
+                    }
+                    MouseArea {
+                        anchors.fill: parent
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: UVEditorController.selectionSyncEnabled
+                            = !UVEditorController.selectionSyncEnabled
+                    }
+                }
+                Text {
+                    text: "Sync"
+                    color: ThemeManager.textColor
+                    font.pixelSize: 11
+                    anchors.verticalCenter: parent.verticalCenter
+                }
             }
 
             Text {
@@ -247,7 +359,9 @@ Rectangle {
                     }
 
                     drawGrid(ctx)
+                    drawContextIslands(ctx)
                     drawTriangles(ctx)
+                    drawSelection(ctx)
                     drawUnitBoundary(ctx)
                 }
 
@@ -289,6 +403,68 @@ Rectangle {
                     ctx.restore()
                 }
 
+                function drawContextIslands(ctx) {
+                    if (ctxIslandCache.length === 0)
+                        return
+                    ctx.save()
+                    for (let i = 0; i < ctxIslandCache.length; ++i) {
+                        const t = ctxIslandCache[i]
+                        const p0 = root.uvToScreen(t.u0, t.v0)
+                        const p1 = root.uvToScreen(t.u1, t.v1)
+                        const p2 = root.uvToScreen(t.u2, t.v2)
+                        ctx.beginPath()
+                        ctx.moveTo(p0.x, p0.y)
+                        ctx.lineTo(p1.x, p1.y)
+                        ctx.lineTo(p2.x, p2.y)
+                        ctx.closePath()
+                        ctx.fillStyle = Qt.rgba(ThemeManager.accentColor.r,
+                                                ThemeManager.accentColor.g,
+                                                ThemeManager.accentColor.b, 0.18)
+                        ctx.fill()
+                    }
+                    ctx.restore()
+                }
+
+                function drawSelection(ctx) {
+                    ctx.save()
+                    for (let i = 0; i < selFaceCache.length; ++i) {
+                        const t = selFaceCache[i]
+                        const p0 = root.uvToScreen(t.u0, t.v0)
+                        const p1 = root.uvToScreen(t.u1, t.v1)
+                        const p2 = root.uvToScreen(t.u2, t.v2)
+                        ctx.beginPath()
+                        ctx.moveTo(p0.x, p0.y)
+                        ctx.lineTo(p1.x, p1.y)
+                        ctx.lineTo(p2.x, p2.y)
+                        ctx.closePath()
+                        ctx.fillStyle = Qt.rgba(ThemeManager.highlightColor.r,
+                                                ThemeManager.highlightColor.g,
+                                                ThemeManager.highlightColor.b, 0.35)
+                        ctx.fill()
+                    }
+                    ctx.lineWidth = 2
+                    ctx.strokeStyle = ThemeManager.highlightColor
+                    for (let i = 0; i < selEdgeCache.length; ++i) {
+                        const e = selEdgeCache[i]
+                        const a = root.uvToScreen(e.u0, e.v0)
+                        const b = root.uvToScreen(e.u1, e.v1)
+                        ctx.beginPath()
+                        ctx.moveTo(a.x, a.y)
+                        ctx.lineTo(b.x, b.y)
+                        ctx.stroke()
+                    }
+                    const r = 4
+                    ctx.fillStyle = ThemeManager.highlightColor
+                    for (let i = 0; i < selVertCache.length; ++i) {
+                        const v = selVertCache[i]
+                        const p = root.uvToScreen(v.u, v.v)
+                        ctx.beginPath()
+                        ctx.arc(p.x, p.y, r, 0, Math.PI * 2)
+                        ctx.fill()
+                    }
+                    ctx.restore()
+                }
+
                 function drawTriangles(ctx) {
                     if (!UVEditorController.hasMesh)
                         return
@@ -323,20 +499,56 @@ Rectangle {
                 font.pixelSize: 12
             }
 
+            // Drag marquee for box select (issue #460).
+            Canvas {
+                id: marqueeCanvas
+                anchors.fill: viewCanvas
+                visible: root.draggingSelect
+                renderTarget: Canvas.Immediate
+                onPaint: {
+                    const ctx = getContext("2d")
+                    ctx.clearRect(0, 0, width, height)
+                    if (!root.draggingSelect)
+                        return
+                    const x = Math.min(root.dragStartX, root.dragEndX)
+                    const y = Math.min(root.dragStartY, root.dragEndY)
+                    const w = Math.abs(root.dragEndX - root.dragStartX)
+                    const h = Math.abs(root.dragEndY - root.dragStartY)
+                    ctx.strokeStyle = ThemeManager.highlightColor
+                    ctx.lineWidth = 1
+                    ctx.setLineDash([4, 3])
+                    ctx.strokeRect(x, y, w, h)
+                    ctx.fillStyle = Qt.rgba(ThemeManager.highlightColor.r,
+                                            ThemeManager.highlightColor.g,
+                                            ThemeManager.highlightColor.b, 0.12)
+                    ctx.fillRect(x, y, w, h)
+                }
+            }
+
             MouseArea {
+                id: selectMa
                 anchors.fill: parent
-                acceptedButtons: Qt.MiddleButton | Qt.NoButton
+                acceptedButtons: Qt.LeftButton | Qt.MiddleButton
                 hoverEnabled: true
                 preventStealing: false
 
                 property real lastX: 0
                 property real lastY: 0
+                property int activeModifiers: modNone
 
                 onPressed: function(mouse) {
+                    activeModifiers = eventModifiers(mouse)
                     if (mouse.button === Qt.MiddleButton) {
                         lastX = mouse.x
                         lastY = mouse.y
+                        return
                     }
+                    root.draggingSelect = true
+                    root.dragStartX = mouse.x
+                    root.dragStartY = mouse.y
+                    root.dragEndX = mouse.x
+                    root.dragEndY = mouse.y
+                    marqueeCanvas.requestPaint()
                 }
                 onPositionChanged: function(mouse) {
                     if (mouse.buttons & Qt.MiddleButton) {
@@ -347,7 +559,38 @@ Rectangle {
                         lastX = mouse.x
                         lastY = mouse.y
                         viewCanvas.requestPaint()
+                        return
                     }
+                    if (root.draggingSelect) {
+                        root.dragEndX = mouse.x
+                        root.dragEndY = mouse.y
+                        marqueeCanvas.requestPaint()
+                    }
+                }
+                onReleased: function(mouse) {
+                    if (mouse.button === Qt.MiddleButton)
+                        return
+                    if (!root.draggingSelect)
+                        return
+                    root.draggingSelect = false
+                    marqueeCanvas.requestPaint()
+
+                    const dx = mouse.x - root.dragStartX
+                    const dy = mouse.y - root.dragStartY
+                    const dist = Math.sqrt(dx * dx + dy * dy)
+                    const mods = activeModifiers
+
+                    if (dist < 4) {
+                        const uv = root.screenToUv(mouse.x - viewCanvas.x, mouse.y - viewCanvas.y)
+                        UVEditorController.pickAt(uv.x, uv.y, mods, root.pickRadiusUv())
+                    } else {
+                        const a = root.screenToUv(root.dragStartX - viewCanvas.x,
+                                                  root.dragStartY - viewCanvas.y)
+                        const b = root.screenToUv(root.dragEndX - viewCanvas.x,
+                                                  root.dragEndY - viewCanvas.y)
+                        UVEditorController.boxSelect(a.x, a.y, b.x, b.y, mods)
+                    }
+                    root.rebuildTriangleCache()
                 }
             }
 

--- a/qml/UVEditorPanel.qml
+++ b/qml/UVEditorPanel.qml
@@ -199,38 +199,6 @@ Rectangle {
                 }
             }
 
-            Row {
-                spacing: 4
-                anchors.verticalCenter: parent.verticalCenter
-                Rectangle {
-                    width: 18; height: 18; radius: 3
-                    color: UVEditorController.selectionSyncEnabled
-                        ? ThemeManager.highlightColor
-                        : ThemeManager.inputColor
-                    border.color: ThemeManager.borderColor
-                    border.width: 1
-                    anchors.verticalCenter: parent.verticalCenter
-                    Text {
-                        anchors.centerIn: parent
-                        text: UVEditorController.selectionSyncEnabled ? "\u2713" : ""
-                        color: ThemeManager.textColor
-                        font.pixelSize: 10
-                    }
-                    MouseArea {
-                        anchors.fill: parent
-                        cursorShape: Qt.PointingHandCursor
-                        onClicked: UVEditorController.selectionSyncEnabled
-                            = !UVEditorController.selectionSyncEnabled
-                    }
-                }
-                Text {
-                    text: "Sync"
-                    color: ThemeManager.textColor
-                    font.pixelSize: 11
-                    anchors.verticalCenter: parent.verticalCenter
-                }
-            }
-
             Text {
                 text: "Channel"
                 color: ThemeManager.disabledTextColor

--- a/src/UVEditorController.cpp
+++ b/src/UVEditorController.cpp
@@ -134,14 +134,6 @@ namespace {
 
 constexpr float kUvEpsilon = 1e-5f;
 
-uint64_t packUvKey(float u, float v)
-{
-    const auto iu = static_cast<int64_t>(std::llround(static_cast<double>(u) / kUvEpsilon));
-    const auto iv = static_cast<int64_t>(std::llround(static_cast<double>(v) / kUvEpsilon));
-    return (static_cast<uint64_t>(static_cast<uint32_t>(iu)) << 32)
-           | static_cast<uint32_t>(iv);
-}
-
 bool pointInTriangle(double u, double v, float u0, float v0, float u1, float v1, float u2, float v2)
 {
     const double dX = static_cast<double>(u) - static_cast<double>(u2);
@@ -317,10 +309,12 @@ void UVEditorController::pickAt(double u, double v, int modifiers, double pickRa
     if (m_selectionMode == FaceMode) {
         int bestFace = -1;
         double bestDistSq = 1e30;
+        bool insideTri = false;
         for (size_t fi = 0; fi < m_uvTris.size(); ++fi) {
             const auto& tri = m_uvTris[fi];
             if (pointInTriangle(u, v, tri.u[0], tri.v[0], tri.u[1], tri.v[1], tri.u[2], tri.v[2])) {
                 bestFace = static_cast<int>(fi);
+                insideTri = true;
                 break;
             }
             const double cx = (tri.u[0] + tri.u[1] + tri.u[2]) / 3.0;
@@ -331,7 +325,7 @@ void UVEditorController::pickAt(double u, double v, int modifiers, double pickRa
                 bestFace = static_cast<int>(fi);
             }
         }
-        if (bestFace >= 0)
+        if (insideTri || (bestFace >= 0 && bestDistSq <= pickRadiusSq))
             faces.insert(bestFace);
     } else if (m_selectionMode == EdgeMode) {
         int bestEdge = -1;
@@ -928,18 +922,45 @@ bool UVEditorController::buildFromEntity(Ogre::Entity* entity, const QSet<int>& 
     tris.reserve(static_cast<int>(hem.faceCount()));
 
     int heFaceIdx = 0;
-    int globalVertOffset = 0;
-    int globalTriIndex = 0;
 
-    for (size_t subIdx = 0; subIdx < mesh.subMeshes().size(); ++subIdx) {
-        const auto& sub = mesh.subMeshes()[subIdx];
+    std::vector<size_t> sourceSubIndices;
+    sourceSubIndices.reserve(displayMesh.subMeshes().size());
+    if (submeshFilter.isEmpty()) {
+        for (size_t si = 0; si < displayMesh.subMeshes().size(); ++si)
+            sourceSubIndices.push_back(si);
+    } else {
+        for (size_t si = 0; si < displayMesh.subMeshes().size(); ++si) {
+            if (submeshFilter.contains(static_cast<int>(si)))
+                sourceSubIndices.push_back(si);
+        }
+    }
 
-        auto emitTriangle = [&](const EditableTriangle& tri) {
+    auto globalVertOffsetForSub = [&](size_t sourceSubIdx) {
+        int off = 0;
+        for (size_t si = 0; si < sourceSubIdx; ++si)
+            off += static_cast<int>(displayMesh.subMeshes()[si].vertices.size());
+        return off;
+    };
+
+    auto globalTriOffsetForSub = [&](size_t sourceSubIdx) {
+        int off = 0;
+        for (size_t si = 0; si < sourceSubIdx; ++si)
+            off += static_cast<int>(displayMesh.subMeshes()[si].triangles.size());
+        return off;
+    };
+
+    for (size_t meshSubIdx = 0; meshSubIdx < mesh.subMeshes().size(); ++meshSubIdx) {
+        const size_t sourceSubIdx = sourceSubIndices[meshSubIdx];
+        const auto& sub = mesh.subMeshes()[meshSubIdx];
+        const int globalVertOffset = globalVertOffsetForSub(sourceSubIdx);
+        const int globalTriOffset = globalTriOffsetForSub(sourceSubIdx);
+
+        auto emitTriangle = [&](const EditableTriangle& tri, int meshGlobalTri) {
             if (heFaceIdx >= static_cast<int>(islands.faceIslandIds.size()))
                 return;
 
             UvTri uvTri;
-            uvTri.meshGlobalTri = globalTriIndex++;
+            uvTri.meshGlobalTri = meshGlobalTri;
             uvTri.island = islands.faceIslandIds[heFaceIdx];
 
             Ogre::Vector2 uvs[3];
@@ -978,26 +999,31 @@ bool UVEditorController::buildFromEntity(Ogre::Entity* entity, const QSet<int>& 
         };
 
         if (!sub.faces.empty()) {
+            size_t localTriCursor = 0;
             for (const auto& face : sub.faces) {
                 if (!face.isValid())
                     continue;
+                const int faceBaseGlobalTri =
+                    globalTriOffset + static_cast<int>(localTriCursor);
                 for (size_t i = 1; i + 1 < face.indices.size(); ++i) {
                     EditableTriangle tri;
                     tri.indices[0] = face.indices[0];
                     tri.indices[1] = face.indices[i];
                     tri.indices[2] = face.indices[i + 1];
-                    emitTriangle(tri);
+                    emitTriangle(tri, faceBaseGlobalTri);
                 }
+                if (face.indices.size() >= 3)
+                    localTriCursor += face.indices.size() - 2;
                 ++heFaceIdx;
             }
         } else {
+            size_t localTri = 0;
             for (const auto& tri : sub.triangles) {
-                emitTriangle(tri);
+                emitTriangle(tri, globalTriOffset + static_cast<int>(localTri));
+                ++localTri;
                 ++heFaceIdx;
             }
         }
-
-        globalVertOffset += static_cast<int>(sub.vertices.size());
     }
 
     // Weld UV corners on shared manifold edges and build UV-edge list.
@@ -1018,8 +1044,12 @@ bool UVEditorController::buildFromEntity(Ogre::Entity* entity, const QSet<int>& 
         const auto& tri = m_uvTris[ti];
         for (int e = 0; e < 3; ++e) {
             const int n = (e + 1) % 3;
-            const uint64_t key = (packUvKey(tri.u[e], tri.v[e]) << 1)
-                                 ^ packUvKey(tri.u[n], tri.v[n]);
+            int gv0 = tri.meshGlobalVert[e];
+            int gv1 = tri.meshGlobalVert[n];
+            if (gv0 > gv1)
+                std::swap(gv0, gv1);
+            const uint64_t key = (static_cast<uint64_t>(static_cast<uint32_t>(gv0)) << 32)
+                                 | static_cast<uint32_t>(gv1);
             edgeOccMap[key].push_back({static_cast<int>(ti), e, n});
         }
     }
@@ -1177,7 +1207,12 @@ void UVEditorController::rebuildMeshCache()
 
     const bool built = buildFromEntity(entity, submeshFilter, m_uvChannel);
     if (!built || entity != prevEntity) {
+        const bool pendingPull = m_selectionSyncEnabled && built && entity != prevEntity;
+        if (pendingPull)
+            m_syncInProgress = true;
         clearUvSelection();
+        if (pendingPull)
+            m_syncInProgress = false;
     }
     updateContextIslandsFromEdit();
     ++m_meshRevision;

--- a/src/UVEditorController.cpp
+++ b/src/UVEditorController.cpp
@@ -105,6 +105,8 @@ void UVEditorController::clearUvSelection()
 {
     if (m_selectedUvVerts.isEmpty() && m_selectedUvEdges.isEmpty() && m_selectedUvFaces.isEmpty())
         return;
+    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+        QStringLiteral("UV editor clear selection"));
     m_selectedUvVerts.clear();
     m_selectedUvEdges.clear();
     m_selectedUvFaces.clear();
@@ -286,6 +288,9 @@ void UVEditorController::pickAt(double u, double v, int modifiers, double pickRa
     if (!m_hasMesh || m_uvTris.empty())
         return;
 
+    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+        QStringLiteral("UV editor pick selection"));
+
     const double pickRadiusSq = pickRadiusUv * pickRadiusUv;
     QSet<int> verts;
     QSet<int> edges;
@@ -353,6 +358,9 @@ void UVEditorController::boxSelect(double uMin, double vMin, double uMax, double
 {
     if (!m_hasMesh)
         return;
+
+    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+        QStringLiteral("UV editor box selection"));
 
     if (uMin > uMax)
         std::swap(uMin, uMax);

--- a/src/UVEditorController.cpp
+++ b/src/UVEditorController.cpp
@@ -101,17 +101,6 @@ void UVEditorController::setSelectionMode(int mode)
     emit selectionModeChanged();
 }
 
-void UVEditorController::setSelectionSyncEnabled(bool on)
-{
-    if (m_selectionSyncEnabled == on)
-        return;
-    m_selectionSyncEnabled = on;
-    emit selectionSyncEnabledChanged();
-    if (on)
-        pullSelectionFromEdit();
-    notifyUvSelectionChanged();
-}
-
 void UVEditorController::clearUvSelection()
 {
     if (m_selectedUvVerts.isEmpty() && m_selectedUvEdges.isEmpty() && m_selectedUvFaces.isEmpty())
@@ -120,8 +109,6 @@ void UVEditorController::clearUvSelection()
     m_selectedUvEdges.clear();
     m_selectedUvFaces.clear();
     notifyUvSelectionChanged();
-    if (m_selectionSyncEnabled && !m_syncInProgress)
-        pushSelectionToEdit();
 }
 
 void UVEditorController::notifyUvSelectionChanged()
@@ -292,8 +279,6 @@ void UVEditorController::applySelectionSet(const QSet<int>& verts, const QSet<in
     }
 
     notifyUvSelectionChanged();
-    if (m_selectionSyncEnabled && !m_syncInProgress)
-        pushSelectionToEdit();
 }
 
 void UVEditorController::pickAt(double u, double v, int modifiers, double pickRadiusUv)
@@ -485,10 +470,7 @@ QVariantList UVEditorController::contextIslandFaces() const
 void UVEditorController::onEditSelectionChanged()
 {
     updateContextIslandsFromEdit();
-    if (m_selectionSyncEnabled && !m_syncInProgress)
-        pullSelectionFromEdit();
-    else
-        notifyUvSelectionChanged();
+    notifyUvSelectionChanged();
 }
 
 void UVEditorController::updateContextIslandsFromEdit()
@@ -530,85 +512,6 @@ void UVEditorController::updateContextIslandsFromEdit()
     }
 
     m_contextIslandIds = islands;
-}
-
-void UVEditorController::pullSelectionFromEdit()
-{
-    auto* edit = EditModeController::instance();
-    if (!edit || !edit->isEditModeActive() || !m_activeEntity
-        || edit->editEntity() != m_activeEntity)
-        return;
-
-    const bool prevSync = m_syncInProgress;
-    m_syncInProgress = true;
-    QSet<int> verts;
-    QSet<int> edges;
-    QSet<int> faces;
-
-    for (int gv : edit->selectedVertices()) {
-        for (size_t vi = 0; vi < m_uvVerts.size(); ++vi) {
-            if (m_uvVerts[vi].meshGlobalVert == gv)
-                verts.insert(static_cast<int>(vi));
-        }
-    }
-    for (const auto& ge : edit->selectedEdges()) {
-        for (size_t ei = 0; ei < m_uvEdges.size(); ++ei) {
-            const auto& ue = m_uvEdges[ei];
-            if ((ue.meshGlobalV0 == ge.first && ue.meshGlobalV1 == ge.second)
-                || (ue.meshGlobalV0 == ge.second && ue.meshGlobalV1 == ge.first))
-                edges.insert(static_cast<int>(ei));
-        }
-    }
-    for (int gt : edit->selectedFaces()) {
-        for (size_t fi = 0; fi < m_uvTris.size(); ++fi) {
-            if (m_uvTris[fi].meshGlobalTri == gt)
-                faces.insert(static_cast<int>(fi));
-        }
-    }
-
-    m_selectedUvVerts = verts;
-    m_selectedUvEdges = edges;
-    m_selectedUvFaces = faces;
-    m_syncInProgress = prevSync;
-    notifyUvSelectionChanged();
-}
-
-void UVEditorController::pushSelectionToEdit()
-{
-    auto* edit = EditModeController::instance();
-    if (!edit || !edit->isEditModeActive() || !m_activeEntity
-        || edit->editEntity() != m_activeEntity)
-        return;
-
-    m_syncInProgress = true;
-    edit->setSelectionMode(static_cast<int>(m_selectionMode));
-    edit->deselectAll();
-
-    bool first = true;
-    if (m_selectionMode == FaceMode) {
-        for (int fi : m_selectedUvFaces) {
-            if (fi < 0 || fi >= static_cast<int>(m_uvTris.size()))
-                continue;
-            edit->selectFace(m_uvTris[fi].meshGlobalTri, !first);
-            first = false;
-        }
-    } else if (m_selectionMode == EdgeMode) {
-        for (int ei : m_selectedUvEdges) {
-            if (ei < 0 || ei >= static_cast<int>(m_uvEdges.size()))
-                continue;
-            const auto& e = m_uvEdges[ei];
-            edit->selectEdge(e.meshGlobalV0, e.meshGlobalV1, !first);
-            first = false;
-        }
-    } else {
-        for (int vi : m_selectedUvVerts) {
-            if (vi < 0 || vi >= static_cast<int>(m_uvVerts.size()))
-                continue;
-            edit->selectVertex(m_uvVerts[vi].meshGlobalVert, !first);
-            first = false;
-        }
-    }
-    m_syncInProgress = false;
 }
 
 void UVEditorController::setShowTextureBackground(bool on)
@@ -1206,17 +1109,9 @@ void UVEditorController::rebuildMeshCache()
         : tr("UV layout — %1 (sub-mesh selection)").arg(QString::fromStdString(entity->getName()));
 
     const bool built = buildFromEntity(entity, submeshFilter, m_uvChannel);
-    if (!built || entity != prevEntity) {
-        const bool pendingPull = m_selectionSyncEnabled && built && entity != prevEntity;
-        if (pendingPull)
-            m_syncInProgress = true;
+    if (!built || entity != prevEntity)
         clearUvSelection();
-        if (pendingPull)
-            m_syncInProgress = false;
-    }
     updateContextIslandsFromEdit();
     ++m_meshRevision;
     emit meshDataChanged();
-    if (m_selectionSyncEnabled && !m_syncInProgress)
-        pullSelectionFromEdit();
 }

--- a/src/UVEditorController.cpp
+++ b/src/UVEditorController.cpp
@@ -29,6 +29,8 @@
 #include <queue>
 #include <cmath>
 #include <algorithm>
+#include <unordered_map>
+#include <utility>
 
 UVEditorController* UVEditorController::s_instance = nullptr;
 
@@ -72,6 +74,8 @@ void UVEditorController::connectSignals()
     if (auto* edit = EditModeController::instance()) {
         connect(edit, &EditModeController::meshDataChanged, this, &UVEditorController::refresh);
         connect(edit, &EditModeController::editModeChanged, this, &UVEditorController::refresh);
+        connect(edit, &EditModeController::editSelectionChanged, this,
+                &UVEditorController::onEditSelectionChanged);
     }
 }
 
@@ -83,6 +87,534 @@ void UVEditorController::setUvChannel(int channel)
     m_uvChannel = channel;
     emit uvChannelChanged();
     rebuildMeshCache();
+}
+
+void UVEditorController::setSelectionMode(int mode)
+{
+    mode = std::max(0, std::min(mode, 2));
+    const auto next = static_cast<SelectionMode>(mode);
+    if (m_selectionMode == next)
+        return;
+    m_selectionMode = next;
+    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+        QStringLiteral("UV editor selection mode: %1").arg(mode));
+    emit selectionModeChanged();
+}
+
+void UVEditorController::setSelectionSyncEnabled(bool on)
+{
+    if (m_selectionSyncEnabled == on)
+        return;
+    m_selectionSyncEnabled = on;
+    emit selectionSyncEnabledChanged();
+    if (on)
+        pullSelectionFromEdit();
+    notifyUvSelectionChanged();
+}
+
+void UVEditorController::clearUvSelection()
+{
+    if (m_selectedUvVerts.isEmpty() && m_selectedUvEdges.isEmpty() && m_selectedUvFaces.isEmpty())
+        return;
+    m_selectedUvVerts.clear();
+    m_selectedUvEdges.clear();
+    m_selectedUvFaces.clear();
+    notifyUvSelectionChanged();
+    if (m_selectionSyncEnabled && !m_syncInProgress)
+        pushSelectionToEdit();
+}
+
+void UVEditorController::notifyUvSelectionChanged()
+{
+    ++m_selectionRevision;
+    emit uvSelectionChanged();
+}
+
+namespace {
+
+constexpr float kUvEpsilon = 1e-5f;
+
+uint64_t packUvKey(float u, float v)
+{
+    const auto iu = static_cast<int64_t>(std::llround(static_cast<double>(u) / kUvEpsilon));
+    const auto iv = static_cast<int64_t>(std::llround(static_cast<double>(v) / kUvEpsilon));
+    return (static_cast<uint64_t>(static_cast<uint32_t>(iu)) << 32)
+           | static_cast<uint32_t>(iv);
+}
+
+bool pointInTriangle(double u, double v, float u0, float v0, float u1, float v1, float u2, float v2)
+{
+    const double dX = static_cast<double>(u) - static_cast<double>(u2);
+    const double dY = static_cast<double>(v) - static_cast<double>(v2);
+    const double dX21 = static_cast<double>(u2) - static_cast<double>(u1);
+    const double dY12 = static_cast<double>(v1) - static_cast<double>(v2);
+    const double D = dY12 * (static_cast<double>(u0) - static_cast<double>(u2))
+                     + dX21 * (static_cast<double>(v0) - static_cast<double>(v2));
+    if (std::abs(D) < 1e-12)
+        return false;
+    const double s = dY12 * dX + dX21 * dY;
+    const double t = (static_cast<double>(v2) - static_cast<double>(v0)) * dX
+                     + (static_cast<double>(u0) - static_cast<double>(u2)) * dY;
+    if (D < 0)
+        return s <= 0 && t <= 0 && s + t >= D;
+    return s >= 0 && t >= 0 && s + t <= D;
+}
+
+double distPointToSegmentSq(double u, double v, float u0, float v0, float u1, float v1)
+{
+    const double dx = static_cast<double>(u1) - static_cast<double>(u0);
+    const double dy = static_cast<double>(v1) - static_cast<double>(v0);
+    const double lenSq = dx * dx + dy * dy;
+    if (lenSq < 1e-18)
+        return (u - u0) * (u - u0) + (v - v0) * (v - v0);
+    double t = ((u - u0) * dx + (v - v0) * dy) / lenSq;
+    t = std::max(0.0, std::min(1.0, t));
+    const double px = u0 + t * dx;
+    const double py = v0 + t * dy;
+    const double ddx = u - px;
+    const double ddy = v - py;
+    return ddx * ddx + ddy * ddy;
+}
+
+bool segmentIntersectsRect(double u0, double v0, double u1, double v1,
+                           double minU, double minV, double maxU, double maxV)
+{
+    if ((u0 >= minU && u0 <= maxU && v0 >= minV && v0 <= maxV)
+        || (u1 >= minU && u1 <= maxU && v1 >= minV && v1 <= maxV))
+        return true;
+    const auto inside = [&](double u, double v) {
+        return u >= minU && u <= maxU && v >= minV && v <= maxV;
+    };
+    const double rectU[4] = {minU, maxU, maxU, minU};
+    const double rectV[4] = {minV, minV, maxV, maxV};
+    for (int i = 0; i < 4; ++i) {
+        const double ru0 = rectU[i];
+        const double rv0 = rectV[i];
+        const double ru1 = rectU[(i + 1) % 4];
+        const double rv1 = rectV[(i + 1) % 4];
+        const double d1x = u1 - u0;
+        const double d1y = v1 - v0;
+        const double d2x = ru1 - ru0;
+        const double d2y = rv1 - rv0;
+        const double denom = d1x * d2y - d1y * d2x;
+        if (std::abs(denom) < 1e-18)
+            continue;
+        const double t = ((ru0 - u0) * d2y - (rv0 - v0) * d2x) / denom;
+        const double s = ((ru0 - u0) * d1y - (rv0 - v0) * d1x) / denom;
+        if (t >= 0.0 && t <= 1.0 && s >= 0.0 && s <= 1.0)
+            return true;
+    }
+    return inside(u0, v0) || inside(u1, v1);
+}
+
+bool triangleTouchesRect(const float u[3], const float v[3],
+                         double minU, double minV, double maxU, double maxV)
+{
+    for (int c = 0; c < 3; ++c) {
+        if (u[c] >= minU && u[c] <= maxU && v[c] >= minV && v[c] <= maxV)
+            return true;
+    }
+    const double cx = (u[0] + u[1] + u[2]) / 3.0;
+    const double cy = (v[0] + v[1] + v[2]) / 3.0;
+    if (cx >= minU && cx <= maxU && cy >= minV && cy <= maxV)
+        return true;
+    for (int e = 0; e < 3; ++e) {
+        const int n = (e + 1) % 3;
+        if (segmentIntersectsRect(u[e], v[e], u[n], v[n], minU, minV, maxU, maxV))
+            return true;
+    }
+    return pointInTriangle((minU + maxU) * 0.5, (minV + maxV) * 0.5,
+                           u[0], v[0], u[1], v[1], u[2], v[2]);
+}
+
+class UnionFind {
+public:
+    explicit UnionFind(int n) : parent(n), rank(n, 0)
+    {
+        for (int i = 0; i < n; ++i)
+            parent[i] = i;
+    }
+
+    int find(int x)
+    {
+        while (parent[x] != x) {
+            parent[x] = parent[parent[x]];
+            x = parent[x];
+        }
+        return x;
+    }
+
+    void unite(int a, int b)
+    {
+        a = find(a);
+        b = find(b);
+        if (a == b)
+            return;
+        if (rank[a] < rank[b])
+            std::swap(a, b);
+        parent[b] = a;
+        if (rank[a] == rank[b])
+            ++rank[a];
+    }
+
+private:
+    std::vector<int> parent;
+    std::vector<int> rank;
+};
+
+} // namespace
+
+void UVEditorController::applySelectionSet(const QSet<int>& verts, const QSet<int>& edges,
+                                           const QSet<int>& faces, int modifiers)
+{
+    const bool add = (modifiers & static_cast<int>(ShiftModifier)) != 0;
+    const bool toggle = (modifiers & static_cast<int>(ControlModifier)) != 0;
+
+    if (!add && !toggle) {
+        m_selectedUvVerts = verts;
+        m_selectedUvEdges = edges;
+        m_selectedUvFaces = faces;
+    } else if (add) {
+        m_selectedUvVerts.unite(verts);
+        m_selectedUvEdges.unite(edges);
+        m_selectedUvFaces.unite(faces);
+    } else {
+        for (int id : verts) {
+            if (m_selectedUvVerts.contains(id))
+                m_selectedUvVerts.remove(id);
+            else
+                m_selectedUvVerts.insert(id);
+        }
+        for (int id : edges) {
+            if (m_selectedUvEdges.contains(id))
+                m_selectedUvEdges.remove(id);
+            else
+                m_selectedUvEdges.insert(id);
+        }
+        for (int id : faces) {
+            if (m_selectedUvFaces.contains(id))
+                m_selectedUvFaces.remove(id);
+            else
+                m_selectedUvFaces.insert(id);
+        }
+    }
+
+    notifyUvSelectionChanged();
+    if (m_selectionSyncEnabled && !m_syncInProgress)
+        pushSelectionToEdit();
+}
+
+void UVEditorController::pickAt(double u, double v, int modifiers, double pickRadiusUv)
+{
+    if (!m_hasMesh || m_uvTris.empty())
+        return;
+
+    const double pickRadiusSq = pickRadiusUv * pickRadiusUv;
+    QSet<int> verts;
+    QSet<int> edges;
+    QSet<int> faces;
+
+    if (m_selectionMode == FaceMode) {
+        int bestFace = -1;
+        double bestDistSq = 1e30;
+        for (size_t fi = 0; fi < m_uvTris.size(); ++fi) {
+            const auto& tri = m_uvTris[fi];
+            if (pointInTriangle(u, v, tri.u[0], tri.v[0], tri.u[1], tri.v[1], tri.u[2], tri.v[2])) {
+                bestFace = static_cast<int>(fi);
+                break;
+            }
+            const double cx = (tri.u[0] + tri.u[1] + tri.u[2]) / 3.0;
+            const double cy = (tri.v[0] + tri.v[1] + tri.v[2]) / 3.0;
+            const double d = (u - cx) * (u - cx) + (v - cy) * (v - cy);
+            if (d < bestDistSq) {
+                bestDistSq = d;
+                bestFace = static_cast<int>(fi);
+            }
+        }
+        if (bestFace >= 0)
+            faces.insert(bestFace);
+    } else if (m_selectionMode == EdgeMode) {
+        int bestEdge = -1;
+        double bestDistSq = 1e30;
+        for (size_t ei = 0; ei < m_uvEdges.size(); ++ei) {
+            const auto& edge = m_uvEdges[ei];
+            if (edge.v0 < 0 || edge.v1 < 0
+                || edge.v0 >= static_cast<int>(m_uvVerts.size())
+                || edge.v1 >= static_cast<int>(m_uvVerts.size()))
+                continue;
+            const auto& a = m_uvVerts[edge.v0];
+            const auto& b = m_uvVerts[edge.v1];
+            const double d = distPointToSegmentSq(u, v, a.u, a.v, b.u, b.v);
+            if (d < bestDistSq) {
+                bestDistSq = d;
+                bestEdge = static_cast<int>(ei);
+            }
+        }
+        if (bestEdge >= 0 && bestDistSq <= pickRadiusSq)
+            edges.insert(bestEdge);
+    } else {
+        int bestVert = -1;
+        double bestDistSq = 1e30;
+        for (size_t vi = 0; vi < m_uvVerts.size(); ++vi) {
+            const auto& vert = m_uvVerts[vi];
+            const double d = (u - vert.u) * (u - vert.u) + (v - vert.v) * (v - vert.v);
+            if (d < bestDistSq) {
+                bestDistSq = d;
+                bestVert = static_cast<int>(vi);
+            }
+        }
+        if (bestVert >= 0 && bestDistSq <= pickRadiusSq)
+            verts.insert(bestVert);
+    }
+
+    applySelectionSet(verts, edges, faces, modifiers);
+}
+
+void UVEditorController::boxSelect(double uMin, double vMin, double uMax, double vMax, int modifiers)
+{
+    if (!m_hasMesh)
+        return;
+
+    if (uMin > uMax)
+        std::swap(uMin, uMax);
+    if (vMin > vMax)
+        std::swap(vMin, vMax);
+
+    QSet<int> verts;
+    QSet<int> edges;
+    QSet<int> faces;
+
+    if (m_selectionMode == VertexMode) {
+        for (size_t vi = 0; vi < m_uvVerts.size(); ++vi) {
+            const auto& vert = m_uvVerts[vi];
+            if (vert.u >= uMin && vert.u <= uMax && vert.v >= vMin && vert.v <= vMax)
+                verts.insert(static_cast<int>(vi));
+        }
+    } else if (m_selectionMode == EdgeMode) {
+        for (size_t ei = 0; ei < m_uvEdges.size(); ++ei) {
+            const auto& edge = m_uvEdges[ei];
+            if (edge.v0 < 0 || edge.v1 < 0
+                || edge.v0 >= static_cast<int>(m_uvVerts.size())
+                || edge.v1 >= static_cast<int>(m_uvVerts.size()))
+                continue;
+            const auto& a = m_uvVerts[edge.v0];
+            const auto& b = m_uvVerts[edge.v1];
+            if (segmentIntersectsRect(a.u, a.v, b.u, b.v, uMin, vMin, uMax, vMax))
+                edges.insert(static_cast<int>(ei));
+        }
+    } else {
+        for (size_t fi = 0; fi < m_uvTris.size(); ++fi) {
+            if (triangleTouchesRect(m_uvTris[fi].u, m_uvTris[fi].v, uMin, vMin, uMax, vMax))
+                faces.insert(static_cast<int>(fi));
+        }
+    }
+
+    applySelectionSet(verts, edges, faces, modifiers);
+}
+
+QVariantList UVEditorController::selectionVertices() const
+{
+    QVariantList out;
+    for (int id : m_selectedUvVerts) {
+        if (id < 0 || id >= static_cast<int>(m_uvVerts.size()))
+            continue;
+        const auto& v = m_uvVerts[id];
+        out.push_back(QVariantMap{
+            {QStringLiteral("u"), v.u},
+            {QStringLiteral("v"), v.v}
+        });
+    }
+    return out;
+}
+
+QVariantList UVEditorController::selectionEdges() const
+{
+    QVariantList out;
+    for (int id : m_selectedUvEdges) {
+        if (id < 0 || id >= static_cast<int>(m_uvEdges.size()))
+            continue;
+        const auto& e = m_uvEdges[id];
+        if (e.v0 < 0 || e.v1 < 0
+            || e.v0 >= static_cast<int>(m_uvVerts.size())
+            || e.v1 >= static_cast<int>(m_uvVerts.size()))
+            continue;
+        const auto& a = m_uvVerts[e.v0];
+        const auto& b = m_uvVerts[e.v1];
+        out.push_back(QVariantMap{
+            {QStringLiteral("u0"), a.u},
+            {QStringLiteral("v0"), a.v},
+            {QStringLiteral("u1"), b.u},
+            {QStringLiteral("v1"), b.v}
+        });
+    }
+    return out;
+}
+
+QVariantList UVEditorController::selectionFaces() const
+{
+    QVariantList out;
+    for (int id : m_selectedUvFaces) {
+        if (id < 0 || id >= static_cast<int>(m_uvTris.size()))
+            continue;
+        const auto& tri = m_uvTris[id];
+        out.push_back(QVariantMap{
+            {QStringLiteral("u0"), tri.u[0]},
+            {QStringLiteral("v0"), tri.v[0]},
+            {QStringLiteral("u1"), tri.u[1]},
+            {QStringLiteral("v1"), tri.v[1]},
+            {QStringLiteral("u2"), tri.u[2]},
+            {QStringLiteral("v2"), tri.v[2]}
+        });
+    }
+    return out;
+}
+
+QVariantList UVEditorController::contextIslandFaces() const
+{
+    QVariantList out;
+    for (size_t fi = 0; fi < m_uvTris.size(); ++fi) {
+        if (!m_contextIslandIds.contains(m_uvTris[fi].island))
+            continue;
+        const auto& tri = m_uvTris[fi];
+        out.push_back(QVariantMap{
+            {QStringLiteral("u0"), tri.u[0]},
+            {QStringLiteral("v0"), tri.v[0]},
+            {QStringLiteral("u1"), tri.u[1]},
+            {QStringLiteral("v1"), tri.v[1]},
+            {QStringLiteral("u2"), tri.u[2]},
+            {QStringLiteral("v2"), tri.v[2]}
+        });
+    }
+    return out;
+}
+
+void UVEditorController::onEditSelectionChanged()
+{
+    updateContextIslandsFromEdit();
+    if (m_selectionSyncEnabled && !m_syncInProgress)
+        pullSelectionFromEdit();
+    else
+        notifyUvSelectionChanged();
+}
+
+void UVEditorController::updateContextIslandsFromEdit()
+{
+    m_contextIslandIds.clear();
+    auto* edit = EditModeController::instance();
+    if (!edit || !edit->isEditModeActive() || !m_activeEntity
+        || edit->editEntity() != m_activeEntity)
+        return;
+
+    QSet<int> islands;
+    for (int gv : edit->selectedVertices()) {
+        for (size_t fi = 0; fi < m_uvTris.size(); ++fi) {
+            const auto& tri = m_uvTris[fi];
+            for (int c = 0; c < 3; ++c) {
+                if (tri.meshGlobalVert[c] == gv)
+                    islands.insert(tri.island);
+            }
+        }
+    }
+    for (const auto& edge : edit->selectedEdges()) {
+        for (size_t fi = 0; fi < m_uvTris.size(); ++fi) {
+            const auto& tri = m_uvTris[fi];
+            for (int e = 0; e < 3; ++e) {
+                const int n = (e + 1) % 3;
+                const int a = tri.meshGlobalVert[e];
+                const int b = tri.meshGlobalVert[n];
+                if ((a == edge.first && b == edge.second)
+                    || (a == edge.second && b == edge.first))
+                    islands.insert(tri.island);
+            }
+        }
+    }
+    for (int gt : edit->selectedFaces()) {
+        for (size_t fi = 0; fi < m_uvTris.size(); ++fi) {
+            if (m_uvTris[fi].meshGlobalTri == gt)
+                islands.insert(m_uvTris[fi].island);
+        }
+    }
+
+    m_contextIslandIds = islands;
+}
+
+void UVEditorController::pullSelectionFromEdit()
+{
+    auto* edit = EditModeController::instance();
+    if (!edit || !edit->isEditModeActive() || !m_activeEntity
+        || edit->editEntity() != m_activeEntity)
+        return;
+
+    const bool prevSync = m_syncInProgress;
+    m_syncInProgress = true;
+    QSet<int> verts;
+    QSet<int> edges;
+    QSet<int> faces;
+
+    for (int gv : edit->selectedVertices()) {
+        for (size_t vi = 0; vi < m_uvVerts.size(); ++vi) {
+            if (m_uvVerts[vi].meshGlobalVert == gv)
+                verts.insert(static_cast<int>(vi));
+        }
+    }
+    for (const auto& ge : edit->selectedEdges()) {
+        for (size_t ei = 0; ei < m_uvEdges.size(); ++ei) {
+            const auto& ue = m_uvEdges[ei];
+            if ((ue.meshGlobalV0 == ge.first && ue.meshGlobalV1 == ge.second)
+                || (ue.meshGlobalV0 == ge.second && ue.meshGlobalV1 == ge.first))
+                edges.insert(static_cast<int>(ei));
+        }
+    }
+    for (int gt : edit->selectedFaces()) {
+        for (size_t fi = 0; fi < m_uvTris.size(); ++fi) {
+            if (m_uvTris[fi].meshGlobalTri == gt)
+                faces.insert(static_cast<int>(fi));
+        }
+    }
+
+    m_selectedUvVerts = verts;
+    m_selectedUvEdges = edges;
+    m_selectedUvFaces = faces;
+    m_syncInProgress = prevSync;
+    notifyUvSelectionChanged();
+}
+
+void UVEditorController::pushSelectionToEdit()
+{
+    auto* edit = EditModeController::instance();
+    if (!edit || !edit->isEditModeActive() || !m_activeEntity
+        || edit->editEntity() != m_activeEntity)
+        return;
+
+    m_syncInProgress = true;
+    edit->setSelectionMode(static_cast<int>(m_selectionMode));
+    edit->deselectAll();
+
+    bool first = true;
+    if (m_selectionMode == FaceMode) {
+        for (int fi : m_selectedUvFaces) {
+            if (fi < 0 || fi >= static_cast<int>(m_uvTris.size()))
+                continue;
+            edit->selectFace(m_uvTris[fi].meshGlobalTri, !first);
+            first = false;
+        }
+    } else if (m_selectionMode == EdgeMode) {
+        for (int ei : m_selectedUvEdges) {
+            if (ei < 0 || ei >= static_cast<int>(m_uvEdges.size()))
+                continue;
+            const auto& e = m_uvEdges[ei];
+            edit->selectEdge(e.meshGlobalV0, e.meshGlobalV1, !first);
+            first = false;
+        }
+    } else {
+        for (int vi : m_selectedUvVerts) {
+            if (vi < 0 || vi >= static_cast<int>(m_uvVerts.size()))
+                continue;
+            edit->selectVertex(m_uvVerts[vi].meshGlobalVert, !first);
+            first = false;
+        }
+    }
+    m_syncInProgress = false;
 }
 
 void UVEditorController::setShowTextureBackground(bool on)
@@ -365,6 +897,10 @@ bool UVEditorController::buildFromEntity(Ogre::Entity* entity, const QSet<int>& 
     if (!entity)
         return false;
 
+    m_uvVerts.clear();
+    m_uvTris.clear();
+    m_uvEdges.clear();
+
     EditableMesh displayMesh;
     if (auto* edit = EditModeController::instance()) {
         if (edit->isEditModeActive() && edit->editEntity() == entity && edit->currentMesh()) {
@@ -392,10 +928,19 @@ bool UVEditorController::buildFromEntity(Ogre::Entity* entity, const QSet<int>& 
     tris.reserve(static_cast<int>(hem.faceCount()));
 
     int heFaceIdx = 0;
-    for (const auto& sub : mesh.subMeshes()) {
+    int globalVertOffset = 0;
+    int globalTriIndex = 0;
+
+    for (size_t subIdx = 0; subIdx < mesh.subMeshes().size(); ++subIdx) {
+        const auto& sub = mesh.subMeshes()[subIdx];
+
         auto emitTriangle = [&](const EditableTriangle& tri) {
             if (heFaceIdx >= static_cast<int>(islands.faceIslandIds.size()))
                 return;
+
+            UvTri uvTri;
+            uvTri.meshGlobalTri = globalTriIndex++;
+            uvTri.island = islands.faceIslandIds[heFaceIdx];
 
             Ogre::Vector2 uvs[3];
             bool ok = true;
@@ -406,6 +951,9 @@ bool UVEditorController::buildFromEntity(Ogre::Entity* entity, const QSet<int>& 
                     break;
                 }
                 uvs[c] = sub.vertices[vi].uv;
+                uvTri.u[c] = uvs[c].x;
+                uvTri.v[c] = uvs[c].y;
+                uvTri.meshGlobalVert[c] = globalVertOffset + static_cast<int>(vi);
             }
             if (!ok)
                 return;
@@ -426,6 +974,7 @@ bool UVEditorController::buildFromEntity(Ogre::Entity* entity, const QSet<int>& 
                 {QStringLiteral("island"), islandId},
                 {QStringLiteral("color"), colorForIsland(islandId)}
             });
+            m_uvTris.push_back(uvTri);
         };
 
         if (!sub.faces.empty()) {
@@ -447,6 +996,97 @@ bool UVEditorController::buildFromEntity(Ogre::Entity* entity, const QSet<int>& 
                 ++heFaceIdx;
             }
         }
+
+        globalVertOffset += static_cast<int>(sub.vertices.size());
+    }
+
+    // Weld UV corners on shared manifold edges and build UV-edge list.
+    const int cornerCount = static_cast<int>(m_uvTris.size()) * 3;
+    UnionFind uf(cornerCount);
+
+    struct EdgeOcc {
+        int tri = -1;
+        int c0 = -1;
+        int c1 = -1;
+    };
+    std::unordered_map<uint64_t, std::vector<EdgeOcc>> edgeOccMap;
+    edgeOccMap.reserve(m_uvTris.size() * 3);
+
+    auto cornerIndex = [](int tri, int corner) { return tri * 3 + corner; };
+
+    for (size_t ti = 0; ti < m_uvTris.size(); ++ti) {
+        const auto& tri = m_uvTris[ti];
+        for (int e = 0; e < 3; ++e) {
+            const int n = (e + 1) % 3;
+            const uint64_t key = (packUvKey(tri.u[e], tri.v[e]) << 1)
+                                 ^ packUvKey(tri.u[n], tri.v[n]);
+            edgeOccMap[key].push_back({static_cast<int>(ti), e, n});
+        }
+    }
+
+    for (const auto& [key, occs] : edgeOccMap) {
+        if (occs.size() != 2)
+            continue;
+        const EdgeOcc& a = occs[0];
+        const EdgeOcc& b = occs[1];
+        const auto& ta = m_uvTris[a.tri];
+        const auto& tb = m_uvTris[b.tri];
+
+        auto weldCorner = [&](int triA, int cornerA, int triB, int cornerB) {
+            if (std::abs(ta.u[cornerA] - tb.u[cornerB]) > kUvEpsilon
+                || std::abs(ta.v[cornerA] - tb.v[cornerB]) > kUvEpsilon)
+                return;
+            uf.unite(cornerIndex(triA, cornerA), cornerIndex(triB, cornerB));
+        };
+
+        weldCorner(a.tri, a.c0, b.tri, b.c0);
+        weldCorner(a.tri, a.c1, b.tri, b.c1);
+    }
+
+    std::unordered_map<int, int> rootToUvVert;
+    rootToUvVert.reserve(cornerCount);
+    for (int ci = 0; ci < cornerCount; ++ci) {
+        const int tri = ci / 3;
+        const int corner = ci % 3;
+        const int root = uf.find(ci);
+        auto it = rootToUvVert.find(root);
+        if (it == rootToUvVert.end()) {
+            const int vid = static_cast<int>(m_uvVerts.size());
+            UvVert vert;
+            vert.u = m_uvTris[tri].u[corner];
+            vert.v = m_uvTris[tri].v[corner];
+            vert.meshGlobalVert = m_uvTris[tri].meshGlobalVert[corner];
+            m_uvVerts.push_back(vert);
+            rootToUvVert.emplace(root, vid);
+            it = rootToUvVert.find(root);
+        }
+        m_uvTris[tri].uvVertId[corner] = it->second;
+    }
+
+    std::unordered_map<uint64_t, int> edgeDedup;
+    edgeDedup.reserve(m_uvTris.size() * 3);
+    for (size_t ti = 0; ti < m_uvTris.size(); ++ti) {
+        const auto& tri = m_uvTris[ti];
+        for (int e = 0; e < 3; ++e) {
+            const int n = (e + 1) % 3;
+            int v0 = tri.uvVertId[e];
+            int v1 = tri.uvVertId[n];
+            if (v0 < 0 || v1 < 0)
+                continue;
+            if (v0 > v1)
+                std::swap(v0, v1);
+            const uint64_t key = (static_cast<uint64_t>(static_cast<uint32_t>(v0)) << 32)
+                                 | static_cast<uint32_t>(v1);
+            if (edgeDedup.find(key) != edgeDedup.end())
+                continue;
+            UvEdge edge;
+            edge.v0 = v0;
+            edge.v1 = v1;
+            edge.meshGlobalV0 = tri.meshGlobalVert[e];
+            edge.meshGlobalV1 = tri.meshGlobalVert[n];
+            edgeDedup.emplace(key, static_cast<int>(m_uvEdges.size()));
+            m_uvEdges.push_back(edge);
+        }
     }
 
     m_triangles = tris;
@@ -467,20 +1107,28 @@ bool UVEditorController::buildFromEntity(Ogre::Entity* entity, const QSet<int>& 
         ? 0
         : *std::min_element(submeshFilter.begin(), submeshFilter.end());
     m_textureBackgroundSource = resolveDiffuseTextureSource(entity, previewSub);
+    m_activeEntity = entity;
     return m_hasMesh;
 }
 
 void UVEditorController::rebuildMeshCache()
 {
+    Ogre::Entity* prevEntity = m_activeEntity;
     m_triangles.clear();
+    m_uvVerts.clear();
+    m_uvTris.clear();
+    m_uvEdges.clear();
     m_hasMesh = false;
     m_islandCount = 0;
     m_textureBackgroundSource.clear();
     m_uvBounds = QRectF(0, 0, 1, 1);
     m_statusText = tr("Select a mesh to view UVs.");
+    m_activeEntity = nullptr;
 
     auto* sel = SelectionSet::getSingleton();
     if (!sel) {
+        clearUvSelection();
+        m_contextIslandIds.clear();
         ++m_meshRevision;
         emit meshDataChanged();
         return;
@@ -516,6 +1164,8 @@ void UVEditorController::rebuildMeshCache()
     }
 
     if (!entity) {
+        clearUvSelection();
+        m_contextIslandIds.clear();
         ++m_meshRevision;
         emit meshDataChanged();
         return;
@@ -525,7 +1175,13 @@ void UVEditorController::rebuildMeshCache()
         ? tr("UV layout — %1").arg(QString::fromStdString(entity->getName()))
         : tr("UV layout — %1 (sub-mesh selection)").arg(QString::fromStdString(entity->getName()));
 
-    buildFromEntity(entity, submeshFilter, m_uvChannel);
+    const bool built = buildFromEntity(entity, submeshFilter, m_uvChannel);
+    if (!built || entity != prevEntity) {
+        clearUvSelection();
+    }
+    updateContextIslandsFromEdit();
     ++m_meshRevision;
     emit meshDataChanged();
+    if (m_selectionSyncEnabled && !m_syncInProgress)
+        pullSelectionFromEdit();
 }

--- a/src/UVEditorController.h
+++ b/src/UVEditorController.h
@@ -20,7 +20,7 @@ class VertexData;
 
 /// QML-facing singleton for the UV editor panel (issues #459 / #460).
 /// Extracts UV layouts, groups islands, supports UV-space component
-/// selection (vertex / edge / face), and optional sync with Edit Mode.
+/// selection (vertex / edge / face), with read-only island tint from Edit Mode.
 class UVEditorController : public QObject
 {
     Q_OBJECT
@@ -38,8 +38,6 @@ class UVEditorController : public QObject
     Q_PROPERTY(int islandCount READ islandCount NOTIFY meshDataChanged)
 
     Q_PROPERTY(int selectionMode READ selectionMode WRITE setSelectionMode NOTIFY selectionModeChanged)
-    Q_PROPERTY(bool selectionSyncEnabled READ selectionSyncEnabled WRITE setSelectionSyncEnabled
-                   NOTIFY selectionSyncEnabledChanged)
     Q_PROPERTY(int selectionRevision READ selectionRevision NOTIFY uvSelectionChanged)
     Q_PROPERTY(int selectedVertexCount READ selectedVertexCount NOTIFY uvSelectionChanged)
     Q_PROPERTY(int selectedEdgeCount READ selectedEdgeCount NOTIFY uvSelectionChanged)
@@ -86,9 +84,6 @@ public:
     int selectionMode() const { return static_cast<int>(m_selectionMode); }
     void setSelectionMode(int mode);
 
-    bool selectionSyncEnabled() const { return m_selectionSyncEnabled; }
-    void setSelectionSyncEnabled(bool on);
-
     int selectionRevision() const { return m_selectionRevision; }
     int selectedVertexCount() const { return static_cast<int>(m_selectedUvVerts.size()); }
     int selectedEdgeCount() const { return static_cast<int>(m_selectedUvEdges.size()); }
@@ -103,7 +98,7 @@ public:
     Q_INVOKABLE QVariantList selectionEdges() const;
     Q_INVOKABLE QVariantList selectionFaces() const;
 
-    /// Read-only island tint for the current 3D Edit Mode selection (sync off).
+    /// Read-only island tint for the current 3D Edit Mode selection.
     Q_INVOKABLE QVariantList contextIslandFaces() const;
 
     Q_INVOKABLE void clearUvSelection();
@@ -124,7 +119,6 @@ signals:
     void meshDataChanged();
     void fitToViewRequested();
     void selectionModeChanged();
-    void selectionSyncEnabledChanged();
     void uvSelectionChanged();
 
 private:
@@ -161,8 +155,6 @@ private:
     void notifyUvSelectionChanged();
     void onEditSelectionChanged();
     void updateContextIslandsFromEdit();
-    void pullSelectionFromEdit();
-    void pushSelectionToEdit();
     static IslandResult computeIslandsFromHalfEdgeMesh(const HalfEdgeMesh& hem);
     static bool readUvChannel(const Ogre::VertexData* vertexData, int channel,
                               std::vector<Ogre::Vector2>& outUvs);
@@ -184,7 +176,6 @@ private:
     QVariantList m_triangles;
 
     SelectionMode m_selectionMode = VertexMode;
-    bool m_selectionSyncEnabled = false;
     int m_selectionRevision = 0;
     QSet<int> m_selectedUvVerts;
     QSet<int> m_selectedUvEdges;
@@ -196,7 +187,6 @@ private:
     std::vector<UvEdge> m_uvEdges;
 
     Ogre::Entity* m_activeEntity = nullptr;
-    bool m_syncInProgress = false;
 };
 
 #endif // UV_EDITOR_CONTROLLER_H

--- a/src/UVEditorController.h
+++ b/src/UVEditorController.h
@@ -18,10 +18,9 @@ class Entity;
 class VertexData;
 }
 
-/// QML-facing singleton for the read-only UV editor panel (issue #459).
-/// Extracts UV layouts from the active mesh selection, groups triangles
-/// into islands via HalfEdgeMesh adjacency, and exposes draw data to
-/// UVEditorPanel.qml (Canvas2D, software rendering).
+/// QML-facing singleton for the UV editor panel (issues #459 / #460).
+/// Extracts UV layouts, groups islands, supports UV-space component
+/// selection (vertex / edge / face), and optional sync with Edit Mode.
 class UVEditorController : public QObject
 {
     Q_OBJECT
@@ -38,7 +37,30 @@ class UVEditorController : public QObject
     Q_PROPERTY(QRectF uvBounds READ uvBounds NOTIFY meshDataChanged)
     Q_PROPERTY(int islandCount READ islandCount NOTIFY meshDataChanged)
 
+    Q_PROPERTY(int selectionMode READ selectionMode WRITE setSelectionMode NOTIFY selectionModeChanged)
+    Q_PROPERTY(bool selectionSyncEnabled READ selectionSyncEnabled WRITE setSelectionSyncEnabled
+                   NOTIFY selectionSyncEnabledChanged)
+    Q_PROPERTY(int selectionRevision READ selectionRevision NOTIFY uvSelectionChanged)
+    Q_PROPERTY(int selectedVertexCount READ selectedVertexCount NOTIFY uvSelectionChanged)
+    Q_PROPERTY(int selectedEdgeCount READ selectedEdgeCount NOTIFY uvSelectionChanged)
+    Q_PROPERTY(int selectedFaceCount READ selectedFaceCount NOTIFY uvSelectionChanged)
+
 public:
+    enum SelectionMode {
+        VertexMode = 0,
+        EdgeMode = 1,
+        FaceMode = 2
+    };
+    Q_ENUM(SelectionMode)
+
+    /// Pick / box-select modifier flags (match Qt::KeyboardModifier bits used from QML).
+    enum SelectionModifier {
+        NoModifier = 0,
+        ShiftModifier = 0x02000000,
+        ControlModifier = 0x04000000
+    };
+    Q_ENUM(SelectionModifier)
+
     struct IslandResult {
         int islandCount = 0;
         std::vector<int> faceIslandIds;
@@ -61,9 +83,33 @@ public:
     QRectF uvBounds() const { return m_uvBounds; }
     int islandCount() const { return m_islandCount; }
 
+    int selectionMode() const { return static_cast<int>(m_selectionMode); }
+    void setSelectionMode(int mode);
+
+    bool selectionSyncEnabled() const { return m_selectionSyncEnabled; }
+    void setSelectionSyncEnabled(bool on);
+
+    int selectionRevision() const { return m_selectionRevision; }
+    int selectedVertexCount() const { return static_cast<int>(m_selectedUvVerts.size()); }
+    int selectedEdgeCount() const { return static_cast<int>(m_selectedUvEdges.size()); }
+    int selectedFaceCount() const { return static_cast<int>(m_selectedUvFaces.size()); }
+
     /// Triangle draw payload for QML Canvas: list of
     /// { u0,v0,u1,v1,u2,v2, island, color } maps.
     Q_INVOKABLE QVariantList triangles() const { return m_triangles; }
+
+    /// Highlight geometry for the active UV selection.
+    Q_INVOKABLE QVariantList selectionVertices() const;
+    Q_INVOKABLE QVariantList selectionEdges() const;
+    Q_INVOKABLE QVariantList selectionFaces() const;
+
+    /// Read-only island tint for the current 3D Edit Mode selection (sync off).
+    Q_INVOKABLE QVariantList contextIslandFaces() const;
+
+    Q_INVOKABLE void clearUvSelection();
+    Q_INVOKABLE void pickAt(double u, double v, int modifiers, double pickRadiusUv);
+    /// Box rules: vertex = fully enclosed; edge/face = any intersection/touch.
+    Q_INVOKABLE void boxSelect(double uMin, double vMin, double uMax, double vMax, int modifiers);
 
     /// Re-read the active selection and rebuild cached draw data.
     Q_INVOKABLE void refresh();
@@ -77,14 +123,46 @@ signals:
     void showTextureBackgroundChanged();
     void meshDataChanged();
     void fitToViewRequested();
+    void selectionModeChanged();
+    void selectionSyncEnabledChanged();
+    void uvSelectionChanged();
 
 private:
+    struct UvVert {
+        float u = 0.f;
+        float v = 0.f;
+        int meshGlobalVert = -1;
+    };
+
+    struct UvTri {
+        float u[3]{};
+        float v[3]{};
+        int meshGlobalVert[3]{-1, -1, -1};
+        int meshGlobalTri = -1;
+        int island = 0;
+        int uvVertId[3]{-1, -1, -1};
+    };
+
+    struct UvEdge {
+        int v0 = -1;
+        int v1 = -1;
+        int meshGlobalV0 = -1;
+        int meshGlobalV1 = -1;
+    };
+
     explicit UVEditorController(QObject* parent = nullptr);
     ~UVEditorController() override = default;
 
     void connectSignals();
     void rebuildMeshCache();
     bool buildFromEntity(Ogre::Entity* entity, const QSet<int>& submeshFilter, int uvChannel);
+    void applySelectionSet(const QSet<int>& verts, const QSet<int>& edges, const QSet<int>& faces,
+                           int modifiers);
+    void notifyUvSelectionChanged();
+    void onEditSelectionChanged();
+    void updateContextIslandsFromEdit();
+    void pullSelectionFromEdit();
+    void pushSelectionToEdit();
     static IslandResult computeIslandsFromHalfEdgeMesh(const HalfEdgeMesh& hem);
     static bool readUvChannel(const Ogre::VertexData* vertexData, int channel,
                               std::vector<Ogre::Vector2>& outUvs);
@@ -104,6 +182,21 @@ private:
     QRectF m_uvBounds;
     int m_islandCount = 0;
     QVariantList m_triangles;
+
+    SelectionMode m_selectionMode = VertexMode;
+    bool m_selectionSyncEnabled = false;
+    int m_selectionRevision = 0;
+    QSet<int> m_selectedUvVerts;
+    QSet<int> m_selectedUvEdges;
+    QSet<int> m_selectedUvFaces;
+    QSet<int> m_contextIslandIds;
+
+    std::vector<UvVert> m_uvVerts;
+    std::vector<UvTri> m_uvTris;
+    std::vector<UvEdge> m_uvEdges;
+
+    Ogre::Entity* m_activeEntity = nullptr;
+    bool m_syncInProgress = false;
 };
 
 #endif // UV_EDITOR_CONTROLLER_H

--- a/src/UVEditorController_test.cpp
+++ b/src/UVEditorController_test.cpp
@@ -4,6 +4,7 @@
 
 #include "UVEditorController.h"
 #include "EditableMesh.h"
+#include "EditModeController.h"
 #include "Manager.h"
 #include "SelectionSet.h"
 #include "TestHelpers.h"
@@ -91,6 +92,10 @@ protected:
     }
 
     void TearDown() override {
+        if (auto* edit = EditModeController::instance()) {
+            if (edit->isEditModeActive())
+                edit->exitEditMode(false);
+        }
         UVEditorController::kill();
         Manager::kill();
     }
@@ -193,4 +198,233 @@ TEST_F(UVEditorControllerTest, ShowTextureBackgroundToggle)
     EXPECT_GE(spy.count(), 1);
 
     ctrl->setShowTextureBackground(initial);
+}
+
+TEST_F(UVEditorControllerTest, FacePickSelectsTriangle)
+{
+    auto mesh = createInMemoryTriangleMesh("UVEditor_pick_tri");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = sceneMgr->getRootSceneNode()->createChildSceneNode("UVEditor_pick_node");
+    auto* entity = sceneMgr->createEntity("UVEditor_pick_entity", mesh);
+    node->attachObject(entity);
+
+    UVEditorController* ctrl = UVEditorController::instance();
+    SelectionSet::getSingleton()->selectOne(entity);
+    ctrl->setSelectionMode(UVEditorController::FaceMode);
+    ctrl->refresh();
+
+    ASSERT_TRUE(ctrl->hasMesh());
+    ctrl->pickAt(0.25, 0.25, UVEditorController::NoModifier, 0.5);
+    EXPECT_EQ(ctrl->selectedFaceCount(), 1);
+    EXPECT_EQ(ctrl->selectionFaces().size(), 1);
+}
+
+TEST_F(UVEditorControllerTest, ShiftClickAddsVertexSelection)
+{
+    auto mesh = createSeamedQuadMesh("UVEditor_multi_pick");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = sceneMgr->getRootSceneNode()->createChildSceneNode("UVEditor_multi_node");
+    auto* entity = sceneMgr->createEntity("UVEditor_multi_entity", mesh);
+    node->attachObject(entity);
+
+    UVEditorController* ctrl = UVEditorController::instance();
+    SelectionSet::getSingleton()->selectOne(entity);
+    ctrl->setSelectionMode(UVEditorController::VertexMode);
+    ctrl->refresh();
+    ASSERT_TRUE(ctrl->hasMesh());
+
+    ctrl->pickAt(0.0, 0.0, UVEditorController::NoModifier, 0.5);
+    EXPECT_EQ(ctrl->selectedVertexCount(), 1);
+
+    ctrl->pickAt(1.0, 0.2, UVEditorController::ShiftModifier, 0.5);
+    EXPECT_GE(ctrl->selectedVertexCount(), 2);
+}
+
+TEST_F(UVEditorControllerTest, BoxSelectFacesTouchesPartialOverlap)
+{
+    auto mesh = createSeamedQuadMesh("UVEditor_box_pick");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = sceneMgr->getRootSceneNode()->createChildSceneNode("UVEditor_box_node");
+    auto* entity = sceneMgr->createEntity("UVEditor_box_entity", mesh);
+    node->attachObject(entity);
+
+    UVEditorController* ctrl = UVEditorController::instance();
+    SelectionSet::getSingleton()->selectOne(entity);
+    ctrl->setSelectionMode(UVEditorController::FaceMode);
+    ctrl->refresh();
+    ASSERT_TRUE(ctrl->hasMesh());
+
+    ctrl->boxSelect(0.4, 0.0, 1.1, 1.3, UVEditorController::NoModifier);
+    EXPECT_GE(ctrl->selectedFaceCount(), 1);
+}
+
+TEST_F(UVEditorControllerTest, BoxSelectVerticesRequiresFullEnclosure)
+{
+    auto mesh = createSeamedQuadMesh("UVEditor_box_vert");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = sceneMgr->getRootSceneNode()->createChildSceneNode("UVEditor_box_vert_node");
+    auto* entity = sceneMgr->createEntity("UVEditor_box_vert_entity", mesh);
+    node->attachObject(entity);
+
+    UVEditorController* ctrl = UVEditorController::instance();
+    SelectionSet::getSingleton()->selectOne(entity);
+    ctrl->setSelectionMode(UVEditorController::VertexMode);
+    ctrl->refresh();
+    ASSERT_TRUE(ctrl->hasMesh());
+
+    ctrl->boxSelect(0.45, 0.45, 0.55, 0.55, UVEditorController::NoModifier);
+    EXPECT_EQ(ctrl->selectedVertexCount(), 0);
+
+    ctrl->boxSelect(-0.05, -0.05, 0.15, 0.15, UVEditorController::NoModifier);
+    EXPECT_GE(ctrl->selectedVertexCount(), 1);
+}
+
+TEST_F(UVEditorControllerTest, SelectionModeEmitsBreadcrumbSignal)
+{
+    UVEditorController* ctrl = UVEditorController::instance();
+    QSignalSpy spy(ctrl, &UVEditorController::selectionModeChanged);
+    ctrl->setSelectionMode(UVEditorController::EdgeMode);
+    EXPECT_EQ(ctrl->selectionMode(), UVEditorController::EdgeMode);
+    EXPECT_GE(spy.count(), 1);
+}
+
+TEST_F(UVEditorControllerTest, ContextIslandsHighlightWithoutSync)
+{
+    auto mesh = createInMemoryTriangleMesh("UVEditor_ctx_island");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = sceneMgr->getRootSceneNode()->createChildSceneNode("UVEditor_ctx_node");
+    auto* entity = sceneMgr->createEntity("UVEditor_ctx_entity", mesh);
+    node->attachObject(entity);
+
+    UVEditorController* ctrl = UVEditorController::instance();
+    SelectionSet::getSingleton()->selectOne(entity);
+    ctrl->refresh();
+    ASSERT_TRUE(ctrl->hasMesh());
+
+    auto* edit = EditModeController::instance();
+    ASSERT_TRUE(edit->enterEditMode());
+    ctrl->refresh();
+
+    edit->setSelectionMode(EditModeController::FaceMode);
+    edit->selectFace(0);
+    EXPECT_FALSE(ctrl->selectionSyncEnabled());
+    EXPECT_EQ(ctrl->selectedFaceCount(), 0);
+    EXPECT_FALSE(ctrl->contextIslandFaces().isEmpty());
+}
+
+TEST_F(UVEditorControllerTest, SyncPullsEditSelectionIntoUv)
+{
+    auto mesh = createInMemoryTriangleMesh("UVEditor_sync_pull");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = sceneMgr->getRootSceneNode()->createChildSceneNode("UVEditor_sync_pull_node");
+    auto* entity = sceneMgr->createEntity("UVEditor_sync_pull_entity", mesh);
+    node->attachObject(entity);
+
+    UVEditorController* ctrl = UVEditorController::instance();
+    SelectionSet::getSingleton()->selectOne(entity);
+    ctrl->refresh();
+    ASSERT_TRUE(ctrl->hasMesh());
+
+    auto* edit = EditModeController::instance();
+    ASSERT_TRUE(edit->enterEditMode());
+    ctrl->refresh();
+
+    edit->selectVertex(0);
+    ctrl->setSelectionSyncEnabled(true);
+    EXPECT_GE(ctrl->selectedVertexCount(), 1);
+    EXPECT_EQ(edit->selectedVertexCount(), ctrl->selectedVertexCount());
+}
+
+TEST_F(UVEditorControllerTest, FacePickWorksInEditModeWithoutSync)
+{
+    auto mesh = createInMemoryTriangleMesh("UVEditor_edit_pick");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = sceneMgr->getRootSceneNode()->createChildSceneNode("UVEditor_edit_pick_node");
+    auto* entity = sceneMgr->createEntity("UVEditor_edit_pick_entity", mesh);
+    node->attachObject(entity);
+
+    UVEditorController* ctrl = UVEditorController::instance();
+    SelectionSet::getSingleton()->selectOne(entity);
+    ctrl->setSelectionMode(UVEditorController::FaceMode);
+    ctrl->refresh();
+    ASSERT_TRUE(ctrl->hasMesh());
+
+    auto* edit = EditModeController::instance();
+    ASSERT_TRUE(edit->enterEditMode());
+    ctrl->refresh();
+    ASSERT_TRUE(ctrl->hasMesh());
+    ASSERT_GE(ctrl->triangles().size(), 1);
+
+    ctrl->pickAt(0.25, 0.25, UVEditorController::NoModifier, 0.5);
+    EXPECT_GE(ctrl->selectedFaceCount(), 1);
+}
+
+TEST_F(UVEditorControllerTest, SyncPickKeepsSelectionWhenEditModeInactive)
+{
+    auto mesh = createInMemoryTriangleMesh("UVEditor_sync_no_edit");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = sceneMgr->getRootSceneNode()->createChildSceneNode("UVEditor_sync_no_edit_node");
+    auto* entity = sceneMgr->createEntity("UVEditor_sync_no_edit_entity", mesh);
+    node->attachObject(entity);
+
+    UVEditorController* ctrl = UVEditorController::instance();
+    SelectionSet::getSingleton()->selectOne(entity);
+    ctrl->setSelectionMode(UVEditorController::FaceMode);
+    ctrl->setSelectionSyncEnabled(true);
+    ctrl->refresh();
+    ASSERT_TRUE(ctrl->hasMesh());
+
+    ctrl->pickAt(0.25, 0.25, UVEditorController::NoModifier, 0.5);
+    EXPECT_GE(ctrl->selectedFaceCount(), 1);
+}
+
+TEST_F(UVEditorControllerTest, SyncPushesUvSelectionToEdit)
+{
+    auto mesh = createInMemoryTriangleMesh("UVEditor_sync_push");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = sceneMgr->getRootSceneNode()->createChildSceneNode("UVEditor_sync_push_node");
+    auto* entity = sceneMgr->createEntity("UVEditor_sync_push_entity", mesh);
+    node->attachObject(entity);
+
+    UVEditorController* ctrl = UVEditorController::instance();
+    SelectionSet::getSingleton()->selectOne(entity);
+    ctrl->setSelectionMode(UVEditorController::FaceMode);
+    ctrl->refresh();
+    ASSERT_TRUE(ctrl->hasMesh());
+
+    auto* edit = EditModeController::instance();
+    ASSERT_TRUE(edit->enterEditMode());
+    ctrl->setSelectionSyncEnabled(true);
+    ctrl->refresh();
+    ASSERT_TRUE(ctrl->hasMesh());
+    ASSERT_GE(ctrl->triangles().size(), 1);
+
+    ctrl->pickAt(0.25, 0.25, UVEditorController::NoModifier, 0.5);
+    EXPECT_GE(ctrl->selectedFaceCount(), 1);
+    EXPECT_GE(edit->selectedFaceCount(), 1);
+}
+
+TEST_F(UVEditorControllerTest, SyncDoesNotLoopOnUvPick)
+{
+    auto mesh = createInMemoryTriangleMesh("UVEditor_sync_loop");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = sceneMgr->getRootSceneNode()->createChildSceneNode("UVEditor_sync_loop_node");
+    auto* entity = sceneMgr->createEntity("UVEditor_sync_loop_entity", mesh);
+    node->attachObject(entity);
+
+    UVEditorController* ctrl = UVEditorController::instance();
+    SelectionSet::getSingleton()->selectOne(entity);
+    ctrl->setSelectionMode(UVEditorController::FaceMode);
+    ctrl->refresh();
+    ASSERT_TRUE(ctrl->hasMesh());
+
+    auto* edit = EditModeController::instance();
+    ASSERT_TRUE(edit->enterEditMode());
+    ctrl->setSelectionSyncEnabled(true);
+    ctrl->refresh();
+
+    QSignalSpy editSpy(edit, &EditModeController::editSelectionChanged);
+    ctrl->pickAt(0.25, 0.25, UVEditorController::NoModifier, 0.5);
+    EXPECT_GE(ctrl->selectedFaceCount(), 1);
+    EXPECT_LT(editSpy.count(), 8);
 }

--- a/src/UVEditorController_test.cpp
+++ b/src/UVEditorController_test.cpp
@@ -288,6 +288,24 @@ TEST_F(UVEditorControllerTest, SelectionModeEmitsBreadcrumbSignal)
     EXPECT_GE(spy.count(), 1);
 }
 
+TEST_F(UVEditorControllerTest, FacePickMissesEmptySpaceOutsideRadius)
+{
+    auto mesh = createInMemoryTriangleMesh("UVEditor_pick_miss");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = sceneMgr->getRootSceneNode()->createChildSceneNode("UVEditor_pick_miss_node");
+    auto* entity = sceneMgr->createEntity("UVEditor_pick_miss_entity", mesh);
+    node->attachObject(entity);
+
+    UVEditorController* ctrl = UVEditorController::instance();
+    SelectionSet::getSingleton()->selectOne(entity);
+    ctrl->setSelectionMode(UVEditorController::FaceMode);
+    ctrl->refresh();
+    ASSERT_TRUE(ctrl->hasMesh());
+
+    ctrl->pickAt(5.0, 5.0, UVEditorController::NoModifier, 0.1);
+    EXPECT_EQ(ctrl->selectedFaceCount(), 0);
+}
+
 TEST_F(UVEditorControllerTest, ContextIslandsHighlightWithoutSync)
 {
     auto mesh = createInMemoryTriangleMesh("UVEditor_ctx_island");

--- a/src/UVEditorController_test.cpp
+++ b/src/UVEditorController_test.cpp
@@ -306,7 +306,7 @@ TEST_F(UVEditorControllerTest, FacePickMissesEmptySpaceOutsideRadius)
     EXPECT_EQ(ctrl->selectedFaceCount(), 0);
 }
 
-TEST_F(UVEditorControllerTest, ContextIslandsHighlightWithoutSync)
+TEST_F(UVEditorControllerTest, ContextIslandsHighlightFromEditSelection)
 {
     auto mesh = createInMemoryTriangleMesh("UVEditor_ctx_island");
     auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
@@ -325,35 +325,11 @@ TEST_F(UVEditorControllerTest, ContextIslandsHighlightWithoutSync)
 
     edit->setSelectionMode(EditModeController::FaceMode);
     edit->selectFace(0);
-    EXPECT_FALSE(ctrl->selectionSyncEnabled());
     EXPECT_EQ(ctrl->selectedFaceCount(), 0);
     EXPECT_FALSE(ctrl->contextIslandFaces().isEmpty());
 }
 
-TEST_F(UVEditorControllerTest, SyncPullsEditSelectionIntoUv)
-{
-    auto mesh = createInMemoryTriangleMesh("UVEditor_sync_pull");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
-    auto* node = sceneMgr->getRootSceneNode()->createChildSceneNode("UVEditor_sync_pull_node");
-    auto* entity = sceneMgr->createEntity("UVEditor_sync_pull_entity", mesh);
-    node->attachObject(entity);
-
-    UVEditorController* ctrl = UVEditorController::instance();
-    SelectionSet::getSingleton()->selectOne(entity);
-    ctrl->refresh();
-    ASSERT_TRUE(ctrl->hasMesh());
-
-    auto* edit = EditModeController::instance();
-    ASSERT_TRUE(edit->enterEditMode());
-    ctrl->refresh();
-
-    edit->selectVertex(0);
-    ctrl->setSelectionSyncEnabled(true);
-    EXPECT_GE(ctrl->selectedVertexCount(), 1);
-    EXPECT_EQ(edit->selectedVertexCount(), ctrl->selectedVertexCount());
-}
-
-TEST_F(UVEditorControllerTest, FacePickWorksInEditModeWithoutSync)
+TEST_F(UVEditorControllerTest, FacePickWorksInEditMode)
 {
     auto mesh = createInMemoryTriangleMesh("UVEditor_edit_pick");
     auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
@@ -375,74 +351,4 @@ TEST_F(UVEditorControllerTest, FacePickWorksInEditModeWithoutSync)
 
     ctrl->pickAt(0.25, 0.25, UVEditorController::NoModifier, 0.5);
     EXPECT_GE(ctrl->selectedFaceCount(), 1);
-}
-
-TEST_F(UVEditorControllerTest, SyncPickKeepsSelectionWhenEditModeInactive)
-{
-    auto mesh = createInMemoryTriangleMesh("UVEditor_sync_no_edit");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
-    auto* node = sceneMgr->getRootSceneNode()->createChildSceneNode("UVEditor_sync_no_edit_node");
-    auto* entity = sceneMgr->createEntity("UVEditor_sync_no_edit_entity", mesh);
-    node->attachObject(entity);
-
-    UVEditorController* ctrl = UVEditorController::instance();
-    SelectionSet::getSingleton()->selectOne(entity);
-    ctrl->setSelectionMode(UVEditorController::FaceMode);
-    ctrl->setSelectionSyncEnabled(true);
-    ctrl->refresh();
-    ASSERT_TRUE(ctrl->hasMesh());
-
-    ctrl->pickAt(0.25, 0.25, UVEditorController::NoModifier, 0.5);
-    EXPECT_GE(ctrl->selectedFaceCount(), 1);
-}
-
-TEST_F(UVEditorControllerTest, SyncPushesUvSelectionToEdit)
-{
-    auto mesh = createInMemoryTriangleMesh("UVEditor_sync_push");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
-    auto* node = sceneMgr->getRootSceneNode()->createChildSceneNode("UVEditor_sync_push_node");
-    auto* entity = sceneMgr->createEntity("UVEditor_sync_push_entity", mesh);
-    node->attachObject(entity);
-
-    UVEditorController* ctrl = UVEditorController::instance();
-    SelectionSet::getSingleton()->selectOne(entity);
-    ctrl->setSelectionMode(UVEditorController::FaceMode);
-    ctrl->refresh();
-    ASSERT_TRUE(ctrl->hasMesh());
-
-    auto* edit = EditModeController::instance();
-    ASSERT_TRUE(edit->enterEditMode());
-    ctrl->setSelectionSyncEnabled(true);
-    ctrl->refresh();
-    ASSERT_TRUE(ctrl->hasMesh());
-    ASSERT_GE(ctrl->triangles().size(), 1);
-
-    ctrl->pickAt(0.25, 0.25, UVEditorController::NoModifier, 0.5);
-    EXPECT_GE(ctrl->selectedFaceCount(), 1);
-    EXPECT_GE(edit->selectedFaceCount(), 1);
-}
-
-TEST_F(UVEditorControllerTest, SyncDoesNotLoopOnUvPick)
-{
-    auto mesh = createInMemoryTriangleMesh("UVEditor_sync_loop");
-    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
-    auto* node = sceneMgr->getRootSceneNode()->createChildSceneNode("UVEditor_sync_loop_node");
-    auto* entity = sceneMgr->createEntity("UVEditor_sync_loop_entity", mesh);
-    node->attachObject(entity);
-
-    UVEditorController* ctrl = UVEditorController::instance();
-    SelectionSet::getSingleton()->selectOne(entity);
-    ctrl->setSelectionMode(UVEditorController::FaceMode);
-    ctrl->refresh();
-    ASSERT_TRUE(ctrl->hasMesh());
-
-    auto* edit = EditModeController::instance();
-    ASSERT_TRUE(edit->enterEditMode());
-    ctrl->setSelectionSyncEnabled(true);
-    ctrl->refresh();
-
-    QSignalSpy editSpy(edit, &EditModeController::editSelectionChanged);
-    ctrl->pickAt(0.25, 0.25, UVEditorController::NoModifier, 0.5);
-    EXPECT_GE(ctrl->selectedFaceCount(), 1);
-    EXPECT_LT(editSpy.count(), 8);
 }


### PR DESCRIPTION
## Summary
- Adds UV-vertex / UV-edge / UV-face component selection to the UV editor panel (Slice B of #458)
- Selection state lives on `UVEditorController` (not `SelectionSet`); supports click, Shift-add, Ctrl-toggle, and drag-box select
- Toolbar mode buttons + `1`/`2`/`3` shortcuts (panel focus)
- Read-only **context island highlight** when 3D Edit Mode selects components on the same entity (no live sync — bidirectional sync was removed after it caused main-thread freezes)
- Box rules: vertices fully enclosed; edges/faces any touched
- 14 unit tests covering pick, multi-select, box select, context islands, and edit-mode coexistence

Closes #460

## Review feedback addressed
- Face pick gated by `pickRadiusUv` (no arbitrary face on empty click)
- UV corner welding via undirected mesh-edge keys
- Filtered submesh views preserve original global vertex/triangle offsets (for context-island mapping)
- N-gon fan triangles share one `meshGlobalTri` for context lookup
- Live Edit Mode sync removed (replaced by read-only island tint only)

## Test plan
- [x] `./build_local/bin/UnitTests --gtest_filter="UVEditorControllerTest.*"` (14/14 pass)
- [ ] Manual: open UV panel, verify V/E/F modes, Shift/Ctrl multi-select, box select marquee
- [ ] Manual: 3D Edit Mode face selection tints the owning UV island without changing UV selection
- [ ] Manual: UV picking does not freeze the app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UV editing is now interactive with vertex/edge/face selection modes, keyboard shortcuts, and mode buttons.
  * Added modifier-aware picking and box selection, plus selection clearing and zoom-aware hit detection.
  * Selection highlighting now renders selected elements and shows related UV “context island” faces.

* **Bug Fixes**
  * Selection overlays stay in sync as the active mesh, selection mode, or UV selection changes.

* **Tests**
  * Added coverage for picking, shift-click behavior, box-selection rules, and context island highlighting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->