### PR TITLE
Mocap Slice F (#875): live Performance Capture panel — MocapController + QML + MCP live tools

### DIFF
--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -609,6 +609,31 @@ Rectangle {
                 Component.onCompleted: content = skinningToolsComponent
             }
 
+            // ---- Performance Capture (Animation mode, epic #869) ----
+            // Live webcam capture: preview drives the selected entity's
+            // morph targets + Head bone in real time; Record writes an
+            // ordinary undoable clip. Gated on a selection that has either
+            // ARKit-style morph targets or a resolvable Head bone; disabled
+            // builds show the rebuild hint inside the section.
+            CollapsibleSection {
+                id: performanceCaptureSection
+                title: "Performance Capture"
+                sectionVisible: root.currentTab === root.modeToolsTab
+                    && root.modeToolMatches(EditorModeController.AnimationMode)
+                    && PropertiesPanelController.hasEntitySelection
+                expanded: false
+
+                Component.onCompleted: content = performanceCaptureComponent
+
+                // never leave the camera running when the section disappears
+                // (mode change / deselect) — the AutoRig marker-session
+                // precedent.
+                onSectionVisibleChanged: if (!sectionVisible
+                        && MocapController.available
+                        && MocapController.state !== 0)
+                    MocapController.stopPreview()
+            }
+
             // ---- Rigging (Animation mode) ----
             // Issue #407: native auto-rig. Shown in Animation Mode for a
             // STATIC (skeleton-less) selection — embedding a skeleton is the
@@ -2275,6 +2300,211 @@ Rectangle {
     // Issue #402: auto skin weights. The "Compute Skin Weights…"
     // button opens the dialog; it disables on static meshes
     // (no skeleton). The operation is undoable (Ctrl+Z).
+    Component {
+        id: performanceCaptureComponent
+
+        Column {
+            width: parent ? parent.width : 200
+            padding: 8
+            spacing: 6
+
+            readonly property bool mocapReady: MocapController.available
+            readonly property bool previewing: MocapController.state >= 2
+            readonly property bool recording: MocapController.state === 3
+
+            Text {
+                width: parent.width - 16
+                wrapMode: Text.Wrap
+                opacity: 0.8
+                color: PropertiesPanelController.textColor
+                font.pixelSize: 10
+                text: mocapReady
+                    ? "Webcam performance capture: Preview drives the selection's "
+                      + "ARKit-style morph targets and Head bone live; Record writes "
+                      + "an undoable clip onto the timeline. Body capture runs "
+                      + "offline via 'qtmesh mocap --body'."
+                    : MocapController.unavailableReason
+            }
+
+            // device picker + preview toggle
+            Row {
+                width: parent.width - 16
+                spacing: 6
+                visible: mocapReady
+
+                ComboBox {
+                    id: mocapDeviceCombo
+                    width: parent.width - previewBtn.width - 6
+                    model: MocapController.availableDevices
+                    textRole: "description"
+                    valueRole: "id"
+                    enabled: MocapController.state === 0
+                    Component.onCompleted: MocapController.refreshDevices()
+                }
+
+                Rectangle {
+                    id: previewBtn
+                    width: 70
+                    height: 26
+                    radius: 3
+                    color: previewMa.containsMouse
+                        ? PropertiesPanelController.highlightColor
+                        : PropertiesPanelController.headerColor
+                    border.color: PropertiesPanelController.borderColor
+                    border.width: 1
+                    Text {
+                        anchors.centerIn: parent
+                        color: PropertiesPanelController.textColor
+                        font.pixelSize: 11
+                        text: MocapController.state === 0 ? "Preview" : "Stop"
+                    }
+                    MouseArea {
+                        id: previewMa
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        onClicked: {
+                            if (MocapController.state === 0)
+                                MocapController.startPreview(
+                                    mocapDeviceCombo.currentValue !== undefined
+                                        ? mocapDeviceCombo.currentValue : "")
+                            else
+                                MocapController.stopPreview()
+                        }
+                    }
+                }
+            }
+
+            // camera preview + HUD
+            Rectangle {
+                width: parent.width - 16
+                height: visible ? 140 : 0
+                visible: mocapReady && MocapController.previewDataUrl !== ""
+                color: "black"
+                radius: 3
+
+                Image {
+                    anchors.fill: parent
+                    anchors.margins: 2
+                    fillMode: Image.PreserveAspectFit
+                    source: MocapController.previewDataUrl
+                    cache: false
+                }
+                Rectangle {
+                    width: 10; height: 10; radius: 5
+                    anchors.top: parent.top
+                    anchors.right: parent.right
+                    anchors.margins: 6
+                    color: MocapController.faceDetected ? "#4caf50" : "#f44336"
+                }
+                Text {
+                    anchors.bottom: parent.bottom
+                    anchors.left: parent.left
+                    anchors.margins: 4
+                    color: "white"
+                    font.pixelSize: 10
+                    style: Text.Outline
+                    styleColor: "black"
+                    text: MocapController.liveFps.toFixed(0) + " fps"
+                        + (recording
+                           ? "  ● REC " + MocapController.recordingSeconds.toFixed(1) + "s"
+                           : "")
+                }
+            }
+
+            // channel summary
+            Text {
+                width: parent.width - 16
+                wrapMode: Text.Wrap
+                visible: mocapReady && previewing
+                opacity: 0.8
+                color: PropertiesPanelController.textColor
+                font.pixelSize: 10
+                text: MocapController.matchedChannelCount + " morph channels matched"
+                    + (MocapController.headAvailable ? " + Head bone" : "")
+                    + (MocapController.unmatchedChannels.length > 0
+                       ? " (" + MocapController.unmatchedChannels.length
+                         + " capture channels unmatched)"
+                       : "")
+            }
+
+            // clip name + record controls
+            Row {
+                width: parent.width - 16
+                spacing: 6
+                visible: mocapReady && previewing
+
+                TextField {
+                    id: mocapClipName
+                    width: parent.width - calibrateBtn.width - recordBtn.width - 12
+                    text: MocapController.clipName
+                    font.pixelSize: 11
+                    enabled: !recording
+                    onEditingFinished: MocapController.clipName = text
+                }
+                Rectangle {
+                    id: calibrateBtn
+                    width: 64
+                    height: 26
+                    radius: 3
+                    color: calibrateMa.containsMouse
+                        ? PropertiesPanelController.highlightColor
+                        : PropertiesPanelController.headerColor
+                    border.color: PropertiesPanelController.borderColor
+                    border.width: 1
+                    Text {
+                        anchors.centerIn: parent
+                        color: PropertiesPanelController.textColor
+                        font.pixelSize: 11
+                        text: "Neutral"
+                    }
+                    MouseArea {
+                        id: calibrateMa
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        onClicked: MocapController.calibrateNeutral()
+                    }
+                }
+                Rectangle {
+                    id: recordBtn
+                    width: 70
+                    height: 26
+                    radius: 3
+                    color: recording ? "#b23b3b"
+                        : (recordMa.containsMouse
+                           ? PropertiesPanelController.highlightColor
+                           : PropertiesPanelController.headerColor)
+                    border.color: PropertiesPanelController.borderColor
+                    border.width: 1
+                    Text {
+                        anchors.centerIn: parent
+                        color: recording ? "white" : PropertiesPanelController.textColor
+                        font.pixelSize: 11
+                        text: recording ? "■ Stop" : "● Record"
+                    }
+                    MouseArea {
+                        id: recordMa
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        onClicked: recording ? MocapController.stopRecording()
+                                             : MocapController.startRecording()
+                    }
+                }
+            }
+
+            // status line
+            Text {
+                width: parent.width - 16
+                wrapMode: Text.Wrap
+                visible: mocapReady && MocapController.statusMessage !== ""
+                color: PropertiesPanelController.textColor
+                opacity: 0.9
+                font.pixelSize: 10
+                font.italic: true
+                text: MocapController.statusMessage
+            }
+        }
+    }
+
     Component {
         id: skinningToolsComponent
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -171,6 +171,7 @@ Mocap/MocapRecorder.cpp
 Mocap/PoseCapPredictor.cpp
 Mocap/PoseIKSolver.cpp
 Mocap/MocapCLI.cpp
+Mocap/MocapController.cpp
 commands/RecordMocapClipCommand.cpp
 ApplyAtlas.cpp
 EmbeddedTextureCache.cpp

--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -20,6 +20,7 @@
 #include "Mocap/PoseIKSolver.h"
 #include "Mocap/VideoFrameSource.h"
 #include "commands/RecordMocapClipCommand.h"
+#include "Mocap/MocapController.h"
 #endif
 #include "NodeAnimationManager.h"
 #include "PoseLibrary.h"
@@ -706,6 +707,9 @@ const QMap<QString, MCPServer::ToolHandler>& MCPServer::toolHandlers()
         {QStringLiteral("import_alembic"), &MCPServer::toolImportAlembic},
         {QStringLiteral("capture_face_from_video"), &MCPServer::toolCaptureFaceFromVideo},
         {QStringLiteral("capture_body_from_video"), &MCPServer::toolCaptureBodyFromVideo},
+        {QStringLiteral("list_capture_devices"), &MCPServer::toolListCaptureDevices},
+        {QStringLiteral("start_live_capture"), &MCPServer::toolStartLiveCapture},
+        {QStringLiteral("stop_live_capture"), &MCPServer::toolStopLiveCapture},
         {QStringLiteral("play_vertex_animation"), &MCPServer::toolPlayVertexAnimation},
         {QStringLiteral("list_node_animations"), &MCPServer::toolListNodeAnimations},
         {QStringLiteral("add_node_animation_clip"), &MCPServer::toolAddNodeAnimationClip},
@@ -6636,6 +6640,81 @@ QJsonObject MCPServer::toolCaptureFaceFromVideo(const QJsonObject &args)
 #endif // ENABLE_MOCAP
 }
 
+QJsonObject MCPServer::toolListCaptureDevices(const QJsonObject &args)
+{
+    Q_UNUSED(args);
+    SentryReporter::addBreadcrumb("ai.tool_call", "list_capture_devices");
+#ifndef ENABLE_MOCAP
+    return makeErrorResult(
+        "Error: this build has no performance-capture support. Rebuild with "
+        "-DENABLE_MOCAP=ON -DENABLE_ONNX=ON.");
+#else
+    QJsonArray devices;
+    for (const auto& dev : CameraFrameSource::availableDevices()) {
+        QJsonObject o;
+        o["id"] = dev.id;
+        o["description"] = dev.description;
+        devices.append(o);
+    }
+    QJsonObject content;
+    content["devices"] = devices;
+    return makeSuccessResult(
+        QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Indented)));
+#endif
+}
+
+QJsonObject MCPServer::toolStartLiveCapture(const QJsonObject &args)
+{
+    SentryReporter::addBreadcrumb("ai.tool_call", "start_live_capture");
+#ifndef ENABLE_MOCAP
+    Q_UNUSED(args);
+    return makeErrorResult(
+        "Error: this build has no performance-capture support. Rebuild with "
+        "-DENABLE_MOCAP=ON -DENABLE_ONNX=ON.");
+#else
+    Manager* mgr = Manager::getSingletonPtr();
+    if (!mgr || !mgr->getMainWindow())
+        return makeErrorResult(
+            "Error: live capture needs the GUI (run with --with-mcp, not --mcp).");
+    auto* c = MocapController::instance();
+    if (c->state() != MocapController::Idle)
+        return makeErrorResult("Error: a live capture session is already running");
+    if (!c->startPreview(args.value("device_id").toString()))
+        return makeErrorResult(QString("Error: %1").arg(c->statusMessage()));
+    QJsonObject content;
+    content["ok"] = true;
+    content["state"] = "previewing";
+    content["matchedChannels"] = c->matchedChannelCount();
+    content["headAvailable"] = c->headAvailable();
+    return makeSuccessResult(
+        QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Indented)));
+#endif
+}
+
+QJsonObject MCPServer::toolStopLiveCapture(const QJsonObject &args)
+{
+    SentryReporter::addBreadcrumb("ai.tool_call", "stop_live_capture");
+#ifndef ENABLE_MOCAP
+    Q_UNUSED(args);
+    return makeErrorResult(
+        "Error: this build has no performance-capture support. Rebuild with "
+        "-DENABLE_MOCAP=ON -DENABLE_ONNX=ON.");
+#else
+    auto* c = MocapController::instance();
+    if (c->state() == MocapController::Idle)
+        return makeErrorResult("Error: no live capture session is running");
+    if (args.value("record").toBool(false)
+        && c->state() == MocapController::Recording)
+        c->stopRecording();
+    c->stopPreview();
+    QJsonObject content;
+    content["ok"] = true;
+    content["status"] = c->statusMessage();
+    return makeSuccessResult(
+        QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Indented)));
+#endif
+}
+
 QJsonObject MCPServer::toolCaptureBodyFromVideo(const QJsonObject &args)
 {
     SentryReporter::addBreadcrumb("ai.tool_call", "capture_body_from_video");
@@ -9605,6 +9684,36 @@ QJsonArray MCPServer::buildToolsList()
             props,
             required
         );
