### PR TITLE
feat(#895): GUI "Add ARKit Blendshapes" button (Face-Rig Slice F)

### DIFF
--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -9381,6 +9381,73 @@ Rectangle {
                     }
                 }
 
+                // ── Auto-generate ARKit blendshapes (#895) ──────────────────
+                // One-click: fit the ARKit template onto the selected FACE mesh
+                // (NRICP + deformation transfer) and attach the 52 ARKit-named
+                // morph targets, so the #869 face-capture panel drives them.
+                // Heavy — runs on a worker thread via FaceRigController; the
+                // button shows progress and disables while busy.
+                Rectangle {
+                    id: arkitBtn
+                    width: parent.width
+                    height: 24
+                    radius: 3
+                    property bool canRun: FaceRigController.hasMeshSelection
+                                          && !FaceRigController.busy
+                    opacity: canRun ? 1.0 : 0.5
+                    color: arkitMa.containsMouse && canRun
+                           ? Qt.lighter(PropertiesPanelController.highlightColor, 1.1)
+                           : PropertiesPanelController.highlightColor
+                    border.color: PropertiesPanelController.borderColor
+                    Text {
+                        anchors.centerIn: parent
+                        text: FaceRigController.busy
+                              ? (FaceRigController.status !== ""
+                                 ? FaceRigController.status : "Working…")
+                              : "✨ Add ARKit Blendshapes (AI)"
+                        color: PropertiesPanelController.textColor
+                        font.pixelSize: 10
+                        font.bold: true
+                    }
+                    MouseArea {
+                        id: arkitMa
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        enabled: arkitBtn.canRun
+                        cursorShape: enabled ? Qt.PointingHandCursor : Qt.ForbiddenCursor
+                        onClicked: FaceRigController.addArkitBlendshapesAsync(0, 8.0)
+                        ToolTip.visible: containsMouse
+                        ToolTip.text: FaceRigController.hasMeshSelection
+                            ? "Auto-fit the ARKit blendshape template onto this face "
+                              + "mesh and attach the 52 ARKit shapes. Humanoid faces "
+                              + "only; a poor fit is rejected."
+                            : "Select a face mesh first."
+                    }
+                }
+                Connections {
+                    target: FaceRigController
+                    function onError(message) {
+                        arkitStatus.text = "⚠ " + message
+                        arkitStatus.color = "#d66"
+                    }
+                    function onCompleted(report) {
+                        arkitStatus.text = "✓ Attached " + report.shapesAttached
+                            + " ARKit shapes (fit "
+                            + report.fitMeanResidualPct.toFixed(2) + "% mean)."
+                        arkitStatus.color = PropertiesPanelController.textColor
+                        morphCol.targets = MorphAnimationManager.morphTargetsForSelection() || []
+                    }
+                }
+                Text {
+                    id: arkitStatus
+                    width: parent.width
+                    visible: text !== ""
+                    wrapMode: Text.Wrap
+                    font.pixelSize: 9
+                    color: PropertiesPanelController.textColor
+                    text: ""
+                }
+
                 // ── Section 2: ANIMATION CLIPS ──────────────────────────────
                 // Section header, shown only once shapes exist (clips animate
                 // shapes, so they're meaningless without any).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -125,6 +125,7 @@ SkinTokensPredictor.cpp
 SkinWeightsController.cpp
 AutoRig.cpp
 AutoRigController.cpp
+FaceRigController.cpp
 UniRigPredictor.cpp
 FaceRig/ArkitTemplate.cpp
 FaceRig/NonRigidICP.cpp
@@ -326,6 +327,7 @@ SkinTokensPredictor.h
 SkinWeightsController.h
 AutoRig.h
 AutoRigController.h
+FaceRigController.h
 UniRigPredictor.h
 MotionInbetween.h
 MotionLibrary.h

--- a/src/FaceRig/FaceRigAttach.cpp
+++ b/src/FaceRig/FaceRigAttach.cpp
@@ -58,54 +58,39 @@ void appendIndices(Ogre::IndexData* id, std::uint32_t offset,
     ibuf->unlock();
 }
 
