### PR TITLE
t2m: foot-contact detection + IK pinning post-pass (#856)

### DIFF
--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -8493,7 +8493,7 @@ Rectangle {
                         // skewing every new clip is exactly the bug this fixes).
                         var gr = AnimationControlController.generateMotion(
                                      genPromptIn.text, 0.0, useModelChk.checked,
-                                     0.0)
+                                     0.0, footPinChk.checked)
                         if (gr && gr.animation) {
                             lastGeneratedAnim = gr.animation
                             // Point the slider at the fresh clip at a neutral 0
@@ -8532,6 +8532,29 @@ Rectangle {
                 }
                 Text {
                     text: "Use trained model (experimental)"
+                    color: PropertiesPanelController.textColor; font.pixelSize: 10
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+            }
+            // #856: foot-contact cleanup — ON by default (detect ground-contact
+            // spans + IK-pin the feet so they plant instead of skating).
+            Row {
+                spacing: 6
+                Rectangle {
+                    id: footPinChk
+                    property bool checked: true
+                    width: 14; height: 14; radius: 2
+                    anchors.verticalCenter: parent.verticalCenter
+                    color: checked ? PropertiesPanelController.highlightColor
+                                   : PropertiesPanelController.inputColor
+                    border.color: PropertiesPanelController.borderColor
+                    Text { anchors.centerIn: parent; visible: parent.checked
+                           text: "✓"; color: "white"; font.pixelSize: 10 }
+                    MouseArea { anchors.fill: parent
+                                onClicked: footPinChk.checked = !footPinChk.checked }
+                }
+                Text {
+                    text: "Pin feet (contact cleanup)"
                     color: PropertiesPanelController.textColor; font.pixelSize: 10
                     anchors.verticalCenter: parent.verticalCenter
                 }

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -1833,7 +1833,7 @@ double AnimationControlController::currentArmSpace(const QString& animName,
 
 QVariantMap AnimationControlController::generateMotion(const QString& prompt,
                                                        double duration, bool useModel,
-                                                       double armSpaceDeg)
+                                                       double armSpaceDeg, bool footPin)
 {
     QVariantMap out;
     out["ok"] = false;
@@ -1936,6 +1936,13 @@ QVariantMap AnimationControlController::generateMotion(const QString& prompt,
     if (std::abs(armSpaceDeg) > 1e-4)
         AnimationMerger::adjustArmSpace(skel.get(), animName,
                                         static_cast<float>(armSpaceDeg));
+
+    // #856: foot-contact cleanup — ON by default (checkbox opts out).
+    if (footPin) {
+        const auto fp = AnimationMerger::pinFeet(skel.get(), animName);
+        if (fp.ok && fp.spans > 0)
+            out["footPinSpans"] = fp.spans;
+    }
 
     entity->refreshAvailableAnimationState();
     // Make the generated clip the ONLY enabled animation. Ogre AVERAGES all

--- a/src/AnimationControlController.h
+++ b/src/AnimationControlController.h
@@ -343,10 +343,13 @@ public:
     /// (MotionGenerator/ONNX); it falls back to the template library automatically
     /// when the model is unavailable or the action isn't in its vocab. Default
     /// false = the reliable template-clip retarget.
+    /// `footPin` (default true) runs the #856 foot-contact cleanup on the
+    /// generated clip (contact detection + two-bone IK pinning).
     Q_INVOKABLE QVariantMap generateMotion(const QString& prompt,
                                            double duration = 0.0,
                                            bool useModel = false,
-                                           double armSpaceDeg = 0.0);
+                                           double armSpaceDeg = 0.0,
+                                           bool footPin = true);
 
     /// #854: Mixamo-style arm-space post-process on an EXISTING animation of
     /// the selected entity. Positive `degrees` widens the arms away from the

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -1,5 +1,6 @@
 #include "AnimationMerger.h"
 #include "AutoRig.h"
+#include "FootContact.h"
 #include "MotionInbetween.h"
 #include <OgreSkeleton.h>
 #include <OgreSkeletonInstance.h>
@@ -1470,6 +1471,235 @@ bool AnimationMerger::adjustArmSpace(Ogre::Skeleton* skel,
     return true;
 }
 
+namespace {
+std::string footPinKey(const std::string& animName)
+{
+    return "qtme.footpin." + animName;
+}
+}  // namespace
+
+AnimationMerger::FootPinResult AnimationMerger::pinFeet(
+    Ogre::Skeleton* skel, const std::string& animName, int blendFrames)
+{
+    FootPinResult res;
+    if (!skel || !skel->hasAnimation(animName)) {
+        res.error = QStringLiteral("animation not found");
+        return res;
+    }
+    Ogre::Animation* anim = skel->getAnimation(animName);
+
+    const int nBones = static_cast<int>(skel->getNumBones());
+    std::vector<int> boneToCanon(static_cast<size_t>(nBones), -1);
+    for (int i = 0; i < nBones; ++i)
+        boneToCanon[static_cast<size_t>(i)] =
+            MotionInbetween::canonicalIndexForBone(QString::fromStdString(
+                skel->getBone(static_cast<unsigned short>(i))->getName()));
+    const TargetBindFrame tb = readTargetBindFrame(skel, boneToCanon);
+    // Bind-local POSITIONS (parent-relative) for the manual FK below — the
+    // skeleton is still in its reset pose after readTargetBindFrame.
+    std::vector<Ogre::Vector3> bindLocalPos(static_cast<size_t>(nBones));
+    for (int i = 0; i < nBones; ++i)
+        bindLocalPos[static_cast<size_t>(i)] =
+            skel->getBone(static_cast<unsigned short>(i))->getPosition();
+
+    // Leg chains: thigh / knee / foot roles per side (first bone per role).
+    struct Leg { int thigh, shin, foot; };
+    const Leg legs[2] = {
+        {tb.roleBoneIdx[15], tb.roleBoneIdx[16], tb.roleBoneIdx[17]},   // right
+        {tb.roleBoneIdx[19], tb.roleBoneIdx[20], tb.roleBoneIdx[21]},   // left
+    };
+
+    auto trackOf = [&](int bone) -> Ogre::NodeAnimationTrack* {
+        if (bone < 0 || !anim->hasNodeTrack(static_cast<unsigned short>(bone)))
+            return nullptr;
+        auto* t = anim->getNodeTrack(static_cast<unsigned short>(bone));
+        return (t && t->getNumKeyFrames() > 0) ? t : nullptr;
+    };
+
+    // Keyframe times come from the first available thigh track — generated
+    // clips write one keyframe per frame on every mapped bone.
+    Ogre::NodeAnimationTrack* timeSrc = trackOf(legs[0].thigh);
+    if (!timeSrc) timeSrc = trackOf(legs[1].thigh);
+    if (!timeSrc) {
+        res.error = QStringLiteral("no leg tracks on this rig/animation");
+        return res;
+    }
+    const int nk = static_cast<int>(timeSrc->getNumKeyFrames());
+    if (nk < 4) {
+        res.error = QStringLiteral("too few keyframes to detect contacts");
+        return res;
+    }
+    std::vector<float> times(static_cast<size_t>(nk));
+    for (int k = 0; k < nk; ++k)
+        times[static_cast<size_t>(k)] =
+            timeSrc->getNodeKeyFrame(static_cast<unsigned short>(k))->getTime();
+
+    // ---- manual FK over the tracks (pure math; the live skeleton — which
+    // may be a SkeletonInstance driving an on-screen entity — is untouched).
+    std::vector<std::vector<Ogre::Quaternion>> Wrot(
+        static_cast<size_t>(nk),
+        std::vector<Ogre::Quaternion>(static_cast<size_t>(nBones)));
+    std::vector<std::vector<Ogre::Vector3>> Wpos(
+        static_cast<size_t>(nk),
+        std::vector<Ogre::Vector3>(static_cast<size_t>(nBones)));
+    for (int k = 0; k < nk; ++k) {
+        const Ogre::TimeIndex ti =
+            anim->_getTimeIndex(times[static_cast<size_t>(k)]);
+        for (int i : tb.order) {
+            Ogre::Quaternion lrot = tb.bindLocal[static_cast<size_t>(i)];
+            Ogre::Vector3 lpos = bindLocalPos[static_cast<size_t>(i)];
+            if (auto* trk = trackOf(i)) {
+                Ogre::TransformKeyFrame kf(nullptr, 0.0f);
+                trk->getInterpolatedKeyFrame(ti, &kf);
+                lrot = lrot * kf.getRotation();       // applyToNode: rotate()
+                lpos = lpos + kf.getTranslate();      // translate(TS_PARENT)
+            }
+            const int pi = tb.parentIdx[static_cast<size_t>(i)];
+            if (pi >= 0) {
+                Wrot[static_cast<size_t>(k)][static_cast<size_t>(i)] =
+                    Wrot[static_cast<size_t>(k)][static_cast<size_t>(pi)] * lrot;
+                Wpos[static_cast<size_t>(k)][static_cast<size_t>(i)] =
+                    Wpos[static_cast<size_t>(k)][static_cast<size_t>(pi)]
+                    + Wrot[static_cast<size_t>(k)][static_cast<size_t>(pi)] * lpos;
+            } else {
+                Wrot[static_cast<size_t>(k)][static_cast<size_t>(i)] = lrot;
+                Wpos[static_cast<size_t>(k)][static_cast<size_t>(i)] = lpos;
+            }
+        }
+    }
+
+    // Detection runs in the CANONICAL frame (Ct maps rig world → X=left,
+    // Y=up, Z=forward) so "ground" is a horizontal plane regardless of the
+    // rig's own axes.
+    auto toCanon = [&](const Ogre::Vector3& p) { return tb.Ct * p; };
+    auto fromCanon = [&](const FootContact::V3& p) {
+        return tb.Ct.Inverse() * Ogre::Vector3(p[0], p[1], p[2]);
+    };
+    auto v3 = [](const Ogre::Vector3& p) {
+        return FootContact::V3{p.x, p.y, p.z};
+    };
+
+    for (const Leg& leg : legs) {
+        if (leg.thigh < 0 || leg.shin < 0 || leg.foot < 0)
+            continue;
+        auto* thighTrk = trackOf(leg.thigh);
+        auto* shinTrk = trackOf(leg.shin);
+        auto* footTrk = trackOf(leg.foot);
+        if (!thighTrk || !shinTrk
+            || static_cast<int>(thighTrk->getNumKeyFrames()) != nk
+            || static_cast<int>(shinTrk->getNumKeyFrames()) != nk
+            || (footTrk && static_cast<int>(footTrk->getNumKeyFrames()) != nk))
+            continue;   // mixed keyframe grids — not a generated clip
+
+        std::vector<FootContact::V3> footC(static_cast<size_t>(nk));
+        for (int k = 0; k < nk; ++k)
+            footC[static_cast<size_t>(k)] = v3(toCanon(
+                Wpos[static_cast<size_t>(k)][static_cast<size_t>(leg.foot)]));
+        const float legLen =
+            (Wpos[0][static_cast<size_t>(leg.shin)]
+             - Wpos[0][static_cast<size_t>(leg.thigh)]).length()
+            + (Wpos[0][static_cast<size_t>(leg.foot)]
+               - Wpos[0][static_cast<size_t>(leg.shin)]).length();
+        const auto spans = FootContact::detectContacts(footC, legLen);
+        if (spans.empty())
+            continue;
+        res.spans += static_cast<int>(spans.size());
+
+        for (const auto& span : spans) {
+            const FootContact::V3 anchor = footC[static_cast<size_t>(span.start)];
+            for (int k = span.start; k <= span.end; ++k) {
+                const float w = FootContact::blendWeight(span, k, blendFrames);
+                if (w <= 0.0f)
+                    continue;
+                const size_t kc = static_cast<size_t>(k);
+                const Ogre::Vector3 hipW = Wpos[kc][static_cast<size_t>(leg.thigh)];
+                const Ogre::Vector3 kneeW = Wpos[kc][static_cast<size_t>(leg.shin)];
+                const Ogre::Vector3 footW = Wpos[kc][static_cast<size_t>(leg.foot)];
+                // pinned target: blend the current foot toward the anchor
+                const FootContact::V3 cur = footC[kc];
+                const FootContact::V3 tgtC{
+                    cur[0] + (anchor[0] - cur[0]) * w,
+                    cur[1] + (anchor[1] - cur[1]) * w,
+                    cur[2] + (anchor[2] - cur[2]) * w};
+                const FootContact::V3 kneeNewC = FootContact::solveKnee(
+                    v3(toCanon(hipW)), v3(toCanon(kneeW)), v3(toCanon(footW)),
+                    tgtC);
+                const Ogre::Vector3 kneeNew = fromCanon(kneeNewC);
+                const Ogre::Vector3 tgt = fromCanon(tgtC);
+
+                Ogre::Vector3 dThighOld = kneeW - hipW;
+                Ogre::Vector3 dThighNew = kneeNew - hipW;
+                Ogre::Vector3 dShinOld = footW - kneeW;
+                Ogre::Vector3 dShinNew = tgt - kneeNew;
+                if (dThighOld.squaredLength() < 1e-12f
+                    || dThighNew.squaredLength() < 1e-12f
+                    || dShinOld.squaredLength() < 1e-12f
+                    || dShinNew.squaredLength() < 1e-12f)
+                    continue;
+                dThighOld.normalise(); dThighNew.normalise();
+                dShinOld.normalise(); dShinNew.normalise();
+                const Ogre::Quaternion S1 = dThighOld.getRotationTo(dThighNew);
+                const Ogre::Quaternion S2 =
+                    (S1 * dShinOld).getRotationTo(dShinNew);
+
+                // Rewrite the three keyframes as world premultipliers folded
+                // into parent-relative deltas (keyframes compose as
+                // local = bindLocal · kf; world = Wp · local).
+                const Ogre::Quaternion& WpT =
+                    (tb.parentIdx[static_cast<size_t>(leg.thigh)] >= 0)
+                        ? Wrot[kc][static_cast<size_t>(
+                              tb.parentIdx[static_cast<size_t>(leg.thigh)])]
+                        : Ogre::Quaternion::IDENTITY;
+                const Ogre::Quaternion Wthigh =
+                    Wrot[kc][static_cast<size_t>(leg.thigh)];
+                const Ogre::Quaternion WthighNew = S1 * Wthigh;
+                auto* kfT = thighTrk->getNodeKeyFrame(
+                    static_cast<unsigned short>(k));
+                kfT->setRotation(
+                    tb.bindLocal[static_cast<size_t>(leg.thigh)].Inverse()
+                    * WpT.Inverse() * WthighNew);
+
+                const Ogre::Quaternion& WpS =
+                    Wrot[kc][static_cast<size_t>(
+                        tb.parentIdx[static_cast<size_t>(leg.shin)])];
+                const Ogre::Quaternion Wshin =
+                    Wrot[kc][static_cast<size_t>(leg.shin)];
+                const Ogre::Quaternion WshinNew = S2 * S1 * Wshin;
+                auto* kfS = shinTrk->getNodeKeyFrame(
+                    static_cast<unsigned short>(k));
+                kfS->setRotation(
+                    tb.bindLocal[static_cast<size_t>(leg.shin)].Inverse()
+                    * (S1 * WpS).Inverse() * WshinNew);
+
+                if (footTrk) {
+                    // foot keeps its ORIGINAL world orientation (no toe pop
+                    // inherited from the parent corrections)
+                    const Ogre::Quaternion& WpF =
+                        Wrot[kc][static_cast<size_t>(
+                            tb.parentIdx[static_cast<size_t>(leg.foot)])];
+                    auto* kfF = footTrk->getNodeKeyFrame(
+                        static_cast<unsigned short>(k));
+                    kfF->setRotation(
+                        tb.bindLocal[static_cast<size_t>(leg.foot)].Inverse()
+                        * (S2 * S1 * WpF).Inverse()
+                        * Wrot[kc][static_cast<size_t>(leg.foot)]);
+                }
+                ++res.keyframesAdjusted;
+            }
+        }
+        // setRotation does NOT invalidate the track caches (#854 lesson).
+        thighTrk->_keyFrameDataChanged();
+        shinTrk->_keyFrameDataChanged();
+        if (footTrk) footTrk->_keyFrameDataChanged();
+    }
+
+    if (skel->getNumBones() > 0)
+        skel->getBone(0)->getUserObjectBindings().setUserAny(
+            footPinKey(animName), Ogre::Any(true));
+    res.ok = true;
+    return res;
+}
+
 AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
     Ogre::Skeleton* skel,
     const std::string& animName,
@@ -1570,9 +1800,13 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
     // stored angle from a prior generation of the same name would make a
     // re-request of that same angle a no-op (delta 0) on the new keyframes —
     // forget it.
-    if (skel->getNumBones() > 0)
+    if (skel->getNumBones() > 0) {
         skel->getBone(0)->getUserObjectBindings().eraseUserAny(
             armSpaceKey(animName));
+        // #856: same for the foot-pin marker — a regenerated clip is unpinned.
+        skel->getBone(0)->getUserObjectBindings().eraseUserAny(
+            "qtme.footpin." + animName);
+    }
     Ogre::Animation* anim = skel->createAnimation(animName, length);
     anim->setInterpolationMode(Ogre::Animation::IM_LINEAR);
     anim->setRotationInterpolationMode(Ogre::Animation::RIM_LINEAR);

--- a/src/AnimationMerger.h
+++ b/src/AnimationMerger.h
@@ -260,6 +260,37 @@ public:
                                    const std::string& oldAnim,
                                    const std::string& newAnim);
 
+    /// Outcome of pinFeet.
+    struct FootPinResult {
+        bool ok = false;
+        QString error;
+        int spans = 0;            ///< contact spans pinned (both feet)
+        int keyframesAdjusted = 0;
+    };
+
+    /// #856 — foot-contact cleanup. Retargeted clips slide/float feet on rigs
+    /// whose proportions differ from the source (the direction retarget
+    /// transfers bone DIRECTIONS, not world foot positions). Per foot role,
+    /// detect contact spans (foot near the clip's ground level AND nearly
+    /// stationary horizontally — FootContact::detectContacts, canonical-frame,
+    /// leg-length-scaled thresholds) and lock the foot's world position to its
+    /// span-start position with an analytic two-bone hip–knee–foot IK
+    /// (FootContact::solveKnee — keeps segment lengths and the pose's own
+    /// bend plane), blending in/out over `blendFrames` at span edges so knees
+    /// don't pop. Rewrites ONLY the thigh/shin/foot keyframes (foot keeps its
+    /// original world orientation); everything else untouched. Pure track
+    /// math — nothing is applied to the live skeleton.
+    ///
+    /// Effectively idempotent: a second run detects the already-planted spans
+    /// and re-pins to the same targets (near-no-op). The application is
+    /// recorded on bone[0]'s UserObjectBindings ("qtme.footpin.<anim>") so a
+    /// UI can reflect state; applyMotionClip clears it on clip regeneration.
+    /// Designed for generated clips (dense uniform keyframes); sparse
+    /// authored clips get keyframe-rate detection (approximate).
+    static FootPinResult pinFeet(Ogre::Skeleton* skel,
+                                 const std::string& animName,
+                                 int blendFrames = 3);
+
     /// Sample every (or one) skeletal animation of `entity` at `fps` and
     /// express each canonical joint's world orientation per frame. Bone→role
     /// mapping is MotionInbetween::canonicalIndexForBone — the same matcher

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -2017,7 +2017,7 @@ int CLIPipeline::cmdFix(int argc, char* argv[])
 int CLIPipeline::cmdAnimGenerate(const QString& filePath, const QString& prompt,
                                  float duration, const QString& outputPath,
                                  bool jsonOutput, bool useModel,
-                                 float armSpaceDeg)
+                                 float armSpaceDeg, bool footPin)
 {
     // #411 text-to-motion (template-clip MVP): match the prompt to a permissive
     // CMU motion clip from the downloadable library, retarget it onto the mesh's
@@ -2147,6 +2147,19 @@ int CLIPipeline::cmdAnimGenerate(const QString& filePath, const QString& prompt,
                   << Qt::endl;
     }
 
+    // #856: foot-contact cleanup — ON by default (--no-foot-pin disables).
+    if (footPin) {
+        const auto fp = AnimationMerger::pinFeet(skel.get(), animName);
+        if (fp.ok && fp.spans > 0) {
+            SentryReporter::addBreadcrumb(
+                QStringLiteral("ai.tool_call"),
+                QStringLiteral("foot_pin %1 spans").arg(fp.spans));
+            err() << "(foot-pin: " << fp.spans << " contact span(s), "
+                  << fp.keyframesAdjusted << " keyframes)" << Qt::endl;
+        } else if (!fp.ok)
+            err() << "Note: foot-pin skipped (" << fp.error << ")." << Qt::endl;
+    }
+
     auto* node = entity->getParentSceneNode();
     const QString fmt = formatForExtension(outputPath);
     if (MeshImporterExporter::exporter(node, QFileInfo(outputPath).absoluteFilePath(), fmt) != 0) {
@@ -2200,6 +2213,8 @@ int CLIPipeline::cmdAnim(int argc, char* argv[])
     bool generateUseModel = false;    // --model → experimental trained t2m model (template fallback)
     float armSpaceDeg = 0.0f;         // #854: Mixamo-style arm-space swing (degrees)
     bool armSpaceSet = false;         // --arm-space given (standalone post-adjust)
+    bool generateFootPin = true;      // #856: pin feet after --generate (default ON)
+    bool footPinSet = false;          // --foot-pin given (standalone post-process)
     bool jsonOutput = false;
     int resampleCount = 0;
     int decimateStep = 0;
@@ -2293,6 +2308,11 @@ int CLIPipeline::cmdAnim(int argc, char* argv[])
             armSpaceSet = true;
             continue;
         }
+        // #856 foot-contact cleanup: ON by default during --generate
+        // (--no-foot-pin opts out); --foot-pin alone post-processes an
+        // EXISTING animation (standalone, needs --animation).
+        if (arg == "--no-foot-pin") { generateFootPin = false; continue; }
+        if (arg == "--foot-pin") { footPinSet = true; continue; }
         if (arg == "--simplify") { simplifyMode = true; continue; }
         if (arg == "--analyze")  { analyzeMode  = true; continue; }
         if (arg == "--preset" && i + 1 < argc) {
@@ -2388,7 +2408,7 @@ int CLIPipeline::cmdAnim(int argc, char* argv[])
         }
         return cmdAnimGenerate(filePath, generatePrompt, generateDuration,
                                outputPath.isEmpty() ? filePath : outputPath, jsonOutput,
-                               generateUseModel, armSpaceDeg);
+                               generateUseModel, armSpaceDeg, generateFootPin);
     }
 
     // #854 standalone: post-adjust the arm space of an EXISTING animation
@@ -2430,6 +2450,45 @@ int CLIPipeline::cmdAnim(int argc, char* argv[])
         }
         cliWrite(QString("Adjusted arm space of '%1' to %2 deg → %3\n")
                      .arg(animationFilter).arg(armSpaceDeg)
+                     .arg(QFileInfo(out).fileName()));
+        return 0;
+    }
+
+    // #856 standalone: pin the feet of an EXISTING animation (no --generate).
+    // `qtmesh anim <file> --foot-pin --animation <name> -o out`.
+    if (footPinSet) {
+        if (animationFilter.isEmpty()) {
+            err() << "Error: --foot-pin (standalone) requires --animation <name>."
+                  << Qt::endl;
+            return 2;
+        }
+        if (!initOgreHeadless()) return 1;
+        MeshImporterExporter::importer({QFileInfo(filePath).absoluteFilePath()});
+        Ogre::Entity* entity = nullptr;
+        for (auto* e : Manager::getSingleton()->getEntities())
+            if (e && e->getMovableType() == "Entity" && e->hasSkeleton()) { entity = e; break; }
+        if (!entity) {
+            err() << "Error: " << filePath << " has no skinned mesh." << Qt::endl;
+            return 1;
+        }
+        Ogre::SkeletonPtr skel = entity->getMesh()->getSkeleton();
+        const auto fp = AnimationMerger::pinFeet(
+            skel.get(), animationFilter.toStdString());
+        if (!fp.ok) {
+            err() << "Error: foot-pin failed: " << fp.error << Qt::endl;
+            return 1;
+        }
+        SentryReporter::addBreadcrumb(QStringLiteral("ai.tool_call"),
+            QStringLiteral("foot_pin %1 spans").arg(fp.spans));
+        const QString out = outputPath.isEmpty() ? filePath : outputPath;
+        auto* node = entity->getParentSceneNode();
+        if (MeshImporterExporter::exporter(node, QFileInfo(out).absoluteFilePath(),
+                                           formatForExtension(out)) != 0) {
+            err() << "Error: export failed." << Qt::endl; return 1;
+        }
+        cliWrite(QString("Pinned feet of '%1' (%2 span(s), %3 keyframes) → %4\n")
+                     .arg(animationFilter).arg(fp.spans)
+                     .arg(fp.keyframesAdjusted)
                      .arg(QFileInfo(out).fileName()));
         return 0;
     }

