### PR TITLE
Mocap Slice D (#873): MocapRecorder + CLI 'qtmesh mocap --face' + MCP capture_face_from_video

### DIFF
--- a/src/AppLaunchHandler.cpp
+++ b/src/AppLaunchHandler.cpp
@@ -31,6 +31,7 @@ bool isCliSubcommand(const QString& arg)
         QStringLiteral("generate3d"),
         QStringLiteral("morph"),
         QStringLiteral("nodeanim"), QStringLiteral("ps1"), QStringLiteral("cloud"),
+        QStringLiteral("mocap"),
     };
     return kSubcommands.contains(arg);
 }

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -6,6 +6,7 @@
 #include "AlembicImporter.h"
 #include "SceneLightsIO.h"
 #include "SceneLightsCLI.h"
+#include "Mocap/MocapCLI.h"
 #include "AnimationMerger.h"
 #include "MotionInbetween.h"
 #include "MotionLibrary.h"
@@ -591,7 +592,10 @@ void CLIPipeline::writeOutput(const QString& text)
 
 void CLIPipeline::writeCliError(const QString& text)
 {
-    err() << text;
+    // Explicit flush: the CLI exits via _exit(), which skips the static
+    // QTextStream's destructor — without this the error text is silently
+    // lost in the stream buffer.
+    err() << text << Qt::flush;
 }
 
 void CLIPipeline::printUsage()
@@ -866,6 +870,12 @@ void CLIPipeline::printUsage()
         "  nodeanim <file> --list [--json]   List node-animation clips on a scene (props, doors, machinery,\n"
         "                                    animated lights — anything non-skeletal). Authoring on the CLI\n"
         "                                    side needs the C5 glTF/FBX exporter round-trip first.\n"
+        "  mocap <video> --face --mesh <meshfile> [-o out.glb] [--clip-name NAME] [--fps N]\n"
+        "              [--smooth-cutoff HZ] [--no-smooth] [--map overrides.json] [--no-head]\n"
+        "              [--frames-dir DIR] [--json]\n"
+        "                                    Performance capture: facial expressions from a video onto the\n"
+        "                                    mesh's ARKit-style morph targets as a weight clip, plus head\n"
+        "                                    rotation (needs -DENABLE_MOCAP; body capture lands with #874).\n"
         "\n"
         "  ps1 capture <iso> --bios <bios> [--frames N | --scene Ns] [--script in.json]\n"
         "              [--auto-input] [--tracked-only] [--smooth] [--drop-slivers]\n"
@@ -1596,6 +1606,7 @@ int CLIPipeline::run(int argc, char* argv[])
     else if (cmd == "uv") rc = cmdUv(argc, argv);
     else if (cmd == "hdri") rc = cmdHdri(argc, argv);
     else if (cmd == "light") rc = SceneLightsCLI::run(argc, argv);
+    else if (cmd == "mocap") rc = MocapCLI::run(argc, argv);
     else if (cmd == "retopo") rc = cmdRetopo(argc, argv);
     else if (cmd == "skin") rc = cmdSkin(argc, argv);
     else if (cmd == "rig") rc = cmdRig(argc, argv);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -167,6 +167,9 @@ Mocap/FaceCapMapper.cpp
 Mocap/FaceCapPose.cpp
 Mocap/FaceCapGeom.cpp
 Mocap/FaceCapPredictor.cpp
+Mocap/MocapRecorder.cpp
+Mocap/MocapCLI.cpp
+commands/RecordMocapClipCommand.cpp
 ApplyAtlas.cpp
 EmbeddedTextureCache.cpp
 NormalMapGenerator.cpp

--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -11,6 +11,14 @@
 #include "VATBaker.h"
 #include "MorphAnimationManager.h"
 #include "AlembicImporter.h"
+#ifdef ENABLE_MOCAP
+#include "Mocap/FaceCapMapper.h"
+#include "Mocap/FaceCapPredictor.h"
+#include "Mocap/MocapRecorder.h"
+#include "Mocap/OneEuroFilter.h"
+#include "Mocap/VideoFrameSource.h"
+#include "commands/RecordMocapClipCommand.h"
+#endif
 #include "NodeAnimationManager.h"
 #include "PoseLibrary.h"
 #include "PrimitiveObject.h"
@@ -694,6 +702,7 @@ const QMap<QString, MCPServer::ToolHandler>& MCPServer::toolHandlers()
         {QStringLiteral("list_morph_targets"), &MCPServer::toolListMorphTargets},
         {QStringLiteral("set_morph_weight"), &MCPServer::toolSetMorphWeight},
         {QStringLiteral("import_alembic"), &MCPServer::toolImportAlembic},
+        {QStringLiteral("capture_face_from_video"), &MCPServer::toolCaptureFaceFromVideo},
         {QStringLiteral("play_vertex_animation"), &MCPServer::toolPlayVertexAnimation},
         {QStringLiteral("list_node_animations"), &MCPServer::toolListNodeAnimations},
         {QStringLiteral("add_node_animation_clip"), &MCPServer::toolAddNodeAnimationClip},
@@ -746,6 +755,7 @@ bool MCPServer::isHeavyTool(const QString &name)
         QStringLiteral("bake_vat"),
         QStringLiteral("list_morph_targets"),
         QStringLiteral("import_alembic"),
+        QStringLiteral("capture_face_from_video"),
         QStringLiteral("cloud_upload")
     };
     return heavyTools.contains(name);
@@ -802,6 +812,7 @@ QJsonObject MCPServer::callTool(const QString &name, const QJsonObject &args)
             {QStringLiteral("generate_motion"), QStringLiteral("animation_blend")},
             {QStringLiteral("merge_animations"), QStringLiteral("animation_blend")},
             {QStringLiteral("segment_mesh"), QStringLiteral("ai_assist")},
+            {QStringLiteral("capture_face_from_video"), QStringLiteral("ai_assist")},
             {QStringLiteral("generate_mesh_from_image"), QStringLiteral("image_to_3d")},
             {QStringLiteral("generate_pbr_maps"), QStringLiteral("pbr_synth")},
             {QStringLiteral("upscale_texture"), QStringLiteral("pbr_synth")},
