### PR TITLE
feat(skeleton): viewport bone picking with gizmo priority

### DIFF
--- a/src/PropertiesPanelController.cpp
+++ b/src/PropertiesPanelController.cpp
@@ -1144,6 +1144,26 @@ void PropertiesPanelController::applySkeletonDebug(const QString& entityName, bo
     emit animationStateChanged();
 }
 
+bool PropertiesPanelController::isSkeletonDebugActive(const QString& entityName) const
+{
+    if (!mAnimationWidget || entityName.isEmpty()) return false;
+    Ogre::Entity* ent = entityByName(entityName);
+    return ent && mAnimationWidget->isSkeletonDebugActive(ent);
+}
+
+bool PropertiesPanelController::hasAnySkeletonDebugActive() const
+{
+    if (!mAnimationWidget) return false;
+    if (auto* mgr = Manager::getSingletonPtr()) {
+        for (Ogre::Entity* ent : mgr->getEntities()) {
+            if (!ent || ent->getMovableType() != "Entity") continue;
+            if (mAnimationWidget->isSkeletonDebugActive(ent))
+                return true;
+        }
+    }
+    return false;
+}
+
 void PropertiesPanelController::toggleSkeletonDebug(const QString& entityName, bool show)
 {
     if (!mAnimationWidget) return;

--- a/src/PropertiesPanelController.h
+++ b/src/PropertiesPanelController.h
@@ -248,6 +248,10 @@ public:
     Q_INVOKABLE bool isPlaying() const { return mPlaying; }
     Q_INVOKABLE void toggleSkeletonDebug(const QString& entityName, bool show);
     Q_INVOKABLE void toggleBoneWeights(const QString& entityName, bool show);
+    /// True when the skeleton debug overlay is active for `entityName`.
+    Q_INVOKABLE bool isSkeletonDebugActive(const QString& entityName) const;
+    /// True when any entity in the scene has skeleton debug enabled.
+    bool hasAnySkeletonDebugActive() const;
     /// Apply skeleton overlay visibility without pushing undo (used by undo commands).
     void applySkeletonDebug(const QString& entityName, bool show);
     /// Rebuild skeleton/weight viewport overlays after bone CRUD.

--- a/src/SkeletonDebug.cpp
+++ b/src/SkeletonDebug.cpp
@@ -6,10 +6,15 @@
 
 namespace {
 constexpr const char* kBoneNameTag = "skeletonDebugBoneName";
+constexpr const char* kEntityNameTag = "skeletonDebugEntityName";
 
-void tagBoneVisual(Ogre::MovableObject* obj, const Ogre::String& boneName) {
+void tagBoneVisual(Ogre::MovableObject* obj,
+                   const Ogre::String& boneName,
+                   const Ogre::String& entityName)
+{
     if (!obj) return;
     obj->getUserObjectBindings().setUserAny(kBoneNameTag, Ogre::Any(boneName));
+    obj->getUserObjectBindings().setUserAny(kEntityNameTag, Ogre::Any(entityName));
     obj->setQueryFlags(BONE_QUERY_FLAGS);
 }
 }
@@ -18,6 +23,18 @@ Ogre::String SkeletonDebug::boneNameForMovable(const Ogre::MovableObject* obj)
 {
     if (!obj) return {};
     const auto& any = obj->getUserObjectBindings().getUserAny(kBoneNameTag);
+    if (!any.has_value()) return {};
+    try {
+        return Ogre::any_cast<Ogre::String>(any);
+    } catch (const std::exception&) {
+        return {};
+    }
+}
+
+Ogre::String SkeletonDebug::entityNameForMovable(const Ogre::MovableObject* obj)
+{
+    if (!obj) return {};
+    const auto& any = obj->getUserObjectBindings().getUserAny(kEntityNameTag);
     if (!any.has_value()) return {};
     try {
         return Ogre::any_cast<Ogre::String>(any);
@@ -154,7 +171,7 @@ void SkeletonDebug::createChildBoneRepresentations(const Ogre::Bone* pBone, Ogre
         // Tag every child bone visual with the parent bone's name —
         // dragging this segment in the viewport edits the parent bone's
         // pose (the segment visually represents that bone, not the child).
-        tagBoneVisual(lastEnt, pBone->getName());
+        tagBoneVisual(lastEnt, pBone->getName(), mEntity->getName());
     }
 }
 
@@ -184,7 +201,7 @@ std::map<std::string, Ogre::Entity*, std::less<>> SkeletonDebug::createBoneVisua
             if(length >= 0.00001f)
                 tp->setScale(length, length, length);
 
-            tagBoneVisual(ent, pBone->getName());
+            tagBoneVisual(ent, pBone->getName(), mEntity->getName());
         }
         else
         {
@@ -199,7 +216,7 @@ std::map<std::string, Ogre::Entity*, std::less<>> SkeletonDebug::createBoneVisua
         mAxisEntities.push_back(ent);
         // Tag the axes overlay too — clicking the axis cross is the most
         // visible target for users when scaling/rotating.
-        tagBoneVisual(ent, pBone->getName());
+        tagBoneVisual(ent, pBone->getName(), mEntity->getName());
     }
 
     return mapEntities;

--- a/src/SkeletonDebug.h
+++ b/src/SkeletonDebug.h
@@ -36,6 +36,8 @@ public:
     // meshes) so a ray-pick in the viewport can map back to the bone.
     // Returns empty string when the movable isn't a SkeletonDebug visual.
     static Ogre::String boneNameForMovable(const Ogre::MovableObject* obj);
+    /// Owning skinned entity name (paired with boneNameForMovable).
+    static Ogre::String entityNameForMovable(const Ogre::MovableObject* obj);
 
 signals:
     void boneSelected(unsigned short boneIndex);

--- a/src/SkeletonDebug_test.cpp
+++ b/src/SkeletonDebug_test.cpp
@@ -122,9 +122,15 @@ TEST_F(SkeletonDebugTests, BoneNameForMovableReturnsBoneNameForTaggedVisuals)
         {
             ++taggedCount;
             EXPECT_EQ(obj->getQueryFlags(), static_cast<Ogre::uint32>(BONE_QUERY_FLAGS));
+            EXPECT_FALSE(SkeletonDebug::entityNameForMovable(obj).empty());
         }
     }
     EXPECT_GT(taggedCount, 0) << "no SkeletonDebug visuals were tagged";
+}
+
+TEST_F(SkeletonDebugTests, EntityNameForMovableReturnsEmptyForNullptr)
+{
+    EXPECT_TRUE(SkeletonDebug::entityNameForMovable(nullptr).empty());
 }
 
 TEST_F(SkeletonDebugTests, SetAxesScaleZero)

