### PR TITLE
ci: make ccache rolling so the test build actually caches

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1010,10 +1010,18 @@ jobs:
       # Cache compiler outputs across CI runs so the test build (the
       # slowest step in this job, dominated by ~500 .cpp compiles)
       # gets near-instant replays for files that haven't changed.
-      # The cache survives across PRs via the shared key prefix.
+      #
+      # The key MUST be unique per run (github.run_id) so the action
+      # uploads a FRESH cache after every build. GitHub cache entries are
+      # immutable — with a static key the cache is written once and then
+      # never updated, so its hit rate decays to ~0 as the code drifts.
+      # `restore-keys` then pulls the most recent prior cache as the base,
+      # so each run starts warm and saves back the updated cache.
       uses: hendrikmuhs/ccache-action@v1.2
       with:
-        key: sonar-tests-${{ runner.os }}
+        key: sonar-tests-${{ runner.os }}-${{ github.run_id }}
+        restore-keys: |
+          sonar-tests-${{ runner.os }}-
         max-size: 2G
         # ccache wraps gcc/g++ so build-wrapper still sees every
         # invocation it needs to record for SonarCloud.
@@ -1074,6 +1082,12 @@ jobs:
         CCACHE_NOHASHDIR: "true"
       run: |
           echo "=== Running build-wrapper for SonarCloud analysis ==="
+
+          # Zero the ccache hit/miss counters so the post-build `ccache -s`
+          # reflects ONLY this run's compiles (hit rate = how effective the
+          # restored cache was for this build). The cached objects themselves
+          # are untouched — this clears statistics, not the cache.
+          ccache -z || true
 
           # NB: no `make clean` — ccache handles correctness via its hash,
           # and incremental builds let unchanged TUs replay as cached hits.


### PR DESCRIPTION
## Problem

The Linux test/coverage job takes ~1h, dominated by recompiling the ~500-TU test build almost from scratch every run — even though `hendrikmuhs/ccache-action` is already wired in.

The cause: the ccache key was **static** (`sonar-tests-Linux`) with no `restore-keys`. GitHub cache entries are immutable, so the action wrote the cache **once** on the first run and never updated it again. Every run since restored that frozen snapshot, and as the code drifted the hit rate decayed toward zero.

## Fix

Switch to the standard rolling-cache pattern:

- **`key: sonar-tests-Linux-${{ github.run_id }}`** — unique per run, so the exact lookup always misses and the action saves a **fresh** cache at job end.
- **`restore-keys: sonar-tests-Linux-`** — prefix fallback that restores the **newest prior** cache as the warm base.

Net effect: each run starts warm from the last run and only changed TUs recompile.

Also added `ccache -z` before the build so the existing post-build `ccache -s` reports **this run's** hit rate in isolation (was reporting cumulative).

## Expected behavior

- **First run after merge:** partially warm (restores the old stale cache via the prefix), then saves a fresh full cache.
- **Second run onward:** on a small PR the `=== ccache statistics ===` block should show a high hit rate and the `make` step should drop from ~40–50 min to a few minutes.

If the hit rate plateaus below ~90% on small PRs, that's the signal to raise `max-size` past 2G (eviction) — deferred for now; the stats will tell us.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Linux build caching to provide a fresh cache entry for each workflow run while reusing the most recent prior cache as a starting point.
  * Updated build reporting so cache hit and miss statistics reflect only the current run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->