+    }
+
+    // live capture (epic #869, Slice F #875) — GUI-attached sessions only
+    {
+        QJsonObject props;
+        appendTool(
+            "list_capture_devices",
+            "List the available camera devices for live performance capture "
+            "(id + description). Requires a build with ENABLE_MOCAP=ON.",
+            props, QJsonArray());
+    }
+    {
+        QJsonObject props;
+        props["device_id"] = QJsonObject{{"type", "string"}, {"description", "Camera id from list_capture_devices (default camera when omitted)."}};
+        QJsonArray required;
+        appendTool(
+            "start_live_capture",
+            "Start a live webcam performance-capture preview driving the SELECTED entity's "
+            "morph targets + Head bone (the GUI Performance Capture panel's session). Only "
+            "works in --with-mcp (GUI) mode. Follow with stop_live_capture.",
+            props, required);
+    }
+    {
+        QJsonObject props;
+        props["record"] = QJsonObject{{"type", "boolean"}, {"description", "true: stop and commit the recording in progress (if any) before stopping the preview."}};
+        appendTool(
+            "stop_live_capture",
+            "Stop the live performance-capture preview started by start_live_capture, "
+            "restoring the entity's prior state exactly.",
+            props, QJsonArray());
     }
 
     // import_alembic

--- a/src/MCPServer.h
+++ b/src/MCPServer.h
@@ -283,6 +283,9 @@ private:
     QJsonObject toolImportAlembic(const QJsonObject &args);
     QJsonObject toolCaptureFaceFromVideo(const QJsonObject &args);
     QJsonObject toolCaptureBodyFromVideo(const QJsonObject &args);
