### PR TITLE
HDR: Slice C — Cook-Torrance + split-sum IBL wiring (#469)

### DIFF
--- a/media/RTShaderLib/QTSLib_IBL.glsl
+++ b/media/RTShaderLib/QTSLib_IBL.glsl
@@ -1,0 +1,54 @@
+// QtMeshEditor HDR slice C — split-sum IBL with separate irradiance / prefilter / BRDF LUT.
+// Builds on Ogre's RTSLib_IBL helpers (PrefilteredDFG_LUT, prefilteredRadiance, …).
+
+#include "RTSLib_IBL.glsl"
+
+vec3 sampleIrradianceCube(samplerCube irradianceTex, vec3 n)
+{
+    return decodeDataForIBL(textureCube(irradianceTex, n));
+}
+
+void evaluateIBLQtme(inout PixelParams pixel,
+                     in vec3 vNormal,
+                     in vec3 viewPos,
+                     in mat4 invViewMat,
+                     in sampler2D brdfLut,
+                     in samplerCube irradianceTex,
+                     in samplerCube prefilterTex,
+                     in float prefilterMaxLod,
+                     in vec3 envTint,
+                     in float envIntensity,
+                     inout vec3 color)
+{
+    vec3 shading_normal = normalize(vNormal);
+    vec3 shading_view = -normalize(viewPos);
+    float shading_NoV = clampNoV(abs(dot(shading_normal, shading_view)));
+    vec3 shading_reflected = reflect(-shading_view, shading_normal);
+
+    pixel.dfg = PrefilteredDFG_LUT(brdfLut, pixel.perceptualRoughness, shading_NoV);
+    vec3 E = specularDFG(pixel);
+    vec3 r = getSpecularDominantDirection(shading_normal, shading_reflected, pixel.roughness);
+
+    r = normalize(mul(invViewMat, vec4(r, 0.0)).xyz);
+    r.z *= -1.0;
+    shading_normal = normalize(mul(invViewMat, vec4(shading_normal, 0.0)).xyz);
+
+    vec3 Fr = E * prefilteredRadiance(prefilterTex, r, pixel.perceptualRoughness, prefilterMaxLod);
+    vec3 diffuseIrradiance = sampleIrradianceCube(irradianceTex, shading_normal);
+    vec3 Fd = pixel.diffuseColor * diffuseIrradiance * (1.0 - E);
+
+    vec3 tint = envTint * envIntensity;
+    Fr *= tint;
+    Fd *= tint;
+
+#ifndef USE_LINEAR_COLOURS
+    color = pow(color, vec3_splat(2.2));
+#endif
+
+    color += Fr + Fd;
+
+#ifndef USE_LINEAR_COLOURS
+    color = pow(color, vec3_splat(1.0 / 2.2));
+    color = saturate(color);
+#endif
+}

--- a/src/Assimp/MaterialProcessor.cpp
+++ b/src/Assimp/MaterialProcessor.cpp
@@ -319,14 +319,10 @@ Ogre::MaterialPtr MaterialProcessor::processMaterial(const aiMaterial *material,
     // NOTE: We deliberately do NOT tag the pass with `pbr_workflow` on
     // import. Tagging would trigger applyPbrIfTagged via the slice F2
     // applyNormalMap redirect, attaching SRS_COOK_TORRANCE_LIGHTING.
-    // Without IBL, Cook-Torrance produces near-black output for
-    // metallic surfaces (the diffuse term is baseColor × (1 - metallic)
-    // and there's no env map to supply indirect specular). A future
-    // slice with proper IBL can either tag-on-import then or expose a
-    // "Convert to PBR" inspector action that adds the tag deliberately.
-    // For now: slots are populated and visible in the Material Editor,
-    // and the rendered material continues using the legacy FFP diffuse
-    // path (correct on-import visuals).
+    // Without a loaded HDR environment, Cook-Torrance produces near-black output for
+    // metallic surfaces (no indirect specular/diffuse). Slice C (#469) wires IBL into
+    // RTShaderHelper when HDREnvironmentManager has finished precomputing; until then
+    // the legacy FFP diffuse path keeps on-import visuals correct.
     (void)gotPbrMap;
 
     // Wire the slice E PBR slot colour-ops so the freshly-imported

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -123,6 +123,7 @@ HDR/HdrEquirectLoader.cpp
 HDR/HdrIblPrecompute.cpp
 HDR/HdrCache.cpp
 HDR/HdrPrecomputeWorker.cpp
+HDR/HdrIblRtss.cpp
 MorphAnimationManager.cpp
 NodeAnimationManager.cpp
 PoseLibrary.cpp
@@ -314,6 +315,7 @@ HDR/HdrEquirectLoader.h
 HDR/HdrIblPrecompute.h
 HDR/HdrCache.h
 HDR/HdrPrecomputeWorker.h
+HDR/HdrIblRtss.h
 )
 
 set(TEST_SOURCES "")

--- a/src/HDR/HDREnvironmentManager.cpp
+++ b/src/HDR/HDREnvironmentManager.cpp
@@ -2,6 +2,7 @@
 
 #include "HDR/HdrEquirectLoader.h"
 #include "HDR/HdrPrecomputeWorker.h"
+#include "RTShaderHelper.h"
 #include "SentryReporter.h"
 
 #include <OgreTextureManager.h>
@@ -289,8 +290,16 @@ bool HDREnvironmentManager::registerIblTextures(const QString& cacheKey,
     m_brdfLut->getBuffer()->blitFromMemory(lutBox);
     m_brdfLut->load();
 
+    m_prefilterMaxLodLevel = static_cast<float>(std::max(0, mipCount - 1));
     m_iblReady = true;
     return true;
+}
+
+bool HDREnvironmentManager::installIblBake(const QString& cacheKey,
+                                           HdrIbl::IblBakeResult& result,
+                                           QString& error)
+{
+    return registerIblTextures(cacheKey, result, error);
 }
 
 void HDREnvironmentManager::startIblPrecompute(const QString& cacheKey,
@@ -300,6 +309,7 @@ void HDREnvironmentManager::startIblPrecompute(const QString& cacheKey,
         return;
 
     m_iblReady = false;
+    m_prefilterMaxLodLevel = 0.f;
     removeTextureIfExists(m_irradiance);
     removeTextureIfExists(m_prefiltered);
     removeTextureIfExists(m_brdfLut);
@@ -337,6 +347,8 @@ void HDREnvironmentManager::onPrecomputeCompleted(HdrIbl::IblBakeResult result,
             .arg(fromDiskCache ? QStringLiteral("yes") : QStringLiteral("no")));
 
     emit iblPrecomputeCompleted(fromDiskCache);
+
+    RTShaderHelper::refreshAllPbrMaterialsForHdr();
 }
 
 void HDREnvironmentManager::onPrecomputeError(const QString& error, quint64 generation)

--- a/src/HDR/HDREnvironmentManager.cpp
+++ b/src/HDR/HDREnvironmentManager.cpp
@@ -317,6 +317,8 @@ void HDREnvironmentManager::startIblPrecompute(const QString& cacheKey,
     m_prefiltered.reset();
     m_brdfLut.reset();
 
+    RTShaderHelper::refreshAllPbrMaterialsForHdr();
+
     const quint64 generation = ++m_precomputeGeneration;
     QMetaObject::invokeMethod(
         m_worker,
@@ -357,6 +359,7 @@ void HDREnvironmentManager::onPrecomputeError(const QString& error, quint64 gene
         return;
     Q_UNUSED(error);
     m_iblReady = false;
+    RTShaderHelper::refreshAllPbrMaterialsForHdr();
 }
 
 bool HDREnvironmentManager::loadEnvironment(const QString& pathOrBundledName)

--- a/src/HDR/HDREnvironmentManager.h
+++ b/src/HDR/HDREnvironmentManager.h
@@ -12,7 +12,7 @@
 class HdrPrecomputeWorker;
 class QThread;
 
-/// Slice A (#467) + B (#468): HDR environment + IBL precompute.
+/// Slice A (#467) + B (#468) + C (#469): HDR environment, IBL precompute, RTSS wiring.
 class HDREnvironmentManager : public QObject
 {
     Q_OBJECT
@@ -49,9 +49,15 @@ public:
     /// True once IBL textures for the active environment are registered.
     bool isIblReady() const { return m_iblReady; }
 
+    /// Highest prefiltered-specular mip level (0-based) for RTSS lod lookup.
+    float prefilterMaxLodLevel() const { return m_prefilterMaxLodLevel; }
+
     /// When false, `loadEnvironment` skips the background IBL worker (used by
     /// fast integration tests — bake/cache logic is covered in HdrIbl/ HdrCache tests).
     void setBackgroundIblPrecomputeEnabled(bool enabled) { m_backgroundIblPrecompute = enabled; }
+
+    /// Register precomputed IBL textures with Ogre (worker path + unit tests).
+    bool installIblBake(const QString& cacheKey, HdrIbl::IblBakeResult& result, QString& error);
 
 signals:
     void environmentChanged();
@@ -86,6 +92,7 @@ private:
     QString m_cacheKey;
     int m_faceSize = 0;
     bool m_iblReady = false;
+    float m_prefilterMaxLodLevel = 0.f;
     bool m_backgroundIblPrecompute = true;
     quint64 m_precomputeGeneration = 0;
 

--- a/src/HDR/HdrIblRtss.cpp
+++ b/src/HDR/HdrIblRtss.cpp
@@ -157,10 +157,19 @@ public:
     }
 
     void updateGpuProgramsParams(Ogre::Renderable* /*rend*/,
-                                 const Ogre::Pass* /*pass*/,
+                                 const Ogre::Pass* pass,
                                  const Ogre::AutoParamDataSource* /*source*/,
                                  const Ogre::LightList* /*ll*/) override
     {
+        if (pass) {
+            const float intensity = readEnvIntensity(pass);
+            const Ogre::ColourValue tint = readEnvTint(pass);
+            if (intensity != mEnvIntensity || tint != mEnvTint) {
+                mEnvIntensity = intensity;
+                mEnvTint = tint;
+                mGpuParamsDirty = true;
+            }
+        }
         if (!mGpuParamsDirty)
             return;
         if (mIntensityParam)

--- a/src/HDR/HdrIblRtss.cpp
+++ b/src/HDR/HdrIblRtss.cpp
@@ -1,0 +1,264 @@
+// LCOV_EXCL_START — requires initialized Ogre RTSS with GPU/render system
+
+#include "HDR/HdrIblRtss.h"
+
+#include <OgreLogManager.h>
+#include <OgreShaderFFPRenderState.h>
+#include <OgreShaderParameter.h>
+#include <OgreShaderProgram.h>
+#include <OgreShaderSubRenderState.h>
+
+namespace HdrIblRtss {
+namespace {
+
+const Ogre::String kType = "QtmeHdrIbl";
+
+const char* kParamIrradiance = "irradiance_texture";
+const char* kParamPrefilter = "prefilter_texture";
+const char* kParamBrdfLut = "brdf_lut_texture";
+const char* kParamMaxLod = "prefilter_max_lod";
+const char* kParamIntensity = "env_intensity";
+const char* kParamTint = "env_tint";
+
+class QtmeHdrIblLighting : public Ogre::RTShader::SubRenderState
+{
+public:
+    const Ogre::String& getType() const override { return kType; }
+    int getExecutionOrder() const override { return Ogre::RTShader::FFP_LIGHTING + 10; }
+
+    bool setParameter(const Ogre::String& name, const Ogre::String& value) override
+    {
+        if (name == kParamIrradiance && !value.empty()) {
+            mIrradianceName = value;
+            return true;
+        }
+        if (name == kParamPrefilter && !value.empty()) {
+            mPrefilterName = value;
+            return true;
+        }
+        if (name == kParamBrdfLut && !value.empty()) {
+            mBrdfLutName = value;
+            return true;
+        }
+        if (name == kParamMaxLod) {
+            mPrefilterMaxLod = Ogre::StringConverter::parseReal(value);
+            mGpuParamsDirty = true;
+            return true;
+        }
+        if (name == kParamIntensity) {
+            mEnvIntensity = Ogre::StringConverter::parseReal(value);
+            mGpuParamsDirty = true;
+            return true;
+        }
+        if (name == kParamTint) {
+            const Ogre::StringVector parts = Ogre::StringUtil::split(value, " ");
+            if (parts.size() >= 3) {
+                mEnvTint.r = Ogre::StringConverter::parseReal(parts[0]);
+                mEnvTint.g = Ogre::StringConverter::parseReal(parts[1]);
+                mEnvTint.b = Ogre::StringConverter::parseReal(parts[2]);
+                mGpuParamsDirty = true;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    void copyFrom(const Ogre::RTShader::SubRenderState& rhs) override
+    {
+        const auto& other = static_cast<const QtmeHdrIblLighting&>(rhs);
+        mIrradianceName = other.mIrradianceName;
+        mPrefilterName = other.mPrefilterName;
+        mBrdfLutName = other.mBrdfLutName;
+        mPrefilterMaxLod = other.mPrefilterMaxLod;
+        mEnvIntensity = other.mEnvIntensity;
+        mEnvTint = other.mEnvTint;
+        mGpuParamsDirty = true;
+    }
+
+    bool preAddToRenderState(const Ogre::RTShader::RenderState* /*renderState*/,
+                             Ogre::Pass* /*srcPass*/,
+                             Ogre::Pass* dstPass) override
+    {
+        if (mIrradianceName.empty() || mPrefilterName.empty() || mBrdfLutName.empty())
+            return false;
+
+        auto* brdfTus = dstPass->createTextureUnitState();
+        brdfTus->setTextureName(mBrdfLutName);
+        brdfTus->setTextureFiltering(Ogre::TFO_TRILINEAR);
+        mBrdfSamplerIndex = static_cast<int>(dstPass->getNumTextureUnitStates()) - 1;
+
+        auto* irrTus = dstPass->createTextureUnitState();
+        irrTus->setTextureName(mIrradianceName, Ogre::TEX_TYPE_CUBE_MAP);
+        irrTus->setTextureFiltering(Ogre::TFO_TRILINEAR);
+        mIrradianceSamplerIndex = static_cast<int>(dstPass->getNumTextureUnitStates()) - 1;
+
+        auto* preTus = dstPass->createTextureUnitState();
+        preTus->setTextureName(mPrefilterName, Ogre::TEX_TYPE_CUBE_MAP);
+        preTus->setTextureFiltering(Ogre::TFO_TRILINEAR);
+        mPrefilterSamplerIndex = static_cast<int>(dstPass->getNumTextureUnitStates()) - 1;
+
+        return true;
+    }
+
+    bool createCpuSubPrograms(Ogre::RTShader::ProgramSet* programSet) override
+    {
+        Ogre::RTShader::Program* vsProgram = programSet->getCpuProgram(Ogre::GPT_VERTEX_PROGRAM);
+        Ogre::RTShader::Function* vsMain = vsProgram->getEntryPointFunction();
+        Ogre::RTShader::Program* psProgram = programSet->getCpuProgram(Ogre::GPT_FRAGMENT_PROGRAM);
+        Ogre::RTShader::Function* psMain = psProgram->getEntryPointFunction();
+
+        auto vsOutViewPos = vsMain->resolveOutputParameter(Ogre::RTShader::Parameter::SPC_POSITION_VIEW_SPACE);
+        auto viewPos = psMain->resolveInputParameter(vsOutViewPos);
+
+        auto pixel = psMain->getLocalParameter("pixel");
+        if (!pixel) {
+            Ogre::LogManager::getSingleton().logError(
+                "QtmeHdrIbl must be used with the Cook-Torrance (metal_roughness) SRS");
+            return true;
+        }
+
+        auto viewNormal = psMain->getLocalParameter(Ogre::RTShader::Parameter::SPC_NORMAL_VIEW_SPACE);
+        if (!viewNormal) {
+            auto vsOutNormal = vsMain->resolveOutputParameter(Ogre::RTShader::Parameter::SPC_NORMAL_VIEW_SPACE);
+            viewNormal = psMain->resolveInputParameter(vsOutNormal);
+        }
+
+        psProgram->addDependency("SGXLib_CookTorrance");
+        psProgram->addDependency("QTSLib_IBL");
+
+        mIntensityParam = psProgram->resolveParameter(Ogre::GCT_FLOAT1, "qtmeEnvIntensity");
+        mTintParam = psProgram->resolveParameter(Ogre::GCT_FLOAT3, "qtmeEnvTint");
+        mMaxLodParam = psProgram->resolveParameter(Ogre::GCT_FLOAT1, "qtmePrefilterMaxLod");
+
+        auto outDiffuse = psMain->resolveOutputParameter(Ogre::RTShader::Parameter::SPC_COLOR_DIFFUSE);
+        auto brdfSampler = psProgram->resolveParameter(Ogre::GCT_SAMPLER2D, "qtmeBrdfLut", mBrdfSamplerIndex);
+        auto irradianceSampler =
+            psProgram->resolveParameter(Ogre::GCT_SAMPLERCUBE, "qtmeIrradiance", mIrradianceSamplerIndex);
+        auto prefilterSampler =
+            psProgram->resolveParameter(Ogre::GCT_SAMPLERCUBE, "qtmePrefilter", mPrefilterSamplerIndex);
+        auto invViewMat = psProgram->resolveParameter(Ogre::GpuProgramParameters::ACT_INVERSE_VIEW_MATRIX);
+
+        auto fstage = psMain->getStage(355);
+        fstage.callFunction(
+            "evaluateIBLQtme",
+            {Ogre::RTShader::InOut(pixel),
+             Ogre::RTShader::In(viewNormal),
+             Ogre::RTShader::In(viewPos),
+             Ogre::RTShader::In(invViewMat),
+             Ogre::RTShader::In(brdfSampler),
+             Ogre::RTShader::In(irradianceSampler),
+             Ogre::RTShader::In(prefilterSampler),
+             Ogre::RTShader::In(mMaxLodParam),
+             Ogre::RTShader::In(mTintParam),
+             Ogre::RTShader::In(mIntensityParam),
+             Ogre::RTShader::InOut(outDiffuse).xyz()});
+
+        return true;
+    }
+
+    void updateGpuProgramsParams(Ogre::Renderable* /*rend*/,
+                                 const Ogre::Pass* /*pass*/,
+                                 const Ogre::AutoParamDataSource* /*source*/,
+                                 const Ogre::LightList* /*ll*/) override
+    {
+        if (!mGpuParamsDirty)
+            return;
+        if (mIntensityParam)
+            mIntensityParam->setGpuParameter(mEnvIntensity);
+        if (mTintParam)
+            mTintParam->setGpuParameter(mEnvTint);
+        if (mMaxLodParam)
+            mMaxLodParam->setGpuParameter(mPrefilterMaxLod);
+        mGpuParamsDirty = false;
+    }
+
+private:
+    Ogre::String mIrradianceName;
+    Ogre::String mPrefilterName;
+    Ogre::String mBrdfLutName;
+    float mPrefilterMaxLod = 5.0f;
+    float mEnvIntensity = 1.0f;
+    Ogre::ColourValue mEnvTint = Ogre::ColourValue::White;
+
+    int mBrdfSamplerIndex = 0;
+    int mIrradianceSamplerIndex = 0;
+    int mPrefilterSamplerIndex = 0;
+
+    Ogre::RTShader::UniformParameterPtr mIntensityParam;
+    Ogre::RTShader::UniformParameterPtr mTintParam;
+    Ogre::RTShader::UniformParameterPtr mMaxLodParam;
+    bool mGpuParamsDirty = true;
+};
+
+class QtmeHdrIblFactory : public Ogre::RTShader::SubRenderStateFactory
+{
+public:
+    const Ogre::String& getType() const override { return kType; }
+
+protected:
+    Ogre::RTShader::SubRenderState* createInstanceImpl() override
+    {
+        return OGRE_NEW QtmeHdrIblLighting; // NOSONAR — Ogre factory pattern
+    }
+};
+
+QtmeHdrIblFactory s_factory;
+bool s_factoryRegistered = false;
+
+} // namespace
+
+const Ogre::String SRS_QTME_HDR_IBL = kType;
+const char* kPbrEnvIntensityKey = "pbr_env_intensity";
+const char* kPbrEnvTintKey = "pbr_env_tint";
+
+float readEnvIntensity(const Ogre::Pass* pass)
+{
+    if (!pass)
+        return 1.0f;
+    const auto any = pass->getUserObjectBindings().getUserAny(kPbrEnvIntensityKey);
+    if (!any.has_value())
+        return 1.0f;
+    try {
+        return Ogre::any_cast<float>(any);
+    } catch (...) {
+        return 1.0f;
+    }
+}
+
+Ogre::ColourValue readEnvTint(const Ogre::Pass* pass)
+{
+    if (!pass)
+        return Ogre::ColourValue::White;
+    const auto any = pass->getUserObjectBindings().getUserAny(kPbrEnvTintKey);
+    if (!any.has_value())
+        return Ogre::ColourValue::White;
+    try {
+        return Ogre::any_cast<Ogre::ColourValue>(any);
+    } catch (...) {
+        return Ogre::ColourValue::White;
+    }
+}
+
+void registerFactory()
+{
+    if (s_factoryRegistered)
+        return;
+    auto* shaderGen = Ogre::RTShader::ShaderGenerator::getSingletonPtr();
+    if (!shaderGen)
+        return;
+    shaderGen->addSubRenderStateFactory(&s_factory);
+    s_factoryRegistered = true;
+}
+
+void unregisterFactory()
+{
+    if (!s_factoryRegistered)
+        return;
+    if (auto* shaderGen = Ogre::RTShader::ShaderGenerator::getSingletonPtr())
+        shaderGen->removeSubRenderStateFactory(&s_factory);
+    s_factoryRegistered = false;
+}
+
+} // namespace HdrIblRtss
+
+// LCOV_EXCL_STOP

--- a/src/HDR/HdrIblRtss.h
+++ b/src/HDR/HdrIblRtss.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <OgreRTShaderSystem.h>
+
+namespace HdrIblRtss {
+
+/// RTSS type string for the QtMeshEditor split-sum IBL sub-render state.
+extern const Ogre::String SRS_QTME_HDR_IBL;
+
+/// Per-pass user-binding keys (slice C).
+extern const char* kPbrEnvIntensityKey;
+extern const char* kPbrEnvTintKey;
+
+void registerFactory();
+void unregisterFactory();
+
+float readEnvIntensity(const Ogre::Pass* pass);
+Ogre::ColourValue readEnvTint(const Ogre::Pass* pass);
+
+} // namespace HdrIblRtss

--- a/src/RTShaderHdrIbl_test.cpp
+++ b/src/RTShaderHdrIbl_test.cpp
@@ -1,0 +1,137 @@
+#include <gtest/gtest.h>
+
+#include "HDR/HDREnvironmentManager.h"
+#include "HDR/HdrIblPrecompute.h"
+#include "HDR/HdrIblRtss.h"
+#include "MaterialPresetLibrary.h"
+#include "RTShaderHelper.h"
+#include "TestHelpers.h"
+
+#include <OgreRTShaderSystem.h>
+
+namespace {
+
+HdrIbl::IblBakeResult makeTinyIblBake()
+{
+    HdrIbl::IblBakeResult result;
+    result.irradiance.faceSize = 4;
+    const size_t irrPixels = 4u * 4u * 3u;
+    for (auto& face : result.irradiance.faces)
+        face.assign(irrPixels, 0.5f);
+
+    result.prefilter.mips.resize(2);
+    for (int mip = 0; mip < 2; ++mip) {
+        const int faceSize = 4 >> mip;
+        auto& level = result.prefilter.mips[static_cast<size_t>(mip)];
+        level.faceSize = faceSize;
+        level.faces.faceSize = faceSize;
+        const size_t pixels = static_cast<size_t>(faceSize) * static_cast<size_t>(faceSize) * 3u;
+        for (auto& face : level.faces.faces)
+            face.assign(pixels, 0.75f);
+    }
+
+    result.brdfLut.size = 4;
+    result.brdfLut.rg.assign(4u * 4u * 2u, 0.25f);
+    return result;
+}
+
+Ogre::RTShader::SubRenderState* findQtmeHdrIblSrs(Ogre::MaterialPtr& mat)
+{
+    auto* shaderGen = Ogre::RTShader::ShaderGenerator::getSingletonPtr();
+    if (!shaderGen)
+        return nullptr;
+    auto* renderState = shaderGen->getRenderState(
+        Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME, *mat, 0);
+    if (!renderState)
+        return nullptr;
+    return renderState->getSubRenderState(HdrIblRtss::SRS_QTME_HDR_IBL);
+}
+
+} // namespace
+
+class RTShaderHdrIblTest : public ::testing::Test {
+protected:
+    void SetUp() override
+    {
+        Manager::kill();
+        HDREnvironmentManager::kill();
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+        ASSERT_TRUE(canLoadMeshFiles());
+        createStandardOgreMaterials();
+
+        auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+        ASSERT_NE(sceneMgr, nullptr);
+        RTShaderHelper::initialize(sceneMgr);
+        m_rtssShutdown = [sceneMgr] { RTShaderHelper::shutdown(sceneMgr); };
+    }
+
+    void TearDown() override
+    {
+        if (m_rtssShutdown)
+            m_rtssShutdown();
+        HDREnvironmentManager::kill();
+        Manager::kill();
+    }
+
+    std::function<void()> m_rtssShutdown;
+};
+
+TEST_F(RTShaderHdrIblTest, PbrMaterialGetsQtmeHdrIblSrs)
+{
+    auto* hdrMgr = HDREnvironmentManager::getSingleton();
+    hdrMgr->setBackgroundIblPrecomputeEnabled(false);
+
+    HdrIbl::IblBakeResult bake = makeTinyIblBake();
+    const QString cacheKey = QStringLiteral("0123456789abcdef0123456789abcdef01234567");
+    QString installError;
+    ASSERT_TRUE(hdrMgr->installIblBake(cacheKey, bake, installError)) << installError.toStdString();
+    ASSERT_TRUE(hdrMgr->isIblReady());
+
+    MaterialPresetLibrary::instance()->applyPreset("Metallic-Roughness");
+    auto mat = Ogre::MaterialManager::getSingleton().getByName("Preset/Metallic-Roughness");
+    ASSERT_TRUE(bool(mat));
+
+    auto* pass = mat->getTechnique(0)->getPass(0);
+    RTShaderHelper::setPbrEnvIntensity(pass, 2.0f);
+    RTShaderHelper::setPbrEnvTint(pass, Ogre::ColourValue(0.8f, 0.9f, 1.0f));
+
+    ASSERT_TRUE(RTShaderHelper::applyPbrIfTagged(mat));
+
+    auto* cook = Ogre::RTShader::ShaderGenerator::getSingletonPtr()
+                     ->getRenderState(Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME, *mat, 0)
+                     ->getSubRenderState(Ogre::RTShader::SRS_COOK_TORRANCE_LIGHTING);
+    EXPECT_NE(cook, nullptr);
+
+    auto* ibl = findQtmeHdrIblSrs(mat);
+    ASSERT_NE(ibl, nullptr) << "QtmeHdrIbl SRS missing on PBR material when IBL is ready";
+    EXPECT_EQ(ibl->getType(), HdrIblRtss::SRS_QTME_HDR_IBL);
+}
+
+TEST_F(RTShaderHdrIblTest, PhongMaterialDoesNotGetQtmeHdrIblSrs)
+{
+    auto* hdrMgr = HDREnvironmentManager::getSingleton();
+    hdrMgr->setBackgroundIblPrecomputeEnabled(false);
+
+    HdrIbl::IblBakeResult bake = makeTinyIblBake();
+    const QString cacheKey = QStringLiteral("0123456789abcdef0123456789abcdef01234567");
+    QString installError;
+    ASSERT_TRUE(hdrMgr->installIblBake(cacheKey, bake, installError));
+
+    MaterialPresetLibrary::instance()->applyPreset("Plastic (Red)");
+    auto mat = Ogre::MaterialManager::getSingleton().getByName("Preset/Plastic (Red)");
+    ASSERT_TRUE(bool(mat));
+
+    EXPECT_FALSE(RTShaderHelper::applyPbrIfTagged(mat));
+    EXPECT_EQ(findQtmeHdrIblSrs(mat), nullptr);
+}
+
+TEST_F(RTShaderHdrIblTest, PbrMaterialWithoutIblDoesNotAttachQtmeHdrIblSrs)
+{
+    MaterialPresetLibrary::instance()->applyPreset("Metallic-Roughness");
+    auto mat = Ogre::MaterialManager::getSingleton().getByName("Preset/Metallic-Roughness");
+    ASSERT_TRUE(bool(mat));
+
+    ASSERT_TRUE(RTShaderHelper::applyPbrIfTagged(mat));
+    EXPECT_EQ(findQtmeHdrIblSrs(mat), nullptr)
+        << "IBL SRS must not attach when no environment is loaded";
+}

--- a/src/RTShaderHelper.cpp
+++ b/src/RTShaderHelper.cpp
@@ -2,6 +2,9 @@
 
 #include "RTShaderHelper.h"
 #include "EmbeddedTextureCache.h"
+#include "HDR/HDREnvironmentManager.h"
+#include "HDR/HdrIblRtss.h"
+#include "SentryReporter.h"
 #include <OgreRTShaderSystem.h>
 #include <OgreMaterialSerializer.h>
 #include <cstring>
@@ -9,6 +12,7 @@
 #include <QDir>
 #include <QString>
 #include <QSet>
+#include <QString>
 
 // Scheme resolver listener — generates RTSS shader techniques on demand
 // when Ogre can't find a technique for the ShaderGenerator scheme.
@@ -162,10 +166,14 @@ void RTShaderHelper::initialize(Ogre::SceneManager* sceneMgr)
     // Register scheme resolver so RTSS techniques are generated on demand
     sListener = new SchemeResolverListener(shaderGen);
     Ogre::MaterialManager::getSingleton().addListener(sListener);
+
+    HdrIblRtss::registerFactory();
 }
 
 void RTShaderHelper::shutdown(Ogre::SceneManager* sceneMgr)
 {
+    HdrIblRtss::unregisterFactory();
+
     if (sListener) {
         Ogre::MaterialManager::getSingleton().removeListener(sListener);
         delete sListener;
@@ -244,6 +252,48 @@ bool isMetallicRoughnessMaterial(const Ogre::MaterialPtr& mat)
     const Ogre::String tag = readPbrWorkflowTag(pass);
     return tag == "metallic_roughness"
         || (tag.empty() && detectMetallicRoughnessByLayout(pass));
+}
+
+bool tryApplyHdrIbl(Ogre::RTShader::ShaderGenerator* shaderGen,
+                    Ogre::RTShader::RenderState* renderState,
+                    const Ogre::Pass* srcPass,
+                    const Ogre::MaterialPtr& mat)
+{
+    auto* hdrMgr = HDREnvironmentManager::getSingletonPtr();
+    if (!hdrMgr || !hdrMgr->isIblReady())
+        return false;
+
+    const Ogre::TexturePtr irradiance = hdrMgr->irradianceMap();
+    const Ogre::TexturePtr prefilter = hdrMgr->prefilteredSpecularMap();
+    const Ogre::TexturePtr brdfLut = hdrMgr->brdfLut();
+    if (!irradiance || !prefilter || !brdfLut)
+        return false;
+
+    auto* iblSrs = shaderGen->createSubRenderState(HdrIblRtss::SRS_QTME_HDR_IBL);
+    if (!iblSrs)
+        return false;
+
+    const float intensity = HdrIblRtss::readEnvIntensity(srcPass);
+    const Ogre::ColourValue tint = HdrIblRtss::readEnvTint(srcPass);
+    iblSrs->setParameter("irradiance_texture", irradiance->getName());
+    iblSrs->setParameter("prefilter_texture", prefilter->getName());
+    iblSrs->setParameter("brdf_lut_texture", brdfLut->getName());
+    iblSrs->setParameter("prefilter_max_lod",
+                         Ogre::StringConverter::toString(hdrMgr->prefilterMaxLodLevel()));
+    iblSrs->setParameter("env_intensity", Ogre::StringConverter::toString(intensity));
+    iblSrs->setParameter("env_tint",
+                         Ogre::StringUtil::format("%f %f %f", tint.r, tint.g, tint.b));
+
+    renderState->addTemplateSubRenderState(iblSrs);
+
+    static QSet<QString> s_boundMaterials;
+    const QString matKey = QString::fromStdString(mat->getName());
+    if (!s_boundMaterials.contains(matKey)) {
+        s_boundMaterials.insert(matKey);
+        SentryReporter::addBreadcrumb(QStringLiteral("render.hdr.bind"),
+                                      QStringLiteral("material=%1").arg(matKey));
+    }
+    return true;
 }
 
 bool isAlbedoSlotName(const Ogre::String& name)
@@ -1138,6 +1188,8 @@ bool RTShaderHelper::applyPbrIfTagged(Ogre::MaterialPtr& mat)
             }
         }
 
+        tryApplyHdrIbl(shaderGen, renderState, srcPass, mat);
+
         shaderGen->invalidateMaterial(
             Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME, mat->getName());
         shaderGen->validateMaterial(
@@ -1156,4 +1208,44 @@ bool RTShaderHelper::applyPbrIfTagged(Ogre::MaterialPtr& mat)
             "RTShaderHelper: Exception applying PBR: " + std::string(e.what()));
     }
     return false;
+}
+
+void RTShaderHelper::refreshAllPbrMaterialsForHdr()
+{
+    if (!Ogre::RTShader::ShaderGenerator::getSingletonPtr())
+        return;
+
+    auto& materialMgr = Ogre::MaterialManager::getSingleton();
+    auto it = materialMgr.getResourceIterator();
+    while (it.hasMoreElements()) {
+        Ogre::MaterialPtr mat =
+            Ogre::static_pointer_cast<Ogre::Material>(it.getNext());
+        if (!mat || !isMetallicRoughnessMaterial(mat))
+            continue;
+        applyPbrIfTagged(mat);
+    }
+}
+
+void RTShaderHelper::setPbrEnvIntensity(Ogre::Pass* pass, float intensity)
+{
+    if (!pass)
+        return;
+    pass->getUserObjectBindings().setUserAny(HdrIblRtss::kPbrEnvIntensityKey, Ogre::Any(intensity));
+}
+
+void RTShaderHelper::setPbrEnvTint(Ogre::Pass* pass, const Ogre::ColourValue& tint)
+{
+    if (!pass)
+        return;
+    pass->getUserObjectBindings().setUserAny(HdrIblRtss::kPbrEnvTintKey, Ogre::Any(tint));
+}
+
+float RTShaderHelper::pbrEnvIntensity(const Ogre::Pass* pass)
+{
+    return HdrIblRtss::readEnvIntensity(pass);
+}
+
+Ogre::ColourValue RTShaderHelper::pbrEnvTint(const Ogre::Pass* pass)
+{
+    return HdrIblRtss::readEnvTint(pass);
 }

--- a/src/RTShaderHelper.h
+++ b/src/RTShaderHelper.h
@@ -62,4 +62,14 @@ namespace RTShaderHelper {
     /// Full viewport sync matching Material Editor script Apply + updateMaterialText:
     /// round-trip material script, hydrate embedded textures, rebuild RTSS, rebind TUS.
     void syncMaterialForViewport(Ogre::MaterialPtr& mat);
+
+    /// Re-attach Cook-Torrance + IBL on every metallic-roughness material after the
+    /// active HDR environment finishes precomputing or changes.
+    void refreshAllPbrMaterialsForHdr();
+
+    /// Per-pass PBR environment controls (stored as pass user bindings).
+    void setPbrEnvIntensity(Ogre::Pass* pass, float intensity);
+    void setPbrEnvTint(Ogre::Pass* pass, const Ogre::ColourValue& tint);
+    float pbrEnvIntensity(const Ogre::Pass* pass);
+    Ogre::ColourValue pbrEnvTint(const Ogre::Pass* pass);
 }

--- a/src/RTShaderHelper_test.cpp
+++ b/src/RTShaderHelper_test.cpp
@@ -91,6 +91,11 @@ TEST_F(RTSSResourcesTest, HasSGXLibCookTorrance)
     EXPECT_TRUE(QFile::exists(rtssDir + "/SGXLib_CookTorrance.glsl"));
 }
 
+TEST_F(RTSSResourcesTest, HasQTSLibIbl)
+{
+    EXPECT_TRUE(QFile::exists(rtssDir + "/QTSLib_IBL.glsl"));
+}
+
 TEST_F(RTSSResourcesTest, HasSGXLibDualQuaternion)
 {
     EXPECT_TRUE(QFile::exists(rtssDir + "/SGXLib_DualQuaternion.glsl"));
@@ -142,7 +147,7 @@ TEST_F(RTSSResourcesTest, RTShaderLibHasExpectedFileCount)
     QDir dir(rtssDir);
     auto entries = dir.entryList(QDir::Files | QDir::NoDotAndDotDot);
     // 16 .glsl + 3 .dds + 1 .material = 20 files
-    EXPECT_GE(entries.size(), 20) << "Expected at least 20 files in RTShaderLib/";
+    EXPECT_GE(entries.size(), 21) << "Expected at least 21 files in RTShaderLib/";
 }
 
 TEST_F(RTSSResourcesTest, MainDirHasMinimumFiles)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -113,6 +113,12 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/IsometricSpritesController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/VATShaderEmitter.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MinimalEXRWriter.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/HDR/HDREnvironmentManager.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/HDR/HdrEquirectLoader.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/HDR/HdrIblPrecompute.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/HDR/HdrCache.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/HDR/HdrPrecomputeWorker.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/HDR/HdrIblRtss.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MorphAnimationManager.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/MorphCommands.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/NodeAnimationManager.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -479,6 +479,17 @@ if(BUILD_TESTS)
         POSITION_INDEPENDENT_CODE ON
     )
     target_include_directories(qtmesh_test_common PRIVATE ${TEST_SUPPORT_INCLUDES})
+    if(stb_SOURCE_DIR)
+        target_include_directories(qtmesh_test_common PRIVATE ${stb_SOURCE_DIR})
+    endif()
+    if(ENABLE_OPENEXR AND tinyexr_SOURCE_DIR)
+        target_include_directories(qtmesh_test_common PRIVATE
+            ${tinyexr_SOURCE_DIR}
+            ${tinyexr_SOURCE_DIR}/deps/miniz)
+        if(TARGET tinyexr_miniz)
+            target_link_libraries(qtmesh_test_common PUBLIC tinyexr_miniz)
+        endif()
+    endif()
     target_compile_definitions(qtmesh_test_common PRIVATE
         BATCH_EXPORTER_TEST_SEAM
         QTMESH_UNIT_TESTS


### PR DESCRIPTION
## Summary

Implements epic #466 **Slice C** (#469): wire split-sum image-based lighting into the Cook-Torrance PBR path via a custom RTSS sub-render state (`QtmeHdrIbl`).

- Adds `QTSLib_IBL.glsl` + `HdrIblRtss` factory/SRS that binds irradiance, prefiltered specular, and BRDF LUT from `HDREnvironmentManager` when a material is tagged `pbr_workflow`
- Extends `RTShaderHelper` with `tryApplyHdrIbl()`, per-pass `pbr_env_intensity` / `pbr_env_tint` user bindings, and `refreshAllPbrMaterialsForHdr()` on IBL precompute completion
- Unit tests in `RTShaderHdrIbl_test.cpp` (PBR gets SRS when env ready; Phong excluded; PBR without env skipped)

**Not in this slice:** HDR load UI, skybox/tonemap (D), bundled HDRIs (F), MCP `set_hdr_environment` (G). Manual visual test still needs a dev hook to call `HDREnvironmentManager::loadEnvironment()` until a later slice.

## Test plan

- [x] `./build_local/bin/UnitTests --gtest_filter="RTShaderHdrIblTest.*:Hdr*:HDREnvironment*"` (17 tests)
- [ ] CI `unit-tests-linux` green
- [ ] SonarCloud gate (if applicable)

Closes #469


Made with [Cursor](https://cursor.com)