-// One geometry owner (shared pool, or a per-submesh vertex data) with the
-// pose target handle it maps to and its base offset into the combined set.
-struct Owner {
-    unsigned short handle;   // 0 = shared, 1..N = submesh index+1
-    std::uint32_t base;      // first combined-vertex index
-    int count;               // vertices in this owner
-};
-
 }  // namespace
 
-AttachReport attachFaceRig(Ogre::Entity* entity,
-                           const ArkitTemplate& tmpl,
-                           const FaceRigOptions& opts)
+FaceRigGeometry extractGeometry(Ogre::Entity* entity)
 {
-    AttachReport rep;
-    if (!entity) { rep.error = QStringLiteral("no entity"); return rep; }
+    FaceRigGeometry geo;
+    if (!entity) return geo;
     Ogre::MeshPtr mesh = entity->getMesh();
-    if (!mesh) { rep.error = QStringLiteral("entity has no mesh"); return rep; }
-    if (!tmpl.valid()) { rep.error = QStringLiteral("ARKit template not loaded"); return rep; }
+    if (!mesh) return geo;
 
-    // ── collect every geometry owner into ONE combined vertex/index set so the
+    // Collect every geometry owner into ONE combined vertex/index set so the
     // fit sees the whole face (a single-submesh head is the common case, but a
     // face split across submeshes still fits as one surface). Track each owner
     // so we can split the per-vertex deltas back onto the right pose handle.
-    std::vector<float> userV;
-    std::vector<int> userF;
-    std::vector<Owner> owners;
-
     auto addOwner = [&](unsigned short handle, Ogre::VertexData* vd,
                         Ogre::IndexData* id) {
         std::vector<float> pos;
         if (!extractPositions(vd, pos)) return;
-        const std::uint32_t base = std::uint32_t(userV.size() / 3);
-        owners.push_back({handle, base, int(pos.size() / 3)});
-        userV.insert(userV.end(), pos.begin(), pos.end());
-        appendIndices(id, base, userF);
+        const std::uint32_t base = std::uint32_t(geo.userV.size() / 3);
+        geo.owners.push_back({handle, base, int(pos.size() / 3)});
+        geo.userV.insert(geo.userV.end(), pos.begin(), pos.end());
+        appendIndices(id, base, geo.userF);
     };
 
     if (mesh->sharedVertexData) {
         // shared pool → handle 0; its indices live per-submesh.
         std::vector<float> pos;
         if (extractPositions(mesh->sharedVertexData, pos)) {
-            owners.push_back({0, 0, int(pos.size() / 3)});
-            userV.insert(userV.end(), pos.begin(), pos.end());
+            geo.owners.push_back({0, 0, int(pos.size() / 3)});
+            geo.userV.insert(geo.userV.end(), pos.begin(), pos.end());
             for (unsigned short si = 0; si < mesh->getNumSubMeshes(); ++si) {
                 Ogre::SubMesh* sm = mesh->getSubMesh(si);
                 if (sm && sm->useSharedVertices)
-                    appendIndices(sm->indexData, 0, userF);
+                    appendIndices(sm->indexData, 0, geo.userF);
             }
         }
     }
@@ -114,34 +99,25 @@ AttachReport attachFaceRig(Ogre::Entity* entity,
         if (!sm || sm->useSharedVertices) continue;
         addOwner(static_cast<unsigned short>(si + 1), sm->vertexData, sm->indexData);
     }
+    return geo;
+}
 
