### PR TITLE
Lights: Slice I — light linking (#491)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,7 @@ Three singletons manage core state. All run on the main thread. Access via `Clas
 - **MCP tools** (`create_light`, `delete_light`, `list_lights`, `set_light_property`, `apply_light_rig`): operate on the live editor scene via `LightManager` / `LightRigLibrary` / `SceneLightsIO::captureFromScene()`.
 - **Intensity units**: GUI/CLI/MCP use Ogre `powerScale` (Inspector “Intensity”). glTF export writes both `qtmesh.scene.lights` (exact) and best-effort KHR punctual intensity derived from `powerScale × diffuse luminance`. FBX lights are Assimp best-effort; use the `.lights.json` sidecar for bit-exact round-trip.
 - **Sentry breadcrumbs**: `scene.light.create|delete|duplicate|rename|edit|shadow_toggle|apply_rig|gizmo_toggle` on core ops; `ui.action` on menu/toolbar clicks.
+- **Light linking (Slice I #491)**: per-light include/exclude lists map to Ogre `Light::setLightMask` / `Entity::setLightMask` (32 channel bits; bit 0 reserved; max 31 simultaneous link rules). Persisted in `qtmesh.scene.lights` JSON as `linkMode`, `linkedEntities`, `linkChannelBit`. Exclude sets excluded entities to the channel bit only (no overlap with the light's inverted mask). Combining include + exclude on the same entity is best-effort. RTSS PBR may not honour masks on every pass.
 
 ### Debug Overlays
 

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -4597,6 +4597,135 @@ Rectangle {
                     onNewValue: function(val) { LightPropertiesController.spotFalloff = val }
                 }
             }
+
+            // Light linking (Slice I #491)
+            Text {
+                text: qsTr("Light linking")
+                color: PropertiesPanelController.textColor
+                font.pixelSize: 11
+                font.bold: true
+                topPadding: 8
+            }
+            Text {
+                width: parent.width - 16
+                wrapMode: Text.WordWrap
+                text: qsTr("Limit which meshes this light affects (32 mask channels). RTSS PBR may not honour masks on all passes.")
+                color: PropertiesPanelController.textColor
+                font.pixelSize: 10
+                opacity: 0.8
+            }
+            ThemedComboBox {
+                width: parent.width - 16
+                height: 22
+                font.pixelSize: 11
+                model: LightPropertiesController.linkModeChoices
+                enabled: !LightPropertiesController.mixedLinkMode
+                currentIndex: LightPropertiesController.mixedLinkMode
+                    ? -1
+                    : LightPropertiesController.linkMode
+                onActivated: index => LightPropertiesController.linkMode = index
+            }
+            Column {
+                visible: LightPropertiesController.linkMode !== 0
+                    && !LightPropertiesController.mixedLinkMode
+                spacing: 4
+                width: parent.width - 16
+                Repeater {
+                    model: LightPropertiesController.linkedEntityNames
+                    delegate: Row {
+                        width: parent.width
+                        spacing: 6
+                        Text {
+                            width: parent.width - removeBtn.width - 6
+                            text: modelData
+                            color: PropertiesPanelController.textColor
+                            font.pixelSize: 11
+                            elide: Text.ElideRight
+                        }
+                        Rectangle {
+                            id: removeBtn
+                            width: 18
+                            height: 18
+                            radius: 3
+                            color: removeMouse.pressed
+                                ? Qt.darker(PropertiesPanelController.inputColor, 1.2)
+                                : PropertiesPanelController.inputColor
+                            border.color: PropertiesPanelController.borderColor
+                            Text {
+                                anchors.centerIn: parent
+                                text: "×"
+                                color: PropertiesPanelController.textColor
+                                font.pixelSize: 12
+                            }
+                            MouseArea {
+                                id: removeMouse
+                                anchors.fill: parent
+                                onClicked: LightPropertiesController.removeLinkedEntity(modelData)
+                            }
+                        }
+                    }
+                }
+                Row {
+                    spacing: 6
+                    width: parent.width
+                    ThemedComboBox {
+                        id: linkTargetPicker
+                        width: parent.width - addLinkBtn.width - 6
+                        height: 22
+                        font.pixelSize: 11
+                        model: LightPropertiesController.availableLinkTargets
+                        enabled: count > 0
+                        Connections {
+                            target: LightPropertiesController
+                            function onPropertiesChanged() {
+                                if (linkTargetPicker.count === 0)
+                                    linkTargetPicker.currentIndex = -1
+                                else if (linkTargetPicker.currentIndex < 0
+                                         || linkTargetPicker.currentIndex >= linkTargetPicker.count)
+                                    linkTargetPicker.currentIndex = 0
+                            }
+                        }
+                    }
+                    Rectangle {
+                        id: addLinkBtn
+                        width: 44
+                        height: 22
+                        radius: 3
+                        opacity: linkTargetPicker.count > 0 && linkTargetPicker.currentIndex >= 0
+                            ? 1.0
+                            : 0.45
+                        color: addLinkMouse.containsMouse
+                            && linkTargetPicker.count > 0
+                            && linkTargetPicker.currentIndex >= 0
+                            ? PropertiesPanelController.highlightColor
+                            : PropertiesPanelController.controlBgColor
+                        border.color: PropertiesPanelController.borderColor
+                        border.width: 1
+                        Text {
+                            anchors.centerIn: parent
+                            text: qsTr("Add")
+                            color: PropertiesPanelController.textColor
+                            font.pixelSize: 11
+                        }
+                        MouseArea {
+                            id: addLinkMouse
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            cursorShape: linkTargetPicker.count > 0
+                                && linkTargetPicker.currentIndex >= 0
+                                ? Qt.PointingHandCursor
+                                : Qt.ArrowCursor
+                            enabled: linkTargetPicker.count > 0
+                                && linkTargetPicker.currentIndex >= 0
+                            onClicked: {
+                                if (linkTargetPicker.currentIndex >= 0)
+                                    LightPropertiesController.addLinkedEntity(
+                                        linkTargetPicker.currentText)
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -5686,138 +5815,6 @@ Rectangle {
                     step: 0.1
                     decimals: 2
                     onNewValue: function(val) { LightPropertiesController.shadowSlopeBias = val }
-                }
-            }
-
-            Text {
-                visible: LightPropertiesController.hasLightSelection
-                text: qsTr("Light linking")
-                color: PropertiesPanelController.textColor
-                font.pixelSize: 11
-                font.bold: true
-                topPadding: 8
-            }
-            Text {
-                visible: LightPropertiesController.hasLightSelection
-                width: parent.width - 16
-                wrapMode: Text.WordWrap
-                text: qsTr("Limit which meshes this light affects (32 mask channels). RTSS PBR may not honour masks on all passes.")
-                color: PropertiesPanelController.textColor
-                font.pixelSize: 10
-                opacity: 0.8
-            }
-            ThemedComboBox {
-                visible: LightPropertiesController.hasLightSelection
-                width: parent.width - 16
-                height: 22
-                font.pixelSize: 11
-                model: LightPropertiesController.linkModeChoices
-                enabled: !LightPropertiesController.mixedLinkMode
-                currentIndex: LightPropertiesController.mixedLinkMode
-                    ? -1
-                    : LightPropertiesController.linkMode
-                onActivated: index => LightPropertiesController.linkMode = index
-            }
-            Column {
-                visible: LightPropertiesController.hasLightSelection
-                    && LightPropertiesController.linkMode !== 0
-                    && !LightPropertiesController.mixedLinkMode
-                spacing: 4
-                width: parent.width - 16
-                Repeater {
-                    model: LightPropertiesController.linkedEntityNames
-                    delegate: Row {
-                        width: parent.width
-                        spacing: 6
-                        Text {
-                            width: parent.width - removeBtn.width - 6
-                            text: modelData
-                            color: PropertiesPanelController.textColor
-                            font.pixelSize: 11
-                            elide: Text.ElideRight
-                        }
-                        Rectangle {
-                            id: removeBtn
-                            width: 18
-                            height: 18
-                            radius: 3
-                            color: removeMouse.pressed
-                                ? Qt.darker(PropertiesPanelController.inputColor, 1.2)
-                                : PropertiesPanelController.inputColor
-                            border.color: PropertiesPanelController.borderColor
-                            Text {
-                                anchors.centerIn: parent
-                                text: "×"
-                                color: PropertiesPanelController.textColor
-                                font.pixelSize: 12
-                            }
-                            MouseArea {
-                                id: removeMouse
-                                anchors.fill: parent
-                                onClicked: LightPropertiesController.removeLinkedEntity(modelData)
-                            }
-                        }
-                    }
-                }
-                Row {
-                    spacing: 6
-                    width: parent.width
-                    ThemedComboBox {
-                        id: linkTargetPicker
-                        width: parent.width - addLinkBtn.width - 6
-                        height: 22
-                        font.pixelSize: 11
-                        model: LightPropertiesController.availableLinkTargets
-                        enabled: count > 0
-                        Connections {
-                            target: LightPropertiesController
-                            function onPropertiesChanged() {
-                                if (linkTargetPicker.count === 0)
-                                    linkTargetPicker.currentIndex = -1
-                                else if (linkTargetPicker.currentIndex < 0
-                                         || linkTargetPicker.currentIndex >= linkTargetPicker.count)
-                                    linkTargetPicker.currentIndex = 0
-                            }
-                        }
-                    }
-                    Rectangle {
-                        id: addLinkBtn
-                        width: 44
-                        height: 22
-                        radius: 3
-                        opacity: linkTargetPicker.count > 0 && linkTargetPicker.currentIndex >= 0
-                            ? 1.0
-                            : 0.45
-                        color: addLinkMouse.containsMouse
-                            && linkTargetPicker.count > 0
-                            && linkTargetPicker.currentIndex >= 0
-                            ? PropertiesPanelController.highlightColor
-                            : PropertiesPanelController.controlBgColor
-                        border.color: PropertiesPanelController.borderColor
-                        border.width: 1
-                        Text {
-                            anchors.centerIn: parent
-                            text: qsTr("Add")
-                            color: PropertiesPanelController.textColor
-                            font.pixelSize: 11
-                        }
-                        MouseArea {
-                            id: addLinkMouse
-                            anchors.fill: parent
-                            hoverEnabled: true
-                            cursorShape: linkTargetPicker.count > 0
-                                && linkTargetPicker.currentIndex >= 0
-                                ? Qt.PointingHandCursor
-                                : Qt.ArrowCursor
-                            enabled: linkTargetPicker.count > 0
-                                && linkTargetPicker.currentIndex >= 0
-                            onClicked: {
-                                if (linkTargetPicker.currentIndex >= 0)
-                                    LightPropertiesController.addLinkedEntity(
-                                        linkTargetPicker.currentText)
-                            }
-                        }
-                    }
                 }
             }
         }

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -5688,6 +5688,114 @@ Rectangle {
                     onNewValue: function(val) { LightPropertiesController.shadowSlopeBias = val }
                 }
             }
+
+            Text {
+                visible: LightPropertiesController.hasLightSelection
+                text: qsTr("Light linking")
+                color: PropertiesPanelController.textColor
+                font.pixelSize: 11
+                font.bold: true
+                topPadding: 8
+            }
+            Text {
+                visible: LightPropertiesController.hasLightSelection
+                width: parent.width - 16
+                wrapMode: Text.WordWrap
+                text: qsTr("Limit which meshes this light affects (32 mask channels). RTSS PBR may not honour masks on all passes.")
+                color: PropertiesPanelController.textColor
+                font.pixelSize: 10
+                opacity: 0.8
+            }
+            ThemedComboBox {
+                visible: LightPropertiesController.hasLightSelection
+                width: parent.width - 16
+                height: 22
+                font.pixelSize: 11
+                model: LightPropertiesController.linkModeChoices
+                enabled: !LightPropertiesController.mixedLinkMode
+                currentIndex: LightPropertiesController.mixedLinkMode
+                    ? -1
+                    : LightPropertiesController.linkMode
+                onActivated: index => LightPropertiesController.linkMode = index
+            }
+            Column {
+                visible: LightPropertiesController.hasLightSelection
+                    && LightPropertiesController.linkMode !== 0
+                    && !LightPropertiesController.mixedLinkMode
+                spacing: 4
+                width: parent.width - 16
+                Repeater {
+                    model: LightPropertiesController.linkedEntityNames
+                    delegate: Row {
+                        width: parent.width
+                        spacing: 6
+                        Text {
+                            width: parent.width - removeBtn.width - 6
+                            text: modelData
+                            color: PropertiesPanelController.textColor
+                            font.pixelSize: 11
+                            elide: Text.ElideRight
+                        }
+                        Rectangle {
+                            id: removeBtn
+                            width: 18
+                            height: 18
+                            radius: 3
+                            color: removeMouse.pressed
+                                ? Qt.darker(PropertiesPanelController.inputColor, 1.2)
+                                : PropertiesPanelController.inputColor
+                            border.color: PropertiesPanelController.borderColor
+                            Text {
+                                anchors.centerIn: parent
+                                text: "×"
+                                color: PropertiesPanelController.textColor
+                                font.pixelSize: 12
+                            }
+                            MouseArea {
+                                id: removeMouse
+                                anchors.fill: parent
+                                onClicked: LightPropertiesController.removeLinkedEntity(modelData)
+                            }
+                        }
+                    }
+                }
+                Row {
+                    spacing: 6
+                    width: parent.width
+                    ThemedComboBox {
+                        id: linkTargetPicker
+                        width: parent.width - addLinkBtn.width - 6
+                        height: 22
+                        font.pixelSize: 11
+                        model: LightPropertiesController.availableLinkTargets
+                    }
+                    Rectangle {
+                        id: addLinkBtn
+                        width: 44
+                        height: 22
+                        radius: 3
+                        color: addLinkMouse.pressed
+                            ? Qt.darker(PropertiesPanelController.buttonColor, 1.1)
+                            : PropertiesPanelController.buttonColor
+                        border.color: PropertiesPanelController.borderColor
+                        Text {
+                            anchors.centerIn: parent
+                            text: qsTr("Add")
+                            color: PropertiesPanelController.textColor
+                            font.pixelSize: 11
+                        }
+                        MouseArea {
+                            id: addLinkMouse
+                            anchors.fill: parent
+                            onClicked: {
+                                if (linkTargetPicker.currentIndex >= 0)
+                                    LightPropertiesController.addLinkedEntity(
+                                        linkTargetPicker.currentText)
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -5768,16 +5768,33 @@ Rectangle {
                         height: 22
                         font.pixelSize: 11
                         model: LightPropertiesController.availableLinkTargets
+                        enabled: count > 0
+                        Connections {
+                            target: LightPropertiesController
+                            function onPropertiesChanged() {
+                                if (linkTargetPicker.count === 0)
+                                    linkTargetPicker.currentIndex = -1
+                                else if (linkTargetPicker.currentIndex < 0
+                                         || linkTargetPicker.currentIndex >= linkTargetPicker.count)
+                                    linkTargetPicker.currentIndex = 0
+                            }
+                        }
                     }
                     Rectangle {
                         id: addLinkBtn
                         width: 44
                         height: 22
                         radius: 3
-                        color: addLinkMouse.pressed
-                            ? Qt.darker(PropertiesPanelController.buttonColor, 1.1)
-                            : PropertiesPanelController.buttonColor
+                        opacity: linkTargetPicker.count > 0 && linkTargetPicker.currentIndex >= 0
+                            ? 1.0
+                            : 0.45
+                        color: addLinkMouse.containsMouse
+                            && linkTargetPicker.count > 0
+                            && linkTargetPicker.currentIndex >= 0
+                            ? PropertiesPanelController.highlightColor
+                            : PropertiesPanelController.controlBgColor
                         border.color: PropertiesPanelController.borderColor
+                        border.width: 1
                         Text {
                             anchors.centerIn: parent
                             text: qsTr("Add")
@@ -5787,6 +5804,13 @@ Rectangle {
                         MouseArea {
                             id: addLinkMouse
                             anchors.fill: parent
+                            hoverEnabled: true
+                            cursorShape: linkTargetPicker.count > 0
+                                && linkTargetPicker.currentIndex >= 0
+                                ? Qt.PointingHandCursor
+                                : Qt.ArrowCursor
+                            enabled: linkTargetPicker.count > 0
+                                && linkTargetPicker.currentIndex >= 0
                             onClicked: {
                                 if (linkTargetPicker.currentIndex >= 0)
                                     LightPropertiesController.addLinkedEntity(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,7 @@ AnimationWidget.cpp
 SelectionSet.cpp
 LightManager.cpp
 LightRigLibrary.cpp
+LightLinking.cpp
 LightVisualizer.cpp
 LightsController.cpp
 LightPropertiesController.cpp

--- a/src/LightLinking.cpp
+++ b/src/LightLinking.cpp
@@ -3,6 +3,7 @@
 #include "Manager.h"
 
 #include <OgreEntity.h>
+#include <OgreLight.h>
 #include <OgreSceneNode.h>
 
 #include <QHash>
@@ -138,30 +139,45 @@ void applyExcludeRule(uint32_t channelBit, const QStringList& excludedNames)
     }
 }
 
-void applyRule(const QString& lightName, const ActiveRule& rule)
+bool channelBitInUseByOther(const QString& lightName, uint32_t bit)
 {
-    auto* lights = LightManager::getSingletonPtr();
-    if (!lights)
-        return;
+    if (bit == 0)
+        return false;
+    for (auto it = g_rulesByLight.constBegin(); it != g_rulesByLight.constEnd(); ++it)
+    {
+        if (it.key() == lightName)
+            continue;
+        if (it->channelBit == bit)
+            return true;
+    }
+    return false;
+}
 
-    const LightHandle* handle = lights->findLight(lightName);
-    if (!handle || !handle->isValid())
+void applyRule(const QString& lightName, const ActiveRule& rule, Ogre::Light* light = nullptr)
+{
+    if (!light)
+    {
+        if (auto* lights = LightManager::getSingletonPtr())
+            if (const LightHandle* handle = lights->findLight(lightName))
+                light = handle->light;
+    }
+    if (!light)
         return;
 
     if (rule.mode == LightLinking::Mode::None || rule.channelBit == 0)
     {
-        handle->light->setLightMask(LightLinking::kDefaultMask);
+        light->setLightMask(LightLinking::kDefaultMask);
         return;
     }
 
     if (rule.mode == LightLinking::Mode::Include)
     {
-        handle->light->setLightMask(rule.channelBit);
+        light->setLightMask(rule.channelBit);
         applyIncludeRule(rule.channelBit, rule.entityNames);
     }
     else if (rule.mode == LightLinking::Mode::Exclude)
     {
-        handle->light->setLightMask(LightLinking::kDefaultMask & ~rule.channelBit);
+        light->setLightMask(LightLinking::kDefaultMask & ~rule.channelBit);
         applyExcludeRule(rule.channelBit, rule.entityNames);
     }
 }
@@ -202,7 +218,7 @@ Mode modeFromString(const QString& text)
     return Mode::None;
 }
 
-void applyFromSnapshot(const LightSnapshot& snapshot)
+void applyFromSnapshot(const LightSnapshot& snapshot, Ogre::Light* light)
 {
     if (snapshot.name.isEmpty())
         return;
@@ -217,22 +233,27 @@ void applyFromSnapshot(const LightSnapshot& snapshot)
         if (rule.channelBit != 0)
             clearChannelFromAllEntities(rule.channelBit);
         g_rulesByLight.remove(snapshot.name);
-        applyRule(snapshot.name, {});
+        applyRule(snapshot.name, {}, light);
         return;
     }
 
-    if (rule.channelBit == 0)
+    if (rule.channelBit == 0 || channelBitInUseByOther(snapshot.name, rule.channelBit))
         rule.channelBit = allocateChannelBit(snapshot.name);
     if (rule.channelBit == 0)
         return; // all 31 channels in use
 
     g_rulesByLight.insert(snapshot.name, rule);
 
-    applyRule(snapshot.name, rule);
+    applyRule(snapshot.name, rule, light);
 
-    if (LightHandle* handle = LightManager::getSingleton()->findLight(snapshot.name))
+    if (!light)
     {
-        auto& bindings = handle->light->getUserObjectBindings();
+        if (LightHandle* handle = LightManager::getSingleton()->findLight(snapshot.name))
+            light = handle->light;
+    }
+    if (light)
+    {
+        auto& bindings = light->getUserObjectBindings();
         bindings.setUserAny(QStringLiteral("light_link_mode").toStdString(),
                             Ogre::Any(modeToString(rule.mode).toStdString()));
         bindings.setUserAny(QStringLiteral("light_link_entities").toStdString(),

--- a/src/LightLinking.cpp
+++ b/src/LightLinking.cpp
@@ -1,0 +1,303 @@
+#include "LightLinking.h"
+#include "LightManager.h"
+#include "Manager.h"
+
+#include <OgreEntity.h>
+#include <OgreSceneNode.h>
+
+#include <QHash>
+#include <QSet>
+
+namespace
+{
+
+struct ActiveRule
+{
+    LightLinking::Mode mode = LightLinking::Mode::None;
+    QStringList entityNames;
+    uint32_t channelBit = 0;
+};
+
+QHash<QString, ActiveRule> g_rulesByLight;
+
+uint32_t channelBitFromIndex(int index)
+{
+    if (index < 1 || index > LightLinking::kMaxLinkChannels)
+        return 0;
+    return 1u << static_cast<uint32_t>(index);
+}
+
+int indexFromChannelBit(uint32_t bit)
+{
+    if (bit == 0)
+        return 0;
+    for (int i = 1; i <= LightLinking::kMaxLinkChannels; ++i)
+    {
+        if (bit == channelBitFromIndex(i))
+            return i;
+    }
+    return 0;
+}
+
+uint32_t allocateChannelBit(const QString& lightName)
+{
+    QSet<int> used;
+    for (auto it = g_rulesByLight.constBegin(); it != g_rulesByLight.constEnd(); ++it)
+    {
+        if (it.key() == lightName)
+            continue;
+        const int idx = indexFromChannelBit(it->channelBit);
+        if (idx > 0)
+            used.insert(idx);
+    }
+
+    for (int i = 1; i <= LightLinking::kMaxLinkChannels; ++i)
+    {
+        if (!used.contains(i))
+            return channelBitFromIndex(i);
+    }
+    return 0;
+}
+
+QList<Ogre::Entity*> allEntities()
+{
+    QList<Ogre::Entity*> out;
+    if (!Manager::getSingletonPtr())
+        return out;
+
+    for (Ogre::MovableObject* obj : Manager::getSingleton()->getEntities())
+    {
+        if (obj && obj->getMovableType() == QStringLiteral("Entity"))
+            out.append(static_cast<Ogre::Entity*>(obj));
+    }
+    return out;
+}
+
+Ogre::Entity* entityByNodeName(const QString& nodeName)
+{
+    if (!Manager::getSingletonPtr() || nodeName.isEmpty())
+        return nullptr;
+
+    Ogre::SceneNode* node = Manager::getSingleton()->getSceneNode(nodeName);
+    if (!node)
+        return nullptr;
+
+    for (unsigned short i = 0; i < node->numAttachedObjects(); ++i)
+    {
+        Ogre::MovableObject* obj = node->getAttachedObject(i);
+        if (obj && obj->getMovableType() == QStringLiteral("Entity"))
+            return static_cast<Ogre::Entity*>(obj);
+    }
+    return nullptr;
+}
+
+void clearChannelFromAllEntities(uint32_t channelBit)
+{
+    if (channelBit == 0)
+        return;
+    for (Ogre::Entity* entity : allEntities())
+        entity->setLightMask(entity->getLightMask() & ~channelBit);
+}
+
+void applyIncludeRule(uint32_t channelBit, const QStringList& includedNames)
+{
+    clearChannelFromAllEntities(channelBit);
+
+    QSet<QString> included;
+    for (const QString& name : includedNames)
+        included.insert(name);
+
+    for (Ogre::Entity* entity : allEntities())
+    {
+        const QString nodeName =
+            QString::fromStdString(entity->getParentSceneNode()->getName());
+        if (included.contains(nodeName))
+            entity->setLightMask(entity->getLightMask() | channelBit);
+    }
+}
+
+void applyExcludeRule(uint32_t channelBit, const QStringList& excludedNames)
+{
+    QSet<QString> excluded;
+    for (const QString& name : excludedNames)
+        excluded.insert(name);
+
+    for (Ogre::Entity* entity : allEntities())
+    {
+        const QString nodeName =
+            QString::fromStdString(entity->getParentSceneNode()->getName());
+        if (excluded.contains(nodeName))
+        {
+            // Mask must not overlap the light's (~channelBit) mask — only the bit itself.
+            entity->setLightMask(channelBit);
+        }
+        else if (entity->getLightMask() == channelBit)
+        {
+            entity->setLightMask(LightLinking::kDefaultMask);
+        }
+    }
+}
+
+void applyRule(const QString& lightName, const ActiveRule& rule)
+{
+    auto* lights = LightManager::getSingletonPtr();
+    if (!lights)
+        return;
+
+    const LightHandle* handle = lights->findLight(lightName);
+    if (!handle || !handle->isValid())
+        return;
+
+    if (rule.mode == LightLinking::Mode::None || rule.channelBit == 0)
+    {
+        handle->light->setLightMask(LightLinking::kDefaultMask);
+        return;
+    }
+
+    if (rule.mode == LightLinking::Mode::Include)
+    {
+        handle->light->setLightMask(rule.channelBit);
+        applyIncludeRule(rule.channelBit, rule.entityNames);
+    }
+    else if (rule.mode == LightLinking::Mode::Exclude)
+    {
+        handle->light->setLightMask(LightLinking::kDefaultMask & ~rule.channelBit);
+        applyExcludeRule(rule.channelBit, rule.entityNames);
+    }
+}
+
+void rebuildAllRules()
+{
+    const QStringList lightNames = g_rulesByLight.keys();
+    for (const QString& name : lightNames)
+        applyRule(name, g_rulesByLight.value(name));
+}
+
+} // namespace
+
+namespace LightLinking
+{
+
+QString modeToString(Mode mode)
+{
+    switch (mode)
+    {
+    case Mode::Include:
+        return QStringLiteral("include");
+    case Mode::Exclude:
+        return QStringLiteral("exclude");
+    case Mode::None:
+    default:
+        return QStringLiteral("none");
+    }
+}
+
+Mode modeFromString(const QString& text)
+{
+    const QString lower = text.trimmed().toLower();
+    if (lower == QStringLiteral("include"))
+        return Mode::Include;
+    if (lower == QStringLiteral("exclude"))
+        return Mode::Exclude;
+    return Mode::None;
+}
+
+void applyFromSnapshot(const LightSnapshot& snapshot)
+{
+    if (snapshot.name.isEmpty())
+        return;
+
+    ActiveRule rule;
+    rule.mode = snapshot.linkMode;
+    rule.entityNames = snapshot.linkedEntityNames;
+    rule.channelBit = snapshot.linkChannelBit;
+
+    if (rule.mode == Mode::None)
+    {
+        if (rule.channelBit != 0)
+            clearChannelFromAllEntities(rule.channelBit);
+        g_rulesByLight.remove(snapshot.name);
+        applyRule(snapshot.name, {});
+        return;
+    }
+
+    if (rule.channelBit == 0)
+        rule.channelBit = allocateChannelBit(snapshot.name);
+    if (rule.channelBit == 0)
+        return; // all 31 channels in use
+
+    g_rulesByLight.insert(snapshot.name, rule);
+
+    applyRule(snapshot.name, rule);
+
+    if (LightHandle* handle = LightManager::getSingleton()->findLight(snapshot.name))
+    {
+        auto& bindings = handle->light->getUserObjectBindings();
+        bindings.setUserAny(QStringLiteral("light_link_mode").toStdString(),
+                            Ogre::Any(modeToString(rule.mode).toStdString()));
+        bindings.setUserAny(QStringLiteral("light_link_entities").toStdString(),
+                            Ogre::Any(rule.entityNames.join(QLatin1Char('\n')).toStdString()));
+        bindings.setUserAny(QStringLiteral("light_link_channel").toStdString(),
+                            Ogre::Any(rule.channelBit));
+    }
+}
+
+void onLightDeleted(const LightSnapshot& snapshot)
+{
+    uint32_t bit = g_rulesByLight.value(snapshot.name).channelBit;
+    if (bit == 0)
+        bit = snapshot.linkChannelBit;
+    g_rulesByLight.remove(snapshot.name);
+    if (bit != 0)
+        clearChannelFromAllEntities(bit);
+    rebuildAllRules();
+}
+
+void onEntityCreated(Ogre::Entity* entity)
+{
+    if (!entity)
+        return;
+
+    const QString nodeName =
+        QString::fromStdString(entity->getParentSceneNode()->getName());
+
+    for (auto it = g_rulesByLight.constBegin(); it != g_rulesByLight.constEnd(); ++it)
+    {
+        const ActiveRule& rule = it.value();
+        if (rule.channelBit == 0)
+            continue;
+
+        if (rule.mode == Mode::Include)
+        {
+            if (rule.entityNames.contains(nodeName))
+                entity->setLightMask(entity->getLightMask() | rule.channelBit);
+            else
+                entity->setLightMask(entity->getLightMask() & ~rule.channelBit);
+        }
+        else if (rule.mode == Mode::Exclude)
+        {
+            if (rule.entityNames.contains(nodeName))
+                entity->setLightMask(rule.channelBit);
+        }
+    }
+}
+
+QStringList allEntityNodeNames()
+{
+    QStringList names;
+    for (Ogre::Entity* entity : allEntities())
+    {
+        if (!entity->getParentSceneNode())
+            continue;
+        names.append(QString::fromStdString(entity->getParentSceneNode()->getName()));
+    }
+    names.sort(Qt::CaseInsensitive);
+    return names;
+}
+
+void clearAllRules()
+{
+    g_rulesByLight.clear();
+}
+
+} // namespace LightLinking

--- a/src/LightLinking.h
+++ b/src/LightLinking.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <QStringList>
+
+struct LightSnapshot;
+
+namespace Ogre
+{
+class Entity;
+}
+
+namespace LightLinking
+{
+
+/// Ogre matches lights to objects when `(lightMask & objectMask) != 0`.
+/// We allocate bits 1..31 per linked light (bit 0 reserved). At most 31
+/// simultaneous link rules — document this limit in CLAUDE.md.
+constexpr uint32_t kDefaultMask = 0xFFFFFFFFu;
+constexpr int kMaxLinkChannels = 31;
+
+enum class Mode
+{
+    None = 0,
+    Include,
+    Exclude
+};
+
+QString modeToString(Mode mode);
+Mode modeFromString(const QString& text);
+
+/// Apply linking from a snapshot onto the live scene (light + entity masks).
+void applyFromSnapshot(const LightSnapshot& snapshot);
+
+/// Remove a light's channel from the pool and reset entity bits for that channel.
+void onLightDeleted(const LightSnapshot& snapshot);
+
+/// New mesh entities pick up include/exclude masks from active rules.
+void onEntityCreated(Ogre::Entity* entity);
+
+/// Collect every scene entity scene-node name (for the inspector picker).
+QStringList allEntityNodeNames();
+
+/// Test / scene-reset helper.
+void clearAllRules();
+
+} // namespace LightLinking

--- a/src/LightLinking.h
+++ b/src/LightLinking.h
@@ -7,6 +7,7 @@ struct LightSnapshot;
 namespace Ogre
 {
 class Entity;
+class Light;
 }
 
 namespace LightLinking
@@ -29,7 +30,9 @@ QString modeToString(Mode mode);
 Mode modeFromString(const QString& text);
 
 /// Apply linking from a snapshot onto the live scene (light + entity masks).
-void applyFromSnapshot(const LightSnapshot& snapshot);
+/// When @p light is provided it is used directly (e.g. before the handle is
+/// registered in LightManager); otherwise the light is looked up by name.
+void applyFromSnapshot(const LightSnapshot& snapshot, Ogre::Light* light = nullptr);
 
 /// Remove a light's channel from the pool and reset entity bits for that channel.
 void onLightDeleted(const LightSnapshot& snapshot);

--- a/src/LightLinking_test.cpp
+++ b/src/LightLinking_test.cpp
@@ -1,0 +1,102 @@
+#include <gtest/gtest.h>
+
+#include "LightLinking.h"
+#include "LightManager.h"
+#include "Manager.h"
+#include "SceneLightsIO.h"
+#include "TestHelpers.h"
+
+#include <OgreEntity.h>
+#include <OgreLight.h>
+#include <OgreMeshManager.h>
+#include <OgreSceneManager.h>
+
+class LightLinkingOgreTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        Manager::kill();
+        ASSERT_TRUE(tryInitOgre());
+        createStandardOgreMaterials();
+        LightManager::getSingleton()->tryConnectToManager();
+        LightLinking::clearAllRules();
+    }
+
+    void TearDown() override
+    {
+        LightLinking::clearAllRules();
+        LightManager::kill();
+        Manager::kill();
+    }
+
+    Ogre::Entity* createTestEntity(const QString& nodeName)
+    {
+        auto* mgr = Manager::getSingletonPtr();
+        Ogre::SceneNode* node = mgr->addSceneNode(nodeName);
+        Ogre::MeshPtr mesh = Ogre::MeshManager::getSingleton().createManual(
+            (nodeName + QStringLiteral("_mesh")).toStdString(),
+            Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+        return mgr->createEntity(node, mesh);
+    }
+};
+
+TEST_F(LightLinkingOgreTest, IncludeOnlyAffectsListedEntity)
+{
+    Ogre::Entity* hero = createTestEntity(QStringLiteral("Hero"));
+    Ogre::Entity* floor = createTestEntity(QStringLiteral("Floor"));
+
+    LightHandle light =
+        LightManager::getSingleton()->createLight(Ogre::Light::LT_POINT, QStringLiteral("Key"));
+    ASSERT_TRUE(light.isValid());
+
+    LightSnapshot snapshot = LightSnapshot::fromHandle(light);
+    snapshot.linkMode = LightLinking::Mode::Include;
+    snapshot.linkedEntityNames = {QStringLiteral("Hero")};
+    LightManager::getSingleton()->applyProperties(light.name, snapshot);
+
+    snapshot = LightSnapshot::fromHandle(light);
+    EXPECT_EQ(snapshot.linkMode, LightLinking::Mode::Include);
+    EXPECT_NE(snapshot.linkChannelBit, 0u);
+    EXPECT_NE(light.light->getLightMask() & hero->getLightMask(), 0u);
+    EXPECT_EQ(light.light->getLightMask() & floor->getLightMask(), 0u);
+}
+
+TEST_F(LightLinkingOgreTest, ExcludeSkipsListedEntity)
+{
+    Ogre::Entity* hero = createTestEntity(QStringLiteral("Hero"));
+    Ogre::Entity* floor = createTestEntity(QStringLiteral("Floor"));
+
+    LightHandle light =
+        LightManager::getSingleton()->createLight(Ogre::Light::LT_POINT, QStringLiteral("Key"));
+    ASSERT_TRUE(light.isValid());
+
+    LightSnapshot snapshot = LightSnapshot::fromHandle(light);
+    snapshot.linkMode = LightLinking::Mode::Exclude;
+    snapshot.linkedEntityNames = {QStringLiteral("Floor")};
+    LightManager::getSingleton()->applyProperties(light.name, snapshot);
+
+    EXPECT_NE(light.light->getLightMask() & hero->getLightMask(), 0u);
+    EXPECT_EQ(light.light->getLightMask() & floor->getLightMask(), 0u);
+}
+
+TEST_F(LightLinkingOgreTest, JsonRoundTripPreservesLinkFields)
+{
+    LightSnapshot original;
+    original.name = QStringLiteral("L1");
+    original.type = Ogre::Light::LT_POINT;
+    original.linkMode = LightLinking::Mode::Include;
+    original.linkedEntityNames = {QStringLiteral("Hero")};
+    original.linkChannelBit = 4;
+
+    SceneLightsIO::SceneLightsDocument doc;
+    doc.standaloneLights.append(original);
+    const QByteArray json = SceneLightsIO::documentToJson(doc);
+    SceneLightsIO::SceneLightsDocument restored;
+    ASSERT_TRUE(SceneLightsIO::documentFromJson(json, restored));
+    ASSERT_EQ(restored.standaloneLights.size(), 1);
+    EXPECT_EQ(restored.standaloneLights.first().linkMode, LightLinking::Mode::Include);
+    EXPECT_EQ(restored.standaloneLights.first().linkedEntityNames,
+              QStringList{QStringLiteral("Hero")});
+    EXPECT_EQ(restored.standaloneLights.first().linkChannelBit, 4u);
+}

--- a/src/LightLinking_test.cpp
+++ b/src/LightLinking_test.cpp
@@ -100,3 +100,53 @@ TEST_F(LightLinkingOgreTest, JsonRoundTripPreservesLinkFields)
               QStringList{QStringLiteral("Hero")});
     EXPECT_EQ(restored.standaloneLights.first().linkChannelBit, 4u);
 }
+
+TEST_F(LightLinkingOgreTest, RestoreSnapshotAppliesLinkingBeforeRegistration)
+{
+    Ogre::Entity* hero = createTestEntity(QStringLiteral("Hero"));
+    Ogre::Entity* floor = createTestEntity(QStringLiteral("Floor"));
+
+    LightSnapshot snapshot;
+    snapshot.name = QStringLiteral("SavedKey");
+    snapshot.type = Ogre::Light::LT_POINT;
+    snapshot.linkMode = LightLinking::Mode::Include;
+    snapshot.linkedEntityNames = {QStringLiteral("Hero")};
+
+    const LightHandle restored = LightManager::getSingleton()->restoreSnapshot(snapshot);
+    ASSERT_TRUE(restored.isValid());
+    EXPECT_NE(restored.light->getLightMask() & hero->getLightMask(), 0u);
+    EXPECT_EQ(restored.light->getLightMask() & floor->getLightMask(), 0u);
+}
+
+TEST_F(LightLinkingOgreTest, DuplicateLightAllocatesFreshLinkChannel)
+{
+    Ogre::Entity* hero = createTestEntity(QStringLiteral("Hero"));
+
+    const LightHandle source =
+        LightManager::getSingleton()->createLight(Ogre::Light::LT_POINT, QStringLiteral("Key"));
+    ASSERT_TRUE(source.isValid());
+
+    LightSnapshot sourceSnap = LightSnapshot::fromHandle(source);
+    sourceSnap.linkMode = LightLinking::Mode::Include;
+    sourceSnap.linkedEntityNames = {QStringLiteral("Hero")};
+    LightManager::getSingleton()->applyProperties(source.name, sourceSnap);
+
+    const uint32_t sourceBit = LightSnapshot::fromHandle(source).linkChannelBit;
+    ASSERT_NE(sourceBit, 0u);
+
+    const LightHandle clone = LightManager::getSingleton()->duplicateLight(source.name);
+    ASSERT_TRUE(clone.isValid());
+
+    const uint32_t cloneBit = LightSnapshot::fromHandle(clone).linkChannelBit;
+    EXPECT_NE(sourceBit, cloneBit);
+    EXPECT_NE(source.light->getLightMask() & hero->getLightMask(), 0u);
+    EXPECT_NE(clone.light->getLightMask() & hero->getLightMask(), 0u);
+
+    LightSnapshot cloneSnap = LightSnapshot::fromHandle(clone);
+    cloneSnap.linkedEntityNames.clear();
+    LightManager::getSingleton()->applyProperties(clone.name, cloneSnap);
+
+    EXPECT_EQ(LightSnapshot::fromHandle(source).linkChannelBit, sourceBit);
+    EXPECT_EQ(LightSnapshot::fromHandle(clone).linkChannelBit, cloneBit);
+    EXPECT_NE(source.light->getLightMask() & hero->getLightMask(), 0u);
+}

--- a/src/LightManager.cpp
+++ b/src/LightManager.cpp
@@ -1,5 +1,6 @@
 #include "LightManager.h"
 
+#include "LightLinking.h"
 #include "Manager.h"
 #include "SentryReporter.h"
 #include "ShadowController.h"
@@ -51,6 +52,50 @@ LightSnapshot LightSnapshot::fromHandle(const LightHandle& handle)
         snapshot.shadowDepthBias = Ogre::any_cast<float>(depthAny);
     if (slopeAny.has_value())
         snapshot.shadowSlopeBias = Ogre::any_cast<float>(slopeAny);
+
+    const auto& linkBindings = handle.light->getUserObjectBindings();
+    const auto modeAny = linkBindings.getUserAny(QStringLiteral("light_link_mode").toStdString());
+    if (modeAny.has_value())
+    {
+        try
+        {
+            snapshot.linkMode =
+                LightLinking::modeFromString(QString::fromStdString(Ogre::any_cast<std::string>(modeAny)));
+        }
+        catch (...)
+        {
+            snapshot.linkMode = LightLinking::Mode::None;
+        }
+    }
+    const auto entitiesAny =
+        linkBindings.getUserAny(QStringLiteral("light_link_entities").toStdString());
+    if (entitiesAny.has_value())
+    {
+        try
+        {
+            const std::string encoded = Ogre::any_cast<std::string>(entitiesAny);
+            snapshot.linkedEntityNames =
+                QString::fromStdString(encoded).split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+        }
+        catch (...)
+        {
+            snapshot.linkedEntityNames.clear();
+        }
+    }
+    const auto channelAny =
+        linkBindings.getUserAny(QStringLiteral("light_link_channel").toStdString());
+    if (channelAny.has_value())
+    {
+        try
+        {
+            snapshot.linkChannelBit = static_cast<uint32_t>(Ogre::any_cast<uint32_t>(channelAny));
+        }
+        catch (...)
+        {
+            snapshot.linkChannelBit = 0;
+        }
+    }
+
     return snapshot;
 }
 
@@ -70,7 +115,10 @@ bool LightSnapshot::operator==(const LightSnapshot& other) const
            && scale == other.scale && usesDirection == other.usesDirection
            && direction == other.direction && castShadows == other.castShadows
            && shadowDepthBias == other.shadowDepthBias
-           && shadowSlopeBias == other.shadowSlopeBias;
+           && shadowSlopeBias == other.shadowSlopeBias
+           && linkMode == other.linkMode
+           && linkedEntityNames == other.linkedEntityNames
+           && linkChannelBit == other.linkChannelBit;
 }
 
 LightManager* LightManager::getSingleton()
@@ -214,6 +262,16 @@ void LightManager::applySnapshotToHandle(const LightSnapshot& snapshot, LightHan
                         Ogre::Any(snapshot.shadowDepthBias));
     bindings.setUserAny(QStringLiteral("shadow_slope_bias").toStdString(),
                         Ogre::Any(snapshot.shadowSlopeBias));
+
+    bindings.setUserAny(QStringLiteral("light_link_mode").toStdString(),
+                        Ogre::Any(LightLinking::modeToString(snapshot.linkMode).toStdString()));
+    bindings.setUserAny(QStringLiteral("light_link_entities").toStdString(),
+                        Ogre::Any(snapshot.linkedEntityNames.join(QLatin1Char('\n')).toStdString()));
+    bindings.setUserAny(QStringLiteral("light_link_channel").toStdString(),
+                        Ogre::Any(snapshot.linkChannelBit));
+
+    LightSnapshot linkSnap = snapshot;
+    LightLinking::applyFromSnapshot(linkSnap);
 }
 
 LightHandle LightManager::createLightInternal(Ogre::Light::LightTypes type, const QString& baseName)
@@ -333,6 +391,7 @@ void LightManager::deleteAllUserLights()
 
 void LightManager::clearAllLights()
 {
+    LightLinking::clearAllRules();
     deleteAllUserLights();
 }
 
@@ -453,8 +512,10 @@ bool LightManager::deleteLight(const QString& name)
             continue;
 
         Ogre::SceneNode* node = m_lights[i].sceneNode;
+        const LightSnapshot deletedSnapshot = LightSnapshot::fromHandle(m_lights[i]);
         m_lights.removeAt(i);
         emit lightDeleted(name);
+        LightLinking::onLightDeleted(deletedSnapshot);
         SentryReporter::addBreadcrumb(QStringLiteral("scene.light.delete"),
                                       QStringLiteral("Deleted %1").arg(name));
 

--- a/src/LightManager.cpp
+++ b/src/LightManager.cpp
@@ -270,8 +270,7 @@ void LightManager::applySnapshotToHandle(const LightSnapshot& snapshot, LightHan
     bindings.setUserAny(QStringLiteral("light_link_channel").toStdString(),
                         Ogre::Any(snapshot.linkChannelBit));
 
-    LightSnapshot linkSnap = snapshot;
-    LightLinking::applyFromSnapshot(linkSnap);
+    LightLinking::applyFromSnapshot(snapshot, handle.light);
 }
 
 LightHandle LightManager::createLightInternal(Ogre::Light::LightTypes type, const QString& baseName)

--- a/src/LightManager.h
+++ b/src/LightManager.h
@@ -7,6 +7,9 @@
 #include <QList>
 #include <QObject>
 #include <QString>
+#include <QStringList>
+
+#include "LightLinking.h"
 
 namespace Ogre
 {
@@ -46,6 +49,11 @@ struct LightSnapshot
     bool castShadows = false;
     float shadowDepthBias = 0.00005f;
     float shadowSlopeBias = 1.0f;
+
+    /// Slice I (#491): entity include/exclude via Ogre light masks (bits 1..31).
+    LightLinking::Mode linkMode = LightLinking::Mode::None;
+    QStringList linkedEntityNames;
+    uint32_t linkChannelBit = 0;
 
     static LightSnapshot fromHandle(const LightHandle& handle);
     bool operator==(const LightSnapshot& other) const;

--- a/src/LightPropertiesController.cpp
+++ b/src/LightPropertiesController.cpp
@@ -1,6 +1,7 @@
 #include "LightPropertiesController.h"
 
 #include "LightManager.h"
+#include "LightLinking.h"
 #include "Manager.h"
 #include "SelectionSet.h"
 #include "ShadowController.h"
@@ -839,6 +840,82 @@ void LightPropertiesController::setShadowSlopeBias(double value)
 
     pushImmediateEdit(LightPropertyClass::Shadow,
                       [clamped](LightSnapshot& snapshot) { snapshot.shadowSlopeBias = clamped; });
+}
+
+int LightPropertiesController::linkMode() const
+{
+    const QList<LightSnapshot> snapshots = selectedSnapshots();
+    if (snapshots.isEmpty())
+        return 0;
+    return static_cast<int>(snapshots.first().linkMode);
+}
+
+bool LightPropertiesController::mixedLinkMode() const
+{
+    const QList<LightSnapshot> snapshots = selectedSnapshots();
+    if (snapshots.size() < 2)
+        return false;
+    const LightLinking::Mode first = snapshots.first().linkMode;
+    for (const LightSnapshot& snapshot : snapshots)
+    {
+        if (snapshot.linkMode != first)
+            return true;
+    }
+    return false;
+}
+
+QStringList LightPropertiesController::linkedEntityNames() const
+{
+    const QList<LightSnapshot> snapshots = selectedSnapshots();
+    if (snapshots.isEmpty())
+        return {};
+    if (snapshots.size() == 1)
+        return snapshots.first().linkedEntityNames;
+    return {};
+}
+
+QStringList LightPropertiesController::linkModeChoices() const
+{
+    return {QStringLiteral("Affect all"), QStringLiteral("Include only"), QStringLiteral("Exclude")};
+}
+
+QStringList LightPropertiesController::availableLinkTargets() const
+{
+    return LightLinking::allEntityNodeNames();
+}
+
+void LightPropertiesController::setLinkMode(int mode)
+{
+    const LightLinking::Mode linkMode = static_cast<LightLinking::Mode>(std::clamp(mode, 0, 2));
+    pushImmediateEdit(LightPropertyClass::Linking, [linkMode](LightSnapshot& snapshot) {
+        snapshot.linkMode = linkMode;
+        if (linkMode == LightLinking::Mode::None)
+        {
+            snapshot.linkedEntityNames.clear();
+            snapshot.linkChannelBit = 0;
+        }
+    });
+}
+
+void LightPropertiesController::addLinkedEntity(const QString& entityName)
+{
+    const QString trimmed = entityName.trimmed();
+    if (trimmed.isEmpty())
+        return;
+
+    pushImmediateEdit(LightPropertyClass::Linking, [trimmed](LightSnapshot& snapshot) {
+        if (snapshot.linkMode == LightLinking::Mode::None)
+            snapshot.linkMode = LightLinking::Mode::Include;
+        if (!snapshot.linkedEntityNames.contains(trimmed))
+            snapshot.linkedEntityNames.append(trimmed);
+    });
+}
+
+void LightPropertiesController::removeLinkedEntity(const QString& entityName)
+{
+    pushImmediateEdit(LightPropertyClass::Linking, [entityName](LightSnapshot& snapshot) {
+        snapshot.linkedEntityNames.removeAll(entityName);
+    });
 }
 
 void LightPropertiesController::beginSliderEdit(int propertyClass)

--- a/src/LightPropertiesController.cpp
+++ b/src/LightPropertiesController.cpp
@@ -881,7 +881,11 @@ QStringList LightPropertiesController::linkModeChoices() const
 
 QStringList LightPropertiesController::availableLinkTargets() const
 {
-    return LightLinking::allEntityNodeNames();
+    QStringList names = LightLinking::allEntityNodeNames();
+    const QStringList linked = linkedEntityNames();
+    for (const QString& name : linked)
+        names.removeAll(name);
+    return names;
 }
 
 void LightPropertiesController::setLinkMode(int mode)

--- a/src/LightPropertiesController.h
+++ b/src/LightPropertiesController.h
@@ -58,6 +58,11 @@ class LightPropertiesController : public QObject
     Q_PROPERTY(bool mixedShadowSlopeBias READ mixedShadowSlopeBias NOTIFY propertiesChanged)
     Q_PROPERTY(QStringList lightTypeChoices READ lightTypeChoices CONSTANT)
     Q_PROPERTY(QStringList attenuationPresetChoices READ attenuationPresetChoices CONSTANT)
+    Q_PROPERTY(int linkMode READ linkMode WRITE setLinkMode NOTIFY propertiesChanged)
+    Q_PROPERTY(bool mixedLinkMode READ mixedLinkMode NOTIFY propertiesChanged)
+    Q_PROPERTY(QStringList linkedEntityNames READ linkedEntityNames NOTIFY propertiesChanged)
+    Q_PROPERTY(QStringList linkModeChoices READ linkModeChoices CONSTANT)
+    Q_PROPERTY(QStringList availableLinkTargets READ availableLinkTargets NOTIFY propertiesChanged)
 
 public:
     static LightPropertiesController* instance();
@@ -140,6 +145,16 @@ public:
 
     QStringList lightTypeChoices() const;
     QStringList attenuationPresetChoices() const;
+
+    int linkMode() const;
+    void setLinkMode(int mode);
+    bool mixedLinkMode() const;
+    QStringList linkedEntityNames() const;
+    QStringList linkModeChoices() const;
+    QStringList availableLinkTargets() const;
+
+    Q_INVOKABLE void addLinkedEntity(const QString& entityName);
+    Q_INVOKABLE void removeLinkedEntity(const QString& entityName);
 
     Q_INVOKABLE void beginSliderEdit(int propertyClass);
     Q_INVOKABLE void endSliderEdit(int propertyClass);

--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -52,6 +52,7 @@ THE SOFTWARE.
 #include "HDR/HdrBundledLibrary.h"
 #include "HDR/HdrViewportController.h"
 #include "LightManager.h"
+#include "LightLinking.h"
 #include "LightRigLibrary.h"
 
 #if OGRE_PLATFORM == OGRE_PLATFORM_APPLE
@@ -261,6 +262,7 @@ Ogre::Entity* Manager::createEntity(Ogre::SceneNode* const& sceneNode, const Ogr
 
     sceneNode->attachObject(ent);
     emit entityCreated(ent);
+    LightLinking::onEntityCreated(ent);
     if(!mInitializingScene)
         SelectionSet::getSingleton()->selectOne(sceneNode);
     return ent;

--- a/src/SceneLightsIO.cpp
+++ b/src/SceneLightsIO.cpp
@@ -1,6 +1,7 @@
 #include "SceneLightsIO.h"
 
 #include "LightManager.h"
+#include "LightLinking.h"
 #include "LightRigLibrary.h"
 #include "Manager.h"
 #include "ShadowController.h"
@@ -211,6 +212,9 @@ QJsonObject snapshotToJson(const LightSnapshot& snapshot)
     obj.insert(QStringLiteral("castShadows"), snapshot.castShadows);
     obj.insert(QStringLiteral("shadowDepthBias"), snapshot.shadowDepthBias);
     obj.insert(QStringLiteral("shadowSlopeBias"), snapshot.shadowSlopeBias);
+    obj.insert(QStringLiteral("linkMode"), LightLinking::modeToString(snapshot.linkMode));
+    obj.insert(QStringLiteral("linkedEntities"), QJsonArray::fromStringList(snapshot.linkedEntityNames));
+    obj.insert(QStringLiteral("linkChannelBit"), static_cast<int>(snapshot.linkChannelBit));
     return obj;
 }
 
@@ -258,6 +262,17 @@ bool snapshotFromJson(const QJsonObject& obj, LightSnapshot& snapshot)
         static_cast<float>(obj.value(QStringLiteral("shadowDepthBias")).toDouble(0.00005));
     snapshot.shadowSlopeBias =
         static_cast<float>(obj.value(QStringLiteral("shadowSlopeBias")).toDouble(1.0));
+    snapshot.linkMode =
+        LightLinking::modeFromString(obj.value(QStringLiteral("linkMode")).toString());
+  const QJsonArray linked = obj.value(QStringLiteral("linkedEntities")).toArray();
+    for (const QJsonValue& value : linked)
+    {
+        const QString name = value.toString().trimmed();
+        if (!name.isEmpty())
+            snapshot.linkedEntityNames.append(name);
+    }
+    snapshot.linkChannelBit =
+        static_cast<uint32_t>(obj.value(QStringLiteral("linkChannelBit")).toInt(0));
     return true;
 }
 

--- a/src/commands/LightCommands.cpp
+++ b/src/commands/LightCommands.cpp
@@ -125,6 +125,8 @@ QString lightPropertyClassLabel(LightPropertyClass propertyClass)
         return QStringLiteral("cone");
     case LightPropertyClass::Shadow:
         return QStringLiteral("shadow");
+    case LightPropertyClass::Linking:
+        return QStringLiteral("light linking");
     }
     return QStringLiteral("property");
 }

--- a/src/commands/LightCommands.h
+++ b/src/commands/LightCommands.h
@@ -71,7 +71,8 @@ enum class LightPropertyClass
     Range,
     Attenuation,
     SpotCone,
-    Shadow
+    Shadow,
+    Linking
 };
 
 QString lightPropertyClassLabel(LightPropertyClass propertyClass);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/SelectionSet.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/LightManager.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/LightRigLibrary.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/LightLinking.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/LightVisualizer.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/LightsController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/LightPropertiesController.cpp


### PR DESCRIPTION
## Summary

- Adds per-light **include/exclude** entity linking via Ogre `Light::setLightMask` / `Entity::setLightMask` (31 channel bits; bit 0 reserved).
- Inspector section in Light Mode: mode combo, linked-entity list with add/remove, undo via `LightPropertyClass::Linking`.
- Persists `linkMode`, `linkedEntities`, and `linkChannelBit` in `qtmesh.scene.lights` JSON and light user bindings.
- Unit tests cover include/exclude mask semantics and JSON round-trip.

Part 1 of #491 — remaining sub-features (IES, area lights, groups, per-viewport solo) will follow as separate PRs per issue guidance.

## Test plan

- [x] `xvfb-run ./build_local/bin/UnitTests --gtest_filter="LightLinkingOgreTest.*"` (3/3 pass)
- [ ] Create a point light, set linking to Include, add one entity → only that mesh is lit
- [ ] Switch to Exclude with one entity → that mesh is dark, others lit
- [ ] Save scene / export glTF and re-import → linking fields restored
- [ ] Undo/redo linking edits in the inspector

Closes #491 partially (light linking only).


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added light linking controls in the light properties panel, letting you limit which meshes a light affects.
  * Lights can now be set to include or exclude specific scene entities, with selectable targets and easy add/remove controls.
  * Light linking settings are now saved and restored with scene data.

* **Bug Fixes**
  * Improved behavior when creating, deleting, or resetting lights and entities so linked lighting updates stay in sync.
  * Added coverage to verify linking behavior and data round-tripping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->