### PR TITLE
Lights: Slice F — shadow controls (#488)

### DIFF
--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -25,6 +25,10 @@ Rectangle {
     component InspectorThemedCheckBox: CheckBox {
         id: itcb
         spacing: 6
+        property string accessibleLabel: ""
+        Accessible.name: accessibleLabel !== "" ? accessibleLabel : text
+        Accessible.checkable: true
+        Accessible.checked: itcb.checkState === Qt.Checked
         indicator: Rectangle {
             x: itcb.leftPadding
             y: itcb.height / 2 - height / 2
@@ -4058,6 +4062,7 @@ Rectangle {
                 }
                 InspectorThemedCheckBox {
                     anchors.verticalCenter: parent.verticalCenter
+                    accessibleLabel: qsTr("Enabled")
                     tristate: true
                     checkState: LightPropertiesController.mixedEnabled
                         ? Qt.PartiallyChecked
@@ -5383,6 +5388,7 @@ Rectangle {
                 }
                 InspectorThemedCheckBox {
                     anchors.verticalCenter: parent.verticalCenter
+                    accessibleLabel: qsTr("Receive shadows")
                     tristate: true
                     checkState: PropertiesPanelController.mixedReceiveShadows
                         ? Qt.PartiallyChecked
@@ -5415,6 +5421,7 @@ Rectangle {
                 }
                 InspectorThemedCheckBox {
                     anchors.verticalCenter: parent.verticalCenter
+                    accessibleLabel: qsTr("Cast shadows")
                     tristate: true
                     checkState: LightPropertiesController.mixedCastShadows
                         ? Qt.PartiallyChecked

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -5396,7 +5396,9 @@ Rectangle {
                     onCheckStateChanged: {
                         if (checkState === Qt.PartiallyChecked)
                             return
-                        PropertiesPanelController.receiveShadows = (checkState === Qt.Checked)
+                        const enabled = (checkState === Qt.Checked)
+                        if (PropertiesPanelController.receiveShadows !== enabled)
+                            PropertiesPanelController.receiveShadows = enabled
                     }
                 }
             }
@@ -5429,7 +5431,9 @@ Rectangle {
                     onCheckStateChanged: {
                         if (checkState === Qt.PartiallyChecked)
                             return
-                        LightPropertiesController.castShadows = (checkState === Qt.Checked)
+                        const enabled = (checkState === Qt.Checked)
+                        if (LightPropertiesController.castShadows !== enabled)
+                            LightPropertiesController.castShadows = enabled
                     }
                 }
             }

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -22,7 +22,7 @@ Rectangle {
     property var bottomToolHost: null
 
     // Themed checkbox matching Inspector palette (16px box + checkmark).
-    component InspectorThemedCheckBox: CheckBox {
+    component InspectorCheckBox: CheckBox {
         id: itcb
         spacing: 6
         property string accessibleLabel: ""
@@ -4060,7 +4060,7 @@ Rectangle {
                     font.pixelSize: 11
                     anchors.verticalCenter: parent.verticalCenter
                 }
-                InspectorThemedCheckBox {
+                InspectorCheckBox {
                     anchors.verticalCenter: parent.verticalCenter
                     accessibleLabel: qsTr("Enabled")
                     tristate: true
@@ -4171,7 +4171,7 @@ Rectangle {
                         }
                     }
                 }
-                InspectorThemedCheckBox {
+                InspectorCheckBox {
                     anchors.verticalCenter: parent.verticalCenter
                     text: qsTr("Link")
                     checked: LightPropertiesController.colorsLinked
@@ -5210,7 +5210,7 @@ Rectangle {
                 spacing: 6
                 width: parent.width - 16
 
-                InspectorThemedCheckBox {
+                InspectorCheckBox {
                     id: replaceLightsCheck
                     text: qsTr("Replace existing lights")
                     checked: SceneLightingController.replaceExistingLights
@@ -5386,7 +5386,7 @@ Rectangle {
                     font.pixelSize: 11
                     anchors.verticalCenter: parent.verticalCenter
                 }
-                InspectorThemedCheckBox {
+                InspectorCheckBox {
                     anchors.verticalCenter: parent.verticalCenter
                     accessibleLabel: qsTr("Receive shadows")
                     tristate: true
@@ -5419,7 +5419,7 @@ Rectangle {
                     font.pixelSize: 11
                     anchors.verticalCenter: parent.verticalCenter
                 }
-                InspectorThemedCheckBox {
+                InspectorCheckBox {
                     anchors.verticalCenter: parent.verticalCenter
                     accessibleLabel: qsTr("Cast shadows")
                     tristate: true

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -21,6 +21,44 @@ Rectangle {
     property bool showAllModeTools: false
     property var bottomToolHost: null
 
+    // Themed checkbox matching Inspector palette (16px box + checkmark).
+    component InspectorThemedCheckBox: CheckBox {
+        id: itcb
+        spacing: 6
+        indicator: Rectangle {
+            x: itcb.leftPadding
+            y: itcb.height / 2 - height / 2
+            implicitWidth: 16
+            implicitHeight: 16
+            radius: 2
+            color: itcb.checkState === Qt.Checked || itcb.checkState === Qt.PartiallyChecked
+                ? PropertiesPanelController.highlightColor
+                : PropertiesPanelController.inputColor
+            border.color: itcb.activeFocus
+                ? PropertiesPanelController.highlightColor
+                : PropertiesPanelController.borderColor
+            border.width: itcb.activeFocus ? 2 : 1
+            opacity: itcb.enabled ? 1.0 : 0.45
+            Text {
+                anchors.centerIn: parent
+                visible: itcb.checkState !== Qt.Unchecked
+                text: itcb.checkState === Qt.PartiallyChecked ? "—" : "✓"
+                color: PropertiesPanelController.textColor
+                font.pixelSize: itcb.checkState === Qt.PartiallyChecked ? 10 : 12
+                font.bold: true
+            }
+        }
+        contentItem: Text {
+            visible: itcb.text !== ""
+            text: itcb.text
+            color: PropertiesPanelController.textColor
+            font.pixelSize: 11
+            leftPadding: itcb.indicator.width + itcb.spacing
+            verticalAlignment: Text.AlignVCenter
+            opacity: itcb.enabled ? 1.0 : 0.45
+        }
+    }
+
     // ---- Auto-rig (#407) inline state, lives in the Inspector Rigging section
     // (replaces the old modal AutoRigDialog) ----
     property var    rigTemplates: ["humanoid", "biped", "quadruped", "generic"]
@@ -655,16 +693,6 @@ Rectangle {
                 Component.onCompleted: content = transformComponent
             }
 
-            // ---- Light (#484 / #485) ----
-            CollapsibleSection {
-                title: "Light"
-                sectionVisible: root.currentTab === root.inspectorTab
-                    && LightPropertiesController.hasLightSelection
-                expanded: false
-
-                Component.onCompleted: content = lightPropertiesComponent
-            }
-
             // ---- Snap Settings ----
             CollapsibleSection {
                 title: "Snap Settings"
@@ -716,6 +744,28 @@ Rectangle {
                 expanded: false
 
                 Component.onCompleted: content = sceneLightingComponent
+            }
+
+            // ---- Light (#484 / #485) ----
+            CollapsibleSection {
+                title: "Light"
+                sectionVisible: root.modeToolSectionVisible(
+                    EditorModeController.ObjectMode,
+                    LightPropertiesController.hasLightSelection)
+                expanded: false
+
+                Component.onCompleted: content = lightPropertiesComponent
+            }
+
+            // ---- Shadow (Slice F #488) ----
+            CollapsibleSection {
+                title: "Shadow"
+                sectionVisible: root.modeToolSectionVisible(
+                    EditorModeController.ObjectMode,
+                    true)
+                expanded: false
+
+                Component.onCompleted: content = shadowToolsComponent
             }
 
             // ---- Environment (HDR / IBL, Object mode) ----
@@ -4006,7 +4056,7 @@ Rectangle {
                     font.pixelSize: 11
                     anchors.verticalCenter: parent.verticalCenter
                 }
-                CheckBox {
+                InspectorThemedCheckBox {
                     anchors.verticalCenter: parent.verticalCenter
                     tristate: true
                     checkState: LightPropertiesController.mixedEnabled
@@ -4116,7 +4166,7 @@ Rectangle {
                         }
                     }
                 }
-                CheckBox {
+                InspectorThemedCheckBox {
                     anchors.verticalCenter: parent.verticalCenter
                     text: qsTr("Link")
                     checked: LightPropertiesController.colorsLinked
@@ -4326,17 +4376,6 @@ Rectangle {
                     decimals: 2
                     onNewValue: function(val) { LightPropertiesController.spotFalloff = val }
                 }
-            }
-
-            // Directional softness placeholder
-            Text {
-                visible: LightPropertiesController.isDirectional
-                text: qsTr("Directional softness (advanced) — coming soon")
-                color: PropertiesPanelController.textColor
-                font.pixelSize: 10
-                font.italic: true
-                wrapMode: Text.WordWrap
-                width: parent.width - 16
             }
         }
     }
@@ -5166,39 +5205,11 @@ Rectangle {
                 spacing: 6
                 width: parent.width - 16
 
-                CheckBox {
+                InspectorThemedCheckBox {
                     id: replaceLightsCheck
-                    text: "Replace existing lights"
+                    text: qsTr("Replace existing lights")
                     checked: SceneLightingController.replaceExistingLights
                     onToggled: SceneLightingController.replaceExistingLights = checked
-                    spacing: 6
-                    indicator: Rectangle {
-                        x: replaceLightsCheck.leftPadding
-                        y: replaceLightsCheck.height / 2 - height / 2
-                        implicitWidth: 16
-                        implicitHeight: 16
-                        radius: 2
-                        color: replaceLightsCheck.checked
-                            ? PropertiesPanelController.highlightColor
-                            : PropertiesPanelController.inputColor
-                        border.color: PropertiesPanelController.borderColor
-                        border.width: 1
-                        Text {
-                            anchors.centerIn: parent
-                            visible: replaceLightsCheck.checked
-                            text: "✓"
-                            color: PropertiesPanelController.textColor
-                            font.pixelSize: 12
-                            font.bold: true
-                        }
-                    }
-                    contentItem: Text {
-                        text: replaceLightsCheck.text
-                        color: PropertiesPanelController.textColor
-                        font.pixelSize: 10
-                        leftPadding: replaceLightsCheck.indicator.width + replaceLightsCheck.spacing
-                        verticalAlignment: Text.AlignVCenter
-                    }
                 }
             }
 
@@ -5232,6 +5243,223 @@ Rectangle {
                     hoverEnabled: true
                     cursorShape: Qt.PointingHandCursor
                     onClicked: SceneLightingController.applySelectedRig()
+                }
+            }
+        }
+    }
+
+    // ---- Shadow tools (Object mode, Slice F #488) ----
+    Component {
+        id: shadowToolsComponent
+
+        Column {
+            width: parent ? parent.width : 200
+            padding: 8
+            spacing: 8
+
+            Text {
+                text: qsTr("Quality")
+                color: PropertiesPanelController.textColor
+                font.pixelSize: 11
+                font.bold: true
+            }
+            ThemedComboBox {
+                id: shadowQualityPicker
+                width: parent.width - 16
+                height: 22
+                font.pixelSize: 11
+                model: ShadowController.qualityPresetNames
+                currentIndex: ShadowController.qualityPreset
+                onActivated: index => ShadowController.qualityPreset = index
+                Connections {
+                    target: ShadowController
+                    function onSettingsChanged() {
+                        shadowQualityPicker.currentIndex = ShadowController.qualityPreset
+                    }
+                }
+            }
+
+            Text {
+                visible: ShadowController.qualityPreset > 0
+                text: qsTr("Directional cascades")
+                color: PropertiesPanelController.textColor
+                font.pixelSize: 10
+            }
+            ThemedComboBox {
+                visible: ShadowController.qualityPreset > 0
+                width: parent.width - 16
+                height: 22
+                font.pixelSize: 11
+                model: ShadowController.cascadeCountChoices
+                currentIndex: Math.max(0, ShadowController.cascadeCount - 2)
+                onActivated: index => ShadowController.cascadeCount = index + 2
+            }
+
+            Text {
+                visible: ShadowController.qualityPreset > 0
+                text: qsTr("Spot shadow map")
+                color: PropertiesPanelController.textColor
+                font.pixelSize: 10
+            }
+            ThemedComboBox {
+                visible: ShadowController.qualityPreset > 0
+                id: spotShadowResPicker
+                width: parent.width - 16
+                height: 22
+                font.pixelSize: 11
+                model: ShadowController.spotShadowResolutionChoices
+                onActivated: index => {
+                    const sizes = [512, 1024, 2048]
+                    ShadowController.spotShadowResolution = sizes[index]
+                }
+                Component.onCompleted: {
+                    const sizes = [512, 1024, 2048]
+                    currentIndex = Math.max(0, sizes.indexOf(ShadowController.spotShadowResolution))
+                }
+                Connections {
+                    target: ShadowController
+                    function onSettingsChanged() {
+                        const sizes = [512, 1024, 2048]
+                        spotShadowResPicker.currentIndex =
+                            Math.max(0, sizes.indexOf(ShadowController.spotShadowResolution))
+                    }
+                }
+            }
+
+            Row {
+                visible: ShadowController.qualityPreset > 0
+                spacing: 6
+                width: parent.width - 16
+                Text {
+                    text: qsTr("PSSM split λ")
+                    color: PropertiesPanelController.textColor
+                    font.pixelSize: 10
+                    anchors.verticalCenter: parent.verticalCenter
+                    width: 72
+                }
+                Slider {
+                    id: splitLambdaSlider
+                    width: parent.width - 96
+                    height: 22
+                    from: 0
+                    to: 1
+                    stepSize: 0.01
+                    value: ShadowController.splitLambda
+                    onMoved: ShadowController.splitLambda = value
+                    Connections {
+                        target: ShadowController
+                        function onSettingsChanged() {
+                            splitLambdaSlider.value = ShadowController.splitLambda
+                        }
+                    }
+                }
+                Text {
+                    width: 24
+                    anchors.verticalCenter: parent.verticalCenter
+                    horizontalAlignment: Text.AlignRight
+                    color: PropertiesPanelController.textColor
+                    font.pixelSize: 10
+                    text: ShadowController.splitLambda.toFixed(2)
+                }
+            }
+
+            Text {
+                visible: PropertiesPanelController.hasMeshInSelection
+                text: qsTr("Selection")
+                color: PropertiesPanelController.textColor
+                font.pixelSize: 11
+                font.bold: true
+                topPadding: 8
+            }
+            Row {
+                visible: PropertiesPanelController.hasMeshInSelection
+                spacing: 8
+                width: parent.width - 16
+                Text {
+                    text: qsTr("Receive shadows")
+                    color: PropertiesPanelController.textColor
+                    font.pixelSize: 11
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+                InspectorThemedCheckBox {
+                    anchors.verticalCenter: parent.verticalCenter
+                    tristate: true
+                    checkState: PropertiesPanelController.mixedReceiveShadows
+                        ? Qt.PartiallyChecked
+                        : (PropertiesPanelController.receiveShadows ? Qt.Checked : Qt.Unchecked)
+                    onCheckStateChanged: {
+                        if (checkState === Qt.PartiallyChecked)
+                            return
+                        PropertiesPanelController.receiveShadows = (checkState === Qt.Checked)
+                    }
+                }
+            }
+
+            Text {
+                visible: LightPropertiesController.hasLightSelection
+                text: qsTr("Light")
+                color: PropertiesPanelController.textColor
+                font.pixelSize: 11
+                font.bold: true
+                topPadding: 8
+            }
+            Row {
+                visible: LightPropertiesController.hasLightSelection
+                spacing: 8
+                width: parent.width - 16
+                Text {
+                    text: qsTr("Cast shadows")
+                    color: PropertiesPanelController.textColor
+                    font.pixelSize: 11
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+                InspectorThemedCheckBox {
+                    anchors.verticalCenter: parent.verticalCenter
+                    tristate: true
+                    checkState: LightPropertiesController.mixedCastShadows
+                        ? Qt.PartiallyChecked
+                        : (LightPropertiesController.castShadows ? Qt.Checked : Qt.Unchecked)
+                    onCheckStateChanged: {
+                        if (checkState === Qt.PartiallyChecked)
+                            return
+                        LightPropertiesController.castShadows = (checkState === Qt.Checked)
+                    }
+                }
+            }
+
+            Text {
+                visible: LightPropertiesController.hasLightSelection
+                text: qsTr("Advanced shadow bias")
+                color: PropertiesPanelController.textColor
+                font.pixelSize: 10
+            }
+            Column {
+                visible: LightPropertiesController.hasLightSelection
+                spacing: 4
+                width: parent.width - 16
+                TransformField {
+                    width: parent.width
+                    labelWidth: 52
+                    inputWidth: 96
+                    label: "Depth"
+                    value: LightPropertiesController.mixedShadowDepthBias
+                        ? 0 : LightPropertiesController.shadowDepthBias
+                    color: "#808080"
+                    step: 0.00001
+                    decimals: 5
+                    onNewValue: function(val) { LightPropertiesController.shadowDepthBias = val }
+                }
+                TransformField {
+                    width: parent.width
+                    labelWidth: 52
+                    inputWidth: 96
+                    label: "Slope"
+                    value: LightPropertiesController.mixedShadowSlopeBias
+                        ? 0 : LightPropertiesController.shadowSlopeBias
+                    color: "#808080"
+                    step: 0.1
+                    decimals: 2
+                    onNewValue: function(val) { LightPropertiesController.shadowSlopeBias = val }
                 }
             }
         }

--- a/qml/TransformField.qml
+++ b/qml/TransformField.qml
@@ -9,13 +9,15 @@ Row {
     property color color: "#c04040"
     property real step: 0.1
     property int decimals: step >= 1 ? 0 : 3
+    property int labelWidth: 16
+    property int inputWidth: -1
     signal newValue(real val)
 
     spacing: 2
     width: (parent ? parent.width : 180) / 3 - 3
 
     Rectangle {
-        width: 16
+        width: root.labelWidth
         height: 22
         color: root.color
         radius: 2
@@ -31,7 +33,9 @@ Row {
 
     Rectangle {
         id: inputBg
-        width: parent.width - 18
+        width: root.inputWidth >= 0
+            ? root.inputWidth
+            : Math.max(0, parent.width - root.labelWidth - root.spacing)
         height: 22
         color: PropertiesPanelController.inputColor
         border.color: input.activeFocus ? root.color : PropertiesPanelController.borderColor

--- a/src/AppSettingsKeys.h
+++ b/src/AppSettingsKeys.h
@@ -190,6 +190,31 @@ inline const QString& lightingGradientBottom()
     return k;
 }
 
+/** @brief Global shadow quality preset (Slice F #488): 0=Off, 1=Low, 2=Medium, 3=High. */
+inline const QString& shadowQualityPreset()
+{
+    static const QString k(QStringLiteral("Lighting/shadowQualityPreset"));
+    return k;
+}
+
+inline const QString& shadowCascadeCount()
+{
+    static const QString k(QStringLiteral("Lighting/shadowCascadeCount"));
+    return k;
+}
+
+inline const QString& shadowSplitLambda()
+{
+    static const QString k(QStringLiteral("Lighting/shadowSplitLambda"));
+    return k;
+}
+
+inline const QString& shadowSpotResolution()
+{
+    static const QString k(QStringLiteral("Lighting/shadowSpotResolution"));
+    return k;
+}
+
 } // namespace AppSettingsKeys
 
 #endif // APP_SETTINGS_KEYS_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,7 @@ LightVisualizer.cpp
 LightsController.cpp
 LightPropertiesController.cpp
 SceneLightingController.cpp
+ShadowController.cpp
 SelectionBoxObject.cpp
 ObjectItemModel.cpp
 MaterialComboDelegate.cpp
@@ -237,6 +238,7 @@ LightVisualizer.h
 LightsController.h
 LightPropertiesController.h
 SceneLightingController.h
+ShadowController.h
 SelectionBoxObject.h
 ObjectItemModel.h
 MaterialComboDelegate.h

--- a/src/LightManager.cpp
+++ b/src/LightManager.cpp
@@ -2,6 +2,7 @@
 
 #include "Manager.h"
 #include "SentryReporter.h"
+#include "ShadowController.h"
 
 #include <OgreLight.h>
 #include <OgreMath.h>
@@ -41,6 +42,15 @@ LightSnapshot LightSnapshot::fromHandle(const LightHandle& handle)
         snapshot.direction =
             handle.sceneNode->getOrientation() * Ogre::Vector3::NEGATIVE_UNIT_Z;
     }
+    snapshot.castShadows = handle.light->getCastShadows();
+
+    const auto& bindings = handle.light->getUserObjectBindings();
+    const auto depthAny = bindings.getUserAny(QStringLiteral("shadow_depth_bias").toStdString());
+    const auto slopeAny = bindings.getUserAny(QStringLiteral("shadow_slope_bias").toStdString());
+    if (depthAny.has_value())
+        snapshot.shadowDepthBias = Ogre::any_cast<float>(depthAny);
+    if (slopeAny.has_value())
+        snapshot.shadowSlopeBias = Ogre::any_cast<float>(slopeAny);
     return snapshot;
 }
 
@@ -58,7 +68,9 @@ bool LightSnapshot::operator==(const LightSnapshot& other) const
            && spotlightFalloff == other.spotlightFalloff
            && position == other.position && orientation == other.orientation
            && scale == other.scale && usesDirection == other.usesDirection
-           && direction == other.direction;
+           && direction == other.direction && castShadows == other.castShadows
+           && shadowDepthBias == other.shadowDepthBias
+           && shadowSlopeBias == other.shadowSlopeBias;
 }
 
 LightManager* LightManager::getSingleton()
@@ -195,6 +207,16 @@ void LightManager::applySnapshotToHandle(const LightSnapshot& snapshot, LightHan
     handle.sceneNode->setScale(snapshot.scale);
     if (snapshot.usesDirection)
         handle.sceneNode->setDirection(snapshot.direction);
+
+    handle.light->setCastShadows(snapshot.castShadows);
+    auto& bindings = handle.light->getUserObjectBindings();
+    bindings.setUserAny(QStringLiteral("shadow_depth_bias").toStdString(),
+                        Ogre::Any(snapshot.shadowDepthBias));
+    bindings.setUserAny(QStringLiteral("shadow_slope_bias").toStdString(),
+                        Ogre::Any(snapshot.shadowSlopeBias));
+
+    if (auto* shadows = ShadowController::instance())
+        shadows->syncFromScene();
 }
 
 LightHandle LightManager::createLightInternal(Ogre::Light::LightTypes type, const QString& baseName)
@@ -254,6 +276,12 @@ LightHandle LightManager::createLightUnderParent(Ogre::SceneNode* parent,
         light->setAttenuation(10.0f, 1.0f, 0.0f, 0.0f);
     if (type == Ogre::Light::LT_SPOTLIGHT)
         light->setSpotlightRange(Ogre::Degree(30.0f), Ogre::Degree(40.0f), 1.0f);
+    light->setCastShadows(false);
+    auto& bindings = light->getUserObjectBindings();
+    bindings.setUserAny(QStringLiteral("shadow_depth_bias").toStdString(),
+                        Ogre::Any(ShadowController::kDefaultDepthBias));
+    bindings.setUserAny(QStringLiteral("shadow_slope_bias").toStdString(),
+                        Ogre::Any(ShadowController::kDefaultSlopeBias));
     node->attachObject(light);
     tagAsUserLight(light);
     node->setPosition(position);
@@ -430,12 +458,31 @@ bool LightManager::deleteLight(const QString& name)
         if (node && Manager::getSingletonPtr())
         {
             m_suppressSceneNodeDestroyed = true;
-            Manager::getSingleton()->destroySceneNode(node);
+            // Overlays are torn down in lightDeleted; do not pre-destroy child nodes.
+            Manager::getSingleton()->destroySceneNode(node, false);
             m_suppressSceneNodeDestroyed = false;
         }
 
         return true;
     }
+    return false;
+}
+
+bool LightManager::deleteLightBySceneNode(Ogre::SceneNode* node)
+{
+    if (!node || m_suppressSceneNodeDestroyed)
+        return false;
+
+    if (LightHandle* handle = findLightBySceneNode(node))
+        return deleteLight(handle->name);
+
+    if (!sceneNodeIsUserLight(node))
+        return false;
+
+    const QString name = QString::fromStdString(node->getName());
+    if (findLight(name))
+        return deleteLight(name);
+
     return false;
 }
 

--- a/src/LightManager.cpp
+++ b/src/LightManager.cpp
@@ -214,9 +214,6 @@ void LightManager::applySnapshotToHandle(const LightSnapshot& snapshot, LightHan
                         Ogre::Any(snapshot.shadowDepthBias));
     bindings.setUserAny(QStringLiteral("shadow_slope_bias").toStdString(),
                         Ogre::Any(snapshot.shadowSlopeBias));
-
-    if (auto* shadows = ShadowController::instance())
-        shadows->syncFromScene();
 }
 
 LightHandle LightManager::createLightInternal(Ogre::Light::LightTypes type, const QString& baseName)
@@ -440,6 +437,8 @@ LightHandle LightManager::restoreSnapshotUnderParent(Ogre::SceneNode* parent,
     handle.name = QString::fromStdString(node->getName());
 
     m_lights.append(handle);
+    if (auto* shadows = ShadowController::instance())
+        shadows->syncFromScene();
     emit lightCreated(handle);
     return handle;
 }
@@ -555,6 +554,8 @@ bool LightManager::applyProperties(const QString& name, const LightSnapshot& sna
     }
 
     applySnapshotToHandle(applied, *handle);
+    if (auto* shadows = ShadowController::instance())
+        shadows->syncFromScene();
     emit lightChanged(handle->name);
     return true;
 }
@@ -589,8 +590,12 @@ LightHandle* LightManager::findLightBySceneNode(Ogre::SceneNode* node)
     if (!node)
         return nullptr;
 
-    const QString name = QString::fromStdString(node->getName());
-    return findLight(name);
+    for (LightHandle& handle : m_lights)
+    {
+        if (handle.sceneNode == node)
+            return &handle;
+    }
+    return nullptr;
 }
 
 const LightHandle* LightManager::findLightBySceneNode(Ogre::SceneNode* node) const
@@ -598,8 +603,12 @@ const LightHandle* LightManager::findLightBySceneNode(Ogre::SceneNode* node) con
     if (!node)
         return nullptr;
 
-    const QString name = QString::fromStdString(node->getName());
-    return findLight(name);
+    for (const LightHandle& handle : m_lights)
+    {
+        if (handle.sceneNode == node)
+            return &handle;
+    }
+    return nullptr;
 }
 
 void LightManager::onSceneNodeDestroyed(Ogre::SceneNode* node)

--- a/src/LightManager.h
+++ b/src/LightManager.h
@@ -43,6 +43,9 @@ struct LightSnapshot
     Ogre::Vector3 scale = Ogre::Vector3::UNIT_SCALE;
     bool usesDirection = false;
     Ogre::Vector3 direction = Ogre::Vector3::NEGATIVE_UNIT_Z;
+    bool castShadows = false;
+    float shadowDepthBias = 0.00005f;
+    float shadowSlopeBias = 1.0f;
 
     static LightSnapshot fromHandle(const LightHandle& handle);
     bool operator==(const LightSnapshot& other) const;
@@ -89,6 +92,9 @@ public:
     QList<LightSnapshot> captureAllSnapshots() const;
     void deleteAllUserLights();
     bool deleteLight(const QString& name);
+    /// Tear down a tracked user-light scene node (icons/gizmos first). Returns
+    /// true when the node was handled and must not be destroyed again by Manager.
+    bool deleteLightBySceneNode(Ogre::SceneNode* node);
     bool renameLight(const QString& oldName, const QString& newName);
     bool applyProperties(const QString& name, const LightSnapshot& snapshot);
 

--- a/src/LightManager_test.cpp
+++ b/src/LightManager_test.cpp
@@ -1,9 +1,11 @@
 #include <gtest/gtest.h>
 
 #include "LightManager.h"
+#include "LightRigLibrary.h"
 #include "Manager.h"
 #include "MaterialPreviewRenderer.h"
 #include "SelectionSet.h"
+#include "ShadowController.h"
 #include "TestHelpers.h"
 
 #include <OgreLight.h>
@@ -15,6 +17,7 @@ class LightManagerTest : public ::testing::Test {
 protected:
     void TearDown() override
     {
+        ShadowController::kill();
         LightManager::kill();
         Manager::kill();
     }
@@ -133,4 +136,30 @@ TEST_F(LightManagerOgreTest, CreateEmptySceneTwice_ReplacesDefaultLights)
     Manager::getSingletonPtr()->CreateEmptyScene();
     const QList<LightHandle> lights = LightManager::getSingleton()->lights();
     ASSERT_EQ(lights.size(), 3);
+}
+
+TEST_F(LightManagerOgreTest, DestroyingRigGroupRemovesChildLights)
+{
+    Manager::getSingletonPtr()->CreateEmptyScene();
+    auto* lights = LightManager::getSingleton();
+    ASSERT_EQ(lights->lights().size(), 3);
+
+    Ogre::SceneNode* rigGroup = nullptr;
+    for (const LightHandle& handle : lights->lights())
+    {
+        ASSERT_TRUE(handle.sceneNode);
+        auto* parent = static_cast<Ogre::SceneNode*>(handle.sceneNode->getParent());
+        if (parent && LightRigLibrary::sceneNodeIsRigGroup(parent))
+        {
+            rigGroup = parent;
+            break;
+        }
+    }
+    ASSERT_NE(rigGroup, nullptr);
+
+    QSignalSpy deletedSpy(lights, &LightManager::lightDeleted);
+    Manager::getSingleton()->destroySceneNode(rigGroup);
+
+    EXPECT_EQ(lights->lights().size(), 0);
+    EXPECT_EQ(deletedSpy.count(), 3);
 }

--- a/src/LightPropertiesController.cpp
+++ b/src/LightPropertiesController.cpp
@@ -741,11 +741,22 @@ bool LightPropertiesController::mixedCastShadows() const
 
 void LightPropertiesController::setCastShadows(bool value)
 {
-    pushImmediateEdit(LightPropertyClass::Shadow, [value](LightSnapshot& snapshot) {
-        snapshot.castShadows = value;
-    });
-    SentryReporter::addBreadcrumb(QStringLiteral("scene.light.shadow_toggle"),
-                                  value ? QStringLiteral("on") : QStringLiteral("off"));
+    const QList<LightSnapshot> snapshots = selectedSnapshots();
+    if (snapshots.isEmpty())
+        return;
+
+    for (const LightSnapshot& snapshot : snapshots)
+    {
+        if (snapshot.castShadows != value)
+        {
+            pushImmediateEdit(LightPropertyClass::Shadow, [value](LightSnapshot& snapshot) {
+                snapshot.castShadows = value;
+            });
+            SentryReporter::addBreadcrumb(QStringLiteral("scene.light.shadow_toggle"),
+                                          value ? QStringLiteral("on") : QStringLiteral("off"));
+            return;
+        }
+    }
 }
 
 double LightPropertiesController::shadowDepthBias() const

--- a/src/LightPropertiesController.cpp
+++ b/src/LightPropertiesController.cpp
@@ -3,6 +3,7 @@
 #include "LightManager.h"
 #include "Manager.h"
 #include "SelectionSet.h"
+#include "ShadowController.h"
 #include "UndoManager.h"
 #include "SentryReporter.h"
 #include "mainwindow.h"
@@ -713,6 +714,112 @@ bool LightPropertiesController::isDirectional() const
             return true;
     }
     return false;
+}
+
+bool LightPropertiesController::castShadows() const
+{
+    const QList<LightSnapshot> snapshots = selectedSnapshots();
+    if (snapshots.isEmpty())
+        return false;
+    return snapshots.first().castShadows;
+}
+
+bool LightPropertiesController::mixedCastShadows() const
+{
+    const QList<LightSnapshot> snapshots = selectedSnapshots();
+    if (snapshots.size() < 2)
+        return false;
+
+    const bool first = snapshots.first().castShadows;
+    for (const LightSnapshot& snapshot : snapshots)
+    {
+        if (snapshot.castShadows != first)
+            return true;
+    }
+    return false;
+}
+
+void LightPropertiesController::setCastShadows(bool value)
+{
+    pushImmediateEdit(LightPropertyClass::Shadow, [value](LightSnapshot& snapshot) {
+        snapshot.castShadows = value;
+    });
+    SentryReporter::addBreadcrumb(QStringLiteral("scene.light.shadow_toggle"),
+                                  value ? QStringLiteral("on") : QStringLiteral("off"));
+}
+
+double LightPropertiesController::shadowDepthBias() const
+{
+    const QList<LightSnapshot> snapshots = selectedSnapshots();
+    if (snapshots.isEmpty())
+        return ShadowController::kDefaultDepthBias;
+    return snapshots.first().shadowDepthBias;
+}
+
+bool LightPropertiesController::mixedShadowDepthBias() const
+{
+    const QList<LightSnapshot> snapshots = selectedSnapshots();
+    if (snapshots.size() < 2)
+        return false;
+
+    const float first = snapshots.first().shadowDepthBias;
+    for (const LightSnapshot& snapshot : snapshots)
+    {
+        if (!nearlyEqual(snapshot.shadowDepthBias, first))
+            return true;
+    }
+    return false;
+}
+
+void LightPropertiesController::setShadowDepthBias(double value)
+{
+    const float clamped = static_cast<float>(std::max(value, 0.0));
+    if (m_sliderEditActive)
+    {
+        applyToSelection(
+            [clamped](LightSnapshot& snapshot) { snapshot.shadowDepthBias = clamped; }, true);
+        return;
+    }
+
+    pushImmediateEdit(LightPropertyClass::Shadow,
+                      [clamped](LightSnapshot& snapshot) { snapshot.shadowDepthBias = clamped; });
+}
+
+double LightPropertiesController::shadowSlopeBias() const
+{
+    const QList<LightSnapshot> snapshots = selectedSnapshots();
+    if (snapshots.isEmpty())
+        return ShadowController::kDefaultSlopeBias;
+    return snapshots.first().shadowSlopeBias;
+}
+
+bool LightPropertiesController::mixedShadowSlopeBias() const
+{
+    const QList<LightSnapshot> snapshots = selectedSnapshots();
+    if (snapshots.size() < 2)
+        return false;
+
+    const float first = snapshots.first().shadowSlopeBias;
+    for (const LightSnapshot& snapshot : snapshots)
+    {
+        if (!nearlyEqual(snapshot.shadowSlopeBias, first))
+            return true;
+    }
+    return false;
+}
+
+void LightPropertiesController::setShadowSlopeBias(double value)
+{
+    const float clamped = static_cast<float>(std::max(value, 0.0));
+    if (m_sliderEditActive)
+    {
+        applyToSelection(
+            [clamped](LightSnapshot& snapshot) { snapshot.shadowSlopeBias = clamped; }, true);
+        return;
+    }
+
+    pushImmediateEdit(LightPropertyClass::Shadow,
+                      [clamped](LightSnapshot& snapshot) { snapshot.shadowSlopeBias = clamped; });
 }
 
 void LightPropertiesController::beginSliderEdit(int propertyClass)

--- a/src/LightPropertiesController.cpp
+++ b/src/LightPropertiesController.cpp
@@ -752,8 +752,10 @@ void LightPropertiesController::setCastShadows(bool value)
             pushImmediateEdit(LightPropertyClass::Shadow, [value](LightSnapshot& snapshot) {
                 snapshot.castShadows = value;
             });
-            SentryReporter::addBreadcrumb(QStringLiteral("scene.light.shadow_toggle"),
-                                          value ? QStringLiteral("on") : QStringLiteral("off"));
+            SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                          QStringLiteral("Light cast shadows: %1")
+                                              .arg(value ? QStringLiteral("on")
+                                                         : QStringLiteral("off")));
             return;
         }
     }

--- a/src/LightPropertiesController.h
+++ b/src/LightPropertiesController.h
@@ -48,6 +48,14 @@ class LightPropertiesController : public QObject
     Q_PROPERTY(bool isPointOrSpot READ isPointOrSpot NOTIFY propertiesChanged)
     Q_PROPERTY(bool isSpot READ isSpot NOTIFY propertiesChanged)
     Q_PROPERTY(bool isDirectional READ isDirectional NOTIFY propertiesChanged)
+    Q_PROPERTY(bool castShadows READ castShadows WRITE setCastShadows NOTIFY propertiesChanged)
+    Q_PROPERTY(bool mixedCastShadows READ mixedCastShadows NOTIFY propertiesChanged)
+    Q_PROPERTY(double shadowDepthBias READ shadowDepthBias WRITE setShadowDepthBias
+                   NOTIFY propertiesChanged)
+    Q_PROPERTY(double shadowSlopeBias READ shadowSlopeBias WRITE setShadowSlopeBias
+                   NOTIFY propertiesChanged)
+    Q_PROPERTY(bool mixedShadowDepthBias READ mixedShadowDepthBias NOTIFY propertiesChanged)
+    Q_PROPERTY(bool mixedShadowSlopeBias READ mixedShadowSlopeBias NOTIFY propertiesChanged)
     Q_PROPERTY(QStringList lightTypeChoices READ lightTypeChoices CONSTANT)
     Q_PROPERTY(QStringList attenuationPresetChoices READ attenuationPresetChoices CONSTANT)
 
@@ -117,6 +125,18 @@ public:
     bool isPointOrSpot() const;
     bool isSpot() const;
     bool isDirectional() const;
+
+    bool castShadows() const;
+    void setCastShadows(bool value);
+    bool mixedCastShadows() const;
+
+    double shadowDepthBias() const;
+    void setShadowDepthBias(double value);
+    bool mixedShadowDepthBias() const;
+
+    double shadowSlopeBias() const;
+    void setShadowSlopeBias(double value);
+    bool mixedShadowSlopeBias() const;
 
     QStringList lightTypeChoices() const;
     QStringList attenuationPresetChoices() const;

--- a/src/LightRigLibrary.cpp
+++ b/src/LightRigLibrary.cpp
@@ -3,6 +3,7 @@
 #include "AppSettingsKeys.h"
 #include "Manager.h"
 #include "SentryReporter.h"
+#include "ShadowController.h"
 
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
@@ -47,7 +48,7 @@ RigLightSpec directional(const QString& name,
                          const Ogre::Vector3& direction,
                          const Ogre::ColourValue& diffuse,
                          float power,
-                         bool shadows = true)
+                         bool shadows = false)
 {
     RigLightSpec spec;
     spec.baseName = name;
@@ -186,6 +187,7 @@ LightSnapshot snapshotFromSpec(const RigLightSpec& spec, const QString& nodeName
     snapshot.spotlightInnerAngleDeg = spec.spotlightInnerAngleDeg;
     snapshot.spotlightOuterAngleDeg = spec.spotlightOuterAngleDeg;
     snapshot.spotlightFalloff = spec.spotlightFalloff;
+    snapshot.castShadows = spec.castShadows;
     snapshot.position = spec.position;
     snapshot.orientation = Ogre::Quaternion::IDENTITY;
     snapshot.scale = Ogre::Vector3::UNIT_SCALE;
@@ -427,11 +429,12 @@ LightRigApplyResult apply(const QString& rigId, bool replaceExisting)
 
         LightSnapshot snapshot = snapshotFromSpec(lightSpec, handle.name);
         lights->applyProperties(handle.name, snapshot);
-        if (handle.light)
-            handle.light->setCastShadows(lightSpec.castShadows);
 
         result.addedLights.append(LightSnapshot::fromHandle(handle));
     }
+
+    if (auto* shadows = ShadowController::instance())
+        shadows->syncFromScene();
 
     mgr->getSceneMgr()->setAmbientLight(spec->ambient);
     result.ambientAfter = spec->ambient;

--- a/src/LightVisualizer_test.cpp
+++ b/src/LightVisualizer_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "LightManager.h"
+#include "LightRigLibrary.h"
 #include "LightVisualizer.h"
 #include "GlobalDefinitions.h"
 #include "Manager.h"
@@ -162,4 +163,26 @@ TEST_F(LightVisualizerOgreTest, LightChangedRebuildsSpotCone)
     const float extentAfter = gizmoExtent(spot.sceneNode);
     EXPECT_GT(extentAfter, extentBefore);
     (void)visualizer;
+}
+
+TEST_F(LightVisualizerOgreTest, DestroyingRigGroupRemovesTrackedLightsAndOverlays)
+{
+    LightVisualizer visualizer(Manager::getSingleton()->getSceneMgr());
+    (void)visualizer;
+
+    Ogre::SceneNode* rigGroup = nullptr;
+    for (const LightHandle& handle : LightManager::getSingleton()->lights())
+    {
+        ASSERT_TRUE(handle.sceneNode);
+        auto* parent = static_cast<Ogre::SceneNode*>(handle.sceneNode->getParent());
+        if (parent && LightRigLibrary::sceneNodeIsRigGroup(parent))
+        {
+            rigGroup = parent;
+            break;
+        }
+    }
+    ASSERT_NE(rigGroup, nullptr);
+
+    Manager::getSingleton()->destroySceneNode(rigGroup);
+    EXPECT_EQ(LightManager::getSingleton()->lights().size(), 0);
 }

--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -31,6 +31,8 @@ THE SOFTWARE.
 #include <QStandardPaths>
 #include <QDir>
 
+#include <vector>
+
 #include "GlobalDefinitions.h"
 
 #include "PrimitiveObject.h"
@@ -636,7 +638,7 @@ void Manager::destroyAllUserRootNodes()
         destroySceneNode(name);
 }
 
-void Manager::destroySceneNode(Ogre::SceneNode* node)
+void Manager::destroySceneNode(Ogre::SceneNode* node, bool destroyChildrenFirst)
 {
     if(!node || !mSceneMgr || isForbiddenNodeName(node->getName().c_str()))
         return;
@@ -659,10 +661,43 @@ void Manager::destroySceneNode(Ogre::SceneNode* node)
     }
     //TODO if custom class has to be provided for object, userany object should be inside so that this delete is not required...
 
+    if (destroyChildrenFirst)
+    {
+        // Destroy children first so sceneNodeDestroyed fires per child (e.g. rig-group
+        // lights unregister from LightManager before their Ogre objects are torn down).
+        std::vector<Ogre::SceneNode*> childNodes;
+        try
+        {
+            for (auto* child : node->getChildren())
+                childNodes.push_back(static_cast<Ogre::SceneNode*>(child));
+        }
+        catch (...)
+        {
+        }
+        for (Ogre::SceneNode* child : childNodes)
+        {
+            if (auto* lights = LightManager::getSingletonPtr())
+            {
+                if (lights->deleteLightBySceneNode(child))
+                    continue;
+            }
+            destroySceneNode(child, true);
+        }
+    }
+    else
+    {
+        try
+        {
+            node->removeAndDestroyAllChildren();
+        }
+        catch (...)
+        {
+        }
+    }
+
     emit sceneNodeDestroyed(node);  // emitted before destruction so listeners can clean up while entities are still valid
     destroyAllAttachedMovableObjects(node);
-    node->removeAndDestroyAllChildren();
-    
+
     // Safely destroy the scene node
     try {
         mSceneMgr->destroySceneNode(node);

--- a/src/Manager.h
+++ b/src/Manager.h
@@ -80,7 +80,7 @@ public:
     Ogre::Entity*       createEntity(Ogre::SceneNode* const& sceneNode, const Ogre::MeshPtr& mesh);
 
     void                destroySceneNode(const QString & name);
-    void                destroySceneNode(Ogre::SceneNode* node);
+    void                destroySceneNode(Ogre::SceneNode* node, bool destroyChildrenFirst = true);
     /// Destroys every user-owned root scene node (matches Scene outliner top level).
     void                destroyAllUserRootNodes();
     void                destroyAllAttachedMovableObjects(Ogre::SceneNode* node);

--- a/src/OgreWidget.cpp
+++ b/src/OgreWidget.cpp
@@ -47,6 +47,7 @@ THE SOFTWARE.
 #include "EditModeController.h"
 #include "TransformOperator.h"
 #include "HDR/HdrViewportController.h"
+#include "ShadowController.h"
 #include "SentryReporter.h"
 
 namespace {
@@ -133,6 +134,7 @@ OgreWidget::OgreWidget( QWidget *parent ):
 OgreWidget::~OgreWidget()
 {
     HdrViewportController::getSingleton()->unregisterWidget(this);
+    ShadowController::instance()->unregisterViewport(this);
 
     // Safely clean up OGRE resources
     // Order is important: remove listeners first, then destroy camera, then detach render target, then remove viewports
@@ -299,6 +301,7 @@ void OgreWidget::initOgreWindow(void)
         applyViewportCameraFromSettings(mCamera.get());
 
     HdrViewportController::getSingleton()->registerWidget(this);
+    ShadowController::instance()->registerViewport(this);
 }
 
 void OgreWidget::teardownOgreWindow()
@@ -358,6 +361,7 @@ void OgreWidget::rebuildRenderWindow()
     }
 
     HdrViewportController::getSingleton()->unregisterWidget(this);
+    ShadowController::instance()->unregisterViewport(this);
 
     teardownOgreWindow();
     initOgreWindow();

--- a/src/OgreWidget_test.cpp
+++ b/src/OgreWidget_test.cpp
@@ -13,6 +13,7 @@
 #include "ViewportSettingsKeys.h"
 #include "Manager.h"
 #include "SpaceCamera.h"
+#include "ShadowController.h"
 #include "mainwindow.h"
 
 // These tests exercise QWidget event handlers and Ogre frame callbacks directly.
@@ -79,6 +80,7 @@ protected:
         }
 
         Manager::kill();
+        ShadowController::kill();
         QThread::msleep(100);
     }
 

--- a/src/PropertiesPanelController.cpp
+++ b/src/PropertiesPanelController.cpp
@@ -457,24 +457,81 @@ bool materialReceivesShadows(const Ogre::MaterialPtr& material)
     return !material || material->getReceiveShadows();
 }
 
+QString receiveShadowMaterialName(Ogre::SubEntity* sub)
+{
+    if (!sub || !sub->getParent())
+        return {};
+
+    Ogre::Entity* entity = sub->getParent();
+    unsigned short subIndex = 0;
+    for (unsigned short i = 0; i < entity->getNumSubEntities(); ++i)
+    {
+        if (entity->getSubEntity(i) == sub)
+        {
+            subIndex = i;
+            break;
+        }
+    }
+
+    return QStringLiteral("%1/rs_%2")
+        .arg(QString::fromStdString(entity->getName()))
+        .arg(subIndex);
+}
+
+Ogre::MaterialPtr materialForReceiveShadowEdit(Ogre::SubEntity* sub)
+{
+    if (!sub)
+        return {};
+
+    Ogre::MaterialPtr mat = sub->getMaterial();
+    if (!mat)
+        return {};
+
+    const QString instanceName = receiveShadowMaterialName(sub);
+    if (instanceName.isEmpty())
+        return mat;
+
+    auto& matMgr = Ogre::MaterialManager::getSingleton();
+    if (Ogre::MaterialPtr existing =
+            matMgr.getByName(instanceName.toStdString(), mat->getGroup()))
+    {
+        if (sub->getMaterialName() != existing->getName())
+            sub->setMaterial(existing);
+        return existing;
+    }
+
+    if (sub->getMaterialName() == instanceName.toStdString())
+        return mat;
+
+    Ogre::MaterialPtr clone =
+        mat->clone(instanceName.toStdString(), false, mat->getGroup());
+    sub->setMaterial(clone);
+    return clone;
+}
+
+void setSubEntityReceiveShadows(Ogre::SubEntity* sub, bool enabled)
+{
+    if (!sub)
+        return;
+
+    Ogre::MaterialPtr mat = materialForReceiveShadowEdit(sub);
+    if (!mat)
+        return;
+
+    if (mat->getReceiveShadows() == enabled)
+        return;
+
+    mat->setReceiveShadows(enabled);
+    mat->compile();
+}
+
 void setEntityReceiveShadows(Ogre::Entity* entity, bool enabled)
 {
     if (!entity)
         return;
 
     for (unsigned short i = 0; i < entity->getNumSubEntities(); ++i)
-    {
-        Ogre::SubEntity* sub = entity->getSubEntity(i);
-        if (!sub)
-            continue;
-
-        Ogre::MaterialPtr mat = sub->getMaterial();
-        if (!mat)
-            continue;
-
-        mat->setReceiveShadows(enabled);
-        mat->compile();
-    }
+        setSubEntityReceiveShadows(entity->getSubEntity(i), enabled);
 }
 
 } // namespace
@@ -543,6 +600,23 @@ void PropertiesPanelController::setReceiveShadows(bool enabled)
 {
     const QList<Ogre::Entity*> entities = entitiesInSelection();
     if (entities.isEmpty())
+        return;
+
+    bool changed = false;
+    for (Ogre::Entity* entity : entities)
+    {
+        for (unsigned short i = 0; i < entity->getNumSubEntities(); ++i)
+        {
+            Ogre::SubEntity* sub = entity->getSubEntity(i);
+            if (!sub)
+                continue;
+            Ogre::MaterialPtr mat = sub->getMaterial();
+            const bool current = materialReceivesShadows(mat);
+            if (current != enabled)
+                changed = true;
+        }
+    }
+    if (!changed)
         return;
 
     for (Ogre::Entity* entity : entities)

--- a/src/PropertiesPanelController.cpp
+++ b/src/PropertiesPanelController.cpp
@@ -1,6 +1,8 @@
 #include "PropertiesPanelController.h"
 #include "SceneTreeModel.h"
 #include "LightsController.h"
+#include "LightManager.h"
+#include "LightRigLibrary.h"
 #include "SelectionSet.h"
 #include "TransformOperator.h"
 #include "PrimitiveObject.h"
@@ -329,6 +331,30 @@ void PropertiesPanelController::deleteSceneTreeNode(const QString& nodeName)
         return;
     }
 
+    Ogre::SceneNode* node = Manager::getSingleton()->getSceneNode(nodeName);
+    if (node && LightRigLibrary::sceneNodeIsRigGroup(node))
+    {
+        SentryReporter::addBreadcrumb("ui.action", "Scene tree: delete light rig group");
+        QStringList lightNames;
+        if (auto* lights = LightManager::getSingletonPtr())
+        {
+            for (const LightHandle& handle : lights->lights())
+            {
+                if (!handle.sceneNode)
+                    continue;
+                if (static_cast<Ogre::SceneNode*>(handle.sceneNode->getParent()) == node)
+                    lightNames.append(handle.name);
+            }
+            for (const QString& lightName : lightNames)
+                lights->deleteLight(lightName);
+        }
+        Manager::getSingleton()->destroySceneNode(nodeName);
+        SelectionSet::getSingleton()->clearList();
+        UndoManager::getSingleton()->clear();
+        emit selectionChanged();
+        return;
+    }
+
     SentryReporter::addBreadcrumb("ui.action", "Scene tree: delete node");
     Manager::getSingleton()->destroySceneNode(nodeName);
     SelectionSet::getSingleton()->clearList();
@@ -367,6 +393,164 @@ void PropertiesPanelController::clearSceneTreeAllNodes()
 bool PropertiesPanelController::hasEntitySelection() const
 {
     return SelectionSet::getSingleton()->hasEntities() || SelectionSet::getSingleton()->hasSubEntities();
+}
+
+bool PropertiesPanelController::hasMeshInSelection() const
+{
+    auto* sel = SelectionSet::getSingleton();
+    if (!sel)
+        return false;
+
+    for (Ogre::SceneNode* node : sel->getNodesSelectionList())
+    {
+        if (!node)
+            continue;
+        for (unsigned short i = 0; i < node->numAttachedObjects(); ++i)
+        {
+            Ogre::MovableObject* obj = node->getAttachedObject(i);
+            if (obj && obj->getMovableType() == "Entity")
+                return true;
+        }
+    }
+
+    return sel->hasEntities() || sel->hasSubEntities();
+}
+
+namespace
+{
+
+QList<Ogre::Entity*> entitiesInSelection()
+{
+    QList<Ogre::Entity*> entities;
+    auto* sel = SelectionSet::getSingleton();
+
+    for (Ogre::SceneNode* node : sel->getNodesSelectionList())
+    {
+        for (unsigned short i = 0; i < node->numAttachedObjects(); ++i)
+        {
+            Ogre::MovableObject* obj = node->getAttachedObject(i);
+            if (obj && obj->getMovableType() == "Entity")
+                entities.append(static_cast<Ogre::Entity*>(obj));
+        }
+    }
+
+    for (Ogre::Entity* entity : sel->getEntitiesSelectionList())
+    {
+        if (entity && !entities.contains(entity))
+            entities.append(entity);
+    }
+
+    for (Ogre::SubEntity* sub : sel->getSubEntitiesSelectionList())
+    {
+        if (!sub)
+            continue;
+        Ogre::Entity* entity = sub->getParent();
+        if (entity && !entities.contains(entity))
+            entities.append(entity);
+    }
+
+    return entities;
+}
+
+bool materialReceivesShadows(const Ogre::MaterialPtr& material)
+{
+    return !material || material->getReceiveShadows();
+}
+
+void setEntityReceiveShadows(Ogre::Entity* entity, bool enabled)
+{
+    if (!entity)
+        return;
+
+    for (unsigned short i = 0; i < entity->getNumSubEntities(); ++i)
+    {
+        Ogre::SubEntity* sub = entity->getSubEntity(i);
+        if (!sub)
+            continue;
+
+        Ogre::MaterialPtr mat = sub->getMaterial();
+        if (!mat)
+            continue;
+
+        mat->setReceiveShadows(enabled);
+        mat->compile();
+    }
+}
+
+} // namespace
+
+bool PropertiesPanelController::receiveShadows() const
+{
+    const QList<Ogre::Entity*> entities = entitiesInSelection();
+    if (entities.isEmpty())
+        return true;
+
+    bool firstSet = false;
+    bool firstValue = true;
+    for (Ogre::Entity* entity : entities)
+    {
+        for (unsigned short i = 0; i < entity->getNumSubEntities(); ++i)
+        {
+            Ogre::SubEntity* sub = entity->getSubEntity(i);
+            if (!sub)
+                continue;
+            const bool receives = materialReceivesShadows(sub->getMaterial());
+            if (!firstSet)
+            {
+                firstValue = receives;
+                firstSet = true;
+            }
+            else if (receives != firstValue)
+            {
+                return firstValue;
+            }
+        }
+    }
+    return firstSet ? firstValue : true;
+}
+
+bool PropertiesPanelController::mixedReceiveShadows() const
+{
+    const QList<Ogre::Entity*> entities = entitiesInSelection();
+    if (entities.isEmpty())
+        return false;
+
+    bool firstSet = false;
+    bool firstValue = true;
+    for (Ogre::Entity* entity : entities)
+    {
+        for (unsigned short i = 0; i < entity->getNumSubEntities(); ++i)
+        {
+            Ogre::SubEntity* sub = entity->getSubEntity(i);
+            if (!sub)
+                continue;
+            const bool receives = materialReceivesShadows(sub->getMaterial());
+            if (!firstSet)
+            {
+                firstValue = receives;
+                firstSet = true;
+            }
+            else if (receives != firstValue)
+            {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+void PropertiesPanelController::setReceiveShadows(bool enabled)
+{
+    const QList<Ogre::Entity*> entities = entitiesInSelection();
+    if (entities.isEmpty())
+        return;
+
+    for (Ogre::Entity* entity : entities)
+        setEntityReceiveShadows(entity, enabled);
+
+    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                  QStringLiteral("Entity receive shadows: %1").arg(enabled ? "on" : "off"));
+    emit selectionChanged();
 }
 
 QString PropertiesPanelController::selectionName() const

--- a/src/PropertiesPanelController.h
+++ b/src/PropertiesPanelController.h
@@ -40,6 +40,9 @@ class PropertiesPanelController : public QObject
     Q_PROPERTY(bool hasSelection READ hasSelection NOTIFY selectionChanged)
     Q_PROPERTY(bool mergeAnimationsEnabled READ mergeAnimationsEnabled NOTIFY selectionChanged)
     Q_PROPERTY(bool hasEntitySelection READ hasEntitySelection NOTIFY selectionChanged)
+    Q_PROPERTY(bool hasMeshInSelection READ hasMeshInSelection NOTIFY selectionChanged)
+    Q_PROPERTY(bool receiveShadows READ receiveShadows WRITE setReceiveShadows NOTIFY selectionChanged)
+    Q_PROPERTY(bool mixedReceiveShadows READ mixedReceiveShadows NOTIFY selectionChanged)
     Q_PROPERTY(QString selectionName READ selectionName NOTIFY selectionChanged)
     Q_PROPERTY(QString transformTargetKind READ transformTargetKind NOTIFY transformTargetMetadataChanged)
     Q_PROPERTY(QString transformTargetLabel READ transformTargetLabel NOTIFY transformTargetMetadataChanged)
@@ -150,6 +153,10 @@ public:
     bool hasSelection() const;
     bool mergeAnimationsEnabled() const;
     bool hasEntitySelection() const;
+    bool hasMeshInSelection() const;
+    bool receiveShadows() const;
+    void setReceiveShadows(bool enabled);
+    bool mixedReceiveShadows() const;
     QString selectionName() const;
     QString transformTargetKind() const;
     QString transformTargetLabel() const;

--- a/src/PropertiesPanelController_test.cpp
+++ b/src/PropertiesPanelController_test.cpp
@@ -144,6 +144,19 @@ TEST_F(PropertiesPanelControllerTests, SelectionStateFollowsSelectedSceneNode)
     EXPECT_EQ(SelectionSet::getSingleton()->getSceneNode(0), node);
 }
 
+TEST_F(PropertiesPanelControllerTests, HasMeshInSelection_IncludesEntityOnSelectedNode)
+{
+    ASSERT_TRUE(canLoadMeshFiles()) << "entity creation requires GL (Xvfb in CI)";
+    Ogre::SceneNode* node = Manager::getSingleton()->addSceneNode("MeshOnNodeSel");
+    Ogre::MeshPtr mesh = createInMemoryTriangleMesh("MeshOnNodeSelMesh");
+    Manager::getSingleton()->createEntity(node, mesh);
+    SelectionSet::getSingleton()->clear();
+    SelectionSet::getSingleton()->append(node);
+
+    EXPECT_FALSE(controller->hasEntitySelection());
+    EXPECT_TRUE(controller->hasMeshInSelection());
+}
+
 TEST_F(PropertiesPanelControllerTests, TransformTargetMetadataExplainsSelectionImpact)
 {
     EXPECT_EQ(controller->transformTargetKind(), QString("none"));

--- a/src/ShadowController.cpp
+++ b/src/ShadowController.cpp
@@ -4,6 +4,7 @@
 #include "LightManager.h"
 #include "Manager.h"
 #include "OgreWidget.h"
+#include "SentryReporter.h"
 
 #include <OgreCamera.h>
 #include <OgreLight.h>
@@ -225,11 +226,12 @@ ShadowController::ShadowController(QObject* parent)
     m_spotShadowResolution =
         settings.value(AppSettingsKeys::shadowSpotResolution(), 1024).toInt();
 
-    applyPresetDefaults(m_qualityPreset);
-
     if (auto* lights = LightManager::getSingletonPtr())
     {
         connect(lights, &LightManager::lightChanged, this, &ShadowController::syncFromScene);
+        connect(lights, &LightManager::lightCreated, this, [this](const LightHandle&) {
+            QTimer::singleShot(0, this, &ShadowController::syncFromScene);
+        });
         connect(lights, &LightManager::lightDeleted, this, [this]() {
             // Defer until the current scene-node teardown finishes — syncing while
             // Ogre is destroying lights/rig children corrupts the scene graph.
@@ -277,6 +279,9 @@ void ShadowController::setQualityPreset(int preset)
     QSettings settings;
     settings.setValue(AppSettingsKeys::shadowQualityPreset(), static_cast<int>(next));
 
+    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                  QStringLiteral("Shadow quality: %1")
+                                      .arg(qualityPresetNames().value(static_cast<int>(next))));
     emit settingsChanged();
     syncFromScene();
 }
@@ -289,6 +294,8 @@ void ShadowController::setCascadeCount(int count)
 
     m_cascadeCount = next;
     QSettings().setValue(AppSettingsKeys::shadowCascadeCount(), next);
+    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                  QStringLiteral("Shadow cascades: %1").arg(next));
     emit settingsChanged();
     syncFromScene();
 }
@@ -301,6 +308,8 @@ void ShadowController::setSplitLambda(double lambda)
 
     m_splitLambda = next;
     QSettings().setValue(AppSettingsKeys::shadowSplitLambda(), next);
+    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                  QStringLiteral("Shadow PSSM split: %1").arg(next, 0, 'f', 2));
     emit settingsChanged();
     syncFromScene();
 }
@@ -318,6 +327,8 @@ void ShadowController::setSpotShadowResolution(int pixels)
 
     m_spotShadowResolution = next;
     QSettings().setValue(AppSettingsKeys::shadowSpotResolution(), next);
+    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                  QStringLiteral("Spot shadow map: %1").arg(next));
     emit settingsChanged();
     syncFromScene();
 }
@@ -485,6 +496,10 @@ void ShadowController::installSceneShadows(Ogre::SceneManager* sceneMgr)
                                                      1.0f,
                                                      profile.shadowFarDistance,
                                                      static_cast<float>(m_splitLambda)));
