### PR TITLE
chore(models): mirror all aggregate models to dedicated HF repos

### DIFF
--- a/THIRD_PARTY_AI_MODELS.md
+++ b/THIRD_PARTY_AI_MODELS.md
@@ -11,7 +11,10 @@ the binary). Attribution + licenses for the models and their training data:
 > [`QtMeshEditor-skintokens-onnx`](https://huggingface.co/fernandotonon/QtMeshEditor-skintokens-onnx),
 > [`QtMeshEditor-triposr-onnx`](https://huggingface.co/fernandotonon/QtMeshEditor-triposr-onnx),
 > [`QtMeshEditor-triposg-onnx`](https://huggingface.co/fernandotonon/QtMeshEditor-triposg-onnx),
-> [`QtMeshEditor-pbrify-onnx`](https://huggingface.co/fernandotonon/QtMeshEditor-pbrify-onnx)
+> [`QtMeshEditor-pbrify-onnx`](https://huggingface.co/fernandotonon/QtMeshEditor-pbrify-onnx),
+> [`QtMeshEditor-realesrgan-onnx`](https://huggingface.co/fernandotonon/QtMeshEditor-realesrgan-onnx),
+> [`QtMeshEditor-u2net-onnx`](https://huggingface.co/fernandotonon/QtMeshEditor-u2net-onnx),
+> [`QtMeshEditor-smolvlm-gguf`](https://huggingface.co/fernandotonon/QtMeshEditor-smolvlm-gguf)
 > (plus the in-house
 > [`QtMeshEditor-rmib-inbetween`](https://huggingface.co/fernandotonon/QtMeshEditor-rmib-inbetween),
 > [`QtMeshEditor-mesh-segmentation`](https://huggingface.co/fernandotonon/QtMeshEditor-mesh-segmentation),

--- a/scripts/sync-hf-model-repos.sh
+++ b/scripts/sync-hf-model-repos.sh
@@ -13,14 +13,18 @@
 # script deliberately does NOT touch — edit cards on the hub or via
 # `huggingface-cli upload <repo> README.md`.
 #
-# Mirrors (created 2026-07-10; -onnx suffix = converted third-party weights):
-#   pbrify     → QtMeshEditor-pbrify-onnx      (CC0,  Kim2091/PBRify_Remix)
-#   unirig     → QtMeshEditor-unirig-onnx      (MIT,  VAST-AI UniRig skeleton stage)
-#   skintokens → QtMeshEditor-skintokens-onnx  (MIT,  VAST-AI SkinTokens/TokenRig)
-#   triposr    → QtMeshEditor-triposr-onnx     (MIT,  Stability/Tripo TripoSR)
-#   triposg    → QtMeshEditor-triposg-onnx     (MIT,  VAST-AI TripoSG; int8 tier NOT mirrored — deprecated)
-# In-house models have their own repos already (rmib-inbetween,
-# mesh-segmentation, t2m) with their own upload flows.
+# Mirrors (created 2026-07-10; -onnx/-gguf suffix = converted third-party
+# weights; the in-house rmib-inbetween / mesh-segmentation / t2m repos have
+# their own upload flows, but the t2m repo also mirrors motion-library.json):
+#   pbrify     → QtMeshEditor-pbrify-onnx      (CC0,    Kim2091/PBRify_Remix)
+#   realesrgan → QtMeshEditor-realesrgan-onnx  (BSD-3,  xinntao Real-ESRGAN)
+#   unirig     → QtMeshEditor-unirig-onnx      (MIT,    VAST-AI UniRig skeleton stage)
+#   skintokens → QtMeshEditor-skintokens-onnx  (MIT,    VAST-AI SkinTokens/TokenRig)
+#   triposr    → QtMeshEditor-triposr-onnx     (MIT,    Stability/Tripo TripoSR)
+#   triposg    → QtMeshEditor-triposg-onnx     (MIT,    VAST-AI TripoSG; int8 tier NOT mirrored — deprecated)
+#   u2net      → QtMeshEditor-u2net-onnx       (Apache, U²-Net / rembg)
+#   smolvlm    → QtMeshEditor-smolvlm-gguf     (Apache, HuggingFaceTB SmolVLM Q8_0)
+#   motion     → QtMeshEditor-t2m              (CC0,    in-house; template clip library)
 set -euo pipefail
 
 OWNER=fernandotonon
@@ -28,16 +32,31 @@ AGG=$OWNER/QtMeshEditor-models
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
 
+declare -A REPOS=(
+  [pbrify]=QtMeshEditor-pbrify-onnx
+  [realesrgan]=QtMeshEditor-realesrgan-onnx
+  [unirig]=QtMeshEditor-unirig-onnx
+  [skintokens]=QtMeshEditor-skintokens-onnx
+  [triposr]=QtMeshEditor-triposr-onnx
+  [triposg]=QtMeshEditor-triposg-onnx
+  [u2net]=QtMeshEditor-u2net-onnx
+  [smolvlm]=QtMeshEditor-smolvlm-gguf
+  [motion]=QtMeshEditor-t2m
+)
 declare -A FILES=(
   [pbrify]="1x-PBRify_NormalV3.onnx 1x-PBRify_RoughnessV2.onnx 1x-PBRify_Height.onnx"
+  [realesrgan]="RealESRGAN_x2plus.onnx RealESRGAN_x4plus.onnx"
   [unirig]="unirig/encoder.onnx unirig/decoder.onnx unirig/embed.onnx"
   [skintokens]="skintokens/skintokens.json skintokens/mesh_cond.onnx skintokens/vae_cond.onnx skintokens/embed.onnx skintokens/skin_decode.onnx skintokens/decoder.onnx skintokens/decoder.onnx.data"
   [triposr]="triposr/triposr_encoder.onnx triposr/triposr_encoder_int8.onnx triposr/triposr_decoder.onnx"
   [triposg]="triposg/triposg_image_encoder.onnx triposg/triposg_dit_step.onnx triposg/triposg_dit_step.onnx.data triposg/triposg_vae_latents.onnx triposg/triposg_vae_decoder.onnx"
+  [u2net]="rembg/u2net.onnx"
+  [smolvlm]="caption/SmolVLM-500M-Instruct-Q8_0.gguf caption/mmproj-SmolVLM-500M-Instruct-Q8_0.gguf"
+  [motion]="motion/motion-library.json"
 )
 
 sync_one() {
-  local model=$1 repo="$OWNER/QtMeshEditor-$1-onnx"
+  local model=$1 repo="$OWNER/${REPOS[$model]}"
   echo "=== $model → $repo"
   for f in ${FILES[$model]}; do
     echo "  $f"


### PR DESCRIPTION
Follow-up to the HF hosting split: every file in the aggregate `fernandotonon/QtMeshEditor-models` repo now has a dedicated mirror repo with its own model card and license — this round adds `QtMeshEditor-realesrgan-onnx` (BSD-3), `QtMeshEditor-u2net-onnx` (Apache-2.0), `QtMeshEditor-smolvlm-gguf` (Apache-2.0), and mirrors `motion-library.json` into the existing `QtMeshEditor-t2m` repo.

`scripts/sync-hf-model-repos.sh` gains a repo map covering the `-gguf` suffix and the t2m special case; `THIRD_PARTY_AI_MODELS.md` links the new mirrors. Docs/script only — no app code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded the third-party AI model attribution list with additional ONNX and GGUF model mirrors, including Real-ESRGAN, U²-Net, and SmolVLM.

- **Maintenance**
  - Improved synchronization of hosted AI model repositories, supporting additional model types and dedicated mirror destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->