### PR TITLE
fix(#410): segmentation works in-app — sampling bug + flat model (3.13.1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 3.13.0 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 3.13.1 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Available on the [GitHub Actions Marketplace](https://github.com/marketplace/act
 **Versioning**
 
 - **Always follow the latest GitHub release** — use the Marketplace floating tag `fernandotonon/QtMeshEditor@v1` (same pattern as the [Marketplace example](https://github.com/marketplace/actions/qtmesheditor)). The composite action defaults to `image-tag: latest`, so the Docker CLI tracks the newest published `ghcr.io/fernandotonon/qtmesh` image.
-- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.13.0**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
+- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.13.1**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
 
 Pinned workflow template (action + `ghcr.io` image aligned):
 
@@ -53,10 +53,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run QtMesh scan
-        uses: fernandotonon/QtMeshEditor@3.13.0
+        uses: fernandotonon/QtMeshEditor@3.13.1
         with:
           command: scan
-          image-tag: "3.13.0"
+          image-tag: "3.13.1"
         env:
           QTMESH_CLOUD_TOKEN: ${{ secrets.QTMESH_CLOUD_TOKEN }}
 ```
@@ -81,37 +81,37 @@ Release tags are listed on the [releases page](https://github.com/fernandotonon/
 
 ```yaml
 # Validate a specific mesh
-- uses: fernandotonon/QtMeshEditor@3.13.0
+- uses: fernandotonon/QtMeshEditor@3.13.1
   with:
     command: validate
     input-file: ./models/character.fbx
-    image-tag: "3.13.0"
+    image-tag: "3.13.1"
 
 # Convert FBX → glTF
-- uses: fernandotonon/QtMeshEditor@3.13.0
+- uses: fernandotonon/QtMeshEditor@3.13.1
   with:
     command: convert
     input-file: ./models/character.fbx
     output-file: ./output/character.gltf2
-    image-tag: "3.13.0"
+    image-tag: "3.13.1"
 
 # Resample Mixamo animations (200+ keyframes → 30)
-- uses: fernandotonon/QtMeshEditor@3.13.0
+- uses: fernandotonon/QtMeshEditor@3.13.1
   with:
     command: anim
     input-file: ./animations/dance.fbx
     output-file: ./output/dance_optimized.fbx
     options: --resample 30
-    image-tag: "3.13.0"
+    image-tag: "3.13.1"
 
 # Get mesh info as JSON
-- uses: fernandotonon/QtMeshEditor@3.13.0
+- uses: fernandotonon/QtMeshEditor@3.13.1
   id: info
   with:
     command: info
     input-file: ./models/character.fbx
     options: --json
-    image-tag: "3.13.0"
+    image-tag: "3.13.1"
 
 # Docker (alternative — :latest tracks newest image; pin :3.4.0 to match semver action ref)
 docker run --rm -v $(pwd):/workspace ghcr.io/fernandotonon/qtmesh:latest scan ./assets --fail-on error

--- a/scripts/export-meshseg-onnx.py
+++ b/scripts/export-meshseg-onnx.py
@@ -111,10 +111,12 @@ def make_humanoid(rng, npp=700):
 
     P = np.concatenate(pts).astype(np.float32); L = np.concatenate(lab)
 
-    # Augmentation: keep UPRIGHT (real meshes are +Y up) and keep LEFT/RIGHT
-    # meaningful — so only a SMALL yaw (about the up axis) + tiny tilt, never the
-    # old ±0.4rad on all 3 axes that scrambled orientation + which-side-is-which.
-    yaw = rng.uniform(-0.25, 0.25)
+    # Augmentation: FULL 360° yaw about the up axis so the model is invariant to
+    # which way the character faces (a real mesh can face any compass direction;
+    # the old ±0.25rad yaw made the model brittle — a 180°-yawed mesh got its
+    # left/right mirrored and head mislabelled). We keep it UPRIGHT (only a tiny
+    # tilt) and DO NOT mirror, so true left/right handedness is preserved.
+    yaw = rng.uniform(0.0, 2*np.pi)
     tilt = rng.uniform(-0.08, 0.08, size=2)
     cy, sy = np.cos(yaw), np.sin(yaw)
     Ry = np.array([[cy,0,sy],[0,1,0],[-sy,0,cy]])
@@ -149,7 +151,7 @@ def gen_dataset(samples, points, seed):
 # the model real-world surface distributions (dense faces, true limb shapes)
 # that synthetic primitives can't.
 def _augment_upright(P, rng):
-    yaw = rng.uniform(-0.25, 0.25)
+    yaw = rng.uniform(0.0, 2*np.pi)   # full 360° facing (see make_humanoid note)
     tilt = rng.uniform(-0.08, 0.08, size=2)
     cy, sy = np.cos(yaw), np.sin(yaw)
     Ry = np.array([[cy, 0, sy], [0, 1, 0], [-sy, 0, cy]])
@@ -207,6 +209,11 @@ def main():
                          "samples (rig-prior ground truth) to MIX with synthetic data")
     ap.add_argument("--real-aug", type=int, default=8,
                     help="augmented copies per real mesh (yaw/tilt/jitter)")
+    ap.add_argument("--real-weight", type=float, default=1.0,
+                    help="oversample factor for real samples so they aren't drowned "
+                         "out by synthetic. 0 = auto-balance to ~50/50 real:synthetic")
+    ap.add_argument("--dim", type=int, default=128, help="model feature width")
+    ap.add_argument("--knn", type=int, default=12, help="local kNN neighbours")
     a = ap.parse_args()
 
     import torch
@@ -214,53 +221,73 @@ def main():
 
     print("generating synthetic data…")
     P, L = gen_dataset(a.samples, a.points, a.seed)
+    # `src`: 0 = synthetic, 1 = real — kept so we can report val accuracy PER
+    # SOURCE (real-mesh accuracy is what actually matters; a synthetic-only
+    # average hides it).
+    src = np.zeros(len(P), np.int64)
     if a.real_data:
         rP, rL = load_real_data(a.real_data, a.points, a.real_aug, a.seed)
         if len(rP):
-            # Shuffle real samples into the synthetic set so the held-out val
-            # split (first n//10) contains both, and training sees a true mix.
+            # Oversample real so it isn't drowned out by synthetic. With the
+            # default (auto, --real-weight 0) we replicate real to ~match the
+            # synthetic count (≈50/50); the per-mesh augmentation already makes
+            # the copies non-identical, and we re-augment replicas below.
+            reps = a.real_weight
+            if reps <= 0:
+                reps = max(1.0, len(P) / max(1, len(rP)))
+            reps_i = int(round(reps))
+            if reps_i > 1:
+                rng = np.random.default_rng(a.seed + 2)
+                extraP, extraL = [], []
+                for _ in range(reps_i - 1):
+                    for i in range(len(rP)):
+                        extraP.append(_augment_upright(rP[i], rng)); extraL.append(rL[i])
+                rP = np.concatenate([rP, np.stack(extraP)])
+                rL = np.concatenate([rL, np.stack(extraL)])
             P = np.concatenate([P, rP]); L = np.concatenate([L, rL])
+            src = np.concatenate([src, np.ones(len(rP), np.int64)])
             sh = np.random.default_rng(a.seed + 1).permutation(len(P))
-            P = P[sh]; L = L[sh]
+            P = P[sh]; L = L[sh]; src = src[sh]
             print(f"combined dataset: {len(P)} samples "
-                  f"({a.samples} synthetic + {len(rP)} real)")
+                  f"({a.samples} synthetic + {len(rP)} real @ {reps_i}x = "
+                  f"{100*len(rP)/len(P):.0f}% real)")
     P = torch.tensor(P); L = torch.tensor(L)
+    srcT = torch.tensor(src)
     n = P.shape[0]; N = P.shape[1]
     nval = max(1, n // 10)
     dev = "mps" if torch.backends.mps.is_available() else "cpu"
-    print(f"data N={n} points={N} dev={dev}")
+    print(f"data N={n} points={N} dev={dev} dim={a.dim} knn={a.knn}")
 
     class PointSeg(nn.Module):
-        # PointNet++-style: per-point MLP + a LOCAL feature aggregated over each
-        # point's k nearest neighbours (so adjacent-but-distinct parts — arm vs
-        # torso, ear vs head — separate, the flat-PointNet weakness) + the global
-        # max-pooled feature. kNN is computed in-graph (exportable to ONNX).
+        # Classic PointNet SEGMENTATION network — deliberately uses ONLY ops that
+        # every ONNX Runtime build executes identically (Linear / GELU / max).
+        #
+        # NO in-graph kNN (cdist / topk / gather): the prebuilt
+        # onnxruntime-osx-universal2 binary the app links MIS-EXECUTES those ops
+        # on arm64 (verified: Python ORT 1.20.1 gives 0.98 on the same model +
+        # input, the C++ universal2 build gives 0.33). A flat PointNet sidesteps
+        # the broken kernels entirely and runs correctly in the app.
+        #
+        # Local context is recovered the PointNet-seg way: per-point features are
+        # concatenated with the GLOBAL max-pooled feature (broadcast back to every
+        # point), so each point classifies in the context of the whole shape. `k`
+        # is accepted but unused (kept for CLI compat).
         def __init__(s, d=128, k=12):
             super().__init__()
-            s.k = k
-            s.mlp1 = nn.Sequential(nn.Linear(3,64), nn.GELU(), nn.Linear(64,d), nn.GELU())
-            # local: consumes [self feat ; max over neighbours of (neighbour-self)]
-            s.local = nn.Sequential(nn.Linear(2*d, d), nn.GELU(), nn.Linear(d, d), nn.GELU())
-            s.mlp2 = nn.Sequential(nn.Linear(d,d), nn.GELU(), nn.Linear(d,d), nn.GELU())
-            s.head = nn.Sequential(nn.Linear(d+d+d, d), nn.GELU(), nn.Linear(d, C))
+            s.mlp1 = nn.Sequential(nn.Linear(3, 64), nn.GELU(), nn.Linear(64, d), nn.GELU())
+            s.mlp2 = nn.Sequential(nn.Linear(d, d), nn.GELU(), nn.Linear(d, d), nn.GELU())
+            # segmentation head: [per-point f ; per-point g ; global maxpool(g)]
+            s.head = nn.Sequential(nn.Linear(d + d + d, d), nn.GELU(),
+                                   nn.Linear(d, d), nn.GELU(), nn.Linear(d, C))
 
         def forward(s, pts):                      # pts: [B,N,3]
             f = s.mlp1(pts)                        # [B,N,d]
-            # kNN by Euclidean distance in xyz.
-            d2 = torch.cdist(pts, pts)             # [B,N,N]
-            kk = min(s.k, pts.shape[1])
-            nbr = d2.topk(kk, dim=-1, largest=False).indices  # [B,N,k]
-            B, N, dimf = f.shape
-            idx = nbr.reshape(B, N*kk, 1).expand(-1, -1, dimf)   # [B,N*k,d]
-            gathered = torch.gather(f, 1, idx).reshape(B, N, kk, dimf)  # [B,N,k,d]
-            rel = gathered - f.unsqueeze(2)        # neighbour minus self
-            localfeat = rel.max(dim=2).values      # [B,N,d]
-            loc = s.local(torch.cat([f, localfeat], dim=-1))
-            g = s.mlp2(loc)
-            glob = g.max(dim=1, keepdim=True).values.expand(-1, N, -1)
-            return s.head(torch.cat([f, loc, glob], dim=-1))
+            g = s.mlp2(f)                          # [B,N,d]
+            B, N, _ = f.shape
+            glob = g.max(dim=1, keepdim=True).values.expand(-1, N, -1)  # global ctx
+            return s.head(torch.cat([f, g, glob], dim=-1))
 
-    net = PointSeg().to(dev)
+    net = PointSeg(d=a.dim, k=a.knn).to(dev)
     opt = torch.optim.AdamW(net.parameters(), lr=2e-3, weight_decay=1e-4)
     sch = torch.optim.lr_scheduler.CosineAnnealingLR(opt, a.epochs)
     lossf = nn.CrossEntropyLoss()
@@ -276,13 +303,23 @@ def main():
         sch.step()
         if ep % 5 == 0 or ep == a.epochs - 1:
             net.eval()
-            correct = 0; total = 0
+            # Report val accuracy split by source — real-mesh accuracy is the
+            # number that matters; a blended average hides it.
+            cor = {0: 0, 1: 0}; tot = {0: 0, 1: 0}
             with torch.no_grad():
                 for b in range(0, nval, bs):     # batch val too (cdist is O(N^2) memory)
                     pv = P[b:b+bs].to(dev); lv = L[b:b+bs].to(dev)
-                    correct += (net(pv).argmax(-1) == lv).sum().item()
-                    total += lv.numel()
-            print(f"ep{ep:3d} loss{loss.item():.4f} val_pt_acc{correct/max(1,total):.4f}")
+                    sv = srcT[b:b+bs]
+                    ok = (net(pv).argmax(-1) == lv)
+                    for srcid in (0, 1):
+                        m = (sv == srcid)
+                        if m.any():
+                            cor[srcid] += ok[m.to(dev)].sum().item()
+                            tot[srcid] += int(m.sum().item()) * lv.shape[1]
+            syn = cor[0] / max(1, tot[0]); real = cor[1] / max(1, tot[1])
+            allc = (cor[0] + cor[1]) / max(1, tot[0] + tot[1])
+            print(f"ep{ep:3d} loss{loss.item():.4f} val_acc{allc:.4f} "
+                  f"synth{syn:.4f} real{real:.4f}(n={tot[1]//max(1,N)})")
 
     net.eval().cpu()
     torch.onnx.export(

--- a/src/MeshSegmenter.cpp
+++ b/src/MeshSegmenter.cpp
@@ -466,14 +466,24 @@ MeshSegmenter::Result MeshSegmenter::predict(const float* positions, int vertexC
             }
         }
 
-        const int N = std::max(256, opts.samplePoints);
+        // Cap N at the vertex count: padding a small mesh up to samplePoints with
+        // random duplicate points only adds noise to the model's global max-pool
+        // and never improves coverage (every real vert is already point i). Sample
+        // DOWN only when the mesh is larger than samplePoints.
+        const int N = std::min(std::max(256, opts.samplePoints), vertexCount);
         // Deterministic point sample (with replacement if the mesh is small).
         std::mt19937 rng(0x5e6u);  // NOSONAR — non-crypto, fixed for reproducibility
         std::uniform_int_distribution<int> pick(0, vertexCount - 1);
         std::vector<float> pts(static_cast<size_t>(N) * 3);
         std::vector<int> srcVert(N);
         for (int i = 0; i < N; ++i) {
-            const int v = (vertexCount >= N) ? (i < vertexCount ? i : pick(rng)) : pick(rng);
+            // The first min(N, vertexCount) points are verts 0..vc-1 IN ORDER so
+            // every vertex is covered 1:1 (the scatter's `vertexCount <= N`
+            // branch relies on this). Only the padding beyond vc (when N > vc) is
+            // random. (Previously this was inverted: when vc < N — the common
+            // case — every point was random, so ~37% of verts never got a real
+            // label and fell back to the Torso default, wrecking the result.)
+            const int v = (i < vertexCount) ? i : pick(rng);
             srcVert[i] = v;
             for (int c = 0; c < 3; ++c) {
                 const int a = axisFor[c];

--- a/website/src/hooks/useQtmeshActionRef.js
+++ b/website/src/hooks/useQtmeshActionRef.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 const QTMESH_RELEASES_LATEST_API = 'https://api.github.com/repos/fernandotonon/QtMeshEditor/releases/latest';
-const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.13.0';
+const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.13.1';
 const CACHE_KEY = 'qtmesh.actionRef.cache.v1';
 const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 


### PR DESCRIPTION
## Problem

The mesh part segmentation shipped in 3.13.0 (#771) was effectively broken **in the app** — it scored ≈0.33 per-vertex accuracy even on a correctly-oriented rigged mesh (the model itself was fine: 0.98 in Python). Two independent root causes, found by feeding the C++ path's exact points back through Python ORT:

### 1. Inverted point sampling (`MeshSegmenter::predict`)
For meshes with fewer vertices than `samplePoints` (4096 — i.e. **most** meshes), the sampling loop drew **every** point at random instead of covering verts `0..vc-1` in order. The nearest-point scatter then only labelled the randomly-hit verts (~63% coverage) and left the rest at the `Torso` default. Fixed: the first `min(N, vc)` points are verts in order (1:1 coverage), and `N` is capped at the vertex count so small meshes aren't padded with noisy duplicates.

### 2. In-graph kNN incompatible with the linked ONNX Runtime
The model used an in-graph kNN (`cdist`/`topk`/`gather`). Those ops did **not** execute correctly in the app's ONNX Runtime build — identical model + input gave 0.98 in Python ORT but 0.33 in the C++ app. Reworked the exported model to a **flat PointNet segmentation network** (per-point MLP → global max-pool → per-point head) using only `Linear`/`GELU`/`max`, which every ORT build runs identically.

**Verified in the C++ app:** 0.33 → **0.99** on a correctly-oriented rigged mesh.

## Model — meshseg v1.2.0 (flat)

Retrained on synthetic + **~89 CC0 rigged characters** (Quaternius CC0, Khronos glTF-Sample-Assets, ToxSam/Polygonal-Mind `xyz` CC0). Hosted on the HF repos (combined + dedicated). Training script gains: flat arch, `--real-data`/`--real-weight` rebalance with per-source (synth vs real) val reporting, and full 360° yaw augmentation.

**Known limitation (documented):** left/right limb assignment is inherently orientation-dependent — best on upright, front-facing meshes; a backward-facing mesh may mislabel L/R. **Rigged meshes are unaffected** — they use the exact rig-prior path, not the model.

## Version

Bumps to **3.13.1** (3.13.0 shipped the broken model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mesh segmentation now labels small meshes more reliably, reducing missing or default labels.
  * Training and validation workflows now better distinguish real and synthetic data, with support for weighting real samples more heavily.

* **Bug Fixes**
  * Improved point sampling so it no longer exceeds the number of vertices.
  * Updated ONNX export behavior and reporting for more consistent results.

* **Documentation**
  * Bumped release and CI examples to version **3.13.1** throughout the docs and website fallback settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->