### PR TITLE
feat(#461): UV editor transforms with undo and live viewport sync

### DIFF
--- a/qml/MaterialListModal.qml
+++ b/qml/MaterialListModal.qml
@@ -37,10 +37,22 @@ ApplicationWindow {
     // Filtered material list
     property var allMaterials: []
     property var filteredMaterials: []
+    property var materialPreviewUris: ({})
     property string searchText: ""
+
+    function rebuildMaterialPreviews(names) {
+        var uris = {}
+        for (var i = 0; i < names.length; ++i) {
+            var n = names[i]
+            if (n && n.length > 0)
+                uris[n] = MaterialEditorQML.materialPreview(n)
+        }
+        materialPreviewUris = uris
+    }
 
     function refreshMaterialList() {
         allMaterials = MaterialEditorQML.getMaterialList()
+        rebuildMaterialPreviews(allMaterials)
         applyFilter()
     }
 
@@ -149,7 +161,7 @@ ApplicationWindow {
                             Image {
                                 anchors.horizontalCenter: parent.horizontalCenter
                                 width: 52; height: 52
-                                source: MaterialEditorQML.materialPreview(modelData)
+                                source: materialListModal.materialPreviewUris[modelData] || ""
                                 fillMode: Image.PreserveAspectFit
                                 asynchronous: true
                                 sourceSize.width: 52

--- a/qml/MaterialListModal.qml
+++ b/qml/MaterialListModal.qml
@@ -164,6 +164,7 @@ ApplicationWindow {
                                 source: materialListModal.materialPreviewUris[modelData] || ""
                                 fillMode: Image.PreserveAspectFit
                                 asynchronous: true
+                                cache: false
                                 sourceSize.width: 52
                                 sourceSize.height: 52
 
@@ -323,6 +324,13 @@ ApplicationWindow {
     Component.onCompleted: {
         refreshMaterialList()
         selectedMaterial = ""
+    }
+
+    Connections {
+        target: MaterialEditorQML
+        function onMaterialApplied() {
+            rebuildMaterialPreviews(allMaterials)
+        }
     }
 
     onImportMaterials: openImportDialog()

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -4514,6 +4514,10 @@ Rectangle {
                     target: materialToolCol
                     function onSelectedMaterialNameChanged() { previewHost.schedulePreviewRefresh() }
                 }
+                Connections {
+                    target: MaterialEditorQML
+                    function onMaterialApplied() { previewHost.schedulePreviewRefresh() }
+                }
                 onPreviewShapeChanged: schedulePreviewRefresh()
                 onPreviewYawChanged: schedulePreviewRefresh()
                 onWidthChanged: schedulePreviewRefresh()

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -3941,10 +3941,22 @@ Rectangle {
             // Drives the preview thumbnail and the action buttons.
             property string selectedMaterialName: ""
             property var materialNames: []
+            property var materialPreviewUris: ({})
+
+            function rebuildMaterialPreviews() {
+                var uris = {}
+                for (var i = 0; i < materialNames.length; ++i) {
+                    var n = materialNames[i]
+                    if (n && n.length > 0)
+                        uris[n] = MaterialEditorQML.materialPreview(n)
+                }
+                materialPreviewUris = uris
+            }
 
             // Refresh the list when materials are imported/created.
             function refreshMaterialList() {
                 materialNames = MaterialEditorQML.getMaterialList()
+                rebuildMaterialPreviews()
             }
 
             // Defer the model load by one event-loop tick so the
@@ -3970,6 +3982,7 @@ Rectangle {
             Connections {
                 target: MaterialEditorQML
                 function onMaterialNameChanged() { materialToolCol.refreshMaterialList() }
+                function onMaterialApplied() { materialToolCol.rebuildMaterialPreviews() }
             }
 
             // Also refresh when the scene's material set may have changed —
@@ -4154,8 +4167,8 @@ Rectangle {
                                     Image {
                                         anchors.horizontalCenter: parent.horizontalCenter
                                         width: 52; height: 52
-                                        source: (modelData && modelData.length > 0)
-                                            ? MaterialEditorQML.materialPreview(modelData)
+                                        source: (modelData && materialToolCol.materialPreviewUris[modelData])
+                                            ? materialToolCol.materialPreviewUris[modelData]
                                             : ""
                                         fillMode: Image.PreserveAspectFit
                                         asynchronous: true
@@ -4469,6 +4482,42 @@ Rectangle {
                 property real previewYaw: 0.0
                 property real dragStartX: 0
                 property real dragStartYaw: 0
+                property string previewSource: ""
+
+                function schedulePreviewRefresh() {
+                    previewRefreshTimer.restart()
+                }
+
+                function refreshPreviewSource() {
+                    const mat = materialToolCol.selectedMaterialName
+                    if (!mat || mat.length === 0) {
+                        previewSource = ""
+                        return
+                    }
+                    const size = Math.min(Math.floor(previewHost.width), 256)
+                    if (size < 8)
+                        return
+                    const uri = MaterialEditorQML.interactiveMaterialPreview(
+                        mat, size, previewHost.previewShape, previewHost.previewYaw)
+                    if (uri && uri.length > 0)
+                        previewSource = uri
+                }
+
+                Timer {
+                    id: previewRefreshTimer
+                    interval: 80
+                    repeat: false
+                    onTriggered: previewHost.refreshPreviewSource()
+                }
+
+                Connections {
+                    target: materialToolCol
+                    function onSelectedMaterialNameChanged() { previewHost.schedulePreviewRefresh() }
+                }
+                onPreviewShapeChanged: schedulePreviewRefresh()
+                onPreviewYawChanged: schedulePreviewRefresh()
+                onWidthChanged: schedulePreviewRefresh()
+                Component.onCompleted: schedulePreviewRefresh()
 
                 Rectangle {
                     id: previewBg
@@ -4486,15 +4535,7 @@ Rectangle {
                         smooth: true
                         cache: false
                         asynchronous: true
-                        source: {
-                            const mat = materialToolCol.selectedMaterialName
-                            if (!mat || mat.length === 0) return ""
-                            return MaterialEditorQML.interactiveMaterialPreview(
-                                mat,
-                                Math.min(Math.floor(previewHost.width), 256),
-                                previewHost.previewShape,
-                                previewHost.previewYaw)
-                        }
+                        source: previewHost.previewSource
                     }
                     Text {
                         visible: previewImage.source.toString().length === 0

--- a/qml/UVEditorPanel.qml
+++ b/qml/UVEditorPanel.qml
@@ -24,10 +24,12 @@ Rectangle {
     property var ctxIslandCache: []
 
     property bool draggingSelect: false
+    property bool draggingTransform: false
     property real dragStartX: 0
     property real dragStartY: 0
     property real dragEndX: 0
     property real dragEndY: 0
+    property string numericBuffer: ""
 
     readonly property int modNone: 0
     readonly property int modShift: 0x02000000
@@ -120,6 +122,48 @@ Rectangle {
         Qt.callLater(fitToView)
     }
 
+    function transformModeLabel() {
+        switch (UVEditorController.transformMode) {
+        case -1: return "Select (Q)"
+        case 0: return "Move (W)"
+        case 1: return "Rotate (E)"
+        case 2: return "Scale (R)"
+        default: return ""
+        }
+    }
+
+    // Match the main viewport transform shortcuts (Unity convention).
+    function setTransformModeFromKey(key) {
+        if (key === Qt.Key_Q)
+            UVEditorController.transformMode = -1
+        else if (key === Qt.Key_W || key === Qt.Key_G)
+            UVEditorController.transformMode = 0
+        else if (key === Qt.Key_E)
+            UVEditorController.transformMode = 1
+        else if (key === Qt.Key_R)
+            UVEditorController.transformMode = 2
+    }
+
+    function appendNumericChar(ch) {
+        if (UVEditorController.transformMode < 0)
+            return
+        if (ch === "." && numericBuffer.indexOf(".") >= 0)
+            return
+        if (ch === "-" && numericBuffer.length > 0)
+            return
+        numericBuffer += ch
+    }
+
+    function applyNumericBuffer() {
+        if (numericBuffer.length === 0)
+            return
+        const val = parseFloat(numericBuffer)
+        if (isNaN(val))
+            return
+        UVEditorController.applyNumericTransform(val)
+        numericBuffer = ""
+    }
+
     Keys.onPressed: function(event) {
         if (event.key === Qt.Key_F) {
             fitToView()
@@ -135,6 +179,30 @@ Rectangle {
             event.accepted = true
         } else if (event.key === Qt.Key_3) {
             UVEditorController.selectionMode = 2
+            event.accepted = true
+        } else if (event.key === Qt.Key_Q || event.key === Qt.Key_W || event.key === Qt.Key_E
+                   || event.key === Qt.Key_R || event.key === Qt.Key_G) {
+            setTransformModeFromKey(event.key)
+            event.accepted = true
+        } else if (event.key === Qt.Key_Escape) {
+            if (root.draggingTransform)
+                UVEditorController.cancelTransformDrag()
+            else
+                UVEditorController.transformMode = -1
+            numericBuffer = ""
+            root.draggingTransform = false
+            event.accepted = true
+        } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+            applyNumericBuffer()
+            event.accepted = numericBuffer.length > 0
+        } else if (event.key >= Qt.Key_0 && event.key <= Qt.Key_9) {
+            appendNumericChar(String.fromCharCode(event.key))
+            event.accepted = true
+        } else if (event.key === Qt.Key_Minus) {
+            appendNumericChar("-")
+            event.accepted = true
+        } else if (event.key === Qt.Key_Period) {
+            appendNumericChar(".")
             event.accepted = true
         }
     }
@@ -162,6 +230,120 @@ Rectangle {
                       : ""
                 color: ThemeManager.disabledTextColor
                 font.pixelSize: 10
+            }
+
+            Text {
+                text: UVEditorController.hasMesh ? transformModeLabel() : ""
+                color: ThemeManager.accentColor
+                font.pixelSize: 10
+            }
+
+            Text {
+                visible: numericBuffer.length > 0
+                text: numericBuffer
+                color: ThemeManager.highlightColor
+                font.pixelSize: 11
+                font.bold: true
+            }
+
+            Row {
+                spacing: 2
+                Repeater {
+                    model: [
+                        { label: "Q", mode: -1, tip: "Select (Q)" },
+                        { label: "W", mode: 0, tip: "Move (W)" },
+                        { label: "E", mode: 1, tip: "Rotate (E)" },
+                        { label: "R", mode: 2, tip: "Scale (R)" }
+                    ]
+                    delegate: Rectangle {
+                        width: 20; height: 18; radius: 3
+                        color: UVEditorController.transformMode === modelData.mode
+                            ? ThemeManager.accentColor
+                            : ThemeManager.inputColor
+                        border.color: ThemeManager.borderColor
+                        border.width: 1
+                        ToolTip.visible: xformMa.containsMouse
+                        ToolTip.text: modelData.tip
+                        Text {
+                            anchors.centerIn: parent
+                            text: modelData.label
+                            color: ThemeManager.textColor
+                            font.pixelSize: 10
+                            font.bold: UVEditorController.transformMode === modelData.mode
+                        }
+                        MouseArea {
+                            id: xformMa
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: UVEditorController.transformMode = modelData.mode
+                        }
+                    }
+                }
+            }
+
+            ThemedComboBox {
+                id: pivotBox
+                Layout.preferredWidth: 72
+                model: ["Median", "Individual", "Cursor"]
+                currentIndex: UVEditorController.pivotMode
+                onActivated: UVEditorController.pivotMode = currentIndex
+            }
+
+            Rectangle {
+                width: 18; height: 18; radius: 3
+                color: UVEditorController.snapEnabled ? ThemeManager.highlightColor : ThemeManager.inputColor
+                border.color: ThemeManager.borderColor
+                ToolTip.visible: snapMa.containsMouse
+                ToolTip.text: "Snap (Ctrl inverts while dragging)"
+                Text {
+                    anchors.centerIn: parent
+                    text: "Snap"
+                    color: ThemeManager.textColor
+                    font.pixelSize: 8
+                }
+                MouseArea {
+                    id: snapMa
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: UVEditorController.snapEnabled = !UVEditorController.snapEnabled
+                }
+            }
+
+            ThemedComboBox {
+                id: snapBox
+                Layout.preferredWidth: 64
+                model: ["Grid", "Vertex", "Pixel"]
+                currentIndex: UVEditorController.snapMode
+                onActivated: UVEditorController.snapMode = currentIndex
+            }
+
+            Text {
+                text: "Mx"
+                color: ThemeManager.textColor
+                font.pixelSize: 10
+                font.underline: mxMa.containsMouse
+                MouseArea {
+                    id: mxMa
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: UVEditorController.mirrorSelectionX()
+                }
+            }
+            Text {
+                text: "My"
+                color: ThemeManager.textColor
+                font.pixelSize: 10
+                font.underline: myMa.containsMouse
+                MouseArea {
+                    id: myMa
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: UVEditorController.mirrorSelectionY()
+                }
             }
 
             Row {
@@ -496,7 +678,7 @@ Rectangle {
             MouseArea {
                 id: selectMa
                 anchors.fill: parent
-                acceptedButtons: Qt.LeftButton | Qt.MiddleButton
+                acceptedButtons: Qt.LeftButton | Qt.MiddleButton | Qt.RightButton
                 hoverEnabled: true
                 preventStealing: false
 
@@ -510,6 +692,21 @@ Rectangle {
                         lastX = mouse.x
                         lastY = mouse.y
                         return
+                    }
+                    if (mouse.button === Qt.RightButton) {
+                        const uv = root.screenToUv(mouse.x - viewCanvas.x, mouse.y - viewCanvas.y)
+                        UVEditorController.setCursorFromUv(uv.x, uv.y)
+                        return
+                    }
+                    if (UVEditorController.transformMode >= 0
+                            && UVEditorController.selectedVertexCount
+                               + UVEditorController.selectedEdgeCount
+                               + UVEditorController.selectedFaceCount > 0) {
+                        const uv = root.screenToUv(mouse.x - viewCanvas.x, mouse.y - viewCanvas.y)
+                        if (UVEditorController.beginTransformDrag(uv.x, uv.y, activeModifiers)) {
+                            root.draggingTransform = true
+                            return
+                        }
                     }
                     root.draggingSelect = true
                     root.dragStartX = mouse.x
@@ -529,6 +726,12 @@ Rectangle {
                         viewCanvas.requestPaint()
                         return
                     }
+                    if (root.draggingTransform && (mouse.buttons & Qt.LeftButton)) {
+                        const uv = root.screenToUv(mouse.x - viewCanvas.x, mouse.y - viewCanvas.y)
+                        UVEditorController.updateTransformDrag(uv.x, uv.y, activeModifiers)
+                        root.rebuildTriangleCache()
+                        return
+                    }
                     if (root.draggingSelect) {
                         root.dragEndX = mouse.x
                         root.dragEndY = mouse.y
@@ -536,8 +739,14 @@ Rectangle {
                     }
                 }
                 onReleased: function(mouse) {
-                    if (mouse.button === Qt.MiddleButton)
+                    if (mouse.button === Qt.MiddleButton || mouse.button === Qt.RightButton)
                         return
+                    if (root.draggingTransform) {
+                        UVEditorController.commitTransformDrag()
+                        root.draggingTransform = false
+                        root.rebuildTriangleCache()
+                        return
+                    }
                     if (!root.draggingSelect)
                         return
                     root.draggingSelect = false

--- a/qml/UVEditorPanel.qml
+++ b/qml/UVEditorPanel.qml
@@ -156,12 +156,13 @@ Rectangle {
 
     function applyNumericBuffer() {
         if (numericBuffer.length === 0)
-            return
+            return false
         const val = parseFloat(numericBuffer)
         if (isNaN(val))
-            return
+            return false
         UVEditorController.applyNumericTransform(val)
         numericBuffer = ""
+        return true
     }
 
     Keys.onPressed: function(event) {
@@ -170,6 +171,19 @@ Rectangle {
             event.accepted = true
         } else if (event.key === Qt.Key_Home) {
             resetView()
+            event.accepted = true
+        } else if (UVEditorController.transformMode >= 0
+                   && (event.key === Qt.Key_Return || event.key === Qt.Key_Enter)) {
+            event.accepted = applyNumericBuffer()
+        } else if (UVEditorController.transformMode >= 0
+                   && event.key >= Qt.Key_0 && event.key <= Qt.Key_9) {
+            appendNumericChar(String.fromCharCode(event.key))
+            event.accepted = true
+        } else if (UVEditorController.transformMode >= 0 && event.key === Qt.Key_Minus) {
+            appendNumericChar("-")
+            event.accepted = true
+        } else if (UVEditorController.transformMode >= 0 && event.key === Qt.Key_Period) {
+            appendNumericChar(".")
             event.accepted = true
         } else if (event.key === Qt.Key_1) {
             UVEditorController.selectionMode = 0
@@ -191,18 +205,6 @@ Rectangle {
                 UVEditorController.transformMode = -1
             numericBuffer = ""
             root.draggingTransform = false
-            event.accepted = true
-        } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
-            applyNumericBuffer()
-            event.accepted = numericBuffer.length > 0
-        } else if (event.key >= Qt.Key_0 && event.key <= Qt.Key_9) {
-            appendNumericChar(String.fromCharCode(event.key))
-            event.accepted = true
-        } else if (event.key === Qt.Key_Minus) {
-            appendNumericChar("-")
-            event.accepted = true
-        } else if (event.key === Qt.Key_Period) {
-            appendNumericChar(".")
             event.accepted = true
         }
     }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,6 +76,7 @@ commands/PoseLibraryCommands.cpp
 commands/SkeletonResolver.cpp
 commands/ComputeSkinWeightsCommand.cpp
 commands/AutoRigCommand.cpp
+commands/UVEditCommand.cpp
 BoneDragRelease.cpp
 PropertiesPanelController.cpp
 SceneTreeModel.cpp
@@ -88,6 +89,7 @@ ExportOptimizer.cpp
 UvUnwrap.cpp
 UvUnwrapController.cpp
 UVEditorController.cpp
+UVTransform.cpp
 QuadRetopo.cpp
 QuadRetopoController.cpp
 SkinWeights.cpp

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -639,6 +639,11 @@ void EditModeController::exitEditMode(bool commitChanges)
     emit validationChanged();
 }
 
+void EditModeController::notifyMeshDataChanged()
+{
+    emit meshDataChanged();
+}
+
 void EditModeController::onSelectionChanged()
 {
     // If selection changes while in edit mode and the edited entity is no

--- a/src/EditModeController.h
+++ b/src/EditModeController.h
@@ -160,6 +160,8 @@ public:
     Q_INVOKABLE void toggleEditMode();
     Q_INVOKABLE bool enterEditMode();
     Q_INVOKABLE void exitEditMode(bool commitChanges = true);
+    /// Notify listeners that editable mesh UV/attribute data changed (issue #461).
+    Q_INVOKABLE void notifyMeshDataChanged();
     /// @}
 
     /// @name Component selection mode (Vertex/Edge/Face)

--- a/src/EditableMesh.cpp
+++ b/src/EditableMesh.cpp
@@ -826,7 +826,10 @@ bool entityHasNormalMap(Ogre::Entity* ent)
         }
         if (mat->getNumTechniques() == 0)
             continue;
-        auto* pass = mat->getTechnique(0)->getPass(0);
+        auto* technique = mat->getTechnique(0);
+        if (!technique || technique->getNumPasses() == 0)
+            continue;
+        auto* pass = technique->getPass(0);
         if (!pass)
             continue;
         for (unsigned short t = 0; t < pass->getNumTextureUnitStates(); ++t) {

--- a/src/EditableMesh.cpp
+++ b/src/EditableMesh.cpp
@@ -27,7 +27,10 @@ THE SOFTWARE.
 */
 
 #include "EditableMesh.h"
+#include "Manager.h"
+#include "MeshImporterExporter.h"
 #include "SubMeshTransform.h"
+#include <OgreRTShaderSystem.h>
 #include <OgreSubEntity.h>
 #include <OgrePlatform.h>
 #include <algorithm>
@@ -35,6 +38,7 @@ THE SOFTWARE.
 #include <iterator>
 #include <limits>
 #include <cmath>
+#include <unordered_set>
 #include <cstring>
 #include <map>
 
@@ -801,6 +805,198 @@ bool EditableMesh::commitToEntity(Ogre::Entity* entity)
     writeNgonFacesToMesh(mesh, m_subMeshes);
 
     return true;
+}
+
+namespace {
+
+bool entityHasNormalMap(Ogre::Entity* ent)
+{
+    if (!ent)
+        return false;
+    for (unsigned int i = 0; i < ent->getNumSubEntities(); ++i) {
+        auto mat = ent->getSubEntity(i)->getMaterial();
+        if (!mat)
+            continue;
+        if (!mat->isLoaded()) {
+            try {
+                mat->load();
+            } catch (const Ogre::Exception&) {
+                continue;
+            }
+        }
+        if (mat->getNumTechniques() == 0)
+            continue;
+        auto* pass = mat->getTechnique(0)->getPass(0);
+        if (!pass)
+            continue;
+        for (unsigned short t = 0; t < pass->getNumTextureUnitStates(); ++t) {
+            const auto& tusName = pass->getTextureUnitState(t)->getName();
+            if (tusName == "normal_map" || tusName == "NormalMap")
+                return true;
+        }
+    }
+    return false;
+}
+
+/// Rebuild tangents / RTSS after UV edits on bump-mapped materials.
+void refreshEntityAfterUvCommit(Ogre::Entity* entity)
+{
+    if (!entity || !entity->getMesh())
+        return;
+
+    if (Manager::getSingletonPtr()) {
+        bool inScene = false;
+        for (auto* obj : Manager::getSingleton()->getEntities()) {
+            if (obj == entity && obj->getMovableType() == "Entity") {
+                inScene = true;
+                break;
+            }
+        }
+        if (!inScene)
+            return;
+    }
+
+    if (!entityHasNormalMap(entity))
+        return;
+
+    try {
+        entity->getMesh()->buildTangentVectors(
+            /*sourceTexCoordSet=*/0,
+            /*splitMirrored=*/false,
+            /*splitRotated=*/false,
+            /*storeParityInW=*/true);
+        MeshImporterExporter::applyNormalMapsToEntity(entity);
+    } catch (const Ogre::Exception&) {
+    } catch (...) {
+    }
+}
+
+} // namespace
+
+void EditableMesh::refreshEntityGpuCachesAfterUvWrite(Ogre::Entity* entity)
+{
+    refreshEntityAfterUvCommit(entity);
+}
+
+bool EditableMesh::commitUvsToEntity(Ogre::Entity* entity, int uvChannel,
+                                     bool* outBufferRebound)
+{
+    if (outBufferRebound)
+        *outBufferRebound = false;
+
+    if (!entity || uvChannel < 0)
+        return false;
+
+    Ogre::MeshPtr meshPtr = entity->getMesh();
+    if (!meshPtr)
+        return false;
+
+    Ogre::Mesh* mesh = meshPtr.get();
+
+    if (m_subMeshes.size() != static_cast<size_t>(mesh->getNumSubMeshes()))
+        return false;
+
+    bool wroteAny = false;
+    bool anyRebound = false;
+
+    // Shared pool: merge UVs from every submesh that references it so edits
+    // routed through a later submesh index still reach the GPU buffer.
+    if (mesh->sharedVertexData) {
+        const size_t sharedCount = mesh->sharedVertexData->vertexCount;
+        std::vector<EditableVertex> merged(sharedCount);
+        for (unsigned short i = 0; i < mesh->getNumSubMeshes(); ++i) {
+            if (!mesh->getSubMesh(i)->useSharedVertices)
+                continue;
+            const EditableSubMesh& editSub = m_subMeshes[i];
+            const size_t n = std::min(editSub.vertices.size(), sharedCount);
+            for (size_t vi = 0; vi < n; ++vi) {
+                if (editSub.vertices[vi].hasUV) {
+                    merged[vi].uv = editSub.vertices[vi].uv;
+                    merged[vi].hasUV = true;
+                }
+            }
+        }
+        bool rebound = false;
+        if (!writeUvChannel(mesh->sharedVertexData, uvChannel, merged, &rebound))
+            return false;
+        anyRebound = anyRebound || rebound;
+        wroteAny = true;
+    }
+
+    for (unsigned short i = 0; i < mesh->getNumSubMeshes(); ++i) {
+        Ogre::SubMesh* subMesh = mesh->getSubMesh(i);
+        if (subMesh->useSharedVertices)
+            continue;
+
+        const EditableSubMesh& editSub = m_subMeshes[i];
+        if (editSub.vertices.empty() || !subMesh->vertexData)
+            continue;
+
+        bool rebound = false;
+        if (!writeUvChannel(subMesh->vertexData, uvChannel, editSub.vertices, &rebound))
+            return false;
+        anyRebound = anyRebound || rebound;
+        wroteAny = true;
+    }
+
+    if (outBufferRebound)
+        *outBufferRebound = anyRebound;
+
+    if (wroteAny && entity->hasSkeleton())
+        syncSkelAnimUvBuffers(entity, uvChannel);
+
+    if (wroteAny)
+        refreshEntityGpuCachesAfterUvWrite(entity);
+
+    return wroteAny;
+}
+
+void EditableMesh::syncSkelAnimUvBuffers(Ogre::Entity* entity, int uvChannel)
+{
+    if (!entity || !entity->hasSkeleton())
+        return;
+
+    Ogre::Mesh* mesh = entity->getMesh().get();
+    if (!mesh)
+        return;
+
+    std::unordered_set<Ogre::VertexData*> updated;
+
+    if (mesh->sharedVertexData) {
+        Ogre::VertexData* sharedAnim = entity->_getSkelAnimVertexData();
+        if (sharedAnim && updated.insert(sharedAnim).second) {
+            const size_t sharedCount = sharedAnim->vertexCount;
+            std::vector<EditableVertex> merged(sharedCount);
+            for (unsigned short i = 0; i < mesh->getNumSubMeshes(); ++i) {
+                if (!mesh->getSubMesh(i)->useSharedVertices)
+                    continue;
+                const EditableSubMesh& editSub = m_subMeshes[i];
+                const size_t n = std::min(editSub.vertices.size(), sharedCount);
+                for (size_t vi = 0; vi < n; ++vi) {
+                    if (editSub.vertices[vi].hasUV) {
+                        merged[vi].uv = editSub.vertices[vi].uv;
+                        merged[vi].hasUV = true;
+                    }
+                }
+            }
+            writeUvChannel(sharedAnim, uvChannel, merged, nullptr);
+        }
+    }
+
+    for (unsigned short i = 0; i < entity->getNumSubEntities() && i < mesh->getNumSubMeshes(); ++i) {
+        Ogre::SubMesh* subMesh = mesh->getSubMesh(i);
+        if (subMesh->useSharedVertices)
+            continue;
+
+        Ogre::VertexData* animData = entity->getSubEntity(i)->_getSkelAnimVertexData();
+        if (!animData || !updated.insert(animData).second)
+            continue;
+
+        const EditableSubMesh& editSub = m_subMeshes[i];
+        if (editSub.vertices.empty())
+            continue;
+        writeUvChannel(animData, uvChannel, editSub.vertices, nullptr);
+    }
 }
 
 bool EditableMesh::commitVertexColorsToEntity(Ogre::Entity* entity)
@@ -1673,6 +1869,64 @@ bool EditableMesh::writeVertexData(Ogre::VertexData* vertexData, const std::vect
             *p = packDiffuseColour(vertices[j].color);
         });
 
+    return true;
+}
+
+bool EditableMesh::writeUvChannel(Ogre::VertexData* vertexData, int uvChannel,
+                                  const std::vector<EditableVertex>& vertices,
+                                  bool* outBufferRebound)
+{
+    if (outBufferRebound)
+        *outBufferRebound = false;
+
+    if (!vertexData || vertices.empty() || uvChannel < 0)
+        return false;
+
+    auto* decl = vertexData->vertexDeclaration;
+    auto* binding = vertexData->vertexBufferBinding;
+    const auto* elem = decl->findElementBySemantic(
+        Ogre::VES_TEXTURE_COORDINATES, static_cast<unsigned short>(uvChannel));
+    if (!elem)
+        return true;
+
+    unsigned short source = elem->getSource();
+    auto vbuf = binding->getBuffer(source);
+    if (!vbuf)
+        return false;
+
+    const size_t bufSize = vbuf->getSizeInBytes();
+    const size_t vertexSize = vbuf->getVertexSize();
+    const size_t count = std::min(vertices.size(), static_cast<size_t>(vertexData->vertexCount));
+
+    if (vbuf->getUsage() & Ogre::HardwareBuffer::HBU_STATIC) {
+        std::vector<unsigned char> oldData(bufSize);
+        vbuf->readData(0, bufSize, oldData.data());
+
+        auto newBuf = Ogre::HardwareBufferManager::getSingleton().createVertexBuffer(
+            vertexSize, vertexData->vertexCount,
+            Ogre::HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY, true /* useShadowBuffer */);
+        newBuf->writeData(0, bufSize, oldData.data(), true);
+        binding->setBinding(source, newBuf);
+        vbuf = newBuf;
+        if (outBufferRebound)
+            *outBufferRebound = true;
+    }
+
+    std::vector<unsigned char> bufCopy(bufSize);
+    vbuf->readData(0, bufSize, bufCopy.data());
+
+    for (size_t j = 0; j < count; ++j) {
+        if (!vertices[j].hasUV)
+            continue;
+        float* p = nullptr;
+        elem->baseVertexPointerToElement(bufCopy.data() + j * vertexSize, &p);
+        p[0] = vertices[j].uv.x;
+        p[1] = vertices[j].uv.y;
+    }
+
+    auto* dest = static_cast<unsigned char*>(vbuf->lock(Ogre::HardwareBuffer::HBL_DISCARD));
+    memcpy(dest, bufCopy.data(), bufSize);
+    vbuf->unlock();
     return true;
 }
 

--- a/src/EditableMesh.h
+++ b/src/EditableMesh.h
@@ -467,6 +467,24 @@ public:
     bool commitVertexColorsToEntity(Ogre::Entity* entity);
 
     /**
+     * @brief Write only UV coordinates back to the Ogre::Entity's buffers.
+     *
+     * Does not recalculate normals or mesh bounds. Writes the editable
+     * `EditableVertex::uv` values into the requested texture coordinate set.
+     * Does not re-init the entity. For bump-mapped materials call
+     * refreshEntityGpuCachesAfterUvWrite() to rebuild tangents.
+     *
+     * @param outBufferRebound Optional; set true when a static VBO was
+     *        replaced with a dynamic one (SubEntity caches must be refreshed).
+     */
+    bool commitUvsToEntity(Ogre::Entity* entity, int uvChannel = 0,
+                             bool* outBufferRebound = nullptr);
+
+    /// Rebuild tangents / RTSS after UV writes when the entity uses normal maps.
+    /// Does not tear down the entity (safe during live drag and animation).
+    static void refreshEntityGpuCachesAfterUvWrite(Ogre::Entity* entity);
+
+    /**
      * @brief Ensure diffuse vertex colors exist in memory and on the GPU.
      *
      * Vertices without `hasColor` become white. Rebuilds mesh buffers when the
@@ -596,6 +614,10 @@ private:
      */
     bool writeVertexData(Ogre::VertexData* vertexData, const std::vector<EditableVertex>& vertices);
     bool writeVertexColors(Ogre::VertexData* vertexData, const std::vector<EditableVertex>& vertices);
+    bool writeUvChannel(Ogre::VertexData* vertexData, int uvChannel,
+                        const std::vector<EditableVertex>& vertices,
+                        bool* outBufferRebound = nullptr);
+    void syncSkelAnimUvBuffers(Ogre::Entity* entity, int uvChannel);
 
     /**
      * @brief Build vertex/index hardware buffers for a single submesh.

--- a/src/MaterialEditorQML.cpp
+++ b/src/MaterialEditorQML.cpp
@@ -437,6 +437,8 @@ bool MaterialEditorQML::applyMaterial()
 
         // Reload the material to update UI
         loadMaterial(m_materialName);
+
+        MaterialPreviewRenderer::instance()->clearCache();
         
         emit materialApplied();
         return true;

--- a/src/MaterialPreviewRenderer.cpp
+++ b/src/MaterialPreviewRenderer.cpp
@@ -10,7 +10,10 @@
 #include <OgreMeshManager.h>
 #include <OgreTextureManager.h>
 #include <OgreRoot.h>
+#include <OgreRenderWindow.h>
 
+#include "Manager.h"
+#include "OgreRenderTargetUtil.h"
 #include "ProceduralBoxGenerator.h"
 #include "ProceduralPlaneGenerator.h"
 #include "ProceduralSphereGenerator.h"
@@ -160,6 +163,7 @@ bool MaterialPreviewRenderer::ensureScene()
             Ogre::TU_RENDERTARGET);
 
         m_renderTarget = m_rttTexture->getBuffer()->getRenderTarget();
+        OgreRenderTargetUtil::configureOffscreenRenderTarget(m_renderTarget);
         Ogre::Viewport* vp = m_renderTarget->addViewport(m_camera);
         vp->setClearEveryFrame(true);
         vp->setBackgroundColour(Ogre::ColourValue(0.15f, 0.15f, 0.15f, 1.0f));
@@ -292,10 +296,13 @@ QImage MaterialPreviewRenderer::renderPreview(const QString& materialName)
             Ogre::Box(0, 0, PREVIEW_SIZE, PREVIEW_SIZE), pb,
             Ogre::RenderTarget::FB_AUTO);
 
+        OgreRenderTargetUtil::restoreEditorRenderTarget();
         return image;
     } catch (const Ogre::Exception&) {
+        OgreRenderTargetUtil::restoreEditorRenderTarget();
         return {};
     } catch (...) {
+        OgreRenderTargetUtil::restoreEditorRenderTarget();
         return {};
     }
 }
@@ -339,6 +346,12 @@ QString MaterialPreviewRenderer::renderInteractivePreview(const QString& materia
     // Clamp size to a sane band: too small wastes pixels, too large
     // burns frame time for a docked preview.
     const int cappedSize = std::clamp(size, 32, 1024);
+    const double wrappedYaw = std::fmod(std::fmod(yawDegrees, 360.0) + 360.0, 360.0);
+    const int yawKey = static_cast<int>(std::lround(wrappedYaw));
+    const QString cacheKey =
+        QStringLiteral("%1|%2|%3|%4").arg(materialName).arg(cappedSize).arg(shape).arg(yawKey);
+    if (auto it = m_interactiveCache.constFind(cacheKey); it != m_interactiveCache.constEnd())
+        return it.value();
 
     // Allocate / resize the interactive render target when the requested
     // size changes. Reuses the existing texture when the size matches.
@@ -356,6 +369,7 @@ QString MaterialPreviewRenderer::renderInteractivePreview(const QString& materia
                 cappedSize, cappedSize, 0,
                 Ogre::PF_BYTE_RGBA, Ogre::TU_RENDERTARGET);
             m_interactiveRenderTarget = m_interactiveRtt->getBuffer()->getRenderTarget();
+            OgreRenderTargetUtil::configureOffscreenRenderTarget(m_interactiveRenderTarget);
             Ogre::Viewport* vp = m_interactiveRenderTarget->addViewport(m_camera);
             vp->setClearEveryFrame(true);
             vp->setBackgroundColour(Ogre::ColourValue(0.12f, 0.12f, 0.13f, 1.0f));
@@ -397,7 +411,6 @@ QString MaterialPreviewRenderer::renderInteractivePreview(const QString& materia
         // Apply environment yaw — rotate the light around the world
         // up-axis so the model appears illuminated from a different
         // angle. Modulo to [0, 360) so the cache key is stable.
-        const double wrappedYaw = std::fmod(std::fmod(yawDegrees, 360.0) + 360.0, 360.0);
         const Ogre::Radian yaw(Ogre::Degree(static_cast<float>(wrappedYaw)));
         Ogre::Vector3 baseDir = Ogre::Vector3(-1, -1, -1).normalisedCopy();
         Ogre::Quaternion rot(yaw, Ogre::Vector3::UNIT_Y);
@@ -411,14 +424,20 @@ QString MaterialPreviewRenderer::renderInteractivePreview(const QString& materia
             Ogre::Box(0, 0, cappedSize, cappedSize), pb,
             Ogre::RenderTarget::FB_AUTO);
 
+        OgreRenderTargetUtil::restoreEditorRenderTarget();
+
         QByteArray ba;
         QBuffer buf(&ba);
         buf.open(QIODevice::WriteOnly);
         if (!image.save(&buf, "PNG")) return {};
-        return QStringLiteral("data:image/png;base64,") + ba.toBase64();
+        const QString dataUri = QStringLiteral("data:image/png;base64,") + ba.toBase64();
+        m_interactiveCache.insert(cacheKey, dataUri);
+        return dataUri;
     } catch (const Ogre::Exception&) {
+        OgreRenderTargetUtil::restoreEditorRenderTarget();
         return {};
     } catch (...) {
+        OgreRenderTargetUtil::restoreEditorRenderTarget();
         return {};
     }
 }
@@ -426,6 +445,7 @@ QString MaterialPreviewRenderer::renderInteractivePreview(const QString& materia
 void MaterialPreviewRenderer::clearCache()
 {
     m_cache.clear();
+    m_interactiveCache.clear();
 }
 
 QString MaterialPreviewRenderer::firstMaterialNameInFile(const QString& filePath)

--- a/src/MaterialPreviewRenderer.cpp
+++ b/src/MaterialPreviewRenderer.cpp
@@ -346,8 +346,8 @@ QString MaterialPreviewRenderer::renderInteractivePreview(const QString& materia
     // Clamp size to a sane band: too small wastes pixels, too large
     // burns frame time for a docked preview.
     const int cappedSize = std::clamp(size, 32, 1024);
-    const double wrappedYaw = std::fmod(std::fmod(yawDegrees, 360.0) + 360.0, 360.0);
-    const int yawKey = static_cast<int>(std::lround(wrappedYaw));
+    const int yawKey = static_cast<int>(std::lround(
+        std::fmod(std::fmod(yawDegrees, 360.0) + 360.0, 360.0)));
     const QString cacheKey =
         QStringLiteral("%1|%2|%3|%4").arg(materialName).arg(cappedSize).arg(shape).arg(yawKey);
     if (auto it = m_interactiveCache.constFind(cacheKey); it != m_interactiveCache.constEnd())
@@ -411,7 +411,7 @@ QString MaterialPreviewRenderer::renderInteractivePreview(const QString& materia
         // Apply environment yaw — rotate the light around the world
         // up-axis so the model appears illuminated from a different
         // angle. Modulo to [0, 360) so the cache key is stable.
-        const Ogre::Radian yaw(Ogre::Degree(static_cast<float>(wrappedYaw)));
+        const Ogre::Radian yaw(Ogre::Degree(static_cast<float>(yawKey)));
         Ogre::Vector3 baseDir = Ogre::Vector3(-1, -1, -1).normalisedCopy();
         Ogre::Quaternion rot(yaw, Ogre::Vector3::UNIT_Y);
         m_lightNode->setDirection((rot * baseDir).normalisedCopy());

--- a/src/MaterialPreviewRenderer.h
+++ b/src/MaterialPreviewRenderer.h
@@ -52,6 +52,7 @@ public:
     /// `data:image/png;base64,…` URL the QML Image element shows directly.
     /// `size` is clamped to [32, 1024]; `yawDegrees` is wrapped to [0, 360).
     /// `shape` is one of the Shape enum values; out-of-range falls back to Sphere.
+    /// Results are cached per (material, size, shape, yaw) tuple.
     Q_INVOKABLE QString renderInteractivePreview(const QString& materialName,
                                                   int size,
                                                   int shape,
@@ -102,6 +103,10 @@ private:
 
     // Cache: materialName -> base64 data URI for the 64x64 thumbnail path.
     QHash<QString, QString> m_cache;
+
+    /// Slice I: interactive preview was documented as uncached; cache now
+    /// avoids re-entering Ogre RTT when QML re-evaluates bindings.
+    QHash<QString, QString> m_interactiveCache;
 
     static constexpr int PREVIEW_SIZE = 64;
 };

--- a/src/MaterialPreviewRenderer_test.cpp
+++ b/src/MaterialPreviewRenderer_test.cpp
@@ -1,3 +1,6 @@
+#include <OgreRoot.h>
+#include <OgreTextureManager.h>
+
 #include <gtest/gtest.h>
 #include "MaterialPreviewRenderer.h"
 #include "TestHelpers.h"
@@ -118,6 +121,12 @@ TEST_F(MaterialPreviewRendererTests, RenderPreviewWithOgreBaseWhite) {
     EXPECT_EQ(img.width(), 64);
     EXPECT_EQ(img.height(), 64);
     EXPECT_EQ(img.format(), QImage::Format_RGBA8888);
+
+    auto* tex = Ogre::TextureManager::getSingleton().getByName("MatPreviewRTT").get();
+    ASSERT_NE(tex, nullptr);
+    auto* thumbRtt = tex->getBuffer()->getRenderTarget();
+    ASSERT_NE(thumbRtt, nullptr);
+    EXPECT_FALSE(thumbRtt->isAutoUpdated());
 }
 
 TEST_F(MaterialPreviewRendererTests, FirstMaterialNameWithCommentLines) {

--- a/src/MeshDepthRenderer.cpp
+++ b/src/MeshDepthRenderer.cpp
@@ -1,6 +1,7 @@
 #include "MeshDepthRenderer.h"
 
 #include "Manager.h"
+#include "OgreRenderTargetUtil.h"
 #include "GlobalDefinitions.h"
 
 #include <OgreCamera.h>
@@ -87,6 +88,7 @@ bool ensureRenderTarget(int size, QString* errorOut)
         static_cast<Ogre::uint32>(size), static_cast<Ogre::uint32>(size), 0,
         Ogre::PF_BYTE_RGBA, Ogre::TU_RENDERTARGET);
     st.renderTarget = st.rttTexture->getBuffer()->getRenderTarget();
+    OgreRenderTargetUtil::configureOffscreenRenderTarget(st.renderTarget);
     st.size = size;
 
     if (!st.camera) {
@@ -270,6 +272,7 @@ MeshDepthRenderer::RenderResult MeshDepthRenderer::renderDepthMapView(
     // Render a single frame.
     st.renderTarget->update();
     QImage rgba = readRenderTarget(size);
+    OgreRenderTargetUtil::restoreEditorRenderTarget();
 
     // Capture the EXACT view/projection the frame was rendered with, so the
     // multi-view baker re-projects mesh triangles through the identical camera.

--- a/src/ModelIsometricRenderer.cpp
+++ b/src/ModelIsometricRenderer.cpp
@@ -4,6 +4,7 @@
 #include "Manager.h"
 #include "MeshImporterExporter.h"
 #include "RTShaderHelper.h"
+#include "OgreRenderTargetUtil.h"
 #include "SelectionSet.h"
 #include "SentryReporter.h"
 
@@ -183,6 +184,7 @@ bool ensureRenderTarget(int width, int height, const Ogre::ColourValue &bg, QStr
         static_cast<Ogre::uint32>(width), static_cast<Ogre::uint32>(height), 0, Ogre::PF_BYTE_RGBA,
         Ogre::TU_RENDERTARGET);
     st.renderTarget = st.rttTexture->getBuffer()->getRenderTarget();
+    OgreRenderTargetUtil::configureOffscreenRenderTarget(st.renderTarget);
     st.rttWidth = width;
     st.rttHeight = height;
 

--- a/src/ModelTurntableRenderer.cpp
+++ b/src/ModelTurntableRenderer.cpp
@@ -4,6 +4,7 @@
 #include "Manager.h"
 #include "MeshImporterExporter.h"
 #include "RTShaderHelper.h"
+#include "OgreRenderTargetUtil.h"
 #include "SelectionSet.h"
 #include "SentryReporter.h"
 
@@ -112,6 +113,7 @@ bool ensureRenderTarget(int width, int height, const Ogre::ColourValue &bg, QStr
         static_cast<Ogre::uint32>(width), static_cast<Ogre::uint32>(height), 0, Ogre::PF_BYTE_RGBA,
         Ogre::TU_RENDERTARGET);
     st.renderTarget = st.rttTexture->getBuffer()->getRenderTarget();
+    OgreRenderTargetUtil::configureOffscreenRenderTarget(st.renderTarget);
     st.rttWidth = width;
     st.rttHeight = height;
 

--- a/src/OgreRenderTargetUtil.h
+++ b/src/OgreRenderTargetUtil.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <OgreRenderSystem.h>
+#include <OgreRenderTarget.h>
+#include <OgreRenderWindow.h>
+#include <OgreRoot.h>
+
+#include <string>
+
+#include "Manager.h"
+
+namespace OgreRenderTargetUtil {
+
+/// Manual RTTs default to auto-update in Ogre, so every `renderOneFrame()`
+/// re-renders them and GL3+ logs `GL_INVALID_OPERATION` from `glDrawBuffer(GL_BACK)`.
+inline void configureOffscreenRenderTarget(Ogre::RenderTarget* target)
+{
+    if (target)
+        target->setAutoUpdated(false);
+}
+
+/// After an offscreen RTT pass, re-bind the editor viewport so the next
+/// `renderOneFrame()` does not inherit a stale FBO binding.
+inline void restoreEditorRenderTarget()
+{
+    auto* root = Ogre::Root::getSingletonPtr();
+    if (!root)
+        return;
+    auto* rs = root->getRenderSystem();
+    if (!rs)
+        return;
+
+    Ogre::RenderWindow* editorWindow = nullptr;
+    if (auto* mgr = Manager::getSingletonPtr()) {
+        if (auto* rt = mgr->getRoot()->getRenderTarget("Viewport 0"))
+            editorWindow = dynamic_cast<Ogre::RenderWindow*>(rt);
+    }
+    if (!editorWindow) {
+        for (unsigned short i = 0; i < 16; ++i) {
+            const std::string name = "Viewport " + std::to_string(i);
+            if (auto* rt = root->getRenderTarget(name))
+                if (auto* rw = dynamic_cast<Ogre::RenderWindow*>(rt)) {
+                    editorWindow = rw;
+                    break;
+                }
+        }
+    }
+    if (editorWindow)
+        rs->_setRenderTarget(editorWindow);
+}
+
+} // namespace OgreRenderTargetUtil

--- a/src/UVEditorController.cpp
+++ b/src/UVEditorController.cpp
@@ -885,8 +885,11 @@ bool UVEditorController::applyUvRefChanges(
     if (changes.empty())
         return false;
 
-    if (!commitWorkingMeshUvs())
+    if (!commitWorkingMeshUvs()) {
+        for (const auto& ch : changes)
+            applyWorkingMeshUv(ch.subMeshIndex, ch.vertexIndex, ch.oldUv);
         return false;
+    }
 
     if (auto* edit = EditModeController::instance()) {
         if (edit->isEditModeActive() && edit->editEntity() == m_activeEntity)

--- a/src/UVEditorController.cpp
+++ b/src/UVEditorController.cpp
@@ -7,12 +7,15 @@
 #include "Manager.h"
 #include "SelectionSet.h"
 #include "SentryReporter.h"
+#include "UndoManager.h"
+#include "commands/UVEditCommand.h"
 
 #include <QImage>
 #include <QColor>
 #include <QCoreApplication>
 #include <QDir>
 #include <QFileInfo>
+#include <QImageReader>
 #include <QRegularExpression>
 #include <QStandardPaths>
 #include <QUrl>
@@ -62,6 +65,7 @@ UVEditorController::UVEditorController(QObject* parent)
     m_refreshTimer->setSingleShot(true);
     m_refreshTimer->setInterval(75);
     connect(m_refreshTimer, &QTimer::timeout, this, &UVEditorController::rebuildMeshCache);
+
     connectSignals();
 }
 
@@ -562,7 +566,534 @@ void UVEditorController::setShowTextureBackground(bool on)
     if (m_showTextureBackground == on)
         return;
     m_showTextureBackground = on;
+    updateTexturePixelSize();
     emit showTextureBackgroundChanged();
+}
+
+void UVEditorController::setTransformMode(int mode)
+{
+    mode = std::max(-1, std::min(mode, 2));
+    const auto next = static_cast<TransformMode>(mode);
+    if (m_transformMode == next)
+        return;
+    m_transformMode = next;
+    emit transformModeChanged();
+}
+
+void UVEditorController::setPivotMode(int mode)
+{
+    mode = std::max(0, std::min(mode, 2));
+    const auto next = static_cast<PivotMode>(mode);
+    if (m_pivotMode == next)
+        return;
+    m_pivotMode = next;
+    emit pivotModeChanged();
+}
+
+void UVEditorController::setSnapMode(int mode)
+{
+    mode = std::max(0, std::min(mode, 2));
+    const auto next = static_cast<SnapMode>(mode);
+    if (m_snapMode == next)
+        return;
+    m_snapMode = next;
+    emit snapModeChanged();
+}
+
+void UVEditorController::setSnapEnabled(bool on)
+{
+    if (m_snapEnabled == on)
+        return;
+    m_snapEnabled = on;
+    emit snapEnabledChanged();
+}
+
+void UVEditorController::setUseBlenderTransformKeys(bool on)
+{
+    if (m_useBlenderTransformKeys == on)
+        return;
+    m_useBlenderTransformKeys = on;
+    emit useBlenderTransformKeysChanged();
+}
+
+void UVEditorController::setCursorU(double u)
+{
+    if (std::abs(m_cursorU - u) < 1e-9)
+        return;
+    m_cursorU = u;
+    emit cursorChanged();
+}
+
+void UVEditorController::setCursorV(double v)
+{
+    if (std::abs(m_cursorV - v) < 1e-9)
+        return;
+    m_cursorV = v;
+    emit cursorChanged();
+}
+
+void UVEditorController::setCursorFromUv(double u, double v)
+{
+    setCursorU(u);
+    setCursorV(v);
+}
+
+EditableMesh* UVEditorController::workingMeshForEntity(Ogre::Entity* entity)
+{
+    if (!entity || entity != m_activeEntity || m_workingMesh.subMeshes().empty())
+        return nullptr;
+    return &m_workingMesh;
+}
+
+void UVEditorController::refreshAfterUvEdit()
+{
+    syncUvLayoutFromWorkingMesh();
+}
+
+void UVEditorController::syncWorkingMeshFromEntity()
+{
+    if (!m_activeEntity)
+        return;
+
+    if (auto* edit = EditModeController::instance()) {
+        if (edit->isEditModeActive() && edit->editEntity() == m_activeEntity && edit->currentMesh()) {
+            m_workingMesh.subMeshes() = edit->currentMesh()->subMeshes();
+            applyUvChannel(m_workingMesh, m_activeEntity, m_uvChannel, m_submeshFilter);
+            return;
+        }
+    }
+
+    if (!m_workingMesh.loadFromEntity(m_activeEntity))
+        return;
+    applyUvChannel(m_workingMesh, m_activeEntity, m_uvChannel, m_submeshFilter);
+}
+
+void UVEditorController::applyWorkingMeshUv(int subMeshIndex, int localVert, const Ogre::Vector2& uv)
+{
+    if (subMeshIndex < 0 || localVert < 0)
+        return;
+
+    m_workingMesh.setVertexUV(static_cast<size_t>(subMeshIndex),
+                              static_cast<size_t>(localVert), uv);
+
+    if (m_activeEntity) {
+        Ogre::Mesh* mesh = m_activeEntity->getMesh().get();
+        if (mesh && static_cast<unsigned short>(subMeshIndex) < mesh->getNumSubMeshes()
+            && mesh->getSubMesh(static_cast<unsigned short>(subMeshIndex))->useSharedVertices) {
+            for (size_t si = 0; si < m_workingMesh.subMeshes().size(); ++si) {
+                if (static_cast<int>(si) == subMeshIndex)
+                    continue;
+                if (si >= mesh->getNumSubMeshes() || !mesh->getSubMesh(static_cast<unsigned short>(si))->useSharedVertices)
+                    continue;
+                m_workingMesh.setVertexUV(si, static_cast<size_t>(localVert), uv);
+            }
+        }
+    }
+
+    if (auto* edit = EditModeController::instance()) {
+        if (edit->isEditModeActive() && edit->editEntity() == m_activeEntity && edit->currentMesh()) {
+            edit->currentMesh()->setVertexUV(static_cast<size_t>(subMeshIndex),
+                                             static_cast<size_t>(localVert), uv);
+            if (m_activeEntity) {
+                Ogre::Mesh* mesh = m_activeEntity->getMesh().get();
+                if (mesh && static_cast<unsigned short>(subMeshIndex) < mesh->getNumSubMeshes()
+                    && mesh->getSubMesh(static_cast<unsigned short>(subMeshIndex))->useSharedVertices) {
+                    for (size_t si = 0; si < edit->currentMesh()->subMeshes().size(); ++si) {
+                        if (static_cast<int>(si) == subMeshIndex)
+                            continue;
+                        if (si >= mesh->getNumSubMeshes()
+                            || !mesh->getSubMesh(static_cast<unsigned short>(si))->useSharedVertices)
+                            continue;
+                        edit->currentMesh()->setVertexUV(si, static_cast<size_t>(localVert), uv);
+                    }
+                }
+            }
+        }
+    }
+}
+
+void UVEditorController::syncUvLayoutFromWorkingMesh()
+{
+    for (auto& vert : m_uvVerts) {
+        int subIdx = 0;
+        int localVert = 0;
+        if (!mapGlobalVertToSubLocal(vert.meshGlobalVert, subIdx, localVert))
+            continue;
+        const Ogre::Vector2 uv = m_workingMesh.getVertexUV(
+            static_cast<size_t>(subIdx), static_cast<size_t>(localVert));
+        vert.u = uv.x;
+        vert.v = uv.y;
+    }
+
+    for (auto& tri : m_uvTris) {
+        for (int c = 0; c < 3; ++c) {
+            const int id = tri.uvVertId[c];
+            if (id < 0 || id >= static_cast<int>(m_uvVerts.size()))
+                continue;
+            tri.u[c] = m_uvVerts[static_cast<size_t>(id)].u;
+            tri.v[c] = m_uvVerts[static_cast<size_t>(id)].v;
+        }
+    }
+
+    QVariantList tris;
+    tris.reserve(static_cast<int>(m_uvTris.size()));
+    for (const auto& tri : m_uvTris) {
+        tris.push_back(QVariantMap{
+            {QStringLiteral("u0"), tri.u[0]},
+            {QStringLiteral("v0"), tri.v[0]},
+            {QStringLiteral("u1"), tri.u[1]},
+            {QStringLiteral("v1"), tri.v[1]},
+            {QStringLiteral("u2"), tri.u[2]},
+            {QStringLiteral("v2"), tri.v[2]},
+            {QStringLiteral("island"), tri.island},
+            {QStringLiteral("color"), colorForIsland(tri.island)},
+        });
+    }
+    m_triangles = tris;
+
+    ++m_meshRevision;
+    emit meshDataChanged();
+}
+
+void UVEditorController::updateTexturePixelSize()
+{
+    m_texturePixelSize = 0;
+    if (!m_showTextureBackground || m_textureBackgroundSource.isEmpty())
+        return;
+
+    const QUrl url(m_textureBackgroundSource);
+    const QString path = url.isLocalFile() ? url.toLocalFile() : m_textureBackgroundSource;
+    QImageReader reader(path);
+    if (!reader.canRead())
+        return;
+    const QSize size = reader.size();
+    if (size.isValid())
+        m_texturePixelSize = std::max(size.width(), size.height());
+}
+
+QSet<int> UVEditorController::affectedUvVertIds() const
+{
+    QSet<int> ids = m_selectedUvVerts;
+    for (int eid : m_selectedUvEdges) {
+        if (eid < 0 || eid >= m_uvEdges.size())
+            continue;
+        ids.insert(m_uvEdges[static_cast<size_t>(eid)].v0);
+        ids.insert(m_uvEdges[static_cast<size_t>(eid)].v1);
+    }
+    for (int fid : m_selectedUvFaces) {
+        if (fid < 0 || fid >= static_cast<int>(m_uvTris.size()))
+            continue;
+        const auto& tri = m_uvTris[static_cast<size_t>(fid)];
+        for (int c = 0; c < 3; ++c)
+            ids.insert(tri.uvVertId[c]);
+    }
+    return ids;
+}
+
+bool UVEditorController::mapGlobalVertToSubLocal(int globalVert, int& subMeshIndex, int& localVert) const
+{
+    if (globalVert < 0 || m_workingMesh.subMeshes().empty())
+        return false;
+
+    int off = 0;
+    for (size_t si = 0; si < m_workingMesh.subMeshes().size(); ++si) {
+        const int count = static_cast<int>(m_workingMesh.subMeshes()[si].vertices.size());
+        if (globalVert >= off && globalVert < off + count) {
+            subMeshIndex = static_cast<int>(si);
+            localVert = globalVert - off;
+            return true;
+        }
+        off += count;
+    }
+    return false;
+}
+
+UVTransform::Settings UVEditorController::transformSettings(bool invertSnap) const
+{
+    UVTransform::Settings settings;
+    settings.pivot = static_cast<UVTransform::PivotMode>(static_cast<int>(m_pivotMode));
+    settings.snap = static_cast<UVTransform::SnapMode>(static_cast<int>(m_snapMode));
+    settings.snapEnabled = m_snapEnabled;
+    settings.invertSnap = invertSnap;
+    settings.cursor = {static_cast<float>(m_cursorU), static_cast<float>(m_cursorV)};
+    settings.texturePixelSize = m_texturePixelSize;
+    return settings;
+}
+
+std::vector<UVTransform::VertRef> UVEditorController::collectSelectedUvRefs() const
+{
+    std::vector<UVTransform::VertRef> refs;
+    const QSet<int> ids = affectedUvVertIds();
+    refs.reserve(ids.size());
+    for (int id : ids) {
+        if (id < 0 || id >= static_cast<int>(m_uvVerts.size()))
+            continue;
+        const auto& v = m_uvVerts[static_cast<size_t>(id)];
+        refs.push_back({id, {v.u, v.v}});
+    }
+    return refs;
+}
+
+std::vector<UVTransform::VertRef> UVEditorController::collectAllUvRefs() const
+{
+    std::vector<UVTransform::VertRef> refs;
+    refs.reserve(m_uvVerts.size());
+    for (size_t i = 0; i < m_uvVerts.size(); ++i) {
+        const auto& v = m_uvVerts[i];
+        refs.push_back({static_cast<int>(i), {v.u, v.v}});
+    }
+    return refs;
+}
+
+bool UVEditorController::applyUvRefChanges(
+    const std::vector<UVTransform::VertRef>& refs,
+    const std::vector<UVTransform::VertRef>& before,
+    UVTransform::TransformOp op,
+    const QString& description)
+{
+    if (!m_activeEntity || refs.empty() || refs.size() != before.size())
+        return false;
+
+    if (m_workingMesh.subMeshes().empty())
+        return false;
+
+    std::vector<UVEditCommand::VertChange> changes;
+    changes.reserve(refs.size());
+
+    for (size_t i = 0; i < refs.size(); ++i) {
+        const auto& after = refs[i];
+        const auto& prev = before[i];
+        if (after.id < 0 || after.id >= static_cast<int>(m_uvVerts.size()))
+            continue;
+
+        const int globalVert = m_uvVerts[static_cast<size_t>(after.id)].meshGlobalVert;
+        int subIdx = 0;
+        int localVert = 0;
+        if (!mapGlobalVertToSubLocal(globalVert, subIdx, localVert))
+            continue;
+
+        applyWorkingMeshUv(subIdx, localVert, after.uv);
+
+        UVEditCommand::VertChange change;
+        change.subMeshIndex = subIdx;
+        change.vertexIndex = localVert;
+        change.oldUv = prev.uv;
+        change.newUv = after.uv;
+        changes.push_back(change);
+    }
+
+    if (changes.empty())
+        return false;
+
+    if (!commitWorkingMeshUvs())
+        return false;
+
+    if (auto* edit = EditModeController::instance()) {
+        if (edit->isEditModeActive() && edit->editEntity() == m_activeEntity)
+            edit->notifyMeshDataChanged();
+    }
+
+    if (UndoManager* undo = UndoManager::getSingleton())
+        undo->push(new UVEditCommand(m_activeEntity, m_uvChannel, changes, description));
+
+    SentryReporter::addBreadcrumb(QStringLiteral("mesh.uv.transform"), description);
+    syncUvLayoutFromWorkingMesh();
+    return true;
+}
+
+Ogre::Vector2 UVEditorController::transformDeltaFromDrag(double u, double v) const
+{
+    const float du = static_cast<float>(u - m_dragStartU);
+    const float dv = static_cast<float>(v - m_dragStartV);
+
+    switch (m_transformMode) {
+    case MoveTransform:
+        return {du, dv};
+    case RotateTransform:
+        return {du * 180.f, 0.f};
+    case ScaleTransform: {
+        const float dist = std::sqrt(du * du + dv * dv);
+        const float sign = (du + dv) >= 0.f ? 1.f : -1.f;
+        return {1.f + sign * dist, 0.f};
+    }
+    default:
+        return Ogre::Vector2::ZERO;
+    }
+}
+
+bool UVEditorController::beginTransformDrag(double u, double v, int modifiers)
+{
+    if (!m_hasMesh || m_transformMode == NoTransform)
+        return false;
+
+    const auto selected = collectSelectedUvRefs();
+    if (selected.empty())
+        return false;
+
+    m_dragBeforeChanges.clear();
+    m_dragBeforeRefs = selected;
+    for (const auto& ref : selected) {
+        if (ref.id < 0 || ref.id >= static_cast<int>(m_uvVerts.size()))
+            continue;
+        const int globalVert = m_uvVerts[static_cast<size_t>(ref.id)].meshGlobalVert;
+        int subIdx = 0;
+        int localVert = 0;
+        if (!mapGlobalVertToSubLocal(globalVert, subIdx, localVert))
+            continue;
+        UVEditCommand::VertChange change;
+        change.subMeshIndex = subIdx;
+        change.vertexIndex = localVert;
+        change.oldUv = ref.uv;
+        change.newUv = ref.uv;
+        m_dragBeforeChanges.push_back(change);
+    }
+    if (m_dragBeforeChanges.empty())
+        return false;
+
+    m_dragStartU = u;
+    m_dragStartV = v;
+    m_draggingTransform = true;
+    m_transformActive = true;
+    emit transformActiveChanged();
+    return true;
+}
+
+void UVEditorController::updateTransformDrag(double u, double v, int modifiers)
+{
+    if (!m_draggingTransform || m_transformMode == NoTransform)
+        return;
+
+    const bool invertSnap = (modifiers & static_cast<int>(ControlModifier)) != 0;
+    const auto& before = m_dragBeforeRefs;
+    UVTransform::TransformOp op = UVTransform::TransformOp::Move;
+    switch (m_transformMode) {
+    case MoveTransform: op = UVTransform::TransformOp::Move; break;
+    case RotateTransform: op = UVTransform::TransformOp::Rotate; break;
+    case ScaleTransform: op = UVTransform::TransformOp::Scale; break;
+    default: return;
+    }
+
+    const Ogre::Vector2 delta = transformDeltaFromDrag(u, v);
+    const auto after = UVTransform::applyTransform(
+        op, before, transformSettings(invertSnap), collectAllUvRefs(), delta, 0.f, false);
+
+    for (size_t i = 0; i < after.size() && i < before.size(); ++i) {
+        const int globalVert = m_uvVerts[static_cast<size_t>(after[i].id)].meshGlobalVert;
+        int subIdx = 0;
+        int localVert = 0;
+        if (!mapGlobalVertToSubLocal(globalVert, subIdx, localVert))
+            continue;
+        applyWorkingMeshUv(subIdx, localVert, after[i].uv);
+    }
+    commitWorkingMeshUvs();
+    syncUvLayoutFromWorkingMesh();
+}
+
+void UVEditorController::commitTransformDrag()
+{
+    if (!m_draggingTransform)
+        return;
+
+    m_draggingTransform = false;
+    m_transformActive = false;
+    emit transformActiveChanged();
+
+    if (m_dragBeforeChanges.empty() || m_dragBeforeRefs.empty())
+        return;
+
+    QString desc = tr("UV Move");
+    if (m_transformMode == RotateTransform)
+        desc = tr("UV Rotate");
+    else if (m_transformMode == ScaleTransform)
+        desc = tr("UV Scale");
+
+    std::vector<UVEditCommand::VertChange> changes = m_dragBeforeChanges;
+    for (auto& ch : changes) {
+        ch.newUv = m_workingMesh.getVertexUV(
+            static_cast<size_t>(ch.subMeshIndex),
+            static_cast<size_t>(ch.vertexIndex));
+    }
+
+    // GPU buffers were already updated during drag; record undo only.
+    if (UndoManager* undo = UndoManager::getSingleton())
+        undo->push(new UVEditCommand(m_activeEntity, m_uvChannel, std::move(changes), desc));
+
+    SentryReporter::addBreadcrumb(QStringLiteral("mesh.uv.transform"), desc);
+
+    m_dragBeforeChanges.clear();
+    m_dragBeforeRefs.clear();
+}
+
+void UVEditorController::cancelTransformDrag()
+{
+    if (!m_draggingTransform)
+        return;
+
+    syncWorkingMeshFromEntity();
+    for (const auto& ch : m_dragBeforeChanges)
+        applyWorkingMeshUv(ch.subMeshIndex, ch.vertexIndex, ch.oldUv);
+    commitWorkingMeshUvs();
+    m_dragBeforeChanges.clear();
+    m_dragBeforeRefs.clear();
+    m_draggingTransform = false;
+    m_transformActive = false;
+    emit transformActiveChanged();
+    syncUvLayoutFromWorkingMesh();
+}
+
+bool UVEditorController::applyNumericTransform(double value)
+{
+    if (m_transformMode == NoTransform)
+        return false;
+
+    const auto before = collectSelectedUvRefs();
+    if (before.empty())
+        return false;
+
+    UVTransform::TransformOp op = UVTransform::TransformOp::Move;
+    QString desc = tr("UV Move");
+    if (m_transformMode == RotateTransform) {
+        op = UVTransform::TransformOp::Rotate;
+        desc = tr("UV Rotate");
+    } else if (m_transformMode == ScaleTransform) {
+        op = UVTransform::TransformOp::Scale;
+        desc = tr("UV Scale");
+    }
+
+    const auto after = UVTransform::applyTransform(
+        op, before, transformSettings(false), collectAllUvRefs(),
+        Ogre::Vector2::ZERO, static_cast<float>(value), true);
+    return applyUvRefChanges(after, before, op, desc);
+}
+
+void UVEditorController::mirrorSelectionX()
+{
+    const auto before = collectSelectedUvRefs();
+    if (before.empty())
+        return;
+    const auto after = UVTransform::applyTransform(
+        UVTransform::TransformOp::MirrorX, before, transformSettings(false),
+        collectAllUvRefs(), Ogre::Vector2::ZERO, 0.f, false);
+    applyUvRefChanges(after, before, UVTransform::TransformOp::MirrorX, tr("UV Mirror X"));
+}
+
+void UVEditorController::mirrorSelectionY()
+{
+    const auto before = collectSelectedUvRefs();
+    if (before.empty())
+        return;
+    const auto after = UVTransform::applyTransform(
+        UVTransform::TransformOp::MirrorY, before, transformSettings(false),
+        collectAllUvRefs(), Ogre::Vector2::ZERO, 0.f, false);
+    applyUvRefChanges(after, before, UVTransform::TransformOp::MirrorY, tr("UV Mirror Y"));
+}
+
+bool UVEditorController::commitWorkingMeshUvs()
+{
+    if (!m_activeEntity)
+        return false;
+
+    return m_workingMesh.commitUvsToEntity(m_activeEntity, m_uvChannel, nullptr);
 }
 
 void UVEditorController::refresh()
@@ -603,7 +1134,7 @@ bool UVEditorController::readUvChannel(const Ogre::VertexData* vertexData, int c
 void UVEditorController::applyUvChannel(EditableMesh& mesh, Ogre::Entity* entity, int channel,
                                         const QSet<int>& submeshFilter)
 {
-    if (channel == 0 || !entity || !entity->getMesh())
+    if (!entity || !entity->getMesh())
         return;
 
     Ogre::Mesh* ogreMesh = entity->getMesh().get();
@@ -1108,6 +1639,23 @@ bool UVEditorController::buildFromEntity(Ogre::Entity* entity, const QSet<int>& 
         : *std::min_element(submeshFilter.begin(), submeshFilter.end());
     m_textureBackgroundSource = resolveDiffuseTextureSource(entity, previewSub);
     m_activeEntity = entity;
+
+    m_sourceSubIndices.clear();
+    m_subVertOffsets.clear();
+    m_submeshFilter = submeshFilter;
+    m_sourceSubIndices.reserve(sourceSubIndices.size());
+    m_subVertOffsets.reserve(sourceSubIndices.size());
+    int vertOff = 0;
+    for (size_t si : sourceSubIndices) {
+        m_sourceSubIndices.push_back(static_cast<int>(si));
+        m_subVertOffsets.push_back(vertOff);
+        vertOff += static_cast<int>(displayMesh.subMeshes()[si].vertices.size());
+    }
+
+    m_workingMesh.subMeshes() = displayMesh.subMeshes();
+    applyUvChannel(m_workingMesh, entity, uvChannel, submeshFilter);
+    updateTexturePixelSize();
+
     return m_hasMesh;
 }
 

--- a/src/UVEditorController.h
+++ b/src/UVEditorController.h
@@ -12,7 +12,10 @@
 
 #include <Ogre.h>
 
-class EditableMesh;
+#include "UVTransform.h"
+#include "commands/UVEditCommand.h"
+#include "EditableMesh.h"
+
 class HalfEdgeMesh;
 
 namespace Ogre {
@@ -45,6 +48,16 @@ class UVEditorController : public QObject
     Q_PROPERTY(int selectedEdgeCount READ selectedEdgeCount NOTIFY uvSelectionChanged)
     Q_PROPERTY(int selectedFaceCount READ selectedFaceCount NOTIFY uvSelectionChanged)
 
+    Q_PROPERTY(int transformMode READ transformMode WRITE setTransformMode NOTIFY transformModeChanged)
+    Q_PROPERTY(int pivotMode READ pivotMode WRITE setPivotMode NOTIFY pivotModeChanged)
+    Q_PROPERTY(int snapMode READ snapMode WRITE setSnapMode NOTIFY snapModeChanged)
+    Q_PROPERTY(bool snapEnabled READ snapEnabled WRITE setSnapEnabled NOTIFY snapEnabledChanged)
+    Q_PROPERTY(bool useBlenderTransformKeys READ useBlenderTransformKeys WRITE setUseBlenderTransformKeys
+                   NOTIFY useBlenderTransformKeysChanged)
+    Q_PROPERTY(double cursorU READ cursorU WRITE setCursorU NOTIFY cursorChanged)
+    Q_PROPERTY(double cursorV READ cursorV WRITE setCursorV NOTIFY cursorChanged)
+    Q_PROPERTY(bool transformActive READ transformActive NOTIFY transformActiveChanged)
+
 public:
     enum SelectionMode {
         VertexMode = 0,
@@ -60,6 +73,28 @@ public:
         ControlModifier = 0x04000000
     };
     Q_ENUM(SelectionModifier)
+
+    enum TransformMode {
+        NoTransform = -1,
+        MoveTransform = 0,
+        RotateTransform = 1,
+        ScaleTransform = 2
+    };
+    Q_ENUM(TransformMode)
+
+    enum PivotMode {
+        MedianPivot = 0,
+        IndividualOriginsPivot = 1,
+        CursorPivot = 2
+    };
+    Q_ENUM(PivotMode)
+
+    enum SnapMode {
+        GridSnap = 0,
+        VertexSnap = 1,
+        PixelSnap = 2
+    };
+    Q_ENUM(SnapMode)
 
     struct IslandResult {
         int islandCount = 0;
@@ -108,8 +143,46 @@ public:
     /// Box rules: vertex = fully enclosed; edge/face = any intersection/touch.
     Q_INVOKABLE void boxSelect(double uMin, double vMin, double uMax, double vMax, int modifiers);
 
+    int transformMode() const { return static_cast<int>(m_transformMode); }
+    void setTransformMode(int mode);
+
+    int pivotMode() const { return static_cast<int>(m_pivotMode); }
+    void setPivotMode(int mode);
+
+    int snapMode() const { return static_cast<int>(m_snapMode); }
+    void setSnapMode(int mode);
+
+    bool snapEnabled() const { return m_snapEnabled; }
+    void setSnapEnabled(bool on);
+
+    bool useBlenderTransformKeys() const { return m_useBlenderTransformKeys; }
+    void setUseBlenderTransformKeys(bool on);
+
+    double cursorU() const { return m_cursorU; }
+    double cursorV() const { return m_cursorV; }
+    void setCursorU(double u);
+    void setCursorV(double v);
+
+    bool transformActive() const { return m_transformActive; }
+
+    Q_INVOKABLE void setCursorFromUv(double u, double v);
+    Q_INVOKABLE bool beginTransformDrag(double u, double v, int modifiers);
+    Q_INVOKABLE void updateTransformDrag(double u, double v, int modifiers);
+    Q_INVOKABLE void commitTransformDrag();
+    Q_INVOKABLE void cancelTransformDrag();
+    Q_INVOKABLE bool applyNumericTransform(double value);
+    Q_INVOKABLE void mirrorSelectionX();
+    Q_INVOKABLE void mirrorSelectionY();
+
     /// Re-read the active selection and rebuild cached draw data.
     Q_INVOKABLE void refresh();
+
+    /// Used by UVEditCommand undo/redo when edit mode is inactive.
+    EditableMesh* workingMeshForEntity(Ogre::Entity* entity);
+    void refreshAfterUvEdit();
+
+    bool commitWorkingMeshUvs();
+    void applyWorkingMeshUv(int subMeshIndex, int localVert, const Ogre::Vector2& uv);
 
     /// When false (UV Editor dock hidden), scene/selection changes are not
     /// rebuilt — avoids blocking the main thread during mesh import.
@@ -127,6 +200,13 @@ signals:
     void fitToViewRequested();
     void selectionModeChanged();
     void uvSelectionChanged();
+    void transformModeChanged();
+    void pivotModeChanged();
+    void snapModeChanged();
+    void snapEnabledChanged();
+    void useBlenderTransformKeysChanged();
+    void cursorChanged();
+    void transformActiveChanged();
 
 private:
     struct UvVert {
@@ -171,6 +251,20 @@ private:
     static QString resolveDiffuseTextureSource(Ogre::Entity* entity, int submeshIndex);
     static QString colorForIsland(int islandId);
 
+    QSet<int> affectedUvVertIds() const;
+    bool mapGlobalVertToSubLocal(int globalVert, int& subMeshIndex, int& localVert) const;
+    UVTransform::Settings transformSettings(bool invertSnap) const;
+    std::vector<UVTransform::VertRef> collectSelectedUvRefs() const;
+    std::vector<UVTransform::VertRef> collectAllUvRefs() const;
+    bool applyUvRefChanges(const std::vector<UVTransform::VertRef>& refs,
+                           const std::vector<UVTransform::VertRef>& before,
+                           UVTransform::TransformOp op,
+                           const QString& description);
+    void syncWorkingMeshFromEntity();
+    void syncUvLayoutFromWorkingMesh();
+    void updateTexturePixelSize();
+    Ogre::Vector2 transformDeltaFromDrag(double u, double v) const;
+
     static UVEditorController* s_instance;
 
     int m_uvChannel = 0;
@@ -189,6 +283,27 @@ private:
     QSet<int> m_selectedUvEdges;
     QSet<int> m_selectedUvFaces;
     QSet<int> m_contextIslandIds;
+
+    TransformMode m_transformMode = NoTransform;
+    PivotMode m_pivotMode = MedianPivot;
+    SnapMode m_snapMode = GridSnap;
+    bool m_snapEnabled = false;
+    bool m_useBlenderTransformKeys = false;
+    double m_cursorU = 0.5;
+    double m_cursorV = 0.5;
+    int m_texturePixelSize = 0;
+
+    bool m_transformActive = false;
+    bool m_draggingTransform = false;
+    double m_dragStartU = 0.0;
+    double m_dragStartV = 0.0;
+    std::vector<UVTransform::VertRef> m_dragBeforeRefs;
+    std::vector<UVEditCommand::VertChange> m_dragBeforeChanges;
+
+    std::vector<int> m_sourceSubIndices;
+    std::vector<int> m_subVertOffsets;
+    QSet<int> m_submeshFilter;
+    EditableMesh m_workingMesh;
 
     std::vector<UvVert> m_uvVerts;
     std::vector<UvTri> m_uvTris;

--- a/src/UVEditorController_test.cpp
+++ b/src/UVEditorController_test.cpp
@@ -8,6 +8,7 @@
 #include "Manager.h"
 #include "SelectionSet.h"
 #include "TestHelpers.h"
+#include "UndoManager.h"
 
 #include <OgreEntity.h>
 #include <OgreHardwareBufferManager.h>
@@ -92,6 +93,8 @@ protected:
     }
 
     void TearDown() override {
+        if (auto* undo = UndoManager::getSingleton())
+            undo->clear();
         if (auto* edit = EditModeController::instance()) {
             if (edit->isEditModeActive())
                 edit->exitEditMode(false);
@@ -375,4 +378,151 @@ TEST_F(UVEditorControllerTest, FacePickWorksInEditMode)
 
     ctrl->pickAt(0.25, 0.25, UVEditorController::NoModifier, 0.5);
     EXPECT_GE(ctrl->selectedFaceCount(), 1);
+}
+
+static Ogre::Vector2 readEntityUv0(Ogre::Entity* entity, int localVert)
+{
+    const Ogre::SubMesh* sub = entity->getMesh()->getSubMesh(0);
+    const Ogre::VertexData* vd = sub->useSharedVertices
+        ? entity->getMesh()->sharedVertexData
+        : sub->vertexData;
+    const auto* elem = vd->vertexDeclaration->findElementBySemantic(
+        Ogre::VES_TEXTURE_COORDINATES, 0);
+    auto vbuf = vd->vertexBufferBinding->getBuffer(elem->getSource());
+    const size_t stride = vbuf->getVertexSize();
+    auto* base = static_cast<unsigned char*>(vbuf->lock(Ogre::HardwareBuffer::HBL_READ_ONLY));
+    float* p = nullptr;
+    elem->baseVertexPointerToElement(base + static_cast<size_t>(localVert) * stride, &p);
+    const Ogre::Vector2 uv(p[0], p[1]);
+    vbuf->unlock();
+    return uv;
+}
+
+TEST_F(UVEditorControllerTest, MoveSelectionUpdatesGpuAndUndoRoundTrip)
+{
+    auto mesh = createInMemoryTriangleMesh("UVEditor_move_undo");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = sceneMgr->getRootSceneNode()->createChildSceneNode("UVEditor_move_node");
+    auto* entity = sceneMgr->createEntity("UVEditor_move_entity", mesh);
+    node->attachObject(entity);
+
+    UVEditorController* ctrl = UVEditorController::instance();
+    ctrl->setPanelActive(true);
+    SelectionSet::getSingleton()->selectOne(entity);
+    ctrl->setSelectionMode(UVEditorController::FaceMode);
+    ctrl->refresh();
+    ASSERT_TRUE(ctrl->hasMesh());
+
+    ctrl->pickAt(0.2, 0.2, UVEditorController::NoModifier, 0.5);
+    ASSERT_GT(ctrl->selectedFaceCount(), 0);
+
+    const Ogre::Vector2 before = readEntityUv0(entity, 0);
+    ctrl->setTransformMode(UVEditorController::MoveTransform);
+    ASSERT_TRUE(ctrl->applyNumericTransform(0.25));
+
+    const Ogre::Vector2 after = readEntityUv0(entity, 0);
+    EXPECT_NEAR(after.x, before.x + 0.25f, 1e-4f);
+
+    UndoManager::getSingleton()->undo();
+    const Ogre::Vector2 restored = readEntityUv0(entity, 0);
+    EXPECT_NEAR(restored.x, before.x, 1e-4f);
+    EXPECT_NEAR(restored.y, before.y, 1e-4f);
+
+    UndoManager::getSingleton()->redo();
+    const Ogre::Vector2 redone = readEntityUv0(entity, 0);
+    EXPECT_NEAR(redone.x, after.x, 1e-4f);
+}
+
+TEST_F(UVEditorControllerTest, MirrorXCommandIsUndoable)
+{
+    auto mesh = createInMemoryTriangleMesh("UVEditor_mirror_undo");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = sceneMgr->getRootSceneNode()->createChildSceneNode("UVEditor_mirror_node");
+    auto* entity = sceneMgr->createEntity("UVEditor_mirror_entity", mesh);
+    node->attachObject(entity);
+
+    UVEditorController* ctrl = UVEditorController::instance();
+    ctrl->setPanelActive(true);
+    SelectionSet::getSingleton()->selectOne(entity);
+    ctrl->setSelectionMode(UVEditorController::FaceMode);
+    ctrl->refresh();
+    ctrl->pickAt(0.2, 0.2, UVEditorController::NoModifier, 0.5);
+    ASSERT_GT(ctrl->selectedFaceCount(), 0);
+
+    const Ogre::Vector2 before0 = readEntityUv0(entity, 0);
+    const Ogre::Vector2 before1 = readEntityUv0(entity, 1);
+    ctrl->mirrorSelectionX();
+    const Ogre::Vector2 mirrored0 = readEntityUv0(entity, 0);
+    const Ogre::Vector2 mirrored1 = readEntityUv0(entity, 1);
+    EXPECT_NE(mirrored0.x, before0.x);
+    EXPECT_NE(mirrored1.x, before1.x);
+
+    UndoManager::getSingleton()->undo();
+    const Ogre::Vector2 restored0 = readEntityUv0(entity, 0);
+    const Ogre::Vector2 restored1 = readEntityUv0(entity, 1);
+    EXPECT_NEAR(restored0.x, before0.x, 1e-4f);
+    EXPECT_NEAR(restored0.y, before0.y, 1e-4f);
+    EXPECT_NEAR(restored1.x, before1.x, 1e-4f);
+    EXPECT_NEAR(restored1.y, before1.y, 1e-4f);
+}
+
+static Ogre::MeshPtr createTwoSharedSubmeshTriangleMesh(const std::string& name)
+{
+    auto mesh = Ogre::MeshManager::getSingleton().createManual(
+        name, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+
+    mesh->sharedVertexData = new Ogre::VertexData();
+    auto* decl = mesh->sharedVertexData->vertexDeclaration;
+    size_t offset = 0;
+    decl->addElement(0, offset, Ogre::VET_FLOAT3, Ogre::VES_POSITION);
+    offset += Ogre::VertexElement::getTypeSize(Ogre::VET_FLOAT3);
+    decl->addElement(0, offset, Ogre::VET_FLOAT3, Ogre::VES_NORMAL);
+    offset += Ogre::VertexElement::getTypeSize(Ogre::VET_FLOAT3);
+    decl->addElement(0, offset, Ogre::VET_FLOAT2, Ogre::VES_TEXTURE_COORDINATES);
+
+    auto vbuf = Ogre::HardwareBufferManager::getSingleton().createVertexBuffer(
+        decl->getVertexSize(0), 3, Ogre::HardwareBuffer::HBU_STATIC_WRITE_ONLY);
+    static constexpr std::array<float, 24> verts{{
+        0,0,0,   0,0,1,  0.0f,0.0f,
+        1,0,0,   0,0,1,  1.0f,0.0f,
+        0,1,0,   0,0,1,  0.0f,1.0f,
+    }};
+    vbuf->writeData(0, verts.size() * sizeof(float), verts.data());
+    mesh->sharedVertexData->vertexBufferBinding->setBinding(0, vbuf);
+    mesh->sharedVertexData->vertexCount = 3;
+
+    for (int sub = 0; sub < 2; ++sub) {
+        auto* sm = mesh->createSubMesh();
+        auto ibuf = Ogre::HardwareBufferManager::getSingleton().createIndexBuffer(
+            Ogre::HardwareIndexBuffer::IT_16BIT, 3, Ogre::HardwareBuffer::HBU_STATIC_WRITE_ONLY);
+        static constexpr std::array<uint16_t, 3> idx{{0, 1, 2}};
+        ibuf->writeData(0, idx.size() * sizeof(uint16_t), idx.data());
+        sm->useSharedVertices = true;
+        sm->indexData->indexBuffer = ibuf;
+        sm->indexData->indexCount = 3;
+    }
+
+    mesh->_setBounds(Ogre::AxisAlignedBox(-1, -1, -1, 1, 1, 1));
+    mesh->_setBoundingSphereRadius(2.0);
+    mesh->load();
+    return mesh;
+}
+
+TEST_F(UVEditorControllerTest, SharedPoolCommitUsesLaterSubmeshCopy)
+{
+    auto mesh = createTwoSharedSubmeshTriangleMesh("UVEditor_two_shared");
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    auto* node = sceneMgr->getRootSceneNode()->createChildSceneNode("UVEditor_two_shared_node");
+    auto* entity = sceneMgr->createEntity("UVEditor_two_shared_entity", mesh);
+    node->attachObject(entity);
+
+    EditableMesh editMesh;
+    ASSERT_TRUE(editMesh.loadFromEntity(entity));
+    ASSERT_GE(editMesh.subMeshes().size(), 2u);
+    editMesh.setVertexUV(1, 0, Ogre::Vector2(0.42f, 0.17f));
+    ASSERT_TRUE(editMesh.commitUvsToEntity(entity, 0));
+
+    const Ogre::Vector2 gpu = readEntityUv0(entity, 0);
+    EXPECT_NEAR(gpu.x, 0.42f, 1e-4f);
+    EXPECT_NEAR(gpu.y, 0.17f, 1e-4f);
 }

--- a/src/UVTransform.cpp
+++ b/src/UVTransform.cpp
@@ -1,0 +1,136 @@
+#include "UVTransform.h"
+
+#include <algorithm>
+#include <limits>
+
+namespace UVTransform {
+
+namespace {
+
+constexpr float kPi = 3.14159265358979323846f;
+
+float snapToGrid(float value, float gridSize)
+{
+    if (gridSize <= 0.f)
+        return value;
+    return std::round(value / gridSize) * gridSize;
+}
+
+} // namespace
+
+Ogre::Vector2 medianPivot(const std::vector<VertRef>& verts)
+{
+    if (verts.empty())
+        return Ogre::Vector2::ZERO;
+    Ogre::Vector2 sum = Ogre::Vector2::ZERO;
+    for (const auto& v : verts)
+        sum += v.uv;
+    return sum / static_cast<float>(verts.size());
+}
+
+Ogre::Vector2 snapUv(Ogre::Vector2 uv, const Settings& settings,
+                     const std::vector<VertRef>& allVerts,
+                     const std::vector<int>& selectedIds)
+{
+    const bool doSnap = settings.snapEnabled != settings.invertSnap;
+    if (!doSnap)
+        return uv;
+
+    switch (settings.snap) {
+    case SnapMode::Grid:
+        return {snapToGrid(uv.x, settings.gridSize), snapToGrid(uv.y, settings.gridSize)};
+    case SnapMode::Vertex: {
+        float bestDistSq = settings.snapThreshold * settings.snapThreshold;
+        Ogre::Vector2 best = uv;
+        for (const auto& v : allVerts) {
+            if (std::find(selectedIds.begin(), selectedIds.end(), v.id) != selectedIds.end())
+                continue;
+            const float dx = v.uv.x - uv.x;
+            const float dy = v.uv.y - uv.y;
+            const float d = dx * dx + dy * dy;
+            if (d <= bestDistSq) {
+                bestDistSq = d;
+                best = v.uv;
+            }
+        }
+        return best;
+    }
+    case SnapMode::Pixel:
+        if (settings.texturePixelSize <= 0)
+            return uv;
+        {
+            const float step = 1.f / static_cast<float>(settings.texturePixelSize);
+            return {snapToGrid(uv.x, step), snapToGrid(uv.y, step)};
+        }
+    }
+    return uv;
+}
+
+Ogre::Vector2 transformPoint(TransformOp op, const Ogre::Vector2& uv,
+                             const Ogre::Vector2& pivot, const Ogre::Vector2& delta,
+                             float numericValue, bool numericInput)
+{
+    switch (op) {
+    case TransformOp::Move:
+        if (numericInput)
+            return {uv.x + numericValue, uv.y};
+        return {uv.x + delta.x, uv.y + delta.y};
+    case TransformOp::Rotate: {
+        const float angleDeg = numericInput ? numericValue : delta.x;
+        const float rad = angleDeg * (kPi / 180.f);
+        const float c = std::cos(rad);
+        const float s = std::sin(rad);
+        const float dx = uv.x - pivot.x;
+        const float dy = uv.y - pivot.y;
+        return {pivot.x + dx * c - dy * s, pivot.y + dx * s + dy * c};
+    }
+    case TransformOp::Scale: {
+        const float factor = numericInput ? numericValue : std::max(1e-4f, delta.x);
+        return {pivot.x + (uv.x - pivot.x) * factor, pivot.y + (uv.y - pivot.y) * factor};
+    }
+    case TransformOp::MirrorX:
+        return {pivot.x - (uv.x - pivot.x), uv.y};
+    case TransformOp::MirrorY:
+        return {uv.x, pivot.y - (uv.y - pivot.y)};
+    }
+    return uv;
+}
+
+std::vector<VertRef> applyTransform(TransformOp op,
+                                    const std::vector<VertRef>& input,
+                                    const Settings& settings,
+                                    const std::vector<VertRef>& allVertsForSnap,
+                                    const Ogre::Vector2& delta,
+                                    float numericValue,
+                                    bool numericInput)
+{
+    if (input.empty())
+        return {};
+
+    std::vector<int> selectedIds;
+    selectedIds.reserve(input.size());
+    for (const auto& v : input)
+        selectedIds.push_back(v.id);
+
+    const Ogre::Vector2 median = medianPivot(input);
+    const Ogre::Vector2 cursorPivot = settings.cursor;
+
+    std::vector<VertRef> out;
+    out.reserve(input.size());
+
+    for (const auto& src : input) {
+        Ogre::Vector2 pivot = median;
+        if (settings.pivot == PivotMode::IndividualOrigins)
+            pivot = src.uv;
+        else if (settings.pivot == PivotMode::Cursor)
+            pivot = cursorPivot;
+
+        Ogre::Vector2 uv = transformPoint(op, src.uv, pivot, delta, numericValue, numericInput);
+        uv = snapUv(uv, settings, allVertsForSnap, selectedIds);
+        out.push_back({src.id, uv});
+    }
+
+    return out;
+}
+
+} // namespace UVTransform

--- a/src/UVTransform.cpp
+++ b/src/UVTransform.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <unordered_set>
 
 namespace UVTransform {
 
@@ -30,7 +31,7 @@ Ogre::Vector2 medianPivot(const std::vector<VertRef>& verts)
 
 Ogre::Vector2 snapUv(Ogre::Vector2 uv, const Settings& settings,
                      const std::vector<VertRef>& allVerts,
-                     const std::vector<int>& selectedIds)
+                     const std::unordered_set<int>& selectedIds)
 {
     const bool doSnap = settings.snapEnabled != settings.invertSnap;
     if (!doSnap)
@@ -43,7 +44,7 @@ Ogre::Vector2 snapUv(Ogre::Vector2 uv, const Settings& settings,
         float bestDistSq = settings.snapThreshold * settings.snapThreshold;
         Ogre::Vector2 best = uv;
         for (const auto& v : allVerts) {
-            if (std::find(selectedIds.begin(), selectedIds.end(), v.id) != selectedIds.end())
+            if (selectedIds.count(v.id) != 0)
                 continue;
             const float dx = v.uv.x - uv.x;
             const float dy = v.uv.y - uv.y;
@@ -107,10 +108,10 @@ std::vector<VertRef> applyTransform(TransformOp op,
     if (input.empty())
         return {};
 
-    std::vector<int> selectedIds;
+    std::unordered_set<int> selectedIds;
     selectedIds.reserve(input.size());
     for (const auto& v : input)
-        selectedIds.push_back(v.id);
+        selectedIds.insert(v.id);
 
     const Ogre::Vector2 median = medianPivot(input);
     const Ogre::Vector2 cursorPivot = settings.cursor;

--- a/src/UVTransform.h
+++ b/src/UVTransform.h
@@ -1,0 +1,68 @@
+#ifndef UV_TRANSFORM_H
+#define UV_TRANSFORM_H
+
+#include <OgreVector2.h>
+
+#include <cmath>
+#include <vector>
+
+/// Pure UV-space transform helpers for the UV editor (issue #461).
+namespace UVTransform {
+
+enum class PivotMode {
+    Median = 0,
+    IndividualOrigins = 1,
+    Cursor = 2
+};
+
+enum class SnapMode {
+    Grid = 0,
+    Vertex = 1,
+    Pixel = 2
+};
+
+enum class TransformOp {
+    Move = 0,
+    Rotate = 1,
+    Scale = 2,
+    MirrorX = 3,
+    MirrorY = 4
+};
+
+struct VertRef {
+    int id = -1;
+    Ogre::Vector2 uv;
+};
+
+struct Settings {
+    PivotMode pivot = PivotMode::Median;
+    SnapMode snap = SnapMode::Grid;
+    bool snapEnabled = false;
+    bool invertSnap = false;
+    float gridSize = 0.125f;
+    float snapThreshold = 0.02f;
+    Ogre::Vector2 cursor{0.5f, 0.5f};
+    int texturePixelSize = 0; // largest dimension when texture preview is active
+};
+
+Ogre::Vector2 medianPivot(const std::vector<VertRef>& verts);
+
+Ogre::Vector2 snapUv(Ogre::Vector2 uv, const Settings& settings,
+                     const std::vector<VertRef>& allVerts,
+                     const std::vector<int>& selectedIds);
+
+Ogre::Vector2 transformPoint(TransformOp op, const Ogre::Vector2& uv,
+                             const Ogre::Vector2& pivot, const Ogre::Vector2& delta,
+                             float numericValue, bool numericInput);
+
+std::vector<VertRef> applyTransform(TransformOp op,
+                                      const std::vector<VertRef>& input,
+                                      const Settings& settings,
+                                      const std::vector<VertRef>& allVertsForSnap,
+                                      const Ogre::Vector2& delta,
+                                      float numericValue,
+                                      bool numericInput);
+
+} // namespace UVTransform
+
+#endif // UV_TRANSFORM_H

--- a/src/UVTransform.h
+++ b/src/UVTransform.h
@@ -4,6 +4,7 @@
 #include <OgreVector2.h>
 
 #include <cmath>
+#include <unordered_set>
 #include <vector>
 
 /// Pure UV-space transform helpers for the UV editor (issue #461).
@@ -49,7 +50,7 @@ Ogre::Vector2 medianPivot(const std::vector<VertRef>& verts);
 
 Ogre::Vector2 snapUv(Ogre::Vector2 uv, const Settings& settings,
                      const std::vector<VertRef>& allVerts,
-                     const std::vector<int>& selectedIds);
+                     const std::unordered_set<int>& selectedIds);
 
 Ogre::Vector2 transformPoint(TransformOp op, const Ogre::Vector2& uv,
                              const Ogre::Vector2& pivot, const Ogre::Vector2& delta,

--- a/src/UVTransform_test.cpp
+++ b/src/UVTransform_test.cpp
@@ -1,0 +1,126 @@
+#include <gtest/gtest.h>
+
+#include "UVTransform.h"
+
+TEST(UVTransformTest, MedianPivotAtSelectionCenter)
+{
+    const std::vector<UVTransform::VertRef> verts = {
+        {0, {0.f, 0.f}},
+        {1, {1.f, 0.f}},
+        {2, {0.f, 1.f}},
+        {3, {1.f, 1.f}},
+    };
+    const Ogre::Vector2 pivot = UVTransform::medianPivot(verts);
+    EXPECT_NEAR(pivot.x, 0.5f, 1e-5f);
+    EXPECT_NEAR(pivot.y, 0.5f, 1e-5f);
+}
+
+TEST(UVTransformTest, MoveUsesMedianPivotByDefault)
+{
+    UVTransform::Settings settings;
+    settings.pivot = UVTransform::PivotMode::Median;
+    const std::vector<UVTransform::VertRef> verts = {
+        {0, {0.f, 0.f}},
+        {1, {1.f, 0.f}},
+        {2, {0.f, 1.f}},
+        {3, {1.f, 1.f}},
+    };
+    const auto out = UVTransform::applyTransform(
+        UVTransform::TransformOp::Move, verts, settings, verts,
+        {0.1f, 0.2f}, 0.f, false);
+    ASSERT_EQ(out.size(), 4u);
+    EXPECT_NEAR(out[0].uv.x, 0.1f, 1e-5f);
+    EXPECT_NEAR(out[0].uv.y, 0.2f, 1e-5f);
+    EXPECT_NEAR(out[3].uv.x, 1.1f, 1e-5f);
+    EXPECT_NEAR(out[3].uv.y, 1.2f, 1e-5f);
+}
+
+TEST(UVTransformTest, IndividualOriginsRotateDiffersFromMedian)
+{
+    UVTransform::Settings medianSettings;
+    medianSettings.pivot = UVTransform::PivotMode::Median;
+
+    UVTransform::Settings individualSettings;
+    individualSettings.pivot = UVTransform::PivotMode::IndividualOrigins;
+
+    const std::vector<UVTransform::VertRef> verts = {
+        {0, {0.f, 0.f}},
+        {1, {1.f, 0.f}},
+    };
+    const auto medianOut = UVTransform::applyTransform(
+        UVTransform::TransformOp::Rotate, verts, medianSettings, verts,
+        Ogre::Vector2::ZERO, 90.f, true);
+    const auto individualOut = UVTransform::applyTransform(
+        UVTransform::TransformOp::Rotate, verts, individualSettings, verts,
+        Ogre::Vector2::ZERO, 90.f, true);
+    ASSERT_EQ(medianOut.size(), 2u);
+    ASSERT_EQ(individualOut.size(), 2u);
+    EXPECT_NEAR(medianOut[0].uv.x, 0.5f, 1e-4f);
+    EXPECT_NEAR(medianOut[0].uv.y, -0.5f, 1e-4f);
+    EXPECT_NEAR(medianOut[1].uv.x, 0.5f, 1e-4f);
+    EXPECT_NEAR(medianOut[1].uv.y, 0.5f, 1e-4f);
+    EXPECT_NEAR(individualOut[0].uv.x, 0.f, 1e-4f);
+    EXPECT_NEAR(individualOut[1].uv.x, 1.f, 1e-4f);
+}
+
+TEST(UVTransformTest, CursorPivotRotate90)
+{
+    UVTransform::Settings settings;
+    settings.pivot = UVTransform::PivotMode::Cursor;
+    settings.cursor = {0.5f, 0.5f};
+    const std::vector<UVTransform::VertRef> verts = {
+        {0, {1.f, 0.5f}},
+    };
+    const auto out = UVTransform::applyTransform(
+        UVTransform::TransformOp::Rotate, verts, settings, verts,
+        Ogre::Vector2::ZERO, 90.f, true);
+    ASSERT_EQ(out.size(), 1u);
+    EXPECT_NEAR(out[0].uv.x, 0.5f, 1e-4f);
+    EXPECT_NEAR(out[0].uv.y, 1.f, 1e-4f);
+}
+
+TEST(UVTransformTest, SnapToGrid)
+{
+    UVTransform::Settings settings;
+    settings.snapEnabled = true;
+    settings.gridSize = 0.25f;
+    const Ogre::Vector2 snapped = UVTransform::snapUv({0.13f, 0.38f}, settings, {}, {});
+    EXPECT_NEAR(snapped.x, 0.25f, 1e-5f);
+    EXPECT_NEAR(snapped.y, 0.5f, 1e-5f);
+}
+
+TEST(UVTransformTest, MirrorXReversible)
+{
+    UVTransform::Settings settings;
+    settings.pivot = UVTransform::PivotMode::Median;
+    const std::vector<UVTransform::VertRef> verts = {
+        {0, {0.2f, 0.3f}},
+        {1, {0.8f, 0.7f}},
+    };
+    const auto mirrored = UVTransform::applyTransform(
+        UVTransform::TransformOp::MirrorX, verts, settings, verts,
+        Ogre::Vector2::ZERO, 0.f, false);
+    const auto restored = UVTransform::applyTransform(
+        UVTransform::TransformOp::MirrorX, mirrored, settings, mirrored,
+        Ogre::Vector2::ZERO, 0.f, false);
+    ASSERT_EQ(restored.size(), 2u);
+    EXPECT_NEAR(restored[0].uv.x, verts[0].uv.x, 1e-5f);
+    EXPECT_NEAR(restored[0].uv.y, verts[0].uv.y, 1e-5f);
+    EXPECT_NEAR(restored[1].uv.x, verts[1].uv.x, 1e-5f);
+    EXPECT_NEAR(restored[1].uv.y, verts[1].uv.y, 1e-5f);
+}
+
+TEST(UVTransformTest, NumericScaleHalf)
+{
+    UVTransform::Settings settings;
+    const std::vector<UVTransform::VertRef> verts = {
+        {0, {0.f, 0.f}},
+        {1, {1.f, 1.f}},
+    };
+    const auto out = UVTransform::applyTransform(
+        UVTransform::TransformOp::Scale, verts, settings, verts,
+        Ogre::Vector2::ZERO, 0.5f, true);
+    ASSERT_EQ(out.size(), 2u);
+    EXPECT_NEAR(out[1].uv.x, 0.75f, 1e-5f);
+    EXPECT_NEAR(out[1].uv.y, 0.75f, 1e-5f);
+}

--- a/src/commands/UVEditCommand.cpp
+++ b/src/commands/UVEditCommand.cpp
@@ -52,12 +52,28 @@ void UVEditCommand::apply(bool useNew)
         }
     }
 
+    const auto rollback = [&]() {
+        for (const auto& ch : m_changes) {
+            const Ogre::Vector2& uv = useNew ? ch.oldUv : ch.newUv;
+            if (useControllerMesh) {
+                uvCtrl->applyWorkingMeshUv(ch.subMeshIndex, ch.vertexIndex, uv);
+            } else {
+                mesh->setVertexUV(static_cast<size_t>(ch.subMeshIndex),
+                                  static_cast<size_t>(ch.vertexIndex), uv);
+            }
+        }
+    };
+
     if (useControllerMesh) {
-        if (!uvCtrl->commitWorkingMeshUvs())
+        if (!uvCtrl->commitWorkingMeshUvs()) {
+            rollback();
             return;
+        }
     } else {
-        if (!mesh->commitUvsToEntity(m_entity, m_uvChannel))
+        if (!mesh->commitUvsToEntity(m_entity, m_uvChannel)) {
+            rollback();
             return;
+        }
     }
 
     if (edit && edit->isEditModeActive() && edit->editEntity() == m_entity)

--- a/src/commands/UVEditCommand.cpp
+++ b/src/commands/UVEditCommand.cpp
@@ -1,0 +1,86 @@
+#include "UVEditCommand.h"
+
+#include "EditableMesh.h"
+#include "EditModeController.h"
+#include "SentryReporter.h"
+#include "UVEditorController.h"
+
+#include <OgreEntity.h>
+
+UVEditCommand::UVEditCommand(Ogre::Entity* entity,
+                             int uvChannel,
+                             std::vector<VertChange> changes,
+                             const QString& description,
+                             QUndoCommand* parent)
+    : QUndoCommand(description, parent)
+    , m_entity(entity)
+    , m_uvChannel(uvChannel)
+    , m_changes(std::move(changes))
+{
+}
+
+void UVEditCommand::apply(bool useNew)
+{
+    if (!m_entity || m_changes.empty())
+        return;
+
+    EditableMesh localMesh;
+    EditableMesh* mesh = nullptr;
+    auto* edit = EditModeController::instance();
+    if (edit && edit->isEditModeActive() && edit->editEntity() == m_entity && edit->currentMesh()) {
+        mesh = edit->currentMesh();
+    } else if (auto* uv = UVEditorController::instance()) {
+        mesh = uv->workingMeshForEntity(m_entity);
+    }
+    if (!mesh) {
+        if (!localMesh.loadFromEntity(m_entity))
+            return;
+        mesh = &localMesh;
+    }
+
+    UVEditorController* uvCtrl = UVEditorController::instance();
+    const bool useControllerMesh =
+        uvCtrl && uvCtrl->workingMeshForEntity(m_entity) == mesh;
+
+    for (const auto& ch : m_changes) {
+        const Ogre::Vector2& uv = useNew ? ch.newUv : ch.oldUv;
+        if (useControllerMesh) {
+            uvCtrl->applyWorkingMeshUv(ch.subMeshIndex, ch.vertexIndex, uv);
+        } else {
+            mesh->setVertexUV(static_cast<size_t>(ch.subMeshIndex),
+                              static_cast<size_t>(ch.vertexIndex), uv);
+        }
+    }
+
+    if (useControllerMesh) {
+        if (!uvCtrl->commitWorkingMeshUvs())
+            return;
+    } else {
+        if (!mesh->commitUvsToEntity(m_entity, m_uvChannel))
+            return;
+    }
+
+    if (edit && edit->isEditModeActive() && edit->editEntity() == m_entity)
+        edit->notifyMeshDataChanged();
+
+    if (uvCtrl)
+        uvCtrl->refreshAfterUvEdit();
+}
+
+void UVEditCommand::undo()
+{
+    SentryReporter::addBreadcrumb(QStringLiteral("mesh.uv.transform"),
+                                  QStringLiteral("Undo UV edit"));
+    apply(false);
+}
+
+void UVEditCommand::redo()
+{
+    if (m_firstRedo) {
+        m_firstRedo = false;
+        return;
+    }
+    SentryReporter::addBreadcrumb(QStringLiteral("mesh.uv.transform"),
+                                  QStringLiteral("Redo UV edit"));
+    apply(true);
+}

--- a/src/commands/UVEditCommand.h
+++ b/src/commands/UVEditCommand.h
@@ -1,0 +1,42 @@
+#ifndef UV_EDIT_COMMAND_H
+#define UV_EDIT_COMMAND_H
+
+#include <OgreVector2.h>
+#include <QUndoCommand>
+
+#include <vector>
+
+namespace Ogre {
+class Entity;
+}
+
+/// Undo record for a UV transform in the UV editor (issue #461).
+class UVEditCommand : public QUndoCommand
+{
+public:
+    struct VertChange {
+        int subMeshIndex = 0;
+        int vertexIndex = 0;
+        Ogre::Vector2 oldUv;
+        Ogre::Vector2 newUv;
+    };
+
+    UVEditCommand(Ogre::Entity* entity,
+                  int uvChannel,
+                  std::vector<VertChange> changes,
+                  const QString& description,
+                  QUndoCommand* parent = nullptr);
+
+    void undo() override;
+    void redo() override;
+
+private:
+    void apply(bool useNew);
+
+    Ogre::Entity* m_entity = nullptr;
+    int m_uvChannel = 0;
+    std::vector<VertChange> m_changes;
+    bool m_firstRedo = true;
+};
+
+#endif // UV_EDIT_COMMAND_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -62,6 +62,7 @@
 #include "QtMeshCloudSession.h"
 #include "ui_mainwindow.h"
 #include "OgreWidget.h"
+#include "OgreRenderTargetUtil.h"
 #include "QtInputManager.h"
 #include "Manager.h"
 #include "material.h"
@@ -361,6 +362,7 @@ MainWindow::MainWindow(QWidget *parent) :
         if(m_pRoot && m_pRoot->getRenderSystem())
         {
             try {
+                OgreRenderTargetUtil::restoreEditorRenderTarget();
                 m_pRoot->renderOneFrame();
             } catch (Ogre::Exception& e) {
                 fprintf(stderr, "RENDER ERROR (Ogre): %s\n", e.getFullDescription().c_str());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -121,6 +121,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/PoseLibraryCommands.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/ComputeSkinWeightsCommand.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/AutoRigCommand.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/UVEditCommand.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/ApplyAtlas.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/EmbeddedTextureCache.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/NormalMapGenerator.cpp
@@ -135,6 +136,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MeshLodController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/UvUnwrapController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/UVEditorController.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/UVTransform.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/QuadRetopo.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/QuadRetopoController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/SkinWeights.cpp


### PR DESCRIPTION
## Summary
- Add UV move/rotate/scale/mirror transforms in the UV Editor with Q/W/E/R shortcuts (aligned with the main viewport)
- Undo/redo via `UVEditCommand`; live 3D viewport updates during drag without entity re-init (mesh + skeletal anim buffers)
- Fix GL `setDrawBuffer` spam from material-preview RTTs and cache inspector preview URIs

## Test plan
- [x] `UnitTests --gtest_filter="UVTransformTest.*:UVEditorControllerTest.*"` (26 passed)
- [ ] Drag UV verts in UV Editor — 3D viewport updates live; release mouse does not crash
- [ ] Undo/redo UV transform (Ctrl+Z / Ctrl+Shift+Z)
- [ ] Mirror X/Y toolbar buttons
- [ ] Skinned/animated mesh (e.g. Mixamo FBX)
- [ ] Material preview in Inspector — no GL spam flood

Closes #461

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer UV editing tools, including transform mode switching, numeric input, snapping, mirroring, and pivot controls.
  * Improved material previews with faster thumbnail loading and more responsive refreshes.
  * Added support for updating UV changes directly in the editor with undo/redo.

* **Bug Fixes**
  * Fixed preview and render target handling so editor views restore correctly after offscreen rendering.
  * Ensured UV changes are applied consistently across meshes and reflected properly in the viewport.

* **Tests**
  * Expanded automated coverage for UV transforms, undo/redo, shared-vertex meshes, and preview rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->