--- a/src/CLIPipeline.h
+++ b/src/CLIPipeline.h
@@ -93,7 +93,7 @@ public:
     static int cmdAnimGenerate(const QString& filePath, const QString& prompt,
                                float duration, const QString& outputPath,
                                bool jsonOutput, bool useModel = false,
-                               float armSpaceDeg = 0.0f);
+                               float armSpaceDeg = 0.0f, bool footPin = true);
     static int cmdValidate(int argc, char* argv[]);
     static int cmdLod(int argc, char* argv[]);
     static int cmdPose(int argc, char* argv[]);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,6 +65,7 @@ SentryReporter.cpp
 BoneWeightOverlay.cpp
 NormalVisualizer.cpp
 AnimationMerger.cpp
+FootContact.cpp
 CLIPipeline.cpp
 ConsoleLogSanitize.cpp
 MeshInfoOverlay.cpp
@@ -280,6 +281,7 @@ SentryReporter.h
 BoneWeightOverlay.h
 NormalVisualizer.h
 AnimationMerger.h
+FootContact.h
 CLIPipeline.h
 MeshInfoOverlay.h
 RTShaderHelper.h

--- a/src/FootContact.cpp
+++ b/src/FootContact.cpp
@@ -1,0 +1,115 @@
+#include "FootContact.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace FootContact {
+
+namespace {
+
+V3 sub(const V3& a, const V3& b) { return {a[0] - b[0], a[1] - b[1], a[2] - b[2]}; }
+V3 add(const V3& a, const V3& b) { return {a[0] + b[0], a[1] + b[1], a[2] + b[2]}; }
+V3 mul(const V3& a, float s) { return {a[0] * s, a[1] * s, a[2] * s}; }
+float dot(const V3& a, const V3& b) { return a[0]*b[0] + a[1]*b[1] + a[2]*b[2]; }
+V3 cross(const V3& a, const V3& b)
+{
+    return {a[1]*b[2] - a[2]*b[1], a[2]*b[0] - a[0]*b[2], a[0]*b[1] - a[1]*b[0]};
+}
+float len(const V3& a) { return std::sqrt(dot(a, a)); }
+V3 normed(const V3& a)
+{
+    const float l = len(a);
+    return l > 1e-9f ? mul(a, 1.0f / l) : V3{0, 0, 0};
+}
+
+}  // namespace
+
+float groundLevel(const std::vector<V3>& foot, int upAxis)
+{
+    if (foot.empty()) return 0.0f;
+    std::vector<float> h(foot.size());
+    for (size_t i = 0; i < foot.size(); ++i) h[i] = foot[i][upAxis];
+    const size_t k = std::min(foot.size() - 1,
+                              static_cast<size_t>(foot.size() / 10));
+    std::nth_element(h.begin(), h.begin() + static_cast<long>(k), h.end());
+    return h[k];
+}
+
+std::vector<Span> detectContacts(const std::vector<V3>& foot,
+                                 float legLength,
+                                 const DetectOptions& opt)
+{
+    std::vector<Span> spans;
+    const int n = static_cast<int>(foot.size());
+    if (n < opt.minFrames || legLength <= 1e-6f) return spans;
+    const int up = std::clamp(opt.upAxis, 0, 2);
+    const float ground = groundLevel(foot, up);
+    const float band = ground + opt.heightBandFrac * legLength;
+    const float vmax = opt.velThreshFrac * legLength;
+
+    auto horizSpeed = [&](int f) {
+        // central difference where possible; edges take the one-sided step
+        const int a = std::max(0, f - 1);
+        const int b = std::min(n - 1, f + 1);
+        V3 d = sub(foot[b], foot[a]);
+        d[up] = 0.0f;
+        return len(d) / static_cast<float>(std::max(1, b - a));
+    };
+
+    int start = -1;
+    for (int f = 0; f <= n; ++f) {
+        const bool contact = f < n && foot[f][up] <= band && horizSpeed(f) <= vmax;
+        if (contact && start < 0) start = f;
+        if (!contact && start >= 0) {
+            if (f - start >= opt.minFrames) spans.push_back({start, f - 1});
+            start = -1;
+        }
+    }
+    return spans;
+}
+
+V3 solveKnee(const V3& hip, const V3& knee, const V3& foot, const V3& target)
+{
+    const float l1 = len(sub(knee, hip));
+    const float l2 = len(sub(foot, knee));
+    if (l1 <= 1e-6f || l2 <= 1e-6f) return knee;
+
+    V3 toT = sub(target, hip);
+    float d = len(toT);
+    const float dMin = std::abs(l1 - l2) + 1e-4f;
+    const float dMax = l1 + l2 - 1e-4f;
+    if (d < 1e-6f) return knee;                    // target on the hip: give up
+    const V3 dirT = mul(toT, 1.0f / d);
+    d = std::clamp(d, dMin, dMax);
+
+    // Bend direction: the current knee's offset from the hip→foot line keeps
+    // the pose's own bend plane (the knee axis of the existing pose).
+    V3 bend = sub(knee, hip);
+    bend = sub(bend, mul(dirT, dot(bend, dirT)));
+    if (dot(bend, bend) < 1e-10f) {
+        // straight leg — bend forward of the current chain plane, or any
+        // perpendicular when even that is degenerate
+        bend = cross(dirT, cross(sub(foot, hip), sub(knee, hip)));
+        if (dot(bend, bend) < 1e-10f)
+            bend = cross(dirT, std::abs(dirT[1]) < 0.9f ? V3{0, 1, 0}
+                                                        : V3{1, 0, 0});
+    }
+    bend = normed(bend);
+
+    // law of cosines: knee at distance l1 from hip, l2 from target
+    const float cosA = std::clamp((l1 * l1 + d * d - l2 * l2)
+                                  / (2.0f * l1 * d), -1.0f, 1.0f);
+    const float sinA = std::sqrt(std::max(0.0f, 1.0f - cosA * cosA));
+    return add(hip, add(mul(dirT, l1 * cosA), mul(bend, l1 * sinA)));
+}
+
+float blendWeight(const Span& s, int f, int blend)
+{
+    if (f < s.start || f > s.end) return 0.0f;
+    if (blend <= 0) return 1.0f;
+    const float in = static_cast<float>(f - s.start + 1) / blend;
+    const float out = static_cast<float>(s.end - f + 1) / blend;
+    return std::clamp(std::min(in, out), 0.0f, 1.0f);
+}
+
+}  // namespace FootContact

