### PR TITLE
fix(#410): segmentation bone-side detection for non-Mixamo rigs

### DIFF
--- a/src/MeshSegmenter.cpp
+++ b/src/MeshSegmenter.cpp
@@ -32,16 +32,26 @@ const char* const kPartIds[] = {
     "unknown", "head", "torso", "left_arm", "right_arm", "left_leg", "right_leg",
 };
 
-// Normalise a bone name for matching: lowercase, strip a leading
-// "mixamorig[N]:" / "bip01 " / "def_"-style prefix, drop separators so
-// "LeftArm" / "L_Arm" / "arm.l" / "DEF-upper_arm.L" compare alike.
-QString normaliseBoneName(const QString& raw)
+// Strip non-semantic prefixes (lowercased): a "mixamorig[N]:" / namespace
+// colon prefix and a leading "def_"/"org-"/"mch-"/"ctrl-" rig prefix. Keeps
+// separators intact (delimited-token side detection needs them). A namespace
+// like "LeftRig:Spine1" MUST be dropped here, or its "left" leaks into side
+// detection and a centre bone loses its torso mapping.
+QString stripBonePrefixes(const QString& raw)
 {
     QString s = raw.toLower();
     const int colon = s.lastIndexOf(':');           // mixamorig:LeftArm → leftarm
     if (colon >= 0) s = s.mid(colon + 1);
     for (const char* p : {"def-", "def_", "def", "org-", "mch-", "ctrl-"})
         if (s.startsWith(QLatin1String(p))) { s = s.mid(int(qstrlen(p))); break; }
+    return s;
+}
+
+// Normalise a bone name for matching: strip prefixes, then drop separators so
+// "LeftArm" / "L_Arm" / "arm.l" / "DEF-upper_arm.L" compare alike.
+QString normaliseBoneName(const QString& raw)
+{
+    QString s = stripBonePrefixes(raw);
     s.remove(' ').remove('_').remove('-').remove('.');
     return s;
 }
@@ -104,9 +114,12 @@ MeshSegmenter::Part MeshSegmenter::partForBoneName(const QString& boneName)
 {
     const QString n = normaliseBoneName(boneName);
     if (n.isEmpty()) return Part::Unknown;
-    // Prefer explicit side tokens in the raw name (catches `_R_1`/`.l`/`-r`
-    // delimited markers); fall back to the normalised-name heuristic.
-    char side = boneSideFromRaw(boneName.toLower());
+    // Prefer explicit side tokens in the PREFIX-STRIPPED name (catches
+    // `_R_1`/`.l`/`-r` delimited markers); fall back to the normalised-name
+    // heuristic. Strip prefixes first so a namespace like "LeftRig:Spine1"
+    // doesn't leak its "left" into the side (which would skip the torso
+    // mapping for a centre bone).
+    char side = boneSideFromRaw(stripBonePrefixes(boneName));
     if (side == 0) side = boneSide(n);
     auto has = [&](std::initializer_list<const char*> cores) {
         for (const char* c : cores) if (n.contains(QLatin1String(c))) return true;

--- a/src/MeshSegmenter.cpp
+++ b/src/MeshSegmenter.cpp
@@ -46,6 +46,35 @@ QString normaliseBoneName(const QString& raw)
     return s;
 }
 
+// Side from the RAW (lower-cased) bone name using explicit side tokens that
+// survive separators — handles `_R_`, `.l`, `-r`, and the very common
+// `..._joint_R_1` / `arm_joint_L__4_` style where the side letter sits BETWEEN
+// separators and a trailing index (which the normalised-name heuristic misses
+// because stripping separators leaves `armjointr1`, ending in a digit). Word
+// forms ("left"/"right") always win.
+char boneSideFromRaw(const QString& rawLower)
+{
+    if (rawLower.contains(QLatin1String("left")))  return 'l';
+    if (rawLower.contains(QLatin1String("right"))) return 'r';
+    // A side letter delimited by a separator (or string end) on at least one
+    // side, e.g. "_r_", ".l", "_r1", "armr" → side token, not part of a word.
+    auto isSep = [](QChar c) {
+        return c == '_' || c == '-' || c == '.' || c == ' ' || c == ':';
+    };
+    for (int i = 0; i < rawLower.size(); ++i) {
+        const QChar c = rawLower[i];
+        if (c != 'l' && c != 'r') continue;
+        const bool sepBefore = (i == 0) || isSep(rawLower[i - 1]);
+        if (!sepBefore) continue;                       // must start a token
+        // followed by a separator, a digit, or end-of-string → a side marker
+        const bool ok = (i + 1 >= rawLower.size())
+                        || isSep(rawLower[i + 1])
+                        || rawLower[i + 1].isDigit();
+        if (ok) return c.toLatin1();
+    }
+    return 0;
+}
+
 // Side from a normalised name → 'l', 'r', or 0 (centre). Word forms win over
 // single-letter affixes.
 char boneSide(const QString& n)
@@ -75,7 +104,10 @@ MeshSegmenter::Part MeshSegmenter::partForBoneName(const QString& boneName)
 {
     const QString n = normaliseBoneName(boneName);
     if (n.isEmpty()) return Part::Unknown;
-    const char side = boneSide(n);
+    // Prefer explicit side tokens in the raw name (catches `_R_1`/`.l`/`-r`
+    // delimited markers); fall back to the normalised-name heuristic.
+    char side = boneSideFromRaw(boneName.toLower());
+    if (side == 0) side = boneSide(n);
     auto has = [&](std::initializer_list<const char*> cores) {
         for (const char* c : cores) if (n.contains(QLatin1String(c))) return true;
         return false;
@@ -94,7 +126,8 @@ MeshSegmenter::Part MeshSegmenter::partForBoneName(const QString& boneName)
     // Centre / spine / tail → torso (tail has no dedicated label; torso is the
     // closest body region and keeps it out of the limbs).
     if (has({"spine", "chest", "hips", "pelvis", "abdomen", "lowerback",
-             "tail", "spine1", "spine2", "ribcage", "belly", "root"}) && side == 0)
+             "tail", "spine1", "spine2", "ribcage", "belly", "root",
+             "torso", "body", "waist", "sternum", "clavicleroot"}) && side == 0)
         return Part::Torso;
 
     // Arms (incl. wings, fingers, hands, clavicle/shoulder) by side.

--- a/src/MeshSegmenter_test.cpp
+++ b/src/MeshSegmenter_test.cpp
@@ -201,6 +201,18 @@ TEST(MeshSegmenter, BoneSideFromDelimitedToken)
     EXPECT_EQ(MS::partForBoneName("body"), MS::Part::Torso);
 }
 
