### PR TITLE
HDR: Slice D — Skybox + tone-mapping compositor (#470)

### DIFF
--- a/cfg/resources.cfg.in
+++ b/cfg/resources.cfg.in
@@ -14,4 +14,5 @@ FileSystem=media/materials/programs/GLSL150
 FileSystem=media/materials/programs/GLSL
 FileSystem=media/materials/programs
 FileSystem=media/materials/scripts
+FileSystem=media/compositors
 FileSystem=media/materials/textures

--- a/cfg/resources_d.cfg.in
+++ b/cfg/resources_d.cfg.in
@@ -14,4 +14,5 @@ FileSystem=media/materials/programs/GLSL150
 FileSystem=media/materials/programs/GLSL
 FileSystem=media/materials/programs
 FileSystem=media/materials/scripts
+FileSystem=media/compositors
 FileSystem=media/materials/textures

--- a/media/compositors/QtMeshHdr.compositor
+++ b/media/compositors/QtMeshHdr.compositor
@@ -13,9 +13,9 @@ compositor QtMeshHdrPipeline
 
         target_output
         {
-            input on rtHdr
             pass render_quad
             {
+                input 0 rtHdr
                 material QtMesh/HdrTonemapPass
             }
         }

--- a/media/compositors/QtMeshHdr.compositor
+++ b/media/compositors/QtMeshHdr.compositor
@@ -1,0 +1,23 @@
+compositor QtMeshHdrPipeline
+{
+    technique
+    {
+        texture rtHdr target_width target_height PF_FLOAT16_RGBA
+
+        target rtHdr
+        {
+            pass render_scene
+            {
+            }
+        }
+
+        target_output
+        {
+            input on rtHdr
+            pass render_quad
+            {
+                material QtMesh/HdrTonemapPass
+            }
+        }
+    }
+}

--- a/media/materials/programs/GLSL150/QtMeshHdrTonemapFp.glsl
+++ b/media/materials/programs/GLSL150/QtMeshHdrTonemapFp.glsl
@@ -1,0 +1,57 @@
+#version 150
+
+uniform sampler2D hdrTex;
+uniform float exposureMul;
+uniform int tonemapOp;
+uniform float whitePoint;
+
+in vec2 oUv0;
+out vec4 fragColour;
+
+vec3 tonemapReinhard(vec3 c)
+{
+    vec3 num = c * (1.0 + c / (whitePoint * whitePoint));
+    return num / (1.0 + c);
+}
+
+vec3 tonemapAces(vec3 x)
+{
+    const float a = 2.51;
+    const float b = 0.03;
+    const float c = 2.43;
+    const float d = 0.59;
+    const float e = 0.14;
+    vec3 num = x * (a * x + vec3(b));
+    vec3 den = x * (c * x + vec3(d)) + vec3(e);
+    return clamp(num / den, 0.0, 1.0);
+}
+
+vec3 tonemapAgx(vec3 x)
+{
+    x = clamp(x, 0.0, 1.0);
+    vec3 agx = vec3(
+        dot(x, vec3(0.224282, 0.130789, 0.044929)),
+        dot(x, vec3(0.050223, 0.873461, 0.076316)),
+        dot(x, vec3(0.020833, 0.080745, 0.898422)));
+    return clamp(pow(max(agx, vec3(0.0)), vec3(1.35)), 0.0, 1.0);
+}
+
+vec3 linearToSrgb(vec3 c)
+{
+    vec3 lo = c * 12.92;
+    vec3 hi = 1.055 * pow(c, vec3(1.0 / 2.4)) - 0.055;
+    return mix(lo, hi, step(vec3(0.0031308), c));
+}
+
+void main()
+{
+    vec3 hdr = texture(hdrTex, oUv0).rgb * exposureMul;
+    vec3 mapped;
+    if (tonemapOp == 1)
+        mapped = tonemapAces(hdr);
+    else if (tonemapOp == 2)
+        mapped = tonemapAgx(hdr);
+    else
+        mapped = tonemapReinhard(hdr);
+    fragColour = vec4(linearToSrgb(mapped), 1.0);
+}

--- a/media/materials/programs/GLSL150/QtMeshHdrTonemapFp.glsl
+++ b/media/materials/programs/GLSL150/QtMeshHdrTonemapFp.glsl
@@ -28,7 +28,7 @@ vec3 tonemapAces(vec3 x)
 
 vec3 tonemapAgx(vec3 x)
 {
-    x = clamp(x, 0.0, 1.0);
+    x = max(x, vec3(0.0));
     vec3 agx = vec3(
         dot(x, vec3(0.224282, 0.130789, 0.044929)),
         dot(x, vec3(0.050223, 0.873461, 0.076316)),

--- a/media/materials/scripts/QtMeshHdr.material
+++ b/media/materials/scripts/QtMeshHdr.material
@@ -1,0 +1,47 @@
+vertex_program QtMeshHdrTonemapVp glsl
+{
+    source StdQuad_vp.glsl
+}
+
+fragment_program QtMeshHdrTonemapFp glsl
+{
+    source QtMeshHdrTonemapFp.glsl
+}
+
+material QtMesh/HdrTonemapPass
+{
+    technique
+    {
+        pass
+        {
+            depth_check off
+            depth_write off
+            cull_hardware none
+
+            vertex_program_ref QtMeshHdrTonemapVp
+            {
+            }
+            fragment_program_ref QtMeshHdrTonemapFp
+            {
+            }
+        }
+    }
+}
+
+material QtMesh/HdrSkybox
+{
+    technique
+    {
+        pass
+        {
+            depth_write off
+            lighting off
+            cull_hardware none
+            texture_unit
+            {
+                tex_address_mode clamp
+                filtering trilinear
+            }
+        }
+    }
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -124,6 +124,9 @@ HDR/HdrIblPrecompute.cpp
 HDR/HdrCache.cpp
 HDR/HdrPrecomputeWorker.cpp
 HDR/HdrIblRtss.cpp
+HDR/HdrTonemap.cpp
+HDR/HdrViewportPipeline.cpp
+HDR/HdrViewportController.cpp
 MorphAnimationManager.cpp
 NodeAnimationManager.cpp
 PoseLibrary.cpp
@@ -316,6 +319,9 @@ HDR/HdrIblPrecompute.h
 HDR/HdrCache.h
 HDR/HdrPrecomputeWorker.h
 HDR/HdrIblRtss.h
+HDR/HdrTonemap.h
+HDR/HdrViewportPipeline.h
+HDR/HdrViewportController.h
 )
 
 set(TEST_SOURCES "")

--- a/src/HDR/HDREnvironmentManager.cpp
+++ b/src/HDR/HDREnvironmentManager.cpp
@@ -475,7 +475,11 @@ void HDREnvironmentManager::setDefaultSkyBoxVisible(bool visible)
     if (m_defaultSkyBoxVisible == visible)
         return;
     m_defaultSkyBoxVisible = visible;
-    emit tonemapChanged();
+    SentryReporter::addBreadcrumb(
+        QStringLiteral("render.hdr.skybox"),
+        QStringLiteral("defaultVisible=%1").arg(visible ? QStringLiteral("yes")
+                                                        : QStringLiteral("no")));
+    emit skyboxDefaultChanged();
 }
 
 void HDREnvironmentManager::updateSkyBoxMaterial()

--- a/src/HDR/HDREnvironmentManager.cpp
+++ b/src/HDR/HDREnvironmentManager.cpp
@@ -5,6 +5,10 @@
 #include "RTShaderHelper.h"
 #include "SentryReporter.h"
 
+#include <OgreMaterialManager.h>
+#include <OgreSceneManager.h>
+
+#include <algorithm>
 #include <OgreTextureManager.h>
 
 #include <QCoreApplication>
@@ -16,6 +20,8 @@
 #include <QThread>
 
 namespace {
+
+constexpr const char* kSkyboxMaterialName = "QtMesh/HdrSkybox";
 
 void removeTextureIfExists(const Ogre::TexturePtr& tex)
 {
@@ -428,4 +434,92 @@ bool HDREnvironmentManager::loadEnvironment(const QString& pathOrBundledName)
 
     emit environmentChanged();
     return true;
+}
+
+void HDREnvironmentManager::setTonemapOperator(TonemapOperator op)
+{
+    if (m_tonemapOperator == op)
+        return;
+    m_tonemapOperator = op;
+    SentryReporter::addBreadcrumb(
+        QStringLiteral("render.hdr.tonemap"),
+        QStringLiteral("operator=%1").arg(static_cast<int>(op)));
+    emit tonemapChanged();
+}
+
+void HDREnvironmentManager::setExposureEv(float exposureEv)
+{
+    if (m_exposureEv == exposureEv)
+        return;
+    m_exposureEv = exposureEv;
+    SentryReporter::addBreadcrumb(
+        QStringLiteral("render.hdr.tonemap"),
+        QStringLiteral("exposureEv=%1").arg(exposureEv));
+    emit tonemapChanged();
+}
+
+void HDREnvironmentManager::setWhitePoint(float whitePoint)
+{
+    const float clamped = std::max(0.001f, whitePoint);
+    if (m_whitePoint == clamped)
+        return;
+    m_whitePoint = clamped;
+    SentryReporter::addBreadcrumb(
+        QStringLiteral("render.hdr.tonemap"),
+        QStringLiteral("whitePoint=%1").arg(clamped));
+    emit tonemapChanged();
+}
+
+void HDREnvironmentManager::setDefaultSkyBoxVisible(bool visible)
+{
+    if (m_defaultSkyBoxVisible == visible)
+        return;
+    m_defaultSkyBoxVisible = visible;
+    emit tonemapChanged();
+}
+
+void HDREnvironmentManager::updateSkyBoxMaterial()
+{
+    if (!m_cubemap || !Ogre::MaterialManager::getSingletonPtr())
+        return;
+
+    auto& matMgr = Ogre::MaterialManager::getSingleton();
+    Ogre::MaterialPtr mat = matMgr.getByName(kSkyboxMaterialName);
+    if (!mat)
+        mat = matMgr.create(kSkyboxMaterialName,
+                            Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+
+    if (!mat->isLoaded())
+        mat->load();
+
+    Ogre::Pass* pass = mat->getTechnique(0)->getPass(0);
+    pass->setLightingEnabled(false);
+    pass->setDepthWriteEnabled(false);
+    pass->setCullingMode(Ogre::CULL_NONE);
+
+    if (pass->getNumTextureUnitStates() == 0)
+        pass->createTextureUnitState();
+    auto* tus = pass->getTextureUnitState(0);
+    tus->setTextureName(m_cubemap->getName(), Ogre::TEX_TYPE_CUBE_MAP);
+    tus->setTextureFiltering(Ogre::TFO_TRILINEAR);
+    tus->setTextureAddressingMode(Ogre::TextureUnitState::TAM_CLAMP);
+}
+
+void HDREnvironmentManager::applySkyBox(Ogre::SceneManager* sceneMgr)
+{
+    if (!sceneMgr || !m_cubemap)
+        return;
+
+    updateSkyBoxMaterial();
+    sceneMgr->setSkyBox(true, kSkyboxMaterialName, 5000.f);
+    sceneMgr->setSkyRenderingEnabled(m_defaultSkyBoxVisible);
+    m_skyBoxInstalled = true;
+}
+
+void HDREnvironmentManager::removeSkyBox(Ogre::SceneManager* sceneMgr)
+{
+    if (!sceneMgr || !m_skyBoxInstalled)
+        return;
+    sceneMgr->setSkyBox(false, kSkyboxMaterialName);
+    m_skyBoxInstalled = false;
 }

--- a/src/HDR/HDREnvironmentManager.h
+++ b/src/HDR/HDREnvironmentManager.h
@@ -84,6 +84,7 @@ signals:
     void environmentChanged();
     void iblPrecomputeCompleted(bool fromDiskCache);
     void tonemapChanged();
+    void skyboxDefaultChanged();
 
 private slots:
     void onPrecomputeCompleted(HdrIbl::IblBakeResult result,

--- a/src/HDR/HDREnvironmentManager.h
+++ b/src/HDR/HDREnvironmentManager.h
@@ -2,6 +2,7 @@
 
 #include "HDR/HdrEquirectLoader.h"
 #include "HDR/HdrIblPrecompute.h"
+#include "HDR/HdrTonemap.h"
 
 #include <Ogre.h>
 
@@ -12,12 +13,14 @@
 class HdrPrecomputeWorker;
 class QThread;
 
-/// Slice A (#467) + B (#468) + C (#469): HDR environment, IBL precompute, RTSS wiring.
+/// Slice A–D (#467–#470): HDR environment, IBL, tonemap defaults, skybox.
 class HDREnvironmentManager : public QObject
 {
     Q_OBJECT
 
 public:
+    using TonemapOperator = HdrTonemap::Operator;
+
     static HDREnvironmentManager* getSingleton();
     static HDREnvironmentManager* getSingletonPtr();
     static void kill();
@@ -59,9 +62,28 @@ public:
     /// Register precomputed IBL textures with Ogre (worker path + unit tests).
     bool installIblBake(const QString& cacheKey, HdrIbl::IblBakeResult& result, QString& error);
 
+    /// Global tone-mapping defaults (Slice D). New viewports inherit these.
+    TonemapOperator tonemapOperator() const { return m_tonemapOperator; }
+    float exposureEv() const { return m_exposureEv; }
+    float whitePoint() const { return m_whitePoint; }
+    bool defaultSkyBoxVisible() const { return m_defaultSkyBoxVisible; }
+
+    void setTonemapOperator(TonemapOperator op);
+    void setExposureEv(float exposureEv);
+    void setWhitePoint(float whitePoint);
+    void setDefaultSkyBoxVisible(bool visible);
+
+    /// Install or refresh the shared scene skybox from the active cubemap.
+    void applySkyBox(Ogre::SceneManager* sceneMgr);
+    void removeSkyBox(Ogre::SceneManager* sceneMgr);
+
+    /// True when an environment cubemap is loaded (IBL may still be baking).
+    bool hasEnvironment() const { return !m_cacheKey.isEmpty() && m_cubemap; }
+
 signals:
     void environmentChanged();
     void iblPrecomputeCompleted(bool fromDiskCache);
+    void tonemapChanged();
 
 private slots:
     void onPrecomputeCompleted(HdrIbl::IblBakeResult result,
@@ -85,6 +107,7 @@ private:
     bool registerIblTextures(const QString& cacheKey,
                              HdrIbl::IblBakeResult& result,
                              QString& error);
+    void updateSkyBoxMaterial();
 
     static HDREnvironmentManager* s_singleton;
 
@@ -95,6 +118,12 @@ private:
     float m_prefilterMaxLodLevel = 0.f;
     bool m_backgroundIblPrecompute = true;
     quint64 m_precomputeGeneration = 0;
+
+    TonemapOperator m_tonemapOperator = TonemapOperator::ACES;
+    float m_exposureEv = 0.f;
+    float m_whitePoint = 1.f;
+    bool m_defaultSkyBoxVisible = true;
+    bool m_skyBoxInstalled = false;
 
     Ogre::TexturePtr m_cubemap;
     Ogre::TexturePtr m_irradiance;

--- a/src/HDR/HdrTonemap.cpp
+++ b/src/HDR/HdrTonemap.cpp
@@ -47,7 +47,11 @@ Rgb tonemapAces(Rgb x)
 Rgb tonemapAgx(Rgb x)
 {
     // Troy Sobotka's AgX default contrast approximation (Blender 4+ default).
-    const Rgb lin = clamp01(x);
+    const Rgb lin = {
+        std::max(0.f, x.r),
+        std::max(0.f, x.g),
+        std::max(0.f, x.b),
+    };
     const Rgb agx = {
         0.224282f * lin.r + 0.130789f * lin.g + 0.044929f * lin.b,
         0.050223f * lin.r + 0.873461f * lin.g + 0.076316f * lin.b,

--- a/src/HDR/HdrTonemap.cpp
+++ b/src/HDR/HdrTonemap.cpp
@@ -1,0 +1,89 @@
+#include "HDR/HdrTonemap.h"
+
+#include <algorithm>
+
+namespace HdrTonemap {
+namespace {
+
+Rgb saturate(Rgb c)
+{
+    return clamp01(c);
+}
+
+} // namespace
+
+Rgb applyExposure(Rgb linear, float exposureEv)
+{
+    return linear * exposureMultiplier(exposureEv);
+}
+
+Rgb tonemapReinhard(Rgb linear, float whitePoint)
+{
+    const float wp = std::max(0.001f, whitePoint);
+    const float invWp2 = 1.f / (wp * wp);
+    Rgb mapped = {
+        linear.r * (1.f + linear.r * invWp2) / (1.f + linear.r),
+        linear.g * (1.f + linear.g * invWp2) / (1.f + linear.g),
+        linear.b * (1.f + linear.b * invWp2) / (1.f + linear.b),
+    };
+    return saturate(mapped);
+}
+
+Rgb tonemapAces(Rgb x)
+{
+    constexpr float a = 2.51f;
+    constexpr float b = 0.03f;
+    constexpr float c = 2.43f;
+    constexpr float d = 0.59f;
+    constexpr float e = 0.14f;
+    auto film = [&](float v) {
+        const float num = v * (a * v + b);
+        const float den = v * (c * v + d) + e;
+        return clamp01(num / den);
+    };
+    return {film(x.r), film(x.g), film(x.b)};
+}
+
+Rgb tonemapAgx(Rgb x)
+{
+    // Troy Sobotka's AgX default contrast approximation (Blender 4+ default).
+    const Rgb lin = clamp01(x);
+    const Rgb agx = {
+        0.224282f * lin.r + 0.130789f * lin.g + 0.044929f * lin.b,
+        0.050223f * lin.r + 0.873461f * lin.g + 0.076316f * lin.b,
+        0.020833f * lin.r + 0.080745f * lin.g + 0.898422f * lin.b,
+    };
+    const Rgb contrast = {
+        std::pow(std::max(0.f, agx.r), 1.35f),
+        std::pow(std::max(0.f, agx.g), 1.35f),
+        std::pow(std::max(0.f, agx.b), 1.35f),
+    };
+    return saturate(contrast);
+}
+
+Rgb tonemap(Rgb linearHdr, Operator op, float exposureEv, float whitePoint)
+{
+    Rgb exposed = applyExposure(linearHdr, exposureEv);
+    switch (op) {
+    case Operator::ACES:
+        return tonemapAces(exposed);
+    case Operator::AgX:
+        return tonemapAgx(exposed);
+    case Operator::Reinhard:
+    default:
+        return tonemapReinhard(exposed, whitePoint);
+    }
+}
+
+Rgb linearToSrgb(Rgb linear)
+{
+    auto encode = [](float c) {
+        c = std::max(0.f, c);
+        if (c <= 0.0031308f)
+            return 12.92f * c;
+        return 1.055f * std::pow(c, 1.f / 2.4f) - 0.055f;
+    };
+    return {encode(linear.r), encode(linear.g), encode(linear.b)};
+}
+
+} // namespace HdrTonemap

--- a/src/HDR/HdrTonemap.h
+++ b/src/HDR/HdrTonemap.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 
 namespace HdrTonemap {

--- a/src/HDR/HdrTonemap.h
+++ b/src/HDR/HdrTonemap.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <cmath>
+
+namespace HdrTonemap {
+
+enum class Operator {
+    Reinhard = 0,
+    ACES = 1,
+    AgX = 2,
+};
+
+struct Rgb {
+    float r = 0.f;
+    float g = 0.f;
+    float b = 0.f;
+};
+
+inline Rgb operator*(Rgb c, float s)
+{
+    return {c.r * s, c.g * s, c.b * s};
+}
+
+inline Rgb operator+(Rgb a, Rgb b)
+{
+    return {a.r + b.r, a.g + b.g, a.b + b.b};
+}
+
+inline Rgb operator/(Rgb c, float s)
+{
+    return {c.r / s, c.g / s, c.b / s};
+}
+
+inline float clamp01(float v)
+{
+    return std::max(0.f, std::min(1.f, v));
+}
+
+inline Rgb clamp01(Rgb c)
+{
+    return {clamp01(c.r), clamp01(c.g), clamp01(c.b)};
+}
+
+/// Exposure in EV stops: linear scale = 2^exposureEv.
+inline float exposureMultiplier(float exposureEv)
+{
+    return std::pow(2.f, exposureEv);
+}
+
+Rgb applyExposure(Rgb linear, float exposureEv);
+Rgb tonemapReinhard(Rgb linear, float whitePoint);
+Rgb tonemapAces(Rgb linear);
+Rgb tonemapAgx(Rgb linear);
+Rgb tonemap(Rgb linearHdr, Operator op, float exposureEv, float whitePoint);
+Rgb linearToSrgb(Rgb linear);
+
+} // namespace HdrTonemap

--- a/src/HDR/HdrTonemap_test.cpp
+++ b/src/HDR/HdrTonemap_test.cpp
@@ -1,0 +1,54 @@
+#include "HDR/HdrTonemap.h"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+using namespace HdrTonemap;
+
+TEST(HdrTonemapTest, ExposureOneStopDoublesLinear)
+{
+    const Rgb input{0.25f, 0.5f, 1.0f};
+    const Rgb ev0 = applyExposure(input, 0.f);
+    const Rgb ev1 = applyExposure(input, 1.f);
+    EXPECT_NEAR(ev1.r, ev0.r * 2.f, 1e-5f);
+    EXPECT_NEAR(ev1.g, ev0.g * 2.f, 1e-5f);
+    EXPECT_NEAR(ev1.b, ev0.b * 2.f, 1e-5f);
+}
+
+TEST(HdrTonemapTest, ReinhardConstantGrey_MatchesReference)
+{
+    const Rgb grey{2.f, 2.f, 2.f};
+    const Rgb mapped = tonemapReinhard(grey, 1.f);
+    const Rgb unit = tonemapReinhard({1.f, 1.f, 1.f}, 1.f);
+    EXPECT_NEAR(mapped.r, unit.r, 1e-5f);
+    EXPECT_NEAR(mapped.g, unit.g, 1e-5f);
+    EXPECT_NEAR(mapped.b, unit.b, 1e-5f);
+    EXPECT_GT(mapped.r, 0.5f);
+    EXPECT_LE(mapped.r, 1.f);
+}
+
+TEST(HdrTonemapTest, OperatorsProduceDifferentOutputs)
+{
+    const Rgb hdr{4.f, 2.f, 1.f};
+    const Rgb reinhard = tonemap(hdr, Operator::Reinhard, 0.f, 1.f);
+    const Rgb aces = tonemap(hdr, Operator::ACES, 0.f, 1.f);
+    const Rgb agx = tonemap(hdr, Operator::AgX, 0.f, 1.f);
+    EXPECT_NE(reinhard.r, aces.r);
+    EXPECT_NE(aces.r, agx.r);
+}
+
+TEST(HdrTonemapTest, ExposureScalesBeforeTonemap)
+{
+    const Rgb base{0.25f, 0.25f, 0.25f};
+    const Rgb oneStop = tonemap(base, Operator::Reinhard, 1.f, 1.f);
+    const Rgb zeroStop = tonemap(base, Operator::Reinhard, 0.f, 1.f);
+    EXPECT_GT(oneStop.r, zeroStop.r);
+}
+
+TEST(HdrTonemapTest, LinearToSrgb_IsMonotonic)
+{
+    const Rgb lo = linearToSrgb({0.1f, 0.1f, 0.1f});
+    const Rgb hi = linearToSrgb({0.5f, 0.5f, 0.5f});
+    EXPECT_LT(lo.r, hi.r);
+}

--- a/src/HDR/HdrViewportController.cpp
+++ b/src/HDR/HdrViewportController.cpp
@@ -1,0 +1,111 @@
+#include "HDR/HdrViewportController.h"
+
+#include "HDR/HDREnvironmentManager.h"
+#include "HDR/HdrViewportPipeline.h"
+#include "Manager.h"
+#include "OgreWidget.h"
+
+#include <OgreSceneManager.h>
+
+HdrViewportController* HdrViewportController::s_singleton = nullptr;
+
+HdrViewportController* HdrViewportController::getSingleton()
+{
+    if (!s_singleton)
+        s_singleton = new HdrViewportController(); // NOSONAR — singleton
+    return s_singleton;
+}
+
+HdrViewportController* HdrViewportController::getSingletonPtr()
+{
+    return s_singleton;
+}
+
+void HdrViewportController::kill()
+{
+    delete s_singleton; // NOSONAR — singleton
+    s_singleton = nullptr;
+}
+
+HdrViewportController::HdrViewportController(QObject* parent)
+    : QObject(parent)
+{
+    auto* hdrMgr = HDREnvironmentManager::getSingleton();
+    connect(hdrMgr, &HDREnvironmentManager::environmentChanged,
+            this, &HdrViewportController::onEnvironmentChanged);
+    connect(hdrMgr, &HDREnvironmentManager::tonemapChanged,
+            this, &HdrViewportController::onTonemapChanged);
+}
+
+HdrViewportController::~HdrViewportController() = default;
+
+void HdrViewportController::registerWidget(OgreWidget* widget)
+{
+    if (!widget || m_pipelines.find(widget) != m_pipelines.end())
+        return;
+
+    m_pipelines.emplace(widget, std::make_unique<HdrViewportPipeline>(widget));
+    if (auto* pipe = pipelineFor(widget))
+        pipe->setSkyBoxVisible(HDREnvironmentManager::getSingleton()->defaultSkyBoxVisible());
+    onEnvironmentChanged();
+}
+
+void HdrViewportController::unregisterWidget(OgreWidget* widget)
+{
+    m_pipelines.erase(widget);
+}
+
+void HdrViewportController::setSkyBoxVisible(OgreWidget* widget, bool visible)
+{
+    if (auto* pipe = pipelineFor(widget))
+        pipe->setSkyBoxVisible(visible);
+}
+
+bool HdrViewportController::skyBoxVisible(const OgreWidget* widget) const
+{
+    if (!widget)
+        return true;
+    auto it = m_pipelines.find(const_cast<OgreWidget*>(widget));
+    if (it == m_pipelines.end())
+        return HDREnvironmentManager::getSingleton()->defaultSkyBoxVisible();
+    return it->second->skyBoxVisible();
+}
+
+void HdrViewportController::tickActiveViewports()
+{
+    for (auto& [widget, pipeline] : m_pipelines) {
+        Q_UNUSED(widget);
+        pipeline->updateTonemapUniforms();
+    }
+}
+
+void HdrViewportController::onEnvironmentChanged()
+{
+    auto* hdrMgr = HDREnvironmentManager::getSingletonPtr();
+    if (auto* mgr = Manager::getSingletonPtr()) {
+        if (hdrMgr && hdrMgr->hasEnvironment())
+            hdrMgr->applySkyBox(mgr->getSceneMgr());
+        else if (hdrMgr)
+            hdrMgr->removeSkyBox(mgr->getSceneMgr());
+    }
+    refreshAll();
+}
+
+void HdrViewportController::onTonemapChanged()
+{
+    refreshAll();
+}
+
+HdrViewportPipeline* HdrViewportController::pipelineFor(OgreWidget* widget) const
+{
+    auto it = m_pipelines.find(widget);
+    return it == m_pipelines.end() ? nullptr : it->second.get();
+}
+
+void HdrViewportController::refreshAll()
+{
+    for (auto& [widget, pipeline] : m_pipelines) {
+        Q_UNUSED(widget);
+        pipeline->refresh();
+    }
+}

--- a/src/HDR/HdrViewportController.cpp
+++ b/src/HDR/HdrViewportController.cpp
@@ -35,18 +35,24 @@ HdrViewportController::HdrViewportController(QObject* parent)
             this, &HdrViewportController::onEnvironmentChanged);
     connect(hdrMgr, &HDREnvironmentManager::tonemapChanged,
             this, &HdrViewportController::onTonemapChanged);
+    connect(hdrMgr, &HDREnvironmentManager::skyboxDefaultChanged,
+            this, &HdrViewportController::onSkyboxDefaultChanged);
 }
 
 HdrViewportController::~HdrViewportController() = default;
 
 void HdrViewportController::registerWidget(OgreWidget* widget)
 {
-    if (!widget || m_pipelines.find(widget) != m_pipelines.end())
+    if (!widget)
         return;
 
+    auto it = m_pipelines.find(widget);
+    if (it != m_pipelines.end()) {
+        it->second->refresh();
+        return;
+    }
+
     m_pipelines.emplace(widget, std::make_unique<HdrViewportPipeline>(widget));
-    if (auto* pipe = pipelineFor(widget))
-        pipe->setSkyBoxVisible(HDREnvironmentManager::getSingleton()->defaultSkyBoxVisible());
     onEnvironmentChanged();
 }
 
@@ -94,6 +100,15 @@ void HdrViewportController::onEnvironmentChanged()
 void HdrViewportController::onTonemapChanged()
 {
     refreshAll();
+}
+
+void HdrViewportController::onSkyboxDefaultChanged()
+{
+    auto* hdrMgr = HDREnvironmentManager::getSingletonPtr();
+    if (auto* mgr = Manager::getSingletonPtr(); hdrMgr && mgr && mgr->getSceneMgr()
+        && hdrMgr->hasEnvironment()) {
+        mgr->getSceneMgr()->setSkyRenderingEnabled(hdrMgr->defaultSkyBoxVisible());
+    }
 }
 
 HdrViewportPipeline* HdrViewportController::pipelineFor(OgreWidget* widget) const

--- a/src/HDR/HdrViewportController.h
+++ b/src/HDR/HdrViewportController.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <QObject>
+
+#include <memory>
+#include <unordered_map>
+
+class OgreWidget;
+class HdrViewportPipeline;
+
+/// Registers per-viewport HDR pipelines and syncs them with HDREnvironmentManager.
+class HdrViewportController : public QObject
+{
+    Q_OBJECT
+
+public:
+    static HdrViewportController* getSingleton();
+    static HdrViewportController* getSingletonPtr();
+    static void kill();
+
+    void registerWidget(OgreWidget* widget);
+    void unregisterWidget(OgreWidget* widget);
+
+    void setSkyBoxVisible(OgreWidget* widget, bool visible);
+    bool skyBoxVisible(const OgreWidget* widget) const;
+
+    void tickActiveViewports();
+
+private slots:
+    void onEnvironmentChanged();
+    void onTonemapChanged();
+
+private:
+    explicit HdrViewportController(QObject* parent = nullptr);
+    ~HdrViewportController() override;
+
+    HdrViewportPipeline* pipelineFor(OgreWidget* widget) const;
+    void refreshAll();
+
+    static HdrViewportController* s_singleton;
+    std::unordered_map<OgreWidget*, std::unique_ptr<HdrViewportPipeline>> m_pipelines;
+};

--- a/src/HDR/HdrViewportController.h
+++ b/src/HDR/HdrViewportController.h
@@ -29,6 +29,7 @@ public:
 private slots:
     void onEnvironmentChanged();
     void onTonemapChanged();
+    void onSkyboxDefaultChanged();
 
 private:
     explicit HdrViewportController(QObject* parent = nullptr);

--- a/src/HDR/HdrViewportPipeline.cpp
+++ b/src/HDR/HdrViewportPipeline.cpp
@@ -39,6 +39,8 @@ void updateTonemapMaterialConstants()
 HdrViewportPipeline::HdrViewportPipeline(OgreWidget* widget)
     : m_widget(widget)
 {
+    if (auto* hdrMgr = HDREnvironmentManager::getSingletonPtr())
+        m_skyBoxVisible = hdrMgr->defaultSkyBoxVisible();
 }
 
 HdrViewportPipeline::~HdrViewportPipeline()
@@ -78,8 +80,11 @@ void HdrViewportPipeline::enablePipeline()
     if (!vpConst)
         return;
 
-    m_viewport = const_cast<Ogre::Viewport*>(vpConst);
-    m_skyBoxVisible = HDREnvironmentManager::getSingleton()->defaultSkyBoxVisible();
+    Ogre::Viewport* vp = const_cast<Ogre::Viewport*>(vpConst);
+    if (m_viewport != vp && m_compositor)
+        disablePipeline();
+
+    m_viewport = vp;
     m_viewport->setSkiesEnabled(m_skyBoxVisible);
 
     if (!Ogre::CompositorManager::getSingletonPtr())

--- a/src/HDR/HdrViewportPipeline.cpp
+++ b/src/HDR/HdrViewportPipeline.cpp
@@ -1,0 +1,110 @@
+#include "HDR/HdrViewportPipeline.h"
+
+#include "HDR/HDREnvironmentManager.h"
+#include "HDR/HdrTonemap.h"
+#include "OgreWidget.h"
+
+#include <OgreCompositorManager.h>
+#include <OgreMaterialManager.h>
+#include <OgreRoot.h>
+#include <OgreViewport.h>
+
+namespace {
+
+constexpr const char* kTonemapMaterialName = "QtMesh/HdrTonemapPass";
+
+void updateTonemapMaterialConstants()
+{
+    auto* hdrMgr = HDREnvironmentManager::getSingletonPtr();
+    if (!hdrMgr || !Ogre::MaterialManager::getSingletonPtr())
+        return;
+
+    Ogre::MaterialPtr mat = Ogre::MaterialManager::getSingleton().getByName(kTonemapMaterialName);
+    if (!mat || mat->getNumTechniques() == 0)
+        return;
+
+    Ogre::Pass* pass = mat->getTechnique(0)->getPass(0);
+    if (!pass->getFragmentProgramParameters())
+        return;
+
+    const float exposureMul = HdrTonemap::exposureMultiplier(hdrMgr->exposureEv());
+    const int tonemapOp = static_cast<int>(hdrMgr->tonemapOperator());
+    pass->getFragmentProgramParameters()->setNamedConstant("exposureMul", exposureMul);
+    pass->getFragmentProgramParameters()->setNamedConstant("tonemapOp", tonemapOp);
+    pass->getFragmentProgramParameters()->setNamedConstant("whitePoint", hdrMgr->whitePoint());
+}
+
+} // namespace
+
+HdrViewportPipeline::HdrViewportPipeline(OgreWidget* widget)
+    : m_widget(widget)
+{
+}
+
+HdrViewportPipeline::~HdrViewportPipeline()
+{
+    disablePipeline();
+}
+
+void HdrViewportPipeline::refresh()
+{
+    auto* hdrMgr = HDREnvironmentManager::getSingletonPtr();
+    if (hdrMgr && hdrMgr->hasEnvironment())
+        enablePipeline();
+    else
+        disablePipeline();
+}
+
+void HdrViewportPipeline::updateTonemapUniforms()
+{
+    if (!m_enabled)
+        return;
+    updateTonemapMaterialConstants();
+}
+
+void HdrViewportPipeline::setSkyBoxVisible(bool visible)
+{
+    m_skyBoxVisible = visible;
+    if (m_viewport)
+        m_viewport->setSkiesEnabled(visible);
+}
+
+void HdrViewportPipeline::enablePipeline()
+{
+    if (!m_widget)
+        return;
+
+    const Ogre::Viewport* vpConst = m_widget->getViewport();
+    if (!vpConst)
+        return;
+
+    m_viewport = const_cast<Ogre::Viewport*>(vpConst);
+    m_skyBoxVisible = HDREnvironmentManager::getSingleton()->defaultSkyBoxVisible();
+    m_viewport->setSkiesEnabled(m_skyBoxVisible);
+
+    if (!Ogre::CompositorManager::getSingletonPtr())
+        return;
+
+    if (!m_compositor) {
+        m_compositor = Ogre::CompositorManager::getSingleton().addCompositor(
+            m_viewport, kCompositorName);
+        if (m_compositor)
+            Ogre::CompositorManager::getSingleton().setCompositorEnabled(
+                m_viewport, kCompositorName, true);
+    }
+
+    updateTonemapMaterialConstants();
+    m_enabled = m_compositor != nullptr;
+}
+
+void HdrViewportPipeline::disablePipeline()
+{
+    if (m_viewport && m_compositor && Ogre::CompositorManager::getSingletonPtr()) {
+        Ogre::CompositorManager::getSingleton().setCompositorEnabled(
+            m_viewport, kCompositorName, false);
+        Ogre::CompositorManager::getSingleton().removeCompositor(m_viewport, kCompositorName);
+    }
+    m_compositor = nullptr;
+    m_viewport = nullptr;
+    m_enabled = false;
+}

--- a/src/HDR/HdrViewportPipeline.h
+++ b/src/HDR/HdrViewportPipeline.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "HDR/HdrTonemap.h"
+
+#include <Ogre.h>
+
+class OgreWidget;
+
+/// Per-viewport HDR render target + tonemap compositor (Slice D, #470).
+class HdrViewportPipeline
+{
+public:
+    static constexpr const char* kCompositorName = "QtMeshHdrPipeline";
+
+    explicit HdrViewportPipeline(OgreWidget* widget);
+    ~HdrViewportPipeline();
+
+    void refresh();
+    void updateTonemapUniforms();
+
+    void setSkyBoxVisible(bool visible);
+    bool skyBoxVisible() const { return m_skyBoxVisible; }
+
+private:
+    void enablePipeline();
+    void disablePipeline();
+
+    OgreWidget* m_widget = nullptr;
+    Ogre::Viewport* m_viewport = nullptr;
+    Ogre::CompositorInstance* m_compositor = nullptr;
+    bool m_skyBoxVisible = true;
+    bool m_enabled = false;
+};

--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -46,6 +46,8 @@ THE SOFTWARE.
 #include "TransformOperator.h"
 #include "mainwindow.h"
 #include "ViewportGrid.h"
+#include "HDR/HDREnvironmentManager.h"
+#include "HDR/HdrViewportController.h"
 
 #if OGRE_PLATFORM == OGRE_PLATFORM_APPLE
  #include <CoreFoundation/CoreFoundation.h>
@@ -125,6 +127,9 @@ Manager::Manager(MainWindow* parent):
     initRoot();         // Init Ogre Root
     initRenderSystem(); // Init Ogre Render System
     initSceneMgr();     // Init Ogre SceneManager
+
+    HDREnvironmentManager::getSingleton();
+    HdrViewportController::getSingleton();
 
     if (SelectionSet *sel = SelectionSet::getSingletonPtr())
         sel->tryConnectToManager();

--- a/src/OgreWidget.cpp
+++ b/src/OgreWidget.cpp
@@ -46,6 +46,7 @@ THE SOFTWARE.
 #include "QtInputManager.h"
 #include "EditModeController.h"
 #include "TransformOperator.h"
+#include "HDR/HdrViewportController.h"
 #include "SentryReporter.h"
 
 namespace {
@@ -131,6 +132,9 @@ OgreWidget::OgreWidget( QWidget *parent ):
 
 OgreWidget::~OgreWidget()
 {
+    if (auto* hdrVp = HdrViewportController::getSingletonPtr())
+        hdrVp->unregisterWidget(this);
+
     // Safely clean up OGRE resources
     // Order is important: remove listeners first, then destroy camera, then detach render target, then remove viewports
     
@@ -294,6 +298,9 @@ void OgreWidget::initOgreWindow(void)
 
     if (mCamera)
         applyViewportCameraFromSettings(mCamera.get());
+
+    if (auto* hdrVp = HdrViewportController::getSingletonPtr())
+        hdrVp->registerWidget(this);
 }
 
 void OgreWidget::teardownOgreWindow()
@@ -355,6 +362,9 @@ void OgreWidget::rebuildRenderWindow()
     teardownOgreWindow();
     initOgreWindow();
 
+    if (auto* hdrVp = HdrViewportController::getSingletonPtr())
+        hdrVp->registerWidget(this);
+
     setBackgroundColor(bg);
     if (mViewport)
         mViewport->setVisibilityMask(visMask);
@@ -374,6 +384,9 @@ void OgreWidget::rebuildRenderWindow()
 
 bool OgreWidget::frameStarted(const Ogre::FrameEvent& e)
 {
+    if (auto* hdrVp = HdrViewportController::getSingletonPtr())
+        hdrVp->tickActiveViewports();
+
     // Keep tool gizmos at a constant pixel size by scaling them against the
     // current camera distance each frame. The gizmos are shared editor
     // singletons, so only the ACTIVE viewport should tick them — otherwise

--- a/src/OgreWidget.cpp
+++ b/src/OgreWidget.cpp
@@ -132,8 +132,7 @@ OgreWidget::OgreWidget( QWidget *parent ):
 
 OgreWidget::~OgreWidget()
 {
-    if (auto* hdrVp = HdrViewportController::getSingletonPtr())
-        hdrVp->unregisterWidget(this);
+    HdrViewportController::getSingleton().unregisterWidget(this);
 
     // Safely clean up OGRE resources
     // Order is important: remove listeners first, then destroy camera, then detach render target, then remove viewports
@@ -299,8 +298,7 @@ void OgreWidget::initOgreWindow(void)
     if (mCamera)
         applyViewportCameraFromSettings(mCamera.get());
 
-    if (auto* hdrVp = HdrViewportController::getSingletonPtr())
-        hdrVp->registerWidget(this);
+    HdrViewportController::getSingleton().registerWidget(this);
 }
 
 void OgreWidget::teardownOgreWindow()
@@ -359,11 +357,12 @@ void OgreWidget::rebuildRenderWindow()
         visMask = mViewport->getVisibilityMask();
     }
 
+    HdrViewportController::getSingleton().unregisterWidget(this);
+
     teardownOgreWindow();
     initOgreWindow();
 
-    if (auto* hdrVp = HdrViewportController::getSingletonPtr())
-        hdrVp->registerWidget(this);
+    HdrViewportController::getSingleton().registerWidget(this);
 
     setBackgroundColor(bg);
     if (mViewport)
@@ -384,8 +383,7 @@ void OgreWidget::rebuildRenderWindow()
 
 bool OgreWidget::frameStarted(const Ogre::FrameEvent& e)
 {
-    if (auto* hdrVp = HdrViewportController::getSingletonPtr())
-        hdrVp->tickActiveViewports();
+    HdrViewportController::getSingleton().tickActiveViewports();
 
     // Keep tool gizmos at a constant pixel size by scaling them against the
     // current camera distance each frame. The gizmos are shared editor

--- a/src/OgreWidget.cpp
+++ b/src/OgreWidget.cpp
@@ -132,7 +132,7 @@ OgreWidget::OgreWidget( QWidget *parent ):
 
 OgreWidget::~OgreWidget()
 {
-    HdrViewportController::getSingleton().unregisterWidget(this);
+    HdrViewportController::getSingleton()->unregisterWidget(this);
 
     // Safely clean up OGRE resources
     // Order is important: remove listeners first, then destroy camera, then detach render target, then remove viewports
@@ -298,7 +298,7 @@ void OgreWidget::initOgreWindow(void)
     if (mCamera)
         applyViewportCameraFromSettings(mCamera.get());
 
-    HdrViewportController::getSingleton().registerWidget(this);
+    HdrViewportController::getSingleton()->registerWidget(this);
 }
 
 void OgreWidget::teardownOgreWindow()
@@ -357,12 +357,12 @@ void OgreWidget::rebuildRenderWindow()
         visMask = mViewport->getVisibilityMask();
     }
 
-    HdrViewportController::getSingleton().unregisterWidget(this);
+    HdrViewportController::getSingleton()->unregisterWidget(this);
 
     teardownOgreWindow();
     initOgreWindow();
 
-    HdrViewportController::getSingleton().registerWidget(this);
+    HdrViewportController::getSingleton()->registerWidget(this);
 
     setBackgroundColor(bg);
     if (mViewport)
@@ -383,7 +383,7 @@ void OgreWidget::rebuildRenderWindow()
 
 bool OgreWidget::frameStarted(const Ogre::FrameEvent& e)
 {
-    HdrViewportController::getSingleton().tickActiveViewports();
+    HdrViewportController::getSingleton()->tickActiveViewports();
 
     // Keep tool gizmos at a constant pixel size by scaling them against the
     // current camera distance each frame. The gizmos are shared editor

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -119,6 +119,9 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/HDR/HdrCache.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/HDR/HdrPrecomputeWorker.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/HDR/HdrIblRtss.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/HDR/HdrTonemap.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/HDR/HdrViewportPipeline.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/HDR/HdrViewportController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MorphAnimationManager.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/MorphCommands.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/NodeAnimationManager.cpp


### PR DESCRIPTION
## Summary

Implements epic #466 **Slice D** (#470): HDR viewport skybox + FP16 scene render + tonemap compositor.

- **Skybox**: `HDREnvironmentManager::applySkyBox()` binds the loaded cubemap to `QtMesh/HdrSkybox` via `SceneManager::setSkyBox`. Per-viewport visibility uses `Viewport::setSkiesEnabled` (IBL stays active when skies are hidden).
- **HDR RT + compositor**: `QtMeshHdrPipeline` renders the scene to `PF_FLOAT16_RGBA`, then a fullscreen `render_quad` pass applies `QtMesh/HdrTonemapPass` (Reinhard / ACES / AgX + EV exposure + sRGB output).
- **Global defaults** on `HDREnvironmentManager` (`exposureEv`, `tonemapOperator`, `whitePoint`, `defaultSkyBoxVisible`) with `tonemapChanged` signal and `render.hdr.tonemap` Sentry breadcrumbs.
- **Per-viewport wiring** via `HdrViewportController` + `HdrViewportPipeline`, hooked from `OgreWidget` (register on init, disable when no env loaded — SDR path unchanged).
- **Unit tests**: `HdrTonemap_test.cpp` validates 1-stop exposure scaling and operator output differences on synthetic HDR constants.

**Not in this slice:** Inspector/Material Editor controls (#471), bundled HDRIs (#472), CLI/MCP (#473).

## Test plan

- [x] `./build_local/bin/UnitTests --gtest_filter="HdrTonemapTest.*"`
- [ ] CI `unit-tests-linux`
- [ ] Manual: `HDREnvironmentManager::loadEnvironment(path)` → skybox visible + tonemapped viewport; toggle `setSkyBoxVisible(widget, false)` hides sky only

Closes #470


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HDR tone-mapping with selectable operators (Reinhard, ACES, AgX), plus exposure and white-point controls.
  * Introduced per-viewport HDR tonemapping using a dedicated compositor, automatically enabled when an HDR environment is available.
  * Added shared HDR skybox support with configurable default visibility.
  * Extended resource lookup to include the new HDR compositor media.
* **Bug Fixes**
  * Improved synchronization of HDR settings across viewports, including during render-window rebuilds.
* **Tests**
  * Added unit tests covering exposure scaling, tonemapping behavior differences, and linear-to-sRGB consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->