--- a/src/SkeletonDebug_test.cpp
+++ b/src/SkeletonDebug_test.cpp
@@ -122,7 +122,8 @@ TEST_F(SkeletonDebugTests, BoneNameForMovableReturnsBoneNameForTaggedVisuals)
         {
             ++taggedCount;
             EXPECT_EQ(obj->getQueryFlags(), static_cast<Ogre::uint32>(BONE_QUERY_FLAGS));
-            EXPECT_FALSE(SkeletonDebug::entityNameForMovable(obj).empty());
+            EXPECT_EQ(SkeletonDebug::entityNameForMovable(obj),
+                      Ogre::String("SkeletonDebugTestEntity"));
         }
     }
     EXPECT_GT(taggedCount, 0) << "no SkeletonDebug visuals were tagged";

--- a/src/TransformOperator.cpp
+++ b/src/TransformOperator.cpp
@@ -952,6 +952,78 @@ Ogre::MovableObject* TransformOperator::performRaySelection(const QPoint& pos, b
     return nullptr;
 }
 
+bool TransformOperator::tryPickBoneAt(const QPoint& pos, SelectionMode mode)
+{
+    if (!m_pRayQuery || !m_pActiveWidget || mode == DEL_SELECT)
+        return false;
+
+    auto* props = PropertiesPanelController::instance();
+    if (!props->hasAnySkeletonDebugActive())
+        return false;
+
+    // Gizmos always win over skeleton bones (including when a bone visual
+    // sits under a translate/rotate/scale handle).
+    if (performRaySelection(pos, /*findGizmo=*/true))
+        return false;
+
+    m_pRayQuery->setRay(rayFromScreenPoint(pos));
+    m_pRayQuery->setQueryMask(BONE_QUERY_FLAGS);
+    m_pRayQuery->setSortByDistance(true);
+    Ogre::RaySceneQueryResult& res = m_pRayQuery->execute();
+
+    for (const auto& hit : res) {
+        if (!hit.movable)
+            continue;
+
+        const Ogre::String boneName = SkeletonDebug::boneNameForMovable(hit.movable);
+        const Ogre::String entityName = SkeletonDebug::entityNameForMovable(hit.movable);
+        if (boneName.empty() || entityName.empty())
+            continue;
+
+        const QString entQ = QString::fromStdString(entityName);
+        if (!props->isSkeletonDebugActive(entQ))
+            continue;
+
+        Ogre::Entity* ent = nullptr;
+        for (Ogre::Entity* candidate : Manager::getSingleton()->getEntities()) {
+            if (!candidate || candidate->getMovableType() != "Entity")
+                continue;
+            if (candidate->getName() == entityName) {
+                ent = candidate;
+                break;
+            }
+        }
+        if (!ent || !ent->getParentSceneNode())
+            continue;
+
+        // Keep the mesh selection stable when the hit entity is already
+        // selected. clear()+append of the same node briefly empties
+        // SelectionSet, which makes EditModeController exit Edit → Object.
+        bool alreadySelected = false;
+        for (Ogre::Entity* selected : SelectionSet::getSingleton()->getResolvedEntities()) {
+            if (selected == ent) {
+                alreadySelected = true;
+                break;
+            }
+        }
+        if (!alreadySelected) {
+            if (mode == NEW_SELECT)
+                SelectionSet::getSingleton()->clear();
+            SelectionSet::getSingleton()->append(ent->getParentSceneNode());
+        }
+
+        auto* anim = AnimationControlController::instance();
+        anim->bindSkeletonForEntity(entQ);
+        anim->selectBone(QString::fromStdString(boneName));
+
+        SentryReporter::addBreadcrumb("ui.action",
+            QString("Bone picked: %1 (%2)")
+                .arg(entQ, QString::fromStdString(boneName)));
+        return true;
+    }
+    return false;
+}
+
 
 // from 0 to 1
 void TransformOperator::performBoxSelection(const QPoint& first, const QPoint& second, SelectionMode mode)