+// A NAMESPACE / rig prefix must not leak its "left"/"right" into side
+// detection — "LeftRig:Spine1" is a centre torso bone, not a left limb.
+TEST(MeshSegmenter, BoneNamespacePrefixDoesNotLeakSide)
+{
+    EXPECT_EQ(MS::partForBoneName("LeftRig:Spine1"), MS::Part::Torso);
+    EXPECT_EQ(MS::partForBoneName("RightRig:Hips"),  MS::Part::Torso);
+    EXPECT_EQ(MS::partForBoneName("char_L:spine2"),  MS::Part::Torso);
+    // ...but a real side token AFTER the namespace still resolves.
+    EXPECT_EQ(MS::partForBoneName("LeftRig:arm_R_1"), MS::Part::RightArm);
+    EXPECT_EQ(MS::partForBoneName("Rig:LeftHand"),    MS::Part::LeftArm);
+}
+
 TEST(MeshSegmenter, ModelBackendAvailabilityMatchesBuild)
 {
 #ifdef ENABLE_ONNX

--- a/src/MeshSegmenter_test.cpp
+++ b/src/MeshSegmenter_test.cpp
@@ -180,6 +180,27 @@ TEST(MeshSegmenter, BoneSidesDistinct)
     EXPECT_NE(MS::partForBoneName("LeftFoot"), MS::partForBoneName("RightFoot"));
 }
 
