### PR TITLE
fix: PBR generation renders the surface too dark (roughness/metallic FFP wiring)

### DIFF
--- a/src/ImageTo3D/MeshGenBuilder.cpp
+++ b/src/ImageTo3D/MeshGenBuilder.cpp
@@ -2,6 +2,7 @@
 
 #include "Manager.h"
 #include "AIAssistManager.h"   // #404 PBR map synthesis (normal + roughness)
+#include "MeshImporterExporter.h"  // applyNormalMapsToEntity (tangents + RTSS)
 #include "RTShaderHelper.h"    // canonical-slot FFP wiring + RTSS normal map
 
 #include <QDateTime>
@@ -370,10 +371,16 @@ Ogre::SceneNode* buildSceneNode(const MeshGenPredictor::Result& result,
             bindSlot("normal_map", normalPath);
             bindSlot("roughness",  roughnessPath);
             RTShaderHelper::wirePbrSlotsForFFP(mat.get());
-            if (!normalPath.isEmpty())
-                RTShaderHelper::applyNormalMap(
-                    mat, QFileInfo(normalPath).fileName().toStdString());
             mat->compile();
+            // NOTE: the RTSS SRS_NORMALMAP wiring is deferred to
+            // applyNormalMapsToEntity below — it must run AFTER the entity/mesh
+            // exists so it can first build TANGENT vectors. RTSS normal mapping
+            // needs per-vertex tangents; the generated mesh has none, and
+            // wiring SRS_NORMALMAP without them yields a degenerate tangent
+            // basis that collapses N·L to ~0 — the surface renders unlit/dark
+            // ("lights off on the model") while everything else lights fine.
+            // The import path already does this (MeshImporterExporter.cpp),
+            // which is why an export→reload looked correct but live gen didn't.
         }
     }
 
@@ -382,7 +389,12 @@ Ogre::SceneNode* buildSceneNode(const MeshGenPredictor::Result& result,
     Ogre::SceneNode* node = mgr->addSceneNode(unique);
     if (!node) return nullptr;
     Ogre::MeshPtr ptr = Ogre::MeshManager::getSingleton().getByName(mesh->getName());
-    mgr->createEntity(node, ptr);
+    Ogre::Entity* ent = mgr->createEntity(node, ptr);
+    // Build tangents (if UVs exist) + wire RTSS normal mapping on the live
+    // entity — the same routine the importer uses, so a freshly generated mesh
+    // lights identically to an export→reload of it.
+    if (ent)
+        MeshImporterExporter::applyNormalMapsToEntity(ent);
     return node;
 }
 

--- a/src/MaterialEditorQML.cpp
+++ b/src/MaterialEditorQML.cpp
@@ -326,12 +326,15 @@ void MaterialEditorQML::createNewMaterial(const QString &materialName)
 //   albedo    → modulates with the per-vertex diffuse colour (textured base)
 //   ao        → modulates the per-vertex diffuse (darkens lit base)
 //   emissive  → adds on top of the running colour (self-illumination)
-//   metallic  → ADD_SIGNED with running colour: brightens / tints toward
-//               metal in textured regions (FFP approximation)
-//   roughness → MODULATE_X2 with running colour: brightens smooth (low-
-//               roughness) regions to fake spec gloss; FFP approximation
+//   metallic  → inert (marked non-FFP, passes current colour through). It's
+//               a BRDF specular-lobe input, not a colour channel — the old
+//               ADD_SIGNED tinted the diffuse and darkened the surface.
+//   roughness → inert, same rationale (the old MODULATE_X2 multiplied a
+//               mid-grey map into the colour → "PBR looks in shadow").
 //   normal_map → marked non-FFP; RTShaderHelper::applyNormalMap wires
 //                it through SRS_NORMALMAP elsewhere when a texture is set
+// The real metal-roughness contribution comes from applyPbrIfTagged's
+// Cook-Torrance SRS when the material is PBR-tagged and IBL is present.
 //
 // AO/metallic/roughness use LBS_DIFFUSE (per-vertex diffuse from
 // lighting+material) instead of LBS_CURRENT so the result doesn't

--- a/src/MaterialEditorQML.cpp
+++ b/src/MaterialEditorQML.cpp
@@ -4305,12 +4305,36 @@ void MaterialEditorQML::generatePbrFromDiffuse()
         bindSlot("roughness",  res.roughnessPath);
         RTShaderHelper::wirePbrSlotsForFFP(m_ogreMaterial.get());
         // wirePbrSlotsForFFP only marks the normal unit non-FFP; it does NOT