@@ -971,6 +1043,10 @@ void TransformOperator::performBoxSelection(const QPoint& first, const QPoint& s
 
     if ((right - left) * (bottom - top) < 0.0001)
     {
+        // Small click: skeleton bones (when overlay is visible) before meshes.
+        if (tryPickBoneAt(first, mode))
+            return;
+
         // go to ray scene query as the rectangle is too small
         Ogre::MovableObject* obj = performRaySelection(first);
         if(obj)
@@ -1113,6 +1189,12 @@ void TransformOperator::mousePressEvent(QMouseEvent *e)
                 // Paint mode on: do not start box / component selection on miss.
                 return;
             }
+            // Skeleton bone pick (when overlay is visible) before
+            // vertex/edge/face picks — tryPickBoneAt keeps SelectionSet
+            // stable when the edited mesh is already selected so Edit
+            // Mode is not exited.
+            if (tryPickBoneAt(e->pos()))
+                return;
             mScreenStart = e->pos();
             m_pSelectionBox->clear();
             m_pSelectionBox->setVisible(true);
@@ -1159,30 +1241,10 @@ void TransformOperator::mousePressEvent(QMouseEvent *e)
 
         if(mTransformState == TS_SELECT)
         {
-            // Bone viewport picks before box-select (lights are scene-tree only
-            // in select mode — gizmo hits would block mesh/entity selection).
-            if (m_pRayQuery)
-            {
-                m_pRayQuery->setRay(rayFromScreenPoint(e->pos()));
-                m_pRayQuery->setQueryMask(BONE_QUERY_FLAGS);
-                m_pRayQuery->setSortByDistance(true);
-                Ogre::RaySceneQueryResult& res = m_pRayQuery->execute();
-                for (const auto& hit : res)
-                {
-                    if (!hit.movable)
-                        continue;
-
-                    Ogre::String boneName = SkeletonDebug::boneNameForMovable(hit.movable);
-                    if (!boneName.empty())
-                    {
-                        AnimationControlController::instance()->selectBone(
-                            QString::fromStdString(boneName));
-                        SentryReporter::addBreadcrumb("ui.action",
-                            QString("Bone picked: %1").arg(QString::fromStdString(boneName)));
-                        return;
-                    }
-                }
-            }
+            // Bone picks take priority over mesh/box selection while the
+            // skeleton overlay is visible (gizmos are hidden in select mode).
+            if (tryPickBoneAt(e->pos()))
+                return;
 
             mScreenStart = e->pos();
             m_pSelectionBox->clear();
@@ -1190,6 +1252,7 @@ void TransformOperator::mousePressEvent(QMouseEvent *e)
 
         }
         else if (e->button() == Qt::LeftButton
+                 && performRaySelection(e->pos(), true)
                  && shouldRouteToBoneGizmo(
                         mTransformState,
                         AnimationControlController::instance()->selectedBonePtr(),
@@ -1279,7 +1342,8 @@ void TransformOperator::mousePressEvent(QMouseEvent *e)
             if (mTransformState == TS_SCALE)
                 mScaleDragStartPixel = e->pos();
         }
-        else if((!SelectionSet::getSingleton()->isEmpty()) && (e->button() == Qt::LeftButton))
+        else if (!tryPickBoneAt(e->pos())
+                 && (!SelectionSet::getSingleton()->isEmpty()) && (e->button() == Qt::LeftButton))
         {
             // Log a single breadcrumb per transform gesture (not per mouse-move frame)
             if(mTransformState == TS_TRANSLATE)

--- a/src/TransformOperator.cpp
+++ b/src/TransformOperator.cpp
@@ -207,6 +207,11 @@ bool TransformOperator::shouldRouteToBoneGizmo(TransformState state,
     return false;
 }
 
+bool TransformOperator::shouldPreferGizmoOverBonePick(TransformState state)
+{
+    return state == TS_TRANSLATE || state == TS_ROTATE || state == TS_SCALE;
+}
+
 ////////////////////////////////////////
 // Snap settings
 
@@ -961,9 +966,12 @@ bool TransformOperator::tryPickBoneAt(const QPoint& pos, SelectionMode mode)
     if (!props->hasAnySkeletonDebugActive())
         return false;
 
-    // Gizmos always win over skeleton bones (including when a bone visual
-    // sits under a translate/rotate/scale handle).
-    if (performRaySelection(pos, /*findGizmo=*/true))
+    // Gizmos always win over skeleton bones when transform tools are active.
+    // In Select mode gizmos stay in the scene with GIZMO_QUERY_FLAGS but are
+    // only setVisible(false) — querying them would block bone picks under the
+    // (hidden) handle, so skip the gizmo gate there.
+    if (shouldPreferGizmoOverBonePick(mTransformState)
+        && performRaySelection(pos, /*findGizmo=*/true))
         return false;
 
     m_pRayQuery->setRay(rayFromScreenPoint(pos));

--- a/src/TransformOperator.h
+++ b/src/TransformOperator.h
@@ -173,6 +173,10 @@ public:
     /// keeps a roughly constant pixel size regardless of camera distance.
     /// Called per-frame from OgreWidget::frameStarted.
     void tickTransformGizmoScale(const Ogre::Camera* camera);
+    /// Ray-pick a skeleton-debug bone at `pos`. Only succeeds when the hit
+    /// entity has its skeleton overlay visible. Selects the owning entity and
+    /// bone in the animation controller. Returns false on miss.
+    bool tryPickBoneAt(const QPoint& pos, SelectionMode mode = NEW_SELECT);
 private:
     //Ogre::SceneNode*                        m_pSelectedNode;
     Ogre::RaySceneQuery*                    m_pRayQuery  = nullptr;

--- a/src/TransformOperator.h
+++ b/src/TransformOperator.h
@@ -109,6 +109,11 @@ public:
                                        const Ogre::Bone* selectedBone,
                                        bool boneCanTranslate);
 
+    /// True when a gizmo ray hit should suppress bone picking. Select/None
+    /// leave gizmos in the scene (query flags set, only visibility cleared),
+    /// so bone picks must ignore them in those states.
+    static bool shouldPreferGizmoOverBonePick(TransformState state);
+
 private:
     TransformOperator ();
     ~TransformOperator () override;

--- a/src/TransformOperator_test.cpp
+++ b/src/TransformOperator_test.cpp
@@ -213,6 +213,23 @@ TEST(TransformOperatorTest, ShouldRouteToBoneGizmoNonTransformStatesDoNotRoute)
         TransformOperator::TS_NONE, bone, true));
 }
 