--- a/src/FootContact.h
+++ b/src/FootContact.h
@@ -1,0 +1,65 @@
+#ifndef FOOT_CONTACT_H
+#define FOOT_CONTACT_H
+
+#include <array>
+#include <vector>
+
+// #856 — foot-contact cleanup, pure-data core (Ogre-free, unit-tested).
+//
+// Retargeted clips slide/float feet on rigs whose proportions differ from the
+// source: the bind-referenced direction retarget (PR #843) transfers bone
+// DIRECTIONS, not world foot positions. This core provides the two pieces the
+// track post-process (AnimationMerger::pinFeet) composes:
+//   1. contact detection — frames where a foot is near the clip's ground
+//      level AND nearly stationary horizontally → contact spans,
+//   2. an analytic two-bone IK step — where must the knee sit so the foot
+//      reaches its pinned position, preserving the pose's own bend plane,
+// plus the smooth edge-blend weight that avoids knee pops at span borders.
+namespace FootContact {
+
+using V3 = std::array<float, 3>;
+
+/// Inclusive frame range during which a foot is planted.
+struct Span {
+    int start = 0;
+    int end = 0;
+};
+
+struct DetectOptions {
+    /// Height band above the detected ground level counting as "on the
+    /// ground", as a fraction of leg length.
+    float heightBandFrac = 0.18f;
+    /// Max horizontal speed (units/frame) counting as "stationary", as a
+    /// fraction of leg length.
+    float velThreshFrac = 0.03f;
+    /// Spans shorter than this are noise, not contacts.
+    int minFrames = 3;
+    /// Up axis: 0=X, 1=Y, 2=Z (canonical rigs are +Y-up).
+    int upAxis = 1;
+};
+
+/// Ground level = low percentile of the foot's height trajectory (robust to
+/// a clip that never plants, e.g. a jump apex-only window).
+float groundLevel(const std::vector<V3>& foot, int upAxis);
+
+/// Contact spans of one foot trajectory. `legLength` scales both thresholds
+/// so detection is rig-size-independent.
+std::vector<Span> detectContacts(const std::vector<V3>& foot,
+                                 float legLength,
+                                 const DetectOptions& opt = {});
+
+/// Analytic two-bone IK: given the CURRENT chain (hip → knee → foot) and a
+/// new foot `target`, return the knee position that keeps both segment
+/// lengths and stays in the pose's own bend plane (pole derived from the
+/// current knee). Targets beyond reach are clamped along hip→target;
+/// degenerate poses (straight leg) bend toward the current knee offset or,
+/// failing that, any perpendicular.
+V3 solveKnee(const V3& hip, const V3& knee, const V3& foot, const V3& target);
+
+/// Smooth 0→1→0 weight for frame `f` inside span `s`, ramping linearly over
+/// `blend` frames at each edge (1 in the interior, 0 outside).
+float blendWeight(const Span& s, int f, int blend);
+
+}  // namespace FootContact
+
+#endif  // FOOT_CONTACT_H