-        // make RTSS sample it. applyNormalMap wires the SRS_NORMALMAP (or
-        // Cook-Torrance) sub-render-state so the normal map actually perturbs
-        // viewport shading — without this the bind is invisible on the mesh.
+        // make RTSS sample it. The RTSS SRS_NORMALMAP wiring needs per-vertex
+        // TANGENTS — without them the tangent-space basis is degenerate, N·L
+        // collapses to ~0, and the surface renders unlit/dark ("lights off on
+        // the model"). applyNormalMapsToEntity builds tangents (when UVs
+        // exist) FIRST, then wires SRS_NORMALMAP — the same routine the mesh
+        // importer uses, so live PBR generation lights identically to an
+        // export→reload. Run it on every scene entity that uses this material.
         if (!res.normalPath.isEmpty()) {
-            RTShaderHelper::applyNormalMap(
-                m_ogreMaterial, QFileInfo(res.normalPath).fileName().toStdString());
+            const std::string matName = m_ogreMaterial->getName();
+            bool wiredViaEntity = false;
+            if (auto* mgr = Manager::getSingletonPtr()) {
+                for (Ogre::Entity* ent : mgr->getEntities()) {
+                    if (!ent || ent->getMovableType() != "Entity") continue;
+                    bool uses = false;
+                    for (unsigned int s = 0; s < ent->getNumSubEntities(); ++s) {
+                        const auto sm = ent->getSubEntity(s)->getMaterial();
+                        if (sm && sm->getName() == matName) { uses = true; break; }
+                    }
+                    if (uses) {
+                        MeshImporterExporter::applyNormalMapsToEntity(ent);
+                        wiredViaEntity = true;
+                    }
+                }
+            }
+            // Fallback (no entity found — e.g. editing an unbound material):
+            // wire the SRS directly. Tangents may be missing, but this at least
+            // preserves the previous behaviour.
+            if (!wiredViaEntity)
+                RTShaderHelper::applyNormalMap(
+                    m_ogreMaterial, QFileInfo(res.normalPath).fileName().toStdString());
         }
         m_ogreMaterial->compile();
         // The bind above may have CREATED new texture units (normal_map /

--- a/src/MaterialPresetLibrary.cpp
+++ b/src/MaterialPresetLibrary.cpp
@@ -61,8 +61,18 @@ constexpr const char* kPbrSlots[] = {
 // user can drag textures in via the existing Material Editor inspector.
 // The albedo slot is given a 1×1 white fallback so the material renders
 // before any texture is assigned.
-void configurePbrSlots(Ogre::Pass* pass)
+void configurePbrSlots(Ogre::Pass* pass, const QString& workflow)
 {
+    // The `metallic`/`roughness` slots are canonical texture-unit names reused
+    // across workflows. In METALLIC-ROUGHNESS they are BRDF specular-lobe
+    // inputs (the real response comes from applyPbrIfTagged's Cook-Torrance
+    // SRS) — modulating them into the FFP diffuse only darkens the surface, so
+    // they're kept inert. In SPECULAR-GLOSSINESS the same two slots carry the
+    // specular colour + glossiness, and that workflow stays on the FFP path
+    // (applyPbrIfTagged skips it), so their FFP colour ops are the ONLY thing
+    // that makes those maps visible — keep the legacy approximations there.
+    const bool metalRough =
+        workflow != MaterialPresetLibrary::kPbrWorkflowSpecular;
     for (const char* slotName : kPbrSlots) {
         Ogre::TextureUnitState* tus = pass->createTextureUnitState();
         tus->setName(slotName);
@@ -87,17 +97,27 @@ void configurePbrSlots(Ogre::Pass* pass)
                 Ogre::LBX_ADD,
                 Ogre::LBS_TEXTURE,
                 Ogre::LBS_CURRENT);
-        } else if (n == "metallic" || n == "roughness") {
-            // Metallic/roughness are BRDF specular-lobe inputs, not colour
-            // channels. In the FFP fallback (no real Cook-Torrance BRDF) they
-            // must be inert — the old MODULATE_X2 / ADD_SIGNED ops multiplied
-            // a mid-grey map into the diffuse and darkened the surface. Mark
-            // non-FFP and pass the current colour through unchanged; the real
-            // metal-roughness BRDF is applied by applyPbrIfTagged when IBL is
-            // present. (Mirrors RTShaderHelper::wirePbrSlotsForFFP.)
-            Ogre::RTShader::ShaderGenerator::_markNonFFP(tus);
-            tus->setColourOperationEx(
-                Ogre::LBX_SOURCE1, Ogre::LBS_CURRENT, Ogre::LBS_CURRENT);
+        } else if (n == "metallic") {
+            if (metalRough) {
+                // BRDF input — inert in FFP (real response via Cook-Torrance).
+                Ogre::RTShader::ShaderGenerator::_markNonFFP(tus);
+                tus->setColourOperationEx(
+                    Ogre::LBX_SOURCE1, Ogre::LBS_CURRENT, Ogre::LBS_CURRENT);
+            } else {
+                // Spec-gloss: this slot is the SPECULAR map — brighten.
+                tus->setColourOperationEx(
+                    Ogre::LBX_ADD_SIGNED, Ogre::LBS_TEXTURE, Ogre::LBS_CURRENT);
+            }
+        } else if (n == "roughness") {
+            if (metalRough) {
+                Ogre::RTShader::ShaderGenerator::_markNonFFP(tus);
+                tus->setColourOperationEx(
+                    Ogre::LBX_SOURCE1, Ogre::LBS_CURRENT, Ogre::LBS_CURRENT);
+            } else {
+                // Spec-gloss: this slot is the GLOSSINESS map.
+                tus->setColourOperationEx(
+                    Ogre::LBX_MODULATE_X2, Ogre::LBS_TEXTURE, Ogre::LBS_CURRENT);
+            }
         }
     }
 }