+// Real CC0 rig naming (Khronos CesiumMan / RiggedFigure) puts the side letter
+// between separators and a trailing index: "arm_joint_R_1", "leg_joint_L__4_".
+// The side must be detected from that delimited token (regression for the
+// "armjointr1 ends in a digit → side lost → Torso" bug).
+TEST(MeshSegmenter, BoneSideFromDelimitedToken)
+{
+    EXPECT_EQ(MS::partForBoneName("arm_joint_R_1"),  MS::Part::RightArm);
+    EXPECT_EQ(MS::partForBoneName("arm_joint_L__4_"), MS::Part::LeftArm);
+    EXPECT_EQ(MS::partForBoneName("leg_joint_R_2"),  MS::Part::RightLeg);
+    EXPECT_EQ(MS::partForBoneName("leg_joint_L_5"),  MS::Part::LeftLeg);
+    EXPECT_EQ(MS::partForBoneName("Skeleton_arm_joint_L__3_"), MS::Part::LeftArm);
+    // Blender ".L/.R" and Maya-ish "-r" suffixes too.
+    EXPECT_EQ(MS::partForBoneName("upper_arm.L"), MS::Part::LeftArm);
+    EXPECT_EQ(MS::partForBoneName("hand-r"),      MS::Part::RightArm);
+    // A neck/torso joint with a numeric suffix must NOT be dragged to a side.
+    EXPECT_EQ(MS::partForBoneName("neck_joint_1"), MS::Part::Head);
+    EXPECT_EQ(MS::partForBoneName("torso_joint_1"), MS::Part::Torso);
+    EXPECT_EQ(MS::partForBoneName("Skeleton_torso_joint_2"), MS::Part::Torso);
+    EXPECT_EQ(MS::partForBoneName("body"), MS::Part::Torso);
+}
+
 TEST(MeshSegmenter, ModelBackendAvailabilityMatchesBuild)
 {
 #ifdef ENABLE_ONNX


### PR DESCRIPTION
## Summary

Mining CC0 rigs (Khronos CesiumMan / RiggedFigure) for segmentation training data (#410) surfaced two gaps in `MeshSegmenter::partForBoneName` that affect any non-Mixamo standard rig:

1. **Side detection missed delimited side tokens.** The common `arm_joint_R_1` / `leg_joint_L__4_` naming puts the side letter between separators and a trailing index. `normaliseBoneName` strips separators → `armjointr1`, which ends in a digit, so the old `endsWith('l'/'r')` check failed and the joint fell through to **Torso** (one whole side of the body lost). New `boneSideFromRaw()` scans the raw name for an `l`/`r` token delimited by a separator/start and followed by a separator/digit/end — catches `_R_1`, `.l`, `-r`. It's the primary signal; the normalised heuristic stays as fallback.
2. **`torso`/`body` weren't torso keywords.** `torso_joint_N` bones resolved to Unknown. Added `torso`, `body`, `waist`, `sternum`.

## Impact

On the mined CC0 rigs, full resolution with **symmetric** L/R arms+legs (was missing one side entirely):

| mesh | before | after |
|------|--------|-------|
| CesiumMan | 3039/3273, no L-arm/R-leg | **3273/3273**, all 6 parts |
| RiggedFigure | 281/365, legs only | **365/365**, all 6 parts |

Helps Mixamo and any standard rig too (the rig-prior "Select by Part" path + the training-data miner both improve).

## Tests

Added `BoneSideFromDelimitedToken` (the `_R_1`/`.L`/`-r` cases + the negative case that a numeric-suffixed neck/torso joint is not dragged to a side) and torso-keyword assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bone-side detection for character meshes, correctly recognizing left/right markers in common naming patterns such as separated tokens and trailing numeric suffixes.
  * Reduced misclassification of center-body parts, including spine, neck, and torso-related joints, so they are more reliably grouped as central.
  * Added test coverage for mixed naming styles to help prevent future regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->