--- a/src/FootContact_test.cpp
+++ b/src/FootContact_test.cpp
@@ -1,0 +1,124 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include "FootContact.h"
+
+// #856 pure-data core tests — no Ogre/GL needed.
+
+using FootContact::V3;
+
+namespace {
+float dist(const V3& a, const V3& b)
+{
+    const float dx = a[0] - b[0], dy = a[1] - b[1], dz = a[2] - b[2];
+    return std::sqrt(dx * dx + dy * dy + dz * dz);
+}
+}  // namespace
+
+TEST(FootContactTest, DetectsPlantAndSwingPhases)
+{
+    // Gait-like trajectory: planted at x=0 for 10 frames, swing forward over
+    // 10 frames (lifted), planted at x=1 for 10 frames.
+    std::vector<V3> foot;
+    for (int f = 0; f < 10; ++f) foot.push_back({0.0f, 0.0f, 0.0f});
+    for (int f = 0; f < 10; ++f) {
+        const float t = (f + 1) / 11.0f;
+        foot.push_back({t, 0.25f * std::sin(t * 3.14159f), 0.0f});
+    }
+    for (int f = 0; f < 10; ++f) foot.push_back({1.0f, 0.0f, 0.0f});
+
+    const auto spans = FootContact::detectContacts(foot, /*legLength=*/1.0f);
+    ASSERT_EQ(spans.size(), 2u);
+    EXPECT_EQ(spans[0].start, 0);
+    EXPECT_GE(spans[0].end, 7);      // plant 1 covers most of frames 0..9
+    EXPECT_LE(spans[0].end, 10);
+    EXPECT_GE(spans[1].start, 19);   // plant 2 starts after the swing
+    EXPECT_EQ(spans[1].end, 29);
+}
+
+TEST(FootContactTest, SlidingFootIsNotAContact)
+{
+    // On the ground the whole time but translating fast — foot skate, the
+    // exact artifact we're pinning. Must NOT be detected as one long contact.
+    std::vector<V3> foot;
+    for (int f = 0; f < 30; ++f)
+        foot.push_back({0.1f * f, 0.0f, 0.0f});     // 0.1 leg-lengths/frame
+    const auto spans = FootContact::detectContacts(foot, 1.0f);
+    EXPECT_TRUE(spans.empty());
+}
+
+TEST(FootContactTest, ShortBlipsAreIgnored)
+{
+    std::vector<V3> foot;
+    for (int f = 0; f < 20; ++f)
+        foot.push_back({0.0f, (f == 10 || f == 11) ? 0.0f : 0.6f, 0.0f});
+    FootContact::DetectOptions opt;
+    opt.minFrames = 3;
+    const auto spans = FootContact::detectContacts(foot, 1.0f, opt);
+    EXPECT_TRUE(spans.empty());      // 2-frame touch < minFrames
+}
+
+TEST(FootContactTest, SolveKneePreservesLengthsAndReachesTarget)
+{
+    const V3 hip{0, 1.0f, 0};
+    const V3 knee{0.1f, 0.5f, 0.15f};      // bent slightly forward
+    const V3 foot{0, 0.0f, 0.05f};
+    const float l1 = dist(hip, knee), l2 = dist(knee, foot);
+
+    const V3 target{0.05f, 0.02f, -0.2f};  // pin slightly behind
+    const V3 k2 = FootContact::solveKnee(hip, knee, foot, target);
+    EXPECT_NEAR(dist(hip, k2), l1, 1e-4f);
+    EXPECT_NEAR(dist(k2, target), l2, 1e-4f);
+    // knee keeps bending roughly forward (pose's own bend plane, no flip)
+    EXPECT_GT(k2[2], -0.05f);
+}
+
+TEST(FootContactTest, SolveKneeClampsUnreachableTarget)
+{
+    const V3 hip{0, 1.0f, 0};
+    const V3 knee{0, 0.5f, 0.1f};
+    const V3 foot{0, 0.0f, 0};
+    const float l1 = dist(hip, knee), l2 = dist(knee, foot);
+
+    const V3 far{3.0f, -2.0f, 0};          // beyond l1+l2
+    const V3 k2 = FootContact::solveKnee(hip, knee, foot, far);
+    EXPECT_NEAR(dist(hip, k2), l1, 1e-3f);
+    // the chain extends straight toward the target: knee sits on hip→far
+    const float reach = dist(hip, k2) + l2;
+    EXPECT_NEAR(reach, l1 + l2, 1e-3f);
+}
+
+TEST(FootContactTest, SolveKneeStraightLegPicksStableBend)
+{
+    const V3 hip{0, 1.0f, 0};
+    const V3 knee{0, 0.5f, 0};             // perfectly straight leg
+    const V3 foot{0, 0.0f, 0};
+    const V3 target{0, 0.2f, 0};           // shorten: must bend somewhere
+    const V3 k2 = FootContact::solveKnee(hip, knee, foot, target);
+    EXPECT_NEAR(dist(hip, k2), 0.5f, 1e-4f);
+    EXPECT_NEAR(dist(k2, target), 0.5f, 1e-4f);
+}
+
+TEST(FootContactTest, BlendWeightRampsAtSpanEdges)
+{
+    const FootContact::Span s{10, 20};
+    EXPECT_FLOAT_EQ(FootContact::blendWeight(s, 9, 3), 0.0f);
+    EXPECT_FLOAT_EQ(FootContact::blendWeight(s, 21, 3), 0.0f);
+    EXPECT_NEAR(FootContact::blendWeight(s, 10, 3), 1.0f / 3.0f, 1e-5f);
+    EXPECT_NEAR(FootContact::blendWeight(s, 11, 3), 2.0f / 3.0f, 1e-5f);
+    EXPECT_FLOAT_EQ(FootContact::blendWeight(s, 15, 3), 1.0f);
+    EXPECT_NEAR(FootContact::blendWeight(s, 20, 3), 1.0f / 3.0f, 1e-5f);
+    // zero blend = hard pin
+    EXPECT_FLOAT_EQ(FootContact::blendWeight(s, 10, 0), 1.0f);
+}
+
+TEST(FootContactTest, GroundLevelIsRobustToAirTime)
+{
+    // Foot spends most of the clip in the air (jump) — ground level must
+    // still track the low plateau, not the mean.
+    std::vector<V3> foot;
+    for (int f = 0; f < 40; ++f)
+        foot.push_back({0.0f, (f < 6) ? 0.02f : 0.8f, 0.0f});
+    EXPECT_NEAR(FootContact::groundLevel(foot, 1), 0.02f, 1e-4f);
+}