@@ -127,7 +147,7 @@ void applyPbrTemplate(Ogre::MaterialPtr& mat,
         pass->setLightingEnabled(false);
         pass->setDiffuse(Ogre::ColourValue::White);
     }
-    configurePbrSlots(pass);
+    configurePbrSlots(pass, workflow);
 
     // Tag the workflow on the pass so slice F can detect PBR intent
     // without name-matching the preset string. Ogre::Material doesn't

--- a/src/MaterialPresetLibrary.cpp
+++ b/src/MaterialPresetLibrary.cpp
@@ -87,16 +87,17 @@ void configurePbrSlots(Ogre::Pass* pass)
                 Ogre::LBX_ADD,
                 Ogre::LBS_TEXTURE,
                 Ogre::LBS_CURRENT);
-        } else if (n == "metallic") {
+        } else if (n == "metallic" || n == "roughness") {
+            // Metallic/roughness are BRDF specular-lobe inputs, not colour
+            // channels. In the FFP fallback (no real Cook-Torrance BRDF) they
+            // must be inert — the old MODULATE_X2 / ADD_SIGNED ops multiplied
+            // a mid-grey map into the diffuse and darkened the surface. Mark
+            // non-FFP and pass the current colour through unchanged; the real
+            // metal-roughness BRDF is applied by applyPbrIfTagged when IBL is
+            // present. (Mirrors RTShaderHelper::wirePbrSlotsForFFP.)
+            Ogre::RTShader::ShaderGenerator::_markNonFFP(tus);
             tus->setColourOperationEx(
-                Ogre::LBX_ADD_SIGNED,
-                Ogre::LBS_TEXTURE,
-                Ogre::LBS_CURRENT);
-        } else if (n == "roughness") {
-            tus->setColourOperationEx(
-                Ogre::LBX_MODULATE_X2,
-                Ogre::LBS_TEXTURE,
-                Ogre::LBS_CURRENT);
+                Ogre::LBX_SOURCE1, Ogre::LBS_CURRENT, Ogre::LBS_CURRENT);
         }
     }
 }