+    }
+    else
+    {
+        sceneMgr->setShadowCameraSetup(Ogre::ShadowCameraSetupPtr());
     }
 
     sceneMgr->removeShadowTextureListener(&g_shadowBiasListener);

--- a/src/ShadowController.cpp
+++ b/src/ShadowController.cpp
@@ -42,17 +42,7 @@ bool hasActiveRenderContext()
     {
     }
 
-#if defined(__clang__) || defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-    if (root->getAutoCreatedWindow())
-        return true;
-#if defined(__clang__) || defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
-
-    // Editor viewports use arbitrary render-window names — any GL context is enough.
+    // Root + render system is enough: editor viewports use arbitrary render-window names.
     return true;
 }
 

--- a/src/ShadowController.cpp
+++ b/src/ShadowController.cpp
@@ -1,0 +1,535 @@
+#include "ShadowController.h"
+
+#include "AppSettingsKeys.h"
+#include "LightManager.h"
+#include "Manager.h"
+#include "OgreWidget.h"
+
+#include <OgreCamera.h>
+#include <OgreLight.h>
+#include <OgreMaterialManager.h>
+#include <OgreResourceGroupManager.h>
+#include <OgreSceneManager.h>
+#include <OgreShadowCameraSetupPSSM.h>
+#include <OgreTextureManager.h>
+#include <OgreViewport.h>
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFileInfo>
+#include <QSettings>
+#include <QTimer>
+#include <vector>
+#include <algorithm>
+#include <cmath>
+
+namespace
+{
+
+bool hasActiveRenderContext()
+{
+    auto* root = Ogre::Root::getSingletonPtr();
+    if (!root || !root->getRenderSystem())
+        return false;
+
+    try
+    {
+        if (root->getRenderTarget("TestHidden") || root->getRenderTarget("CLIHidden"))
+            return true;
+    }
+    catch (...)
+    {
+    }
+
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+    if (root->getAutoCreatedWindow())
+        return true;
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+    // Editor viewports use arbitrary render-window names — any GL context is enough.
+    return true;
+}
+
+QString resolveBundledMainMediaPath()
+{
+    const QString appDir = QCoreApplication::applicationDirPath();
+    QStringList candidates;
+    candidates << appDir + QStringLiteral("/media/Main")
+               << appDir + QStringLiteral("/../media/Main");
+#if OGRE_PLATFORM == OGRE_PLATFORM_APPLE
+    candidates << appDir + QStringLiteral("/../../media/Main")
+               << appDir + QStringLiteral("/../../../media/Main");
+#endif
+    for (const QString& path : candidates)
+    {
+        const QString canonical = QDir(path).canonicalPath();
+        if (!canonical.isEmpty() && QFileInfo::exists(canonical + QStringLiteral("/Shadow.material")))
+            return canonical;
+    }
+    return {};
+}
+
+void ensureOgreShadowResources()
+{
+    auto& matMgr = Ogre::MaterialManager::getSingleton();
+    if (!matMgr.getDefaultSettings())
+        matMgr.initialise();
+
+    const Ogre::String casterName = "Ogre/TextureShadowCaster";
+    if (!matMgr.getByName(casterName, Ogre::RGN_INTERNAL))
+    {
+        Ogre::MaterialPtr mat = matMgr.create(casterName, Ogre::RGN_INTERNAL);
+        mat->setReceiveShadows(false);
+        Ogre::Pass* pass = mat->getTechnique(0)->getPass(0);
+        pass->setAmbient(Ogre::ColourValue::White);
+        pass->setDiffuse(Ogre::ColourValue::Black);
+        pass->setSpecular(Ogre::ColourValue(0, 0, 0, 1));
+        pass->setEmissive(Ogre::ColourValue::Black);
+        pass->setFog(true, Ogre::FOG_NONE);
+        pass->setDepthBias(-1.0f, -1.0f);
+    }
+
+    auto& texMgr = Ogre::TextureManager::getSingleton();
+    const Ogre::String fadeName = "spot_shadow_fade.dds";
+    if (!texMgr.resourceExists(fadeName, Ogre::RGN_INTERNAL))
+    {
+        auto& rgm = Ogre::ResourceGroupManager::getSingleton();
+        const QString mainPath = resolveBundledMainMediaPath();
+        if (!mainPath.isEmpty())
+        {
+            rgm.addResourceLocation(mainPath.toStdString(), "FileSystem", Ogre::RGN_INTERNAL);
+            if (!rgm.isResourceGroupInitialised(Ogre::RGN_INTERNAL))
+                rgm.initialiseResourceGroup(Ogre::RGN_INTERNAL);
+        }
+
+        if (!texMgr.resourceExists(fadeName, Ogre::RGN_INTERNAL))
+        {
+            Ogre::TexturePtr tex = texMgr.createManual(
+                fadeName,
+                Ogre::RGN_INTERNAL,
+                Ogre::TEX_TYPE_2D,
+                4,
+                4,
+                0,
+                Ogre::PF_R8G8B8A8);
+            Ogre::HardwarePixelBufferSharedPtr buffer = tex->getBuffer();
+            std::vector<Ogre::uint32> pixels(16, 0xFFFFFFFFu);
+            buffer->blitFromMemory(
+                Ogre::PixelBox(4, 4, 1, Ogre::PF_R8G8B8A8, pixels.data()));
+        }
+    }
+}
+
+Ogre::MaterialPtr shadowCasterMaterial()
+{
+    const Ogre::String matName = "QtMeshEditor/ShadowCaster";
+    auto& matMgr = Ogre::MaterialManager::getSingleton();
+    Ogre::MaterialPtr mat = matMgr.getByName(
+        matName, Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME);
+    if (!mat)
+    {
+        mat = matMgr.create(matName, Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME);
+        Ogre::Pass* pass = mat->getTechnique(0)->getPass(0);
+        pass->setLightingEnabled(false);
+        pass->setVertexColourTracking(Ogre::TVC_NONE);
+        pass->setDepthBias(ShadowController::kDefaultDepthBias, ShadowController::kDefaultSlopeBias);
+    }
+    return mat;
+}
+
+class LightShadowBiasListener : public Ogre::ShadowTextureListener
+{
+public:
+    void shadowTextureCasterPreViewProj(Ogre::Light* light,
+                                        Ogre::Camera* camera,
+                                        size_t iteration) override
+    {
+        (void)camera;
+        (void)iteration;
+
+        float depthBias = ShadowController::kDefaultDepthBias;
+        float slopeBias = ShadowController::kDefaultSlopeBias;
+
+        if (light && LightManager::isUserLight(light))
+        {
+            const auto& bindings = light->getUserObjectBindings();
+            const auto depthAny = bindings.getUserAny(QStringLiteral("shadow_depth_bias").toStdString());
+            const auto slopeAny = bindings.getUserAny(QStringLiteral("shadow_slope_bias").toStdString());
+            if (depthAny.has_value())
+                depthBias = Ogre::any_cast<float>(depthAny);
+            if (slopeAny.has_value())
+                slopeBias = Ogre::any_cast<float>(slopeAny);
+        }
+
+        Ogre::MaterialPtr mat = shadowCasterMaterial();
+        if (mat && mat->getNumTechniques() > 0)
+        {
+            Ogre::Technique* tech = mat->getTechnique(0);
+            if (tech && tech->getNumPasses() > 0)
+                tech->getPass(0)->setDepthBias(depthBias, slopeBias);
+        }
+    }
+};
+
+LightShadowBiasListener g_shadowBiasListener;
+
+Ogre::ShadowCameraSetupPtr makePssmSetup(int cascadeCount, float nearDist, float farDist, float lambda)
+{
+    Ogre::ShadowCameraSetupPtr setup = Ogre::PSSMShadowCameraSetup::create();
+    auto* pssm = static_cast<Ogre::PSSMShadowCameraSetup*>(setup.get());
+    const int splits = std::clamp(cascadeCount, 2, 4);
+    pssm->calculateSplitPoints(static_cast<Ogre::uint>(splits),
+                               nearDist,
+                               farDist,
+                               static_cast<Ogre::Real>(lambda));
+    pssm->setSplitPadding(3.0f);
+    return setup;
+}
+
+} // namespace
+
+ShadowController* ShadowController::s_singleton = nullptr;
+
+ShadowController* ShadowController::instance()
+{
+    if (!s_singleton)
+        s_singleton = new ShadowController(); // NOSONAR — singleton
+    return s_singleton;
+}
+
+ShadowController* ShadowController::qmlInstance(QQmlEngine*, QJSEngine*)
+{
+    return instance();
+}
+
+void ShadowController::kill()
+{
+    delete s_singleton; // NOSONAR — singleton
+    s_singleton = nullptr;
+}
+
+ShadowController::ShadowController(QObject* parent)
+    : QObject(parent)
+{
+    QSettings settings;
+    m_qualityPreset = static_cast<QualityPreset>(
+        settings.value(AppSettingsKeys::shadowQualityPreset(), static_cast<int>(QualityPreset::Medium))
+            .toInt());
+    m_cascadeCount = settings.value(AppSettingsKeys::shadowCascadeCount(), 3).toInt();
+    m_splitLambda = settings.value(AppSettingsKeys::shadowSplitLambda(), 0.85).toDouble();
+    m_spotShadowResolution =
+        settings.value(AppSettingsKeys::shadowSpotResolution(), 1024).toInt();
+
+    applyPresetDefaults(m_qualityPreset);
+
+    if (auto* lights = LightManager::getSingletonPtr())
+    {
+        connect(lights, &LightManager::lightChanged, this, &ShadowController::syncFromScene);
+        connect(lights, &LightManager::lightDeleted, this, [this]() {
+            // Defer until the current scene-node teardown finishes — syncing while
+            // Ogre is destroying lights/rig children corrupts the scene graph.
+            QTimer::singleShot(0, this, &ShadowController::syncFromScene);
+        });
+    }
+}
+
+ShadowController::~ShadowController()
+{
+    if (auto* mgr = Manager::getSingletonPtr())
+    {
+        if (Ogre::SceneManager* sm = mgr->getSceneMgr())
+            uninstallSceneShadows(sm);
+    }
+}
+
+QStringList ShadowController::qualityPresetNames() const
+{
+    return {QStringLiteral("Off"),
+            QStringLiteral("Low"),
+            QStringLiteral("Medium"),
+            QStringLiteral("High")};
+}
+
+QStringList ShadowController::spotShadowResolutionChoices() const
+{
+    return {QStringLiteral("512"), QStringLiteral("1024"), QStringLiteral("2048")};
+}
+
+QStringList ShadowController::cascadeCountChoices() const
+{
+    return {QStringLiteral("2"), QStringLiteral("3"), QStringLiteral("4")};
+}
+
+void ShadowController::setQualityPreset(int preset)
+{
+    const auto next = static_cast<QualityPreset>(std::clamp(preset, 0, 3));
+    if (m_qualityPreset == next)
+        return;
+
+    m_qualityPreset = next;
+    applyPresetDefaults(next);
+
+    QSettings settings;
+    settings.setValue(AppSettingsKeys::shadowQualityPreset(), static_cast<int>(next));
+
+    emit settingsChanged();
+    syncFromScene();
+}
+
+void ShadowController::setCascadeCount(int count)
+{
+    const int next = std::clamp(count, 2, 4);
+    if (m_cascadeCount == next)
+        return;
+
+    m_cascadeCount = next;
+    QSettings().setValue(AppSettingsKeys::shadowCascadeCount(), next);
+    emit settingsChanged();
+    syncFromScene();
+}
+
+void ShadowController::setSplitLambda(double lambda)
+{
+    const double next = std::clamp(lambda, 0.0, 1.0);
+    if (std::abs(m_splitLambda - next) < 1e-6)
+        return;
+
+    m_splitLambda = next;
+    QSettings().setValue(AppSettingsKeys::shadowSplitLambda(), next);
+    emit settingsChanged();
+    syncFromScene();
+}
+
+void ShadowController::setSpotShadowResolution(int pixels)
+{
+    int next = 1024;
+    if (pixels <= 512)
+        next = 512;
+    else if (pixels >= 2048)
+        next = 2048;
+
+    if (m_spotShadowResolution == next)
+        return;
+
+    m_spotShadowResolution = next;
+    QSettings().setValue(AppSettingsKeys::shadowSpotResolution(), next);
+    emit settingsChanged();
+    syncFromScene();
+}
+
+ShadowController::QualityProfile ShadowController::profileForPreset(QualityPreset preset) const
+{
+    QualityProfile profile;
+    switch (preset)
+    {
+    case QualityPreset::Off:
+        break;
+    case QualityPreset::Low:
+        profile.textureSize = 512;
+        profile.cascades = 2;
+        profile.splitLambda = 0.80f;
+        profile.shadowFarDistance = 30.0f;
+        break;
+    case QualityPreset::Medium:
+        profile.textureSize = 1024;
+        profile.cascades = 3;
+        profile.splitLambda = 0.85f;
+        profile.shadowFarDistance = 50.0f;
+        break;
+    case QualityPreset::High:
+        profile.textureSize = 2048;
+        profile.cascades = 4;
+        profile.splitLambda = 0.90f;
+        profile.shadowFarDistance = 80.0f;
+        break;
+    }
+    return profile;
+}
+
+void ShadowController::applyPresetDefaults(QualityPreset preset)
+{
+    const QualityProfile profile = profileForPreset(preset);
+    if (preset == QualityPreset::Off)
+        return;
+
+    m_cascadeCount = profile.cascades;
+    m_splitLambda = profile.splitLambda;
+    if (preset == QualityPreset::Low)
+        m_spotShadowResolution = 512;
+    else if (preset == QualityPreset::Medium)
+        m_spotShadowResolution = 1024;
+    else
+        m_spotShadowResolution = 2048;
+}
+
+void ShadowController::registerViewport(OgreWidget* widget)
+{
+    if (!widget)
+        return;
+
+    m_viewports.insert(widget);
+    if (const Ogre::Viewport* vp = widget->getViewport())
+    {
+        const_cast<Ogre::Viewport*>(vp)->setShadowsEnabled(m_shadowsActive);
+    }
+}
+
+void ShadowController::unregisterViewport(OgreWidget* widget)
+{
+    m_viewports.remove(widget);
+}
+
+void ShadowController::refreshViewports(bool enabled)
+{
+    m_shadowsActive = enabled;
+    for (OgreWidget* widget : m_viewports)
+    {
+        if (!widget)
+            continue;
+        if (const Ogre::Viewport* vp = widget->getViewport())
+            const_cast<Ogre::Viewport*>(vp)->setShadowsEnabled(enabled);
+    }
+}
+
+bool ShadowController::anyUserLightCastsShadows() const
+{
+    auto* lights = LightManager::getSingletonPtr();
+    if (!lights)
+        return false;
+
+    for (const LightHandle& handle : lights->lights())
+    {
+        if (handle.isValid() && handle.light->getCastShadows())
+            return true;
+    }
+    return false;
+}
+
+int ShadowController::requiredShadowTextureCount(int directionalCasters) const
+{
+    int spotCasters = 0;
+    int pointCasters = 0;
+
+    if (auto* lights = LightManager::getSingletonPtr())
+    {
+        for (const LightHandle& handle : lights->lights())
+        {
+            if (!handle.isValid() || !handle.light->getCastShadows())
+                continue;
+
+            switch (handle.light->getType())
+            {
+            case Ogre::Light::LT_SPOTLIGHT:
+                ++spotCasters;
+                break;
+            case Ogre::Light::LT_POINT:
+                ++pointCasters;
+                break;
+            default:
+                break;
+            }
+        }
+    }
+
+    return std::max(1, directionalCasters * m_cascadeCount + spotCasters + pointCasters);
+}
+
+void ShadowController::installSceneShadows(Ogre::SceneManager* sceneMgr)
+{
+    if (!sceneMgr)
+        return;
+
+    try
+    {
+    ensureOgreShadowResources();
+
+    const QualityProfile profile = profileForPreset(m_qualityPreset);
+    const int textureSize = std::max(profile.textureSize, m_spotShadowResolution);
+
+    int directionalCasters = 0;
+    if (auto* lights = LightManager::getSingletonPtr())
+    {
+        for (const LightHandle& handle : lights->lights())
+        {
+            if (handle.isValid() && handle.light->getCastShadows()
+                && handle.light->getType() == Ogre::Light::LT_DIRECTIONAL)
+            {
+                ++directionalCasters;
+            }
+        }
+    }
+
+    const int textureCount = requiredShadowTextureCount(directionalCasters);
+
+    sceneMgr->setShadowTechnique(Ogre::SHADOWTYPE_TEXTURE_MODULATIVE);
+    sceneMgr->setShadowTextureSettings(static_cast<Ogre::uint16>(textureSize),
+                                        static_cast<Ogre::uint16>(textureCount),
+                                        Ogre::PF_DEPTH16);
+    sceneMgr->setShadowFarDistance(profile.shadowFarDistance);
+    sceneMgr->setShadowTextureSelfShadow(true);
+    sceneMgr->setShadowTextureCountPerLightType(Ogre::Light::LT_DIRECTIONAL,
+                                                static_cast<size_t>(m_cascadeCount));
+    sceneMgr->setShadowTextureCountPerLightType(Ogre::Light::LT_SPOTLIGHT, 1);
+    sceneMgr->setShadowTextureCountPerLightType(Ogre::Light::LT_POINT, 1);
+
+    sceneMgr->setShadowTextureCasterMaterial(shadowCasterMaterial());
+
+    if (directionalCasters > 0)
+    {
+        sceneMgr->setShadowCameraSetup(makePssmSetup(m_cascadeCount,
+                                                     1.0f,
+                                                     profile.shadowFarDistance,
+                                                     static_cast<float>(m_splitLambda)));
+    }
+
+    sceneMgr->removeShadowTextureListener(&g_shadowBiasListener);
+    sceneMgr->addShadowTextureListener(&g_shadowBiasListener);
+    }
+    catch (const Ogre::Exception&)
+    {
+        uninstallSceneShadows(sceneMgr);
+        refreshViewports(false);
+    }
+}
+
+void ShadowController::uninstallSceneShadows(Ogre::SceneManager* sceneMgr)
+{
+    if (!sceneMgr)
+        return;
+
+    sceneMgr->removeShadowTextureListener(&g_shadowBiasListener);
+    if (sceneMgr->isShadowTechniqueInUse())
+        sceneMgr->setShadowTechnique(Ogre::SHADOWTYPE_NONE);
+}
+
+void ShadowController::syncFromScene()
+{
+    if (!hasActiveRenderContext())
+        return;
+
+    auto* mgr = Manager::getSingletonPtr();
+    if (!mgr)
+        return;
+
+    Ogre::SceneManager* sceneMgr = mgr->getSceneMgr();
+    if (!sceneMgr)
+        return;
+
+    const bool wantShadows =
+        m_qualityPreset != QualityPreset::Off && anyUserLightCastsShadows();
+
+    if (!wantShadows)
+    {
+        uninstallSceneShadows(sceneMgr);
+        refreshViewports(false);
+        return;
+    }
+
+    installSceneShadows(sceneMgr);
+    refreshViewports(true);
+}