+TEST(TransformOperatorTest, ShouldPreferGizmoOverBonePickOnlyForTransformTools)
+{
+    // Translate/rotate/scale: a gizmo hit suppresses bone picking.
+    EXPECT_TRUE(TransformOperator::shouldPreferGizmoOverBonePick(
+        TransformOperator::TS_TRANSLATE));
+    EXPECT_TRUE(TransformOperator::shouldPreferGizmoOverBonePick(
+        TransformOperator::TS_ROTATE));
+    EXPECT_TRUE(TransformOperator::shouldPreferGizmoOverBonePick(
+        TransformOperator::TS_SCALE));
+    // Select/None: gizmos are hidden but still queryable — do not let them
+    // steal bone picks (Codex P2 on PR #906).
+    EXPECT_FALSE(TransformOperator::shouldPreferGizmoOverBonePick(
+        TransformOperator::TS_SELECT));
+    EXPECT_FALSE(TransformOperator::shouldPreferGizmoOverBonePick(
+        TransformOperator::TS_NONE));
+}
+
 TEST_F(TransformOperatorTests, TransformSpaceChangesOnlyWhenValueDiffers)
 {
     QSignalSpy spy(op, &TransformOperator::transformSpaceChanged);


### PR DESCRIPTION
## Summary
- Mouse-pick skeleton-debug bones in the viewport when the skeleton overlay is visible (bones over meshes).
- Gizmo hits always win over bone picks; bone selection no longer briefly clears `SelectionSet`, so Edit Mode stays active when picking bones on the already-selected mesh.
- Tag bone visuals with owning entity name and gate picks via `PropertiesPanelController::isSkeletonDebugActive` / `hasAnySkeletonDebugActive`.

## Test plan
- [ ] Import a rigged mesh, enable Show Skeleton, pick bones in Select mode (Q)
- [ ] Confirm bone pick works from Edit Mode without switching to Object Mode
- [ ] With W/E/R active and a bone selected, click a gizmo handle that overlaps another bone — expect gizmo drag, not re-picking the other bone
- [ ] With skeleton overlay off, clicking the mesh selects the mesh (no bone pick)
- [ ] Unit tests: `SkeletonDebug*` / `TransformOperator*`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added direct screen-click selection for bones when skeleton debug overlays are enabled.
  * Bone selections now identify and select both the owning entity and its corresponding bone.
  * Added status checks for skeleton debugging on individual entities and across the scene.

* **Bug Fixes**
  * Bone picks take priority over gizmos, meshes, and box-selection interactions when applicable.

* **Tests**
  * Added coverage for identifying owning entities and handling invalid bone-visual references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->