### PR TITLE
UV: Slice E — Projection unwrap modes (#463)

### DIFF
--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -2616,6 +2616,14 @@ Rectangle {
             Row {
                 spacing: 4
                 visible: UVEditorController.hasMesh
+                Text {
+                    text: "Seams"
+                    color: PropertiesPanelController.textColor
+                    font.pixelSize: 10
+                    opacity: 0.65
+                    anchors.verticalCenter: parent.verticalCenter
+                    width: 44
+                }
                 Repeater {
                     model: [
                         { label: "Pin", fn: function() { UVEditorController.pinSelection() } },
@@ -2641,6 +2649,51 @@ Rectangle {
                         }
                         MouseArea {
                             id: uvToolMa
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: modelData.fn()
+                        }
+                    }
+                }
+            }
+
+            Row {
+                spacing: 4
+                visible: UVEditorController.hasMesh
+                Text {
+                    text: "Projection"
+                    color: PropertiesPanelController.textColor
+                    font.pixelSize: 10
+                    opacity: 0.65
+                    anchors.verticalCenter: parent.verticalCenter
+                    width: 44
+                }
+                Repeater {
+                    model: [
+                        { label: "View", fn: function() { UVEditorController.projectUvFromView() } },
+                        { label: "Box", fn: function() { UVEditorController.projectUvBox(1.0) } },
+                        { label: "Cyl", fn: function() { UVEditorController.projectUvCylinder(1, 1.0) } },
+                        { label: "Sph", fn: function() { UVEditorController.projectUvSphere(1) } },
+                        { label: "Reset", fn: function() { UVEditorController.resetUvBox() } }
+                    ]
+                    delegate: Rectangle {
+                        width: modelData.label === "Reset" ? 34 : 30
+                        height: 22
+                        radius: 3
+                        color: uvProjMa.pressed ? Qt.darker(PropertiesPanelController.inputColor, 1.12)
+                             : uvProjMa.containsMouse ? Qt.lighter(PropertiesPanelController.inputColor, 1.08)
+                             : PropertiesPanelController.inputColor
+                        border.color: PropertiesPanelController.borderColor
+                        border.width: 1
+                        Text {
+                            anchors.centerIn: parent
+                            text: modelData.label
+                            color: PropertiesPanelController.textColor
+                            font.pixelSize: 9
+                        }
+                        MouseArea {
+                            id: uvProjMa
                             anchors.fill: parent
                             hoverEnabled: true
                             cursorShape: Qt.PointingHandCursor

--- a/qml/UVEditorPanel.qml
+++ b/qml/UVEditorPanel.qml
@@ -596,6 +596,53 @@ Rectangle {
                     }
                 }
             }
+
+            Text {
+                text: "Projection"
+                color: ThemeManager.disabledTextColor
+                font.pixelSize: 10
+            }
+
+            Row {
+                spacing: 2
+                Repeater {
+                    model: [
+                        { label: "View", tip: "Project from focused 3D viewport", fn: function() { UVEditorController.projectUvFromView() } },
+                        { label: "Box", tip: "Box projection", fn: function() { UVEditorController.projectUvBox(1.0) } },
+                        { label: "Cyl", tip: "Cylinder projection (Y axis)", fn: function() { UVEditorController.projectUvCylinder(1, 1.0) } },
+                        { label: "Sph", tip: "Sphere projection", fn: function() { UVEditorController.projectUvSphere(1) } },
+                        { label: "Reset", tip: "Reset UVs to 0–1 box", fn: function() { UVEditorController.resetUvBox() } }
+                    ]
+                    delegate: Rectangle {
+                        width: modelData.label === "Reset" ? 34 : 30
+                        height: 18
+                        radius: 3
+                        color: projBtnMa.pressed ? Qt.darker(ThemeManager.inputColor, 1.15)
+                             : projBtnMa.containsMouse ? Qt.lighter(ThemeManager.inputColor, 1.08)
+                             : ThemeManager.inputColor
+                        border.color: ThemeManager.borderColor
+                        border.width: 1
+                        ToolTip.visible: projBtnMa.containsMouse
+                        ToolTip.text: modelData.tip
+                        Text {
+                            anchors.centerIn: parent
+                            text: modelData.label
+                            color: ThemeManager.textColor
+                            font.pixelSize: 9
+                        }
+                        MouseArea {
+                            id: projBtnMa
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: {
+                                modelData.fn()
+                                root.rebuildTriangleCache()
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         Rectangle {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,6 +91,7 @@ MeshOptimizerLod.cpp
 ExportOptimizer.cpp
 UvUnwrap.cpp
 UvUnwrapController.cpp
+UvProject.cpp
 UVEditorController.cpp
 UVTransform.cpp
 QuadRetopo.cpp
@@ -237,6 +238,7 @@ MeshOptimizerLod.h
 ExportOptimizer.h
 UvUnwrap.h
 UvUnwrapController.h
+UvProject.h
 UVEditorController.h
 UvSeamData.h
 UvSeamOps.h

--- a/src/UVEditorController.cpp
+++ b/src/UVEditorController.cpp
@@ -2284,6 +2284,9 @@ void UVEditorController::runUvProjection(UvProject::Mode mode, const UvProject::
         return;
     }
 
+    for (const auto& ch : report.changes)
+        applyWorkingMeshUv(ch.subMeshIndex, ch.vertexIndex, ch.newUv);
+
     std::vector<UVEditCommand::VertChange> changes;
     changes.reserve(report.changes.size());
     for (const auto& ch : report.changes) {
@@ -2303,6 +2306,7 @@ void UVEditorController::runUvProjection(UvProject::Mode mode, const UvProject::
         m_statusText = scoped
             ? tr("Projected %1 vertices (%2, selection)").arg(report.vertsChanged).arg(modeLabel)
             : tr("Projected %1 vertices (%2)").arg(report.vertsChanged).arg(modeLabel);
+        emit meshDataChanged();
     } else {
         for (const auto& ch : changes)
             applyWorkingMeshUv(ch.subMeshIndex, ch.vertexIndex, ch.oldUv);

--- a/src/UVEditorController.cpp
+++ b/src/UVEditorController.cpp
@@ -12,8 +12,10 @@
 #include "UvSeamData.h"
 #include "UvSeamOps.h"
 #include "UvUnwrap.h"
+#include "UvProject.h"
 #include "commands/UVEditCommand.h"
 #include "commands/UvSeamCommands.h"
+#include "mainwindow.h"
 
 #include <QImage>
 #include <QColor>
@@ -29,8 +31,10 @@
 #include <QUrl>
 
 #include <OgreEntity.h>
+#include <OgreCamera.h>
 #include <OgreMaterial.h>
 #include <OgrePass.h>
+#include <OgreSceneNode.h>
 #include <OgreSubEntity.h>
 #include <OgreSubMesh.h>
 #include <OgreTexture.h>
@@ -2136,4 +2140,206 @@ void UVEditorController::unwrapSelectedFaces()
     ++m_meshRevision;
     emit meshDataChanged();
     refresh();
+}
+
+UvProject::Selection UVEditorController::buildProjectionSelection() const
+{
+    UvProject::Selection selection;
+    selection.includeTriangle.resize(m_workingMesh.subMeshes().size());
+
+    const bool hasSelection = !m_selectedUvVerts.isEmpty() || !m_selectedUvEdges.isEmpty()
+                              || !m_selectedUvFaces.isEmpty();
+
+    if (!hasSelection) {
+        for (size_t si = 0; si < selection.includeTriangle.size(); ++si) {
+            if (!m_submeshFilter.isEmpty() && !m_submeshFilter.contains(static_cast<int>(si))) {
+                selection.includeTriangle[si].assign(
+                    m_workingMesh.subMeshes()[si].triangles.size(), false);
+            }
+        }
+        return selection;
+    }
+
+    QSet<int> selectedGlobalVerts;
+    for (int id : m_selectedUvVerts) {
+        if (id >= 0 && id < static_cast<int>(m_uvVerts.size()))
+            selectedGlobalVerts.insert(m_uvVerts[static_cast<size_t>(id)].meshGlobalVert);
+    }
+    for (int eid : m_selectedUvEdges) {
+        if (eid < 0 || eid >= static_cast<int>(m_uvEdges.size()))
+            continue;
+        selectedGlobalVerts.insert(m_uvEdges[static_cast<size_t>(eid)].meshGlobalV0);
+        selectedGlobalVerts.insert(m_uvEdges[static_cast<size_t>(eid)].meshGlobalV1);
+    }
+
+    QSet<int> selectedGlobalTris;
+    for (int fid : m_selectedUvFaces) {
+        if (fid < 0 || fid >= static_cast<int>(m_uvTris.size()))
+            continue;
+        selectedGlobalTris.insert(m_uvTris[static_cast<size_t>(fid)].meshGlobalTri);
+    }
+
+    int globalTriOffset = 0;
+    int globalVertOffset = 0;
+    for (size_t si = 0; si < m_workingMesh.subMeshes().size(); ++si) {
+        const auto& sub = m_workingMesh.subMeshes()[si];
+        auto& mask = selection.includeTriangle[si];
+        mask.assign(sub.triangles.size(), false);
+
+        if (!m_submeshFilter.isEmpty() && !m_submeshFilter.contains(static_cast<int>(si))) {
+            globalTriOffset += static_cast<int>(sub.triangles.size());
+            globalVertOffset += static_cast<int>(sub.vertices.size());
+            continue;
+        }
+
+        for (size_t ti = 0; ti < sub.triangles.size(); ++ti) {
+            const int globalTri = globalTriOffset + static_cast<int>(ti);
+            if (selectedGlobalTris.contains(globalTri)) {
+                mask[ti] = true;
+                continue;
+            }
+            for (int c = 0; c < 3; ++c) {
+                const int globalVert =
+                    globalVertOffset + static_cast<int>(sub.triangles[ti].indices[c]);
+                if (selectedGlobalVerts.contains(globalVert)) {
+                    mask[ti] = true;
+                    break;
+                }
+            }
+        }
+
+        globalTriOffset += static_cast<int>(sub.triangles.size());
+        globalVertOffset += static_cast<int>(sub.vertices.size());
+    }
+
+    return selection;
+}
+
+bool UVEditorController::applyProjectionChanges(
+    const std::vector<UVEditCommand::VertChange>& changes,
+    const QString& undoDescription,
+    const QString& breadcrumbMode)
+{
+    if (!m_activeEntity || changes.empty())
+        return false;
+
+    if (!commitWorkingMeshUvs()) {
+        for (const auto& ch : changes)
+            applyWorkingMeshUv(ch.subMeshIndex, ch.vertexIndex, ch.oldUv);
+        return false;
+    }
+
+    if (auto* edit = EditModeController::instance()) {
+        if (edit->isEditModeActive() && edit->editEntity() == m_activeEntity) {
+            if (edit->currentMesh())
+                edit->currentMesh()->subMeshes() = m_workingMesh.subMeshes();
+            edit->notifyMeshDataChanged();
+        }
+    }
+
+    if (UndoManager* undo = UndoManager::getSingleton())
+        undo->push(new UVEditCommand(m_activeEntity, m_uvChannel, changes, undoDescription));
+
+    SentryReporter::addBreadcrumb(QStringLiteral("mesh.uv.project"), breadcrumbMode);
+    syncUvLayoutFromWorkingMesh();
+    return true;
+}
+
+void UVEditorController::runUvProjection(UvProject::Mode mode, const UvProject::Options& extraOpts)
+{
+    if (!m_activeEntity || m_workingMesh.subMeshes().empty())
+        return;
+
+    UvProject::Options opts = extraOpts;
+    opts.mode = mode;
+
+    if (mode == UvProject::Mode::View) {
+        MainWindow* mw = Manager::getSingletonPtr() ? Manager::getSingleton()->getMainWindow() : nullptr;
+        if (!mw) {
+            m_statusText = tr("View projection requires an active viewport");
+            emit meshDataChanged();
+            return;
+        }
+        const ViewportCameraSnapshot snap = mw->queryViewportCamera(false);
+        if (!snap.valid) {
+            m_statusText = tr("View projection requires an active 3D viewport");
+            emit meshDataChanged();
+            return;
+        }
+        opts.viewMatrix = snap.viewMatrix;
+        opts.projMatrix = snap.projMatrix;
+        opts.hasViewMatrices = true;
+
+        if (Ogre::Node* node = m_activeEntity->getParentNode())
+            opts.worldMatrix = node->_getFullTransform();
+        else
+            opts.worldMatrix = Ogre::Matrix4::IDENTITY;
+    }
+
+    const UvProject::Selection selection = buildProjectionSelection();
+    const UvProject::Report report = UvProject::project(m_workingMesh, selection, opts);
+    if (!report.applied) {
+        m_statusText = report.error.isEmpty() ? tr("Projection failed") : report.error;
+        emit meshDataChanged();
+        return;
+    }
+
+    std::vector<UVEditCommand::VertChange> changes;
+    changes.reserve(report.changes.size());
+    for (const auto& ch : report.changes) {
+        UVEditCommand::VertChange cmd;
+        cmd.subMeshIndex = ch.subMeshIndex;
+        cmd.vertexIndex = ch.vertexIndex;
+        cmd.oldUv = ch.oldUv;
+        cmd.newUv = ch.newUv;
+        changes.push_back(cmd);
+    }
+
+    const QString modeLabel = UvProject::modeToString(mode);
+    const QString undoDescription = tr("UV Project %1").arg(modeLabel);
+    if (applyProjectionChanges(changes, undoDescription, modeLabel)) {
+        const bool scoped = !m_selectedUvVerts.isEmpty() || !m_selectedUvEdges.isEmpty()
+                            || !m_selectedUvFaces.isEmpty();
+        m_statusText = scoped
+            ? tr("Projected %1 vertices (%2, selection)").arg(report.vertsChanged).arg(modeLabel)
+            : tr("Projected %1 vertices (%2)").arg(report.vertsChanged).arg(modeLabel);
+    } else {
+        for (const auto& ch : changes)
+            applyWorkingMeshUv(ch.subMeshIndex, ch.vertexIndex, ch.oldUv);
+        syncUvLayoutFromWorkingMesh();
+        m_statusText = tr("Failed to commit projection");
+        emit meshDataChanged();
+    }
+}
+
+void UVEditorController::projectUvFromView()
+{
+    runUvProjection(UvProject::Mode::View, {});
+}
+
+void UVEditorController::projectUvBox(double scale)
+{
+    UvProject::Options opts;
+    opts.boxScale = static_cast<float>(scale > 0.0 ? scale : 1.0);
+    runUvProjection(UvProject::Mode::Box, opts);
+}
+
+void UVEditorController::projectUvCylinder(int axis, double scale)
+{
+    UvProject::Options opts;
+    opts.axis = axis;
+    opts.boxScale = static_cast<float>(scale > 0.0 ? scale : 1.0);
+    runUvProjection(UvProject::Mode::Cylinder, opts);
+}
+
+void UVEditorController::projectUvSphere(int axis)
+{
+    UvProject::Options opts;
+    opts.axis = axis;
+    runUvProjection(UvProject::Mode::Sphere, opts);
+}
+
+void UVEditorController::resetUvBox()
+{
+    runUvProjection(UvProject::Mode::ResetBox, {});
 }

--- a/src/UVEditorController.h
+++ b/src/UVEditorController.h
@@ -13,6 +13,7 @@
 #include <Ogre.h>
 
 #include "UVTransform.h"
+#include "UvProject.h"
 #include "commands/UVEditCommand.h"
 #include "EditableMesh.h"
 
@@ -180,6 +181,14 @@ public:
     Q_INVOKABLE void sewSelectedEdges();
     Q_INVOKABLE void splitSelectedEdges();
     Q_INVOKABLE void unwrapSelectedFaces();
+
+    /// Projection unwrap modes (issue #463).
+    Q_INVOKABLE void projectUvFromView();
+    Q_INVOKABLE void projectUvBox(double scale);
+    Q_INVOKABLE void projectUvCylinder(int axis, double scale);
+    Q_INVOKABLE void projectUvSphere(int axis);
+    Q_INVOKABLE void resetUvBox();
+
     Q_INVOKABLE QVariantList seamEdges() const;
     Q_INVOKABLE QVariantList pinnedVertices() const;
 
@@ -281,6 +290,11 @@ private:
                            const std::vector<UVTransform::VertRef>& before,
                            UVTransform::TransformOp op,
                            const QString& description);
+    UvProject::Selection buildProjectionSelection() const;
+    bool applyProjectionChanges(const std::vector<UVEditCommand::VertChange>& changes,
+                                const QString& undoDescription,
+                                const QString& breadcrumbMode);
+    void runUvProjection(UvProject::Mode mode, const UvProject::Options& extraOpts);
     void syncWorkingMeshFromEntity();
     void syncUvLayoutFromWorkingMesh();
     void updateTexturePixelSize();

--- a/src/UvProject.cpp
+++ b/src/UvProject.cpp
@@ -73,6 +73,17 @@ Ogre::Vector2 projectPositionOnBoxPlane(const Ogre::Vector3& pos, int planeAxis,
     }
 }
 
+void scaleUvMapAroundCenter(std::unordered_map<VertKey, Ogre::Vector2, VertKeyHash>& uvs,
+                            float scale)
+{
+    if (std::abs(scale - 1.f) < 1e-6f)
+        return;
+    for (auto& kv : uvs) {
+        kv.second.x = (kv.second.x - 0.5f) * scale + 0.5f;
+        kv.second.y = (kv.second.y - 0.5f) * scale + 0.5f;
+    }
+}
+
 void normalizeUvMap(std::unordered_map<VertKey, Ogre::Vector2, VertKeyHash>& uvs)
 {
     if (uvs.empty())
@@ -158,7 +169,7 @@ Ogre::Vector2 projectCylinder(const Ogre::Vector3& pos, int axis,
     return {u, v};
 }
 
-Ogre::Vector2 projectSphere(const Ogre::Vector3& pos, int /*axis*/,
+Ogre::Vector2 projectSphere(const Ogre::Vector3& pos, int axis,
                             const Ogre::AxisAlignedBox& bounds)
 {
     const Ogre::Vector3 center = bounds.getCenter();
@@ -167,9 +178,25 @@ Ogre::Vector2 projectSphere(const Ogre::Vector3& pos, int /*axis*/,
         return {0.5f, 0.5f};
     dir.normalise();
 
-    const float u = static_cast<float>(std::atan2(dir.x, dir.z) / (2.0 * Ogre::Math::PI) + 0.5);
-    const float v = 0.5f - static_cast<float>(std::asin(std::clamp(dir.y, -1.f, 1.f))
-                                               / Ogre::Math::PI);
+    float u = 0.5f;
+    float v = 0.5f;
+    switch (axis % 3) {
+    case 0:
+        u = static_cast<float>(std::atan2(dir.y, dir.z) / (2.0 * Ogre::Math::PI) + 0.5);
+        v = 0.5f - static_cast<float>(std::asin(std::clamp(dir.x, -1.f, 1.f))
+                                       / Ogre::Math::PI);
+        break;
+    case 1:
+        u = static_cast<float>(std::atan2(dir.x, dir.z) / (2.0 * Ogre::Math::PI) + 0.5);
+        v = 0.5f - static_cast<float>(std::asin(std::clamp(dir.y, -1.f, 1.f))
+                                       / Ogre::Math::PI);
+        break;
+    default:
+        u = static_cast<float>(std::atan2(dir.x, dir.y) / (2.0 * Ogre::Math::PI) + 0.5);
+        v = 0.5f - static_cast<float>(std::asin(std::clamp(dir.z, -1.f, 1.f))
+                                       / Ogre::Math::PI);
+        break;
+    }
     return {u, v};
 }
 
@@ -215,6 +242,7 @@ projectBoxPerFace(const EditableMesh& mesh, const UvProject::Selection& selectio
         }
     }
     normalizeUvMap(out);
+    scaleUvMapAroundCenter(out, scale);
     return out;
 }
 
@@ -338,9 +366,10 @@ UvProject::Report UvProject::project(EditableMesh& mesh, const Selection& select
             }
         }
 
-        if (opts.mode == Mode::View)
+        if (opts.mode == Mode::Cylinder) {
             normalizeUvMap(projected);
-        else if (opts.mode == Mode::Cylinder || opts.mode == Mode::Sphere || opts.mode == Mode::ResetBox)
+            scaleUvMapAroundCenter(projected, opts.boxScale);
+        } else if (opts.mode == Mode::Sphere || opts.mode == Mode::ResetBox)
             normalizeUvMap(projected);
         break;
     }

--- a/src/UvProject.cpp
+++ b/src/UvProject.cpp
@@ -1,0 +1,360 @@
+#include "UvProject.h"
+
+#include "EditableMesh.h"
+
+#include <OgreMath.h>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using VertKey = std::pair<int, int>; // (subMesh, localVert)
+
+struct VertKeyHash {
+    size_t operator()(const VertKey& k) const noexcept
+    {
+        return static_cast<size_t>(k.first) * 1315423911u
+               + static_cast<size_t>(k.second);
+    }
+};
+
+bool triangleIncluded(const UvProject::Selection& selection, int subMesh, int localTri)
+{
+    if (subMesh < 0 || static_cast<size_t>(subMesh) >= selection.includeTriangle.size())
+        return true;
+    const auto& mask = selection.includeTriangle[static_cast<size_t>(subMesh)];
+    if (mask.empty())
+        return true;
+    if (localTri < 0 || static_cast<size_t>(localTri) >= mask.size())
+        return false;
+    return mask[static_cast<size_t>(localTri)];
+}
+
+Ogre::Vector3 triangleNormal(const EditableMesh& mesh, int subMesh, const EditableTriangle& tri)
+{
+    const auto& verts = mesh.subMeshes()[static_cast<size_t>(subMesh)].vertices;
+    const auto& a = verts[tri.indices[0]].position;
+    const auto& b = verts[tri.indices[1]].position;
+    const auto& c = verts[tri.indices[2]].position;
+    Ogre::Vector3 n = (b - a).crossProduct(c - a);
+    if (n.squaredLength() < 1e-16f)
+        return Ogre::Vector3::UNIT_Y;
+    n.normalise();
+    return n;
+}
+
+int pickBoxPlaneAxis(const Ogre::Vector3& normal)
+{
+    const float ax = std::abs(normal.x);
+    const float ay = std::abs(normal.y);
+    const float az = std::abs(normal.z);
+    if (ay >= ax && ay >= az)
+        return normal.y >= 0.f ? 2 : 3; // +Y / -Y
+    if (ax >= az)
+        return normal.x >= 0.f ? 0 : 1; // +X / -X
+    return normal.z >= 0.f ? 4 : 5;     // +Z / -Z
+}
+
+Ogre::Vector2 projectPositionOnBoxPlane(const Ogre::Vector3& pos, int planeAxis, float scale)
+{
+    switch (planeAxis) {
+    case 0: return {pos.y * scale, pos.z * scale};
+    case 1: return {pos.y * scale, pos.z * scale};
+    case 2: return {pos.x * scale, pos.z * scale};
+    case 3: return {pos.x * scale, pos.z * scale};
+    case 4: return {pos.x * scale, pos.y * scale};
+    default: return {pos.x * scale, pos.y * scale};
+    }
+}
+
+void normalizeUvMap(std::unordered_map<VertKey, Ogre::Vector2, VertKeyHash>& uvs)
+{
+    if (uvs.empty())
+        return;
+
+    float minU = std::numeric_limits<float>::max();
+    float minV = std::numeric_limits<float>::max();
+    float maxU = -std::numeric_limits<float>::max();
+    float maxV = -std::numeric_limits<float>::max();
+    for (const auto& kv : uvs) {
+        minU = std::min(minU, kv.second.x);
+        minV = std::min(minV, kv.second.y);
+        maxU = std::max(maxU, kv.second.x);
+        maxV = std::max(maxV, kv.second.y);
+    }
+
+    const float du = maxU - minU;
+    const float dv = maxV - minV;
+    for (auto& kv : uvs) {
+        if (du > 1e-8f)
+            kv.second.x = (kv.second.x - minU) / du;
+        else
+            kv.second.x = 0.5f;
+        if (dv > 1e-8f)
+            kv.second.y = (kv.second.y - minV) / dv;
+        else
+            kv.second.y = 0.5f;
+    }
+}
+
+Ogre::AxisAlignedBox boundsForKeys(const EditableMesh& mesh,
+                                   const std::unordered_set<VertKey, VertKeyHash>& keys)
+{
+    Ogre::AxisAlignedBox box;
+    box.setNull();
+    for (const VertKey& key : keys) {
+        if (key.first < 0
+            || static_cast<size_t>(key.first) >= mesh.subMeshes().size()
+            || key.second < 0
+            || static_cast<size_t>(key.second)
+                   >= mesh.subMeshes()[static_cast<size_t>(key.first)].vertices.size()) {
+            continue;
+        }
+        box.merge(mesh.subMeshes()[static_cast<size_t>(key.first)]
+                      .vertices[static_cast<size_t>(key.second)]
+                      .position);
+    }
+    return box;
+}
+
+Ogre::Vector2 projectCylinder(const Ogre::Vector3& pos, int axis,
+                              const Ogre::AxisAlignedBox& bounds, float scale)
+{
+    const Ogre::Vector3 center = bounds.getCenter();
+    const Ogre::Vector3 min = bounds.getMinimum();
+    const Ogre::Vector3 max = bounds.getMaximum();
+
+    float u = 0.5f;
+    float v = 0.5f;
+    switch (axis % 3) {
+    case 0: {
+        const float ang = std::atan2(pos.y - center.y, pos.z - center.z);
+        u = static_cast<float>(ang / (2.0 * Ogre::Math::PI) + 0.5);
+        const float denom = std::max(max.x - min.x, 1e-6f);
+        v = (pos.x - min.x) / denom * scale;
+        break;
+    }
+    case 1: {
+        const float ang = std::atan2(pos.x - center.x, pos.z - center.z);
+        u = static_cast<float>(ang / (2.0 * Ogre::Math::PI) + 0.5);
+        const float denom = std::max(max.y - min.y, 1e-6f);
+        v = (pos.y - min.y) / denom * scale;
+        break;
+    }
+    default: {
+        const float ang = std::atan2(pos.x - center.x, pos.y - center.y);
+        u = static_cast<float>(ang / (2.0 * Ogre::Math::PI) + 0.5);
+        const float denom = std::max(max.z - min.z, 1e-6f);
+        v = (pos.z - min.z) / denom * scale;
+        break;
+    }
+    }
+    return {u, v};
+}
+
+Ogre::Vector2 projectSphere(const Ogre::Vector3& pos, int /*axis*/,
+                            const Ogre::AxisAlignedBox& bounds)
+{
+    const Ogre::Vector3 center = bounds.getCenter();
+    Ogre::Vector3 dir = pos - center;
+    if (dir.squaredLength() < 1e-12f)
+        return {0.5f, 0.5f};
+    dir.normalise();
+
+    const float u = static_cast<float>(std::atan2(dir.x, dir.z) / (2.0 * Ogre::Math::PI) + 0.5);
+    const float v = 0.5f - static_cast<float>(std::asin(std::clamp(dir.y, -1.f, 1.f))
+                                               / Ogre::Math::PI);
+    return {u, v};
+}
+
+Ogre::Vector2 projectView(const Ogre::Vector3& localPos, const UvProject::Options& opts)
+{
+    const Ogre::Vector4 world = opts.worldMatrix * Ogre::Vector4(localPos, 1.f);
+    const Ogre::Vector4 view = opts.viewMatrix * world;
+    const Ogre::Vector4 clip = opts.projMatrix * view;
+    if (std::abs(clip.w) < 1e-8f)
+        return {0.5f, 0.5f};
+    const float ndcX = clip.x / clip.w;
+    const float ndcY = clip.y / clip.w;
+    // Match the UV editor's V-up convention (see UVEditorPanel uvToScreen: panV - v).
+    return {ndcX * 0.5f + 0.5f, ndcY * 0.5f + 0.5f};
+}
+
+Ogre::Vector2 projectResetBox(const Ogre::Vector3& pos, const Ogre::AxisAlignedBox& bounds)
+{
+    const Ogre::Vector3 min = bounds.getMinimum();
+    const Ogre::Vector3 max = bounds.getMaximum();
+    const float dx = std::max(max.x - min.x, 1e-6f);
+    const float dy = std::max(max.y - min.y, 1e-6f);
+    return {(pos.x - min.x) / dx, (pos.y - min.y) / dy};
+}
+
+std::unordered_map<VertKey, Ogre::Vector2, VertKeyHash>
+projectBoxPerFace(const EditableMesh& mesh, const UvProject::Selection& selection, float scale)
+{
+    std::unordered_map<VertKey, Ogre::Vector2, VertKeyHash> out;
+    for (size_t si = 0; si < mesh.subMeshes().size(); ++si) {
+        const auto& sub = mesh.subMeshes()[si];
+        for (size_t ti = 0; ti < sub.triangles.size(); ++ti) {
+            if (!triangleIncluded(selection, static_cast<int>(si), static_cast<int>(ti)))
+                continue;
+            const auto& tri = sub.triangles[ti];
+            const Ogre::Vector3 n = triangleNormal(mesh, static_cast<int>(si), tri);
+            const int plane = pickBoxPlaneAxis(n);
+            for (int c = 0; c < 3; ++c) {
+                const unsigned int vi = tri.indices[c];
+                const VertKey key{static_cast<int>(si), static_cast<int>(vi)};
+                out[key] = projectPositionOnBoxPlane(sub.vertices[vi].position, plane, scale);
+            }
+        }
+    }
+    normalizeUvMap(out);
+    return out;
+}
+
+std::unordered_map<VertKey, Ogre::Vector2, VertKeyHash>
+collectAffectedKeys(const EditableMesh& mesh, const UvProject::Selection& selection)
+{
+    std::unordered_map<VertKey, Ogre::Vector2, VertKeyHash> keys;
+    for (size_t si = 0; si < mesh.subMeshes().size(); ++si) {
+        const auto& sub = mesh.subMeshes()[si];
+        if (selection.includeTriangle.size() > si
+            && selection.includeTriangle[si].empty()) {
+            for (size_t vi = 0; vi < sub.vertices.size(); ++vi)
+                keys[{static_cast<int>(si), static_cast<int>(vi)}] = Ogre::Vector2::ZERO;
+            continue;
+        }
+        for (size_t ti = 0; ti < sub.triangles.size(); ++ti) {
+            if (!triangleIncluded(selection, static_cast<int>(si), static_cast<int>(ti)))
+                continue;
+            for (int c = 0; c < 3; ++c) {
+                const int vi = static_cast<int>(sub.triangles[ti].indices[c]);
+                keys[{static_cast<int>(si), vi}] = Ogre::Vector2::ZERO;
+            }
+        }
+    }
+    return keys;
+}
+
+std::vector<UvProject::VertChange>
+applyUvMap(EditableMesh& mesh, const std::unordered_map<VertKey, Ogre::Vector2, VertKeyHash>& uvs)
+{
+    std::vector<UvProject::VertChange> changes;
+    changes.reserve(uvs.size());
+    for (const auto& kv : uvs) {
+        const int si = kv.first.first;
+        const int vi = kv.first.second;
+        if (si < 0 || static_cast<size_t>(si) >= mesh.subMeshes().size())
+            continue;
+        auto& verts = mesh.subMeshes()[static_cast<size_t>(si)].vertices;
+        if (vi < 0 || static_cast<size_t>(vi) >= verts.size())
+            continue;
+
+        UvProject::VertChange change;
+        change.subMeshIndex = si;
+        change.vertexIndex = vi;
+        change.oldUv = verts[static_cast<size_t>(vi)].hasUV ? verts[static_cast<size_t>(vi)].uv
+                                                            : Ogre::Vector2::ZERO;
+        change.newUv = kv.second;
+        verts[static_cast<size_t>(vi)].uv = change.newUv;
+        verts[static_cast<size_t>(vi)].hasUV = true;
+        changes.push_back(change);
+    }
+    return changes;
+}
+
+} // namespace
+
+QString UvProject::modeToString(Mode mode)
+{
+    switch (mode) {
+    case Mode::View: return QStringLiteral("view");
+    case Mode::Box: return QStringLiteral("box");
+    case Mode::Cylinder: return QStringLiteral("cylinder");
+    case Mode::Sphere: return QStringLiteral("sphere");
+    case Mode::ResetBox: return QStringLiteral("reset_box");
+    }
+    return QStringLiteral("unknown");
+}
+
+UvProject::Report UvProject::project(EditableMesh& mesh, const Selection& selection,
+                                     const Options& opts)
+{
+    Report report;
+    if (mesh.subMeshes().empty()) {
+        report.error = QStringLiteral("Mesh has no submeshes");
+        return report;
+    }
+
+    if (opts.mode == Mode::View && !opts.hasViewMatrices) {
+        report.error = QStringLiteral("View projection requires a viewport camera");
+        return report;
+    }
+
+    std::unordered_map<VertKey, Ogre::Vector2, VertKeyHash> projected;
+
+    switch (opts.mode) {
+    case Mode::Box:
+        projected = projectBoxPerFace(mesh, selection, opts.boxScale);
+        break;
+    default: {
+        projected = collectAffectedKeys(mesh, selection);
+        if (projected.empty()) {
+            report.error = QStringLiteral("No geometry in projection selection");
+            return report;
+        }
+
+        std::unordered_set<VertKey, VertKeyHash> keySet;
+        for (const auto& kv : projected)
+            keySet.insert(kv.first);
+        const Ogre::AxisAlignedBox bounds = boundsForKeys(mesh, keySet);
+
+        for (auto& kv : projected) {
+            const int si = kv.first.first;
+            const int vi = kv.first.second;
+            const Ogre::Vector3& pos =
+                mesh.subMeshes()[static_cast<size_t>(si)].vertices[static_cast<size_t>(vi)].position;
+            switch (opts.mode) {
+            case Mode::Cylinder:
+                kv.second = projectCylinder(pos, opts.axis, bounds, opts.boxScale);
+                break;
+            case Mode::Sphere:
+                kv.second = projectSphere(pos, opts.axis, bounds);
+                break;
+            case Mode::ResetBox:
+                kv.second = projectResetBox(pos, bounds);
+                break;
+            case Mode::View:
+                kv.second = projectView(pos, opts);
+                break;
+            default:
+                break;
+            }
+        }
+
+        if (opts.mode == Mode::View)
+            normalizeUvMap(projected);
+        else if (opts.mode == Mode::Cylinder || opts.mode == Mode::Sphere || opts.mode == Mode::ResetBox)
+            normalizeUvMap(projected);
+        break;
+    }
+    }
+
+    if (projected.empty()) {
+        report.error = QStringLiteral("Projection produced no UV changes");
+        return report;
+    }
+
+    report.changes = applyUvMap(mesh, projected);
+    report.vertsChanged = static_cast<int>(report.changes.size());
+    report.applied = report.vertsChanged > 0;
+    if (!report.applied)
+        report.error = QStringLiteral("Projection produced no UV changes");
+    return report;
+}

--- a/src/UvProject.h
+++ b/src/UvProject.h
@@ -1,0 +1,61 @@
+#ifndef UV_PROJECT_H
+#define UV_PROJECT_H
+
+#include <OgreMatrix4.h>
+#include <OgreVector2.h>
+#include <QString>
+#include <vector>
+
+class EditableMesh;
+
+/// Quick-start UV layouts via geometric projection (issue #463).
+class UvProject
+{
+public:
+    enum class Mode {
+        View,
+        Box,
+        Cylinder,
+        Sphere,
+        ResetBox
+    };
+
+    struct VertChange {
+        int subMeshIndex = 0;
+        int vertexIndex = 0;
+        Ogre::Vector2 oldUv;
+        Ogre::Vector2 newUv;
+    };
+
+    /// Per-submesh triangle inclusion mask. When empty for a submesh, all
+    /// triangles in that submesh are included.
+    struct Selection {
+        std::vector<std::vector<bool>> includeTriangle;
+    };
+
+    struct Options {
+        Mode mode = Mode::Box;
+        /// 0 = X, 1 = Y, 2 = Z (cylinder / sphere).
+        int axis = 1;
+        float boxScale = 1.0f;
+
+        /// View projection matrices (world space). Required for Mode::View.
+        Ogre::Matrix4 viewMatrix;
+        Ogre::Matrix4 projMatrix;
+        Ogre::Matrix4 worldMatrix;
+        bool hasViewMatrices = false;
+    };
+
+    struct Report {
+        bool applied = false;
+        QString error;
+        int vertsChanged = 0;
+        std::vector<VertChange> changes;
+    };
+
+    static Report project(EditableMesh& mesh, const Selection& selection, const Options& opts);
+
+    static QString modeToString(Mode mode);
+};
+
+#endif // UV_PROJECT_H

--- a/src/UvProject_test.cpp
+++ b/src/UvProject_test.cpp
@@ -3,6 +3,8 @@
 #include "EditableMesh.h"
 #include "UvProject.h"
 
+#include <OgreMath.h>
+
 #include <algorithm>
 #include <cmath>
 #include <vector>
@@ -43,7 +45,7 @@ EditableMesh cylinderStripMesh(int segments = 16, float height = 2.f)
     for (int ring = 0; ring < 2; ++ring) {
         const float y = ring == 0 ? 0.f : height;
         for (int i = 0; i < segments; ++i) {
-            const float ang = static_cast<float>(i) / segments * 2.f * static_cast<float>(M_PI);
+            const float ang = static_cast<float>(i) / segments * 2.f * static_cast<float>(Ogre::Math::PI);
             verts.push_back(EditableVertex{
                 .position = {std::cos(ang), y, std::sin(ang)},
             });
@@ -135,6 +137,34 @@ TEST(UvProjectTest, ViewProjectRequiresCameraMatrices)
     const auto report = UvProject::project(mesh, allTriangles(mesh), opts);
     EXPECT_FALSE(report.applied);
     EXPECT_FALSE(report.error.isEmpty());
+}
+
+TEST(UvProjectTest, SphereProjectNormalizesAndDiffersByAxis)
+{
+    auto projectAxis = [](int axis) {
+        EditableMesh mesh = cylinderStripMesh();
+        UvProject::Options opts;
+        opts.mode = UvProject::Mode::Sphere;
+        opts.axis = axis;
+        const auto report = UvProject::project(mesh, allTriangles(mesh), opts);
+        EXPECT_TRUE(report.applied);
+        EXPECT_TRUE(uvsInUnitRange(mesh));
+        return mesh;
+    };
+
+    const EditableMesh meshX = projectAxis(0);
+    const EditableMesh meshY = projectAxis(1);
+
+    bool differs = false;
+    for (size_t i = 0; i < meshX.subMeshes()[0].vertices.size(); ++i) {
+        const auto& uvX = meshX.subMeshes()[0].vertices[i].uv;
+        const auto& uvY = meshY.subMeshes()[0].vertices[i].uv;
+        if (std::abs(uvX.x - uvY.x) > 1e-4f || std::abs(uvX.y - uvY.y) > 1e-4f) {
+            differs = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(differs);
 }
 
 TEST(UvProjectTest, ResetBoxFillsUnitSquare)

--- a/src/UvProject_test.cpp
+++ b/src/UvProject_test.cpp
@@ -1,0 +1,150 @@
+#include <gtest/gtest.h>
+
+#include "EditableMesh.h"
+#include "UvProject.h"
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+namespace {
+
+EditableSubMesh makeSubMesh(std::vector<EditableVertex> verts,
+                            std::vector<EditableTriangle> tris)
+{
+    EditableSubMesh sub;
+    sub.vertices = std::move(verts);
+    sub.triangles = std::move(tris);
+    return sub;
+}
+
+EditableMesh xyQuadMesh(float size = 1.f)
+{
+    const float h = size * 0.5f;
+    EditableMesh mesh;
+    mesh.subMeshes().push_back(makeSubMesh(
+        {
+            EditableVertex{.position = {-h, -h, 0.f}},
+            EditableVertex{.position = { h, -h, 0.f}},
+            EditableVertex{.position = { h,  h, 0.f}},
+            EditableVertex{.position = {-h,  h, 0.f}},
+        },
+        {
+            EditableTriangle{.indices = {0, 1, 2}},
+            EditableTriangle{.indices = {0, 2, 3}},
+        }));
+    return mesh;
+}
+
+EditableMesh cylinderStripMesh(int segments = 16, float height = 2.f)
+{
+    std::vector<EditableVertex> verts;
+    verts.reserve(static_cast<size_t>(segments) * 2);
+    for (int ring = 0; ring < 2; ++ring) {
+        const float y = ring == 0 ? 0.f : height;
+        for (int i = 0; i < segments; ++i) {
+            const float ang = static_cast<float>(i) / segments * 2.f * static_cast<float>(M_PI);
+            verts.push_back(EditableVertex{
+                .position = {std::cos(ang), y, std::sin(ang)},
+            });
+        }
+    }
+
+    std::vector<EditableTriangle> tris;
+    for (int i = 0; i < segments; ++i) {
+        const unsigned int i0 = static_cast<unsigned int>(i);
+        const unsigned int i1 = static_cast<unsigned int>((i + 1) % segments);
+        const unsigned int j0 = static_cast<unsigned int>(i + segments);
+        const unsigned int j1 = static_cast<unsigned int>(((i + 1) % segments) + segments);
+        tris.push_back(EditableTriangle{.indices = {i0, j0, i1}});
+        tris.push_back(EditableTriangle{.indices = {i1, j0, j1}});
+    }
+
+    EditableMesh mesh;
+    mesh.subMeshes().push_back(makeSubMesh(std::move(verts), std::move(tris)));
+    return mesh;
+}
+
+UvProject::Selection allTriangles(const EditableMesh& mesh)
+{
+    UvProject::Selection selection;
+    selection.includeTriangle.resize(mesh.subMeshes().size());
+    return selection;
+}
+
+bool uvsInUnitRange(const EditableMesh& mesh)
+{
+    for (const auto& sub : mesh.subMeshes()) {
+        for (const auto& v : sub.vertices) {
+            if (!v.hasUV)
+                return false;
+            if (v.uv.x < -1e-4f || v.uv.x > 1.f + 1e-4f || v.uv.y < -1e-4f || v.uv.y > 1.f + 1e-4f)
+                return false;
+        }
+    }
+    return true;
+}
+
+} // namespace
+
+TEST(UvProjectTest, BoxProjectNormalizesToUnitRange)
+{
+    EditableMesh mesh = xyQuadMesh();
+
+    UvProject::Options opts;
+    opts.mode = UvProject::Mode::Box;
+    opts.boxScale = 1.f;
+
+    const auto report = UvProject::project(mesh, allTriangles(mesh), opts);
+    ASSERT_TRUE(report.applied);
+    EXPECT_GT(report.vertsChanged, 0);
+    EXPECT_TRUE(uvsInUnitRange(mesh));
+}
+
+TEST(UvProjectTest, CylinderProjectWrapsAndSpansHeight)
+{
+    EditableMesh mesh = cylinderStripMesh();
+
+    UvProject::Options opts;
+    opts.mode = UvProject::Mode::Cylinder;
+    opts.axis = 1;
+    opts.boxScale = 1.f;
+
+    const auto report = UvProject::project(mesh, allTriangles(mesh), opts);
+    ASSERT_TRUE(report.applied);
+
+    float minU = 1.f, maxU = 0.f, minV = 1.f, maxV = 0.f;
+    for (const auto& v : mesh.subMeshes()[0].vertices) {
+        ASSERT_TRUE(v.hasUV);
+        minU = std::min(minU, v.uv.x);
+        maxU = std::max(maxU, v.uv.x);
+        minV = std::min(minV, v.uv.y);
+        maxV = std::max(maxV, v.uv.y);
+    }
+    EXPECT_GT(maxU - minU, 0.4f);
+    EXPECT_GT(maxV - minV, 0.8f);
+}
+
+TEST(UvProjectTest, ViewProjectRequiresCameraMatrices)
+{
+    EditableMesh mesh = xyQuadMesh();
+
+    UvProject::Options opts;
+    opts.mode = UvProject::Mode::View;
+
+    const auto report = UvProject::project(mesh, allTriangles(mesh), opts);
+    EXPECT_FALSE(report.applied);
+    EXPECT_FALSE(report.error.isEmpty());
+}
+
+TEST(UvProjectTest, ResetBoxFillsUnitSquare)
+{
+    EditableMesh mesh = xyQuadMesh(2.f);
+
+    UvProject::Options opts;
+    opts.mode = UvProject::Mode::ResetBox;
+
+    const auto report = UvProject::project(mesh, allTriangles(mesh), opts);
+    ASSERT_TRUE(report.applied);
+    EXPECT_TRUE(uvsInUnitRange(mesh));
+}

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -4406,10 +4406,14 @@ ViewportCameraSnapshot MainWindow::queryViewportCamera(bool requireFocus) const
             spaceCam = active->getSpaceCamera();
     }
 
-    if (!spaceCam && !requireFocus && !mDockWidgetList.isEmpty()) {
-        EditorViewport* vp = mDockWidgetList.first();
-        if (vp && vp->getOgreWidget())
-            spaceCam = vp->getOgreWidget()->getSpaceCamera();
+    if (!spaceCam && !requireFocus) {
+        for (EditorViewport* vp : mDockWidgetList) {
+            if (vp && vp->getOgreWidget()) {
+                spaceCam = vp->getOgreWidget()->getSpaceCamera();
+                if (spaceCam)
+                    break;
+            }
+        }
     }
 
     if (!spaceCam || (requireFocus && !focused))

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -65,11 +65,14 @@
 #include "OgreRenderTargetUtil.h"
 #include "QtInputManager.h"
 #include "Manager.h"
+#include <OgreCamera.h>
+
 #include "material.h"
 #include "about.h"
 #include "PrimitivesWidget.h"
 #include "MeshImporterExporter.h"
 #include "EditorViewport.h"
+#include "SpaceCamera.h"
 #include "ViewportGrid.h"
 #include "AnimationWidget.h"
 #include "AnimationMerger.h"
@@ -4378,6 +4381,49 @@ void MainWindow::updateMergeAnimationsButton()
 void MainWindow::triggerMergeAnimations()
 {
     on_actionMerge_Animations_triggered();
+}
+
+ViewportCameraSnapshot MainWindow::queryViewportCamera(bool requireFocus) const
+{
+    ViewportCameraSnapshot snap;
+    SpaceCamera* spaceCam = nullptr;
+    bool focused = false;
+
+    for (EditorViewport* vp : mDockWidgetList) {
+        if (!vp || !vp->getOgreWidget())
+            continue;
+        if (vp->getOgreWidget()->hasFocus()) {
+            spaceCam = vp->getOgreWidget()->getSpaceCamera();
+            focused = true;
+            break;
+        }
+    }
+
+    // UV/material panels steal Qt focus — fall back to the last viewport the
+    // user interacted with (same source as the transform gizmo / view cube).
+    if (!spaceCam) {
+        if (OgreWidget* active = TransformOperator::getSingleton()->getActiveWidget())
+            spaceCam = active->getSpaceCamera();
+    }
+
+    if (!spaceCam && !requireFocus && !mDockWidgetList.isEmpty()) {
+        EditorViewport* vp = mDockWidgetList.first();
+        if (vp && vp->getOgreWidget())
+            spaceCam = vp->getOgreWidget()->getSpaceCamera();
+    }
+
+    if (!spaceCam || (requireFocus && !focused))
+        return snap;
+
+    Ogre::Camera* camera = spaceCam->getCamera();
+    if (!camera)
+        return snap;
+
+    snap.viewMatrix = camera->getViewMatrix();
+    snap.projMatrix = camera->getProjectionMatrix();
+    snap.valid = true;
+    snap.fromFocusedViewport = focused;
+    return snap;
 }
 
 void MainWindow::triggerMaterialEditor()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -40,6 +40,7 @@ class MainWindow;
 }
 class EditorViewport;
 class PrimitivesWidget;
+class SpaceCamera;
 
 namespace Ogre
 {
@@ -48,7 +49,16 @@ namespace Ogre
     class RaySceneQuery;
     class ManualObject;
     class AnimationState;
+    class Matrix4;
 }
+
+/// Snapshot of the active 3D viewport camera (issue #463).
+struct ViewportCameraSnapshot {
+    Ogre::Matrix4 viewMatrix;
+    Ogre::Matrix4 projMatrix;
+    bool valid = false;
+    bool fromFocusedViewport = false;
+};
 
 class MainWindow : public QMainWindow, public Ogre::FrameListener
 {
@@ -81,6 +91,10 @@ public:
 
     /// Invokes the same flow as Options → Material Editor (Mode Tools button).
     void triggerMaterialEditor();
+
+    /// Returns the focused viewport camera when @p requireFocus is true; otherwise
+    /// falls back to the first viewport when none has focus.
+    ViewportCameraSnapshot queryViewportCamera(bool requireFocus = false) const;
 
     void keyPressEvent(QKeyEvent *event) override;
     void dropEvent(QDropEvent *event) override;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -7,6 +7,7 @@
 #include <QTableWidget>
 #include <QColorDialog>
 #include <OgreFrameListener.h>
+#include <OgreMatrix4.h>
 #include <QNetworkAccessManager>
 
 #include "TransformOperator.h"
@@ -49,7 +50,6 @@ namespace Ogre
     class RaySceneQuery;
     class ManualObject;
     class AnimationState;
-    class Matrix4;
 }
 
 /// Snapshot of the active 3D viewport camera (issue #463).

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -153,6 +153,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MeshOptimizerLod.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/ExportOptimizer.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/UvUnwrap.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/UvProject.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MeshValidator.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AIChatManager.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/WelcomeScreenController.cpp
@@ -295,6 +296,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MeshOptimizerLod.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/ExportOptimizer.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/UvUnwrap.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/UvProject.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MeshValidator.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AIChatManager.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/WelcomeScreenController.h


### PR DESCRIPTION
## Summary
- Add `UvProject` with view, box, cylinder, sphere, and reset-to-0–1 box projection modes scoped to the active UV selection (full sub-mesh when nothing is selected).
- Wire projection tools into Material Mode UV Edit and the detached UV editor under labeled **Seams** / **Projection** groups; each operation pushes a single `UVEditCommand` for undo and records `mesh.uv.project` Sentry breadcrumbs.
- View projection uses the last active 3D viewport camera (transform gizmo / view cube tracking) so UV panel clicks do not require viewport focus.

## Test plan
- [x] `./build_local/bin/UnitTests --gtest_filter="UvProject*"` (box, cylinder, view guard, reset)
- [ ] Material Mode → UV Edit: **Projection** buttons (View, Box, Cyl, Sph, Reset) on humanoid + prop mesh
- [ ] View matches 3D viewport orientation after clicking viewport once
- [ ] Ctrl+Z undoes each projection
- [ ] Partial UV selection scopes projection; status shows `(selection)`

Closes #463


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new UV projection tools in the editor, including view-based, box, cylinder, sphere, and reset options.
  * Improved the UV editing panel with clearer grouping for seam and projection controls.
  * Projection tools now appear only when a mesh is available, keeping the interface cleaner.

* **Tests**
  * Added coverage for the new UV projection modes to verify results and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->