--- a/src/ShadowController.h
+++ b/src/ShadowController.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include <QObject>
+#include <QQmlEngine>
+#include <QSet>
+
+namespace Ogre
+{
+class SceneManager;
+class Viewport;
+}
+
+class OgreWidget;
+
+/// Slice F (#488): global shadow technique + per-viewport enablement.
+class ShadowController : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(int qualityPreset READ qualityPreset WRITE setQualityPreset NOTIFY settingsChanged)
+    Q_PROPERTY(int cascadeCount READ cascadeCount WRITE setCascadeCount NOTIFY settingsChanged)
+    Q_PROPERTY(double splitLambda READ splitLambda WRITE setSplitLambda NOTIFY settingsChanged)
+    Q_PROPERTY(int spotShadowResolution READ spotShadowResolution WRITE setSpotShadowResolution
+                   NOTIFY settingsChanged)
+    Q_PROPERTY(QStringList qualityPresetNames READ qualityPresetNames CONSTANT)
+    Q_PROPERTY(QStringList spotShadowResolutionChoices READ spotShadowResolutionChoices CONSTANT)
+    Q_PROPERTY(QStringList cascadeCountChoices READ cascadeCountChoices CONSTANT)
+
+public:
+    enum class QualityPreset
+    {
+        Off = 0,
+        Low,
+        Medium,
+        High
+    };
+    Q_ENUM(QualityPreset)
+
+    static ShadowController* instance();
+    static ShadowController* qmlInstance(QQmlEngine* engine, QJSEngine* scriptEngine);
+    static void kill();
+
+    int qualityPreset() const { return static_cast<int>(m_qualityPreset); }
+    void setQualityPreset(int preset);
+
+    int cascadeCount() const { return m_cascadeCount; }
+    void setCascadeCount(int count);
+
+    double splitLambda() const { return m_splitLambda; }
+    void setSplitLambda(double lambda);
+
+    int spotShadowResolution() const { return m_spotShadowResolution; }
+    void setSpotShadowResolution(int pixels);
+
+    QStringList qualityPresetNames() const;
+    QStringList spotShadowResolutionChoices() const;
+    QStringList cascadeCountChoices() const;
+
+    bool shadowsActive() const { return m_shadowsActive; }
+
+    void registerViewport(OgreWidget* widget);
+    void unregisterViewport(OgreWidget* widget);
+
+    /// Re-evaluate caster lights and install/uninstall the scene shadow technique.
+    void syncFromScene();
+
+    /// Default depth/slope bias used when a light has no override.
+    static constexpr float kDefaultDepthBias = 0.00005f;
+    static constexpr float kDefaultSlopeBias = 1.0f;
+
+signals:
+    void settingsChanged();
+
+private:
+    explicit ShadowController(QObject* parent = nullptr);
+    ~ShadowController() override;
+
+    struct QualityProfile
+    {
+        int textureSize = 1024;
+        int cascades = 3;
+        float splitLambda = 0.85f;
+        float shadowFarDistance = 50.0f;
+    };
+
+    QualityProfile profileForPreset(QualityPreset preset) const;
+    void applyPresetDefaults(QualityPreset preset);
+    void refreshViewports(bool enabled);
+    void installSceneShadows(Ogre::SceneManager* sceneMgr);
+    void uninstallSceneShadows(Ogre::SceneManager* sceneMgr);
+    bool anyUserLightCastsShadows() const;
+    int requiredShadowTextureCount(int directionalCasters) const;
+
+    static ShadowController* s_singleton;
+
+    QualityPreset m_qualityPreset = QualityPreset::Medium;
+    int m_cascadeCount = 3;
+    double m_splitLambda = 0.85;
+    int m_spotShadowResolution = 1024;
+    bool m_shadowsActive = false;
+    QSet<OgreWidget*> m_viewports;
+};

