### PR TITLE
fix: defer UV rebuild on import to prevent UI freeze

### DIFF
--- a/src/AssetBrowserController.cpp
+++ b/src/AssetBrowserController.cpp
@@ -8,6 +8,7 @@
 #include <QFileInfo>
 #include <QSettings>
 #include <QStandardPaths>
+#include <QTimer>
 
 AssetBrowserController* AssetBrowserController::m_pSingleton = nullptr;
 

--- a/src/UVEditorController.cpp
+++ b/src/UVEditorController.cpp
@@ -70,7 +70,14 @@ void UVEditorController::setPanelActive(bool active)
     if (m_panelActive == active)
         return;
     m_panelActive = active;
-    if (m_panelActive && m_refreshPending) {
+    if (!m_panelActive) {
+        if (m_refreshTimer->isActive()) {
+            m_refreshTimer->stop();
+            m_refreshPending = true;
+        }
+        return;
+    }
+    if (m_refreshPending) {
         m_refreshPending = false;
         refresh();
     }

--- a/src/UVEditorController.cpp
+++ b/src/UVEditorController.cpp
@@ -58,22 +58,45 @@ void UVEditorController::kill()
 UVEditorController::UVEditorController(QObject* parent)
     : QObject(parent)
 {
+    m_refreshTimer = new QTimer(this);
+    m_refreshTimer->setSingleShot(true);
+    m_refreshTimer->setInterval(75);
+    connect(m_refreshTimer, &QTimer::timeout, this, &UVEditorController::rebuildMeshCache);
     connectSignals();
-    rebuildMeshCache();
+}
+
+void UVEditorController::setPanelActive(bool active)
+{
+    if (m_panelActive == active)
+        return;
+    m_panelActive = active;
+    if (m_panelActive && m_refreshPending) {
+        m_refreshPending = false;
+        refresh();
+    }
+}
+
+void UVEditorController::scheduleRefresh()
+{
+    if (!m_panelActive) {
+        m_refreshPending = true;
+        return;
+    }
+    m_refreshTimer->start();
 }
 
 void UVEditorController::connectSignals()
 {
     if (auto* sel = SelectionSet::getSingleton()) {
-        connect(sel, &SelectionSet::selectionChanged, this, &UVEditorController::refresh);
+        connect(sel, &SelectionSet::selectionChanged, this, &UVEditorController::scheduleRefresh);
     }
     if (auto* mgr = Manager::getSingletonPtr()) {
-        connect(mgr, &Manager::entityCreated, this, &UVEditorController::refresh);
-        connect(mgr, &Manager::sceneNodeDestroyed, this, &UVEditorController::refresh);
+        connect(mgr, &Manager::entityCreated, this, &UVEditorController::scheduleRefresh);
+        connect(mgr, &Manager::sceneNodeDestroyed, this, &UVEditorController::scheduleRefresh);
     }
     if (auto* edit = EditModeController::instance()) {
-        connect(edit, &EditModeController::meshDataChanged, this, &UVEditorController::refresh);
-        connect(edit, &EditModeController::editModeChanged, this, &UVEditorController::refresh);
+        connect(edit, &EditModeController::meshDataChanged, this, &UVEditorController::scheduleRefresh);
+        connect(edit, &EditModeController::editModeChanged, this, &UVEditorController::scheduleRefresh);
         connect(edit, &EditModeController::editSelectionChanged, this,
                 &UVEditorController::onEditSelectionChanged);
     }
@@ -477,6 +500,10 @@ QVariantList UVEditorController::contextIslandFaces() const
 
 void UVEditorController::onEditSelectionChanged()
 {
+    if (!m_panelActive) {
+        m_refreshPending = true;
+        return;
+    }
     updateContextIslandsFromEdit();
     notifyUvSelectionChanged();
 }
@@ -491,32 +518,33 @@ void UVEditorController::updateContextIslandsFromEdit()
 
     QSet<int> islands;
     for (int gv : edit->selectedVertices()) {
-        for (size_t fi = 0; fi < m_uvTris.size(); ++fi) {
-            const auto& tri = m_uvTris[fi];
-            for (int c = 0; c < 3; ++c) {
-                if (tri.meshGlobalVert[c] == gv)
-                    islands.insert(tri.island);
-            }
-        }
+        if (gv < 0 || gv >= static_cast<int>(m_trisByGlobalVert.size()))
+            continue;
+        for (int fi : m_trisByGlobalVert[static_cast<size_t>(gv)])
+            islands.insert(m_uvTris[static_cast<size_t>(fi)].island);
     }
     for (const auto& edge : edit->selectedEdges()) {
-        for (size_t fi = 0; fi < m_uvTris.size(); ++fi) {
-            const auto& tri = m_uvTris[fi];
+        const int a = edge.first;
+        const int b = edge.second;
+        if (a < 0 || a >= static_cast<int>(m_trisByGlobalVert.size()))
+            continue;
+        for (int fi : m_trisByGlobalVert[static_cast<size_t>(a)]) {
+            const auto& tri = m_uvTris[static_cast<size_t>(fi)];
             for (int e = 0; e < 3; ++e) {
                 const int n = (e + 1) % 3;
-                const int a = tri.meshGlobalVert[e];
-                const int b = tri.meshGlobalVert[n];
-                if ((a == edge.first && b == edge.second)
-                    || (a == edge.second && b == edge.first))
+                const int va = tri.meshGlobalVert[e];
+                const int vb = tri.meshGlobalVert[n];
+                if ((va == a && vb == b) || (va == b && vb == a)) {
                     islands.insert(tri.island);
+                    break;
+                }
             }
         }
     }
     for (int gt : edit->selectedFaces()) {
-        for (size_t fi = 0; fi < m_uvTris.size(); ++fi) {
-            if (m_uvTris[fi].meshGlobalTri == gt)
-                islands.insert(m_uvTris[fi].island);
-        }
+        const auto it = m_fiByGlobalTri.find(gt);
+        if (it != m_fiByGlobalTri.end())
+            islands.insert(m_uvTris[static_cast<size_t>(it->second)].island);
     }
 
     m_contextIslandIds = islands;
@@ -532,6 +560,8 @@ void UVEditorController::setShowTextureBackground(bool on)
 
 void UVEditorController::refresh()
 {
+    m_refreshPending = false;
+    m_refreshTimer->stop();
     rebuildMeshCache();
 }
 
@@ -1030,6 +1060,28 @@ bool UVEditorController::buildFromEntity(Ogre::Entity* entity, const QSet<int>& 
         }
     }
 
+    m_trisByGlobalVert.clear();
+    m_fiByGlobalTri.clear();
+    int maxGlobalVert = -1;
+    for (size_t fi = 0; fi < m_uvTris.size(); ++fi) {
+        const auto& tri = m_uvTris[fi];
+        m_fiByGlobalTri[tri.meshGlobalTri] = static_cast<int>(fi);
+        for (int c = 0; c < 3; ++c) {
+            maxGlobalVert = std::max(maxGlobalVert, tri.meshGlobalVert[c]);
+        }
+    }
+    if (maxGlobalVert >= 0) {
+        m_trisByGlobalVert.assign(static_cast<size_t>(maxGlobalVert + 1), {});
+        for (size_t fi = 0; fi < m_uvTris.size(); ++fi) {
+            const auto& tri = m_uvTris[fi];
+            for (int c = 0; c < 3; ++c) {
+                const int gv = tri.meshGlobalVert[c];
+                if (gv >= 0)
+                    m_trisByGlobalVert[static_cast<size_t>(gv)].push_back(static_cast<int>(fi));
+            }
+        }
+    }
+
     m_triangles = tris;
     m_islandCount = islands.islandCount;
     m_hasMesh = !tris.isEmpty();
@@ -1059,6 +1111,8 @@ void UVEditorController::rebuildMeshCache()
     m_uvVerts.clear();
     m_uvTris.clear();
     m_uvEdges.clear();
+    m_trisByGlobalVert.clear();
+    m_fiByGlobalTri.clear();
     m_hasMesh = false;
     m_islandCount = 0;
     m_textureBackgroundSource.clear();

--- a/src/UVEditorController.h
+++ b/src/UVEditorController.h
@@ -6,7 +6,9 @@
 #include <QRectF>
 #include <QSet>
 #include <QVariantList>
+#include <QTimer>
 #include <vector>
+#include <unordered_map>
 
 #include <Ogre.h>
 
@@ -109,6 +111,11 @@ public:
     /// Re-read the active selection and rebuild cached draw data.
     Q_INVOKABLE void refresh();
 
+    /// When false (UV Editor dock hidden), scene/selection changes are not
+    /// rebuilt — avoids blocking the main thread during mesh import.
+    Q_INVOKABLE void setPanelActive(bool active);
+    bool panelActive() const { return m_panelActive; }
+
     /// Connected UV islands for a mesh snapshot (headless tests).
     /// Caller must populate `EditableMesh` UVs for the channel under test.
     static IslandResult computeIslandsFromEditableMesh(const EditableMesh& mesh);
@@ -148,6 +155,7 @@ private:
     ~UVEditorController() override = default;
 
     void connectSignals();
+    void scheduleRefresh();
     void rebuildMeshCache();
     bool buildFromEntity(Ogre::Entity* entity, const QSet<int>& submeshFilter, int uvChannel);
     void applySelectionSet(const QSet<int>& verts, const QSet<int>& edges, const QSet<int>& faces,
@@ -185,8 +193,15 @@ private:
     std::vector<UvVert> m_uvVerts;
     std::vector<UvTri> m_uvTris;
     std::vector<UvEdge> m_uvEdges;
+    /// Per mesh-global-vertex list of triangle indices in m_uvTris (for fast context islands).
+    std::vector<std::vector<int>> m_trisByGlobalVert;
+    std::unordered_map<int, int> m_fiByGlobalTri;
 
     Ogre::Entity* m_activeEntity = nullptr;
+
+    bool m_panelActive = false;
+    bool m_refreshPending = false;
+    QTimer* m_refreshTimer = nullptr;
 };
 
 #endif // UV_EDITOR_CONTROLLER_H

--- a/src/UVEditorController_test.cpp
+++ b/src/UVEditorController_test.cpp
@@ -195,6 +195,7 @@ TEST_F(UVEditorControllerTest, SkipsBackgroundRebuildWhilePanelHidden)
     auto* entity = sceneMgr->createEntity("UVEditor_hidden_entity", mesh);
     node->attachObject(entity);
 
+    UVEditorController::kill();
     UVEditorController* ctrl = UVEditorController::instance();
     ctrl->setPanelActive(false);
     QSignalSpy spy(ctrl, &UVEditorController::meshDataChanged);
@@ -203,8 +204,9 @@ TEST_F(UVEditorControllerTest, SkipsBackgroundRebuildWhilePanelHidden)
     EXPECT_EQ(spy.count(), 0);
     EXPECT_FALSE(ctrl->hasMesh());
 
+    spy.clear();
     ctrl->setPanelActive(true);
-    ctrl->refresh();
+    EXPECT_GE(spy.count(), 1);
     EXPECT_TRUE(ctrl->hasMesh());
 }
 

--- a/src/UVEditorController_test.cpp
+++ b/src/UVEditorController_test.cpp
@@ -187,6 +187,27 @@ TEST_F(UVEditorControllerTest, ControllerRefreshTracksSelection)
     EXPECT_EQ(ctrl->triangles().size(), 1);
 }
 
