### PR TITLE
feat(#892): DeformationTransfer — Sumner-Popović shape transfer (Face-Rig Slice D)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -128,6 +128,8 @@ AutoRigController.cpp
 UniRigPredictor.cpp
 FaceRig/ArkitTemplate.cpp
 FaceRig/NonRigidICP.cpp
+FaceRig/SparseSolve.cpp
+FaceRig/DeformationTransfer.cpp
 MotionInbetween.cpp
 MotionLibrary.cpp
 MotionGenerator.cpp

--- a/src/FaceRig/DeformationTransfer.cpp
+++ b/src/FaceRig/DeformationTransfer.cpp
@@ -1,0 +1,234 @@
+#include "DeformationTransfer.h"
+
+#include <array>
+#include <cmath>
+
+namespace FaceRig {
+
+namespace {
+
+using Vec3 = std::array<double, 3>;
+using Mat3 = std::array<double, 9>;   // row-major
+
+Vec3 sub(const Vec3& a, const Vec3& b) { return {a[0]-b[0], a[1]-b[1], a[2]-b[2]}; }
+Vec3 cross(const Vec3& a, const Vec3& b)
+{
+    return {a[1]*b[2]-a[2]*b[1], a[2]*b[0]-a[0]*b[2], a[0]*b[1]-a[1]*b[0]};
+}
+double norm(const Vec3& a) { return std::sqrt(a[0]*a[0]+a[1]*a[1]+a[2]*a[2]); }
+
+Vec3 vert(const std::vector<float>& v, int i)
+{
+    return {v[size_t(i)*3], v[size_t(i)*3+1], v[size_t(i)*3+2]};
+}
+
+// 4th "normal" vertex: v4 = v1 + n/√|n|, n = (v2-v1)×(v3-v1)
+Vec3 normalV4(const Vec3& a, const Vec3& b, const Vec3& c)
+{
+    const Vec3 n = cross(sub(b, a), sub(c, a));
+    const double ln = norm(n);
+    const double s = ln > 1e-12 ? 1.0 / std::sqrt(ln) : 0.0;
+    return {a[0]+n[0]*s, a[1]+n[1]*s, a[2]+n[2]*s};
+}
+
+// frame V = [v2-v1, v3-v1, v4-v1] as columns (row-major 3x3)
+Mat3 frame(const Vec3& a, const Vec3& b, const Vec3& c, const Vec3& d)
+{
+    const Vec3 e1 = sub(b,a), e2 = sub(c,a), e3 = sub(d,a);
+    return {e1[0], e2[0], e3[0],
+            e1[1], e2[1], e3[1],
+            e1[2], e2[2], e3[2]};
+}
+
+bool invert3(const Mat3& m, Mat3& out)
+{
+    const double det =
+        m[0]*(m[4]*m[8]-m[5]*m[7]) - m[1]*(m[3]*m[8]-m[5]*m[6])
+      + m[2]*(m[3]*m[7]-m[4]*m[6]);
+    if (std::abs(det) < 1e-18)
+        return false;
+    const double id = 1.0/det;
+    out[0] = (m[4]*m[8]-m[5]*m[7])*id;
+    out[1] = (m[2]*m[7]-m[1]*m[8])*id;
+    out[2] = (m[1]*m[5]-m[2]*m[4])*id;
+    out[3] = (m[5]*m[6]-m[3]*m[8])*id;
+    out[4] = (m[0]*m[8]-m[2]*m[6])*id;
+    out[5] = (m[2]*m[3]-m[0]*m[5])*id;
+    out[6] = (m[3]*m[7]-m[4]*m[6])*id;
+    out[7] = (m[1]*m[6]-m[0]*m[7])*id;
+    out[8] = (m[0]*m[4]-m[1]*m[3])*id;
+    return true;
+}
+
+Mat3 matmul(const Mat3& a, const Mat3& b)
+{
+    Mat3 r{};
+    for (int i = 0; i < 3; ++i)
+        for (int j = 0; j < 3; ++j)
+            for (int k = 0; k < 3; ++k)
+                r[size_t(i*3+j)] += a[size_t(i*3+k)] * b[size_t(k*3+j)];
+    return r;
+}
+
+}  // namespace
+
+bool DeformationTransfer::init(const std::vector<float>& tmplNeutral,
+                               const std::vector<int>& faces,
+                               const std::vector<float>& fitted)
+{
+    m_valid = false;
+    const int N = int(tmplNeutral.size() / 3);
+    const int F = int(faces.size() / 3);
+    if (N < 3 || F < 1 || int(fitted.size() / 3) != N)
+        return false;
+
+    m_n = N;
+    m_tmplNeutral = tmplNeutral;
+    m_faces = faces;
+    m_fitted = fitted;
+    m_srcRestInv.assign(size_t(F), {});
+    m_tgtRestInv.assign(size_t(F), {});
+    m_tgtNormalV4.assign(size_t(F), {});
+
+    // Unknowns (per axis, solved independently): the N deformed FITTED vertices
+    // PLUS one free "4th vertex" per triangle (columns N..N+F-1). The 4th vertex
+    // is Sumner's normal-direction trick: it only exists to make each triangle
+    // frame V = [x1-x0, x2-x0, x4-x0] a full-rank 3x3, and in the DEFORMED solve
+    // it is left UNCONSTRAINED (no normal equation pins it) — it simply absorbs
+    // the out-of-plane component the two edges can't represent.
+    //
+    // Per triangle the deformation gradient w.r.t. the target REST frame is
+    //   A_f = Vtgt_deformed · Vtgt_rest⁻¹,   and we require A_f == S_f (source).
+    // Each of the 3 gradient columns g gives one row (per axis): the deformed
+    // edge combination Σ_col Vinv[col][g]·(x_{col}-x0) must equal S column g.
+    // Anchor rows (small weight x_i == rest_i) fix the translation gauge.
+
+    std::vector<std::array<double, 3>> trip;
+    trip.reserve(size_t(F) * 3 * 4 + size_t(N));
+
+    auto pushGrad = [&](int rowBase, int f) {
+        const int i0 = m_faces[size_t(f)*3];
+        const int i1 = m_faces[size_t(f)*3+1];
+        const int i2 = m_faces[size_t(f)*3+2];
+        const int i3 = N + f;                    // the free 4th-vertex column
+        const Vec3 a = vert(m_fitted, i0), b = vert(m_fitted, i1), c = vert(m_fitted, i2);
+        const Vec3 d = normalV4(a, b, c);
+        m_tgtNormalV4[size_t(f)] = d;
+        Mat3 Vt = frame(a, b, c, d), Vinv;
+        if (!invert3(Vt, Vinv)) {
+            // degenerate target triangle — skip its gradient rows (anchors keep it)
+            m_tgtRestInv[size_t(f)] = {};
+            return;
+        }
+        m_tgtRestInv[size_t(f)] = Vinv;
+        // edges columns are [x1-x0, x2-x0, x4-x0]; gradient column g combines
+        // them by Vinv[col][g]. Distribute onto the four real unknowns:
+        //   x1 → Vinv[0][g], x2 → Vinv[1][g], x4 → Vinv[2][g],
+        //   x0 → -(sum of the three)  (from every -x0 term)
+        for (int g = 0; g < 3; ++g) {
+            const double w1 = Vinv[size_t(0*3+g)];
+            const double w2 = Vinv[size_t(1*3+g)];
+            const double w4 = Vinv[size_t(2*3+g)];
+            const double w0 = -(w1 + w2 + w4);
+            const int row = rowBase + g;
+            trip.push_back({double(row), double(i0), w0});
+            trip.push_back({double(row), double(i1), w1});
+            trip.push_back({double(row), double(i2), w2});
+            trip.push_back({double(row), double(i3), w4});
+        }
+    };
+
+    // rows: 3 per triangle (gradient columns) + ONE anchor row.
+    // columns: N real verts + F free 4th-vertices.
+    //
+    // Deformation gradients are translation-invariant, so the system is only
+    // determined up to a global translation. We pin exactly ONE real vertex
+    // (index 0) to fix that gauge — anchoring EVERY vertex would fight the
+    // shape (the gradients want expr, the anchor wants neutral) and pull the
+    // solution back toward the neutral, corrupting the transfer.
+    for (int f = 0; f < F; ++f)
+        pushGrad(3 * f, f);
+    const double anchorW = 1.0;
+    trip.push_back({double(3 * F), 0.0, anchorW});
+
+    m_A.fromTriplets(3 * F + 1, N + F, trip);
+
+    // source (template) rest inverse frames — for building S_f per shape
+    for (int f = 0; f < F; ++f) {
+        const int i0 = m_faces[size_t(f)*3];
+        const int i1 = m_faces[size_t(f)*3+1];
+        const int i2 = m_faces[size_t(f)*3+2];
+        const Vec3 a = vert(m_tmplNeutral, i0), b = vert(m_tmplNeutral, i1),
+                   c = vert(m_tmplNeutral, i2);
+        const Vec3 d = normalV4(a, b, c);
+        Mat3 Vs = frame(a, b, c, d), Vinv;
+        m_srcRestInv[size_t(f)] = invert3(Vs, Vinv) ? Vinv : Mat3{};
+    }
+
+    m_valid = true;
+    return true;
+}
+
+std::vector<float> DeformationTransfer::transfer(
+    const std::vector<float>& tmplExprDelta) const
+{
+    if (!m_valid || int(tmplExprDelta.size() / 3) != m_n)
+        return {};
+    const int F = int(m_faces.size() / 3);
+
+    // template EXPRESSION verts = neutral + delta
+    std::vector<float> expr(m_tmplNeutral.size());
+    for (size_t i = 0; i < expr.size(); ++i)
+        expr[i] = m_tmplNeutral[i] + tmplExprDelta[i];
+
+    // Build rhs for each of the 3 output axes. For triangle f:
+    //   S_f = Vsrc_expr · Vsrc_rest⁻¹      (3x3 source deformation gradient).
+    // The gradient constraint rows require the target gradient column g == S
+    // column g; the free 4th vertex is an unknown (its normal equation exists
+    // in the matrix), so the rhs is just S — no rest-approximation term.
+    const int nCols = m_n + F;
+    std::vector<std::vector<double>> rhs(3, std::vector<double>(size_t(3 * F + 1), 0.0));
+
+    for (int f = 0; f < F; ++f) {
+        const int i0 = m_faces[size_t(f)*3];
+        const int i1 = m_faces[size_t(f)*3+1];
+        const int i2 = m_faces[size_t(f)*3+2];
+        // source expression frame
+        Vec3 a{expr[size_t(i0)*3], expr[size_t(i0)*3+1], expr[size_t(i0)*3+2]};
+        Vec3 b{expr[size_t(i1)*3], expr[size_t(i1)*3+1], expr[size_t(i1)*3+2]};
+        Vec3 c{expr[size_t(i2)*3], expr[size_t(i2)*3+1], expr[size_t(i2)*3+2]};
+        Vec3 d = normalV4(a, b, c);
+        Mat3 Vexpr = frame(a, b, c, d);
+        const Mat3& VsInv = m_srcRestInv[size_t(f)];
+        const Mat3 S = matmul(Vexpr, VsInv);   // 3x3 source gradient
+        for (int axis = 0; axis < 3; ++axis)
+            for (int g = 0; g < 3; ++g)
+                rhs[size_t(axis)][size_t(3*f+g)] = S[size_t(axis*3+g)];
+    }
+    // anchor rhs: pin vertex 0 to (fitted rest + the template's vertex-0
+    // displacement) — fixes the translation gauge while letting the shape
+    // move vertex 0 the same way the source moved its vertex 0. For the
+    // identity fit this is exactly expr[0].
+    const double anchorW = 1.0;
+    for (int axis = 0; axis < 3; ++axis)
+        rhs[size_t(axis)][size_t(3*F)] =
+            anchorW * (m_fitted[axis] + tmplExprDelta[size_t(axis)]);
+
+    // solve per axis (warm-start real verts at the fitted rest, 4th verts at
+    // their rest normal offset). Read back only the N real vertices as a delta.
+    std::vector<float> out(size_t(m_n) * 3, 0.0f);
+    for (int axis = 0; axis < 3; ++axis) {
+        std::vector<double> x(size_t(nCols), 0.0);
+        for (int i = 0; i < m_n; ++i)
+            x[size_t(i)] = m_fitted[size_t(i)*3+axis];
+        for (int f = 0; f < F; ++f)
+            x[size_t(m_n + f)] = m_tgtNormalV4[size_t(f)][size_t(axis)];
+        solveLeastSquaresCG(m_A, rhs[size_t(axis)], x, 800, 1e-8);
+        for (int i = 0; i < m_n; ++i)
+            out[size_t(i)*3+axis] =
+                float(x[size_t(i)] - m_fitted[size_t(i)*3+axis]);  // delta
+    }
+    return out;
+}
+
+}  // namespace FaceRig

--- a/src/FaceRig/DeformationTransfer.h
+++ b/src/FaceRig/DeformationTransfer.h
@@ -1,0 +1,69 @@
+#ifndef DEFORMATIONTRANSFER_H
+#define DEFORMATIONTRANSFER_H
+
+// Deformation transfer (Sumner & Popović 2004) for face auto-rig (#889,
+// Slice D #892). Pure data — no Ogre, reuses FaceRig::SparseMatrix — and
+// headless-tested.
+//
+// Given the NRICP correspondence (template verts fitted onto the USER
+// identity, in TEMPLATE topology — from NonRigidICP #891) and the template's
+// per-shape neutral→expression delta, transfer each expression's per-triangle
+// deformation onto the fitted (user-identity) mesh. The output is the
+// expression realized on the user's identity, still in template topology, as
+// a per-template-vertex delta from the fitted neutral. FaceRigger (#893)
+// resamples that to the real user vertices via the correspondence.
+//
+// Method: per source triangle build the deformation gradient
+//     S = [e1' e2' n'] · [e1 e2 n]⁻¹
+// (Sumner's 4th "normal" vertex trick: n = (e1×e2)/√|e1×e2|), where the
+// unprimed frame is the template NEUTRAL triangle and the primed is the
+// template EXPRESSION triangle. Then solve, over the FITTED mesh, for vertex
+// positions whose per-triangle deformation gradient matches S — one sparse
+// least-squares (the Sumner-Popović matrix), with the fitted neutral as the
+// rest state, plus a small anchor term to pin the solution (deformation
+// gradients are translation-free).
+
+#include "SparseSolve.h"
+
+#include <vector>
+
+namespace FaceRig {
+
+// Precomputes the per-triangle rest frames of the FITTED mesh once, so all 52
+// shapes transfer without rebuilding the (topology-fixed) system.
+class DeformationTransfer {
+public:
+    // tmplNeutral / faces: the TEMPLATE neutral verts (N*3) + tris (F*3).
+    // fitted: template verts fitted onto the user identity (N*3) — the NRICP
+    // correspondence; SAME topology as the template.
+    bool init(const std::vector<float>& tmplNeutral,
+              const std::vector<int>& faces,
+              const std::vector<float>& fitted);
+
+    bool valid() const { return m_valid; }
+    int vertexCount() const { return m_n; }
+
+    // Transfer one template shape (tmplExprDelta = expr - tmplNeutral, N*3) →
+    // a per-vertex delta on the FITTED mesh (N*3, added to `fitted` gives the
+    // expression on the user identity). Returns empty on failure.
+    std::vector<float> transfer(const std::vector<float>& tmplExprDelta) const;
+
+private:
+    bool m_valid = false;
+    int m_n = 0;
+    std::vector<float> m_tmplNeutral;   // template rest (for source gradients)
+    std::vector<int> m_faces;
+    std::vector<float> m_fitted;        // target rest (user identity)
+    // The transfer system A x = c is fixed by topology + fitted rest; only c
+    // (built from each shape's source deformation gradient) changes per shape.
+    SparseMatrix m_A;
+    // per-triangle inverse rest frames of the TEMPLATE neutral (source) and of
+    // the FITTED mesh (target), cached for building c.
+    std::vector<std::array<double, 9>> m_srcRestInv;   // 3x3 per tri
+    std::vector<std::array<double, 9>> m_tgtRestInv;
+    std::vector<std::array<double, 3>> m_tgtNormalV4;   // fitted 4th vertex/tri
+};
+
+}  // namespace FaceRig
+
+#endif  // DEFORMATIONTRANSFER_H

--- a/src/FaceRig/DeformationTransfer_test.cpp
+++ b/src/FaceRig/DeformationTransfer_test.cpp
@@ -1,0 +1,149 @@
+#include <gtest/gtest.h>
+
+#include "FaceRig/DeformationTransfer.h"
+
+#include <cmath>
+#include <vector>
+
+namespace {
+
+struct Grid {
+    std::vector<float> V;
+    std::vector<int> F;
+};
+
+// A bumpy plane grid — real triangles for the per-face deformation gradients.
+Grid makeGrid(int n, float extent, float bump = 0.0f)
+{
+    Grid g;
+    for (int y = 0; y < n; ++y)
+        for (int x = 0; x < n; ++x) {
+            const float fx = (float(x)/(n-1) - 0.5f) * extent;
+            const float fy = (float(y)/(n-1) - 0.5f) * extent;
+            const float fz = bump * std::sin(float(x)) * std::cos(float(y));
+            g.V.insert(g.V.end(), {fx, fy, fz});
+        }
+    for (int y = 0; y < n-1; ++y)
+        for (int x = 0; x < n-1; ++x) {
+            const int a = y*n+x, b = y*n+x+1, c = (y+1)*n+x, d = (y+1)*n+x+1;
+            g.F.insert(g.F.end(), {a, b, c});
+            g.F.insert(g.F.end(), {b, d, c});
+        }
+    return g;
+}
+
+double diag(const std::vector<float>& v)
+{
+    float lo[3] = {1e30f,1e30f,1e30f}, hi[3] = {-1e30f,-1e30f,-1e30f};
+    for (size_t i = 0; i < v.size(); i += 3)
+        for (int a = 0; a < 3; ++a) {
+            lo[a] = std::min(lo[a], v[i+a]);
+            hi[a] = std::max(hi[a], v[i+a]);
+        }
+    double s = 0;
+    for (int a = 0; a < 3; ++a) s += double(hi[a]-lo[a])*double(hi[a]-lo[a]);
+    return std::sqrt(s);
+}
+
+double maxAbs(const std::vector<float>& v)
+{
+    double m = 0;
+    for (float x : v) m = std::max(m, double(std::abs(x)));
+    return m;
+}
+
+}  // namespace
+
+TEST(DeformationTransfer, RejectsBadInput)
+{
+    FaceRig::DeformationTransfer dt;
+    const Grid g = makeGrid(6, 2.0f);
+    EXPECT_FALSE(dt.init({}, {}, {}));                 // empty
+    EXPECT_FALSE(dt.init(g.V, g.F, {}));               // fitted count mismatch
+    EXPECT_FALSE(dt.valid());
+    // valid init
+    EXPECT_TRUE(dt.init(g.V, g.F, g.V));
+    EXPECT_TRUE(dt.valid());
+    EXPECT_EQ(dt.vertexCount(), int(g.V.size()/3));
+}
+
+// Identity: fitted == template neutral. Transferring a shape's delta should
+// reproduce (approximately) that same delta — the source and target rest
+// frames are identical, so the deformation gradients map back to the input.
+TEST(DeformationTransfer, IdentityFitReproducesShapeDelta)
+{
+    const Grid g = makeGrid(10, 2.0f, 0.1f);
+    FaceRig::DeformationTransfer dt;
+    ASSERT_TRUE(dt.init(g.V, g.F, g.V));
+
+    // a shape: push the centre region up in +Z (like a smile bump)
+    const int n = int(g.V.size()/3);
+    std::vector<float> delta(g.V.size(), 0.0f);
+    for (int i = 0; i < n; ++i) {
+        const float x = g.V[size_t(i)*3], y = g.V[size_t(i)*3+1];
+        const float bump = 0.15f * std::exp(-(x*x + y*y) * 4.0f);
+        delta[size_t(i)*3+2] = bump;
+    }
+    const auto out = dt.transfer(delta);
+    ASSERT_EQ(out.size(), delta.size());
+    for (float v : out) ASSERT_TRUE(std::isfinite(v));
+
+    // out should track delta closely (identity transfer). Compare RMS error.
+    double num = 0, den = 0;
+    for (size_t i = 0; i < delta.size(); ++i) {
+        const double d = double(out[i]) - double(delta[i]);
+        num += d*d;
+        den += double(delta[i])*double(delta[i]);
+    }
+    const double relRms = std::sqrt(num / std::max(den, 1e-12));
+    EXPECT_LT(relRms, 0.15);   // within 15% of the original shape
+}
+
+// Winding / orientation preserved: transferring onto a UNIFORMLY SCALED user
+// identity should scale the shape delta by the same factor (deformation
+// gradients are scale-covariant), and keep signs (no inside-out flip).
+TEST(DeformationTransfer, ScaledIdentityScalesTheDelta)
+{
+    const Grid tmpl = makeGrid(10, 2.0f, 0.1f);
+    // fitted = template scaled 2x (a "bigger head")
+    std::vector<float> fitted(tmpl.V.size());
+    for (size_t i = 0; i < fitted.size(); ++i) fitted[i] = tmpl.V[i] * 2.0f;
+
+    FaceRig::DeformationTransfer dt;
+    ASSERT_TRUE(dt.init(tmpl.V, tmpl.F, fitted));
+
+    const int n = int(tmpl.V.size()/3);
+    std::vector<float> delta(tmpl.V.size(), 0.0f);
+    for (int i = 0; i < n; ++i) {
+        const float x = tmpl.V[size_t(i)*3], y = tmpl.V[size_t(i)*3+1];
+        delta[size_t(i)*3+2] = 0.12f * std::exp(-(x*x + y*y) * 4.0f);
+    }
+    const auto out = dt.transfer(delta);
+    ASSERT_EQ(out.size(), delta.size());
+    for (float v : out) ASSERT_TRUE(std::isfinite(v));
+
+    // on a 2x mesh the same relative deformation should be ~2x the amplitude
+    const double dIn = maxAbs(delta);
+    const double dOut = maxAbs(out);
+    EXPECT_GT(dOut, dIn * 1.3);   // clearly scaled up
+    EXPECT_LT(dOut, dIn * 3.0);   // but bounded
+
+    // sign preserved: peak stays +Z (no flip)
+    double peak = 0;
+    for (int i = 0; i < n; ++i)
+        if (std::abs(out[size_t(i)*3+2]) > std::abs(peak))
+            peak = out[size_t(i)*3+2];
+    EXPECT_GT(peak, 0.0);
+}
+
+// Zero shape → zero delta (the neutral maps to the neutral).
+TEST(DeformationTransfer, ZeroDeltaProducesZero)
+{
+    const Grid g = makeGrid(8, 2.0f, 0.1f);
+    FaceRig::DeformationTransfer dt;
+    ASSERT_TRUE(dt.init(g.V, g.F, g.V));
+    std::vector<float> zero(g.V.size(), 0.0f);
+    const auto out = dt.transfer(zero);
+    ASSERT_EQ(out.size(), zero.size());
+    EXPECT_LT(maxAbs(out) / diag(g.V), 1e-3);
+}

--- a/src/FaceRig/SparseSolve.cpp
+++ b/src/FaceRig/SparseSolve.cpp
@@ -1,0 +1,87 @@
+#include "SparseSolve.h"
+
+namespace FaceRig {
+
+void SparseMatrix::fromTriplets(int r, int c,
+                                const std::vector<std::array<double, 3>>& trip)
+{
+    rows = r;
+    cols = c;
+    std::vector<int> cnt(size_t(r) + 1, 0);
+    for (const auto& t : trip)
+        cnt[size_t(t[0]) + 1]++;
+    for (int i = 0; i < r; ++i)
+        cnt[size_t(i) + 1] += cnt[size_t(i)];
+    m_rowPtr = cnt;
+    m_col.resize(trip.size());
+    m_val.resize(trip.size());
+    std::vector<int> cur = m_rowPtr;
+    for (const auto& t : trip) {
+        const int rr = int(t[0]);
+        const int dst = cur[size_t(rr)]++;
+        m_col[size_t(dst)] = int(t[1]);
+        m_val[size_t(dst)] = t[2];
+    }
+}
+
+void SparseMatrix::mul(const std::vector<double>& x, std::vector<double>& y) const
+{
+    y.assign(size_t(rows), 0.0);
+    for (int r = 0; r < rows; ++r) {
+        double s = 0;
+        for (int k = m_rowPtr[size_t(r)]; k < m_rowPtr[size_t(r) + 1]; ++k)
+            s += m_val[size_t(k)] * x[size_t(m_col[size_t(k)])];
+        y[size_t(r)] = s;
+    }
+}
+
+void SparseMatrix::mulT(const std::vector<double>& x, std::vector<double>& y) const
+{
+    y.assign(size_t(cols), 0.0);
+    for (int r = 0; r < rows; ++r) {
+        const double xr = x[size_t(r)];
+        for (int k = m_rowPtr[size_t(r)]; k < m_rowPtr[size_t(r) + 1]; ++k)
+            y[size_t(m_col[size_t(k)])] += m_val[size_t(k)] * xr;
+    }
+}
+
+void solveLeastSquaresCG(const SparseMatrix& A, const std::vector<double>& b,
+                         std::vector<double>& x, int maxIters, double tol)
+{
+    std::vector<double> Ax, r, p, Ap, AtAp;
+    A.mul(x, Ax);
+    std::vector<double> resid(size_t(A.rows));
+    for (int i = 0; i < A.rows; ++i)
+        resid[size_t(i)] = b[size_t(i)] - Ax[size_t(i)];
+    A.mulT(resid, r);                     // r = Aᵀ(b - Ax)
+    p = r;
+    double rs = 0;
+    for (double v : r)
+        rs += v * v;
+    const double rs0 = rs;
+    if (rs0 <= 0.0)
+        return;
+    for (int it = 0; it < maxIters && rs > tol * tol * rs0; ++it) {
+        A.mul(p, Ap);
+        A.mulT(Ap, AtAp);                 // AtAp = AᵀA p
+        double pAp = 0;
+        for (int i = 0; i < A.cols; ++i)
+            pAp += p[size_t(i)] * AtAp[size_t(i)];
+        if (pAp <= 1e-30)
+            break;
+        const double a = rs / pAp;
+        for (int i = 0; i < A.cols; ++i) {
+            x[size_t(i)] += a * p[size_t(i)];
+            r[size_t(i)] -= a * AtAp[size_t(i)];
+        }
+        double rsn = 0;
+        for (double v : r)
+            rsn += v * v;
+        const double beta = rsn / rs;
+        for (int i = 0; i < A.cols; ++i)
+            p[size_t(i)] = r[size_t(i)] + beta * p[size_t(i)];
+        rs = rsn;
+    }
+}
+
+}  // namespace FaceRig

--- a/src/FaceRig/SparseSolve.h
+++ b/src/FaceRig/SparseSolve.h
@@ -1,0 +1,39 @@
+#ifndef FACERIG_SPARSESOLVE_H
+#define FACERIG_SPARSESOLVE_H
+
+// Minimal dependency-free sparse linear algebra for the face-rig native
+// solvers. A CSR matrix built from triplets + conjugate-gradient on the normal
+// equations (AᵀA x = Aᵀb) — no Eigen, no external solver. Pure data,
+// headless-tested. Used by DeformationTransfer (#892); NonRigidICP (#891) still
+// carries its own equivalent copy and can be migrated onto this in a follow-up.
+
+#include <array>
+#include <vector>
+
+namespace FaceRig {
+
+class SparseMatrix {
+public:
+    int rows = 0, cols = 0;
+
+    // Build from triplets {row, col, value}; duplicates are summed on multiply
+    // (CG only needs the products, so we keep them un-coalesced).
+    void fromTriplets(int r, int c, const std::vector<std::array<double, 3>>& trip);
+
+    void mul(const std::vector<double>& x, std::vector<double>& y) const;   // y = A x
+    void mulT(const std::vector<double>& x, std::vector<double>& y) const;  // y = Aᵀ x
+
+private:
+    std::vector<int> m_rowPtr, m_col;
+    std::vector<double> m_val;
+};
+
+// Solve min ‖A x - b‖² by CG on the normal equations, warm-started at x
+// (in/out). b has A.rows entries, x has A.cols.
+void solveLeastSquaresCG(const SparseMatrix& A, const std::vector<double>& b,
+                         std::vector<double>& x, int maxIters = 400,
+                         double tol = 1e-6);
+
+}  // namespace FaceRig
+
+#endif  // FACERIG_SPARSESOLVE_H


### PR DESCRIPTION
Face-Rig epic #889, **Slice D** (#892). Stacked on Slice C (#899) — review/merge that first.

## What
Transfers each ARKit template expression's per-triangle deformation onto the **user-identity** mesh produced by the NRICP fit (#891), still in template topology. This is the Sumner & Popović (2004) deformation transfer, upgraded from the spike's simplified form to the full **deformation-gradient** method the spike doc (`docs/FACE_RIG_SPIKE.md`) specified for production.

## How
- **`SparseSolve.{h,cpp}`** — dependency-free CSR matrix (`fromTriplets`/`mul`/`mulT`) + conjugate-gradient on the normal equations (CGNR). No Eigen, no external solver (house pattern: zero new dependencies). Factored out so it's the shared home for the face-rig native solvers.
- **`DeformationTransfer.{h,cpp}`** — per source triangle builds the deformation gradient `S = [e1' e2' n']·[e1 e2 n]⁻¹` (Sumner's 4th "normal" vertex trick), then solves one sparse least-squares over the fitted mesh for vertex positions whose per-triangle gradient matches `S`. The 4th vertex is a **free per-triangle unknown**; the translation gauge is fixed by anchoring a **single** vertex to the source's own vertex-0 displacement (anchoring every vertex fights the shape and pulls the result back toward neutral). `init()` precomputes the topology-fixed system once so all 52 shapes transfer without rebuilding.

## Tests (headless, `DeformationTransfer_test.cpp`)
- identity round-trip reproduces the shape delta (<15% RMS)
- transfer onto a 2× identity is scale-covariant with sign/winding preserved
- zero delta → zero
- bad-input rejection

All 4 pass; the full FaceRig suite (NonRigidICP + ArkitTemplate + DeformationTransfer = 15 tests) stays green.

## Next
Slice E (#893): `FaceRigger` chains NRICP → DeformationTransfer over all 52 shapes, resamples to the real user vertices via the correspondence, attaches the targets, `qtmesh facerig` CLI + MCP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)