### PR TITLE
chore: bump version to 3.18.0 (TripoSG image-to-3D release)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 3.17.0 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 3.18.0 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Available on the [GitHub Actions Marketplace](https://github.com/marketplace/act
 **Versioning**
 
 - **Always follow the latest GitHub release** — use the Marketplace floating tag `fernandotonon/QtMeshEditor@v1` (same pattern as the [Marketplace example](https://github.com/marketplace/actions/qtmesheditor)). The composite action defaults to `image-tag: latest`, so the Docker CLI tracks the newest published `ghcr.io/fernandotonon/qtmesh` image.
-- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.17.0**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
+- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.18.0**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
 
 Pinned workflow template (action + `ghcr.io` image aligned):
 
@@ -53,10 +53,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run QtMesh scan
-        uses: fernandotonon/QtMeshEditor@3.17.0
+        uses: fernandotonon/QtMeshEditor@3.18.0
         with:
           command: scan
-          image-tag: "3.17.0"
+          image-tag: "3.18.0"
         env:
           QTMESH_CLOUD_TOKEN: ${{ secrets.QTMESH_CLOUD_TOKEN }}
 ```
@@ -81,37 +81,37 @@ Release tags are listed on the [releases page](https://github.com/fernandotonon/
 
 ```yaml
 # Validate a specific mesh
-- uses: fernandotonon/QtMeshEditor@3.17.0
+- uses: fernandotonon/QtMeshEditor@3.18.0
   with:
     command: validate
     input-file: ./models/character.fbx
-    image-tag: "3.17.0"
+    image-tag: "3.18.0"
 
 # Convert FBX → glTF
-- uses: fernandotonon/QtMeshEditor@3.17.0
+- uses: fernandotonon/QtMeshEditor@3.18.0
   with:
     command: convert
     input-file: ./models/character.fbx
     output-file: ./output/character.gltf2
-    image-tag: "3.17.0"
+    image-tag: "3.18.0"
 
 # Resample Mixamo animations (200+ keyframes → 30)
-- uses: fernandotonon/QtMeshEditor@3.17.0
+- uses: fernandotonon/QtMeshEditor@3.18.0
   with:
     command: anim
     input-file: ./animations/dance.fbx
     output-file: ./output/dance_optimized.fbx
     options: --resample 30
-    image-tag: "3.17.0"
+    image-tag: "3.18.0"
 
 # Get mesh info as JSON
-- uses: fernandotonon/QtMeshEditor@3.17.0
+- uses: fernandotonon/QtMeshEditor@3.18.0
   id: info
   with:
     command: info
     input-file: ./models/character.fbx
     options: --json
-    image-tag: "3.17.0"
+    image-tag: "3.18.0"
 
 # Docker (alternative — :latest tracks newest image; pin :3.4.0 to match semver action ref)
 docker run --rm -v $(pwd):/workspace ghcr.io/fernandotonon/qtmesh:latest scan ./assets --fail-on error

--- a/website/src/hooks/useQtmeshActionRef.js
+++ b/website/src/hooks/useQtmeshActionRef.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 const QTMESH_RELEASES_LATEST_API = 'https://api.github.com/repos/fernandotonon/QtMeshEditor/releases/latest';
-const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.17.0';
+const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.18.0';
 const CACHE_KEY = 'qtmesh.actionRef.cache.v1';
 const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 


### PR DESCRIPTION
Bumps the version to **3.18.0** so the TripoSG image→3D backend + describe-then-generate texturing (PR #794) ships under a fresh version. 3.17.0 was already released on 2026-07-04, before #794 merged.

- `CMakeLists.txt` VERSION → 3.18.0 (single source of truth)
- README.md + website hook doc pins synced via `scripts/sync-doc-versions-from-cmake.sh` (CI `verify-doc-versions` will pass)

After merge: tag 3.18.0 + publish the GitHub Release to trigger the deploy pipeline (Homebrew/WinGet/Snap/Docker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project and documented CI references from version **3.17.0** to **3.18.0**.
  * Refreshed the default version used when falling back to a pinned action reference.
  * Aligned README examples so build and workflow snippets point to the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->