### PR TITLE
HDR Slice G: CLI env flags, MCP IBL tools, skybox off by default (#473)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,8 @@ qtmesh lod model.fbx --count 3 --algo meshopt -o out.fbx  # meshoptimizer backen
 qtmesh lod model.fbx --auto                    # auto-generate LODs
 qtmesh lod model.fbx --remove -o clean.fbx     # strip LODs and save
 qtmesh material model.fbx --preset "Metallic-Roughness" -o out.fbx  # apply a built-in material preset (writes .material sidecar)
+qtmesh material model.fbx --env studio_neutral --env-intensity 1.5 --env-tint "#fff5e6" -o out.fbx  # HDR env + per-material IBL tuning (#473)
+qtmesh material model.fbx --env /path/to/custom.hdr -o out.fbx      # load HDRI + write .hdr-env.json sidecar
 qtmesh material --list-presets                 # list built-in preset names (incl. PBR templates + HDR Environment presets)
 qtmesh hdri --list                             # bundled HDRI catalog + on-disk status (#472)
 qtmesh hdri --download studio_neutral          # fetch optional CC0 HDRI into <AppData>/hdri/
@@ -218,6 +220,15 @@ Three singletons manage core state. All run on the main thread. Access via `Clas
 ### Theme System
 
 - **ThemeManager** (`src/ThemeManager.h/cpp`): QML_SINGLETON providing canonical theme colors synced from QPalette. All colors (window, panel, header, text, button, highlight, border, accent) derived from the active QPalette.
+
+### HDR & IBL (#466)
+
+- **HDREnvironmentManager** (`src/HDR/HDREnvironmentManager.h/cpp`, Slices A–D): global HDR environment load, cubemap registration, async IBL precompute (irradiance + prefiltered specular + BRDF LUT), tonemap defaults, and skybox. Bundled names resolve under `media/hdri/`; user downloads land in `<AppData>/hdri/`. **IBL disk cache:** `<AppData>/hdr_cache/<sha1>/` (delete that folder to force a rebake; see `HdrCache::cacheRootDirectory()`).
+- **HdrEnvironmentController** (`src/HDR/HdrEnvironmentController.h/cpp`, Slice E #471): QML bridge for Inspector **Environment** (Object mode): HDRI picker, Browse, skybox toggle, background blur, tonemap controls. Wired to all viewports via `HdrViewportController`.
+- **HdrMaterialScript** (`src/HDR/HdrMaterialScript.h/cpp`, Slice D): serialises per-material `pbr_environment_intensity` / `pbr_environment_tint` lines in `.material` sidecars; stripped before feeding scripts to Ogre.
+- **HdrBundledLibrary** (Slice F #472): CC0 bundled HDRIs, `qtmesh hdri --list/--download`, first-run defaults (`studio_neutral` + ACES + 0 EV). See `THIRD_PARTY_HDRI.md`.
+- **Slice G (#473) parity:** `qtmesh material --env/--env-intensity/--env-tint`; MCP `set_hdr_environment`, `get_hdr_environment`, `set_tonemap`, `set_env_intensity`, `set_env_tint`. Sentry breadcrumbs: `render.hdr.load`, `render.hdr.precompute`, `render.hdr.bind`, `render.hdr.tonemap`, `render.hdr.preset`, `render.hdr.skybox`, `ui.action` on inspector changes.
+- **Stretch (not in 3.15):** `qtmesh render` headless tonemapped preview PNG — turntable/isometric paths cover most batch preview needs today.
 
 ### Indie Game Dev Features
 

--- a/README.md
+++ b/README.md
@@ -279,11 +279,11 @@ Split View|Skeleton Animation Controls
 - **Pose export** — bake animation frames as static meshes (3D printing)
 - **LOD generation** — automatic level-of-detail mesh reduction
 - **Paint tools** — vertex paint, texture paint (BaseColor), bake vertex colors to texture with seam dilation
-- **Material editor** — visual editing with AI-assisted generation
+- **Material editor** — visual editing with AI-assisted generation; PBR + HDR/IBL materials look correct on first import (bundled studio HDRI, ACES tonemap, env intensity/tint per material)
 - **Skeleton inspection** — bone weights, debug overlays, animation preview
 - **Scene management** — duplicate (Ctrl+D), group (Ctrl+G), snap, pivot modes
 - **AI chat** — natural language scene editing via local LLMs
-- **MCP server** — 52 tools for AI agents (Claude, Cursor, etc.), including QtMesh Cloud (`cloud_*`)
+- **MCP server** — 57+ tools for AI agents (Claude, Cursor, etc.), including HDR/IBL (`set_hdr_environment`, `set_tonemap`, …) and QtMesh Cloud (`cloud_*`)
 - **REST API** — HTTP interface for external automation
 
 ---

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -25,6 +25,13 @@
 #include "ExportOptimizer.h"
 #include "UvUnwrap.h"
 #include "HDR/HdrBundledLibrary.h"
+#include "HDR/HDREnvironmentManager.h"
+#include "HDR/HdrMaterialScript.h"
+#include "RTShaderHelper.h"
+#include <QColor>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSet>
 #include "UvPipeline.h"
 #include "UvProject.h"
 #include "QuadRetopo.h"
@@ -621,6 +628,10 @@ void CLIPipeline::printUsage()
         "                                  Apply a built-in material preset to every sub-entity\n"
         "                                  (Plastic/Metal/Wood/Glass/Unlit/Wireframe + PBR templates:\n"
         "                                  Metallic-Roughness, Specular-Glossiness, Unlit PBR)\n"
+        "  material <file> --env <path-or-bundled-name> [--env-intensity N]\n"
+        "                  [--env-tint \"#rrggbb\"] [-o <output>]\n"
+        "                                  Load an HDRI environment + optional per-material IBL\n"
+        "                                  intensity/tint (writes .hdr-env.json + .material sidecar)\n"
         "  material --list-presets         List the built-in preset names\n"
         "  material <file> --generate-texture \"<prompt>\" [--model <name>]\n"
         "                  [--controlnet <path>] [--controlnet-strength <0..1>]\n"
@@ -3878,16 +3889,121 @@ int CLIPipeline::cmdIsometric(int argc, char* argv[])
     return 0;
 }
 
+namespace {
+
+bool parseEnvTintHex(const QString& hex, QColor& out)
+{
+    if (hex.isEmpty())
+        return false;
+    const QColor c(hex);
+    if (!c.isValid())
+        return false;
+    out = c;
+    return true;
+}
+
+void applyEnvParamsToEntityMaterials(const QList<Ogre::Entity*>& entities,
+                                     float intensity,
+                                     bool hasIntensity,
+                                     const QColor& tint,
+                                     bool hasTint)
+{
+    if (!hasIntensity && !hasTint)
+        return;
+
+    QSet<QString> touched;
+    for (auto* ent : entities) {
+        if (!ent)
+            continue;
+        for (unsigned short i = 0; i < ent->getNumSubEntities(); ++i) {
+            Ogre::SubEntity* sub = ent->getSubEntity(i);
+            Ogre::MaterialPtr mat = sub->getMaterial();
+            if (mat.isNull())
+                continue;
+            const QString matName = QString::fromStdString(mat->getName());
+            if (touched.contains(matName))
+                continue;
+            touched.insert(matName);
+            if (mat->getNumTechniques() == 0)
+                continue;
+            Ogre::Technique* tech = mat->getTechnique(0);
+            if (!tech || tech->getNumPasses() == 0)
+                continue;
+            RTShaderHelper::wirePbrSlotsForFFP(mat.get());
+            mat->compile(false);
+            mat->load();
+            if (mat->getNumTechniques() == 0 || mat->getTechnique(0)->getNumPasses() == 0)
+                continue;
+            Ogre::Pass* pass = mat->getTechnique(0)->getPass(0);
+            if (hasIntensity)
+                RTShaderHelper::setPbrEnvIntensity(pass, intensity);
+            if (hasTint) {
+                RTShaderHelper::setPbrEnvTint(
+                    pass, Ogre::ColourValue(tint.redF(), tint.greenF(), tint.blueF()));
+            }
+        }
+    }
+}
+
+QString serializeMaterialWithEnv(Ogre::MaterialPtr mat, float intensity, const QColor& tint)
+{
+    if (mat.isNull())
+        return {};
+    const std::string matName = mat->getName();
+    Ogre::MaterialSerializer ms;
+    ms.queueForExport(mat, false, false, matName);
+    QString text = QString::fromStdString(ms.getQueuedAsString());
+    return HdrMaterialScript::injectEnvironmentLines(text, intensity, tint);
+}
+
+bool writeTextFile(const QString& path, const QString& text)
+{
+    QFile f(path);
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Text))
+        return false;
+    f.write(text.toUtf8());
+    return true;
+}
+
+QString readTextFileOrEmpty(const QString& path)
+{
+    QFile f(path);
+    if (!f.open(QIODevice::ReadOnly | QIODevice::Text))
+        return {};
+    return QString::fromUtf8(f.readAll());
+}
+
+bool writeEnvironmentSidecar(const QFileInfo& outFi, const QString& envPath)
+{
+    if (envPath.isEmpty())
+        return true;
+    QJsonObject root;
+    root[QStringLiteral("environment")] = envPath;
+    QFile f(outFi.absoluteDir().filePath(outFi.completeBaseName() + QStringLiteral(".hdr-env.json")));
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate))
+        return false;
+    f.write(QJsonDocument(root).toJson(QJsonDocument::Indented));
+    return true;
+}
+
+} // namespace
+
 int CLIPipeline::cmdMaterial(int argc, char* argv[])
 {
     // Parse:
     //   material <file> --preset <name> [-o <output>]
+    //   material <file> --env <path-or-bundled-name> [--env-intensity N] [--env-tint "#rrggbb"]
     //   material <file> --generate-texture <prompt> [--model <name>]
     //                   [--controlnet <path>] [--controlnet-strength <0..1>]
     //                   [--width N] [--height N] [-o <output>]
     //   material <file> --list-presets
     //   material --list-presets
     QString inputPath, outputPath, presetName;
+    QString envName;
+    bool hasEnvIntensity = false;
+    float envIntensity = HdrMaterialScript::kDefaultEnvIntensity;
+    QString envTintHex;
+    bool hasEnvTint = false;
     QString genPrompt, sdModel, controlNetPath;
     double controlStrength = 0.9;
     int genWidth = 512, genHeight = 512;
@@ -3908,6 +4024,25 @@ int CLIPipeline::cmdMaterial(int argc, char* argv[])
         if (arg == "--list-presets") { listPresets = true; continue; }
         if (arg == "--preset" && i + 1 < argc) {
             presetName = QString(argv[++i]);
+            continue;
+        }
+        if (arg == "--env" && i + 1 < argc) {
+            envName = QString(argv[++i]);
+            continue;
+        }
+        if (arg == "--env-intensity" && i + 1 < argc) {
+            bool ok = false;
+            envIntensity = QString(argv[++i]).toFloat(&ok);
+            if (!ok) {
+                err() << "Error: --env-intensity must be a number." << Qt::endl;
+                return 2;
+            }
+            hasEnvIntensity = true;
+            continue;
+        }
+        if (arg == "--env-tint" && i + 1 < argc) {
+            envTintHex = QString(argv[++i]);
+            hasEnvTint = true;
             continue;
         }
         if (arg == "--generate-texture" && i + 1 < argc) {
@@ -4014,15 +4149,34 @@ int CLIPipeline::cmdMaterial(int argc, char* argv[])
         return 0;
     }
 
-    if (inputPath.isEmpty() || presetName.isEmpty()) {
+    const bool hasHdrMaterialOps = !envName.isEmpty() || hasEnvIntensity || hasEnvTint;
+
+    if (inputPath.isEmpty() || (presetName.isEmpty() && !hasHdrMaterialOps)) {
         err() << "Error: Missing required arguments." << Qt::endl;
         err() << "Usage: qtmesh material <file> --preset <name> [-o <output>]" << Qt::endl;
+        err() << "       qtmesh material <file> --env <path-or-name> [--env-intensity N]"
+                 " [--env-tint \"#rrggbb\"] [-o <output>]" << Qt::endl;
         err() << "       qtmesh material <file> --describe \"<description>\" [--model <name>] [-o <output>]" << Qt::endl;
         err() << "       qtmesh material --list-presets" << Qt::endl;
         return 2;
     }
 
-    if (!names.contains(presetName)) {
+    if (hasEnvIntensity
+        && (envIntensity < HdrMaterialScript::kMinEnvIntensity
+            || envIntensity > HdrMaterialScript::kMaxEnvIntensity)) {
+        err() << "Error: --env-intensity must be in ["
+              << HdrMaterialScript::kMinEnvIntensity << ", "
+              << HdrMaterialScript::kMaxEnvIntensity << "]." << Qt::endl;
+        return 2;
+    }
+
+    QColor envTint;
+    if (hasEnvTint && !parseEnvTintHex(envTintHex, envTint)) {
+        err() << "Error: Invalid --env-tint color (use #rrggbb or a QColor name)." << Qt::endl;
+        return 2;
+    }
+
+    if (!presetName.isEmpty() && !names.contains(presetName)) {
         err() << "Error: Unknown preset '" << presetName << "'." << Qt::endl;
         err() << "Available presets:" << Qt::endl;
         for (const QString& n : names)
@@ -4041,9 +4195,20 @@ int CLIPipeline::cmdMaterial(int argc, char* argv[])
 
     if (!initOgreHeadless()) return 1;
 
+    if (!envName.isEmpty()) {
+        auto* hdrMgr = HDREnvironmentManager::getSingletonPtr();
+        if (hdrMgr)
+            hdrMgr->setBackgroundIblPrecomputeEnabled(false);
+        if (!hdrMgr || !hdrMgr->loadEnvironment(envName)) {
+            err() << "Error: Failed to load environment '" << envName << "'." << Qt::endl;
+            return 1;
+        }
+    }
+
     SentryReporter::addBreadcrumb("cli.material",
-        QString("Apply preset '%1' to .%2 -> .%3")
-            .arg(presetName, fi.suffix(), outFi.suffix()));
+        QString("Apply %1 to .%2 -> .%3")
+            .arg(presetName.isEmpty() ? QStringLiteral("HDR env/material") : QStringLiteral("preset '%1'").arg(presetName),
+                  fi.suffix(), outFi.suffix()));
     SentryReporter::addBreadcrumb("file.import",
         QString("Importing file %1").arg(fi.absoluteFilePath()));
 
@@ -4074,7 +4239,35 @@ int CLIPipeline::cmdMaterial(int argc, char* argv[])
         return 1;
     }
 
-    lib->applyPreset(presetName);
+    if (!presetName.isEmpty())
+        lib->applyPreset(presetName);
+
+    auto* matMgr = Ogre::MaterialManager::getSingletonPtr();
+    if (!presetName.isEmpty() && matMgr && (hasEnvIntensity || hasEnvTint)) {
+        const std::string presetMatName = ("Preset/" + presetName).toStdString();
+        if (matMgr->resourceExists(presetMatName)) {
+            Ogre::MaterialPtr presetMat = matMgr->getByName(presetMatName);
+            if (!presetMat.isNull() && presetMat->getNumTechniques() > 0
+                && presetMat->getTechnique(0)->getNumPasses() > 0) {
+                RTShaderHelper::wirePbrSlotsForFFP(presetMat.get());
+                presetMat->compile(false);
+                presetMat->load();
+                if (presetMat->getNumTechniques() > 0
+                    && presetMat->getTechnique(0)->getNumPasses() > 0) {
+                    Ogre::Pass* pass = presetMat->getTechnique(0)->getPass(0);
+                    if (hasEnvIntensity)
+                        RTShaderHelper::setPbrEnvIntensity(pass, envIntensity);
+                    if (hasEnvTint) {
+                        RTShaderHelper::setPbrEnvTint(
+                            pass,
+                            Ogre::ColourValue(envTint.redF(), envTint.greenF(), envTint.blueF()));
+                    }
+                }
+            }
+        }
+    } else if (hasEnvIntensity || hasEnvTint) {
+        applyEnvParamsToEntityMaterials(entities, envIntensity, hasEnvIntensity, envTint, hasEnvTint);
+    }
 
     Ogre::Entity* entity = entities.first();
     Ogre::SceneNode* node = entity->getParentSceneNode();
@@ -4092,44 +4285,103 @@ int CLIPipeline::cmdMaterial(int argc, char* argv[])
     }
 
     // Write a sidecar .material file alongside the output mesh so that
-    // engines/tools that expect Ogre material scripts can pick up the preset.
-    // Sidecar generation is part of the core feature contract — failures
-    // here propagate as a non-zero exit code, not silent success.
-    const std::string matName = ("Preset/" + presetName).toStdString();
-    auto matMgr = Ogre::MaterialManager::getSingletonPtr();
-    if (!matMgr || !matMgr->resourceExists(matName)) {
-        err() << "Error: Material resource not found for sidecar export: "
-              << QString::fromStdString(matName) << Qt::endl;
-        return 1;
-    }
-    Ogre::MaterialPtr mat = matMgr->getByName(matName);
-    if (!mat) {
-        err() << "Error: Failed to resolve material for sidecar export: "
-              << QString::fromStdString(matName) << Qt::endl;
-        return 1;
-    }
-    Ogre::MaterialSerializer ms;
-    ms.queueForExport(mat, false, false, matName);
-    const QString matText = QString::fromStdString(ms.getQueuedAsString());
+    // engines/tools that expect Ogre material scripts can pick up the preset
+    // or per-material IBL tuning. Sidecar generation is part of the core
+    // feature contract — failures here propagate as a non-zero exit code.
+    if (!presetName.isEmpty()) {
+        const std::string matName = ("Preset/" + presetName).toStdString();
+        if (!matMgr || !matMgr->resourceExists(matName)) {
+            err() << "Error: Material resource not found for sidecar export: "
+                  << QString::fromStdString(matName) << Qt::endl;
+            return 1;
+        }
+        Ogre::MaterialPtr mat = matMgr->getByName(matName);
+        if (!mat) {
+            err() << "Error: Failed to resolve material for sidecar export: "
+                  << QString::fromStdString(matName) << Qt::endl;
+            return 1;
+        }
+        Ogre::Pass* pass = mat->getTechnique(0)->getPass(0);
+        const Ogre::ColourValue tintCv = RTShaderHelper::pbrEnvTint(pass);
+        const QColor sidecarTint = QColor::fromRgbF(tintCv.r, tintCv.g, tintCv.b);
+        const QString matText =
+            serializeMaterialWithEnv(mat, RTShaderHelper::pbrEnvIntensity(pass), sidecarTint);
 
-    const QString sidecarPath = QDir(outFi.absolutePath())
-        .filePath(outFi.completeBaseName() + ".material");
-    QFile matFile(sidecarPath);
-    if (!matFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
-        err() << "Error: Failed to write material sidecar: " << sidecarPath << Qt::endl;
-        return 1;
+        const QString sidecarPath = QDir(outFi.absolutePath())
+            .filePath(outFi.completeBaseName() + ".material");
+        if (!writeTextFile(sidecarPath, matText)) {
+            err() << "Error: Failed to write material sidecar: " << sidecarPath << Qt::endl;
+            return 1;
+        }
+        SentryReporter::addBreadcrumb("file.export",
+            QString("Wrote material sidecar %1").arg(sidecarPath));
+    } else if (hasEnvIntensity || hasEnvTint) {
+        const QString sidecarPath =
+            outFi.absoluteDir().filePath(outFi.completeBaseName() + QStringLiteral(".material"));
+        QString script;
+        if (QFile::exists(sidecarPath))
+            script = readTextFileOrEmpty(sidecarPath);
+        if (script.trimmed().isEmpty()) {
+            for (auto* ent : entities) {
+                if (!ent)
+                    continue;
+                for (unsigned short i = 0; i < ent->getNumSubEntities(); ++i) {
+                    Ogre::MaterialPtr mat = ent->getSubEntity(i)->getMaterial();
+                    if (!mat)
+                        continue;
+                    script += serializeMaterialWithEnv(
+                        mat,
+                        hasEnvIntensity ? envIntensity : HdrMaterialScript::kDefaultEnvIntensity,
+                        hasEnvTint ? envTint : QColor::fromRgbF(1., 1., 1.));
+                    script += QLatin1Char('\n');
+                }
+            }
+        } else {
+            script = HdrMaterialScript::injectEnvironmentLines(
+                script,
+                hasEnvIntensity ? envIntensity : HdrMaterialScript::kDefaultEnvIntensity,
+                hasEnvTint ? envTint : QColor::fromRgbF(1., 1., 1.));
+        }
+        if (script.trimmed().isEmpty()) {
+            err() << "Error: No material sidecar content to update." << Qt::endl;
+            return 1;
+        }
+        if (!writeTextFile(sidecarPath, script)) {
+            err() << "Error: Failed to write material sidecar: " << sidecarPath << Qt::endl;
+            return 1;
+        }
+        SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
+                                      QStringLiteral("Wrote material sidecar %1").arg(sidecarPath));
     }
-    matFile.write(matText.toUtf8());
-    matFile.close();
-    SentryReporter::addBreadcrumb("file.export",
-        QString("Wrote material sidecar %1").arg(sidecarPath));
 
-    cliWrite(QString("Applied preset '%1' to %2 (%3 entit%4). Saved: %5\n")
-        .arg(presetName)
-        .arg(fi.fileName())
-        .arg(selectedEntityCount)
-        .arg(selectedEntityCount == 1 ? "y" : "ies")
-        .arg(outFi.fileName()));
+    if (!envName.isEmpty()) {
+        if (!writeEnvironmentSidecar(
+                outFi, HDREnvironmentManager::getSingletonPtr()->currentEnvironment())) {
+            err() << "Error: Failed to write HDR environment sidecar." << Qt::endl;
+            return 1;
+        }
+    }
+
+    QString summary;
+    if (!presetName.isEmpty()) {
+        summary = QString("Applied preset '%1' to %2 (%3 entit%4). Saved: %5\n")
+                      .arg(presetName)
+                      .arg(fi.fileName())
+                      .arg(selectedEntityCount)
+                      .arg(selectedEntityCount == 1 ? "y" : "ies")
+                      .arg(outFi.fileName());
+    } else {
+        summary = QString("Applied HDR material settings to %1 (%2 entit%3). Saved: %4\n")
+                      .arg(fi.fileName())
+                      .arg(selectedEntityCount)
+                      .arg(selectedEntityCount == 1 ? "y" : "ies")
+                      .arg(outFi.fileName());
+    }
+    if (!envName.isEmpty()) {
+        summary += QString("Environment: %1\n")
+                       .arg(HDREnvironmentManager::getSingletonPtr()->currentEnvironment());
+    }
+    cliWrite(summary);
 
     return 0;
 }

--- a/src/CLIPipeline_cmdmaterial_hdr_test.cpp
+++ b/src/CLIPipeline_cmdmaterial_hdr_test.cpp
@@ -1,0 +1,164 @@
+#include <gtest/gtest.h>
+
+#include "CLIPipeline.h"
+#include "HDR/HdrMaterialScript.h"
+#include "SelectionSet.h"
+#include "TestHelpers.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QTemporaryDir>
+#include <vector>
+
+#include "HDR/HdrBundledLibrary.h"
+
+namespace {
+
+class ArgvBuilder {
+public:
+    explicit ArgvBuilder(const QStringList& parts)
+    {
+        m_storage.reserve(static_cast<size_t>(parts.size()));
+        m_argv.reserve(static_cast<size_t>(parts.size() + 1));
+        for (const QString& p : parts) {
+            m_storage.push_back(p.toUtf8());
+            m_argv.push_back(m_storage.back().data());
+        }
+        m_argv.push_back(nullptr);
+        m_argc = static_cast<int>(parts.size());
+    }
+
+    int argc() const { return m_argc; }
+    char** argv() { return m_argv.data(); }
+
+private:
+    std::vector<QByteArray> m_storage;
+    std::vector<char*> m_argv;
+    int m_argc = 0;
+};
+
+class CLIPipelineCmdMaterialHdrTest : public ::testing::Test {
+protected:
+    void SetUp() override
+    {
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+        ASSERT_TRUE(canLoadMeshFiles()) << "Ogre plugins/codecs not available";
+        createStandardOgreMaterials();
+        if (auto* sel = SelectionSet::getSingletonPtr())
+            sel->clear();
+    }
+
+    void TearDown() override
+    {
+        if (auto* sel = SelectionSet::getSingletonPtr())
+            sel->clear();
+    }
+
+    QString copyRobotInto(QTemporaryDir& dir)
+    {
+        const QString fixture = testRobotMeshPath();
+        if (fixture.isEmpty() || !QFile::exists(fixture))
+            return QString();
+        const QString dst = dir.filePath(QStringLiteral("robot.mesh"));
+        QFile::remove(dst);
+        if (!QFile::copy(fixture, dst))
+            return QString();
+
+        const QString skelFixture =
+            QFileInfo(fixture).absolutePath() + QStringLiteral("/robot.skeleton");
+        if (QFile::exists(skelFixture)) {
+            const QString skelDst = dir.filePath(QStringLiteral("robot.skeleton"));
+            QFile::remove(skelDst);
+            QFile::copy(skelFixture, skelDst);
+        }
+        return dst;
+    }
+};
+
+} // namespace
+
+TEST_F(CLIPipelineCmdMaterialHdrTest, EnvIntensityOnlyWritesMaterialSidecar)
+{
+    QTemporaryDir src;
+    ASSERT_TRUE(src.isValid());
+    const QString mesh = copyRobotInto(src);
+    ASSERT_FALSE(mesh.isEmpty()) << "robot.mesh fixture unavailable";
+
+    QTemporaryDir out;
+    ASSERT_TRUE(out.isValid());
+    const QString outMesh = out.filePath(QStringLiteral("hdr_out.mesh"));
+
+    ArgvBuilder args({QStringLiteral("qtmesh"), QStringLiteral("material"), mesh,
+                      QStringLiteral("--env-intensity"), QStringLiteral("1.5"),
+                      QStringLiteral("-o"), outMesh});
+    EXPECT_EQ(CLIPipeline::cmdMaterial(args.argc(), args.argv()), 0);
+
+    EXPECT_TRUE(QFile::exists(outMesh));
+    const QString sidecar = out.filePath(QStringLiteral("hdr_out.material"));
+    ASSERT_TRUE(QFile::exists(sidecar));
+    EXPECT_GT(QFileInfo(sidecar).size(), 0);
+    QFile sidecarFile(sidecar);
+    ASSERT_TRUE(sidecarFile.open(QIODevice::ReadOnly | QIODevice::Text));
+    const QString matText = QString::fromUtf8(sidecarFile.readAll());
+    EXPECT_TRUE(matText.contains(QStringLiteral("pbr_environment_intensity")))
+        << matText.toStdString();
+}
+
+TEST_F(CLIPipelineCmdMaterialHdrTest, InvalidEnvTintReturnsUsageError)
+{
+    QTemporaryDir src;
+    ASSERT_TRUE(src.isValid());
+    const QString mesh = copyRobotInto(src);
+    ASSERT_FALSE(mesh.isEmpty());
+
+    ArgvBuilder args({QStringLiteral("qtmesh"), QStringLiteral("material"), mesh,
+                      QStringLiteral("--env-tint"), QStringLiteral("not-a-color"),
+                      QStringLiteral("-o"), src.filePath(QStringLiteral("out.mesh"))});
+    EXPECT_EQ(CLIPipeline::cmdMaterial(args.argc(), args.argv()), 2);
+}
+
+TEST_F(CLIPipelineCmdMaterialHdrTest, EnvIntensityOutOfRangeReturnsUsageError)
+{
+    QTemporaryDir src;
+    ASSERT_TRUE(src.isValid());
+    const QString mesh = copyRobotInto(src);
+    ASSERT_FALSE(mesh.isEmpty());
+
+    ArgvBuilder args({QStringLiteral("qtmesh"), QStringLiteral("material"), mesh,
+                      QStringLiteral("--env-intensity"),
+                      QString::number(HdrMaterialScript::kMaxEnvIntensity + 1.f),
+                      QStringLiteral("-o"), src.filePath(QStringLiteral("out.mesh"))});
+    EXPECT_EQ(CLIPipeline::cmdMaterial(args.argc(), args.argv()), 2);
+}
+
+TEST_F(CLIPipelineCmdMaterialHdrTest, LoadEnvWritesHdrEnvSidecar)
+{
+    const QString envName = QStringLiteral("flat_grey.hdr");
+    if (HdrBundledLibrary::resolveHdriPath(envName).isEmpty())
+        GTEST_SKIP() << "flat_grey.hdr not available in this build tree";
+
+    QTemporaryDir src;
+    ASSERT_TRUE(src.isValid());
+    const QString mesh = copyRobotInto(src);
+    ASSERT_FALSE(mesh.isEmpty());
+
+    QTemporaryDir out;
+    ASSERT_TRUE(out.isValid());
+    const QString outMesh = out.filePath(QStringLiteral("env_out.mesh"));
+
+    ArgvBuilder args({QStringLiteral("qtmesh"), QStringLiteral("material"), mesh,
+                      QStringLiteral("--env"), envName,
+                      QStringLiteral("-o"), outMesh});
+    EXPECT_EQ(CLIPipeline::cmdMaterial(args.argc(), args.argv()), 0);
+
+    const QString envSidecar = out.filePath(QStringLiteral("env_out.hdr-env.json"));
+    ASSERT_TRUE(QFile::exists(envSidecar));
+    QFile envFile(envSidecar);
+    ASSERT_TRUE(envFile.open(QIODevice::ReadOnly | QIODevice::Text));
+    const QString envJson = QString::fromUtf8(envFile.readAll());
+    EXPECT_FALSE(envJson.isEmpty()) << envSidecar.toStdString();
+    EXPECT_TRUE(envJson.contains(QStringLiteral("flat_grey"))
+                || envJson.contains(QStringLiteral("environment")))
+        << envJson.toStdString();
+}

--- a/src/HDR/HDREnvironmentManager.h
+++ b/src/HDR/HDREnvironmentManager.h
@@ -131,7 +131,7 @@ private:
     TonemapOperator m_tonemapOperator = TonemapOperator::ACES;
     float m_exposureEv = 0.f;
     float m_whitePoint = 1.f;
-    bool m_defaultSkyBoxVisible = true;
+    bool m_defaultSkyBoxVisible = false;
     float m_backgroundBlur = 0.f;
     bool m_skyBoxInstalled = false;
 

--- a/src/HDR/HdrEnvironmentController.cpp
+++ b/src/HDR/HdrEnvironmentController.cpp
@@ -256,7 +256,7 @@ bool HdrEnvironmentController::defaultSkyBoxVisible() const
 {
     if (auto* hdrMgr = HDREnvironmentManager::getSingletonPtr())
         return hdrMgr->defaultSkyBoxVisible();
-    return true;
+    return false;
 }
 
 void HdrEnvironmentController::setDefaultSkyBoxVisible(bool visible)

--- a/src/HDR/HdrViewportController.cpp
+++ b/src/HDR/HdrViewportController.cpp
@@ -76,7 +76,7 @@ void HdrViewportController::tickViewport(OgreWidget* widget)
 void HdrViewportController::syncAllSkyBoxesFromDefault()
 {
     auto* hdrMgr = HDREnvironmentManager::getSingletonPtr();
-    const bool visible = hdrMgr ? hdrMgr->defaultSkyBoxVisible() : true;
+    const bool visible = hdrMgr ? hdrMgr->defaultSkyBoxVisible() : false;
 
     if (auto* mgr = Manager::getSingletonPtr(); hdrMgr && mgr && mgr->getSceneMgr()
         && hdrMgr->hasEnvironment()) {

--- a/src/HDR/HdrViewportPipeline.h
+++ b/src/HDR/HdrViewportPipeline.h
@@ -41,6 +41,6 @@ private:
     Ogre::CompositorInstance* m_compositor = nullptr;
     QString m_compositorName;
     QString m_tonemapMaterialName;
-    bool m_skyBoxVisible = true;
+    bool m_skyBoxVisible = false;
     bool m_enabled = false;
 };

--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -50,8 +50,11 @@
 #ifdef ENABLE_ONNX
 #include "AIAssistManager.h"
 #include "PbrMapSynth.h"
-#include "RTShaderHelper.h"
 #endif
+#include "HDR/HDREnvironmentManager.h"
+#include "HDR/HdrEnvironmentController.h"
+#include "HDR/HdrTonemap.h"
+#include "RTShaderHelper.h"
 #include <QEventLoop>
 #include <QDebug>
 #include <QFile>
@@ -66,6 +69,7 @@
 #include <QMetaObject>
 #include <QPixmap>
 #include <QSet>
+#include <optional>
 #include <OgreException.h>
 #include <OgreMaterialManager.h>
 #include <OgreMaterial.h>
@@ -576,6 +580,11 @@ const QMap<QString, MCPServer::ToolHandler>& MCPServer::toolHandlers()
         {QStringLiteral("apply_material"), &MCPServer::toolApplyMaterial},
         {QStringLiteral("list_material_presets"), &MCPServer::toolListMaterialPresets},
         {QStringLiteral("apply_material_preset"), &MCPServer::toolApplyMaterialPreset},
+        {QStringLiteral("set_hdr_environment"), &MCPServer::toolSetHdrEnvironment},
+        {QStringLiteral("get_hdr_environment"), &MCPServer::toolGetHdrEnvironment},
+        {QStringLiteral("set_tonemap"), &MCPServer::toolSetTonemap},
+        {QStringLiteral("set_env_intensity"), &MCPServer::toolSetEnvIntensity},
+        {QStringLiteral("set_env_tint"), &MCPServer::toolSetEnvTint},
         {QStringLiteral("describe_material"), &MCPServer::toolDescribeMaterial},
         {QStringLiteral("load_mesh"), &MCPServer::toolLoadMesh},
         {QStringLiteral("get_mesh_info"), &MCPServer::toolGetMeshInfo},
@@ -1143,6 +1152,203 @@ QJsonObject MCPServer::toolApplyMaterialPreset(const QJsonObject &args)
         return makeSuccessResult(QString("Applied preset '%1'").arg(preset));
     } catch (Ogre::Exception& e) {
         return makeErrorResult(QString("Ogre error: %1").arg(QString::fromStdString(e.getFullDescription())));
+    }
+}
+
+namespace {
+
+QString hdrTonemapOperatorSlug(HdrTonemap::Operator op)
+{
+    switch (op) {
+    case HdrTonemap::Operator::Reinhard:
+        return QStringLiteral("reinhard");
+    case HdrTonemap::Operator::AgX:
+        return QStringLiteral("agx");
+    case HdrTonemap::Operator::ACES:
+    default:
+        return QStringLiteral("aces");
+    }
+}
+
+std::optional<HdrTonemap::Operator> parseHdrTonemapOperator(const QString& raw)
+{
+    const QString t = raw.trimmed().toLower();
+    if (t.isEmpty())
+        return std::nullopt;
+    if (t == QStringLiteral("reinhard"))
+        return HdrTonemap::Operator::Reinhard;
+    if (t == QStringLiteral("agx"))
+        return HdrTonemap::Operator::AgX;
+    if (t == QStringLiteral("aces"))
+        return HdrTonemap::Operator::ACES;
+    return std::nullopt;
+}
+
+bool parseHexTint(const QString& raw, QColor& out)
+{
+    const QColor c(raw);
+    if (!c.isValid())
+        return false;
+    out = c;
+    return true;
+}
+
+} // namespace
+
+QJsonObject MCPServer::toolSetHdrEnvironment(const QJsonObject &args)
+{
+    QString path = args[QStringLiteral("path_or_name")].toString();
+    if (path.isEmpty()) path = args[QStringLiteral("path")].toString();
+    if (path.isEmpty()) path = args[QStringLiteral("name")].toString();
+    if (path.isEmpty())
+        return makeErrorResult(QStringLiteral("Error: 'path_or_name' is required"));
+
+    auto* ctrl = HdrEnvironmentController::instance();
+    if (!ctrl->loadEnvironment(path))
+        return makeErrorResult(QStringLiteral("Error: Failed to load environment '%1'").arg(path));
+
+    if (auto* hdrMgr = HDREnvironmentManager::getSingletonPtr()) {
+        return makeSuccessResult(QStringLiteral("Loaded HDR environment: %1")
+                                     .arg(hdrMgr->currentEnvironment()));
+    }
+    return makeSuccessResult(QStringLiteral("Loaded HDR environment: %1").arg(path));
+}
+
+QJsonObject MCPServer::toolGetHdrEnvironment(const QJsonObject &)
+{
+    auto* hdrMgr = HDREnvironmentManager::getSingletonPtr();
+    if (!hdrMgr)
+        return makeErrorResult(QStringLiteral("Error: HDREnvironmentManager not available"));
+
+    QJsonObject root;
+    root[QStringLiteral("environment")] = hdrMgr->currentEnvironment();
+    root[QStringLiteral("cache_key")] = hdrMgr->currentCacheKey();
+    root[QStringLiteral("ibl_ready")] = hdrMgr->isIblReady();
+    root[QStringLiteral("has_environment")] = hdrMgr->hasEnvironment();
+
+    QJsonObject tonemap;
+    tonemap[QStringLiteral("operator")] = hdrTonemapOperatorSlug(hdrMgr->tonemapOperator());
+    tonemap[QStringLiteral("exposure_ev")] = hdrMgr->exposureEv();
+    tonemap[QStringLiteral("white_point")] = hdrMgr->whitePoint();
+    root[QStringLiteral("tonemap")] = tonemap;
+    root[QStringLiteral("skybox_visible")] = hdrMgr->defaultSkyBoxVisible();
+    root[QStringLiteral("background_blur")] = hdrMgr->backgroundBlur();
+
+    return makeSuccessResult(QString::fromUtf8(QJsonDocument(root).toJson(QJsonDocument::Indented)));
+}
+
+QJsonObject MCPServer::toolSetTonemap(const QJsonObject &args)
+{
+    auto* ctrl = HdrEnvironmentController::instance();
+    auto* hdrMgr = HDREnvironmentManager::getSingletonPtr();
+    if (!hdrMgr || !ctrl)
+        return makeErrorResult(QStringLiteral("Error: HDREnvironmentManager not available"));
+
+    QString opStr = args[QStringLiteral("operator")].toString();
+    if (opStr.isEmpty())
+        opStr = args[QStringLiteral("tonemap")].toString();
+
+    QStringList changes;
+    if (!opStr.isEmpty()) {
+        const auto parsed = parseHdrTonemapOperator(opStr);
+        if (!parsed)
+            return makeErrorResult(QStringLiteral("Error: Unknown tonemap operator '%1' (use aces, reinhard, or agx)").arg(opStr));
+        ctrl->setTonemapOperator(static_cast<int>(*parsed));
+        changes << QStringLiteral("operator=%1").arg(hdrTonemapOperatorSlug(*parsed));
+    }
+    if (args.contains(QStringLiteral("exposure")) || args.contains(QStringLiteral("exposure_ev"))) {
+        const float exposure = static_cast<float>(
+            args.contains(QStringLiteral("exposure"))
+                ? args[QStringLiteral("exposure")].toDouble()
+                : args[QStringLiteral("exposure_ev")].toDouble());
+        ctrl->setExposureEv(exposure);
+        changes << QStringLiteral("exposure_ev=%1").arg(exposure);
+    }
+    if (args.contains(QStringLiteral("white_point"))) {
+        const float whitePoint = static_cast<float>(args[QStringLiteral("white_point")].toDouble());
+        ctrl->setWhitePoint(whitePoint);
+        changes << QStringLiteral("white_point=%1").arg(whitePoint);
+    }
+
+    if (changes.isEmpty())
+        return makeErrorResult(QStringLiteral("Error: Provide operator and/or exposure and/or white_point"));
+
+    return makeSuccessResult(QStringLiteral("Updated tonemap: %1").arg(changes.join(QStringLiteral(", "))));
+}
+
+QJsonObject MCPServer::toolSetEnvIntensity(const QJsonObject &args)
+{
+    QString name = args[QStringLiteral("material")].toString();
+    if (name.isEmpty()) name = args[QStringLiteral("name")].toString();
+    if (name.isEmpty())
+        return makeErrorResult(QStringLiteral("Error: 'material' is required"));
+
+    if (!args.contains(QStringLiteral("value")) && !args.contains(QStringLiteral("intensity")))
+        return makeErrorResult(QStringLiteral("Error: 'value' (or 'intensity') is required"));
+
+    const float intensity = static_cast<float>(args.contains(QStringLiteral("value"))
+                                                   ? args[QStringLiteral("value")].toDouble()
+                                                   : args[QStringLiteral("intensity")].toDouble());
+
+    try {
+        Ogre::MaterialPtr material =
+            Ogre::MaterialManager::getSingleton().getByName(name.toStdString());
+        if (!material)
+            return makeErrorResult(QStringLiteral("Error: Material '%1' not found").arg(name));
+        if (material->getNumTechniques() == 0 || material->getTechnique(0)->getNumPasses() == 0)
+            return makeErrorResult(QStringLiteral("Error: Material '%1' has no passes").arg(name));
+
+        Ogre::Pass* pass = material->getTechnique(0)->getPass(0);
+        RTShaderHelper::setPbrEnvIntensity(pass, intensity);
+        RTShaderHelper::wirePbrSlotsForFFP(material.get());
+        material->compile(false);
+        material->load();
+
+        SentryReporter::addBreadcrumb(QStringLiteral("ai.tool_call"),
+                                      QStringLiteral("set_env_intensity %1=%2").arg(name).arg(intensity));
+        return makeSuccessResult(QStringLiteral("Set env intensity on '%1' to %2").arg(name).arg(intensity));
+    } catch (const Ogre::Exception& e) {
+        return makeErrorResult(QStringLiteral("Ogre error: %1")
+                                   .arg(QString::fromStdString(e.getFullDescription())));
+    }
+}
+
+QJsonObject MCPServer::toolSetEnvTint(const QJsonObject &args)
+{
+    QString name = args[QStringLiteral("material")].toString();
+    if (name.isEmpty()) name = args[QStringLiteral("name")].toString();
+    if (name.isEmpty())
+        return makeErrorResult(QStringLiteral("Error: 'material' is required"));
+
+    const QString hex = args[QStringLiteral("hex")].toString();
+    if (hex.isEmpty())
+        return makeErrorResult(QStringLiteral("Error: 'hex' is required (e.g. #fff5e6)"));
+
+    QColor tint;
+    if (!parseHexTint(hex, tint))
+        return makeErrorResult(QStringLiteral("Error: Invalid hex color '%1'").arg(hex));
+
+    try {
+        Ogre::MaterialPtr material =
+            Ogre::MaterialManager::getSingleton().getByName(name.toStdString());
+        if (!material)
+            return makeErrorResult(QStringLiteral("Error: Material '%1' not found").arg(name));
+        if (material->getNumTechniques() == 0 || material->getTechnique(0)->getNumPasses() == 0)
+            return makeErrorResult(QStringLiteral("Error: Material '%1' has no passes").arg(name));
+
+        Ogre::Pass* pass = material->getTechnique(0)->getPass(0);
+        RTShaderHelper::setPbrEnvTint(
+            pass, Ogre::ColourValue(tint.redF(), tint.greenF(), tint.blueF()));
+        RTShaderHelper::wirePbrSlotsForFFP(material.get());
+        material->compile(false);
+        material->load();
+
+        SentryReporter::addBreadcrumb(QStringLiteral("ai.tool_call"),
+                                      QStringLiteral("set_env_tint %1=%2").arg(name, hex));
+        return makeSuccessResult(QStringLiteral("Set env tint on '%1' to %2").arg(name, hex));
+    } catch (const Ogre::Exception& e) {
+        return makeErrorResult(QStringLiteral("Ogre error: %1")
+                                   .arg(QString::fromStdString(e.getFullDescription())));
     }
 }
 
@@ -6317,6 +6523,75 @@ QJsonArray MCPServer::buildToolsList()
             "Apply a built-in material preset to a mesh. PBR templates (Metallic-Roughness / Specular-Glossiness / Unlit PBR) create the canonical 6-slot texture-unit layout (albedo / normal_map / metallic / roughness / ao / emissive) and tag the pass with a 'pbr_workflow' user binding so PBR-aware shaders can detect intent.",
             inputSchema
         ));
+    }
+
+    // set_hdr_environment
+  {
+        QJsonObject properties;
+        properties["path_or_name"] = QJsonObject{
+            {"type", "string"},
+            {"description", "Absolute path or bundled HDRI name (e.g. studio_neutral or studio_neutral.hdr)"}};
+        appendTool(
+            "set_hdr_environment",
+            "Load a global HDR environment for image-based lighting (IBL). Mirrors the Inspector Environment picker.",
+            properties,
+            QJsonArray{"path_or_name"});
+    }
+
+    // get_hdr_environment
+    appendTool(
+        "get_hdr_environment",
+        "Return the active HDR environment path, IBL readiness, tonemap settings, and skybox defaults as JSON.",
+        QJsonObject());
+
+    // set_tonemap
+    {
+        QJsonObject properties;
+        properties["operator"] = QJsonObject{
+            {"type", "string"},
+            {"description", "Tonemap operator: aces (default), reinhard, or agx"}};
+        properties["exposure"] = QJsonObject{
+            {"type", "number"},
+            {"description", "Exposure in EV stops (alias: exposure_ev)"}};
+        properties["white_point"] = QJsonObject{
+            {"type", "number"},
+            {"description", "Reinhard white point (ignored for ACES/AgX)"}};
+        appendTool(
+            "set_tonemap",
+            "Set global viewport tonemap operator, exposure, and optional Reinhard white point.",
+            properties);
+    }
+
+    // set_env_intensity
+    {
+        QJsonObject properties;
+        properties["material"] = QJsonObject{
+            {"type", "string"},
+            {"description", "Ogre material name (use list_materials)"}};
+        properties["value"] = QJsonObject{
+            {"type", "number"},
+            {"description", "IBL environment intensity multiplier (0..4, alias: intensity)"}};
+        appendTool(
+            "set_env_intensity",
+            "Set per-material IBL environment intensity (pbr_environment_intensity).",
+            properties,
+            QJsonArray{"material", "value"});
+    }
+
+    // set_env_tint
+    {
+        QJsonObject properties;
+        properties["material"] = QJsonObject{
+            {"type", "string"},
+            {"description", "Ogre material name (use list_materials)"}};
+        properties["hex"] = QJsonObject{
+            {"type", "string"},
+            {"description", "Environment tint as #rrggbb (e.g. #fff5e6)"}};
+        appendTool(
+            "set_env_tint",
+            "Set per-material IBL environment tint (pbr_environment_tint).",
+            properties,
+            QJsonArray{"material", "hex"});
     }
 
     // describe_material (#406)

--- a/src/MCPServer.h
+++ b/src/MCPServer.h
@@ -133,6 +133,11 @@ private:
     QJsonObject toolApplyMaterial(const QJsonObject &args);
     QJsonObject toolListMaterialPresets(const QJsonObject &args);
     QJsonObject toolApplyMaterialPreset(const QJsonObject &args);
+    QJsonObject toolSetHdrEnvironment(const QJsonObject &args);
+    QJsonObject toolGetHdrEnvironment(const QJsonObject &args);
+    QJsonObject toolSetTonemap(const QJsonObject &args);
+    QJsonObject toolSetEnvIntensity(const QJsonObject &args);
+    QJsonObject toolSetEnvTint(const QJsonObject &args);
     /// #406: LLM-assisted material from a natural-language description. Drives
     /// the local LLM synchronously and binds the generated material to the
     /// target/selected mesh. Errors gracefully when no model is loaded.

--- a/src/MCPServer_test.cpp
+++ b/src/MCPServer_test.cpp
@@ -5604,6 +5604,68 @@ TEST_F(MCPServerTest, ListMaterialPresets_AppearsInToolList)
 }
 
 // ==========================================================================
+// HDR / IBL MCP tools (#473)
+// ==========================================================================
+
+TEST_F(MCPServerTest, GetHdrEnvironment_ReturnsJson)
+{
+    QJsonObject result = server->callTool("get_hdr_environment", QJsonObject());
+    EXPECT_FALSE(isError(result));
+    const QString text = getResultText(result);
+    EXPECT_TRUE(text.contains(QStringLiteral("tonemap")));
+    EXPECT_TRUE(text.contains(QStringLiteral("environment")));
+}
+
+TEST_F(MCPServerTest, SetTonemap_AcesExposure)
+{
+    QJsonObject args;
+    args[QStringLiteral("operator")] = QStringLiteral("aces");
+    args[QStringLiteral("exposure")] = 0.5;
+    QJsonObject result = server->callTool("set_tonemap", args);
+    EXPECT_FALSE(isError(result));
+    EXPECT_TRUE(getResultText(result).contains(QStringLiteral("exposure_ev=0.5")));
+}
+
+TEST_F(MCPServerTest, SetEnvIntensity_OnCreatedMaterial)
+{
+    QJsonObject createArgs{{QStringLiteral("name"), QStringLiteral("HdrEnvTestMat")}};
+    ASSERT_FALSE(isError(server->callTool("create_material", createArgs)));
+
+    QJsonObject args;
+    args[QStringLiteral("material")] = QStringLiteral("HdrEnvTestMat");
+    args[QStringLiteral("value")] = 2.0;
+    QJsonObject result = server->callTool("set_env_intensity", args);
+    EXPECT_FALSE(isError(result));
+    EXPECT_TRUE(getResultText(result).contains(QStringLiteral("2")));
+}
+
+TEST_F(MCPServerTest, SetEnvTint_OnCreatedMaterial)
+{
+    QJsonObject createArgs{{QStringLiteral("name"), QStringLiteral("HdrTintTestMat")}};
+    ASSERT_FALSE(isError(server->callTool("create_material", createArgs)));
+
+    QJsonObject args;
+    args[QStringLiteral("material")] = QStringLiteral("HdrTintTestMat");
+    args[QStringLiteral("hex")] = QStringLiteral("#fff5e6");
+    QJsonObject result = server->callTool("set_env_tint", args);
+    EXPECT_FALSE(isError(result));
+    EXPECT_TRUE(getResultText(result).contains(QStringLiteral("#fff5e6")));
+}
+
+TEST_F(MCPServerTest, HdrTools_AppearInToolList)
+{
+    QJsonArray tools = server->buildToolsList();
+    QStringList names;
+    for (const auto& t : tools)
+        names << t.toObject()[QStringLiteral("name")].toString();
+    EXPECT_TRUE(names.contains(QStringLiteral("set_hdr_environment")));
+    EXPECT_TRUE(names.contains(QStringLiteral("get_hdr_environment")));
+    EXPECT_TRUE(names.contains(QStringLiteral("set_tonemap")));
+    EXPECT_TRUE(names.contains(QStringLiteral("set_env_intensity")));
+    EXPECT_TRUE(names.contains(QStringLiteral("set_env_tint")));
+}
+
+// ==========================================================================
 // NEW COVERAGE: apply_material_preset tool
 // ==========================================================================
 


### PR DESCRIPTION
## Summary
- Adds `qtmesh material --env`, `--env-intensity`, and `--env-tint` with `.material` and `.hdr-env.json` sidecar output for headless IBL tuning
- Adds MCP tools: `set_hdr_environment`, `get_hdr_environment`, `set_tonemap`, `set_env_intensity`, `set_env_tint`
- Defaults the HDR viewport skybox to hidden until the user enables it
- Documents HDR/IBL CLI usage in `CLAUDE.md` and updates `README.md`

Closes #473

## Test plan
- [x] `UnitTests --gtest_filter=CLIPipelineCmdMaterialHdrTest.*` (4/4 pass)
- [x] `UnitTests --gtest_filter=MCPServerTest.*Hdr*` (2/2 pass)
- [ ] CI Linux build + unit tests
- [ ] Manual: `qtmesh material robot.mesh --env flat_grey.hdr --env-intensity 1.5 -o out.mesh` writes sidecars


Made with [Cursor](https://cursor.com)