--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -651,6 +651,7 @@ const QMap<QString, MCPServer::ToolHandler>& MCPServer::toolHandlers()
         {QStringLiteral("motion_in_between"), &MCPServer::toolMotionInBetween},
         {QStringLiteral("generate_motion"), &MCPServer::toolGenerateMotion},
         {QStringLiteral("adjust_arm_space"), &MCPServer::toolAdjustArmSpace},
+        {QStringLiteral("pin_feet"), &MCPServer::toolPinFeet},
         {QStringLiteral("segment_mesh"), &MCPServer::toolSegmentMesh},
         {QStringLiteral("generate_mesh_from_image"), &MCPServer::toolGenerateMeshFromImage},
         {QStringLiteral("save_scene"), &MCPServer::toolSaveScene},
@@ -4132,6 +4133,13 @@ QJsonObject MCPServer::toolGenerateMotion(const QJsonObject &args)
             armSpaceApplied = AnimationMerger::adjustArmSpace(
                 skel.get(), animName, static_cast<float>(armSpace));
 
+        // #856: foot-contact cleanup — ON by default (foot_pin:false opts out).
+        int footPinSpans = -1;
+        if (args.value("foot_pin").toBool(true)) {
+            const auto fp = AnimationMerger::pinFeet(skel.get(), animName);
+            footPinSpans = fp.ok ? fp.spans : -1;
+        }
+
         entity->refreshAvailableAnimationState();
         // Exclusively enable the generated clip — enabled states BLEND in
         // Ogre, and mixing with the import's auto-enabled animation renders