@@ -6469,6 +6480,157 @@ QJsonObject MCPServer::toolSetMorphWeight(const QJsonObject &args)
 // Vertex-anim B3 (#519) — Alembic import + vertex-clip playback.
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Performance capture (epic #869, Slice D #873)
+// ---------------------------------------------------------------------------
+
+QJsonObject MCPServer::toolCaptureFaceFromVideo(const QJsonObject &args)
+{
+    SentryReporter::addBreadcrumb("ai.tool_call", "capture_face_from_video");
+#ifndef ENABLE_MOCAP
+    Q_UNUSED(args);
+    return makeErrorResult(
+        "Error: this build has no performance-capture support. Rebuild with "
+        "-DENABLE_MOCAP=ON -DENABLE_ONNX=ON.");
+#else
+    const QString videoPath = args.value("video_path").toString();
+    if (videoPath.isEmpty())
+        return makeErrorResult("Error: missing required 'video_path' argument");
+    if (!QFileInfo::exists(videoPath))
+        return makeErrorResult(QString("Error: video not found: %1").arg(videoPath));
+
+    Manager* mgr = Manager::getSingletonPtr();
+    if (!mgr) return makeErrorResult("Error: Manager not available");
+
+    const QString entityName = args.value("entity_name").toString();
+    Ogre::Entity* entity = nullptr;
+    for (auto* ent : mgr->getEntities()) {
+        if (!ent || ent->getMovableType() != "Entity") continue;
+        if (entityName.isEmpty()
+            || QString::fromStdString(ent->getName()) == entityName) { entity = ent; break; }
+    }
+    if (!entity) {
+        return makeErrorResult(entityName.isEmpty()
+            ? QString("Error: No mesh entity found")
+            : QString("Error: Entity '%1' not found").arg(entityName));
+    }
+
+    const QStringList targets =
+        MorphAnimationManager::instance()->morphTargetsFor(entity);
+    const bool head = args.value("head").toBool(true);
+    if (targets.isEmpty() && !head)
+        return makeErrorResult(
+            "Error: the entity has no morph targets and head=false — nothing to record. "
+            "Face capture drives ARKit-style blendshape targets (jawOpen, mouthSmileLeft, ...).");
+
+    const FaceCapMapper::Mapping mapping =
+        FaceCapMapper::build(targets, args.value("map_path").toString());
+    if (!mapping.error.isEmpty())
+        return makeErrorResult(QString("Error: %1").arg(mapping.error));
+
+    if (!FaceCapPredictor::modelsPresent()
+        && FaceCapPredictor::ensureModelsBlocking().isEmpty())
+        return makeErrorResult(
+            "Error: face capture models are not available (download failed, offline "
+            "guard set, or not hosted yet). Set QTMESH_MOCAP_MODEL_BASE_URL or place "
+            "the graphs in " + FaceCapPredictor::modelDir());
+    auto predictor = std::make_shared<FaceCapPredictor>();
+    if (!predictor->load())
+        return makeErrorResult(QString("Error: %1").arg(predictor->lastError()));
+
+    double fps = args.value("fps").toDouble(30.0);
+    if (fps <= 0 || fps > 240) fps = 30.0;
+    const bool smooth = args.value("smooth").toBool(true);
+
+    auto source = std::make_shared<FileFrameSource>(videoPath, fps);
+    QString openError;
+    if (!source->open(&openError))
+        return makeErrorResult(QString("Error: %1").arg(openError));
+
+    auto samples = std::make_shared<std::vector<FaceSample>>();
+    auto weightFilters = std::make_shared<std::array<OneEuroFilter, 52>>();
+    auto headFilter = std::make_shared<OneEuroQuatFilter>();
+
+    QEventLoop loop;
+    bool finished = false;
+    QString streamError;
+    QObject::connect(source.get(), &VideoFrameSource::frameReady,
+                     [&, predictor, samples, weightFilters, headFilter](const MocapFrame& frame) {
+                         FaceSample s = predictor->predict(frame.image, frame.timeSec);
+                         if (smooth && s.confidence > 0.f) {
+                             for (int c = 0; c < 52; ++c)
+                                 s.weights[c] = static_cast<float>(
+                                     (*weightFilters)[c].filter(s.weights[c], s.timeSec));
+                             s.headRotation = headFilter->filter(s.headRotation, s.timeSec);
+                         }
+                         samples->push_back(s);
+                     });
+    QObject::connect(source.get(), &VideoFrameSource::finished, [&] {
+        finished = true; loop.quit();
+    });
+    QObject::connect(source.get(), &VideoFrameSource::errorOccurred,
+                     [&](const QString& message) {
+                         streamError = message; finished = true; loop.quit();
+                     });
+    source->start();
+    if (!finished)
+        loop.exec();
+    source->stop();
+    if (!streamError.isEmpty())
+        return makeErrorResult(QString("Error: %1").arg(streamError));
+    if (samples->empty())
+        return makeErrorResult("Error: the video produced no frames");
+
+    MocapRecorder::FaceRecordOptions options;
+    options.clipName = args.value("clip_name").toString(QStringLiteral("FaceCap"));
+    options.head = head;
+
+    return runOgreOp([&]() -> QJsonObject {
+        // ONE undoable step for the whole take
+        auto* cmd = new RecordMocapClipCommand(entity->getName(), *samples,
+                                               mapping, options);
+        UndoManager::getSingleton()->push(cmd);
+        const MocapRecorder::FaceRecordReport& report = cmd->report();
+        if (!report.ok())
+            return makeErrorResult(QString("Error: %1").arg(report.error));
+
+        const QString outputPath = args.value("output_path").toString();
+        if (!outputPath.isEmpty()) {
+            Ogre::SceneNode* node = entity->getParentSceneNode();
+            const QString fmt = CLIPipeline::formatForExtension(outputPath);
+            if (!node || MeshImporterExporter::exporter(
+                    node, QFileInfo(outputPath).absoluteFilePath(), fmt) != 0)
+                return makeErrorResult(
+                    QString("Error: recorded, but export to %1 failed").arg(outputPath));
+        }
+
+        GamificationManager::noteOperation(
+            QStringLiteral("mocap_face"),
+            {{QStringLiteral("frames"), static_cast<qint64>(report.framesProcessed)},
+             {QStringLiteral("keyframes"),
+              static_cast<qint64>(report.keyframesWritten + report.headKeyframesWritten)}},
+            GamificationManager::Surface::Mcp);
+
+        QJsonObject content;
+        content["ok"] = true;
+        content["clipName"] = report.clipName;
+        content["framesProcessed"] = report.framesProcessed;
+        content["framesNoFace"] = report.framesNoFace;
+        content["keyframesWritten"] = report.keyframesWritten;
+        content["headKeyframesWritten"] = report.headKeyframesWritten;
+        content["headTarget"] = report.headTarget;
+        content["clipLength"] = report.clipLength;
+        content["matchedChannels"] = QJsonArray::fromStringList(report.matchedChannels);
+        content["unmatchedCanonical"] = QJsonArray::fromStringList(report.unmatchedCanonical);
+        content["unmatchedMesh"] = QJsonArray::fromStringList(report.unmatchedMesh);
+        if (!outputPath.isEmpty())
+            content["output"] = outputPath;
+        return makeSuccessResult(
+            QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Indented)));
+    });
+#endif // ENABLE_MOCAP
+}
+
 QJsonObject MCPServer::toolImportAlembic(const QJsonObject &args)
 {
     SentryReporter::addBreadcrumb("ai.tool_call", "import_alembic");
@@ -9239,6 +9401,31 @@ QJsonArray MCPServer::buildToolsList()
             "Drives the matching Ogre::AnimationState so the mesh deforms in real time. "
             "Returns the actual weight after clamping. Returns an error if no entity is "
             "selected or the named target doesn't exist on the selection.",
+            props,
+            required
+        );
+    }
+
+    // capture_face_from_video (epic #869, Slice D #873)
+    {
+        QJsonObject props;
+        props["video_path"] = QJsonObject{{"type", "string"}, {"description", "Path to a video file of a face performance."}};
+        props["entity_name"] = QJsonObject{{"type", "string"}, {"description", "Target entity (default: first/selected entity)."}};
+        props["output_path"] = QJsonObject{{"type", "string"}, {"description", "Optional export path (e.g. out.glb) written after recording."}};
+        props["clip_name"] = QJsonObject{{"type", "string"}, {"description", "Morph weight clip name (default FaceCap)."}};
+        props["fps"] = QJsonObject{{"type", "number"}, {"description", "Capture rate; frames are decimated to this (default 30)."}};
+        props["smooth"] = QJsonObject{{"type", "boolean"}, {"description", "One-Euro smoothing (default true)."}};
+        props["map_path"] = QJsonObject{{"type", "string"}, {"description", "Optional JSON mapping-override sidecar."}};
+        props["head"] = QJsonObject{{"type", "boolean"}, {"description", "Also record head pose (default true)."}};
+        QJsonArray required;
+        required.append("video_path");
+        appendTool(
+            "capture_face_from_video",
+            "Performance capture: run the face-capture models over a video and record the "
+            "expressions as morph-target weight keyframes (plus head rotation) on the entity, "
+            "as ONE undoable clip. The entity needs ARKit-style blendshape morph targets "
+            "(jawOpen, mouthSmileLeft, ...). Unmatched channels are reported, never dropped. "
+            "Requires a build with ENABLE_MOCAP=ON; models download on first use.",
             props,
             required
         );

--- a/src/MCPServer.h
+++ b/src/MCPServer.h
@@ -281,6 +281,7 @@ private:
     /// live scene as a VAT_POSE-animated mesh. Args: `file` (path). Heavy —
     /// decodes the cache + builds an entity. Needs a build with ENABLE_ALEMBIC.
     QJsonObject toolImportAlembic(const QJsonObject &args);
+    QJsonObject toolCaptureFaceFromVideo(const QJsonObject &args);
 
     /// Vertex-anim B3 (#519): enable + play a vertex-animation clip on an
     /// entity. Args: `entity`, `animation`. Light — state poke on a live entity.

--- a/src/Mocap/MocapCLI.cpp
+++ b/src/Mocap/MocapCLI.cpp
@@ -1,0 +1,428 @@
+#include "MocapCLI.h"
+
+#include "../CLIPipeline.h"
+
+#include <QString>
+
+#ifndef ENABLE_MOCAP
+
+namespace MocapCLI {
+
+int run(int, char*[])
+{
+    CLIPipeline::writeCliError(QStringLiteral(
+        "Error: this build has no performance-capture support — rebuild with "
+        "-DENABLE_MOCAP=ON -DENABLE_ONNX=ON.\n"));
+    return 1;
+}
+
+}  // namespace MocapCLI
+
+#else  // ENABLE_MOCAP
+
+#include "FaceCapCanonicalData.h"
+#include "FaceCapMapper.h"
+#include "FaceCapPredictor.h"
+#include "MocapRecorder.h"
+#include "OneEuroFilter.h"
+#include "VideoFrameSource.h"
+
+#include "../GamificationManager.h"
+#include "../Manager.h"
+#include "../MeshImporterExporter.h"
+#include "../MorphAnimationManager.h"
+#include "../SentryReporter.h"
+
+#include <OgreEntity.h>
+#include <OgreSceneNode.h>
+
+#include <QDir>
+#include <QEventLoop>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+#include <array>
+#include <vector>
+
+namespace MocapCLI {
+
+namespace {
+
+const char* kUsage =
+    "Usage: qtmesh mocap <video> --face --mesh <meshfile> [-o out.glb]\n"
+    "              [--clip-name NAME] [--fps 30] [--smooth-cutoff HZ]\n"
+    "              [--no-smooth] [--map overrides.json] [--no-head]\n"
+    "              [--frames-dir DIR] [--json]\n"
+    "\n"
+    "  Captures facial performance from a video (or an image sequence via\n"
+    "  --frames-dir) onto the mesh's ARKit-style morph targets as a weight\n"
+    "  clip, plus head rotation on the Head bone (skinned) or node (static).\n"
+    "  Body capture (--body) lands with #874.\n";
+
+QJsonObject reportToJson(const MocapRecorder::FaceRecordReport& r)
+{
+    QJsonObject o;
+    o.insert(QLatin1String("clipName"), r.clipName);
+    o.insert(QLatin1String("framesProcessed"), r.framesProcessed);
+    o.insert(QLatin1String("framesNoFace"), r.framesNoFace);
+    o.insert(QLatin1String("keyframesWritten"), r.keyframesWritten);
+    o.insert(QLatin1String("headKeyframesWritten"), r.headKeyframesWritten);
+    o.insert(QLatin1String("headTarget"), r.headTarget);
+    o.insert(QLatin1String("clipLength"), r.clipLength);
+    o.insert(QLatin1String("matchedChannels"),
+             QJsonArray::fromStringList(r.matchedChannels));
+    o.insert(QLatin1String("unmatchedCanonical"),
+             QJsonArray::fromStringList(r.unmatchedCanonical));
+    o.insert(QLatin1String("unmatchedMesh"),
+             QJsonArray::fromStringList(r.unmatchedMesh));
+    if (!r.error.isEmpty())
+        o.insert(QLatin1String("error"), r.error);
+    return o;
+}
+
+}  // namespace
+
+int run(int argc, char* argv[])
+{
+    QString videoPath, meshPath, outputPath, mapPath, framesDir;
+    QString clipName = QStringLiteral("FaceCap");
+    double fps = 30.0;
+    double smoothCutoff = 1.0;
+    bool smooth = true;
+    bool face = false;
+    bool head = true;
+    bool jsonOutput = false;
+
+    for (int i = 1; i < argc; ++i) {
+        const QString arg = QString::fromLocal8Bit(argv[i]);
+        if (arg == QLatin1String("mocap") || arg == QLatin1String("--cli"))
+            continue;
+        if (arg == QLatin1String("--face")) { face = true; continue; }
+        if (arg == QLatin1String("--body")) {
+            CLIPipeline::writeCliError(QStringLiteral(
+                "Error: --body is not implemented yet (tracked in #874); "
+                "only --face is available.\n"));
+            return 2;
+        }
+        if (arg == QLatin1String("--json")) { jsonOutput = true; continue; }
+        if (arg == QLatin1String("--no-head")) { head = false; continue; }
+        if (arg == QLatin1String("--no-smooth")) { smooth = false; continue; }
+        auto value = [&](const char* flag) -> QString {
+            if (i + 1 >= argc) {
+                CLIPipeline::writeCliError(
+                    QStringLiteral("Error: %1 requires a value.\n")
+                        .arg(QLatin1String(flag)));
+                return {};
+            }
+            return QString::fromLocal8Bit(argv[++i]);
+        };
+        if (arg == QLatin1String("--mesh")) {
+            meshPath = value("--mesh");
+            if (meshPath.isEmpty()) return 2;
+            continue;
+        }
+        if (arg == QLatin1String("-o") || arg == QLatin1String("--output")) {
+            outputPath = value("-o");
+            if (outputPath.isEmpty()) return 2;
+            continue;
+        }
+        if (arg == QLatin1String("--clip-name")) {
+            clipName = value("--clip-name");
+            if (clipName.isEmpty()) return 2;
+            continue;
+        }
+        if (arg == QLatin1String("--map")) {
+            mapPath = value("--map");
+            if (mapPath.isEmpty()) return 2;
+            continue;
+        }
+        if (arg == QLatin1String("--frames-dir")) {
+            framesDir = value("--frames-dir");
+            if (framesDir.isEmpty()) return 2;
+            continue;
+        }
+        if (arg == QLatin1String("--fps")) {
+            const QString v = value("--fps");
+            if (v.isEmpty()) return 2;
+            fps = v.toDouble();
+            if (fps <= 0 || fps > 240) {
+                CLIPipeline::writeCliError(
+                    QStringLiteral("Error: --fps out of range (1..240).\n"));
+                return 2;
+            }
+            continue;
+        }
+        if (arg == QLatin1String("--smooth-cutoff")) {
+            const QString v = value("--smooth-cutoff");
+            if (v.isEmpty()) return 2;
+            smoothCutoff = v.toDouble();
+            if (smoothCutoff <= 0) {
+                CLIPipeline::writeCliError(
+                    QStringLiteral("Error: --smooth-cutoff must be > 0 Hz.\n"));
+                return 2;
+            }
+            continue;
+        }
+        if (!arg.startsWith(QLatin1Char('-')) && videoPath.isEmpty()) {
+            videoPath = arg;
+            continue;
+        }
+        CLIPipeline::writeCliError(
+            QStringLiteral("Error: unknown option '%1'.\n%2")
+                .arg(arg, QLatin1String(kUsage)));
+        return 2;
+    }
+
+    if (!face) {
+        CLIPipeline::writeCliError(
+            QStringLiteral("Error: nothing to capture — pass --face.\n%1")
+                .arg(QLatin1String(kUsage)));
+        return 2;
+    }
+    if (meshPath.isEmpty()) {
+        CLIPipeline::writeCliError(
+            QStringLiteral("Error: --mesh <meshfile> is required.\n%1")
+                .arg(QLatin1String(kUsage)));
+        return 2;
+    }
+    if (videoPath.isEmpty() && framesDir.isEmpty()) {
+        CLIPipeline::writeCliError(
+            QStringLiteral("Error: no input video (or --frames-dir).\n%1")
+                .arg(QLatin1String(kUsage)));
+        return 2;
+    }
+    const QFileInfo meshFi(meshPath);
+    if (!meshFi.exists()) {
+        CLIPipeline::writeCliError(
+            QStringLiteral("Error: mesh not found: %1\n").arg(meshPath));
+        return 1;
+    }
+    if (!framesDir.isEmpty() && !QFileInfo(framesDir).isDir()) {
+        CLIPipeline::writeCliError(
+            QStringLiteral("Error: --frames-dir is not a directory: %1\n")
+                .arg(framesDir));
+        return 1;
+    }
+    if (framesDir.isEmpty() && !QFileInfo::exists(videoPath)) {
+        CLIPipeline::writeCliError(
+            QStringLiteral("Error: video not found: %1\n").arg(videoPath));
+        return 1;
+    }
+
+    if (!CLIPipeline::initOgreHeadless())
+        return 1;
+
+    SentryReporter::addBreadcrumb(
+        QStringLiteral("ai.assist.mocap_face"),
+        QStringLiteral("cli mocap --face mesh=.%1 source=%2")
+            .arg(meshFi.suffix(),
+                 framesDir.isEmpty() ? QStringLiteral("video")
+                                     : QStringLiteral("frames-dir")));
+
+    // --- load the mesh + enumerate morph targets -----------------------------
+    MeshImporterExporter::importer({meshFi.absoluteFilePath()});
+    Ogre::Entity* entity = nullptr;
+    for (Ogre::Entity* e : Manager::getSingleton()->getEntities()) {
+        if (e && e->getMovableType() == "Entity") { entity = e; break; }
+    }
+    if (!entity) {
+        CLIPipeline::writeCliError(
+            QStringLiteral("Error: failed to load %1\n").arg(meshPath));
+        return 1;
+    }
+
+    const QStringList targets =
+        MorphAnimationManager::instance()->morphTargetsFor(entity);
+    if (targets.isEmpty() && !head) {
+        CLIPipeline::writeCliError(QStringLiteral(
+            "Error: %1 has NO morph targets and --no-head was given — nothing "
+            "to record.\nFace capture drives ARKit-style blendshape targets "
+            "(jawOpen, mouthSmileLeft, ...). Ready Player Me avatars and\n"
+            "CC/iClone heads ship with them; the Edit-Mode 'Vertex Morph "
+            "Animation' section authors them manually.\n").arg(meshPath));
+        return 1;
+    }
+
+    const FaceCapMapper::Mapping mapping = FaceCapMapper::build(targets, mapPath);
+    if (!mapping.error.isEmpty()) {
+        CLIPipeline::writeCliError(
+            QStringLiteral("Error: %1\n").arg(mapping.error));
+        return 1;
+    }
+    if (!jsonOutput) {
+        QString table = QStringLiteral("Channel mapping (%1 matched):\n")
+                            .arg(mapping.channels.size());
+        for (const auto& ch : mapping.channels)
+            table += QStringLiteral("  %1 -> %2\n")
+                         .arg(QLatin1String(
+                                  FaceCap::kBlendshapeNames[ch.canonicalIndex]),
+                              ch.meshTargetName);
+        if (!mapping.unmatchedCanonical.isEmpty())
+            table += QStringLiteral("  unmatched capture channels: %1\n")
+                         .arg(mapping.unmatchedCanonical.join(
+                             QStringLiteral(", ")));
+        if (!mapping.unmatchedMesh.isEmpty())
+            table += QStringLiteral("  unmatched mesh targets: %1\n")
+                         .arg(mapping.unmatchedMesh.join(QStringLiteral(", ")));
+        CLIPipeline::writeOutput(table);
+    }
+    if (mapping.channels.isEmpty() && !targets.isEmpty() && !head) {
+        CLIPipeline::writeCliError(QStringLiteral(
+            "Error: none of the %1 mesh morph targets matched a capture "
+            "channel — see the table above; a --map overrides.json can bind "
+            "custom names.\n").arg(targets.size()));
+        return 1;
+    }
+
+    // --- predictor ------------------------------------------------------------
+    if (!FaceCapPredictor::modelsPresent()
+        && FaceCapPredictor::ensureModelsBlocking().isEmpty()) {
+        CLIPipeline::writeCliError(QStringLiteral(
+            "Error: face capture models are not available (download failed, "
+            "offline guard set, or not hosted yet).\nSet "
+            "QTMESH_MOCAP_MODEL_BASE_URL or place the three graphs in %1.\n")
+            .arg(FaceCapPredictor::modelDir()));
+        return 1;
+    }
+    FaceCapPredictor predictor;
+    if (!predictor.load()) {
+        CLIPipeline::writeCliError(
+            QStringLiteral("Error: %1\n").arg(predictor.lastError()));
+        return 1;
+    }
+
+    // --- frame source -> samples ----------------------------------------------
+    std::unique_ptr<VideoFrameSource> source;
+    if (!framesDir.isEmpty()) {
+        QDir dir(framesDir);
+        QStringList images = dir.entryList(
+            {QStringLiteral("*.png"), QStringLiteral("*.jpg"),
+             QStringLiteral("*.jpeg"), QStringLiteral("*.bmp")},
+            QDir::Files, QDir::Name);
+        for (QString& f : images)
+            f = dir.filePath(f);
+        source = std::make_unique<ImageSequenceFrameSource>(images, fps);
+    } else {
+        source = std::make_unique<FileFrameSource>(videoPath, fps);
+    }
+    QString openError;
+    if (!source->open(&openError)) {
+        CLIPipeline::writeCliError(
+            QStringLiteral("Error: %1\n").arg(openError));
+        return 1;
+    }
+
+    std::vector<FaceSample> samples;
+    std::array<OneEuroFilter, 52> weightFilters;
+    OneEuroQuatFilter headFilter;
+    if (smooth) {
+        OneEuroFilter::Params params;
+        params.minCutoff = smoothCutoff;
+        for (auto& f : weightFilters)
+            f = OneEuroFilter(params);
+        headFilter = OneEuroQuatFilter(params);
+    }
+
+    QEventLoop loop;
+    bool finished = false;
+    QString streamError;
+    QObject::connect(source.get(), &VideoFrameSource::frameReady,
+                     [&](const MocapFrame& frame) {
+                         FaceSample s = predictor.predict(frame.image,
+                                                          frame.timeSec);
+                         if (smooth && s.confidence > 0.f) {
+                             for (int c = 0; c < 52; ++c)
+                                 s.weights[c] = static_cast<float>(
+                                     weightFilters[c].filter(s.weights[c],
+                                                             s.timeSec));
+                             s.headRotation =
+                                 headFilter.filter(s.headRotation, s.timeSec);
+                         }
+                         samples.push_back(s);
+                     });
+    QObject::connect(source.get(), &VideoFrameSource::finished, [&] {
+        finished = true;
+        loop.quit();
+    });
+    QObject::connect(source.get(), &VideoFrameSource::errorOccurred,
+                     [&](const QString& message) {
+                         streamError = message;
+                         finished = true;
+                         loop.quit();
+                     });
+    source->start();
+    if (!finished)
+        loop.exec();
+    if (!streamError.isEmpty()) {
+        CLIPipeline::writeCliError(
+            QStringLiteral("Error: %1\n").arg(streamError));
+        return 1;
+    }
+    if (samples.empty()) {
+        CLIPipeline::writeCliError(
+            QStringLiteral("Error: the source produced no frames.\n"));
+        return 1;
+    }
+
+    // --- record -----------------------------------------------------------------
+    MocapRecorder::FaceRecordOptions options;
+    options.clipName = clipName;
+    options.head = head;
+    const MocapRecorder::FaceRecordReport report =
+        MocapRecorder::recordFace(entity, samples, mapping, options);
+    if (!report.ok()) {
+        CLIPipeline::writeCliError(
+            QStringLiteral("Error: %1\n").arg(report.error));
+        return 1;
+    }
+
+    // --- export -------------------------------------------------------------------
+    if (!outputPath.isEmpty()) {
+        Ogre::SceneNode* node = entity->getParentSceneNode();
+        const QString fmt = CLIPipeline::formatForExtension(outputPath);
+        if (!node
+            || MeshImporterExporter::exporter(
+                   node, QFileInfo(outputPath).absoluteFilePath(), fmt) != 0) {
+            CLIPipeline::writeCliError(
+                QStringLiteral("Error: export to %1 failed.\n").arg(outputPath));
+            return 1;
+        }
+    }
+
+    if (jsonOutput) {
+        CLIPipeline::writeOutput(QString::fromUtf8(
+            QJsonDocument(reportToJson(report)).toJson(QJsonDocument::Indented)));
+    } else {
+        CLIPipeline::writeOutput(
+            QStringLiteral("Recorded '%1': %2 frames (%3 without a face), "
+                           "%4 weight keys on %5 channels, %6 head keys (%7), "
+                           "clip length %8s%9\n")
+                .arg(report.clipName)
+                .arg(report.framesProcessed)
+                .arg(report.framesNoFace)
+                .arg(report.keyframesWritten)
+                .arg(report.matchedChannels.size())
+                .arg(report.headKeyframesWritten)
+                .arg(report.headTarget)
+                .arg(report.clipLength, 0, 'f', 2)
+                .arg(outputPath.isEmpty()
+                         ? QString()
+                         : QStringLiteral(" -> %1").arg(outputPath)));
+    }
+
+    GamificationManager::noteOperation(
+        QStringLiteral("mocap_face"),
+        {{QStringLiteral("frames"),
+          static_cast<qint64>(report.framesProcessed)},
+         {QStringLiteral("keyframes"),
+          static_cast<qint64>(report.keyframesWritten
+                              + report.headKeyframesWritten)}},
+        GamificationManager::Surface::Cli);
+    return 0;
+}
+
+}  // namespace MocapCLI
+
+#endif  // ENABLE_MOCAP

--- a/src/Mocap/MocapCLI.h
+++ b/src/Mocap/MocapCLI.h
@@ -1,0 +1,25 @@
+#ifndef MOCAPCLI_H
+#define MOCAPCLI_H
+
+// Headless `qtmesh mocap` subcommand (epic #869, Slice D #873):
+//
+//   qtmesh mocap <video> --face --mesh <meshfile> [-o out.glb]
+//          [--clip-name NAME] [--fps 30] [--smooth-cutoff HZ] [--no-smooth]
+//          [--map overrides.json] [--no-head] [--frames-dir DIR] [--json]
+//
+// video file -> FaceCapPredictor -> One-Euro smoothing -> MocapRecorder ->
+// morph-weight clip (+ head clip) on the mesh -> optional re-export.
+// `--frames-dir` replaces the video with an image sequence
+// (ImageSequenceFrameSource) — the headless-CI/debug path that needs no
+// Qt Multimedia decode.
+//
+// Always compiled; a non-ENABLE_MOCAP build prints the standard
+// "rebuild with -DENABLE_MOCAP" message (the Alembic pattern).
+
+namespace MocapCLI {
+
+int run(int argc, char* argv[]);
+
+}  // namespace MocapCLI
+
+#endif  // MOCAPCLI_H

--- a/src/Mocap/MocapRecorder.cpp
+++ b/src/Mocap/MocapRecorder.cpp
@@ -1,0 +1,250 @@
+#ifdef ENABLE_MOCAP
+
+#include "MocapRecorder.h"
+
+#include "FaceCapCanonicalData.h"
+#include "../Manager.h"
+#include "../MorphAnimationManager.h"
+#include "../MotionInbetween.h"
+#include "../NodeAnimationManager.h"
+#include "../SentryReporter.h"
+
+#include <OgreAnimation.h>
+#include <OgreBone.h>
+#include <OgreEntity.h>
+#include <OgreKeyFrame.h>
+#include <OgreMesh.h>
+#include <OgreSceneNode.h>
+#include <OgreSkeletonInstance.h>
+
+#include <algorithm>
+#include <cmath>
+
+namespace MocapRecorder {
+
+namespace {
+
+constexpr int kHeadCanonicalRole = 5;  // MotionInbetween's canonical Head
+
+Ogre::Quaternion toOgre(const std::array<float, 4>& q)  // (x,y,z,w)
+{
+    return Ogre::Quaternion(q[3], q[0], q[1], q[2]);
+}
+
+double quatAngle(const Ogre::Quaternion& a, const Ogre::Quaternion& b)
+{
+    const double dot = std::abs(a.Dot(b));
+    return 2.0 * std::acos(std::min(1.0, dot));
+}
+
+// Key-time selection with epsilon run-length suppression + gap holds, shared
+// by the weight channels and the head track. `values` is any channel the
+// caller can measure a distance on (via `distance(i, j)` between samples).
+template <typename DistanceFn>
+std::vector<int> selectKeyIndices(const std::vector<int>& confident,
+                                  const std::vector<double>& times,
+                                  double gapHoldSeconds, double epsilon,
+                                  DistanceFn distance)
+{
+    std::vector<int> keys;
+    if (confident.empty())
+        return keys;
+    int lastWritten = confident.front();
+    keys.push_back(lastWritten);
+    for (size_t k = 1; k < confident.size(); ++k) {
+        const int i = confident[k];
+        const int prev = confident[k - 1];
+        const bool isLast = (k == confident.size() - 1);
+        // gap edges: hold the old value up to the gap, land the new value at
+        // its end, regardless of epsilon
+        const bool gapEdge =
+            (times[i] - times[prev]) > gapHoldSeconds;
+        if (gapEdge && keys.back() != prev)
+            keys.push_back(prev);
+        const bool moved = distance(i, lastWritten) >= epsilon;
+        // anchor the frame BEFORE a jump so interpolation doesn't start early
+        const bool nextJumps =
+            !isLast && distance(confident[k + 1], i) >= epsilon;
+        if (moved || nextJumps || isLast || gapEdge) {
+            keys.push_back(i);
+            lastWritten = i;
+        }
+    }
+    return keys;
+}
+
+}  // namespace
+
+QString resolveHeadBone(Ogre::Entity* entity)
+{
+    if (!entity || !entity->hasSkeleton())
+        return {};
+    Ogre::SkeletonInstance* skel = entity->getSkeleton();
+    for (unsigned short i = 0; i < skel->getNumBones(); ++i) {
+        Ogre::Bone* bone = skel->getBone(i);
+        if (MotionInbetween::canonicalIndexForBone(
+                QString::fromStdString(bone->getName())) == kHeadCanonicalRole)
+            return QString::fromStdString(bone->getName());
+    }
+    return {};
+}
+
+FaceRecordReport recordFace(Ogre::Entity* entity,
+                            const std::vector<FaceSample>& samples,
+                            const FaceCapMapper::Mapping& mapping,
+                            const FaceRecordOptions& options)
+{
+    FaceRecordReport report;
+    report.clipName = options.clipName;
+    report.unmatchedCanonical = mapping.unmatchedCanonical;
+    report.unmatchedMesh = mapping.unmatchedMesh;
+    for (const auto& ch : mapping.channels)
+        report.matchedChannels
+            << QString::fromLatin1(FaceCap::kBlendshapeNames[ch.canonicalIndex]);
+
+    if (!entity) {
+        report.error = QStringLiteral("no entity");
+        return report;
+    }
+    if (options.clipName.isEmpty()) {
+        report.error = QStringLiteral("empty clip name");
+        return report;
+    }
+    if (mapping.channels.isEmpty() && !options.head) {
+        report.error = QStringLiteral("nothing to record: no mapped morph "
+                                      "channels and head recording disabled");
+        return report;
+    }
+
+    report.framesProcessed = static_cast<int>(samples.size());
+    std::vector<int> confident;
+    confident.reserve(samples.size());
+    for (size_t i = 0; i < samples.size(); ++i) {
+        if (samples[i].confidence > 0.f)
+            confident.push_back(static_cast<int>(i));
+    }
+    report.framesNoFace = report.framesProcessed
+                          - static_cast<int>(confident.size());
+    if (confident.empty()) {
+        report.error = QStringLiteral("no confident face frame in the take");
+        return report;
+    }
+
+    const double t0 = samples[confident.front()].timeSec;
+    std::vector<double> times(samples.size(), 0.0);
+    for (size_t i = 0; i < samples.size(); ++i)
+        times[i] = samples[i].timeSec - t0;
+
+    Ogre::MeshPtr mesh = entity->getMesh();
+
+    // --- morph weight channels ------------------------------------------------
+    if (!mapping.channels.isEmpty() && mesh) {
+        if (options.replaceExisting
+            && mesh->hasAnimation(options.clipName.toStdString()))
+            mesh->removeAnimation(options.clipName.toStdString());
+
+        const std::string clip = options.clipName.toStdString();
+        for (const auto& ch : mapping.channels) {
+            const int ci = ch.canonicalIndex;
+            auto weightAt = [&](int i) {
+                return static_cast<double>(samples[i].weights[ci]);
+            };
+            const std::vector<int> keys = selectKeyIndices(
+                confident, times, options.gapHoldSeconds, options.weightEpsilon,
+                [&](int i, int j) { return std::abs(weightAt(i) - weightAt(j)); });
+            const std::string target = ch.meshTargetName.toStdString();
+            for (int i : keys) {
+                if (MorphAnimationManager::writeWeightKeyOn(
+                        entity, clip, target, static_cast<float>(times[i]),
+                        static_cast<float>(weightAt(i))))
+                    ++report.keyframesWritten;
+            }
+        }
+        if (mesh->hasAnimation(clip))
+            report.clipLength = mesh->getAnimation(clip)->getLength();
+        entity->refreshAvailableAnimationState();
+    }
+
+    // --- head pose --------------------------------------------------------------
+    report.headTarget = QStringLiteral("none");
+    if (options.head) {
+        // calibration: the first confident frame is neutral
+        const Ogre::Quaternion neutral =
+            toOgre(samples[confident.front()].headRotation);
+        auto deltaAt = [&](int i) {
+            // rotation that takes the neutral pose to this frame's pose
+            return toOgre(samples[i].headRotation) * neutral.Inverse();
+        };
+        const std::vector<int> keys = selectKeyIndices(
+            confident, times, options.gapHoldSeconds, options.headEpsilonRad,
+            [&](int i, int j) { return quatAngle(deltaAt(i), deltaAt(j)); });
+        const double length = times[confident.back()];
+
+        const QString headBone = resolveHeadBone(entity);
+        if (!headBone.isEmpty()) {
+            Ogre::SkeletonInstance* skel = entity->getSkeleton();
+            Ogre::Bone* bone = skel->getBone(headBone.toStdString());
+            const std::string clip = (options.clipName
+                                      + QStringLiteral("_Head")).toStdString();
+            const bool exists = skel->hasAnimation(clip);
+            if (exists && options.replaceExisting)
+                skel->removeAnimation(clip);
+            if (!exists || options.replaceExisting) {
+                // Express the camera-frame delta on the bone's local axes:
+                // rel = boneWorldBind^-1 . delta . boneWorldBind, keyed as the
+                // offset Ogre applies onto the binding orientation.
+                const Ogre::Quaternion boneWorld = bone->_getDerivedOrientation();
+                Ogre::Animation* anim = skel->createAnimation(
+                    clip, static_cast<Ogre::Real>(length));
+                Ogre::NodeAnimationTrack* track =
+                    anim->createNodeTrack(bone->getHandle(), bone);
+                for (int i : keys) {
+                    auto* kf = track->createNodeKeyFrame(
+                        static_cast<Ogre::Real>(times[i]));
+                    kf->setRotation(boneWorld.Inverse() * deltaAt(i) * boneWorld);
+                }
+                entity->refreshAvailableAnimationState();
+                report.headKeyframesWritten = static_cast<int>(keys.size());
+                report.headTarget = QStringLiteral("bone:") + headBone;
+            }
+        } else if (entity->getParentSceneNode()) {
+            Ogre::SceneNode* node = entity->getParentSceneNode();
+            auto* nam = NodeAnimationManager::instance();
+            const QString clip = options.clipName + QStringLiteral("_Head");
+            if (nam) {
+                if (options.replaceExisting)
+                    nam->deleteClip(clip);  // no-op when absent
+                if (nam->createClip(clip, std::max(length, 0.001))) {
+                    const QString nodeName = QString::fromStdString(node->getName());
+                    int written = 0;
+                    for (int i : keys) {
+                        if (nam->addKeyframe(clip, nodeName, times[i],
+                                             Ogre::Vector3::ZERO, deltaAt(i),
+                                             Ogre::Vector3::UNIT_SCALE))
+                            ++written;
+                    }
+                    report.headKeyframesWritten = written;
+                    report.headTarget = QStringLiteral("node");
+                }
+            }
+        }
+    }
+    if (report.clipLength <= 0.0)
+        report.clipLength = times[confident.back()];
+
+    SentryReporter::addBreadcrumb(
+        "ai.assist.mocap_face",
+        QStringLiteral("recorded '%1': %2 frames (%3 no-face), %4 weight keys, "
+                       "%5 head keys (%6)")
+            .arg(options.clipName)
+            .arg(report.framesProcessed)
+            .arg(report.framesNoFace)
+            .arg(report.keyframesWritten)
+            .arg(report.headKeyframesWritten)
+            .arg(report.headTarget));
+    return report;
+}
+
+}  // namespace MocapRecorder
+
+#endif  // ENABLE_MOCAP

--- a/src/Mocap/MocapRecorder.h
+++ b/src/Mocap/MocapRecorder.h
@@ -1,0 +1,81 @@
+#ifndef MOCAPRECORDER_H
+#define MOCAPRECORDER_H
+
+// Turns a FaceSample stream into ordinary animation clips (epic #869,
+// Slice D #873) — the only Ogre-touching mocap piece so far.
+//
+//  - Morph weights land as weight keyframes on a named mesh VAT_POSE clip via
+//    MorphAnimationManager::writeWeightKeyOn (the #519 pipeline: dope sheet,
+//    timeline playback and glTF morph-weight export all work downstream).
+//    Epsilon run-length suppression keeps near-constant channels from writing
+//    30 keys/sec; first/last confident samples always key; frames with
+//    confidence 0 write nothing, and gaps > 0.5 s get hold keys at both edges
+//    so interpolation doesn't sweep through them.
+//  - Head pose (camera-relative) is re-based on the take's FIRST confident
+//    sample (the calibration frame: looking at the camera at start == rig
+//    neutral) and keyed as rotation deltas on the Head bone (skinned mesh,
+//    resolved via MotionInbetween::canonicalIndexForBone) in a skeletal clip
+//    named "<clipName>_Head", or as node-TRS deltas via NodeAnimationManager
+//    for a static mesh.
+//
+// Smoothing is the CALLER's job (One-Euro over the stream before recording);
+// the recorder stores what it is given. GUI/MCP wrap a take in ONE
+// RecordMocapClipCommand (src/commands/) so Ctrl+Z removes the whole take.
+
+#ifdef ENABLE_MOCAP
+
+#include "FaceCapMapper.h"
+#include "FaceCapPredictor.h"
+
+#include <QString>
+#include <QStringList>
+
+#include <vector>
+
+namespace Ogre {
+class Entity;
+}
+
+namespace MocapRecorder {
+
+struct FaceRecordOptions {
+    QString clipName = QStringLiteral("FaceCap");  // morph weight clip name
+    bool head = true;                // also record head pose
+    bool replaceExisting = true;     // clip with the same name is replaced
+    double weightEpsilon = 0.01;     // suppress keys that don't change
+    double headEpsilonRad = 0.006;   // ~0.35 deg — head key suppression
+    double gapHoldSeconds = 0.5;     // face-lost gap that forces hold keys
+};
+
+struct FaceRecordReport {
+    int framesProcessed = 0;
+    int framesNoFace = 0;
+    int keyframesWritten = 0;        // morph weight keys
+    int headKeyframesWritten = 0;
+    QStringList matchedChannels;
+    QStringList unmatchedCanonical;
+    QStringList unmatchedMesh;
+    QString headTarget;              // "bone:<name>" | "node" | "none"
+    QString clipName;
+    double clipLength = 0.0;         // seconds
+    QString error;                   // non-empty = nothing was written
+
+    bool ok() const { return error.isEmpty(); }
+};
+
+// Writes the take onto `entity`. Samples must be time-ascending; times are
+// re-based so the first confident sample is t=0. Main thread only.
+FaceRecordReport recordFace(Ogre::Entity* entity,
+                            const std::vector<FaceSample>& samples,
+                            const FaceCapMapper::Mapping& mapping,
+                            const FaceRecordOptions& options = {});
+
+// Head-bone resolution (exposed for the GUI gate + tests): the first bone of
+// the entity's skeleton whose name resolves to the canonical Head role, or
+// empty when the entity is not skinned / has no such bone.
+QString resolveHeadBone(Ogre::Entity* entity);
+
+}  // namespace MocapRecorder
+
+#endif  // ENABLE_MOCAP
+#endif  // MOCAPRECORDER_H

--- a/src/Mocap/MocapRecorder_test.cpp
+++ b/src/Mocap/MocapRecorder_test.cpp
@@ -1,0 +1,305 @@
+#ifdef ENABLE_MOCAP
+
+#include <gtest/gtest.h>
+
+#include "Manager.h"
+#include "TestHelpers.h"
+#include "UndoManager.h"
+#include "commands/RecordMocapClipCommand.h"
+
+#include "Mocap/FaceCapCanonicalData.h"
+#include "Mocap/FaceCapMapper.h"
+#include "Mocap/MocapRecorder.h"
+
+#include <OgreAnimation.h>
+#include <OgreAnimationTrack.h>
+#include <OgreEntity.h>
+#include <OgreHardwareBufferManager.h>
+#include <OgreKeyFrame.h>
+#include <OgreMesh.h>
+#include <OgreMeshManager.h>
+#include <OgrePose.h>
+#include <OgreSceneManager.h>
+#include <OgreSceneNode.h>
+#include <OgreSubMesh.h>
+
+#include <vector>
+
+namespace {
+
+// Tiny mesh with two ARKit-named morph targets (the MorphAnimationManager
+// fixture recipe).
+Ogre::MeshPtr createFaceTestMesh(const std::string& name)
+{
+    auto mesh = Ogre::MeshManager::getSingleton().createManual(
+        name, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+
+    auto* sub = mesh->createSubMesh();
+    sub->useSharedVertices = false;
+    sub->vertexData = new Ogre::VertexData();
+    auto* decl = sub->vertexData->vertexDeclaration;
+    decl->addElement(0, 0, Ogre::VET_FLOAT3, Ogre::VES_POSITION);
+
+    auto vbuf = Ogre::HardwareBufferManager::getSingleton().createVertexBuffer(
+        decl->getVertexSize(0), 3, Ogre::HardwareBuffer::HBU_STATIC_WRITE_ONLY);
+    float verts[] = {0, 0, 0, 1, 0, 0, 0, 1, 0};
+    vbuf->writeData(0, sizeof(verts), verts);
+    sub->vertexData->vertexBufferBinding->setBinding(0, vbuf);
+    sub->vertexData->vertexCount = 3;
+
+    auto ibuf = Ogre::HardwareBufferManager::getSingleton().createIndexBuffer(
+        Ogre::HardwareIndexBuffer::IT_16BIT, 3,
+        Ogre::HardwareBuffer::HBU_STATIC_WRITE_ONLY);
+    uint16_t idx[] = {0, 1, 2};
+    ibuf->writeData(0, sizeof(idx), idx);
+    sub->indexData->indexBuffer = ibuf;
+    sub->indexData->indexCount = 3;
+
+    mesh->_setBounds(Ogre::AxisAlignedBox(-1, -1, -1, 2, 2, 2));
+    mesh->_setBoundingSphereRadius(2.0f);
+    mesh->load();
+
+    {
+        Ogre::Pose* p = mesh->createPose(1, "jawOpen");
+        p->addVertex(0, Ogre::Vector3(0, -0.1f, 0));
+    }
+    {
+        Ogre::Pose* p = mesh->createPose(1, "mouthSmileLeft");
+        p->addVertex(1, Ogre::Vector3(0.05f, 0.02f, 0));
+    }
+    const auto& poses = mesh->getPoseList();
+    for (unsigned short pi = 0; pi < poses.size(); ++pi) {
+        Ogre::Animation* a = mesh->createAnimation(poses[pi]->getName(), 0.0f);
+        auto* track = a->createVertexTrack(poses[pi]->getTarget(), Ogre::VAT_POSE);
+        auto* kf = track->createVertexPoseKeyFrame(0.0f);
+        kf->addPoseReference(pi, 1.0f);
+    }
+    return mesh;
+}
+
+FaceSample makeSample(double t, float jawOpen, float smile,
+                      float confidence = 1.f)
+{
+    FaceSample s;
+    s.timeSec = t;
+    s.confidence = confidence;
+    s.weights[25] = jawOpen;         // jawOpen canonical index
+    s.weights[44] = smile;           // mouthSmileLeft canonical index
+    return s;
+}
+
+// weight of `poseName` at (approx) time t on the recorded clip; -1 if unkeyed
+float weightAt(Ogre::MeshPtr mesh, const std::string& clip,
+               const std::string& poseName, float t)
+{
+    if (!mesh->hasAnimation(clip))
+        return -1.f;
+    int poseIndex = -1;
+    const auto& poses = mesh->getPoseList();
+    for (unsigned short i = 0; i < poses.size(); ++i)
+        if (poses[i]->getName() == poseName) poseIndex = i;
+    if (poseIndex < 0)
+        return -1.f;
+    Ogre::Animation* anim = mesh->getAnimation(clip);
+    for (const auto& [handle, track] : anim->_getVertexTrackList()) {
+        for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+            auto* kf = static_cast<Ogre::VertexPoseKeyFrame*>(track->getKeyFrame(i));
+            if (std::abs(kf->getTime() - t) > 1e-3f)
+                continue;
+            for (const auto& ref : kf->getPoseReferences())
+                if (ref.poseIndex == poseIndex)
+                    return ref.influence;
+        }
+    }
+    return -1.f;
+}
+
+int keyCountFor(Ogre::MeshPtr mesh, const std::string& clip,
+                const std::string& poseName)
+{
+    if (!mesh->hasAnimation(clip))
+        return 0;
+    int poseIndex = -1;
+    const auto& poses = mesh->getPoseList();
+    for (unsigned short i = 0; i < poses.size(); ++i)
+        if (poses[i]->getName() == poseName) poseIndex = i;
+    int count = 0;
+    Ogre::Animation* anim = mesh->getAnimation(clip);
+    for (const auto& [handle, track] : anim->_getVertexTrackList()) {
+        for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+            auto* kf = static_cast<Ogre::VertexPoseKeyFrame*>(track->getKeyFrame(i));
+            for (const auto& ref : kf->getPoseReferences())
+                if (ref.poseIndex == poseIndex)
+                    ++count;
+        }
+    }
+    return count;
+}
+
+class MocapRecorderTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+        static int counter = 0;
+        m_meshName = "mocap_rec_test_" + std::to_string(counter++);
+        m_mesh = createFaceTestMesh(m_meshName);
+        auto* scene = Manager::getSingleton()->getSceneMgr();
+        m_entity = scene->createEntity(m_meshName + "_ent", m_meshName);
+        m_node = scene->getRootSceneNode()->createChildSceneNode();
+        m_node->attachObject(m_entity);
+        m_mapping = FaceCapMapper::build(
+            {QStringLiteral("jawOpen"), QStringLiteral("mouthSmileLeft")});
+        ASSERT_EQ(m_mapping.channels.size(), 2);
+    }
+
+    void TearDown() override
+    {
+        if (m_entity) {
+            m_node->detachObject(m_entity);
+            Manager::getSingleton()->getSceneMgr()->destroyEntity(m_entity);
+        }
+        Ogre::MeshManager::getSingleton().remove(
+            m_meshName, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+    }
+
+    std::string m_meshName;
+    Ogre::MeshPtr m_mesh;
+    Ogre::Entity* m_entity = nullptr;
+    Ogre::SceneNode* m_node = nullptr;
+    FaceCapMapper::Mapping m_mapping;
+};
+
+}  // namespace
+
+TEST_F(MocapRecorderTest, KeyframesLandAtTimesAndValues)
+{
+    std::vector<FaceSample> samples = {
+        makeSample(10.0, 0.1f, 0.9f),   // times re-base to 0
+        makeSample(10.5, 0.5f, 0.9f),
+        makeSample(11.0, 0.9f, 0.9f),
+    };
+    MocapRecorder::FaceRecordOptions options;
+    options.head = false;
+    const auto report =
+        MocapRecorder::recordFace(m_entity, samples, m_mapping, options);
+    ASSERT_TRUE(report.ok()) << report.error.toStdString();
+    EXPECT_EQ(report.framesProcessed, 3);
+    EXPECT_EQ(report.framesNoFace, 0);
+
+    const std::string clip = "FaceCap";
+    EXPECT_FLOAT_EQ(weightAt(m_mesh, clip, "jawOpen", 0.0f), 0.1f);
+    EXPECT_FLOAT_EQ(weightAt(m_mesh, clip, "jawOpen", 0.5f), 0.5f);
+    EXPECT_FLOAT_EQ(weightAt(m_mesh, clip, "jawOpen", 1.0f), 0.9f);
+    EXPECT_NEAR(report.clipLength, 1.0, 1e-4);
+    // the entity can play it
+    EXPECT_TRUE(m_entity->getAnimationState("FaceCap") != nullptr);
+}
+
+TEST_F(MocapRecorderTest, EpsilonSuppressionKeepsConstantChannelsSparse)
+{
+    std::vector<FaceSample> samples;
+    for (int i = 0; i < 60; ++i)
+        samples.push_back(makeSample(i / 30.0, 0.5f, 0.5f));  // constant
+    MocapRecorder::FaceRecordOptions options;
+    options.head = false;
+    const auto report =
+        MocapRecorder::recordFace(m_entity, samples, m_mapping, options);
+    ASSERT_TRUE(report.ok());
+    EXPECT_LE(keyCountFor(m_mesh, "FaceCap", "jawOpen"), 2);   // first + last
+    EXPECT_LE(report.keyframesWritten, 4);
+}
+
+TEST_F(MocapRecorderTest, GapGetsHoldKeysAtEdges)
+{
+    std::vector<FaceSample> samples;
+    samples.push_back(makeSample(0.0, 0.2f, 0.0f));
+    samples.push_back(makeSample(0.1, 0.2f, 0.0f));
+    // face lost for 1.5 s
+    samples.push_back(makeSample(0.2, 0.0f, 0.0f, /*confidence=*/0.f));
+    samples.push_back(makeSample(1.6, 0.8f, 0.0f));
+    samples.push_back(makeSample(1.7, 0.8f, 0.0f));
+    MocapRecorder::FaceRecordOptions options;
+    options.head = false;
+    const auto report =
+        MocapRecorder::recordFace(m_entity, samples, m_mapping, options);
+    ASSERT_TRUE(report.ok());
+    EXPECT_EQ(report.framesNoFace, 1);
+    // hold key at the gap's leading edge (t=0.1) and landing key at t=1.6
+    EXPECT_FLOAT_EQ(weightAt(m_mesh, "FaceCap", "jawOpen", 0.1f), 0.2f);
+    EXPECT_FLOAT_EQ(weightAt(m_mesh, "FaceCap", "jawOpen", 1.6f), 0.8f);
+}
+
+TEST_F(MocapRecorderTest, NoConfidentFramesFailsCleanly)
+{
+    std::vector<FaceSample> samples = {makeSample(0.0, 0.f, 0.f, 0.f)};
+    const auto report =
+        MocapRecorder::recordFace(m_entity, samples, m_mapping, {});
+    EXPECT_FALSE(report.ok());
+    EXPECT_EQ(m_mesh->hasAnimation("FaceCap"), false);
+}
+
+TEST_F(MocapRecorderTest, UnmatchedChannelsAreReported)
+{
+    const auto mapping =
+        FaceCapMapper::build({QStringLiteral("jawOpen"),
+                              QStringLiteral("SomethingCustom")});
+    std::vector<FaceSample> samples = {makeSample(0.0, 0.3f, 0.f),
+                                       makeSample(1.0, 0.6f, 0.f)};
+    MocapRecorder::FaceRecordOptions options;
+    options.head = false;
+    const auto report =
+        MocapRecorder::recordFace(m_entity, samples, mapping, options);
+    ASSERT_TRUE(report.ok());
+    EXPECT_EQ(report.matchedChannels, QStringList{QStringLiteral("jawOpen")});
+    EXPECT_TRUE(report.unmatchedCanonical.contains(QStringLiteral("mouthSmileLeft")));
+    EXPECT_EQ(report.unmatchedMesh,
+              QStringList{QStringLiteral("SomethingCustom")});
+}
+
+TEST_F(MocapRecorderTest, HeadTargetIsNoneForStaticMeshWithoutNode)
+{
+    // static (skeleton-less) entity: head lands on the node path
+    std::vector<FaceSample> samples = {makeSample(0.0, 0.1f, 0.f),
+                                       makeSample(1.0, 0.9f, 0.f)};
+    samples[1].headRotation = {0.f, 0.2588f, 0.f, 0.9659f};  // 30 deg yaw
+    const auto report =
+        MocapRecorder::recordFace(m_entity, samples, m_mapping, {});
+    ASSERT_TRUE(report.ok());
+    // skeleton-less mesh + a parent node exists -> node-TRS head clip
+    EXPECT_EQ(report.headTarget, QStringLiteral("node"));
+    EXPECT_GT(report.headKeyframesWritten, 0);
+    EXPECT_TRUE(MocapRecorder::resolveHeadBone(m_entity).isEmpty());
+}
+
+TEST_F(MocapRecorderTest, RecordCommandIsSingleUndoStep)
+{
+    std::vector<FaceSample> take1 = {makeSample(0.0, 0.1f, 0.1f),
+                                     makeSample(1.0, 0.9f, 0.9f)};
+    MocapRecorder::FaceRecordOptions options;
+    options.head = false;
+
+    // pre-existing clip state to restore: record take 0 directly
+    std::vector<FaceSample> take0 = {makeSample(0.0, 0.4f, 0.4f),
+                                     makeSample(0.5, 0.6f, 0.6f)};
+    ASSERT_TRUE(MocapRecorder::recordFace(m_entity, take0, m_mapping, options).ok());
+    ASSERT_FLOAT_EQ(weightAt(m_mesh, "FaceCap", "jawOpen", 0.5f), 0.6f);
+
+    auto* cmd = new RecordMocapClipCommand(m_entity->getName(), take1,
+                                           m_mapping, options);
+    UndoManager::getSingleton()->push(cmd);  // runs redo()
+    ASSERT_TRUE(cmd->report().ok()) << cmd->report().error.toStdString();
+    EXPECT_FLOAT_EQ(weightAt(m_mesh, "FaceCap", "jawOpen", 1.0f), 0.9f);
+    EXPECT_FLOAT_EQ(weightAt(m_mesh, "FaceCap", "jawOpen", 0.5f), -1.f);  // replaced
+
+    UndoManager::getSingleton()->undo();
+    // take 0 is back, take 1 is gone
+    EXPECT_FLOAT_EQ(weightAt(m_mesh, "FaceCap", "jawOpen", 0.5f), 0.6f);
+    EXPECT_FLOAT_EQ(weightAt(m_mesh, "FaceCap", "jawOpen", 1.0f), -1.f);
+
+    UndoManager::getSingleton()->redo();
+    EXPECT_FLOAT_EQ(weightAt(m_mesh, "FaceCap", "jawOpen", 1.0f), 0.9f);
+}
+
+#endif  // ENABLE_MOCAP