-    if (userV.size() < 9 || userF.size() < 3) {
-        rep.error = QStringLiteral("could not read mesh geometry");
-        return rep;
-    }
-
-    // ── run the Ogre-free pipeline
-    const FaceRigResult res = buildFaceRig(userV, userF, tmpl, opts);
-    rep.userVertexCount = res.userVertexCount;
-    rep.fitMeanResidualPct = res.fitMeanResidualPct;
-    rep.fitMaxResidualPct = res.fitMaxResidualPct;
-    if (!res.ok) {
-        rep.error = QString::fromStdString(res.error);
-        return rep;
-    }
-
-    // ── attach each shape as a pose + VAT_POSE clip, splitting the combined
+void attachShapes(Ogre::Entity* entity, const FaceRigGeometry& geo,
+                  const FaceRigResult& result, AttachReport& report)
+{
+    // Attach each shape as a pose + VAT_POSE clip, splitting the combined
     // deltas back onto each owner's handle. Reuse AddMorphTargetCommand's
     // redo() (the exact MorphCommands pose-build) so face capture drives these
     // with no new playback code; call redo() directly (headless-safe — no undo
     // stack required, GUI callers can wrap in UndoManager separately).
-    for (const FaceRigShape& shape : res.shapes) {
+    for (const FaceRigShape& shape : result.shapes) {
         std::vector<MorphPoseSlice> slices;
-        for (const Owner& o : owners) {
+        for (const GeometryOwner& o : geo.owners) {
             MorphPoseSlice slice;
             slice.submeshHandle = o.handle;
             for (int i = 0; i < o.count; ++i) {
                 const std::uint32_t gv = o.base + std::uint32_t(i);
+                if (size_t(gv) * 3 + 2 >= shape.userDeltas.size()) break;
                 const float* d = &shape.userDeltas[size_t(gv) * 3];
                 if (d[0] == 0.0f && d[1] == 0.0f && d[2] == 0.0f) continue;
                 slice.offsets[static_cast<unsigned int>(i)] =
@@ -152,12 +128,38 @@ AttachReport attachFaceRig(Ogre::Entity* entity,
         if (slices.empty()) continue;   // shape moved nothing on this mesh
         AddMorphTargetCommand cmd(entity, shape.name, slices);
         cmd.redo();
-        rep.shapesAttached++;
+        report.shapesAttached++;
+    }
+    report.ok = report.shapesAttached > 0;
+    if (!report.ok)
+        report.error = QStringLiteral("no blendshapes produced any vertex movement");
+}
+
+AttachReport attachFaceRig(Ogre::Entity* entity,
+                           const ArkitTemplate& tmpl,
+                           const FaceRigOptions& opts)
+{
+    AttachReport rep;
+    if (!entity) { rep.error = QStringLiteral("no entity"); return rep; }
+    if (!entity->getMesh()) { rep.error = QStringLiteral("entity has no mesh"); return rep; }
+    if (!tmpl.valid()) { rep.error = QStringLiteral("ARKit template not loaded"); return rep; }
+
+    const FaceRigGeometry geo = extractGeometry(entity);
+    if (!geo.valid()) {
+        rep.error = QStringLiteral("could not read mesh geometry");
+        return rep;
     }
 
-    rep.ok = rep.shapesAttached > 0;
-    if (!rep.ok)
-        rep.error = QStringLiteral("no blendshapes produced any vertex movement");
+    const FaceRigResult res = buildFaceRig(geo.userV, geo.userF, tmpl, opts);
+    rep.userVertexCount = res.userVertexCount;
+    rep.fitMeanResidualPct = res.fitMeanResidualPct;
+    rep.fitMaxResidualPct = res.fitMaxResidualPct;
+    if (!res.ok) {
+        rep.error = QString::fromStdString(res.error);
+        return rep;
+    }
+
+    attachShapes(entity, geo, res, rep);
     return rep;
 }
 

--- a/src/FaceRig/FaceRigAttach.h
+++ b/src/FaceRig/FaceRigAttach.h
@@ -15,6 +15,9 @@
 
 #include <QString>
 
+#include <cstdint>
+#include <vector>
+
 namespace Ogre { class Entity; }
 
 namespace FaceRig {
@@ -28,6 +31,37 @@ struct AttachReport {
     double fitMaxResidualPct = 0.0;
     QString templateFallback;   // set when the template had to be downloaded/etc.
 };
+
+// One geometry owner (shared vertex pool, or a per-submesh vertex data) with
+// the morph pose target handle it maps to and its base offset into the combined
+// vertex set. Ogre's 1-based convention: 0 = shared, 1..N = submesh index+1.
+struct GeometryOwner {
+    unsigned short handle;
+    std::uint32_t base;
+    int count;
+};
+
+// The user entity's geometry read out of Ogre once, so the heavy Ogre-free
+// buildFaceRig() can run OFF the main thread (the GUI path) while extraction +
+// attach stay on the main thread. Pure data — no Ogre handles retained.
+struct FaceRigGeometry {
+    std::vector<float> userV;   // combined positions (Nu*3)
+    std::vector<int> userF;     // combined triangle indices
+    std::vector<GeometryOwner> owners;
+    bool valid() const { return userV.size() >= 9 && userF.size() >= 3; }
+};
+
+// MAIN-thread: read the entity's combined geometry (locks Ogre hardware
+// buffers — milliseconds). Empty/invalid result on failure.
+FaceRigGeometry extractGeometry(Ogre::Entity* entity);
+
+// MAIN-thread: attach a computed FaceRigResult's shapes to `entity` as
+// Ogre::Pose + VAT_POSE morph targets (via AddMorphTargetCommand), splitting
+// the combined per-vertex deltas back onto each owner's handle. Fills the
+// report's shapesAttached / ok. `geo.owners` must match the geometry the
+// result was computed from.
+void attachShapes(Ogre::Entity* entity, const FaceRigGeometry& geo,
+                  const FaceRigResult& result, AttachReport& report);
 
 // Runs the whole pipeline on `entity` using the given (already-loaded) template
 // and attaches the shapes as poses + a per-target VAT_POSE clip. Re-initialises

--- a/src/FaceRigController.cpp
+++ b/src/FaceRigController.cpp
@@ -1,0 +1,216 @@
+#include "FaceRigController.h"
+
+#include "FaceRig/ArkitTemplate.h"
+#include "FaceRig/FaceRigAttach.h"
+#include "GamificationManager.h"
+#include "Manager.h"
+#include "SelectionSet.h"
+#include "SentryReporter.h"
+#include "UndoManager.h"
+#include "commands/MorphCommands.h"
+
+#include <Ogre.h>
+#include <OgreEntity.h>
+#include <OgreMesh.h>
+
+#include <QCoreApplication>
+#include <QPointer>
+
+#include <cstdint>
+#include <memory>
+#include <thread>
+
+FaceRigController* FaceRigController::m_pSingleton = nullptr;
+
+FaceRigController* FaceRigController::instance()
+{
+    if (!m_pSingleton)
+        m_pSingleton = new FaceRigController();
+    return m_pSingleton;
+}
+
+FaceRigController* FaceRigController::qmlInstance(QQmlEngine* engine, QJSEngine*)
+{
+    Q_UNUSED(engine);
+    auto* inst = instance();
+    QQmlEngine::setObjectOwnership(inst, QQmlEngine::CppOwnership);
+    return inst;
+}
+
+void FaceRigController::kill()
+{
+    delete m_pSingleton;
+    m_pSingleton = nullptr;
+}
+
+FaceRigController::FaceRigController() : QObject(nullptr)
+{
+    connect(SelectionSet::getSingleton(), &SelectionSet::selectionChanged,
+            this, &FaceRigController::selectionChanged);
+}
+
+void FaceRigController::setStatus(const QString& s)
+{
+    if (m_status == s) return;
+    m_status = s;
+    emit statusChanged();
+}
+
+bool FaceRigController::hasMeshSelection() const
+{
+    auto* sel = SelectionSet::getSingleton();
+    if (!sel) return false;
+    const auto entities = sel->getResolvedEntities();
+    if (entities.isEmpty()) return false;
+    Ogre::Entity* first = entities.first();
+    return first && first->getMesh();
+}
+
+bool FaceRigController::addArkitBlendshapesAsync(int maxShapes, double maxResidualPct)
+{
+    if (m_busy) {
+        emit error(QStringLiteral("A face-rig is already running."));
+        return false;
+    }
+    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+        QStringLiteral("Add ARKit Blendshapes requested"));
+
+    auto* sel = SelectionSet::getSingleton();
+    const auto entities = sel ? sel->getResolvedEntities()
+                              : QList<Ogre::Entity*>{};
+    Ogre::Entity* entity = entities.isEmpty() ? nullptr : entities.first();
+    if (!entity || !entity->getMesh()) {
+        emit error(QStringLiteral("No mesh selected."));
+        return false;
+    }
+
+    // MAIN thread: read the entity geometry (locks Ogre buffers — ms).
+    auto geo = std::make_shared<FaceRig::FaceRigGeometry>(
+        FaceRig::extractGeometry(entity));
+    if (!geo->valid()) {
+        emit error(QStringLiteral("Could not read the mesh geometry."));
+        return false;
+    }
+
+    // MAIN thread: ensure + load the bundled template (may download on first
+    // use — surface that to the UI). ensureModelBlocking() can take a while on
+    // a first-run download, so show "Downloading…" first.
+    m_downloading = !FaceRig::ArkitTemplate::present();
+    setStatus(m_downloading ? QStringLiteral("Downloading face template…")
+                            : QStringLiteral("Preparing…"));
+    const QString path = FaceRig::ArkitTemplate::ensureModelBlocking();
+    m_downloading = false;
+    if (path.isEmpty()) {
+        setStatus(QString());
+        emit error(QStringLiteral(
+            "ARKit template unavailable (offline and not yet downloaded, or "
+            "this build has no face-rig model)."));
+        return false;
+    }
+    auto tmpl = std::make_shared<FaceRig::ArkitTemplate>();
+    QString loadErr;
+    if (!tmpl->load(path, &loadErr)) {
+        setStatus(QString());
+        emit error(QStringLiteral("Failed to load ARKit template: %1").arg(loadErr));
+        return false;
+    }
+
+    FaceRig::FaceRigOptions opts;
+    opts.maxShapes = maxShapes;
+    opts.maxFitResidualPct = maxResidualPct;
+
+    SentryReporter::addBreadcrumb(QStringLiteral("ai.assist.face_rig"),
+        QStringLiteral("face_rig entity=%1 verts=%2 template=%3v")
+            .arg(QString::fromStdString(entity->getName()))
+            .arg(geo->userV.size() / 3).arg(tmpl->vertexCount()));
+
+    m_busy = true;
+    emit busyChanged();
+    setStatus(QStringLiteral("Fitting face template…"));
+
+    const std::string entName = entity->getName();
+    QPointer<FaceRigController> self(this);
+
+    // WORKER thread: the heavy Ogre-free fit + transfer over all 52 shapes.
+    std::thread([self, geo, tmpl, opts, entName]() {
+        auto result = std::make_shared<FaceRig::FaceRigResult>(
+            FaceRig::buildFaceRig(geo->userV, geo->userF, *tmpl, opts));
+
+        // MAIN thread: attach (touches Ogre + the undo stack).
+        QMetaObject::invokeMethod(qApp, [self, geo, result, entName]() {
+            if (!self) return;
+            self->m_busy = false;
+            emit self->busyChanged();
+            self->setStatus(QString());
+
+            if (!result->ok) {
+                emit self->error(QString::fromStdString(result->error));
+                return;
+            }
+
+            // Resolve the entity again by name — the selection may have changed
+            // while the worker ran; only attach if it's still around.
+            Ogre::Entity* entity = nullptr;
+            for (Ogre::Entity* e : Manager::getSingleton()->getEntities()) {
+                if (e && e->getMovableType() == "Entity"
+                    && e->getName() == entName) { entity = e; break; }
+            }
+            if (!entity) {
+                emit self->error(QStringLiteral(
+                    "The mesh went away before the face-rig could be applied."));
+                return;
+            }
+
+            // Undoable group: one macro so Ctrl+Z removes all shapes at once.
+            FaceRig::AttachReport rep;
+            rep.userVertexCount = result->userVertexCount;
+            rep.fitMeanResidualPct = result->fitMeanResidualPct;
+            rep.fitMaxResidualPct = result->fitMaxResidualPct;
+
+            auto* undo = UndoManager::getSingleton();
+            auto* stack = undo ? undo->stack() : nullptr;
+            if (stack) stack->beginMacro(QStringLiteral("Add ARKit Blendshapes"));
+            for (const FaceRig::FaceRigShape& shape : result->shapes) {
+                std::vector<MorphPoseSlice> slices;
+                for (const FaceRig::GeometryOwner& o : geo->owners) {
+                    MorphPoseSlice slice;
+                    slice.submeshHandle = o.handle;
+                    for (int i = 0; i < o.count; ++i) {
+                        const std::uint32_t gv = o.base + std::uint32_t(i);
+                        if (size_t(gv) * 3 + 2 >= shape.userDeltas.size()) break;
+                        const float* d = &shape.userDeltas[size_t(gv) * 3];
+                        if (d[0] == 0.0f && d[1] == 0.0f && d[2] == 0.0f) continue;
+                        slice.offsets[static_cast<unsigned int>(i)] =
+                            Ogre::Vector3f(d[0], d[1], d[2]);
+                    }
+                    if (!slice.offsets.empty()) slices.push_back(std::move(slice));
+                }
+                if (slices.empty()) continue;
+                undo->push(new AddMorphTargetCommand(entity, shape.name, slices));
+                rep.shapesAttached++;
+            }
+            if (stack) stack->endMacro();
+            rep.ok = rep.shapesAttached > 0;
+
+            if (!rep.ok) {
+                emit self->error(QStringLiteral(
+                    "No blendshapes produced any vertex movement."));
+                return;
+            }
+
+            GamificationManager::noteOperation(
+                QStringLiteral("morph"),
+                {{QStringLiteral("blendshapes_attached"), rep.shapesAttached}},
+                GamificationManager::Surface::Gui);
+
+            QVariantMap map;
+            map["shapesAttached"] = rep.shapesAttached;
+            map["userVertexCount"] = rep.userVertexCount;
+            map["fitMeanResidualPct"] = rep.fitMeanResidualPct;
+            map["fitMaxResidualPct"] = rep.fitMaxResidualPct;
+            emit self->completed(map);
+        }, Qt::QueuedConnection);
+    }).detach();
+
+    return true;
+}

--- a/src/FaceRigController.h
+++ b/src/FaceRigController.h
@@ -1,0 +1,70 @@
+#ifndef FACE_RIG_CONTROLLER_H
+#define FACE_RIG_CONTROLLER_H
+
+#include <QObject>
+#include <QQmlEngine>
+#include <QVariantMap>
+
+// QML-facing singleton for the face auto-rig (#889, Slice F #895). Wraps
+// FaceRig::attachFaceRig* plus selection state so the Inspector's "Add ARKit
+// Blendshapes" button can enable itself only on a mesh selection and run the
+// (heavy) fit on a worker thread while the UI stays responsive.
+//
+// The pipeline is split across threads: geometry extraction + the pose attach
+// touch Ogre and run on the MAIN thread; the heavy Ogre-free buildFaceRig()
+// (NRICP + deformation transfer over 52 shapes) runs on a WORKER. The attach
+// goes through AddMorphTargetCommand so it is undoable, and it lands the
+// shapes in the same Ogre::Pose + VAT_POSE form the Vertex Morph section reads,
+// so the #869 face-capture panel drives them immediately.
+class FaceRigController : public QObject
+{
+    Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
+
+    Q_PROPERTY(bool hasMeshSelection READ hasMeshSelection NOTIFY selectionChanged)
+    Q_PROPERTY(bool busy READ busy NOTIFY busyChanged)
+    // True while the bundled ARKit template is downloading on first use.
+    Q_PROPERTY(bool downloading READ downloading NOTIFY statusChanged)
+    // Short human-readable status for the button label / tooltip.
+    Q_PROPERTY(QString status READ status NOTIFY statusChanged)
+
+public:
+    static FaceRigController* instance();
+    static FaceRigController* qmlInstance(QQmlEngine* engine, QJSEngine* scriptEngine);
+    static void kill();
+
+    bool hasMeshSelection() const;
+    bool busy() const { return m_busy; }
+    bool downloading() const { return m_downloading; }
+    QString status() const { return m_status; }
+
+    /// Run the face auto-rig on the first selected entity and attach the ARKit
+    /// blendshapes. Prepares (extracts geometry + loads the bundled template)
+    /// on the main thread, runs the fit on a WORKER, commits the undoable
+    /// attach back on the main thread. Returns false when it could not start
+    /// (invalid selection / already busy — `error` is emitted); the real
+    /// outcome arrives via completed(report) or error(msg).
+    Q_INVOKABLE bool addArkitBlendshapesAsync(int maxShapes = 0,
+                                              double maxResidualPct = 8.0);
+
+signals:
+    void selectionChanged();
+    void busyChanged();
+    void statusChanged();
+    void completed(const QVariantMap& report);
+    void error(const QString& message);
+
+private:
+    FaceRigController();
+    ~FaceRigController() override = default;
+
+    void setStatus(const QString& s);
+
+    static FaceRigController* m_pSingleton;
+    bool m_busy = false;
+    bool m_downloading = false;
+    QString m_status;
+};
+
+#endif // FACE_RIG_CONTROLLER_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -118,6 +118,7 @@
 #include "UVEditorController.h"
 #include "QuadRetopoController.h"
 #include "SkinWeightsController.h"
+#include "FaceRigController.h"
 #include "LightsController.h"
 #include "LightRigLibrary.h"
 #include "SceneLightingController.h"
@@ -573,6 +574,7 @@ MainWindow::~MainWindow()
         UVEditorController::kill();
         QuadRetopoController::kill();
         SkinWeightsController::kill();
+        FaceRigController::kill();
         LightsController::kill();
         LightPropertiesController::kill();
         SceneLightingController::kill();
@@ -765,6 +767,11 @@ void MainWindow::initToolBar()
             "PropertiesPanel", 1, 0, "SkinWeightsController",
             [](QQmlEngine* engine, QJSEngine*) -> QObject* {
                 return SkinWeightsController::qmlInstance(engine, nullptr);
+            });
+        qmlRegisterSingletonType<FaceRigController>(
+            "PropertiesPanel", 1, 0, "FaceRigController",
+            [](QQmlEngine* engine, QJSEngine*) -> QObject* {
+                return FaceRigController::qmlInstance(engine, nullptr);
             });
         qmlRegisterSingletonType<LightsController>(
             "PropertiesPanel", 1, 0, "LightsController",


### PR DESCRIPTION
Face-Rig epic #889, **Slice F** (#895). Stacked on Slice E (#901) — review/merge that first.

## What
A one-click **"✨ Add ARKit Blendshapes (AI)"** button in the Inspector's **Vertex Morph Animation** section. It fits the ARKit template onto the selected face mesh and attaches the 52 ARKit morph targets — the same `Ogre::Pose` + `VAT_POSE` form the morph section already reads, so the #869 face-capture panel drives them (name-based hand-off; the shapes are named per `FaceCap::kBlendshapeNames`).

## How
- **`FaceRigController`** (QML_SINGLETON) — `hasMeshSelection` / `busy` / `downloading` / `status` props. `addArkitBlendshapesAsync()`:
  - **main thread**: extract geometry + ensure/load the bundled template (surfaces a "Downloading…" status on first-run fetch),
  - **worker thread**: the heavy Ogre-free `buildFaceRig()` (NRICP + deformation transfer over 52 shapes) — UI stays responsive,
  - **main thread**: commit the attach as **one undo macro** ("Add ARKit Blendshapes") so Ctrl+Z removes all shapes at once. Re-resolves the entity by name after the worker returns (the selection may have changed). Gamification + Sentry breadcrumbs.
- **`FaceRigAttach` refactor**: split `extractGeometry()` (main-thread buffer read) and `attachShapes()` (main-thread pose attach) out of `attachFaceRig`, so the GUI can run the fit off-thread. `attachFaceRig` / CLI / MCP now compose the same helpers — **behavior-preserving** (CLI end-to-end re-verified: 51 shapes, 0.008% mean residual, identical output).
- **QML**: the button lives in the Shapes section, gated on a mesh selection, disabled + showing worker status while busy, with a result/error line, themed with the Inspector's highlight/border/text colors.

## Verification
- App launches with the new singleton registered and PropertiesPanel loads with **no QML errors**.
- CLI end-to-end unchanged after the refactor (51 shapes, mean 0.008% / max 0.61%).
- Full FaceRig unit suite green (18 tests).

## Note on the #869 hand-off
The Performance Capture panel (#869) lives on the **mocap epic branches**, not this stack, so it isn't wired here. The hand-off is automatic once both reach master: the attached shapes already carry the exact `FaceCap::kBlendshapeNames`, so the face-capture mapper matches them with zero unmatched channels (the epic's acceptance criterion).

## Next
Slice G (#896): quality pass, docs, packaging, telemetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)