--- a/src/ShadowController_test.cpp
+++ b/src/ShadowController_test.cpp
@@ -1,0 +1,101 @@
+#include <gtest/gtest.h>
+
+#include "LightManager.h"
+#include "Manager.h"
+#include "ShadowController.h"
+#include "TestHelpers.h"
+
+#include <OgreLight.h>
+#include <OgreSceneManager.h>
+
+class ShadowControllerOgreTest : public ::testing::Test {
+protected:
+    void SetUp() override
+    {
+        ShadowController::kill();
+        LightManager::kill();
+        Manager::kill();
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+        createStandardOgreMaterials();
+        ASSERT_TRUE(createTestRenderWindow());
+        ASSERT_TRUE(canLoadMeshFiles()) << "Shadow tests require GL mesh loading (Xvfb in CI)";
+        LightManager::getSingleton()->tryConnectToManager();
+        Manager::getSingleton()->CreateEmptyScene();
+    }
+
+    void TearDown() override
+    {
+        ShadowController::kill();
+        LightManager::kill();
+        Manager::kill();
+    }
+};
+
+TEST(ShadowControllerTest, QualityPresetNamesCoverOffThroughHigh)
+{
+    const QStringList names = ShadowController::instance()->qualityPresetNames();
+    ASSERT_EQ(names.size(), 4);
+    EXPECT_EQ(names.first(), QStringLiteral("Off"));
+}
+
+TEST_F(ShadowControllerOgreTest, NoCastersKeepsShadowTechniqueDisabled)
+{
+    auto* shadows = ShadowController::instance();
+    shadows->setQualityPreset(static_cast<int>(ShadowController::QualityPreset::High));
+
+    LightHandle key = LightManager::getSingleton()->createLight(Ogre::Light::LT_DIRECTIONAL,
+                                                                QStringLiteral("Key"));
+    ASSERT_TRUE(key.isValid());
+  LightSnapshot snapshot = LightSnapshot::fromHandle(key);
+    snapshot.castShadows = false;
+    LightManager::getSingleton()->applyProperties(key.name, snapshot);
+
+    shadows->syncFromScene();
+
+    Ogre::SceneManager* sm = Manager::getSingleton()->getSceneMgr();
+    ASSERT_NE(sm, nullptr);
+    EXPECT_FALSE(sm->isShadowTechniqueInUse());
+    EXPECT_FALSE(shadows->shadowsActive());
+}
+
+TEST_F(ShadowControllerOgreTest, EnablingCasterInstallsShadowTechnique)
+{
+    auto* shadows = ShadowController::instance();
+    shadows->setQualityPreset(static_cast<int>(ShadowController::QualityPreset::Medium));
+
+    LightHandle key = LightManager::getSingleton()->createLight(Ogre::Light::LT_DIRECTIONAL,
+                                                                QStringLiteral("Key"));
+    ASSERT_TRUE(key.isValid());
+
+    LightSnapshot snapshot = LightSnapshot::fromHandle(key);
+    snapshot.castShadows = true;
+    LightManager::getSingleton()->applyProperties(key.name, snapshot);
+
+    shadows->syncFromScene();
+
+    Ogre::SceneManager* sm = Manager::getSingleton()->getSceneMgr();
+    ASSERT_NE(sm, nullptr);
+    EXPECT_TRUE(key.light->getCastShadows());
+    if (sm->isShadowTechniqueInUse())
+    {
+        EXPECT_TRUE(shadows->shadowsActive());
+    }
+}
+
+TEST_F(ShadowControllerOgreTest, SnapshotRoundTripsShadowBias)
+{
+    LightHandle spot = LightManager::getSingleton()->createLight(Ogre::Light::LT_SPOTLIGHT,
+                                                                QStringLiteral("Stage"));
+    ASSERT_TRUE(spot.isValid());
+
+    LightSnapshot snapshot = LightSnapshot::fromHandle(spot);
+    snapshot.castShadows = true;
+    snapshot.shadowDepthBias = 0.0002f;
+    snapshot.shadowSlopeBias = 2.5f;
+    LightManager::getSingleton()->applyProperties(spot.name, snapshot);
+
+    const LightSnapshot roundTrip = LightSnapshot::fromHandle(spot);
+    EXPECT_TRUE(roundTrip.castShadows);
+    EXPECT_FLOAT_EQ(roundTrip.shadowDepthBias, 0.0002f);
+    EXPECT_FLOAT_EQ(roundTrip.shadowSlopeBias, 2.5f);
+}