--- a/src/MorphAnimationManager.cpp
+++ b/src/MorphAnimationManager.cpp
@@ -231,29 +231,23 @@ bool isPoseShapeClip(Ogre::Mesh* mesh, const std::string& animName)
 
 } // namespace
 
-bool MorphAnimationManager::setMorphWeightKeyframe(const QString& name,
-                                                   double time, double weight)
+bool MorphAnimationManager::writeWeightKeyOn(Ogre::Entity* entity,
+                                             const std::string& clip,
+                                             const std::string& targetName,
+                                             float time, float weight)
 {
-    assertMainThread();
-    if (name.isEmpty() || time < 0.0) return false;
-
-    auto* sel = SelectionSet::getSingleton();
-    if (!sel) return false;
-    auto ents = sel->getResolvedEntities();
-    if (ents.isEmpty() || !ents.first()) return false;
-    Ogre::Entity* entity = ents.first();
+    if (!entity || targetName.empty() || time < 0.0f) return false;
     Ogre::MeshPtr mesh = entity->getMesh();
     if (!mesh) return false;
 
-    const std::string clip = m_activeMorphClip.toStdString();
-    const int pi = poseIndexForName(mesh.get(), name.toStdString());
+    const int pi = poseIndexForName(mesh.get(), targetName);
     if (pi < 0) return false;
     Ogre::VertexAnimationTrack* track =
-        weightTrackFor(mesh.get(), name.toStdString(), clip, true);
+        weightTrackFor(mesh.get(), targetName, clip, true);
     if (!track) return false;
 
-    const float t = static_cast<float>(time);
-    const float w = std::clamp(static_cast<float>(weight), 0.0f, 1.0f);
+    const float t = time;
+    const float w = std::clamp(weight, 0.0f, 1.0f);
 
     // Update in place if a keyframe already exists at ~t, else create one.
     Ogre::VertexPoseKeyFrame* kf = nullptr;
@@ -274,6 +268,26 @@ bool MorphAnimationManager::setMorphWeightKeyframe(const QString& name,
     Ogre::Animation* anim = mesh->getAnimation(clip);
     if (anim && t > anim->getLength())
         anim->setLength(t);
+    return true;
+}
+
+bool MorphAnimationManager::setMorphWeightKeyframe(const QString& name,
+                                                   double time, double weight)
+{
+    assertMainThread();
+    if (name.isEmpty() || time < 0.0) return false;
+
+    auto* sel = SelectionSet::getSingleton();
+    if (!sel) return false;
+    auto ents = sel->getResolvedEntities();
+    if (ents.isEmpty() || !ents.first()) return false;
+    Ogre::Entity* entity = ents.first();
+
+    const float t = static_cast<float>(time);
+    const float w = std::clamp(static_cast<float>(weight), 0.0f, 1.0f);
+    if (!writeWeightKeyOn(entity, m_activeMorphClip.toStdString(),
+                          name.toStdString(), t, w))
+        return false;
 
     // Refresh the entity's animation-state mirror so the new clip is playable.
     entity->refreshAvailableAnimationState();

--- a/src/MorphAnimationManager.h
+++ b/src/MorphAnimationManager.h
@@ -125,6 +125,18 @@ public:
     /// first clip created). Also the glTF export fallback name.
     static const char* kWeightClipName;
 
+    /// Entity-explicit weight-keyframe writer — the core of
+    /// setMorphWeightKeyframe without the SelectionSet/active-clip coupling,
+    /// for batch writers (mocap recording #873) that target a specific entity
+    /// and clip. Handles the shared-track subtlety (targets on the same
+    /// submesh share one VAT_POSE track; only THIS pose's reference at `time`
+    /// is added/updated) and extends the clip length. Does NOT emit signals
+    /// or refresh animation states — callers batch-refresh once via
+    /// `entity->refreshAvailableAnimationState()` after the last key.
+    static bool writeWeightKeyOn(Ogre::Entity* entity, const std::string& clip,
+                                 const std::string& targetName, float time,
+                                 float weight);
+
     /// Make the ACTIVE morph clip the playable animation on the selected entity:
     /// select it in the Animation Control panel + enable its AnimationState so
     /// the timeline scrubs/plays the keyed weights. No-op if it doesn't exist.

--- a/src/commands/RecordMocapClipCommand.cpp
+++ b/src/commands/RecordMocapClipCommand.cpp
@@ -1,0 +1,187 @@
+#ifdef ENABLE_MOCAP
+
+#include "RecordMocapClipCommand.h"
+
+#include "../Manager.h"
+#include "../NodeAnimationManager.h"
+
+#include <OgreAnimation.h>
+#include <OgreAnimationTrack.h>
+#include <OgreBone.h>
+#include <OgreEntity.h>
+#include <OgreKeyFrame.h>
+#include <OgreMesh.h>
+#include <OgreSceneManager.h>
+#include <OgreSkeletonInstance.h>
+
+#include <QObject>
+
+#include <map>
+#include <utility>
+
+namespace {
+
+Ogre::Entity* findEntity(const std::string& name)
+{
+    auto* mgr = Manager::getSingletonPtr();
+    if (!mgr || !mgr->getSceneMgr())
+        return nullptr;
+    auto* scene = mgr->getSceneMgr();
+    return scene->hasEntity(name) ? scene->getEntity(name) : nullptr;
+}
+
+// serialized VAT_POSE clip: per track handle, keyframes with pose references
+struct VertexClipSnapshot {
+    float length = 0.f;
+    struct Key {
+        float time;
+        std::vector<std::pair<unsigned short, float>> poseRefs;
+    };
+    std::map<unsigned short, std::vector<Key>> tracks;
+};
+
+// serialized bone rotation clip: per bone handle, (time, rotation) keys
+struct BoneClipSnapshot {
+    float length = 0.f;
+    struct Key {
+        float time;
+        Ogre::Quaternion rotation;
+        Ogre::Vector3 translate;
+        Ogre::Vector3 scale;
+    };
+    std::map<unsigned short, std::vector<Key>> tracks;
+};
+
+}  // namespace
+
+struct RecordMocapClipCommand::Snapshots {
+    bool hadWeightClip = false;
+    VertexClipSnapshot weightClip;
+    bool hadHeadBoneClip = false;
+    BoneClipSnapshot headBoneClip;
+};
+
+RecordMocapClipCommand::RecordMocapClipCommand(
+    std::string entityName, std::vector<FaceSample> samples,
+    FaceCapMapper::Mapping mapping, MocapRecorder::FaceRecordOptions options,
+    QUndoCommand* parent)
+    : QUndoCommand(parent),
+      m_entityName(std::move(entityName)),
+      m_samples(std::move(samples)),
+      m_mapping(std::move(mapping)),
+      m_options(options)
+{
+    setText(QObject::tr("Record performance capture '%1'")
+                .arg(options.clipName));
+}
+
+RecordMocapClipCommand::~RecordMocapClipCommand() = default;
+
+void RecordMocapClipCommand::redo()
+{
+    Ogre::Entity* entity = findEntity(m_entityName);
+    if (!entity)
+        return;
+
+    if (!m_snapshotTaken) {
+        m_before = std::make_unique<Snapshots>();
+        Ogre::MeshPtr mesh = entity->getMesh();
+        const std::string clip = m_options.clipName.toStdString();
+        if (mesh && mesh->hasAnimation(clip)) {
+            m_before->hadWeightClip = true;
+            Ogre::Animation* anim = mesh->getAnimation(clip);
+            m_before->weightClip.length = anim->getLength();
+            for (const auto& [handle, track] : anim->_getVertexTrackList()) {
+                auto& keys = m_before->weightClip.tracks[handle];
+                for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+                    auto* kf = static_cast<Ogre::VertexPoseKeyFrame*>(
+                        track->getKeyFrame(i));
+                    VertexClipSnapshot::Key key;
+                    key.time = kf->getTime();
+                    for (const auto& ref : kf->getPoseReferences())
+                        key.poseRefs.push_back({ref.poseIndex, ref.influence});
+                    keys.push_back(std::move(key));
+                }
+            }
+        }
+        const std::string headClip =
+            (m_options.clipName + QStringLiteral("_Head")).toStdString();
+        if (entity->hasSkeleton()
+            && entity->getSkeleton()->hasAnimation(headClip)) {
+            m_before->hadHeadBoneClip = true;
+            Ogre::Animation* anim = entity->getSkeleton()->getAnimation(headClip);
+            m_before->headBoneClip.length = anim->getLength();
+            for (const auto& [handle, track] : anim->_getNodeTrackList()) {
+                auto& keys = m_before->headBoneClip.tracks[handle];
+                for (unsigned short i = 0; i < track->getNumKeyFrames(); ++i) {
+                    auto* kf = static_cast<Ogre::TransformKeyFrame*>(
+                        track->getKeyFrame(i));
+                    keys.push_back({kf->getTime(), kf->getRotation(),
+                                    kf->getTranslate(), kf->getScale()});
+                }
+            }
+        }
+        m_snapshotTaken = true;
+    }
+
+    m_report = MocapRecorder::recordFace(entity, m_samples, m_mapping, m_options);
+}
+
+void RecordMocapClipCommand::undo()
+{
+    Ogre::Entity* entity = findEntity(m_entityName);
+    if (!entity || !m_before)
+        return;
+
+    Ogre::MeshPtr mesh = entity->getMesh();
+    const std::string clip = m_options.clipName.toStdString();
+    if (mesh && mesh->hasAnimation(clip))
+        mesh->removeAnimation(clip);
+    if (mesh && m_before->hadWeightClip) {
+        Ogre::Animation* anim =
+            mesh->createAnimation(clip, m_before->weightClip.length);
+        for (const auto& [handle, keys] : m_before->weightClip.tracks) {
+            auto* track = anim->createVertexTrack(handle, Ogre::VAT_POSE);
+            for (const auto& key : keys) {
+                auto* kf = track->createVertexPoseKeyFrame(key.time);
+                for (const auto& [poseIndex, influence] : key.poseRefs)
+                    kf->addPoseReference(poseIndex, influence);
+            }
+        }
+    }
+
+    const std::string headClip =
+        (m_options.clipName + QStringLiteral("_Head")).toStdString();
+    if (entity->hasSkeleton()) {
+        Ogre::SkeletonInstance* skel = entity->getSkeleton();
+        if (skel->hasAnimation(headClip))
+            skel->removeAnimation(headClip);
+        if (m_before->hadHeadBoneClip) {
+            Ogre::Animation* anim =
+                skel->createAnimation(headClip, m_before->headBoneClip.length);
+            for (const auto& [handle, keys] : m_before->headBoneClip.tracks) {
+                auto* track =
+                    anim->createNodeTrack(handle, skel->getBone(handle));
+                for (const auto& key : keys) {
+                    auto* kf = track->createNodeKeyFrame(key.time);
+                    kf->setRotation(key.rotation);
+                    kf->setTranslate(key.translate);
+                    kf->setScale(key.scale);
+                }
+            }
+        }
+    }
+    // node-TRS head clip (static meshes): scene-level, owned by
+    // NodeAnimationManager — a recorded node clip is simply deleted (there is
+    // no pre-existing "<clip>_Head" node clip to restore: recordFace only
+    // creates it fresh, and name collisions with user clips are rejected by
+    // createClip returning false).
+    if (m_report.headTarget == QLatin1String("node")) {
+        if (auto* nam = NodeAnimationManager::instance())
+            nam->deleteClip(m_options.clipName + QStringLiteral("_Head"));
+    }
+
+    entity->refreshAvailableAnimationState();
+}
+
+#endif  // ENABLE_MOCAP

--- a/src/commands/RecordMocapClipCommand.h
+++ b/src/commands/RecordMocapClipCommand.h
@@ -1,0 +1,55 @@
+#ifndef RECORD_MOCAP_CLIP_COMMAND_H
+#define RECORD_MOCAP_CLIP_COMMAND_H
+
+// Undoable wrapper around MocapRecorder::recordFace (epic #869, Slice D
+// #873): a recorded take — potentially thousands of weight keyframes plus a
+// head clip — is ONE undo step.
+//
+// First redo() snapshots the pre-existing clips (the mesh VAT_POSE weight
+// clip, the "<clip>_Head" skeletal clip, and the scene-level node clip, each
+// of which may or may not exist) and runs the recorder with the samples the
+// command owns. undo() removes the recorded clips and restores the snapshots
+// keyframe-for-keyframe. Subsequent redo()s re-run the recorder on the same
+// inputs (deterministic).
+//
+// Only compiled under ENABLE_MOCAP (the recorder doesn't exist otherwise).
+
+#ifdef ENABLE_MOCAP
+
+#include <QUndoCommand>
+
+#include "../Mocap/FaceCapMapper.h"
+#include "../Mocap/MocapRecorder.h"
+
+#include <string>
+#include <vector>
+
+class RecordMocapClipCommand : public QUndoCommand
+{
+public:
+    RecordMocapClipCommand(std::string entityName,
+                           std::vector<FaceSample> samples,
+                           FaceCapMapper::Mapping mapping,
+                           MocapRecorder::FaceRecordOptions options,
+                           QUndoCommand* parent = nullptr);
+    ~RecordMocapClipCommand() override;
+
+    void undo() override;
+    void redo() override;
+
+    const MocapRecorder::FaceRecordReport& report() const { return m_report; }
+
+private:
+    struct Snapshots;
+
+    std::string m_entityName;
+    std::vector<FaceSample> m_samples;
+    FaceCapMapper::Mapping m_mapping;
+    MocapRecorder::FaceRecordOptions m_options;
+    MocapRecorder::FaceRecordReport m_report;
+    std::unique_ptr<Snapshots> m_before;
+    bool m_snapshotTaken = false;
+};
+
+#endif  // ENABLE_MOCAP
+#endif  // RECORD_MOCAP_CLIP_COMMAND_H


### PR DESCRIPTION
Part of epic #869. Closes #873. **Stacked on #881 (Slice C)** — merge order: #880 → #881 → this.

## What this adds

**The first user-visible milestone: one command turns a face video into a playing, exportable morph animation.**

- **`MocapRecorder`** — `FaceSample` stream → weight keyframes on a named morph clip through the #519 pipeline (dope sheet / timeline / glTF export all work downstream for free). Epsilon run-length suppression (constant channels → 2 keys), jump pre-anchoring, first/last always keyed, face-lost gaps > 0.5 s held at both edges. Head pose neutral-calibrates on the first confident frame and lands on the **Head bone** (`<clip>_Head` skeletal clip, `canonicalIndexForBone` role) or as **node TRS** for static meshes.
- **`MorphAnimationManager::writeWeightKeyOn`** — small refactor exposing the entity-explicit keyframe writer (`setMorphWeightKeyframe` now delegates to it); the shared-track pose-reference subtlety stays in one place.
- **`RecordMocapClipCommand`** — a whole take is ONE undo step (snapshot pattern; pre-existing clips restored keyframe-for-keyframe, covered by test).
- **CLI `qtmesh mocap`** (separate `MocapCLI.cpp`, the SceneLightsCLI precedent): mapping table printed (unmatched channels reported, never dropped), `--frames-dir` headless path, `--json` report, clear errors for every failure mode, "rebuild with -DENABLE_MOCAP" on non-mocap builds.
- **MCP `capture_face_from_video`** (heavy): live-scene entity, single undoable clip, optional export, full report JSON.
- **Drive-by fix**: `CLIPipeline::writeCliError` output was silently lost at `_exit()` (unflushed static QTextStream) — affected every existing subcommand's error text.

## Verification (run locally on macOS with the Slice A models)

- Static OBJ + 6-frame sequence (portrait → rotated portrait): `framesProcessed 6, framesNoFace 0, headTarget "node", 5 head keys`, valid glb exported.
- Minimal glTF with `jawOpen`/`mouthSmileLeft` targets: 2 channels matched, **9 weight keys**, exported glb contains the `FaceCap` morph-weights animation (`"path":"weights"` — the #519 round-trip).
- 43 headless unit tests pass locally; the new `MocapRecorder_test.cpp` suite (keyframe times/values, epsilon suppression, gap holds, unmatched reporting, single-undo round-trip, head-target resolution) needs Ogre → runs in the Linux CI lane.
- Known upstream gap (noted, not introduced here): Assimp's glTF exporter doesn't write `extras.targetNames`, so a REimported mesh shows `Shape_N` target names — a `--map` sidecar re-binds them.

Real-webcam-video + ARKit-avatar verification is the Slice F/G QA pass (needs a hosted model + a Ready Player Me head; the pipeline pieces are each proven above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)