--- a/src/MaterialPresetLibrary_test.cpp
+++ b/src/MaterialPresetLibrary_test.cpp
@@ -517,17 +517,18 @@ TEST_F(MaterialPresetLibraryTests, PbrSlotColourOpsApproximatePbrSemantics) {
     EXPECT_EQ(emissiveBlend.source1,   Ogre::LBS_TEXTURE);
     EXPECT_EQ(emissiveBlend.source2,   Ogre::LBS_CURRENT);
 
-    // metallic: ADD_SIGNED brightens the running colour where the texture
-    // is bright, faking a metallic look in pure FFP.
-    EXPECT_EQ(metallicBlend.operation, Ogre::LBX_ADD_SIGNED);
-    EXPECT_EQ(metallicBlend.source1,   Ogre::LBS_TEXTURE);
-    EXPECT_EQ(metallicBlend.source2,   Ogre::LBS_CURRENT);
+    // metallic + roughness are BRDF specular-lobe inputs, NOT colour channels.
+    // In the FFP fallback they must be INERT — pass the running colour through
+    // unchanged (LBX_SOURCE1 / LBS_CURRENT). The earlier ADD_SIGNED (metallic)
+    // / MODULATE_X2 (roughness) ops multiplied a mid-grey map into the diffuse
+    // and darkened the surface ("PBR looks in shadow"). The real metal-
+    // roughness response comes from the Cook-Torrance SRS when PBR-tagged +
+    // IBL is present.
+    EXPECT_EQ(metallicBlend.operation, Ogre::LBX_SOURCE1);
+    EXPECT_EQ(metallicBlend.source1,   Ogre::LBS_CURRENT);
 
-    // roughness: MODULATE_X2 brightens smooth (low-roughness) regions
-    // — opposite-direction approximation of glossiness, again pure FFP.
-    EXPECT_EQ(roughBlend.operation, Ogre::LBX_MODULATE_X2);
-    EXPECT_EQ(roughBlend.source1,   Ogre::LBS_TEXTURE);
-    EXPECT_EQ(roughBlend.source2,   Ogre::LBS_CURRENT);
+    EXPECT_EQ(roughBlend.operation, Ogre::LBX_SOURCE1);
+    EXPECT_EQ(roughBlend.source1,   Ogre::LBS_CURRENT);
 }
 
 // Slice F1: Metallic-Roughness preset auto-attaches Ogre's stock

--- a/src/RTShaderHelper.cpp
+++ b/src/RTShaderHelper.cpp
@@ -829,22 +829,20 @@ void RTShaderHelper::wirePbrSlotsForFFP(Ogre::Material* mat)
                         Ogre::LBX_ADD,
                         Ogre::LBS_TEXTURE,
                         Ogre::LBS_CURRENT);
-                } else if (n == "metallic") {
-                    // FFP approximation: signed-add brightens current
-                    // toward white in textured (metal) regions. Slice F
-                    // shader replaces with a real metal BRDF lobe when
-                    // pbr_workflow is tagged.
-                    tus->setColourOperationEx(
-                        Ogre::LBX_ADD_SIGNED,
-                        Ogre::LBS_TEXTURE,
-                        Ogre::LBS_CURRENT);
-                } else if (n == "roughness") {
-                    // FFP approximation: modulate-x2 brightens smooth
-                    // (low-roughness) regions.
-                    tus->setColourOperationEx(
-                        Ogre::LBX_MODULATE_X2,
-                        Ogre::LBS_TEXTURE,
-                        Ogre::LBS_CURRENT);
+                } else if (n == "metallic" || n == "roughness") {
+                    // Metallic and roughness are BRDF *specular-lobe* inputs,
+                    // not colour channels — in the FFP fallback (no real
+                    // Cook-Torrance BRDF) they must NOT touch the diffuse
+                    // albedo. The old MODULATE_X2 (roughness) / ADD_SIGNED
+                    // (metallic) ops multiplied the roughness/metallic grey
+                    // value straight into the visible colour: a typical
+                    // roughness map (mean ~0.44) × 2 ≈ 0.87, darkening the
+                    // whole surface ("PBR looks like it's in shadow" — the
+                    // AI-PBR-generation bug). Make the unit inert (pass the
+                    // current colour through unchanged) and non-FFP; the real
+                    // metal-roughness BRDF is applied by applyPbrIfTagged when
+                    // the material is PBR-tagged and IBL is present.
+                    markNormalUnitNonFfp(tus);
                 }
             }
         }

--- a/src/RTShaderHelper_syncMaterial_test.cpp
+++ b/src/RTShaderHelper_syncMaterial_test.cpp
@@ -64,3 +64,35 @@ TEST_F(SyncMaterialForViewportTest, HydratesEmbeddedTextureAndBuildsRtssTechniqu
     ASSERT_NE(diffuseTus, nullptr);
     EXPECT_EQ(diffuseTus->getTextureName(), "sync_test_diffuse.png");
 }