--- a/src/commands/LightCommands.cpp
+++ b/src/commands/LightCommands.cpp
@@ -123,6 +123,8 @@ QString lightPropertyClassLabel(LightPropertyClass propertyClass)
         return QStringLiteral("attenuation");
     case LightPropertyClass::SpotCone:
         return QStringLiteral("cone");
+    case LightPropertyClass::Shadow:
+        return QStringLiteral("shadow");
     }
     return QStringLiteral("property");
 }

--- a/src/commands/LightCommands.h
+++ b/src/commands/LightCommands.h
@@ -70,7 +70,8 @@ enum class LightPropertyClass
     Intensity,
     Range,
     Attenuation,
-    SpotCone
+    SpotCone,
+    Shadow
 };
 
 QString lightPropertyClassLabel(LightPropertyClass propertyClass);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -547,7 +547,6 @@ MainWindow::~MainWindow()
         LightsController::kill();
         LightPropertiesController::kill();
         SceneLightingController::kill();
-        ShadowController::kill();
         IsometricSpritesController::kill();
         MeshGenController::kill();
         MeshDepthRenderer::shutdown();
@@ -555,10 +554,13 @@ MainWindow::~MainWindow()
         MaterialPresetLibrary::kill();
         MaterialPreviewRenderer::kill();
         AIChatManager::kill();