@@ -4167,6 +4175,7 @@ QJsonObject MCPServer::toolGenerateMotion(const QJsonObject &args)
         content["tracks_written"] = r.tracksWritten; content["canonical_joints"] = r.canonicalJoints;
         content["entity"] = QString::fromStdString(entity->getName());
         if (std::abs(armSpace) > 1e-4) content["arm_space_applied"] = armSpaceApplied;
+        if (footPinSpans >= 0) content["foot_pin_spans"] = footPinSpans;
         if (!outPath.isEmpty()) content["exported"] = outPath;
         return makeSuccessResult(
             QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Indented)));
@@ -4241,6 +4250,76 @@ QJsonObject MCPServer::toolAdjustArmSpace(const QJsonObject &args)
         content["ok"] = true;
         content["animation"] = animName;
         content["arm_space"] = degrees;
+        content["entity"] = QString::fromStdString(entity->getName());
+        if (!outPath.isEmpty()) content["exported"] = outPath;
+        return makeSuccessResult(
+            QString::fromUtf8(QJsonDocument(content).toJson(QJsonDocument::Indented)));
+    } catch (Ogre::Exception& e) {
+        return makeErrorResult(QString("Error: Ogre exception — %1").arg(e.getFullDescription().c_str()));
+    } catch (std::exception& e) {
+        return makeErrorResult(QString("Error: %1").arg(e.what()));
+    }
+}
+
+QJsonObject MCPServer::toolPinFeet(const QJsonObject &args)
+{
+    try {
+        SentryReporter::addBreadcrumb(QStringLiteral("ai.tool_call"),
+            QStringLiteral("MCP pin_feet"));
+
+        Manager* mgr = Manager::getSingletonPtr();
+        if (!mgr) return makeErrorResult("Error: Manager not available");
+
+        const QString animName = args.value("animation_name").toString();
+        if (animName.isEmpty())
+            return makeErrorResult("Error: animation_name is required.");
+
+        const QString entityName = args.value("entity_name").toString();
+        Ogre::Entity* entity = nullptr;
+        for (auto* ent : mgr->getEntities()) {
+            if (!ent || ent->getMovableType() != "Entity" || !ent->hasSkeleton())
+                continue;
+            if (entityName.isEmpty()
+                || QString::fromStdString(ent->getName()) == entityName) {
+                entity = ent; break;
+            }
+        }
+        if (!entity)
+            return makeErrorResult(entityName.isEmpty()
+                ? QString("Error: no skinned mesh found.")
+                : QString("Error: skinned entity '%1' not found.").arg(entityName));
+
+        // Edit the mesh's MASTER skeleton (exporter serializes the master;
+        // animations are shared, so the live viewport still updates).
+        Ogre::SkeletonPtr skel = entity->getMesh()->getSkeleton();
+        const std::string an = animName.toStdString();
+        if (!skel || !skel->hasAnimation(an))
+            return makeErrorResult(
+                QString("Error: animation '%1' not found on entity.").arg(animName));
+
+        const auto fp = AnimationMerger::pinFeet(skel.get(), an);
+        if (!fp.ok)
+            return makeErrorResult(
+                QString("Error: foot-pin failed: %1").arg(fp.error));
+
+        if (auto* acc = AnimationControlController::instance())
+            acc->notifyExternalAnimationEdit();
+
+        const QString outPath = args.value("output_path").toString();
+        if (!outPath.isEmpty()) {
+            auto* node = entity->getParentSceneNode();
+            if (MeshImporterExporter::exporter(
+                    node, outPath, CLIPipeline::formatForExtension(outPath)) != 0)
+                return makeErrorResult(
+                    QString("Error: pinned feet but export to %1 failed")
+                        .arg(outPath));
+        }
+
+        QJsonObject content;
+        content["ok"] = true;
+        content["animation"] = animName;
+        content["spans"] = fp.spans;
+        content["keyframes_adjusted"] = fp.keyframesAdjusted;
         content["entity"] = QString::fromStdString(entity->getName());
         if (!outPath.isEmpty()) content["exported"] = outPath;
         return makeSuccessResult(
@@ -8134,6 +8213,7 @@ QJsonArray MCPServer::buildToolsList()
         props["output_path"] = QJsonObject{{"type", "string"}, {"description", "Optional path to re-export the mesh with the new animation (e.g. /tmp/out.glb). If omitted, the animation is applied in-session only."}};
         props["model"] = QJsonObject{{"type", "boolean"}, {"description", "EXPERIMENTAL: use the trained from-scratch text-to-motion ONNX model instead of the template clip. Falls back to the template library automatically if the model is unavailable or the action isn't in its vocabulary. Default false (template). Quality is action-dependent (locomotion better than gestures)."}};
         props["arm_space"] = QJsonObject{{"type", "number"}, {"description", "Optional Mixamo-style arm-space post-process in degrees (#854): positive widens the arms away from the body, negative tucks them in. Default 0. Rescues arm-into-torso clipping on rigs whose proportions differ from the clip."}};
+        props["foot_pin"] = QJsonObject{{"type", "boolean"}, {"description", "Foot-contact cleanup (#856): detect ground-contact spans and IK-pin the feet so they plant instead of skating. Default true; set false to keep the raw retarget."}};
         appendTool(
             "generate_motion",
             "AI text-to-motion (#411, experimental): generate a skeletal animation from a text prompt and "
@@ -8163,6 +8243,24 @@ QJsonArray MCPServer::buildToolsList()
             "the prior value), so it maps directly to a UI slider.",
             props,
             QJsonArray{"animation_name", "arm_space"}
+        );
+    }
+
+    // pin_feet
+    {
+        QJsonObject props;
+        props["animation_name"] = QJsonObject{{"type", "string"}, {"description", "Name of the animation to clean up, e.g. \"generated_walk\"."}};
+        props["entity_name"] = QJsonObject{{"type", "string"}, {"description", "Name of the rigged entity. If omitted, uses the first skinned entity."}};
+        props["output_path"] = QJsonObject{{"type", "string"}, {"description", "Optional path to re-export the mesh with the cleaned animation. If omitted, applied in-session only."}};
+        appendTool(
+            "pin_feet",
+            "Foot-contact cleanup (#856): detect frames where each foot is near the clip's ground level and "
+            "nearly stationary (contact spans) and lock the foot's world position to its span-start position "
+            "with an analytic two-bone hip-knee-foot IK, blending in/out at span edges so knees don't pop. "
+            "Fixes foot skating/floating on retargeted clips whose rig proportions differ from the source. "
+            "Only the thigh/shin/foot keyframes are rewritten; effectively idempotent.",
+            props,
+            QJsonArray{"animation_name"}
         );
     }
 

--- a/src/MCPServer.h
+++ b/src/MCPServer.h
@@ -210,6 +210,7 @@ private:
     QJsonObject toolMotionInBetween(const QJsonObject &args);
     QJsonObject toolGenerateMotion(const QJsonObject &args);    // #411 text-to-motion
     QJsonObject toolAdjustArmSpace(const QJsonObject &args);    // #854 arm-space
+    QJsonObject toolPinFeet(const QJsonObject &args);           // #856 foot-contact pin
     QJsonObject toolSegmentMesh(const QJsonObject &args);
     QJsonObject toolGenerateMeshFromImage(const QJsonObject &args);   // #764 image-to-3D
     QJsonObject toolSaveScene(const QJsonObject &args);

--- a/src/MotionInbetween.cpp
+++ b/src/MotionInbetween.cpp
@@ -153,7 +153,7 @@ int MotionInbetween::canonicalIndexForBone(const QString& boneName)
         if (has({"elbow", "forearm", "lowerarm"}))       return 8;   // relbow
         if (has({"hand", "wrist"}))                      return 9;   // rhand
         if (has({"buttock"}))                            return 14;  // rbuttock
-        if (has({"upleg", "thigh", "hip", "femur"}))     return 15;  // rhip
+        if (has({"upleg", "upperleg", "thigh", "hip", "femur"})) return 15;  // rhip
         if (has({"knee", "leg", "shin", "calf"}) && !has({"upleg","thigh"})) return 16; // rknee
         if (has({"foot", "ankle"}))                      return 17;  // rfoot
     } else if (side == 'l') {
@@ -163,7 +163,7 @@ int MotionInbetween::canonicalIndexForBone(const QString& boneName)
         if (has({"elbow", "forearm", "lowerarm"}))       return 12;  // lelbow
         if (has({"hand", "wrist"}))                      return 13;  // lhand
         if (has({"buttock"}))                            return 18;  // lbuttock
-        if (has({"upleg", "thigh", "hip", "femur"}))     return 19;  // lhip
+        if (has({"upleg", "upperleg", "thigh", "hip", "femur"})) return 19;  // lhip
         if (has({"knee", "leg", "shin", "calf"}) && !has({"upleg","thigh"})) return 20; // lknee
         if (has({"foot", "ankle"}))                      return 21;  // lfoot
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -75,6 +75,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/BoneWeightOverlay.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/NormalVisualizer.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AnimationMerger.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/FootContact.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MCPServer.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MCPSettingsDialog.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MeshInfoOverlay.cpp


### PR DESCRIPTION
Closes #856 (epic #837). **Stacked on #886** (base = `feat/t2m-twist-857`) — retarget the base branch to `master` after #886 merges.

Retargeted clips slide/float feet on rigs whose proportions differ from the source: the direction retarget transfers bone directions, not world foot positions.

## What's here

- **`FootContact` pure-data core** (Ogre-free, unit-tested in `FootContact_test.cpp` — runs without GL):
  - `detectContacts` — frames where a foot is within a leg-length-scaled height band of the clip's ground level AND nearly stationary horizontally → contact spans (min-length filtered; ground = low percentile so airborne clips don't skew it). A fast-translating on-ground foot (skating — the exact artifact) is correctly NOT a contact.
  - `solveKnee` — analytic two-bone IK: keeps both segment lengths, preserves the pose's own bend plane (pole from the current knee), clamps unreachable targets, stable on straight legs.
  - `blendWeight` — 0→1→0 edge ramps so knees don't pop at span borders.
- **`AnimationMerger::pinFeet`** — manual FK over the tracks (pure track math; the live skeleton is never `apply()`'d — it may be a SkeletonInstance driving the viewport). Detection runs in the canonical frame (Ct) so "ground" is horizontal regardless of the rig's axes. Per contact frame, the foot is locked to its span-start position: thigh re-aimed at the IK knee, shin at the pinned target, and the **foot keyframe is compensated to keep its original world orientation** (no toe pop from parent corrections). Only thigh/shin/foot keyframes rewritten; `_keyFrameDataChanged()` per track (the #854 cache lesson). Effectively idempotent; `qtme.footpin.<anim>` marker cleared on clip regeneration.
- **Surfaces** (on-by-default in generation, per the issue): CLI `--no-foot-pin` opt-out + standalone `qtmesh anim <f> --foot-pin --animation <name> -o out`; MCP `foot_pin` arg on `generate_motion` + standalone `pin_feet` tool; GUI "Pin feet (contact cleanup)" checkbox.
- **Bone-matcher fix uncovered by this work**: `canonicalIndexForBone` now maps `upperleg` to the thigh role. Quaternius-style rigs (`UpperLeg.L`/`LowerLeg.L`) previously mapped BOTH leg bones onto the knee role — pinning couldn't find a thigh, and the retarget double-aimed the knee (the Knight resolves 14 roles now, up from 13).

## Verified

- Rumba walk: 2 contact spans detected and pinned (6 blended keyframes); renders upright, stride intact.
- Quaternius Knight: pins after the alias fix; controlled render (pinned single-clip eval library) unchanged silhouette, no knee pops.
- 8 pure-data core tests incl. skating rejection, unreachable-target clamp, straight-leg stability, air-time-robust ground level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)