### PR TITLE
t2m v5: flow-matching motion model — canonical training data + in-graph sampler + reference triple (#840, #858)

### DIFF
--- a/scripts/prep-t2m-v5.py
+++ b/scripts/prep-t2m-v5.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+# ruff: noqa: E702, E741
+"""Build the v5 text-to-motion training cache from the motion corpus (#858).
+
+ONE-TIME OFFLINE dev tool — NOT shipped. Successor to prep-t2m-v4.py, fixing
+its structural flaw: v4 trained on raw per-rig world quats, so every rig's
+bone-axis convention leaked into the data (the "convention mush" that made
+the CVAE average modes into gentle motion). v5 CANONICALIZES every clip into
+a rig-independent representation before windowing:
+
+  For each canonical joint c with source reference triple (restWorld Q_r,
+  restDir d_r) — the same triple the bind-referenced retarget (PR #843)
+  consumes — the source bone's world direction trajectory is
+      d(f) = W(f) · (Q_r⁻¹ · d̂_r)                     (canonical axes)
+  and its roll about the bone is the swing/twist residual
+      Δ(f)  = W(f) · Q_r⁻¹
+      aim   = arc(d̂_r → d(f))
+      θ(f)  = signed angle of (aim⁻¹ · Δ(f)) about d̂_r, unwrapped over f.
+  The training quat is rebuilt against a FIXED canonical T-pose direction
+  set D (spine +Y, left arm +X, right arm −X, legs −Y, feet +Z):
+      Q'(f) = twist(θ(f), d(f)) · arc(D_c → d(f))
+
+  Q' is identical for every rig performing the same motion — and it is
+  EXACTLY what the runtime consumes: with the model's reference triple
+  (restWorld = identity, restDir = D), applyMotionClip recovers
+  d(f) = Q'(f)·D_c and (with #857 twist transport) θ(f) losslessly. The
+  model therefore rides the SAME retarget path as v5 template clips, no
+  synthetic-standing-pose shim.
+
+Sources:
+  --corpus   ~/motion_corpus: the *.canonical.json sidecar dumps written by
+             build-motion-library-v5.py / `qtmesh anim --dump-canonical`
+             (#838/#839). Labels via the SAME action keyword table as the
+             template library, so both motion sources cover the same vocab.
+  --bvh      CMU BVH conversion (optional): FK world quats (rest = identity,
+             restDir from the skeleton's rest joint positions), labels from
+             the public CMU index — the v4 path, canonicalized the same way.
+
+Output npz: mo[N,T,22,4] canonical quats, msk[N,22] per-joint validity,
+tk[N,V] one-hot, vocab, fps, canonRestDir[22,3] (= D, for the vocab json).
+
+Usage:
+  python3 scripts/prep-t2m-v5.py --corpus ~/motion_corpus \
+      [--bvh /tmp/cmu-mocap-bvh/data --index /tmp/cmu_index.txt] \
+      --out /tmp/t2m_v5.npz [--T 60]
+"""
+import argparse
+import glob
+import importlib.util
+import json
+import os
+import re
+import sys
+
+import numpy as np
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def load_module(name, fname):
+    spec = importlib.util.spec_from_file_location(name, os.path.join(HERE, fname))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+libv5 = load_module("libv5", "build-motion-library-v5.py")   # action_for, quality
+prep4 = load_module("prep4", "prep-t2m-v4.py")               # BVH FK, index, windows
+
+CANON = prep4.CANON
+J = 22
+FPS = 30
+# canonical chain parent (AnimationMerger kParentCanon)
+PARENT = [-1, 0, 1, 2, 3, 4, 2, 6, 7, 8, 2, 10, 11, 12, 0, 14, 15, 16, 0, 18, 19, 20]
+CHILD = {}
+for _c, _p in enumerate(PARENT):     # chain child = FIRST child (hip→abdomen,
+    if _p >= 0:                      # chest→neck), matching the extractor
+        CHILD.setdefault(_p, _c)
+
+# FIXED canonical T-pose bone directions D (canonical axes: +Y up, +Z fwd,
+# +X left — the CMU frame convention every dump is normalized into).
+D_CANON = np.array([
+    [0, 1, 0],  [0, 1, 0],  [0, 1, 0],  [0, 1, 0],  [0, 1, 0],  [0, 1, 0],
+    [-1, 0, 0], [-1, 0, 0], [-1, 0, 0], [-1, 0, 0],
+    [1, 0, 0],  [1, 0, 0],  [1, 0, 0],  [1, 0, 0],
+    [0, -1, 0], [0, -1, 0], [0, -1, 0], [0, 0, 1],
+    [0, -1, 0], [0, -1, 0], [0, -1, 0], [0, 0, 1],
+], np.float32)
+
+
+# ---------- quat math, (x,y,z,w), vectorised over leading dims ----------
+def qmul(a, b):
+    ax, ay, az, aw = np.moveaxis(a, -1, 0)
+    bx, by, bz, bw = np.moveaxis(b, -1, 0)
+    return np.stack([aw*bx + ax*bw + ay*bz - az*by,
+                     aw*by - ax*bz + ay*bw + az*bx,
+                     aw*bz + ax*by - ay*bx + az*bw,
+                     aw*bw - ax*bx - ay*by - az*bz], -1)
+
+
+def qconj(q):
+    return q * np.array([-1, -1, -1, 1], q.dtype)
+
+
+def qrot(q, v):
+    """Rotate vectors v[...,3] by quats q[...,4]."""
+    qv = q[..., :3]
+    uv = np.cross(qv, v)
+    uuv = np.cross(qv, uv)
+    return v + 2.0 * (q[..., 3:4] * uv + uuv)
+
+
+def qnorm(q):
+    return q / (np.linalg.norm(q, axis=-1, keepdims=True) + 1e-12)
+
+
+def arc(a, b):
+    """Shortest-arc quats rotating unit vectors a[...,3] onto b[...,3]."""
+    d = (a * b).sum(-1, keepdims=True)
+    axis = np.cross(a, b)
+    w = 1.0 + d
+    q = np.concatenate([axis, w], -1)
+    # antiparallel: rotate π about any perpendicular of a
+    bad = (w[..., 0] < 1e-6)
+    if np.any(bad):
+        ab = a[bad]
+        perp = np.cross(ab, np.broadcast_to([1.0, 0, 0], ab.shape))
+        n = np.linalg.norm(perp, axis=-1, keepdims=True)
+        alt = np.cross(ab, np.broadcast_to([0, 1.0, 0], ab.shape))
+        perp = np.where(n > 1e-6, perp, alt)
+        perp /= (np.linalg.norm(perp, axis=-1, keepdims=True) + 1e-12)
+        q[bad] = np.concatenate([perp, np.zeros_like(perp[..., :1])], -1)
+    return qnorm(q)
+
+
+def axis_angle(axis, ang):
+    h = ang[..., None] * 0.5
+    return np.concatenate([axis * np.sin(h), np.cos(h)], -1)
+
+
+def canonicalize(wq, rest_world, rest_dir):
+    """wq[T,J,4] world quats + reference triple → (Q'[T,J,4], valid[J]).
+
+    Q' is the rig-independent training quat; invalid joints (zero restDir)
+    are identity with valid=0.
+    """
+    T = wq.shape[0]
+    out = np.zeros((T, J, 4), np.float32)
+    out[..., 3] = 1.0
+    valid = np.zeros(J, np.float32)
+    for c in range(J):
+        dr = np.asarray(rest_dir[c], np.float32)
+        n = np.linalg.norm(dr)
+        if n < 1e-6:
+            continue
+        dr = dr / n
+        qr = qnorm(np.asarray(rest_world[c], np.float32))
+        a_s = qrot(qconj(qr)[None], dr[None])[0]         # bone's local axis
+        W = qnorm(wq[:, c])                              # [T,4]
+        d = qrot(W, np.broadcast_to(a_s, (T, 3)))        # [T,3] world dir
+        d = d / (np.linalg.norm(d, axis=-1, keepdims=True) + 1e-12)
+        delta = qmul(W, np.broadcast_to(qconj(qr), (T, 4)))
+        aim_s = arc(np.broadcast_to(dr, (T, 3)), d)
+        tw = qmul(qconj(aim_s), delta)                   # twist about dr
+        th = 2.0 * np.arctan2((tw[:, :3] * dr).sum(-1), tw[:, 3])
+        th = np.unwrap(th)
+        # cap runaway unwrap drift (numeric noise on near-degenerate aims)
+        th = np.clip(th, -2.5 * np.pi, 2.5 * np.pi)
+        aim_c = arc(np.broadcast_to(D_CANON[c], (T, 3)), d)
+        out[:, c] = qmul(axis_angle(d, th), aim_c)
+        valid[c] = 1.0
+    return qnorm(out), valid
+
+
+# ---------- corpus source ----------
+def corpus_clips(corpus, min_roles):
+    """Yield (action, Q'[T,J,4], valid[J], src) from every sidecar dump."""
+    manifest = {}
+    mpath = os.path.join(corpus, "manifest.json")
+    if os.path.exists(mpath):
+        manifest = json.load(open(mpath))
+    dumps = sorted(glob.glob(os.path.join(corpus, "raw", "**",
+                                          "*.canonical.json"), recursive=True))
+    for dpath in dumps:
+        try:
+            dump = json.load(open(dpath))
+        except Exception:
+            continue
+        asset = os.path.basename(os.path.dirname(dpath))
+        prov = libv5.manifest_lookup(manifest, asset) or {}
+        tags = prov.get("tags", [])
+        title = prov.get("title", asset)
+        for c in dump.get("clips", []):
+            if c.get("resolvedRoles", 0) < min_roles:
+                continue
+            q = c.get("quats", [])
+            rw = c.get("restWorld", [])
+            rd = c.get("restDir", [])
+            if len(q) < 12 or len(rw) != J or len(rd) != J:
+                continue
+            action = libv5.action_for(c.get("animation", ""), tags)
+            if not action:
+                continue
+            # the library's uprightness/energy gate (#855) — same hygiene bar
+            e = libv5.frame_energy(q)
+            me = sum(e) / max(1, len(e))
+            if me < 0.004:
+                continue
+            quality, drop = libv5.clip_quality(
+                action, q, rw, rd, c.get("resolvedRoles", 0), me, 0.004)
+            if drop:
+                continue
+            wq = np.asarray(q, np.float32)               # [T,J,4]
+            cq, valid = canonicalize(wq, rw, rd)
+            yield action, cq, valid, f"{title} — {c.get('animation')}"
+
+
+# ---------- CMU source ----------
+def bvh_rest(path):
+    """Rest joint positions from a BVH's OFFSET tree → restDir per canonical
+    joint (identity rest rotations ⇒ world dir = offset-chain direction)."""
+    from bvh import Bvh
+    with open(path) as f:
+        m = Bvh(f.read())
+    cmap = prep4.resolve_canon(m.get_joints_names())
+    if cmap is None:
+        return None
+    pos = {}
+    for name in m.get_joints_names():
+        p, cur = np.zeros(3), name
+        while cur is not None:
+            p = p + np.asarray(m.joint_offset(cur), np.float64)
+            try:
+                par = m.joint_parent(cur)
+                cur = par.name if par else None
+            except Exception:
+                cur = None
+        pos[name] = p
+    rd = np.zeros((J, 3), np.float32)
+    for c in range(J):
+        if c in CHILD:
+            v = pos[cmap[CANON[CHILD[c]]]] - pos[cmap[CANON[c]]]
+        else:  # tips: head +Y, hands follow the forearm, feet +Z
+            if c == 5:
+                v = np.array([0, 1.0, 0])
+            elif c in (9, 13):
+                v = pos[cmap[CANON[c]]] - pos[cmap[CANON[PARENT[c]]]]
+            else:
+                v = np.array([0, 0, 1.0])
+        n = np.linalg.norm(v)
+        rd[c] = (v / n) if n > 1e-6 else 0.0
+    return rd
+
+
+def cmu_clips(bvh_dir, index):
+    labels = prep4.load_index(index)
+    files = sorted(glob.glob(os.path.join(bvh_dir, "**/*.bvh"), recursive=True))
+    ident = np.zeros((J, 4), np.float32)
+    ident[:, 3] = 1.0
+    for path in files:
+        mid_m = re.match(r"(\d+_\d+)", os.path.basename(path))
+        mid = mid_m.group(1) if mid_m else None
+        if mid is None or mid not in labels:
+            continue
+        r = prep4.parse_bvh(path)
+        if r is None:
+            continue
+        _lq, wq = r
+        rd = bvh_rest(path)
+        if rd is None:
+            continue
+        cq, valid = canonicalize(wq, ident, rd)
+        yield labels[mid], cq, valid, f"CMU {mid}"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--corpus", default="")
+    ap.add_argument("--bvh", default="")
+    ap.add_argument("--index", default="")
+    ap.add_argument("--out", default="/tmp/t2m_v5.npz")
+    ap.add_argument("--T", type=int, default=40)
+    ap.add_argument("--min-roles", type=int, default=12)
+    ap.add_argument("--min-action-windows", type=int, default=8)
+    a = ap.parse_args()
+
+    mo, msk, acts, srcs = [], [], [], []
+
+    def angdist(x, y):
+        d = np.abs((x * y).sum(-1)).clip(0, 1)
+        return 2.0 * np.arccos(d)
+
+    def window(action, cq, valid, src):
+        # The v4 neutral-start gate is deliberately GONE: model clips now ride
+        # the bind-referenced direction retarget, which references the
+        # reference TRIPLE, not clip frame 0 — any phase is a valid window.
+        T, nF = a.T, cq.shape[0]
+        if nF < max(16, T // 2):
+            return
+        if nF < T:
+            # pad: loop-tile cyclic clips (end pose ≈ start pose), else hold
+            cyc = angdist(cq[-1], cq[0]).mean() < 0.25
+            reps = [cq]
+            while sum(r.shape[0] for r in reps) < T:
+                reps.append(cq if cyc else cq[-1:].repeat(T, 0))
+            cq = np.concatenate(reps, 0)[:T]
+            nF = T
+        for s in range(0, nF - T + 1, max(1, T // 2)):
+            mo.append(cq[s:s + T])
+            msk.append(valid)
+            acts.append(action)
+            srcs.append(src)
+
+    if a.corpus:
+        n0 = 0
+        for action, cq, valid, src in corpus_clips(
+                os.path.expanduser(a.corpus), a.min_roles):
+            window(action, cq, valid, src)
+            n0 += 1
+        print(f"corpus: {n0} clips → {len(mo)} windows")
+    if a.bvh and a.index:
+        n0, w0 = 0, len(mo)
+        for action, cq, valid, src in cmu_clips(a.bvh, a.index):
+            window(action, cq, valid, src)
+            n0 += 1
+        print(f"cmu: {n0} trials → {len(mo) - w0} windows")
+
+    if not mo:
+        sys.exit("no windows extracted")
+
+    # vocab = actions with enough support
+    from collections import Counter
+    cnt = Counter(acts)
+    vocab = sorted(w for w, n in cnt.items() if n >= a.min_action_windows)
+    keep = [i for i, w in enumerate(acts) if w in vocab]
+    mo = np.stack([mo[i] for i in keep]).astype(np.float32)
+    msk = np.stack([msk[i] for i in keep]).astype(np.float32)
+    tk = np.zeros((len(keep), len(vocab)), np.float32)
+    for r, i in enumerate(keep):
+        tk[r, vocab.index(acts[i])] = 1.0
+    print(f"windows: {mo.shape[0]}  vocab({len(vocab)}):",
+          {w: int(tk[:, vocab.index(w)].sum()) for w in vocab})
+    np.savez_compressed(a.out, mo=mo, msk=msk, tk=tk,
+                        vocab=np.array(vocab), fps=FPS,
+                        canonRestDir=D_CANON)
+    print(f"wrote {a.out}  mo{mo.shape}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train-t2m-flow-v5.py
+++ b/scripts/train-t2m-flow-v5.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+# ruff: noqa: E702, E741
+"""Train the v5 FLOW-MATCHING text-to-motion model (#840, epic #837).
+
+ONE-TIME OFFLINE dev tool — NOT shipped. Replaces the v4 CVAE: a conditional-
+mean decoder averages an action's phase-misaligned windows into gentle motion
+(the v4 training notes measured this); flow matching samples a transport path
+from noise to A SINGLE MODE of the data distribution instead — the one
+architectural change that separates MDM-era quality from the CVAE,
+independent of data scale (#837).
+
+Data: /tmp/t2m_v5.npz from prep-t2m-v5.py — CANONICALIZED quats (rig-
+independent aim+twist against the fixed canonical T-pose, #858), per-joint
+validity masks, one-hot action labels.
+
+Architecture: small DiT-style transformer v(x_t, t, action):
+  x[B,T,132] (22 joints × 6D rotation) + sinusoidal frame positions,
+  conditioned on (flow time t, action embedding) via AdaLN-Zero-lite
+  (per-layer scale/shift from the conditioning vector). Rectified-flow
+  objective: x_t=(1−t)x0+t·x1, target v*=x1−x0, masked joint-wise MSE.
+
+Export: ONNX graph with the EULER SAMPLER UNROLLED INSIDE (N fixed steps),
+matching the shipped MotionGenerator contract exactly:
+  inputs  tokens[1,V] one-hot, seed[1,Z]   (Z = T·132 flattened noise;
+          MotionGenerator draws N(0,0.5) — the graph rescales ×2 to unit)
+  output  motion[1,T,220]                  (per joint: tx,ty,tz=0,
+          quat x,y,z,w from Gram-Schmidt 6D→R, sx,sy,sz=1)
+plus t2m-vocab.json carrying the CANONICAL REFERENCE TRIPLE (restWorld =
+identity, restDir = the fixed canonical T-pose directions) so model clips
+ride the same bind-referenced direction retarget as v5 template clips —
+retiring the synthetic-standing-pose shim (#858).
+
+Usage:
+  python3 scripts/train-t2m-flow-v5.py --data /tmp/t2m_v5.npz \
+      --out /tmp/t2m_v5_flow --epochs 60 --device mps [--steps 16]
+"""
+import argparse
+import json
+import math
+import os
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+J, D6 = 22, 6
+C6 = J * D6      # 132
+
+
+# ---------- rotation reps ----------
+def quat_to_6d(q):
+    """q[...,4] (x,y,z,w) → first two rotation-matrix COLUMNS [...,6]."""
+    x, y, z, w = q.unbind(-1)
+    c0 = torch.stack([1 - 2 * (y * y + z * z),
+                      2 * (x * y + z * w),
+                      2 * (x * z - y * w)], -1)
+    c1 = torch.stack([2 * (x * y - z * w),
+                      1 - 2 * (x * x + z * z),
+                      2 * (y * z + x * w)], -1)
+    return torch.cat([c0, c1], -1)
+
+
+def d6_to_quat(d):
+    """[...,6] → unit quats [...,4] (x,y,z,w) via Gram-Schmidt (ONNX-safe)."""
+    a, b = d[..., :3], d[..., 3:]
+    c0 = F.normalize(a, dim=-1, eps=1e-6)
+    b = b - (c0 * b).sum(-1, keepdim=True) * c0
+    c1 = F.normalize(b, dim=-1, eps=1e-6)
+    c2 = torch.cross(c0, c1, dim=-1)
+    m00, m10, m20 = c0.unbind(-1)
+    m01, m11, m21 = c1.unbind(-1)
+    m02, m12, m22 = c2.unbind(-1)
+    # branchless Shepperd: build all four candidates, pick the max-norm one
+    t0 = 1 + m00 + m11 + m22
+    t1 = 1 + m00 - m11 - m22
+    t2 = 1 - m00 + m11 - m22
+    t3 = 1 - m00 - m11 + m22
+    eps = 1e-8
+    q0 = torch.stack([m21 - m12, m02 - m20, m10 - m01, t0], -1) \
+        / (2.0 * torch.sqrt(t0.clamp_min(eps)).unsqueeze(-1))
+    q1 = torch.stack([t1, m01 + m10, m02 + m20, m21 - m12], -1) \
+        / (2.0 * torch.sqrt(t1.clamp_min(eps)).unsqueeze(-1))
+    q2 = torch.stack([m01 + m10, t2, m12 + m21, m02 - m20], -1) \
+        / (2.0 * torch.sqrt(t2.clamp_min(eps)).unsqueeze(-1))
+    q3 = torch.stack([m02 + m20, m12 + m21, t3, m10 - m01], -1) \
+        / (2.0 * torch.sqrt(t3.clamp_min(eps)).unsqueeze(-1))
+    ts = torch.stack([t0, t1, t2, t3], -1)
+    idx = ts.argmax(-1, keepdim=True)
+    qs = torch.stack([q0, q1, q2, q3], -2)               # [...,4cand,4]
+    q = torch.gather(qs, -2,
+                     idx.unsqueeze(-1).expand(*idx.shape, 4)).squeeze(-2)
+    return F.normalize(q, dim=-1, eps=1e-6)
+
+
+# ---------- model ----------
+class Block(nn.Module):
+    def __init__(self, dim, heads):
+        super().__init__()
+        self.n1 = nn.LayerNorm(dim, elementwise_affine=False)
+        self.attn = nn.MultiheadAttention(dim, heads, batch_first=True)
+        self.n2 = nn.LayerNorm(dim, elementwise_affine=False)
+        self.mlp = nn.Sequential(nn.Linear(dim, dim * 4), nn.GELU(),
+                                 nn.Linear(dim * 4, dim))
+        self.ada = nn.Linear(dim, dim * 6)
+        nn.init.zeros_(self.ada.weight)
+        nn.init.zeros_(self.ada.bias)
+
+    def forward(self, x, c):
+        s1, b1, g1, s2, b2, g2 = self.ada(c).unsqueeze(1).chunk(6, -1)
+        h = self.n1(x) * (1 + s1) + b1
+        x = x + g1 * self.attn(h, h, h, need_weights=False)[0]
+        h = self.n2(x) * (1 + s2) + b2
+        return x + g2 * self.mlp(h)
+
+
+class FlowDiT(nn.Module):
+    def __init__(self, V, T, dim=256, layers=6, heads=8):
+        super().__init__()
+        self.T = T
+        self.inp = nn.Linear(C6, dim)
+        self.pos = nn.Parameter(torch.randn(1, T, dim) * 0.02)
+        self.act_emb = nn.Linear(V, dim)
+        self.t_mlp = nn.Sequential(nn.Linear(dim, dim), nn.SiLU(),
+                                   nn.Linear(dim, dim))
+        self.blocks = nn.ModuleList([Block(dim, heads) for _ in range(layers)])
+        self.out_n = nn.LayerNorm(dim, elementwise_affine=False)
+        self.out = nn.Linear(dim, C6)
+        nn.init.zeros_(self.out.weight)
+        nn.init.zeros_(self.out.bias)
+        half = dim // 2
+        self.register_buffer(
+            "freqs", torch.exp(-math.log(1e4)
+                               * torch.arange(half).float() / half))
+
+    def forward(self, x, t, tok):
+        # x[B,T,C6], t[B] in [0,1], tok[B,V]
+        ang = t[:, None] * 1000.0 * self.freqs[None]
+        temb = torch.cat([torch.sin(ang), torch.cos(ang)], -1)
+        c = self.t_mlp(temb) + self.act_emb(tok)
+        h = self.inp(x) + self.pos
+        for blk in self.blocks:
+            h = blk(h, c)
+        return self.out(self.out_n(h))
+
+
+class Sampler(nn.Module):
+    """Euler flow sampler UNROLLED for ONNX export — MotionGenerator contract."""
+
+    def __init__(self, net, V, T, steps, guidance=2.0):
+        super().__init__()
+        self.net, self.V, self.T, self.steps = net, V, T, steps
+        self.guidance = guidance
+
+    def forward(self, tokens, seed):
+        B = 1
+        # MotionGenerator draws seed ~ N(0, 0.5) — rescale to unit noise.
+        x = seed.reshape(B, self.T, C6) * 2.0
+        uncond = torch.zeros_like(tokens)
+        for i in range(self.steps):
+            t = torch.full((B,), i / self.steps, dtype=x.dtype,
+                           device=x.device)
+            vc = self.net(x, t, tokens)
+            vu = self.net(x, t, uncond)
+            v = vu + self.guidance * (vc - vu)
+            x = x + v / self.steps
+        q = d6_to_quat(x.reshape(B, self.T, J, D6))       # [1,T,J,4]
+        zeros3 = torch.zeros(B, self.T, J, 3, dtype=x.dtype, device=x.device)
+        ones3 = torch.ones(B, self.T, J, 3, dtype=x.dtype, device=x.device)
+        motion = torch.cat([zeros3, q, ones3], -1)        # [1,T,J,10]
+        return motion.reshape(B, self.T, J * 10)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--data", default="/tmp/t2m_v5.npz")
+    ap.add_argument("--out", default="/tmp/t2m_v5_flow")
+    ap.add_argument("--epochs", type=int, default=60)
+    ap.add_argument("--batch", type=int, default=256)
+    ap.add_argument("--lr", type=float, default=2e-4)
+    ap.add_argument("--dim", type=int, default=256)
+    ap.add_argument("--layers", type=int, default=6)
+    ap.add_argument("--steps", type=int, default=16, help="Euler export steps")
+    ap.add_argument("--guidance", type=float, default=2.0,
+                    help="CFG scale baked into the exported sampler")
+    ap.add_argument("--device", default="mps")
+    a = ap.parse_args()
+
+    d = np.load(a.data, allow_pickle=True)
+    mo, msk, tk = d["mo"], d["msk"], d["tk"]
+    vocab = [str(w) for w in d["vocab"]]
+    fps = int(d["fps"])
+    canon_rd = d["canonRestDir"]
+    N, T = mo.shape[0], mo.shape[1]
+    V = len(vocab)
+    print(f"data: {N} windows T={T} V={V} vocab={vocab}")
+
+    dev = torch.device(a.device if (a.device != "mps"
+                                    or torch.backends.mps.is_available())
+                       else "cpu")
+    x1 = quat_to_6d(torch.from_numpy(mo)).reshape(N, T, C6)      # data
+    m6 = torch.from_numpy(msk).repeat_interleave(D6, -1)         # [N,C6]
+    tok = torch.from_numpy(tk)
+
+    # class-balanced sampling — walk is 64% of windows (v4 lesson)
+    freq = tk.sum(0)
+    w = (tk @ (1.0 / np.maximum(freq, 1.0))).astype(np.float64)
+    sampler = torch.utils.data.WeightedRandomSampler(
+        torch.from_numpy(w), num_samples=N, replacement=True)
+    ds = torch.utils.data.TensorDataset(x1, m6, tok)
+    dl = torch.utils.data.DataLoader(ds, batch_size=a.batch, sampler=sampler,
+                                     drop_last=True)
+
+    net = FlowDiT(V, T, dim=a.dim, layers=a.layers).to(dev)
+    print("params:", sum(p.numel() for p in net.parameters()) / 1e6, "M")
+    opt = torch.optim.AdamW(net.parameters(), lr=a.lr, weight_decay=1e-4)
+    sched = torch.optim.lr_scheduler.CosineAnnealingLR(
+        opt, T_max=a.epochs * max(1, len(dl)))
+
+    for ep in range(a.epochs):
+        tot, nb = 0.0, 0
+        for xb, mb, tb in dl:
+            xb, mb, tb = xb.to(dev), mb.to(dev), tb.to(dev)
+            x0 = torch.randn_like(xb)
+            # classifier-free guidance: drop the action condition 10% of the
+            # time so the sampler can extrapolate cond vs uncond at export.
+            drop = (torch.rand(tb.shape[0], device=dev) < 0.1).float()
+            tb = tb * (1.0 - drop)[:, None]
+            t = torch.rand(xb.shape[0], device=dev)
+            xt = (1 - t[:, None, None]) * x0 + t[:, None, None] * xb
+            v = net(xt, t, tb)
+            tgt = xb - x0
+            mask = mb[:, None, :]                       # [B,1,C6]
+            loss = ((v - tgt) ** 2 * mask).sum() / mask.sum() / T
+            opt.zero_grad(set_to_none=True)
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(net.parameters(), 1.0)
+            opt.step()
+            sched.step()
+            tot += loss.item(); nb += 1
+        print(f"ep {ep + 1}/{a.epochs} loss {tot / max(1, nb):.4f}", flush=True)
+
+    os.makedirs(a.out, exist_ok=True)
+    torch.save(net.state_dict(), os.path.join(a.out, "flow.pt"))
+
+    # ---- export: sampler-unrolled ONNX + vocab json ----
+    net_cpu = FlowDiT(V, T, dim=a.dim, layers=a.layers)
+    net_cpu.load_state_dict({k: v.cpu() for k, v in net.state_dict().items()})
+    net_cpu.eval()
+    samp = Sampler(net_cpu, V, T, a.steps, a.guidance).eval()
+    Z = T * C6
+    tokens = torch.zeros(1, V); tokens[0, 0] = 1.0
+    seed = torch.randn(1, Z) * 0.5
+    onnx_path = os.path.join(a.out, "t2m.onnx")
+    torch.onnx.export(samp, (tokens, seed), onnx_path,
+                      input_names=["tokens", "seed"],
+                      output_names=["motion"], opset_version=17,
+                      dynamo=False)
+    vj = {
+        "vocab": vocab, "Z": Z, "T": T, "C": J * 10, "J": J,
+        "fps": fps, "frame": "world", "version": "v5-flow",
+        "flowSteps": a.steps,
+        # #858: the canonical reference triple — model clips ride the same
+        # bind-referenced direction retarget as v5 template clips.
+        "restWorld": [[0.0, 0.0, 0.0, 1.0]] * J,
+        "restDir": [[float(v) for v in row] for row in canon_rd],
+    }
+    with open(os.path.join(a.out, "t2m-vocab.json"), "w") as f:
+        json.dump(vj, f)
+    print(f"exported {onnx_path} "
+          f"({os.path.getsize(onnx_path) / 1e6:.1f} MB) + vocab")
+
+    # sanity: run one sample through onnxruntime
+    try:
+        import onnxruntime as ort
+        s = ort.InferenceSession(onnx_path,
+                                 providers=["CPUExecutionProvider"])
+        out = s.run(None, {"tokens": tokens.numpy(),
+                           "seed": seed.numpy()})[0]
+        q = out[0, :, 3:7]
+        nrm = np.linalg.norm(out[0].reshape(T, J, 10)[..., 3:7], axis=-1)
+        print("onnx ok:", out.shape, "quat norms",
+              nrm.min().round(4), nrm.max().round(4))
+    except Exception as e:  # noqa: BLE001
+        print("onnx check failed:", e)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/upload-t2m-v5-model.sh
+++ b/scripts/upload-t2m-v5-model.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Upload the v5 flow-matching text-to-motion model to the QtMeshEditor HF
+# models repo (#840/#858, epic #837). ONE-TIME, run by a maintainer with
+# write access.
+#
+# The app downloads these on first use from
+#   https://huggingface.co/fernandotonon/QtMeshEditor-models/resolve/main/motion/t2m.onnx
+#   https://huggingface.co/fernandotonon/QtMeshEditor-models/resolve/main/motion/t2m-vocab.json
+# The v5 ONNX keeps the exact v4 runtime interface (tokens[1,V], seed[1,Z]
+# -> motion[1,T,220]) so replacing the files is backward-compatible: older
+# builds run the new model too (they ignore the vocab's restWorld/restDir
+# and fall back to the synthetic-standing-pose path). The previous v4 files
+# are preserved under versioned names for rollback.
+#
+# Prereqs:
+#   pip install -U "huggingface_hub[cli]"
+#   huggingface-cli login          # token with write access
+#   train-t2m-flow-v5.py already run -> OUT_DIR holds t2m.onnx + t2m-vocab.json
+#
+# Usage:
+#   OUT_DIR=/tmp/t2m_v5_flow ./scripts/upload-t2m-v5-model.sh
+set -euo pipefail
+
+REPO="${REPO:-fernandotonon/QtMeshEditor-models}"
+OUT_DIR="${OUT_DIR:?set OUT_DIR to the training output dir (t2m.onnx + t2m-vocab.json)}"
+
+for f in t2m.onnx t2m-vocab.json; do
+    [[ -f "$OUT_DIR/$f" ]] || { echo "missing $OUT_DIR/$f" >&2; exit 1; }
+done
+
+# keep the previous (v4 CVAE) files for rollback under versioned names
+TMP=$(mktemp -d)
+for f in t2m.onnx t2m-vocab.json; do
+    if huggingface-cli download "$REPO" "motion/$f" --local-dir "$TMP" >/dev/null 2>&1; then
+        v4name="${f%.onnx}"; v4name="${v4name%.json}"
+        case "$f" in
+            t2m.onnx)       dst="motion/t2m-v4.onnx" ;;
+            t2m-vocab.json) dst="motion/t2m-vocab-v4.json" ;;
+        esac
+        huggingface-cli upload "$REPO" "$TMP/motion/$f" "$dst" \
+            --commit-message "t2m: preserve v4 CVAE as $dst before the v5 flow model (#858)"
+    fi
+done
+
+huggingface-cli upload "$REPO" "$OUT_DIR/t2m.onnx" motion/t2m.onnx \
+    --commit-message "t2m v5: flow-matching model, canonical reference triple (#840/#858)"
+huggingface-cli upload "$REPO" "$OUT_DIR/t2m-vocab.json" motion/t2m-vocab.json \
+    --commit-message "t2m v5: vocab + canonical reference triple (#840/#858)"
+echo "uploaded v5 t2m model + vocab to $REPO/motion/"

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -1877,10 +1877,18 @@ QVariantMap AnimationControlController::generateMotion(const QString& prompt,
             if (mr.ok) {
                 action = mr.matchedAction; quats = mr.clip.quats; fps = mr.clip.fps;
                 worldFrame = mr.worldFrame; clipSource = QStringLiteral("model"); gotClip = true;
-                // Borrow a template clip's reference directions so the
-                // retarget synthesizes a BIND-referenced base pose (no
-                // harvest from the rig's other animations).
-                clipDirs = MotionLibrary::referenceDirsForPrompt(prompt);
+                if (!mr.clip.restWorld.empty() && !mr.clip.restDir.empty()) {
+                    // v5 models (#858) ship their canonical reference triple
+                    // — same bind-referenced retarget as template clips.
+                    cmuRest = mr.clip.restWorld;
+                    clipDirs = mr.clip.restDir;
+                } else {
+                    // Legacy v4: borrow a template clip's reference
+                    // directions so the retarget synthesizes a BIND-
+                    // referenced base pose (no harvest from the rig's
+                    // other animations).
+                    clipDirs = MotionLibrary::referenceDirsForPrompt(prompt);
+                }
             }
         }
         if (!gotClip)

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -1587,13 +1587,17 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
     // Generated clips therefore reference the TARGET BIND — no pose from any
     // other animation is involved (the standing-pose harvest below is only
     // the fallback for restWorld-less clips, e.g. the CMU-built libraries).
+    // A reference orientation is PRESENT when it is a valid (unit-norm) quat;
+    // unresolved roles in dumps are zero-filled. Identity counts — the v5
+    // model's canonical triple (#858) is restWorld = identity ×22 by
+    // construction, and treating it as "absent" would silently demote model
+    // clips to the synthetic-standing-pose path.
     bool haveRestWorld = false;
     if (worldFrame
         && cmuRestWorld.size() == static_cast<size_t>(
                MotionInbetween::canonicalJointCount())) {
         for (const auto& q : cmuRestWorld)
-            if (std::abs(q[0]) > 1e-5f || std::abs(q[1]) > 1e-5f
-                || std::abs(q[2]) > 1e-5f || std::abs(1.f - std::abs(q[3])) > 1e-5f) {
+            if (q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3] > 0.25f) {
                 haveRestWorld = true;
                 break;
             }

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -2056,12 +2056,21 @@ int CLIPipeline::cmdAnimGenerate(const QString& filePath, const QString& prompt,
                 action = mr.matchedAction;
                 quats = mr.clip.quats;
                 fps = mr.clip.fps;
-                worldFrame = mr.worldFrame;  // v4 models: world-frame quats
-                // Model clips carry no reference triple — borrow a template
-                // clip's canonical bone directions so the retarget can
-                // synthesize a BIND-referenced base pose instead of
-                // harvesting the rig's other animations (contamination).
-                clipDirs = MotionLibrary::referenceDirsForPrompt(prompt);
+                worldFrame = mr.worldFrame;  // v4/v5 models: world-frame quats
+                if (!mr.clip.restWorld.empty() && !mr.clip.restDir.empty()) {
+                    // v5 models (#858) ship their canonical reference triple
+                    // in the vocab — the clip rides the same bind-referenced
+                    // direction retarget as v5 template clips.
+                    cmuRest = mr.clip.restWorld;
+                    clipDirs = mr.clip.restDir;
+                } else {
+                    // Legacy v4 models carry no reference triple — borrow a
+                    // template clip's canonical bone directions so the
+                    // retarget can synthesize a BIND-referenced base pose
+                    // instead of harvesting the rig's other animations
+                    // (contamination).
+                    clipDirs = MotionLibrary::referenceDirsForPrompt(prompt);
+                }
                 clipSource = QStringLiteral("model");
                 gotClip = true;
             } else {

--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -4073,10 +4073,18 @@ QJsonObject MCPServer::toolGenerateMotion(const QJsonObject &args)
                 if (mr.ok) {
                     action = mr.matchedAction; quats = mr.clip.quats; fps = mr.clip.fps;
                     worldFrame = mr.worldFrame; clipSource = QStringLiteral("model"); gotClip = true;
-                    // Borrow a template clip's reference directions so the
-                    // retarget synthesizes a BIND-referenced base pose (no
-                    // harvest from the rig's other animations).
-                    clipDirs = MotionLibrary::referenceDirsForPrompt(prompt);
+                    if (!mr.clip.restWorld.empty() && !mr.clip.restDir.empty()) {
+                        // v5 models (#858) ship their canonical reference
+                        // triple — same bind-referenced retarget as templates.
+                        cmuRest = mr.clip.restWorld;
+                        clipDirs = mr.clip.restDir;
+                    } else {
+                        // Legacy v4: borrow a template clip's reference
+                        // directions so the retarget synthesizes a
+                        // BIND-referenced base pose (no harvest from the
+                        // rig's other animations).
+                        clipDirs = MotionLibrary::referenceDirsForPrompt(prompt);
+                    }
                 }
             }
         }

--- a/src/MotionGenerator.cpp
+++ b/src/MotionGenerator.cpp
@@ -191,6 +191,39 @@ MotionGenerator::Result MotionGenerator::generate(
         const bool worldFrame =
             vj.value("frame").toString() == QLatin1String("world");
         const int fps = vj.value("fps").toInt(30);
+        // v5 models (#858) train on CANONICALIZED quats and ship their
+        // reference triple in the vocab: restWorld (identity ×22) + restDir
+        // (the fixed canonical T-pose directions). With it, model clips ride
+        // the SAME bind-referenced direction retarget as v5 template clips —
+        // no synthetic-standing-pose shim.
+        std::vector<std::array<float, 4>> vocabRestWorld;
+        std::vector<std::array<float, 3>> vocabRestDir;
+        {
+            const QJsonArray rw = vj.value("restWorld").toArray();
+            const QJsonArray rd = vj.value("restDir").toArray();
+            if (rw.size() == J && rd.size() == J) {
+                for (const QJsonValue& v : rw) {
+                    const QJsonArray q = v.toArray();
+                    if (q.size() != 4) { vocabRestWorld.clear(); break; }
+                    vocabRestWorld.push_back({float(q[0].toDouble()),
+                                              float(q[1].toDouble()),
+                                              float(q[2].toDouble()),
+                                              float(q[3].toDouble())});
+                }
+                for (const QJsonValue& v : rd) {
+                    const QJsonArray d = v.toArray();
+                    if (d.size() != 3) { vocabRestDir.clear(); break; }
+                    vocabRestDir.push_back({float(d[0].toDouble()),
+                                            float(d[1].toDouble()),
+                                            float(d[2].toDouble())});
+                }
+                if (vocabRestWorld.size() != static_cast<size_t>(J)
+                    || vocabRestDir.size() != static_cast<size_t>(J)) {
+                    vocabRestWorld.clear();
+                    vocabRestDir.clear();
+                }
+            }
+        }
         const int V = vocab.size();
         if (V == 0 || T <= 0 || C != J * 10) {
             r.error = QStringLiteral("t2m vocab json malformed"); return r;
@@ -375,6 +408,8 @@ MotionGenerator::Result MotionGenerator::generate(
             clip.frames = want;
         }
 
+        clip.restWorld = vocabRestWorld;
+        clip.restDir = vocabRestDir;
         r.clip = std::move(clip);
         r.worldFrame = worldFrame;
         r.ok = true;

--- a/src/MotionGenerator.h
+++ b/src/MotionGenerator.h
@@ -22,11 +22,17 @@
 // model is unavailable (no ENABLE_ONNX, model not downloaded, prompt action not
 // in the model's vocab, or inference fails).
 //
-// ONNX contract (must match scripts/train-t2m-onnx-v3.py export):
+// ONNX contract (v5: scripts/train-t2m-flow-v5.py; v4: train-t2m-onnx-v4.py):
 //   input  "tokens" float32 [1, V]    one-hot/bag over the fixed action vocab
-//   input  "seed"   float32 [1, Z]    latent (we pass zeros for the mean clip)
+//   input  "seed"   float32 [1, Z]    latent noise (sampled; best-of-N scored)
 //   output "motion" float32 [1, T, C] C = 22*10 per-joint [t.xyz, q.xyzw, s.xyz]
-// The accompanying t2m-vocab.json gives {vocab, Z, T, C, J, joints}.
+// The accompanying t2m-vocab.json gives {vocab, Z, T, C, J, fps, frame}.
+// v5 FLOW-MATCHING models (#840/#858) keep this exact interface: the Euler
+// sampler is unrolled INSIDE the exported graph (seed = the flattened noise
+// tensor, Z = T·132), and the vocab additionally carries the model's
+// canonical reference triple ("restWorld" identity ×22 + "restDir" canonical
+// T-pose directions) so generated clips ride the same bind-referenced
+// direction retarget as v5 template clips (no standing-pose shim).
 class MotionGenerator {
 public:
     MotionGenerator() = delete;


### PR DESCRIPTION
Closes #840, closes #858 (epic #837). **Stacked on #886** (base = `feat/t2m-twist-857`, the twist transport makes the canonicalization lossless) — retarget to `master` after #886 merges.

## The three pieces

**1. Canonical training data (#858)** — `scripts/prep-t2m-v5.py` re-extracts the full corpus into a rig-independent representation before windowing. Per joint, using each clip's own reference triple (the same one the bind-referenced retarget consumes), the bone's direction trajectory and swing/twist roll residual are rebuilt against a FIXED canonical T-pose direction set:

```
Q'(f) = twist(θ(f), d(f)) · arc(D_c → d(f))
```

Q' is identical for every rig performing the same motion — the v4 "per-rig convention mush" (the measured cause of the CVAE's gentle-average output) is gone by construction. **17,286 windows / 18 actions** (corpus 517 + CMU 16,789; the v4 cache had 47 CMU clips' worth). The neutral-start gate is deliberately dropped: model clips now ride the direction retarget, which references the reference *triple*, not clip frame 0 — any phase is a valid window (huge data win).

**2. Flow-matching model (#840)** — `scripts/train-t2m-flow-v5.py`: 7.3M-param DiT-style velocity transformer (6D rotations, AdaLN-Zero conditioning), rectified-flow objective + classifier-free guidance, class-balanced sampling (walk = 64% of windows). Flow matching samples a transport path to a *single mode* of the data instead of decoding a conditional mean — the architectural fix for the CVAE's structural weakness (per the epic). The Euler sampler (+CFG) is **unrolled inside the exported ONNX graph**, so the shipped `MotionGenerator` contract is byte-identical: `tokens[1,V], seed[1,Z] → motion[1,T,220]` with `seed` = the flattened noise tensor (Z = T·132). No C++ sampler loop needed; best-of-N candidate scoring still works unchanged.

**3. Reference triple wiring (#858)** — the vocab json ships the model's canonical triple (`restWorld` = identity ×22, `restDir` = the canonical T-pose directions). `MotionGenerator` parses it into the generated clip; the CLI/MCP/GUI model paths pass it to `applyMotionClip`, so model clips ride the **same bind-referenced direction retarget as v5 template clips** — the synthetic-standing-pose shim is retired to a legacy-v4 fallback. `applyMotionClip`'s restWorld presence check is now norm-based (identity counts as present; only zero-filled entries mean absent) — the old non-identity check would have silently demoted v5 model clips.

## Evaluation (honest)

Render-verified on the Rumba rig (isometric protocol): model **walk / run / wave / dance are all upright and temporally coherent end-to-end** — every v4 CVAE variant folded, tumbled, or collapsed late-clip. Walk and run read as their actions; wave/dance are coherent but gentler than the template takes.

**Gate verdict: templates remain the default and automatic fallback** (per the epic's eval gate — the model ships opt-in behind `--model` / `model:true` / the GUI checkbox). This is still a step-change over the v4 CVAE for the opt-in path.

Hosting: `scripts/upload-t2m-v5-model.sh` preserves the v4 files under versioned names, then uploads the v5 model+vocab. **Backward-compatible**: the ONNX interface is unchanged, and older builds ignore the vocab's extra keys (they just keep using the standing-pose shim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)