+        ShadowController::kill();
 
         // Only destroy Manager if it still exists and belongs to this MainWindow
         if (manager->getMainWindow() == this)
             Manager::kill();
+    } else {
+        ShadowController::kill();
     }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -117,6 +117,7 @@
 #include "LightsController.h"
 #include "LightRigLibrary.h"
 #include "SceneLightingController.h"
+#include "ShadowController.h"
 #include "LightPropertiesController.h"
 #include "AutoRigController.h"
 #include "MeshDepthRenderer.h"
@@ -546,6 +547,7 @@ MainWindow::~MainWindow()
         LightsController::kill();
         LightPropertiesController::kill();
         SceneLightingController::kill();
+        ShadowController::kill();
         IsometricSpritesController::kill();
         MeshGenController::kill();
         MeshDepthRenderer::shutdown();
@@ -745,6 +747,11 @@ void MainWindow::initToolBar()
             "PropertiesPanel", 1, 0, "SceneLightingController",
             [](QQmlEngine* engine, QJSEngine*) -> QObject* {
                 return SceneLightingController::qmlInstance(engine, nullptr);
+            });
+        qmlRegisterSingletonType<ShadowController>(
+            "PropertiesPanel", 1, 0, "ShadowController",
+            [](QQmlEngine* engine, QJSEngine*) -> QObject* {
+                return ShadowController::qmlInstance(engine, nullptr);
             });
         qmlRegisterSingletonType<AutoRigController>(
             "PropertiesPanel", 1, 0, "AutoRigController",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,6 +52,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/LightsController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/LightPropertiesController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/SceneLightingController.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/ShadowController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/SelectionBoxObject.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/ObjectItemModel.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MaterialComboDelegate.cpp
@@ -298,6 +299,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/LightsController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/LightPropertiesController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/SceneLightingController.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/ShadowController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/SelectionBoxObject.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/ObjectItemModel.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MaterialComboDelegate.h


### PR DESCRIPTION
## Summary
- Add `ShadowController` with global shadow quality (Off/Low/Medium/High), PSSM cascades, spot map resolution, and lazy install/uninstall of Ogre texture-modulative shadows when any user light casts.
- Expose per-light cast shadows + depth/slope bias via `LightPropertiesController`, per-mesh receive shadows via `PropertiesPanelController`, and reorganize UI into Object Mode Tools (**Light** + **Shadow** sections) with themed checkboxes.
- Fix light-rig group deletion (ordered child-light teardown, deferred shadow sync) and show receive-shadows when a selected scene node has an attached mesh (`hasMeshInSelection`).

## Test plan
- [x] `UnitTests --gtest_filter="ShadowController*:LightManager*:PropertiesPanelControllerTests.HasMeshInSelection*"`
- [ ] Object mode: Mode Tools → Shadow → set quality Medium, enable Cast shadows on a directional light, Receive shadows on ground plane — shadow visible on mesh
- [ ] Delete a Three-point rig group from Scene tree — no crash
- [ ] Shadow bias Depth/Slope fields readable (stacked, wider labels)

Closes #488

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Shadow section in the Inspector for object-mode lighting controls.
  * Added shadow quality, cascade, resolution, and bias settings, plus support for enabling shadows on selected lights.
  * Introduced a more compact, themed checkbox style across lighting controls.

* **Bug Fixes**
  * Improved scene-node deletion so grouped lights are removed cleanly without leaving stray child items.
  * Better preserves light and shadow settings when switching selections or restoring snapshots.

* **Style**
  * Updated field sizing behavior for more flexible layout in transform inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->