+TEST_F(UVEditorControllerTest, SkipsBackgroundRebuildWhilePanelHidden)
+{
+    auto mesh = createInMemoryTriangleMesh("UVEditor_hidden_tri");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = sceneMgr->getRootSceneNode()->createChildSceneNode("UVEditor_hidden_node");
+    auto* entity = sceneMgr->createEntity("UVEditor_hidden_entity", mesh);
+    node->attachObject(entity);
+
+    UVEditorController* ctrl = UVEditorController::instance();
+    ctrl->setPanelActive(false);
+    QSignalSpy spy(ctrl, &UVEditorController::meshDataChanged);
+
+    SelectionSet::getSingleton()->selectOne(entity);
+    EXPECT_EQ(spy.count(), 0);
+    EXPECT_FALSE(ctrl->hasMesh());
+
+    ctrl->setPanelActive(true);
+    ctrl->refresh();
+    EXPECT_TRUE(ctrl->hasMesh());
+}
+
 TEST_F(UVEditorControllerTest, ShowTextureBackgroundToggle)
 {
     UVEditorController* ctrl = UVEditorController::instance();
@@ -315,6 +336,7 @@ TEST_F(UVEditorControllerTest, ContextIslandsHighlightFromEditSelection)
     node->attachObject(entity);
 
     UVEditorController* ctrl = UVEditorController::instance();
+    ctrl->setPanelActive(true);
     SelectionSet::getSingleton()->selectOne(entity);
     ctrl->refresh();
     ASSERT_TRUE(ctrl->hasMesh());

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -258,16 +258,29 @@ MainWindow::MainWindow(QWidget *parent) :
     // global repaint that can freeze the UI for tens of seconds.
     {
         QSettings settings;
-        mCurrentPalette = settings.value("palette", "dark").toString();
-        if (mCurrentPalette == "light") {
+        const QString appearanceTheme =
+            settings.value(AppSettingsKeys::appearanceTheme()).toString().trimmed();
+        const QString paletteTheme =
+            settings.value(AppSettingsKeys::palette(), QStringLiteral("dark")).toString().trimmed();
+        const QString paletteThemeLower = paletteTheme.toLower();
+        mCurrentPalette =
+            paletteThemeLower == QStringLiteral("custom")
+                ? paletteTheme
+                : (appearanceTheme.isEmpty() ? paletteTheme : appearanceTheme);
+        ui->actionLight->blockSignals(true);
+        ui->actionDark->blockSignals(true);
+        ui->actionCustom->blockSignals(true);
+        const QString themeLower = mCurrentPalette.trimmed().toLower();
+        if (themeLower == QStringLiteral("light")) {
             ui->actionLight->setChecked(true);
-        } else if (mCurrentPalette == "custom") {
-            ui->actionCustom->blockSignals(true);
+        } else if (themeLower == QStringLiteral("custom")) {
             ui->actionCustom->setChecked(true);
-            ui->actionCustom->blockSignals(false);
         } else {
             ui->actionDark->setChecked(true);
         }
+        ui->actionLight->blockSignals(false);
+        ui->actionDark->blockSignals(false);
+        ui->actionCustom->blockSignals(false);
     }
 
     initToolBar();
@@ -879,17 +892,15 @@ void MainWindow::initToolBar()
         addDockWidget(Qt::BottomDockWidgetArea, m_assetBrowserDock);
         m_assetBrowserDock->hide();
 
+        auto* abController = AssetBrowserController::instance();
+        connect(abController, &AssetBrowserController::importMeshRequested, this,
+                [this](const QStringList& paths) {
+                    SentryReporter::addBreadcrumb("ui.action", "Asset Browser: import mesh");
+                    importMeshs(paths);
+                });
         connect(m_assetBrowserDock, &QDockWidget::visibilityChanged, this, [this](bool vis) {
-            if (!vis)
-                return;
-            ensureLazyDockQml(m_assetBrowserDock);
-            auto* abController = AssetBrowserController::instance();
-            disconnect(abController, &AssetBrowserController::importMeshRequested, this, nullptr);
-            connect(abController, &AssetBrowserController::importMeshRequested, this,
-                    [this](const QStringList& paths) {
-                        SentryReporter::addBreadcrumb("ui.action", "Asset Browser: import mesh");
-                        importMeshs(paths);
-                    });
+            if (vis)
+                ensureLazyDockQml(m_assetBrowserDock);
         });
     }
 
@@ -1150,6 +1161,8 @@ void MainWindow::initToolBar()
     aiFont.setPixelSize(15);
     aiChatButton->setFont(aiFont);
     connect(aiChatButton, &QToolButton::clicked, this, [this]() {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("Toolbar: Open AI Chat"));
         if (m_chatDock) {
             ensureLazyDockQml(m_chatDock);
             m_chatDock->show();
@@ -2419,6 +2432,8 @@ void MainWindow::initToolBar()
     QAction* aiChatAction = aiMenu->addAction(QIcon(":/icones/ai.png"), tr("AI Chat..."));
     aiChatAction->setObjectName("actionAIChatDock");
     connect(aiChatAction, &QAction::triggered, this, [this]() {
+        SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                      QStringLiteral("AI menu: Open AI Chat"));
         if (m_chatDock) {
             ensureLazyDockQml(m_chatDock);
             m_chatDock->show();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -144,6 +144,31 @@ namespace {
 constexpr int kBottomToolHeight = MainWindow::kDefaultDockedHeight;
 constexpr int kBottomDockMaxHeight = MainWindow::kDefaultDockedMaxHeight;
 
+constexpr char kLazyQmlUrlProperty[] = "_lazyQmlUrl";
+
+void markLazyQml(QQuickWidget* widget, const QUrl& url)
+{
+    if (!widget)
+        return;
+    widget->setProperty(kLazyQmlUrlProperty, url);
+}
+
+void ensureLazyQml(QQuickWidget* widget)
+{
+    if (!widget || widget->status() != QQuickWidget::Null)
+        return;
+    const QVariant url = widget->property(kLazyQmlUrlProperty);
+    if (url.isValid())
+        widget->setSource(url.toUrl());
+}
+
+void ensureLazyDockQml(QDockWidget* dock)
+{
+    if (!dock)
+        return;
+    ensureLazyQml(qobject_cast<QQuickWidget*>(dock->widget()));
+}
+
 QString transformSpaceLabel(TransformOperator::TransformSpace space)
 {
     return space == TransformOperator::SPACE_LOCAL
@@ -227,6 +252,24 @@ MainWindow::MainWindow(QWidget *parent) :
 
     manager->CreateEmptyScene();
 
+    // Sync palette menu checkboxes only — ThemeManager::applySavedThemeFromSettings()
+    // in main() already applied the palette before any widgets existed. Re-calling
+    // QApplication::setPalette() here (after initToolBar's QML docks) forces a
+    // global repaint that can freeze the UI for tens of seconds.
+    {
+        QSettings settings;
+        mCurrentPalette = settings.value("palette", "dark").toString();
+        if (mCurrentPalette == "light") {
+            ui->actionLight->setChecked(true);
+        } else if (mCurrentPalette == "custom") {
+            ui->actionCustom->blockSignals(true);
+            ui->actionCustom->setChecked(true);
+            ui->actionCustom->blockSignals(false);
+        } else {
+            ui->actionDark->setChecked(true);
+        }
+    }
+
     initToolBar();
 
     FeedbackReportHelper::setOpenFeedbackHandler([this](const FeedbackPrefill& prefill) {
@@ -285,19 +328,6 @@ MainWindow::MainWindow(QWidget *parent) :
 
     ui->menuOp_es->insertAction(ui->actionChange_Ambient_Light, ui->actionMaterial_Editor);
     ui->menuOp_es->insertSeparator(ui->actionChange_Ambient_Light);
-
-    QSettings settings;
-    mCurrentPalette = settings.value("palette","dark").toString();
-    if(mCurrentPalette == "light"){
-            ui->actionLight->setChecked(true);
-    } else if(mCurrentPalette == "custom"){
-        custom_Palette_Color_Selected(settings.value("customPalette").value<QColor>());
-        ui->actionCustom->blockSignals(true);
-        ui->actionCustom->setChecked(true);
-        ui->actionCustom->blockSignals(false);
-    } else {
-        ui->actionDark->setChecked(true);
-    }
 
     customPaletteColorDialog->setOption(QColorDialog::DontUseNativeDialog);
     customPaletteColorDialog->setObjectName("Custom Color Dialog");
@@ -812,7 +842,7 @@ void MainWindow::initToolBar()
         // StrongFocus: a single click inside the dock routes keyboard events into QML
         // without requiring a prior click in the viewport.
         chatWidget->setFocusPolicy(Qt::StrongFocus);
-        chatWidget->setSource(QUrl("qrc:/AIChatPanel/AIChatPanel.qml"));
+        markLazyQml(chatWidget, QUrl("qrc:/AIChatPanel/AIChatPanel.qml"));
         m_chatDock = new QDockWidget(tr("AI Chat"), this);
         m_chatDock->setWidget(chatWidget);
         m_chatDock->setObjectName("AIChatDock");
@@ -841,7 +871,7 @@ void MainWindow::initToolBar()
         assetBrowserWidget->setMinimumHeight(kBottomToolHeight);
         assetBrowserWidget->setMaximumHeight(kBottomToolHeight);
         assetBrowserWidget->setFocusPolicy(Qt::StrongFocus);
-        assetBrowserWidget->setSource(QUrl("qrc:/AssetBrowser/AssetBrowser.qml"));
+        markLazyQml(assetBrowserWidget, QUrl("qrc:/AssetBrowser/AssetBrowser.qml"));
         m_assetBrowserDock = new QDockWidget(tr("Asset Browser"), this);
         m_assetBrowserDock->setWidget(assetBrowserWidget);
         m_assetBrowserDock->setObjectName("AssetBrowserDock");
@@ -849,12 +879,17 @@ void MainWindow::initToolBar()
         addDockWidget(Qt::BottomDockWidgetArea, m_assetBrowserDock);
         m_assetBrowserDock->hide();
 
-        // Connect Browse button — open a native directory picker from MainWindow
-        // (QFileDialog needs a proper parent widget on macOS)
-        auto* abController = AssetBrowserController::instance();
-        connect(abController, &AssetBrowserController::importMeshRequested, this, [this](const QStringList& paths) {
-            SentryReporter::addBreadcrumb("ui.action", "Asset Browser: import mesh");
-            importMeshs(paths);
+        connect(m_assetBrowserDock, &QDockWidget::visibilityChanged, this, [this](bool vis) {
+            if (!vis)
+                return;
+            ensureLazyDockQml(m_assetBrowserDock);
+            auto* abController = AssetBrowserController::instance();
+            disconnect(abController, &AssetBrowserController::importMeshRequested, this, nullptr);
+            connect(abController, &AssetBrowserController::importMeshRequested, this,
+                    [this](const QStringList& paths) {
+                        SentryReporter::addBreadcrumb("ui.action", "Asset Browser: import mesh");
+                        importMeshs(paths);
+                    });
         });
     }
 
@@ -868,7 +903,7 @@ void MainWindow::initToolBar()
         dopeSheetWidget->setMinimumHeight(kBottomToolHeight);
         dopeSheetWidget->setMaximumHeight(kBottomToolHeight);
         dopeSheetWidget->setFocusPolicy(Qt::StrongFocus);
-        dopeSheetWidget->setSource(QUrl("qrc:/AnimationControl/AnimationDopeSheet.qml"));
+        markLazyQml(dopeSheetWidget, QUrl("qrc:/AnimationControl/AnimationDopeSheet.qml"));
 
         // QQuickWidget inside a QDockWidget on macOS can swallow wheel events
         // before they reach the QML scene's WheelHandler — Qt routes them to
@@ -934,7 +969,7 @@ void MainWindow::initToolBar()
         curveEditorWidget->setMinimumHeight(kBottomToolHeight);
         curveEditorWidget->setMaximumHeight(kBottomToolHeight);
         curveEditorWidget->setFocusPolicy(Qt::StrongFocus);
-        curveEditorWidget->setSource(QUrl("qrc:/AnimationControl/AnimationCurveEditor.qml"));
+        markLazyQml(curveEditorWidget, QUrl("qrc:/AnimationControl/AnimationCurveEditor.qml"));
         m_curveEditorDock = new QDockWidget(tr("Curve Editor"), this); // NOSONAR
         m_curveEditorDock->setWidget(curveEditorWidget);
         m_curveEditorDock->setObjectName("CurveEditorDock");
@@ -958,7 +993,7 @@ void MainWindow::initToolBar()
         uvEditorWidget->setMinimumHeight(kBottomToolHeight);
         uvEditorWidget->setMaximumHeight(kBottomToolHeight);
         uvEditorWidget->setFocusPolicy(Qt::StrongFocus);
-        uvEditorWidget->setSource(QUrl("qrc:/UVEditor/UVEditorPanel.qml"));
+        markLazyQml(uvEditorWidget, QUrl("qrc:/UVEditor/UVEditorPanel.qml"));
 
         m_uvEditorDock = new QDockWidget(tr("UV Editor"), this); // NOSONAR
         m_uvEditorDock->setWidget(uvEditorWidget);
@@ -970,7 +1005,9 @@ void MainWindow::initToolBar()
         connect(m_uvEditorDock, &QDockWidget::visibilityChanged, this, [this](bool vis) {
             SentryReporter::addBreadcrumb("ui.action",
                 vis ? "UV Editor shown" : "UV Editor hidden");
+            UVEditorController::instance()->setPanelActive(vis);
             if (vis) {
+                ensureLazyDockQml(m_uvEditorDock);
                 UVEditorController::instance()->refresh();
                 if (auto* root = qobject_cast<QQuickWidget*>(m_uvEditorDock->widget())) {
                     if (root->rootObject())
@@ -1114,6 +1151,7 @@ void MainWindow::initToolBar()
     aiChatButton->setFont(aiFont);
     connect(aiChatButton, &QToolButton::clicked, this, [this]() {
         if (m_chatDock) {
+            ensureLazyDockQml(m_chatDock);
             m_chatDock->show();
             m_chatDock->raise();
         }
@@ -2382,6 +2420,7 @@ void MainWindow::initToolBar()
     aiChatAction->setObjectName("actionAIChatDock");
     connect(aiChatAction, &QAction::triggered, this, [this]() {
         if (m_chatDock) {
+            ensureLazyDockQml(m_chatDock);
             m_chatDock->show();
             m_chatDock->raise();
         }
@@ -2455,8 +2494,9 @@ void MainWindow::initToolBar()
         }
     });
 
-    // Initialize LLMManager
-    LLMManager::instance();
+    // Initialize LLMManager after the window is up — starting the worker thread
+    // during initToolBar competes with Ogre + QML startup on the main thread.
+    QTimer::singleShot(0, this, []() { LLMManager::instance(); });
 
 #ifdef ENABLE_PS1_RIP
     QMenu *toolsMenu = menuBar()->addMenu(tr("&Tools"));
@@ -3242,6 +3282,8 @@ void MainWindow::showBottomToolDock(QDockWidget* dock)
 {
     if (!dock)
         return;
+
+    ensureLazyDockQml(dock);
 
     if (dock->isFloating())
         dock->setFloating(false);


### PR DESCRIPTION
## Summary

Fixes UI freezes when importing meshes (especially large/skinned FBX assets).

- **UV Editor (#460 follow-up):** `UVEditorController` was rebuilding the full HalfEdge/island cache + `QVariantList` triangle payload on every `entityCreated` / `selectOne` during import (each sub-entity auto-selects). Now skips rebuilds while the UV Editor dock is hidden, debounces (75ms) when open, and indexes vertices→triangles for edit-mode context islands.
- **Startup/import latency:** Lazy-load hidden dock QML (UV Editor, Asset Browser, AI Chat, Dope Sheet, Curve Editor), defer Asset Browser directory scan + `LLMManager` init, and stop re-applying custom palette via `setPalette()` after QML widgets exist.

## Test plan

- [x] `UnitTests --gtest_filter="UVEditorControllerTest.*"` — 16/16 pass
- [ ] Import a large animated FBX — viewport stays responsive with UV Editor closed
- [ ] Open UV Editor after import — layout + context islands populate correctly
- [ ] Custom palette users — menu checkbox still reflects saved theme, no startup repaint stall


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The UV Editor now updates more efficiently in the background and resumes automatically when opened.
  * Several panels and tools now load only when needed, improving startup and display responsiveness.

* **Bug Fixes**
  * Hidden UV Editor panels no longer trigger unnecessary rebuilds or updates.
  * Theme changes now avoid extra UI work, helping prevent freezes.
  * Docked views are more reliable when shown or activated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->