+    QJsonObject toolListCaptureDevices(const QJsonObject &args);
+    QJsonObject toolStartLiveCapture(const QJsonObject &args);
+    QJsonObject toolStopLiveCapture(const QJsonObject &args);
 
     /// Vertex-anim B3 (#519): enable + play a vertex-animation clip on an
     /// entity. Args: `entity`, `animation`. Light — state poke on a live entity.

--- a/src/Mocap/FaceCapPredictor.h
+++ b/src/Mocap/FaceCapPredictor.h
@@ -22,6 +22,7 @@
 #ifdef ENABLE_MOCAP
 
 #include <QImage>
+#include <QMetaType>
 #include <QString>
 
 #include <array>
@@ -37,6 +38,7 @@ struct FaceSample {
     std::array<float, 3> headTranslation{0.f, 0.f, 0.f};    // px units
     float confidence = 0.f;                              // 0 = no face
 };
+Q_DECLARE_METATYPE(FaceSample)
 
 class FaceCapPredictor {
 public:

--- a/src/Mocap/MocapController.cpp
+++ b/src/Mocap/MocapController.cpp
@@ -1,0 +1,617 @@
+#include "MocapController.h"
+
+#ifdef ENABLE_MOCAP
+#include "MocapRecorder.h"
+#include "OneEuroFilter.h"
+#include "VideoFrameSource.h"
+#include "../Manager.h"
+#include "../MorphAnimationManager.h"
+#include "../SelectionSet.h"
+#include "../SentryReporter.h"
+#include "../UndoManager.h"
+#include "../GamificationManager.h"
+#include "../commands/RecordMocapClipCommand.h"
+
+#include <OgreAnimationState.h>
+#include <OgreBone.h>
+#include <OgreEntity.h>
+#include <OgreMesh.h>
+#include <OgreSkeletonInstance.h>
+
+#include <QBuffer>
+#include <QElapsedTimer>
+#include <QThread>
+#endif
+
+#include <QCoreApplication>
+
+namespace {
+MocapController* s_instance = nullptr;
+#ifdef ENABLE_MOCAP
+// queued sampleReady(FaceSample, QImage) needs the metatype
+struct FaceSampleMetaTypeRegistrar {
+    FaceSampleMetaTypeRegistrar() { qRegisterMetaType<FaceSample>("FaceSample"); }
+};
+const FaceSampleMetaTypeRegistrar faceSampleRegistrar;
+#endif
+}
+
+MocapController* MocapController::instance()
+{
+    if (!s_instance)
+        s_instance = new MocapController();
+    return s_instance;
+}
+
+MocapController* MocapController::qmlInstance(QQmlEngine* engine, QJSEngine*)
+{
+    Q_UNUSED(engine);
+    MocapController* inst = instance();
+    QQmlEngine::setObjectOwnership(inst, QQmlEngine::CppOwnership);
+    return inst;
+}
+
+void MocapController::kill()
+{
+    delete s_instance;
+    s_instance = nullptr;
+}
+
+#ifndef ENABLE_MOCAP
+
+// -----------------------------------------------------------------------------
+// Non-mocap build: the section shows a disabled label with the reason.
+// -----------------------------------------------------------------------------
+
+struct MocapController::Impl {};
+
+MocapController::MocapController(QObject* parent) : QObject(parent) {}
+MocapController::~MocapController() = default;
+bool MocapController::available() const { return false; }
+QString MocapController::unavailableReason() const
+{
+    return tr("This build has no performance-capture support — rebuild with "
+              "-DENABLE_MOCAP=ON -DENABLE_ONNX=ON.");
+}
+int MocapController::state() const { return Idle; }
+QVariantList MocapController::availableDevices() const { return {}; }
+bool MocapController::faceDetected() const { return false; }
+double MocapController::liveFps() const { return 0; }
+double MocapController::recordingSeconds() const { return 0; }
+int MocapController::sampleCount() const { return 0; }
+QString MocapController::previewDataUrl() const { return {}; }
+QString MocapController::statusMessage() const { return {}; }
+int MocapController::matchedChannelCount() const { return 0; }
+QStringList MocapController::unmatchedChannels() const { return {}; }
+bool MocapController::headAvailable() const { return false; }
+QString MocapController::clipName() const { return QStringLiteral("FaceCap"); }
+void MocapController::setClipName(const QString&) {}
+double MocapController::smoothingCutoff() const { return 1.0; }
+void MocapController::setSmoothingCutoff(double) {}
+void MocapController::refreshDevices() {}
+bool MocapController::startPreview(const QString&) { return false; }
+void MocapController::stopPreview() {}
+bool MocapController::startRecording() { return false; }
+void MocapController::stopRecording() {}
+void MocapController::calibrateNeutral() {}
+
+#else  // ENABLE_MOCAP
+
+// -----------------------------------------------------------------------------
+// Worker: drains the camera mailbox through the predictor off the main thread.
+// -----------------------------------------------------------------------------
+
+class MocapInferenceWorker : public QObject
+{
+    Q_OBJECT
+public:
+    FrameMailbox* mailbox = nullptr;
+    FaceCapPredictor predictor;
+    std::array<OneEuroFilter, 52> weightFilters;
+    OneEuroQuatFilter headFilter;
+    bool smooth = true;
+
+public slots:
+    void processPending()
+    {
+        if (!mailbox)
+            return;
+        MocapFrame frame;
+        while (mailbox->take(&frame)) {
+            FaceSample s = predictor.predict(frame.image, frame.timeSec);
+            if (smooth && s.confidence > 0.f) {
+                for (int c = 0; c < 52; ++c)
+                    s.weights[c] = static_cast<float>(
+                        weightFilters[c].filter(s.weights[c], s.timeSec));
+                s.headRotation = headFilter.filter(s.headRotation, s.timeSec);
+            }
+            // downscale sparsely for the HUD preview (payload stays small)
+            QImage preview;
+            if (frame.frameIndex % 3 == 0)
+                preview = frame.image.scaledToWidth(240, Qt::FastTransformation);
+            emit sampleReady(s, preview);
+        }
+    }
+
+signals:
+    void sampleReady(const FaceSample& sample, const QImage& preview);
+};
+
+struct MocapController::Impl {
+    State state = Idle;
+    QString status;
+    QString clipName = QStringLiteral("FaceCap");
+    double smoothingCutoff = 1.0;
+
+    std::unique_ptr<CameraFrameSource> camera;
+    VideoFrameSource* injectedSource = nullptr;  // test seam, not owned
+    QThread workerThread;
+    MocapInferenceWorker* worker = nullptr;  // owned by workerThread
+
+    // capture-session state (all main-thread)
+    std::string entityName;
+    FaceCapMapper::Mapping mapping;
+    QString headBone;
+    bool calibrated = false;
+    Ogre::Quaternion neutral = Ogre::Quaternion::IDENTITY;
+    Ogre::Quaternion headBindWorld = Ogre::Quaternion::IDENTITY;
+    Ogre::Quaternion headBindLocal = Ogre::Quaternion::IDENTITY;
+    bool headWasManuallyControlled = false;
+    QHash<QString, float> savedWeights;          // mesh target -> weight
+    QStringList savedEnabledAnimations;
+
+    // recording
+    bool recordPending = false;
+    std::vector<FaceSample> take;
+    double takeStart = 0.0;
+    double lastSampleTime = 0.0;
+
+    // HUD
+    bool faceDetected = false;
+    double liveFps = 0.0;
+    double lastArrival = -1.0;
+    QElapsedTimer clock;
+    QString previewDataUrl;
+    int sampleCount = 0;
+
+    Ogre::Entity* entity() const
+    {
+        auto* mgr = Manager::getSingletonPtr();
+        if (!mgr || !mgr->getSceneMgr() || entityName.empty())
+            return nullptr;
+        auto* scene = mgr->getSceneMgr();
+        return scene->hasEntity(entityName) ? scene->getEntity(entityName)
+                                            : nullptr;
+    }
+};
+
+MocapController::MocapController(QObject* parent)
+    : QObject(parent), d(new Impl)
+{
+}
+
+MocapController::~MocapController()
+{
+    stopPreview();
+}
+
+bool MocapController::available() const { return true; }
+QString MocapController::unavailableReason() const { return {}; }
+int MocapController::state() const { return d->state; }
+
+QVariantList MocapController::availableDevices() const
+{
+    QVariantList out;
+    for (const auto& dev : CameraFrameSource::availableDevices()) {
+        QVariantMap m;
+        m.insert(QStringLiteral("id"), dev.id);
+        m.insert(QStringLiteral("description"), dev.description);
+        out.append(m);
+    }
+    return out;
+}
+
+bool MocapController::faceDetected() const { return d->faceDetected; }
+double MocapController::liveFps() const { return d->liveFps; }
+double MocapController::recordingSeconds() const
+{
+    return d->state == Recording ? d->lastSampleTime - d->takeStart : 0.0;
+}
+int MocapController::sampleCount() const { return d->sampleCount; }
+QString MocapController::previewDataUrl() const { return d->previewDataUrl; }
+QString MocapController::statusMessage() const { return d->status; }
+int MocapController::matchedChannelCount() const
+{
+    return d->mapping.channels.size();
+}
+QStringList MocapController::unmatchedChannels() const
+{
+    return d->mapping.unmatchedCanonical;
+}
+bool MocapController::headAvailable() const { return !d->headBone.isEmpty(); }
+QString MocapController::clipName() const { return d->clipName; }
+void MocapController::setClipName(const QString& name)
+{
+    if (name == d->clipName || name.isEmpty())
+        return;
+    d->clipName = name;
+    emit clipNameChanged();
+}
+double MocapController::smoothingCutoff() const { return d->smoothingCutoff; }
+void MocapController::setSmoothingCutoff(double hz)
+{
+    if (hz <= 0 || hz == d->smoothingCutoff)
+        return;
+    d->smoothingCutoff = hz;
+    emit smoothingChanged();
+}
+
+void MocapController::refreshDevices() { emit devicesChanged(); }
+
+void MocapController::setStatusMessage(const QString& message)
+{
+    d->status = message;
+    emit statusChanged();
+}
+
+bool MocapController::startPreview(const QString& deviceId)
+{
+    if (d->state != Idle)
+        return false;
+
+    auto* sel = SelectionSet::getSingleton();
+    Ogre::Entity* entity = nullptr;
+    if (sel) {
+        const auto ents = sel->getResolvedEntities();
+        if (!ents.isEmpty())
+            entity = ents.first();
+    }
+    if (!entity) {
+        setStatusMessage(tr("Select an entity to drive first."));
+        emit errorOccurred(d->status);
+        return false;
+    }
+
+    // models first (blocking download with a visible status)
+    if (!FaceCapPredictor::modelsPresent()) {
+        setStatusMessage(tr("Downloading face capture models…"));
+        QCoreApplication::processEvents();
+        if (FaceCapPredictor::ensureModelsBlocking().isEmpty()) {
+            setStatusMessage(
+                      tr("Face capture models are not available (offline, or "
+                         "not hosted yet)."));
+            emit errorOccurred(d->status);
+            return false;
+        }
+    }
+
+    d->entityName = entity->getName();
+    d->mapping = FaceCapMapper::build(
+        MorphAnimationManager::instance()->morphTargetsFor(entity));
+    d->headBone = MocapRecorder::resolveHeadBone(entity);
+    emit mappingChanged();
+    if (d->mapping.channels.isEmpty() && d->headBone.isEmpty()) {
+        setStatusMessage(
+                  tr("The selection has no ARKit-style morph targets and no "
+                     "Head bone — nothing to drive."));
+        emit errorOccurred(d->status);
+        return false;
+    }
+
+    // snapshot live state (the restore contract)
+    d->savedWeights.clear();
+    auto* morphMgr = MorphAnimationManager::instance();
+    for (const auto& ch : d->mapping.channels)
+        d->savedWeights.insert(ch.meshTargetName,
+                               morphMgr->weight(entity, ch.meshTargetName));
+    d->savedEnabledAnimations.clear();
+    if (auto* states = entity->getAllAnimationStates()) {
+        for (const auto& [name, st] : states->getAnimationStates()) {
+            if (st->getEnabled()) {
+                d->savedEnabledAnimations << QString::fromStdString(name);
+                st->setEnabled(false);
+            }
+        }
+    }
+    if (!d->headBone.isEmpty() && entity->hasSkeleton()) {
+        Ogre::SkeletonInstance* skel = entity->getSkeleton();
+        Ogre::Bone* bone = skel->getBone(d->headBone.toStdString());
+        d->headWasManuallyControlled = bone->isManuallyControlled();
+        d->headBindLocal = bone->getOrientation();
+        d->headBindWorld = bone->_getDerivedOrientation();
+        bone->setManuallyControlled(true);
+    }
+    d->calibrated = false;
+    d->faceDetected = false;
+    d->liveFps = 0;
+    d->lastArrival = -1;
+    d->sampleCount = 0;
+    d->clock.start();
+
+    // camera + worker
+    d->camera = std::make_unique<CameraFrameSource>(deviceId);
+    QString error;
+    if (!d->camera->open(&error)) {
+        d->camera.reset();
+        restoreEntityState();
+        setStatusMessage(error);
+        emit errorOccurred(error);
+        return false;
+    }
+    d->worker = new MocapInferenceWorker();
+    d->worker->mailbox = &d->camera->mailbox();
+    OneEuroFilter::Params params;
+    params.minCutoff = d->smoothingCutoff;
+    for (auto& f : d->worker->weightFilters)
+        f = OneEuroFilter(params);
+    d->worker->headFilter = OneEuroQuatFilter(params);
+    if (!d->worker->predictor.load()) {
+        const QString msg = d->worker->predictor.lastError();
+        delete d->worker;
+        d->worker = nullptr;
+        d->camera.reset();
+        restoreEntityState();
+        setStatusMessage(msg);
+        emit errorOccurred(msg);
+        return false;
+    }
+    d->worker->moveToThread(&d->workerThread);
+    connect(&d->workerThread, &QThread::finished, d->worker,
+            &QObject::deleteLater);
+    connect(d->camera.get(), &VideoFrameSource::frameReady, d->worker,
+            [w = d->worker](const MocapFrame&) { w->processPending(); },
+            Qt::QueuedConnection);
+    connect(d->camera.get(), &VideoFrameSource::errorOccurred, this,
+            [this](const QString& message) {
+                setStatusMessage(message);
+                emit errorOccurred(message);
+                stopPreview();
+            });
+    connect(d->worker, &MocapInferenceWorker::sampleReady, this,
+            &MocapController::onSample, Qt::QueuedConnection);
+    d->workerThread.start();
+
+    d->state = CameraStarting;
+    emit stateChanged();
+    setStatusMessage(tr("Starting camera…"));
+    d->camera->start();
+
+    SentryReporter::addBreadcrumb("ai.assist.mocap_live", "preview start");
+    GamificationManager::noteFeature(QStringLiteral("mocap"),
+                                     GamificationManager::Surface::Gui);
+    return true;
+}
+
+bool MocapController::startPreviewWithSource(VideoFrameSource* source)
+{
+    // Test seam: synchronous drive, no camera/worker thread. Samples are fed
+    // manually through onSample on THIS thread; source may be null.
+    if (d->state != Idle)
+        return false;
+    auto* sel = SelectionSet::getSingleton();
+    Ogre::Entity* entity = nullptr;
+    if (sel) {
+        const auto ents = sel->getResolvedEntities();
+        if (!ents.isEmpty())
+            entity = ents.first();
+    }
+    if (!entity)
+        return false;
+    d->entityName = entity->getName();
+    d->mapping = FaceCapMapper::build(
+        MorphAnimationManager::instance()->morphTargetsFor(entity));
+    d->headBone = MocapRecorder::resolveHeadBone(entity);
+    emit mappingChanged();
+
+    d->savedWeights.clear();
+    auto* morphMgr = MorphAnimationManager::instance();
+    for (const auto& ch : d->mapping.channels)
+        d->savedWeights.insert(ch.meshTargetName,
+                               morphMgr->weight(entity, ch.meshTargetName));
+    d->savedEnabledAnimations.clear();
+    if (auto* states = entity->getAllAnimationStates()) {
+        for (const auto& [name, st] : states->getAnimationStates()) {
+            if (st->getEnabled()) {
+                d->savedEnabledAnimations << QString::fromStdString(name);
+                st->setEnabled(false);
+            }
+        }
+    }
+    if (!d->headBone.isEmpty() && entity->hasSkeleton()) {
+        Ogre::Bone* bone =
+            entity->getSkeleton()->getBone(d->headBone.toStdString());
+        d->headWasManuallyControlled = bone->isManuallyControlled();
+        d->headBindLocal = bone->getOrientation();
+        d->headBindWorld = bone->_getDerivedOrientation();
+        bone->setManuallyControlled(true);
+    }
+    d->calibrated = false;
+    d->sampleCount = 0;
+    d->clock.start();
+    d->injectedSource = source;
+    d->state = Previewing;
+    emit stateChanged();
+    return true;
+}
+
+// Test seam companion: feed a sample as if it came from the worker.
+void MocapController::onSample(const FaceSample& sample, const QImage& preview)
+{
+    if (d->state == Idle)
+        return;
+    if (d->state == CameraStarting) {
+        d->state = Previewing;
+        emit stateChanged();
+        setStatusMessage(tr("Live — driving the selection."));
+    }
+
+    // HUD
+    d->faceDetected = sample.confidence > 0.f;
+    if (d->lastArrival >= 0.0) {
+        const double dt = sample.timeSec - d->lastArrival;
+        if (dt > 0)
+            d->liveFps = 0.8 * d->liveFps + 0.2 * (1.0 / dt);
+    }
+    d->lastArrival = sample.timeSec;
+    ++d->sampleCount;
+    emit liveStatsChanged();
+    if (!preview.isNull()) {
+        QByteArray png;
+        QBuffer buffer(&png);
+        buffer.open(QIODevice::WriteOnly);
+        preview.save(&buffer, "PNG");
+        d->previewDataUrl =
+            QStringLiteral("data:image/png;base64,") + png.toBase64();
+        emit previewChanged();
+    }
+
+    Ogre::Entity* entity = d->entity();
+    if (!entity || sample.confidence <= 0.f)
+        return;
+
+    // live drive — morphs
+    auto* morphMgr = MorphAnimationManager::instance();
+    for (const auto& ch : d->mapping.channels)
+        morphMgr->setWeight(entity, ch.meshTargetName,
+                            sample.weights[ch.canonicalIndex]);
+
+    // live drive — head
+    if (!d->headBone.isEmpty() && entity->hasSkeleton()) {
+        if (!d->calibrated) {
+            d->neutral = Ogre::Quaternion(
+                sample.headRotation[3], sample.headRotation[0],
+                sample.headRotation[1], sample.headRotation[2]);
+            d->calibrated = true;
+        }
+        const Ogre::Quaternion current(
+            sample.headRotation[3], sample.headRotation[0],
+            sample.headRotation[1], sample.headRotation[2]);
+        const Ogre::Quaternion delta = current * d->neutral.Inverse();
+        const Ogre::Quaternion local =
+            d->headBindWorld.Inverse() * delta * d->headBindWorld;
+        Ogre::SkeletonInstance* skel = entity->getSkeleton();
+        Ogre::Bone* bone = skel->getBone(d->headBone.toStdString());
+        bone->setOrientation(d->headBindLocal * local);
+        skel->_notifyManualBonesDirty();
+    }
+
+    if (d->state == Recording) {
+        d->take.push_back(sample);
+        d->lastSampleTime = sample.timeSec;
+    }
+}
+
+void MocapController::calibrateNeutral()
+{
+    d->calibrated = false;  // the next confident sample becomes neutral
+    setStatusMessage(tr("Hold a neutral face…"));
+}
+
+bool MocapController::startRecording()
+{
+    if (d->state != Previewing)
+        return false;
+    d->take.clear();
+    d->takeStart = d->lastArrival;
+    d->lastSampleTime = d->takeStart;
+    d->state = Recording;
+    emit stateChanged();
+    setStatusMessage(tr("Recording…"));
+    SentryReporter::addBreadcrumb("ai.assist.mocap_live", "record start");
+    return true;
+}
+
+void MocapController::stopRecording()
+{
+    if (d->state != Recording)
+        return;
+    d->state = Previewing;
+    emit stateChanged();
+
+    if (d->take.size() < 2) {
+        setStatusMessage(tr("Nothing recorded (no confident frames)."));
+        return;
+    }
+    MocapRecorder::FaceRecordOptions options;
+    options.clipName = d->clipName;
+    options.head = !d->headBone.isEmpty();
+    auto* cmd = new RecordMocapClipCommand(d->entityName, d->take, d->mapping,
+                                           options);
+    UndoManager::getSingleton()->push(cmd);
+    const auto& report = cmd->report();
+    if (!report.ok()) {
+        setStatusMessage(report.error);
+        return;
+    }
+    setStatusMessage(
+              tr("Recorded %1s → clip '%2' (%3 keyframes) — Ctrl+Z to discard.")
+                  .arg(report.clipLength, 0, 'f', 1)
+                  .arg(report.clipName)
+                  .arg(report.keyframesWritten + report.headKeyframesWritten));
+    GamificationManager::noteOperation(
+        QStringLiteral("mocap_face"),
+        {{QStringLiteral("frames"), static_cast<qint64>(report.framesProcessed)},
+         {QStringLiteral("keyframes"),
+          static_cast<qint64>(report.keyframesWritten
+                              + report.headKeyframesWritten)}},
+        GamificationManager::Surface::Gui);
+}
+
+void MocapController::restoreEntityState()
+{
+    Ogre::Entity* entity = d->entity();
+    if (!entity)
+        return;
+    auto* morphMgr = MorphAnimationManager::instance();
+    for (auto it = d->savedWeights.begin(); it != d->savedWeights.end(); ++it)
+        morphMgr->setWeight(entity, it.key(), it.value());
+    if (!d->headBone.isEmpty() && entity->hasSkeleton()) {
+        Ogre::SkeletonInstance* skel = entity->getSkeleton();
+        Ogre::Bone* bone = skel->getBone(d->headBone.toStdString());
+        bone->setOrientation(d->headBindLocal);
+        bone->setManuallyControlled(d->headWasManuallyControlled);
+        skel->_notifyManualBonesDirty();
+    }
+    if (auto* states = entity->getAllAnimationStates()) {
+        for (const QString& name : d->savedEnabledAnimations) {
+            const std::string n = name.toStdString();
+            if (states->hasAnimationState(n))
+                states->getAnimationState(n)->setEnabled(true);
+        }
+    }
+}
+
+void MocapController::stopPreview()
+{
+    if (d->state == Idle)
+        return;
+    if (d->state == Recording)
+        stopRecording();  // commit the take rather than dropping it
+
+    if (d->camera)
+        d->camera->stop();
+    if (d->workerThread.isRunning()) {
+        d->workerThread.quit();
+        d->workerThread.wait(2000);
+    }
+    d->worker = nullptr;  // deleted via QThread::finished
+    d->camera.reset();
+    d->injectedSource = nullptr;
+
+    restoreEntityState();
+
+    d->state = Idle;
+    d->faceDetected = false;
+    d->liveFps = 0;
+    d->previewDataUrl.clear();
+    emit stateChanged();
+    emit liveStatsChanged();
+    emit previewChanged();
+    if (d->status.isEmpty() || d->status.startsWith(tr("Live")))
+        setStatusMessage(tr("Preview stopped."));
+    SentryReporter::addBreadcrumb("ai.assist.mocap_live", "preview stop");
+}
+
+#include "MocapController.moc"
+
+#endif  // ENABLE_MOCAP

--- a/src/Mocap/MocapController.h
+++ b/src/Mocap/MocapController.h
@@ -1,0 +1,137 @@
+#ifndef MOCAPCONTROLLER_H
+#define MOCAPCONTROLLER_H
+
+// Live performance-capture controller (epic #869, Slice F #875) — the
+// QML_SINGLETON behind the Animation-Mode "Performance Capture" Inspector
+// section: camera preview, live drive of the selected entity's morph weights
+// + Head bone, and Record writing an ordinary undoable clip.
+//
+// Threading (the MeshGenController pattern): CameraFrameSource lives on the
+// main thread (Qt Multimedia), frames land in its latest-wins FrameMailbox;
+// a dedicated worker thread drains the mailbox through FaceCapPredictor and
+// emits FaceSamples QUEUED back to the main thread, where ALL Ogre mutation
+// happens. Never BlockingQueuedConnection (the MCP rule applies everywhere).
+//
+// Live drive is preview-only state: entering preview snapshots the mapped
+// morph weights and the Head bone's {manuallyControlled, orientation} plus
+// which AnimationStates were enabled (they are disabled during preview so
+// they don't fight the manual bone); leaving preview restores everything
+// exactly — the UvUnwrap GUI-safe-restore discipline.
+//
+// Recording buffers samples in memory; stopRecording() runs the take through
+// MocapRecorder via ONE RecordMocapClipCommand (Ctrl+Z discards the take).
+// Face-only live drive in this slice; body capture stays offline (CLI/MCP).
+
+#include <QObject>
+#include <QQmlEngine>
+#include <QStringList>
+#include <QVariantList>
+
+#ifdef ENABLE_MOCAP
+#include "FaceCapMapper.h"
+#include "FaceCapPredictor.h"
+#include <vector>
+#endif
+
+#include <memory>
+
+class QJSEngine;
+
+class MocapController : public QObject
+{
+    Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
+
+    Q_PROPERTY(bool available READ available CONSTANT)
+    Q_PROPERTY(QString unavailableReason READ unavailableReason CONSTANT)
+    Q_PROPERTY(int state READ state NOTIFY stateChanged)
+    Q_PROPERTY(QVariantList availableDevices READ availableDevices
+               NOTIFY devicesChanged)
+    Q_PROPERTY(bool faceDetected READ faceDetected NOTIFY liveStatsChanged)
+    Q_PROPERTY(double liveFps READ liveFps NOTIFY liveStatsChanged)
+    Q_PROPERTY(double recordingSeconds READ recordingSeconds NOTIFY liveStatsChanged)
+    Q_PROPERTY(int sampleCount READ sampleCount NOTIFY liveStatsChanged)
+    Q_PROPERTY(QString previewDataUrl READ previewDataUrl NOTIFY previewChanged)
+    Q_PROPERTY(QString statusMessage READ statusMessage NOTIFY statusChanged)
+    Q_PROPERTY(int matchedChannelCount READ matchedChannelCount
+               NOTIFY mappingChanged)
+    Q_PROPERTY(QStringList unmatchedChannels READ unmatchedChannels
+               NOTIFY mappingChanged)
+    Q_PROPERTY(bool headAvailable READ headAvailable NOTIFY mappingChanged)
+    Q_PROPERTY(QString clipName READ clipName WRITE setClipName
+               NOTIFY clipNameChanged)
+    Q_PROPERTY(double smoothingCutoff READ smoothingCutoff
+               WRITE setSmoothingCutoff NOTIFY smoothingChanged)
+
+public:
+    enum State { Idle = 0, CameraStarting, Previewing, Recording };
+    Q_ENUM(State)
+
+    static MocapController* instance();
+    static MocapController* qmlInstance(QQmlEngine* engine, QJSEngine* scriptEngine);
+    static void kill();
+
+    bool available() const;
+    QString unavailableReason() const;
+    int state() const;
+    QVariantList availableDevices() const;   // [{id, description}]
+    bool faceDetected() const;
+    double liveFps() const;
+    double recordingSeconds() const;
+    int sampleCount() const;
+    QString previewDataUrl() const;
+    QString statusMessage() const;
+    int matchedChannelCount() const;
+    QStringList unmatchedChannels() const;
+    bool headAvailable() const;
+    QString clipName() const;
+    void setClipName(const QString& name);
+    double smoothingCutoff() const;
+    void setSmoothingCutoff(double hz);
+
+    Q_INVOKABLE void refreshDevices();
+    // Start the camera + live drive of the SELECTED entity. Empty deviceId =
+    // default camera.
+    Q_INVOKABLE bool startPreview(const QString& deviceId = {});
+    Q_INVOKABLE void stopPreview();
+    Q_INVOKABLE bool startRecording();
+    Q_INVOKABLE void stopRecording();
+    // Re-base the head-pose neutral on the current sample ("hold a neutral
+    // face"). Auto-applied on the first confident sample of a preview.
+    Q_INVOKABLE void calibrateNeutral();
+
+#ifdef ENABLE_MOCAP
+    // Test seam: enter Previewing without a camera/worker (no camera in CI).
+    // Ownership stays with the caller; feed samples through onSample().
+    bool startPreviewWithSource(class VideoFrameSource* source);
+    // Receives one predicted sample on the MAIN thread (queued from the
+    // inference worker in live mode; called directly by tests).
+    void onSample(const FaceSample& sample, const QImage& preview);
+#endif
+
+signals:
+    void stateChanged();
+    void devicesChanged();
+    void liveStatsChanged();
+    void previewChanged();
+    void statusChanged();
+    void mappingChanged();
+    void clipNameChanged();
+    void smoothingChanged();
+    void errorOccurred(const QString& message);
+
+private:
+    explicit MocapController(QObject* parent = nullptr);
+    ~MocapController() override;
+
+#ifdef ENABLE_MOCAP
+    void restoreEntityState();
+    void setStatusMessage(const QString& message);
+#endif
+
+    struct Impl;
+    std::unique_ptr<Impl> d;
+};
+
+#endif  // MOCAPCONTROLLER_H

--- a/src/Mocap/MocapController_test.cpp
+++ b/src/Mocap/MocapController_test.cpp
@@ -1,0 +1,176 @@
+#ifdef ENABLE_MOCAP
+
+#include <gtest/gtest.h>
+
+#include "Manager.h"
+#include "MorphAnimationManager.h"
+#include "SelectionSet.h"
+#include "TestHelpers.h"
+#include "UndoManager.h"
+
+#include "Mocap/MocapController.h"
+#include "Mocap/MocapRecorder.h"
+
+#include <OgreAnimation.h>
+#include <OgreEntity.h>
+#include <OgreHardwareBufferManager.h>
+#include <OgreMesh.h>
+#include <OgreMeshManager.h>
+#include <OgrePose.h>
+#include <OgreSceneManager.h>
+#include <OgreSceneNode.h>
+#include <OgreSubMesh.h>
+
+namespace {
+
+// same recipe as MocapRecorder_test — a tiny mesh with two ARKit targets
+Ogre::MeshPtr createFaceTestMesh(const std::string& name)
+{
+    auto mesh = Ogre::MeshManager::getSingleton().createManual(
+        name, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+    auto* sub = mesh->createSubMesh();
+    sub->useSharedVertices = false;
+    sub->vertexData = new Ogre::VertexData();
+    sub->vertexData->vertexDeclaration->addElement(0, 0, Ogre::VET_FLOAT3,
+                                                   Ogre::VES_POSITION);
+    auto vbuf = Ogre::HardwareBufferManager::getSingleton().createVertexBuffer(
+        sub->vertexData->vertexDeclaration->getVertexSize(0), 3,
+        Ogre::HardwareBuffer::HBU_STATIC_WRITE_ONLY);
+    float verts[] = {0, 0, 0, 1, 0, 0, 0, 1, 0};
+    vbuf->writeData(0, sizeof(verts), verts);
+    sub->vertexData->vertexBufferBinding->setBinding(0, vbuf);
+    sub->vertexData->vertexCount = 3;
+    auto ibuf = Ogre::HardwareBufferManager::getSingleton().createIndexBuffer(
+        Ogre::HardwareIndexBuffer::IT_16BIT, 3,
+        Ogre::HardwareBuffer::HBU_STATIC_WRITE_ONLY);
+    uint16_t idx[] = {0, 1, 2};
+    ibuf->writeData(0, sizeof(idx), idx);
+    sub->indexData->indexBuffer = ibuf;
+    sub->indexData->indexCount = 3;
+    mesh->_setBounds(Ogre::AxisAlignedBox(-1, -1, -1, 2, 2, 2));
+    mesh->_setBoundingSphereRadius(2.0f);
+    mesh->load();
+    {
+        Ogre::Pose* p = mesh->createPose(1, "jawOpen");
+        p->addVertex(0, Ogre::Vector3(0, -0.1f, 0));
+    }
+    {
+        Ogre::Pose* p = mesh->createPose(1, "mouthSmileLeft");
+        p->addVertex(1, Ogre::Vector3(0.05f, 0.02f, 0));
+    }
+    const auto& poses = mesh->getPoseList();
+    for (unsigned short pi = 0; pi < poses.size(); ++pi) {
+        Ogre::Animation* a = mesh->createAnimation(poses[pi]->getName(), 0.0f);
+        auto* track = a->createVertexTrack(poses[pi]->getTarget(), Ogre::VAT_POSE);
+        track->createVertexPoseKeyFrame(0.0f)->addPoseReference(pi, 1.0f);
+    }
+    return mesh;
+}
+
+FaceSample sample(double t, float jaw, float conf = 1.f)
+{
+    FaceSample s;
+    s.timeSec = t;
+    s.confidence = conf;
+    s.weights[25] = jaw;  // jawOpen
+    return s;
+}
+
+class MocapControllerTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed (Xvfb/GL required in CI)";
+        static int counter = 0;
+        m_meshName = "mocap_ctrl_test_" + std::to_string(counter++);
+        m_mesh = createFaceTestMesh(m_meshName);
+        auto* scene = Manager::getSingleton()->getSceneMgr();
+        m_entity = scene->createEntity(m_meshName + "_ent", m_meshName);
+        m_node = scene->getRootSceneNode()->createChildSceneNode();
+        m_node->attachObject(m_entity);
+        SelectionSet::getSingleton()->clearList();
+        SelectionSet::getSingleton()->append(m_entity);
+    }
+
+    void TearDown() override
+    {
+        MocapController::instance()->stopPreview();
+        SelectionSet::getSingleton()->clearList();
+        if (m_entity) {
+            m_node->detachObject(m_entity);
+            Manager::getSingleton()->getSceneMgr()->destroyEntity(m_entity);
+        }
+        Ogre::MeshManager::getSingleton().remove(
+            m_meshName, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+    }
+
+    std::string m_meshName;
+    Ogre::MeshPtr m_mesh;
+    Ogre::Entity* m_entity = nullptr;
+    Ogre::SceneNode* m_node = nullptr;
+};
+
+}  // namespace
+
+TEST_F(MocapControllerTest, PreviewDrivesWeightsAndRestoresOnStop)
+{
+    auto* c = MocapController::instance();
+    auto* morph = MorphAnimationManager::instance();
+    morph->setWeight(m_entity, QStringLiteral("jawOpen"), 0.33f);
+
+    ASSERT_TRUE(c->startPreviewWithSource(nullptr));  // any non-null seam token
+    EXPECT_EQ(c->state(), MocapController::Previewing);
+    EXPECT_EQ(c->matchedChannelCount(), 2);
+
+    c->onSample(sample(0.0, 0.9f), QImage());
+    EXPECT_NEAR(morph->weight(m_entity, QStringLiteral("jawOpen")), 0.9f, 1e-4);
+
+    c->stopPreview();
+    EXPECT_EQ(c->state(), MocapController::Idle);
+    // the pre-preview weight came back exactly
+    EXPECT_NEAR(morph->weight(m_entity, QStringLiteral("jawOpen")), 0.33f, 1e-4);
+}
+
+TEST_F(MocapControllerTest, RecordProducesUndoableClip)
+{
+    auto* c = MocapController::instance();
+    ASSERT_TRUE(c->startPreviewWithSource(nullptr));
+    c->onSample(sample(0.0, 0.1f), QImage());
+
+    ASSERT_TRUE(c->startRecording());
+    EXPECT_EQ(c->state(), MocapController::Recording);
+    c->onSample(sample(0.1, 0.2f), QImage());
+    c->onSample(sample(0.2, 0.8f), QImage());
+    c->onSample(sample(0.3, 0.4f), QImage());
+    c->stopRecording();
+    EXPECT_EQ(c->state(), MocapController::Previewing);
+    c->stopPreview();
+
+    EXPECT_TRUE(m_mesh->hasAnimation("FaceCap"));
+    UndoManager::getSingleton()->undo();  // ONE undo removes the whole take
+    EXPECT_FALSE(m_mesh->hasAnimation("FaceCap"));
+}
+
+TEST_F(MocapControllerTest, StopDuringRecordingCommitsTheTake)
+{
+    auto* c = MocapController::instance();
+    ASSERT_TRUE(c->startPreviewWithSource(nullptr));
+    ASSERT_TRUE(c->startRecording());
+    c->onSample(sample(0.0, 0.2f), QImage());
+    c->onSample(sample(0.2, 0.7f), QImage());
+    c->stopPreview();  // stop while recording
+    EXPECT_EQ(c->state(), MocapController::Idle);
+    EXPECT_TRUE(m_mesh->hasAnimation("FaceCap"));
+    UndoManager::getSingleton()->undo();
+}
+
+TEST_F(MocapControllerTest, NoSelectionRefusesPreview)
+{
+    SelectionSet::getSingleton()->clearList();
+    auto* c = MocapController::instance();
+    EXPECT_FALSE(c->startPreviewWithSource(nullptr));
+    EXPECT_EQ(c->state(), MocapController::Idle);
+}
+
+#endif  // ENABLE_MOCAP

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -138,6 +138,7 @@
 #include "ThemeManager.h"
 #include "IsometricSpritesController.h"
 #include "ImageTo3D/MeshGenController.h"
+#include "Mocap/MocapController.h"
 #include "MorphAnimationManager.h"
 #include "VertexAnimationManager.h"
 #include "EditorModeController.h"
@@ -580,6 +581,7 @@ MainWindow::~MainWindow()
         ViewportLightSoloController::kill();
         IsometricSpritesController::kill();
         MeshGenController::kill();
+        MocapController::kill();
         MeshDepthRenderer::shutdown();
         MeshValidator::kill();
         MaterialPresetLibrary::kill();
@@ -765,6 +767,11 @@ void MainWindow::initToolBar()
             "PropertiesPanel", 1, 0, "SkinWeightsController",
             [](QQmlEngine* engine, QJSEngine*) -> QObject* {
                 return SkinWeightsController::qmlInstance(engine, nullptr);
+            });
+        qmlRegisterSingletonType<MocapController>(
+            "PropertiesPanel", 1, 0, "MocapController",
+            [](QQmlEngine* engine, QJSEngine*) -> QObject* {
+                return MocapController::qmlInstance(engine, nullptr);
             });
         qmlRegisterSingletonType<LightsController>(
             "PropertiesPanel", 1, 0, "LightsController",


### PR DESCRIPTION
Part of epic #869. Closes #875. **Stacked on #883 (Slice E)** — merge order: #880 → #881 → #882 → #883 → this.

## What this adds

The headline feature: **Animation Mode → Mode Tools → "Performance Capture"** — webcam preview drives the selected entity's morph targets + Head bone in real time; **Record** writes an ordinary, undoable clip that plays on the existing timeline and exports through the existing exporters.

- **`MocapController`** (QML_SINGLETON, MeshGenController threading pattern): camera frames → latest-wins mailbox → inference worker thread → queued samples → main-thread Ogre mutation. Live morphs via `MorphAnimationManager::setWeight`; head via manual-bone control with **exact snapshot/restore** of weights, bone state and enabled AnimationStates (the UvUnwrap discipline — verified by test that a pre-preview weight comes back bit-exact).
- **Recording** buffers in memory and commits on stop as ONE `RecordMocapClipCommand` (single Ctrl+Z discards the take; stop-mid-record commits rather than drops).
- **Panel** (inline Inspector section, no dialog): device picker, live preview thumbnail + face-detected dot + fps HUD, matched-channel summary (unmatched count shown), clip name, `Neutral` calibration, `● Record`/`■ Stop`, status line. Hiding the section (mode change/deselect) stops the camera. Non-mocap builds show the rebuild hint inside the section.
- **MCP**: `list_capture_devices`, `start_live_capture`, `stop_live_capture` (GUI-attached only; headless `--mcp` gets a clear refusal).

## Verification

- App + UnitTests build clean on macOS with `ENABLE_MOCAP=ON`; all 5 new MCP tool registrations verified in the binary.
- 4 controller tests (CI lane, Ogre-gated): live-drive + exact restore, record→single-undo clip, stop-during-recording commits, no-selection refusal. 48 runnable mocap tests green locally.
- Live-camera manual QA (permission prompt → preview → record → undo → export) is the Slice G matrix item — this environment has no camera/WindowServer; the camera path reuses the Slice B `CameraFrameSource` and the same onSample pipeline the tests drive.

Body-live intentionally stays offline-only in this slice (panel copy points at `qtmesh mocap --body`), per the slice spec's fallback plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)