+
+// Regression: the FFP fallback must NOT let the roughness / metallic maps
+// modulate the visible diffuse. They are BRDF specular-lobe inputs; the old
+// MODULATE_X2 (roughness) / ADD_SIGNED (metallic) ops multiplied a mid-grey
+// map straight into the colour and darkened the whole surface (the AI-PBR
+// "looks like it's in shadow" bug). wirePbrSlotsForFFP must make those units
+// inert (LBX_SOURCE1 → pass the current colour through unchanged).
+TEST_F(SyncMaterialForViewportTest, PbrFfpRoughnessMetallicDoNotDarkenDiffuse)
+{
+    Ogre::MaterialPtr mat = Ogre::MaterialManager::getSingleton().create(
+        "SyncMaterialViewportTest",
+        Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+    Ogre::Pass* pass = mat->getTechnique(0)->getPass(0);
+
+    Ogre::TextureUnitState* albedo = pass->createTextureUnitState();
+    albedo->setName("albedo");
+    Ogre::TextureUnitState* rough = pass->createTextureUnitState();
+    rough->setName("roughness");
+    Ogre::TextureUnitState* metal = pass->createTextureUnitState();
+    metal->setName("metallic");
+
+    RTShaderHelper::wirePbrSlotsForFFP(mat.get());
+
+    // Albedo still modulates the lit diffuse (it IS the base colour).
+    EXPECT_EQ(albedo->getColourBlendMode().operation, Ogre::LBX_MODULATE);
+    // Roughness + metallic pass the current colour through untouched — never
+    // MODULATE_X2 / ADD_SIGNED, which darkened the surface.
+    EXPECT_EQ(rough->getColourBlendMode().operation, Ogre::LBX_SOURCE1);
+    EXPECT_EQ(metal->getColourBlendMode().operation, Ogre::LBX_SOURCE1);
+    EXPECT_NE(rough->getColourBlendMode().operation, Ogre::LBX_MODULATE_X2);
+    EXPECT_NE(metal->getColourBlendMode().operation, Ogre::LBX_ADD_SIGNED);
+}


### PR DESCRIPTION
## Summary

Generating PBR maps (Material Editor "Generate PBR maps" or the image-to-3D PBR step) made the model render **dark — "like the lights are off on the model," while other meshes lit normally.** Export→reload of the same mesh looked correct, which localized both bugs to the live in-session material wiring.

Two independent root causes, both fixed:

### 1. Roughness/metallic darkened the diffuse (FFP wiring)

The FFP fallback wired `roughness` as `LBX_MODULATE_X2` and `metallic` as `LBX_ADD_SIGNED` against the running colour — but those are BRDF specular-lobe inputs, not colour channels. A typical generated roughness map (mean ≈ 0.44) multiplied the visible colour by `roughness × 2 ≈ 0.87`, tinting the surface darker. **Fix:** make roughness/metallic inert in the FFP path (`LBX_SOURCE1`, non-FFP), like normal maps; the real contribution comes from the Cook-Torrance SRS when PBR-tagged with IBL. (`RTShaderHelper::wirePbrSlotsForFFP` + `MaterialPresetLibrary::configurePbrSlots`.)

### 2. RTSS normal map without tangents → unlit surface (the main "lights off" symptom)

The live paths wired the RTSS `SRS_NORMALMAP` sub-render-state on a mesh with **no per-vertex tangents**. Ogre's normal-map shader needs tangents to build the tangent-space basis; without them the basis is degenerate, the perturbed normal collapses, `N·L → ~0`, and the surface renders as if unlit. The **mesh importer already builds tangents before wiring normal maps** (`applyNormalMapsToEntity`, *"Build tangent vectors … required by RTSS normal mapping"*) — which is exactly why export→reload looked fine but live generation didn't. **Fix:** route both live paths through that same tested importer routine:
- image-to-3D (`MeshGenBuilder`): defer normal-map wiring until the entity exists, then call `applyNormalMapsToEntity` (builds tangents when UVs exist, then wires SRS_NORMALMAP).
- Material Editor (`generatePbrFromDiffuse`): after binding the maps, run `applyNormalMapsToEntity` on every scene entity using the material.

## Verification

- Roughness tint: lit-face brightness 126 → 150 on the live bind path; regression test asserts roughness/metallic resolve to `LBX_SOURCE1`.
- Normal-map/tangent darkening: reproduced on a primitive sphere (brightness 104 → 81 after the old raw `applyNormalMap`); after the fix the image-to-3D generated mesh lights the same as an export→reload (verified in the viewport).

## Paths covered

Both `wirePbrSlotsForFFP` (Material Editor / image-to-3D / CLI / MCP) and `applyNormalMapsToEntity` routing (the two live viewport paths). Export/CLI/MCP paths were already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PBR metallic and roughness inputs so they no longer darken the material in fixed-function fallback mode.
  * Improved normal map handling for generated and imported materials so lighting appears correctly on live meshes.

* **Tests**
  * Added regression coverage for the updated PBR fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->