### PR TITLE
[codex] Add QtMeshEditor model management tab

### DIFF
--- a/qml/AISettingsDialog.qml
+++ b/qml/AISettingsDialog.qml
@@ -21,6 +21,8 @@ Dialog {
     property color highlightColor: palette.highlight
     property color buttonColor: palette.button
     property color buttonTextColor: palette.buttonText
+    property string pendingDeleteModelId: ""
+    property string pendingDeleteModelName: ""
 
     SystemPalette {
         id: palette
@@ -68,6 +70,10 @@ Dialog {
             }
             TabButton {
                 text: "Download"
+                width: implicitWidth
+            }
+            TabButton {
+                text: "QtMeshEditor Models"
                 width: implicitWidth
             }
             TabButton {
@@ -331,61 +337,208 @@ Dialog {
                             }
                         }
 
-                        // ── AI-Assist models (image-to-3D, #764) ──────────────
-                        // Pre-download the TripoSR encoder/decoder + U²-Net bg
-                        // remover so first use is instant. Reuses ModelDownloader's
-                        // shared progress bar above. Only shown on an ONNX build.
-                        Text {
-                            visible: MeshGenController.available
-                            text: "AI-Assist Models"
-                            font.pointSize: 12
-                            font.bold: true
-                            color: textColor
-                        }
-                        Rectangle {
-                            visible: MeshGenController.available
+                        Item { Layout.preferredHeight: 10 }
+                    }
+                }
+            }
+
+            // ============ QtMeshEditor Models Tab ============
+            ScrollView {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                clip: true
+
+                Flickable {
+                    contentWidth: parent.width
+                    contentHeight: qtMeshModelsCol.implicitHeight
+
+                    ColumnLayout {
+                        id: qtMeshModelsCol
+                        width: parent.width - tabMargin * 2
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        spacing: 12
+
+                        Item { Layout.preferredHeight: 8 }
+
+                        RowLayout {
                             Layout.fillWidth: true
-                            Layout.preferredHeight: gen3dCol.implicitHeight + 20
+                            spacing: 10
+
+                            Text {
+                                Layout.fillWidth: true
+                                text: "QtMeshEditor Models"
+                                font.pointSize: 12
+                                font.bold: true
+                                color: textColor
+                            }
+                            Local.ThemedButton {
+                                text: "Refresh"
+                                enabled: !AIModelCatalog.busy
+                                onClicked: AIModelCatalog.refresh()
+                            }
+                            Local.ThemedButton {
+                                text: "Download All"
+                                enabled: !AIModelCatalog.busy
+                                onClicked: AIModelCatalog.downloadAllModels()
+                            }
+                            Local.ThemedButton {
+                                text: "Remove All"
+                                enabled: !AIModelCatalog.busy
+                                onClicked: removeAllQtMeshModelsDialog.open()
+                            }
+                            Local.ThemedButton {
+                                text: "Open Folder"
+                                onClicked: Qt.openUrlExternally(AIModelCatalog.modelsRootUrl())
+                            }
+                        }
+
+                        Rectangle {
+                            Layout.fillWidth: true
+                            height: 74
                             color: panelColor
                             border.color: borderColor
                             border.width: 1
                             radius: 4
+                            visible: AIModelCatalog.busy || AIModelCatalog.statusMessage !== ""
+
                             ColumnLayout {
-                                id: gen3dCol
                                 anchors.fill: parent
                                 anchors.margins: 10
                                 spacing: 8
 
-                                Text {
-                                    Layout.fillWidth: true
-                                    wrapMode: Text.WordWrap
-                                    text: "Image → 3D (TripoSR) + background removal. Pick a size tier and pre-download so first use is instant. Downloads on first use too."
-                                    font.pointSize: 9
-                                    color: Qt.darker(textColor, 1.3)
-                                }
                                 RowLayout {
                                     Layout.fillWidth: true
-                                    spacing: 8
-                                    ComboBox {
-                                        id: gen3dTier
-                                        Layout.preferredWidth: 200
-                                        model: ["fp32 (best, ~1.7GB)", "int8 (smaller, ~430MB)"]
-                                        currentIndex: 0
-                                        enabled: !MeshGenController.busy
-                                    }
-                                    Item { Layout.fillWidth: true }
                                     Text {
-                                        text: MeshGenController.modelsPresent(gen3dTier.currentIndex)
-                                              ? "Downloaded" : "Not downloaded"
+                                        Layout.fillWidth: true
+                                        text: AIModelCatalog.busy
+                                              ? "Downloading " + AIModelCatalog.activeModelName
+                                              : AIModelCatalog.statusMessage
+                                        color: textColor
+                                        font.pointSize: 10
+                                        elide: Text.ElideRight
+                                    }
+                                    Text {
+                                        visible: ModelDownloader.isDownloading
+                                        text: formatSize(ModelDownloader.bytesReceived) + " / " +
+                                              formatSize(ModelDownloader.bytesTotal) + " (" +
+                                              formatSize(ModelDownloader.downloadSpeed) + "/s)"
                                         font.pointSize: 9
-                                        color: MeshGenController.modelsPresent(gen3dTier.currentIndex)
-                                               ? "#4caf50" : Qt.darker(textColor, 1.5)
+                                        color: Qt.darker(textColor, 1.4)
                                     }
                                     Local.ThemedButton {
-                                        text: "Download"
-                                        enabled: !MeshGenController.busy
-                                                 && !MeshGenController.modelsPresent(gen3dTier.currentIndex)
-                                        onClicked: MeshGenController.downloadModels(gen3dTier.currentIndex)
+                                        text: "Cancel"
+                                        visible: AIModelCatalog.busy
+                                        onClicked: ModelDownloader.cancelDownload()
+                                    }
+                                }
+
+                                ProgressBar {
+                                    Layout.fillWidth: true
+                                    from: 0; to: 1
+                                    value: ModelDownloader.downloadProgress
+                                    visible: AIModelCatalog.busy
+                                }
+                            }
+                        }
+
+                        Repeater {
+                            model: AIModelCatalog.models
+
+                            delegate: Rectangle {
+                                Layout.fillWidth: true
+                                implicitHeight: modelCardCol.implicitHeight + 20
+                                color: panelColor
+                                border.color: modelData.downloaded ? "#4caf50"
+                                             : modelData.partial ? "#ff9800" : borderColor
+                                border.width: 1
+                                radius: 4
+
+                                ColumnLayout {
+                                    id: modelCardCol
+                                    anchors.fill: parent
+                                    anchors.margins: 10
+                                    spacing: 8
+
+                                    RowLayout {
+                                        Layout.fillWidth: true
+                                        spacing: 10
+
+                                        ColumnLayout {
+                                            Layout.fillWidth: true
+                                            spacing: 3
+
+                                            RowLayout {
+                                                Layout.fillWidth: true
+                                                spacing: 8
+
+                                                Text {
+                                                    text: modelData.name
+                                                    color: textColor
+                                                    font.pointSize: 11
+                                                    font.bold: true
+                                                }
+                                                Rectangle {
+                                                    width: statusText.implicitWidth + 14
+                                                    height: 22
+                                                    radius: 3
+                                                    color: modelData.downloaded ? "#e8f5e9"
+                                                         : modelData.partial ? "#fff3e0" : Qt.rgba(0,0,0,0.04)
+                                                    border.color: modelData.downloaded ? "#4caf50"
+                                                                : modelData.partial ? "#ff9800" : borderColor
+                                                    Text {
+                                                        id: statusText
+                                                        anchors.centerIn: parent
+                                                        text: modelData.downloaded ? "Downloaded"
+                                                              : modelData.partial ? "Partial" : "Not downloaded"
+                                                        color: modelData.downloaded ? "#2e7d32"
+                                                             : modelData.partial ? "#e65100" : textColor
+                                                        font.pointSize: 8
+                                                    }
+                                                }
+                                            }
+
+                                            Text {
+                                                Layout.fillWidth: true
+                                                text: modelData.feature + " · " + modelData.size + " · " +
+                                                      modelData.presentFiles + "/" + modelData.totalFiles + " files" +
+                                                      (modelData.installedBytes > 0 ? " · " + formatSize(modelData.installedBytes) + " installed" : "")
+                                                color: Qt.darker(textColor, 1.35)
+                                                font.pointSize: 9
+                                                elide: Text.ElideRight
+                                            }
+                                        }
+
+                                        Local.ThemedButton {
+                                            text: "Download"
+                                            enabled: modelData.available && !modelData.downloaded && !AIModelCatalog.busy
+                                            onClicked: AIModelCatalog.downloadModel(modelData.id)
+                                        }
+                                        Local.ThemedButton {
+                                            text: "Delete"
+                                            enabled: (modelData.downloaded || modelData.partial) && !AIModelCatalog.busy
+                                            onClicked: {
+                                                aiSettingsDialog.pendingDeleteModelId = modelData.id
+                                                aiSettingsDialog.pendingDeleteModelName = modelData.name
+                                                removeQtMeshModelDialog.open()
+                                            }
+                                        }
+                                    }
+
+                                    Text {
+                                        Layout.fillWidth: true
+                                        text: modelData.description
+                                        color: Qt.darker(textColor, 1.25)
+                                        font.pointSize: 9
+                                        wrapMode: Text.WordWrap
+                                    }
+
+                                    Text {
+                                        Layout.fillWidth: true
+                                        visible: !modelData.available
+                                        text: modelData.buildRequirement
+                                        color: "#b71c1c"
+                                        font.pointSize: 9
+                                        wrapMode: Text.WordWrap
                                     }
                                 }
                             }
@@ -801,6 +954,38 @@ Dialog {
                     }
                 }
             }
+        }
+    }
+
+    Dialog {
+        id: removeQtMeshModelDialog
+        title: "Delete Model Files"
+        modal: true
+        anchors.centerIn: parent
+        standardButtons: Dialog.Yes | Dialog.No
+        onAccepted: AIModelCatalog.deleteModel(aiSettingsDialog.pendingDeleteModelId)
+
+        Text {
+            width: 360
+            text: "Delete downloaded files for " + aiSettingsDialog.pendingDeleteModelName + "?"
+            color: textColor
+            wrapMode: Text.WordWrap
+        }
+    }
+
+    Dialog {
+        id: removeAllQtMeshModelsDialog
+        title: "Remove All Model Files"
+        modal: true
+        anchors.centerIn: parent
+        standardButtons: Dialog.Yes | Dialog.No
+        onAccepted: AIModelCatalog.deleteAllModels()
+
+        Text {
+            width: 360
+            text: "Remove all downloaded QtMeshEditor model files?"
+            color: textColor
+            wrapMode: Text.WordWrap
         }
     }
 

--- a/src/AIModelCatalog.cpp
+++ b/src/AIModelCatalog.cpp
@@ -1,0 +1,651 @@
+#include "AIModelCatalog.h"
+
+#include "ModelDownloader.h"
+#include "SentryReporter.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QSettings>
+#include <QStandardPaths>
+#include <QSet>
+#include <QTimer>
+#include <QUrl>
+
+AIModelCatalog* AIModelCatalog::s_instance = nullptr;
+
+namespace {
+QString joinUrl(QString base, const QString& fileName)
+{
+    if (base.isEmpty())
+        return {};
+    if (!base.endsWith('/'))
+        base += '/';
+    return base + fileName;
+}
+}
+
+AIModelCatalog* AIModelCatalog::instance()
+{
+    if (!s_instance)
+        s_instance = new AIModelCatalog();
+    return s_instance;
+}
+
+AIModelCatalog* AIModelCatalog::qmlInstance(QQmlEngine*, QJSEngine*)
+{
+    AIModelCatalog* catalog = instance();
+    QJSEngine::setObjectOwnership(catalog, QJSEngine::CppOwnership);
+    return catalog;
+}
+
+AIModelCatalog::AIModelCatalog(QObject* parent)
+    : QObject(parent)
+{
+    auto* dl = ModelDownloader::instance();
+    connect(dl, &ModelDownloader::downloadCompleted, this,
+            [this](const QString& name, const QString&) {
+                if (!m_busy || m_pendingFiles.isEmpty())
+                    return;
+                if (m_pendingFiles.first().label != name)
+                    return;
+                m_pendingFiles.removeFirst();
+                SentryReporter::addBreadcrumb(QStringLiteral("file.import"),
+                                              tr("Downloaded %1").arg(name));
+                emit modelsChanged();
+                QTimer::singleShot(0, this, &AIModelCatalog::startNextQueuedFile);
+            });
+    connect(dl, &ModelDownloader::downloadError, this,
+            [this](const QString& name, const QString& error) {
+                if (!m_busy || m_pendingFiles.isEmpty())
+                    return;
+                if (m_pendingFiles.first().label != name)
+                    return;
+                SentryReporter::addBreadcrumb(QStringLiteral("file.import"),
+                                              tr("Download failed for %1: %2").arg(name, error),
+                                              QStringLiteral("error"));
+                m_pendingFiles.clear();
+                setStatusMessage(tr("Download failed: %1").arg(error));
+                clearActive();
+                setBusy(false);
+                emit modelsChanged();
+            });
+    connect(dl, &ModelDownloader::downloadCanceled, this,
+            [this](const QString& name) {
+                if (!m_busy || m_pendingFiles.isEmpty())
+                    return;
+                if (m_pendingFiles.first().label != name)
+                    return;
+                SentryReporter::addBreadcrumb(QStringLiteral("file.import"),
+                                              tr("Download canceled for %1").arg(name),
+                                              QStringLiteral("warning"));
+                m_pendingFiles.clear();
+                setStatusMessage(tr("Download canceled."));
+                clearActive();
+                setBusy(false);
+                emit modelsChanged();
+            });
+}
+
+QString AIModelCatalog::rootPath() const
+{
+    return QDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation))
+        .filePath(QStringLiteral("ai_models"));
+}
+
+QString AIModelCatalog::modelsRootUrl() const
+{
+    return QUrl::fromLocalFile(rootPath()).toString();
+}
+
+QString AIModelCatalog::resolveBaseUrl(const char* settingsKey, const char* envKey,
+                                       const char* fallback) const
+{
+    QSettings settings;
+    QString base = settings.value(QString::fromLatin1(settingsKey)).toString();
+    if (base.isEmpty()) {
+        const QByteArray env = qgetenv(envKey);
+        base = env.isEmpty() ? QString::fromLatin1(fallback) : QString::fromUtf8(env);
+    }
+    return base;
+}
+
+QList<AIModelCatalog::ModelSpec> AIModelCatalog::specs() const
+{
+    const QString root = rootPath();
+    auto path = [&](const QString& relative) {
+        return QDir(root).filePath(relative);
+    };
+    auto file = [&](const QString& relative, const QString& fileName,
+                    const QString& base, const QString& label) {
+        return FileSpec{fileName, path(relative + QLatin1Char('/') + fileName),
+                        joinUrl(base, fileName), label};
+    };
+
+#ifdef ENABLE_ONNX
+    constexpr bool onnxAvailable = true;
+#else
+    constexpr bool onnxAvailable = false;
+#endif
+#ifdef ENABLE_MTMD
+    constexpr bool captionAvailable = true;
+#else
+    constexpr bool captionAvailable = false;
+#endif
+
+    const QString pbrBase = resolveBaseUrl(
+        "ai/pbrModelBaseUrl", "QTMESH_PBR_MODEL_BASE_URL",
+        "https://huggingface.co/fernandotonon/QtMeshEditor-models/resolve/main/");
+    const QString rembgBase = resolveBaseUrl(
+        "ai/rembgModelBaseUrl", "QTMESH_REMBG_MODEL_BASE_URL",
+        "https://huggingface.co/fernandotonon/QtMeshEditor-models/resolve/main/rembg/");
+    const QString triposrBase = resolveBaseUrl(
+        "ai/triposrModelBaseUrl", "QTMESH_TRIPOSR_MODEL_BASE_URL",
+        "https://huggingface.co/fernandotonon/QtMeshEditor-models/resolve/main/triposr/");
+    const QString triposgBase = resolveBaseUrl(
+        "ai/triposgModelBaseUrl", "QTMESH_TRIPOSG_MODEL_BASE_URL",
+        "https://huggingface.co/fernandotonon/QtMeshEditor-models/resolve/main/triposg/");
+    const QString unirigBase = resolveBaseUrl(
+        "ai/unirigModelBaseUrl", "QTMESH_UNIRIG_MODEL_BASE_URL",
+        "https://huggingface.co/fernandotonon/QtMeshEditor-models/resolve/main/unirig/");
+    const QString skinTokensBase = resolveBaseUrl(
+        "ai/skintokensModelBaseUrl", "QTMESH_SKINTOKENS_MODEL_BASE_URL",
+        "https://huggingface.co/fernandotonon/QtMeshEditor-models/resolve/main/skintokens/");
+    const QString inbetweenBase = resolveBaseUrl(
+        "ai/inbetweenModelBaseUrl", "QTMESH_INBETWEEN_MODEL_BASE_URL",
+        "https://huggingface.co/fernandotonon/QtMeshEditor-models/resolve/main/inbetween/");
+    const QString motionBase = resolveBaseUrl(
+        "ai/motionLibraryBaseUrl", "QTMESH_MOTION_LIBRARY_BASE_URL",
+        "https://huggingface.co/fernandotonon/QtMeshEditor-models/resolve/main/motion/");
+    const QString t2mBase = resolveBaseUrl(
+        "ai/t2mModelBaseUrl", "QTMESH_T2M_MODEL_BASE_URL",
+        "https://huggingface.co/fernandotonon/QtMeshEditor-models/resolve/main/motion/");
+    const QString segmentBase = resolveBaseUrl(
+        "ai/segmentModelBaseUrl", "QTMESH_SEGMENT_MODEL_BASE_URL",
+        "https://huggingface.co/fernandotonon/QtMeshEditor-models/resolve/main/segment/");
+    const QString captionBase = resolveBaseUrl(
+        "ai/captionModelBaseUrl", "QTMESH_CAPTION_MODEL_BASE_URL",
+        "https://huggingface.co/fernandotonon/QtMeshEditor-models/resolve/main/caption/");
+
+    QList<ModelSpec> out;
+    out << ModelSpec{
+        QStringLiteral("pbr-maps"), tr("PBR Map Synthesis"), tr("Textures"),
+        tr("Normal, roughness, and height ONNX models used to synthesize PBR maps from an albedo texture."),
+        QStringLiteral("Small"), onnxAvailable ? QString() : tr("Requires an ONNX-enabled build"),
+        onnxAvailable,
+        {
+            file(QStringLiteral("pbr"), QStringLiteral("1x-PBRify_NormalV3.onnx"), pbrBase, QStringLiteral("PBR Normal")),
+            file(QStringLiteral("pbr"), QStringLiteral("1x-PBRify_RoughnessV2.onnx"), pbrBase, QStringLiteral("PBR Roughness")),
+            file(QStringLiteral("pbr"), QStringLiteral("1x-PBRify_Height.onnx"), pbrBase, QStringLiteral("PBR Height")),
+        }};
+    out << ModelSpec{
+        QStringLiteral("upscale-2x"), tr("Texture Upscaler 2x"), tr("Textures"),
+        tr("Real-ESRGAN 2x ONNX model used for texture upscaling."),
+        QStringLiteral("Medium"), onnxAvailable ? QString() : tr("Requires an ONNX-enabled build"),
+        onnxAvailable,
+        { file(QStringLiteral("pbr"), QStringLiteral("RealESRGAN_x2plus.onnx"), pbrBase, QStringLiteral("Upscale 2x")) }};
+    out << ModelSpec{
+        QStringLiteral("upscale-4x"), tr("Texture Upscaler 4x"), tr("Textures"),
+        tr("Real-ESRGAN 4x ONNX model used for texture upscaling."),
+        QStringLiteral("Medium"), onnxAvailable ? QString() : tr("Requires an ONNX-enabled build"),
+        onnxAvailable,
+        { file(QStringLiteral("pbr"), QStringLiteral("RealESRGAN_x4plus.onnx"), pbrBase, QStringLiteral("Upscale 4x")) }};
+    out << ModelSpec{
+        QStringLiteral("background-removal"), tr("Background Removal"), tr("Image to 3D"),
+        tr("U2Net ONNX model used to remove backgrounds before image-to-3D generation."),
+        QStringLiteral("~170 MB"), onnxAvailable ? QString() : tr("Requires an ONNX-enabled build"),
+        onnxAvailable,
+        { file(QStringLiteral("rembg"), QStringLiteral("u2net.onnx"), rembgBase, QStringLiteral("U2Net background-removal model")) }};
+    out << ModelSpec{
+        QStringLiteral("triposr-fp32"), tr("TripoSR fp32"), tr("Image to 3D"),
+        tr("High quality TripoSR image encoder and decoder used for image-to-3D mesh generation."),
+        QStringLiteral("~1.7 GB"), onnxAvailable ? QString() : tr("Requires an ONNX-enabled build"),
+        onnxAvailable,
+        {
+            file(QStringLiteral("triposr"), QStringLiteral("triposr_encoder.onnx"), triposrBase, QStringLiteral("TripoSR encoder model")),
+            file(QStringLiteral("triposr"), QStringLiteral("triposr_decoder.onnx"), triposrBase, QStringLiteral("TripoSR decoder model")),
+        }};
+    out << ModelSpec{
+        QStringLiteral("triposr-int8"), tr("TripoSR int8"), tr("Image to 3D"),
+        tr("Smaller quantized TripoSR encoder plus the shared decoder for image-to-3D mesh generation."),
+        QStringLiteral("~430 MB + decoder"), onnxAvailable ? QString() : tr("Requires an ONNX-enabled build"),
+        onnxAvailable,
+        {
+            file(QStringLiteral("triposr"), QStringLiteral("triposr_encoder_int8.onnx"), triposrBase, QStringLiteral("TripoSR encoder model")),
+            file(QStringLiteral("triposr"), QStringLiteral("triposr_decoder.onnx"), triposrBase, QStringLiteral("TripoSR decoder model")),
+        }};
+    out << ModelSpec{
+        QStringLiteral("triposg-fp32"), tr("TripoSG fp32"), tr("Image to 3D"),
+        tr("Large TripoSG rectified-flow image-to-3D model, including the external DiT weights sidecar."),
+        QStringLiteral("~3 GB+"), onnxAvailable ? QString() : tr("Requires an ONNX-enabled build"),
+        onnxAvailable,
+        {
+            file(QStringLiteral("triposg"), QStringLiteral("triposg_image_encoder.onnx"), triposgBase, QStringLiteral("TripoSG triposg_image_encoder.onnx")),
+            file(QStringLiteral("triposg"), QStringLiteral("triposg_vae_latents.onnx"), triposgBase, QStringLiteral("TripoSG triposg_vae_latents.onnx")),
+            file(QStringLiteral("triposg"), QStringLiteral("triposg_vae_decoder.onnx"), triposgBase, QStringLiteral("TripoSG triposg_vae_decoder.onnx")),
+            file(QStringLiteral("triposg"), QStringLiteral("triposg_dit_step.onnx"), triposgBase, QStringLiteral("TripoSG triposg_dit_step.onnx")),
+            file(QStringLiteral("triposg"), QStringLiteral("triposg_dit_step.onnx.data"), triposgBase, QStringLiteral("TripoSG triposg_dit_step.onnx.data")),
+        }};
+    out << ModelSpec{
+        QStringLiteral("triposg-int8"), tr("TripoSG int8"), tr("Image to 3D"),
+        tr("Smaller TripoSG DiT tier plus shared image encoder and VAE models."),
+        QStringLiteral("Large"), onnxAvailable ? QString() : tr("Requires an ONNX-enabled build"),
+        onnxAvailable,
+        {
+            file(QStringLiteral("triposg"), QStringLiteral("triposg_image_encoder.onnx"), triposgBase, QStringLiteral("TripoSG triposg_image_encoder.onnx")),
+            file(QStringLiteral("triposg"), QStringLiteral("triposg_vae_latents.onnx"), triposgBase, QStringLiteral("TripoSG triposg_vae_latents.onnx")),
+            file(QStringLiteral("triposg"), QStringLiteral("triposg_vae_decoder.onnx"), triposgBase, QStringLiteral("TripoSG triposg_vae_decoder.onnx")),
+            file(QStringLiteral("triposg"), QStringLiteral("triposg_dit_step_int8.onnx"), triposgBase, QStringLiteral("TripoSG triposg_dit_step_int8.onnx")),
+        }};
+    out << ModelSpec{
+        QStringLiteral("unirig"), tr("UniRig Auto-Rigging"), tr("Rigging"),
+        tr("Encoder, decoder, and embedding ONNX models used for learned auto-rig joint prediction."),
+        QStringLiteral("~1.4 GB"), onnxAvailable ? QString() : tr("Requires an ONNX-enabled build"),
+        onnxAvailable,
+        {
+            file(QStringLiteral("unirig"), QStringLiteral("encoder.onnx"), unirigBase, QStringLiteral("UniRig encoder model")),
+            file(QStringLiteral("unirig"), QStringLiteral("decoder.onnx"), unirigBase, QStringLiteral("UniRig decoder model")),
+            file(QStringLiteral("unirig"), QStringLiteral("embed.onnx"), unirigBase, QStringLiteral("UniRig embed model")),
+        }};
+    out << ModelSpec{
+        QStringLiteral("skintokens"), tr("SkinTokens Skinning"), tr("Rigging"),
+        tr("Manifest and ONNX models used for learned skin-weight generation."),
+        QStringLiteral("Large"), onnxAvailable ? QString() : tr("Requires an ONNX-enabled build"),
+        onnxAvailable,
+        {
+            file(QStringLiteral("skintokens"), QStringLiteral("skintokens.json"), skinTokensBase, QStringLiteral("SkinTokens manifest")),
+            file(QStringLiteral("skintokens"), QStringLiteral("mesh_cond.onnx"), skinTokensBase, QStringLiteral("SkinTokens mesh conditioner")),
+            file(QStringLiteral("skintokens"), QStringLiteral("vae_cond.onnx"), skinTokensBase, QStringLiteral("SkinTokens VAE conditioner")),
+            file(QStringLiteral("skintokens"), QStringLiteral("embed.onnx"), skinTokensBase, QStringLiteral("SkinTokens embedding model")),
+            file(QStringLiteral("skintokens"), QStringLiteral("decoder.onnx"), skinTokensBase, QStringLiteral("SkinTokens decoder model")),
+            file(QStringLiteral("skintokens"), QStringLiteral("decoder.onnx.data"), skinTokensBase, QStringLiteral("SkinTokens decoder weights")),
+            file(QStringLiteral("skintokens"), QStringLiteral("skin_decode.onnx"), skinTokensBase, QStringLiteral("SkinTokens skin decoder")),
+        }};
+    out << ModelSpec{
+        QStringLiteral("motion-inbetween"), tr("Motion In-Betweening"), tr("Animation"),
+        tr("RMIB ONNX model used to interpolate animation key poses with a learned motion prior."),
+        QStringLiteral("~10 MB"), onnxAvailable ? QString() : tr("Requires an ONNX-enabled build"),
+        onnxAvailable,
+        { file(QStringLiteral("inbetween"), QStringLiteral("rmib.onnx"), inbetweenBase, QStringLiteral("RMIB in-betweening model")) }};
+    out << ModelSpec{
+        QStringLiteral("motion-library"), tr("Motion Library"), tr("Animation"),
+        tr("Prompt-matched animation template library used for text-driven motion generation fallback."),
+        QStringLiteral("~1 MB"), QString(), true,
+        { file(QStringLiteral("motion"), QStringLiteral("motion-library.json"), motionBase, QStringLiteral("Motion library")) }};
+    out << ModelSpec{
+        QStringLiteral("text-to-motion"), tr("Text-to-Motion"), tr("Animation"),
+        tr("ONNX model and vocabulary used to generate motion from text prompts."),
+        QStringLiteral("Small"), onnxAvailable ? QString() : tr("Requires an ONNX-enabled build"),
+        onnxAvailable,
+        {
+            file(QStringLiteral("motion"), QStringLiteral("t2m.onnx"), t2mBase, QStringLiteral("Text-to-motion model")),
+            file(QStringLiteral("motion"), QStringLiteral("t2m-vocab.json"), t2mBase, QStringLiteral("Text-to-motion vocab")),
+        }};
+    out << ModelSpec{
+        QStringLiteral("mesh-segmentation"), tr("Mesh Segmentation"), tr("Mesh Tools"),
+        tr("ONNX models used to classify mesh categories and parts for segmentation-aware tools."),
+        QStringLiteral("Small"), onnxAvailable ? QString() : tr("Requires an ONNX-enabled build"),
+        onnxAvailable,
+        {
+            file(QStringLiteral("segment"), QStringLiteral("meshseg.onnx"), segmentBase, QStringLiteral("Body mesh segmentation model")),
+            file(QStringLiteral("segment"), QStringLiteral("meshseg_vegetation.onnx"), segmentBase, QStringLiteral("Vegetation mesh segmentation model")),
+            file(QStringLiteral("segment"), QStringLiteral("meshseg_vehicle.onnx"), segmentBase, QStringLiteral("Vehicle mesh segmentation model")),
+            file(QStringLiteral("segment"), QStringLiteral("meshseg_building.onnx"), segmentBase, QStringLiteral("Building mesh segmentation model")),
+            file(QStringLiteral("segment"), QStringLiteral("meshseg_category.onnx"), segmentBase, QStringLiteral("Mesh category classifier")),
+        }};
+    out << ModelSpec{
+        QStringLiteral("image-captioning"), tr("Image Captioning"), tr("Image to 3D"),
+        tr("SmolVLM GGUF model and vision projector used to caption reference images."),
+        QStringLiteral("< 600 MB"), captionAvailable ? QString() : tr("Requires an MTMD-enabled build"),
+        captionAvailable,
+        {
+            file(QStringLiteral("caption"), QStringLiteral("SmolVLM-500M-Instruct-Q8_0.gguf"), captionBase, QStringLiteral("Caption SmolVLM-500M-Instruct-Q8_0.gguf")),
+            file(QStringLiteral("caption"), QStringLiteral("mmproj-SmolVLM-500M-Instruct-Q8_0.gguf"), captionBase, QStringLiteral("Caption mmproj-SmolVLM-500M-Instruct-Q8_0.gguf")),
+        }};
+    return out;
+}
+
+QVariantList AIModelCatalog::models() const
+{
+    QVariantList list;
+    const auto all = specs();
+    for (const ModelSpec& spec : all)
+        list << toVariantMap(spec);
+    return list;
+}
+
+QVariantMap AIModelCatalog::toVariantMap(const ModelSpec& spec) const
+{
+    int present = 0;
+    QVariantList files;
+    for (const FileSpec& f : spec.files) {
+        const bool exists = QFileInfo::exists(f.path);
+        if (exists)
+            ++present;
+        files << QVariantMap{
+            {QStringLiteral("fileName"), f.fileName},
+            {QStringLiteral("path"), f.path},
+            {QStringLiteral("downloaded"), exists},
+        };
+    }
+
+    const bool downloaded = present == spec.files.size();
+    const bool partial = present > 0 && !downloaded;
+    return {
+        {QStringLiteral("id"), spec.id},
+        {QStringLiteral("name"), spec.name},
+        {QStringLiteral("feature"), spec.feature},
+        {QStringLiteral("description"), spec.description},
+        {QStringLiteral("size"), spec.size},
+        {QStringLiteral("buildRequirement"), spec.buildRequirement},
+        {QStringLiteral("available"), spec.available},
+        {QStringLiteral("downloaded"), downloaded},
+        {QStringLiteral("partial"), partial},
+        {QStringLiteral("presentFiles"), present},
+        {QStringLiteral("totalFiles"), spec.files.size()},
+        {QStringLiteral("installedBytes"), installedBytes(spec)},
+        {QStringLiteral("files"), files},
+        {QStringLiteral("isActive"), m_activeModelId == spec.id},
+    };
+}
+
+bool AIModelCatalog::isDownloaded(const ModelSpec& spec) const
+{
+    for (const FileSpec& f : spec.files) {
+        if (!QFileInfo::exists(f.path))
+            return false;
+    }
+    return !spec.files.isEmpty();
+}
+
+qint64 AIModelCatalog::installedBytes(const ModelSpec& spec) const
+{
+    qint64 total = 0;
+    for (const FileSpec& f : spec.files) {
+        const QFileInfo info(f.path);
+        if (info.exists())
+            total += info.size();
+    }
+    return total;
+}
+
+void AIModelCatalog::refresh()
+{
+    emit modelsChanged();
+}
+
+void AIModelCatalog::downloadModel(const QString& id)
+{
+    if (m_busy || ModelDownloader::instance()->isDownloading()) {
+        setStatusMessage(tr("Another model download is already running."));
+        return;
+    }
+
+    QList<ModelSpec> owner;
+    const ModelSpec* spec = findSpec(id, &owner);
+    if (!spec)
+        return;
+    if (!spec->available) {
+        setStatusMessage(spec->buildRequirement);
+        return;
+    }
+    if (isDownloaded(*spec)) {
+        setStatusMessage(tr("%1 is already downloaded.").arg(spec->name));
+        return;
+    }
+
+    m_pendingFiles.clear();
+    for (const FileSpec& f : spec->files) {
+        if (!QFileInfo::exists(f.path))
+            m_pendingFiles << f;
+    }
+    if (m_pendingFiles.isEmpty())
+        return;
+
+    m_activeModelId = spec->id;
+    m_activeModelName = spec->name;
+    emit activeModelChanged();
+    SentryReporter::addBreadcrumb(QStringLiteral("file.import"),
+                                  tr("Started download for %1").arg(spec->name));
+    setBusy(true);
+    setStatusMessage(tr("Downloading %1...").arg(spec->name));
+    emit modelsChanged();
+    startNextQueuedFile();
+}
+
+void AIModelCatalog::downloadAllModels()
+{
+    if (m_busy || ModelDownloader::instance()->isDownloading()) {
+        setStatusMessage(tr("Another model download is already running."));
+        return;
+    }
+
+    m_pendingFiles.clear();
+    QSet<QString> queuedPaths;
+    int unavailable = 0;
+    const auto all = specs();
+    for (const ModelSpec& spec : all) {
+        if (!spec.available) {
+            ++unavailable;
+            continue;
+        }
+        for (const FileSpec& f : spec.files) {
+            if (QFileInfo::exists(f.path) || queuedPaths.contains(f.path))
+                continue;
+            queuedPaths.insert(f.path);
+            m_pendingFiles << f;
+        }
+    }
+
+    if (m_pendingFiles.isEmpty()) {
+        setStatusMessage(unavailable > 0
+            ? tr("All available QtMeshEditor models are already downloaded.")
+            : tr("All QtMeshEditor models are already downloaded."));
+        emit modelsChanged();
+        return;
+    }
+
+    m_activeModelId = QStringLiteral("__all__");
+    m_activeModelName = unavailable > 0
+        ? tr("all available QtMeshEditor models")
+        : tr("all QtMeshEditor models");
+    emit activeModelChanged();
+    SentryReporter::addBreadcrumb(QStringLiteral("file.import"),
+                                  tr("Started download for %1").arg(m_activeModelName));
+    setBusy(true);
+    setStatusMessage(tr("Downloading %1...").arg(m_activeModelName));
+    emit modelsChanged();
+    startNextQueuedFile();
+}
+
+void AIModelCatalog::deleteModel(const QString& id)
+{
+    if (m_busy || ModelDownloader::instance()->isDownloading()) {
+        setStatusMessage(tr("Cancel the current download before deleting models."));
+        return;
+    }
+
+    QList<ModelSpec> owner;
+    const ModelSpec* spec = findSpec(id, &owner);
+    if (!spec)
+        return;
+
+    SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
+                                  tr("Deleting files for %1").arg(spec->name));
+
+    QSet<QString> sharedPaths;
+    for (const ModelSpec& other : std::as_const(owner)) {
+        if (other.id == spec->id || !isDownloaded(other))
+            continue;
+        for (const FileSpec& otherFile : other.files) {
+            sharedPaths.insert(otherFile.path);
+        }
+    }
+
+    bool removedAny = false;
+    QStringList failedPaths;
+    QStringList keptSharedPaths;
+    auto removeExisting = [&](const QString& path) {
+        if (!QFileInfo::exists(path))
+            return;
+        if (QFile::remove(path)) {
+            removedAny = true;
+        } else {
+            failedPaths << path;
+        }
+    };
+
+    for (const FileSpec& f : spec->files) {
+        if (sharedPaths.contains(f.path)) {
+            if (QFileInfo::exists(f.path) || QFileInfo::exists(f.path + QStringLiteral(".part")))
+                keptSharedPaths << QFileInfo(f.path).fileName();
+            continue;
+        }
+        removeExisting(f.path);
+        removeExisting(f.path + QStringLiteral(".part"));
+    }
+
+    if (!failedPaths.isEmpty()) {
+        setStatusMessage(tr("Could not delete %1 file(s) for %2.")
+                             .arg(failedPaths.size())
+                             .arg(spec->name));
+        SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
+                                      tr("Failed to delete %1 file(s) for %2")
+                                          .arg(failedPaths.size())
+                                          .arg(spec->name),
+                                      QStringLiteral("error"));
+    } else if (removedAny) {
+        setStatusMessage(keptSharedPaths.isEmpty()
+            ? tr("Deleted %1.").arg(spec->name)
+            : tr("Deleted %1. Shared files used by other models were kept.").arg(spec->name));
+        SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
+                                      tr("Deleted files for %1").arg(spec->name));
+    } else if (!keptSharedPaths.isEmpty()) {
+        setStatusMessage(tr("No exclusive downloaded files found for %1; shared files were kept.")
+                             .arg(spec->name));
+        SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
+                                      tr("Kept shared files for %1").arg(spec->name));
+    } else {
+        setStatusMessage(tr("No downloaded files found for %1.").arg(spec->name));
+    }
+    emit modelsChanged();
+}
+
+void AIModelCatalog::deleteAllModels()
+{
+    if (m_busy || ModelDownloader::instance()->isDownloading()) {
+        setStatusMessage(tr("Cancel the current download before deleting models."));
+        return;
+    }
+
+    SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
+                                  tr("Deleting all QtMeshEditor model files"));
+
+    bool removedAny = false;
+    QStringList failedPaths;
+    QSet<QString> seenPaths;
+    auto removeExisting = [&](const QString& path) {
+        if (!QFileInfo::exists(path))
+            return;
+        if (QFile::remove(path)) {
+            removedAny = true;
+        } else {
+            failedPaths << path;
+        }
+    };
+
+    const auto all = specs();
+    for (const ModelSpec& spec : all) {
+        for (const FileSpec& f : spec.files) {
+            if (seenPaths.contains(f.path))
+                continue;
+            seenPaths.insert(f.path);
+            removeExisting(f.path);
+            removeExisting(f.path + QStringLiteral(".part"));
+        }
+    }
+
+    if (!failedPaths.isEmpty()) {
+        setStatusMessage(tr("Could not delete %1 QtMeshEditor model file(s).").arg(failedPaths.size()));
+        SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
+                                      tr("Failed to delete %1 QtMeshEditor model file(s)")
+                                          .arg(failedPaths.size()),
+                                      QStringLiteral("error"));
+    } else {
+        setStatusMessage(removedAny
+            ? tr("Deleted all downloaded QtMeshEditor model files.")
+            : tr("No downloaded QtMeshEditor model files found."));
+        if (removedAny) {
+            SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
+                                          tr("Deleted all QtMeshEditor model files"));
+        }
+    }
+    emit modelsChanged();
+}
+
+void AIModelCatalog::startNextQueuedFile()
+{
+    if (m_pendingFiles.isEmpty()) {
+        SentryReporter::addBreadcrumb(QStringLiteral("file.import"),
+                                      tr("Completed download for %1").arg(m_activeModelName));
+        setStatusMessage(tr("%1 downloaded.").arg(m_activeModelName));
+        clearActive();
+        setBusy(false);
+        emit modelsChanged();
+        return;
+    }
+
+    const FileSpec f = m_pendingFiles.first();
+    if (f.url.isEmpty()) {
+        m_pendingFiles.clear();
+        SentryReporter::addBreadcrumb(QStringLiteral("file.import"),
+                                      tr("No download URL configured for %1").arg(m_activeModelName),
+                                      QStringLiteral("error"));
+        setStatusMessage(tr("No download URL configured for %1.").arg(m_activeModelName));
+        clearActive();
+        setBusy(false);
+        emit modelsChanged();
+        return;
+    }
+
+    QDir().mkpath(QFileInfo(f.path).absolutePath());
+    ModelDownloader::instance()->startDownload(f.url, f.path, f.label);
+}
+
+void AIModelCatalog::setBusy(bool busy)
+{
+    if (m_busy == busy)
+        return;
+    m_busy = busy;
+    emit busyChanged();
+}
+
+void AIModelCatalog::setStatusMessage(const QString& message)
+{
+    if (m_statusMessage == message)
+        return;
+    m_statusMessage = message;
+    emit statusMessageChanged();
+}
+
+void AIModelCatalog::clearActive()
+{
+    if (m_activeModelId.isEmpty() && m_activeModelName.isEmpty())
+        return;
+    m_activeModelId.clear();
+    m_activeModelName.clear();
+    emit activeModelChanged();
+}
+
+const AIModelCatalog::ModelSpec* AIModelCatalog::findSpec(const QString& id,
+                                                          QList<ModelSpec>* owner) const
+{
+    if (!owner)
+        return nullptr;
+    *owner = specs();
+    for (const ModelSpec& spec : std::as_const(*owner)) {
+        if (spec.id == id)
+            return &spec;
+    }
+    return nullptr;
+}

--- a/src/AIModelCatalog.h
+++ b/src/AIModelCatalog.h
@@ -1,0 +1,87 @@
+#ifndef AIMODELCATALOG_H
+#define AIMODELCATALOG_H
+
+#include <QObject>
+#include <QJSEngine>
+#include <QQmlEngine>
+#include <QVariantList>
+
+class AIModelCatalog : public QObject
+{
+    Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
+
+    Q_PROPERTY(QVariantList models READ models NOTIFY modelsChanged)
+    Q_PROPERTY(bool busy READ busy NOTIFY busyChanged)
+    Q_PROPERTY(QString activeModelId READ activeModelId NOTIFY activeModelChanged)
+    Q_PROPERTY(QString activeModelName READ activeModelName NOTIFY activeModelChanged)
+    Q_PROPERTY(QString statusMessage READ statusMessage NOTIFY statusMessageChanged)
+
+public:
+    static AIModelCatalog* instance();
+    static AIModelCatalog* qmlInstance(QQmlEngine* engine, QJSEngine* scriptEngine);
+
+    QVariantList models() const;
+    bool busy() const { return m_busy; }
+    QString activeModelId() const { return m_activeModelId; }
+    QString activeModelName() const { return m_activeModelName; }
+    QString statusMessage() const { return m_statusMessage; }
+
+    Q_INVOKABLE void refresh();
+    Q_INVOKABLE void downloadModel(const QString& id);
+    Q_INVOKABLE void downloadAllModels();
+    Q_INVOKABLE void deleteModel(const QString& id);
+    Q_INVOKABLE void deleteAllModels();
+    Q_INVOKABLE QString modelsRootUrl() const;
+
+signals:
+    void modelsChanged();
+    void busyChanged();
+    void activeModelChanged();
+    void statusMessageChanged();
+
+private:
+    struct FileSpec {
+        QString fileName;
+        QString path;
+        QString url;
+        QString label;
+    };
+
+    struct ModelSpec {
+        QString id;
+        QString name;
+        QString feature;
+        QString description;
+        QString size;
+        QString buildRequirement;
+        bool available = true;
+        QList<FileSpec> files;
+    };
+
+    explicit AIModelCatalog(QObject* parent = nullptr);
+
+    QList<ModelSpec> specs() const;
+    QVariantMap toVariantMap(const ModelSpec& spec) const;
+    bool isDownloaded(const ModelSpec& spec) const;
+    qint64 installedBytes(const ModelSpec& spec) const;
+    QString rootPath() const;
+    QString resolveBaseUrl(const char* settingsKey, const char* envKey,
+                           const char* fallback) const;
+    void setBusy(bool busy);
+    void setStatusMessage(const QString& message);
+    void startNextQueuedFile();
+    void clearActive();
+    const ModelSpec* findSpec(const QString& id, QList<ModelSpec>* owner = nullptr) const;
+
+    static AIModelCatalog* s_instance;
+
+    bool m_busy = false;
+    QString m_activeModelId;
+    QString m_activeModelName;
+    QString m_statusMessage;
+    QList<FileSpec> m_pendingFiles;
+};
+
+#endif // AIMODELCATALOG_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -183,6 +183,7 @@ MeshDecimator.cpp
 MeshDecimatorController.cpp
 MeshValidator.cpp
 AIChatManager.cpp
+AIModelCatalog.cpp
 WelcomeScreenController.cpp
 WelcomeDialog.cpp
 ScanConfig.cpp
@@ -345,6 +346,7 @@ MeshDecimator.h
 MeshDecimatorController.h
 MeshValidator.h
 AIChatManager.h
+AIModelCatalog.h
 WelcomeScreenController.h
 WelcomeDialog.h
 ScanConfig.h

--- a/src/LLMSettingsWidget.cpp
+++ b/src/LLMSettingsWidget.cpp
@@ -9,7 +9,11 @@
 #include <QMessageBox>
 #include <QDir>
 #include <QDesktopServices>
+#include <QFileInfo>
+#include <QStandardPaths>
 #include <QUrl>
+#include <QVariantMap>
+#include "SentryReporter.h"
 
 LLMSettingsWidget::LLMSettingsWidget(QWidget *parent)
     : QDialog(parent)
@@ -22,6 +26,7 @@ LLMSettingsWidget::LLMSettingsWidget(QWidget *parent)
     updateModelList();
     updateRecommendedModelsList();
     updateStatus();
+    updateAIModelCatalogList();
 #ifdef ENABLE_STABLE_DIFFUSION
     updateSDModelList();
     updateSDRecommendedModelsList();
@@ -36,13 +41,19 @@ LLMSettingsWidget::LLMSettingsWidget(QWidget *parent)
     connect(manager, &LLMManager::availableModelsChanged, this, &LLMSettingsWidget::updateModelList);
 
 #ifdef ENABLE_STABLE_DIFFUSION
-    // Connect to SDManager signals
     SDManager *sdManager = SDManager::instance();
     connect(sdManager, &SDManager::modelLoadCompleted, this, &LLMSettingsWidget::onSDModelLoadCompleted);
     connect(sdManager, &SDManager::modelLoadError, this, &LLMSettingsWidget::onSDModelLoadError);
     connect(sdManager, &SDManager::modelUnloaded, this, &LLMSettingsWidget::onSDModelUnloaded);
     connect(sdManager, &SDManager::availableModelsChanged, this, &LLMSettingsWidget::updateSDModelList);
 #endif
+
+    AIModelCatalog *catalog = AIModelCatalog::instance();
+    connect(catalog, &AIModelCatalog::modelsChanged, this, &LLMSettingsWidget::updateAIModelCatalogList);
+    connect(catalog, &AIModelCatalog::busyChanged, this, &LLMSettingsWidget::updateAIModelCatalogButtons);
+    connect(catalog, &AIModelCatalog::statusMessageChanged, this, [this]() {
+        m_aiModelCatalogStatusLabel->setText(AIModelCatalog::instance()->statusMessage());
+    });
 
     // Connect to ModelDownloader signals
     ModelDownloader *downloader = ModelDownloader::instance();
@@ -60,14 +71,17 @@ void LLMSettingsWidget::setupUI()
     QWidget *modelsTab = new QWidget();
     QWidget *settingsTab = new QWidget();
     QWidget *downloadTab = new QWidget();
+    QWidget *aiModelsTab = new QWidget();
 
     setupModelsTab(modelsTab);
     setupSettingsTab(settingsTab);
     setupDownloadTab(downloadTab);
+    setupAIModelCatalogTab(aiModelsTab);
 
     m_tabWidget->addTab(modelsTab, "LLM Models");
     m_tabWidget->addTab(settingsTab, "LLM Settings");
     m_tabWidget->addTab(downloadTab, "LLM Download");
+    m_tabWidget->addTab(aiModelsTab, "QtMeshEditor Models");
 
 #ifdef ENABLE_STABLE_DIFFUSION
     QWidget *sdModelsTab = new QWidget();
@@ -303,6 +317,58 @@ void LLMSettingsWidget::setupDownloadTab(QWidget *parent)
     connect(m_cancelDownloadButton, &QPushButton::clicked, this, &LLMSettingsWidget::onCancelDownloadClicked);
 }
 
+void LLMSettingsWidget::setupAIModelCatalogTab(QWidget *parent)
+{
+    QVBoxLayout *layout = new QVBoxLayout(parent);
+
+    QGroupBox *modelsGroup = new QGroupBox("QtMeshEditor Models", parent);
+    QVBoxLayout *modelsLayout = new QVBoxLayout(modelsGroup);
+
+    m_aiModelCatalogList = new QListWidget(modelsGroup);
+    m_aiModelCatalogList->setSelectionMode(QAbstractItemView::SingleSelection);
+    modelsLayout->addWidget(m_aiModelCatalogList);
+
+    QHBoxLayout *buttonLayout = new QHBoxLayout();
+    m_aiModelCatalogDownloadButton = new QPushButton("Download", modelsGroup);
+    m_aiModelCatalogDownloadAllButton = new QPushButton("Download All", modelsGroup);
+    m_aiModelCatalogDeleteButton = new QPushButton("Delete", modelsGroup);
+    m_aiModelCatalogDeleteAllButton = new QPushButton("Remove All", modelsGroup);
+    m_aiModelCatalogRefreshButton = new QPushButton("Refresh", modelsGroup);
+    m_aiModelCatalogOpenFolderButton = new QPushButton("Open Folder", modelsGroup);
+    buttonLayout->addWidget(m_aiModelCatalogDownloadButton);
+    buttonLayout->addWidget(m_aiModelCatalogDownloadAllButton);
+    buttonLayout->addWidget(m_aiModelCatalogDeleteButton);
+    buttonLayout->addWidget(m_aiModelCatalogDeleteAllButton);
+    buttonLayout->addWidget(m_aiModelCatalogRefreshButton);
+    buttonLayout->addStretch();
+    buttonLayout->addWidget(m_aiModelCatalogOpenFolderButton);
+    modelsLayout->addLayout(buttonLayout);
+
+    layout->addWidget(modelsGroup);
+
+    QGroupBox *statusGroup = new QGroupBox("Status", parent);
+    QVBoxLayout *statusLayout = new QVBoxLayout(statusGroup);
+    m_aiModelCatalogStatusLabel = new QLabel("Ready", statusGroup);
+    m_aiModelCatalogStatusLabel->setWordWrap(true);
+    statusLayout->addWidget(m_aiModelCatalogStatusLabel);
+    layout->addWidget(statusGroup);
+
+    connect(m_aiModelCatalogList, &QListWidget::currentItemChanged,
+            this, &LLMSettingsWidget::updateAIModelCatalogButtons);
+    connect(m_aiModelCatalogDownloadButton, &QPushButton::clicked,
+            this, &LLMSettingsWidget::onAIModelCatalogDownloadClicked);
+    connect(m_aiModelCatalogDownloadAllButton, &QPushButton::clicked,
+            this, &LLMSettingsWidget::onAIModelCatalogDownloadAllClicked);
+    connect(m_aiModelCatalogDeleteButton, &QPushButton::clicked,
+            this, &LLMSettingsWidget::onAIModelCatalogDeleteClicked);
+    connect(m_aiModelCatalogDeleteAllButton, &QPushButton::clicked,
+            this, &LLMSettingsWidget::onAIModelCatalogDeleteAllClicked);
+    connect(m_aiModelCatalogRefreshButton, &QPushButton::clicked,
+            this, &LLMSettingsWidget::onAIModelCatalogRefreshClicked);
+    connect(m_aiModelCatalogOpenFolderButton, &QPushButton::clicked,
+            this, &LLMSettingsWidget::onAIModelCatalogOpenFolderClicked);
+}
+
 void LLMSettingsWidget::updateModelList()
 {
     m_modelCombo->clear();
@@ -525,6 +591,13 @@ void LLMSettingsWidget::onDownloadProgress(const QString &modelName, qint64 byte
 void LLMSettingsWidget::onDownloadCompleted(const QString &modelName, const QString &filePath)
 {
     Q_UNUSED(filePath);
+    const bool catalogDownload = AIModelCatalog::instance()->busy()
+        && !AIModelCatalog::instance()->activeModelId().isEmpty();
+    if (catalogDownload) {
+        updateAIModelCatalogList();
+        return;
+    }
+
     m_downloadButton->setEnabled(true);
     m_cancelDownloadButton->setEnabled(false);
     m_downloadStatusLabel->setText(QString("Download completed: %1").arg(modelName));
@@ -541,6 +614,7 @@ void LLMSettingsWidget::onDownloadCompleted(const QString &modelName, const QStr
     updateSDRecommendedModelsList();
     m_sdDownloadButton->setEnabled(true);
 #endif
+    updateAIModelCatalogList();
 
     QMessageBox::information(this, "Download Complete",
                              QString("Model %1 has been downloaded successfully.").arg(modelName));
@@ -594,6 +668,154 @@ void LLMSettingsWidget::onResetDefaults()
     m_repeatPenaltySpinBox->setValue(static_cast<double>(defaults.repeatPenalty));
 
     m_applyButton->setEnabled(true);
+}
+
+void LLMSettingsWidget::updateAIModelCatalogList()
+{
+    const QString selectedId = m_aiModelCatalogList->currentItem()
+        ? m_aiModelCatalogList->currentItem()->data(Qt::UserRole).toString()
+        : QString();
+
+    m_aiModelCatalogList->clear();
+    const QVariantList models = AIModelCatalog::instance()->models();
+    int selectedRow = -1;
+    for (int i = 0; i < models.size(); ++i) {
+        const QVariantMap model = models[i].toMap();
+        const bool downloaded = model.value("downloaded").toBool();
+        const bool partial = model.value("partial").toBool();
+        const bool available = model.value("available").toBool();
+        const qint64 installedBytes = model.value("installedBytes").toLongLong();
+
+        QString status = downloaded ? "Downloaded" : (partial ? "Partial" : "Not downloaded");
+        QString text = QString("%1 [%2]\n%3 - %4 - %5/%6 files%7\n%8")
+            .arg(model.value("name").toString())
+            .arg(status)
+            .arg(model.value("feature").toString())
+            .arg(model.value("size").toString())
+            .arg(model.value("presentFiles").toInt())
+            .arg(model.value("totalFiles").toInt())
+            .arg(installedBytes > 0
+                 ? QString(" - %1 installed").arg(formatFileSize(installedBytes))
+                 : QString())
+            .arg(model.value("description").toString());
+        if (!available)
+            text += QString("\n%1").arg(model.value("buildRequirement").toString());
+
+        QListWidgetItem *item = new QListWidgetItem(text, m_aiModelCatalogList);
+        item->setData(Qt::UserRole, model.value("id").toString());
+        item->setData(Qt::UserRole + 1, downloaded);
+        item->setData(Qt::UserRole + 2, partial);
+        item->setData(Qt::UserRole + 3, available);
+        item->setData(Qt::UserRole + 4, model.value("name").toString());
+
+        if (downloaded)
+            item->setForeground(QColor(0, 128, 0));
+        else if (partial)
+            item->setForeground(QColor(180, 100, 0));
+        else if (!available)
+            item->setForeground(QColor(160, 0, 0));
+
+        if (item->data(Qt::UserRole).toString() == selectedId)
+            selectedRow = i;
+    }
+
+    if (m_aiModelCatalogList->count() > 0)
+        m_aiModelCatalogList->setCurrentRow(selectedRow >= 0 ? selectedRow : 0);
+    updateAIModelCatalogButtons();
+}
+
+void LLMSettingsWidget::updateAIModelCatalogButtons()
+{
+    QListWidgetItem *item = m_aiModelCatalogList->currentItem();
+    const bool busy = AIModelCatalog::instance()->busy();
+    const bool hasItem = item != nullptr;
+    const bool downloaded = hasItem && item->data(Qt::UserRole + 1).toBool();
+    const bool partial = hasItem && item->data(Qt::UserRole + 2).toBool();
+    const bool available = hasItem && item->data(Qt::UserRole + 3).toBool();
+
+    m_aiModelCatalogDownloadButton->setEnabled(hasItem && available && !downloaded && !busy);
+    m_aiModelCatalogDeleteButton->setEnabled(hasItem && (downloaded || partial) && !busy);
+    m_aiModelCatalogDownloadAllButton->setEnabled(!busy);
+    m_aiModelCatalogDeleteAllButton->setEnabled(!busy);
+    m_aiModelCatalogRefreshButton->setEnabled(!busy);
+    m_aiModelCatalogOpenFolderButton->setEnabled(true);
+}
+
+void LLMSettingsWidget::onAIModelCatalogDownloadClicked()
+{
+    QListWidgetItem *item = m_aiModelCatalogList->currentItem();
+    if (!item)
+        return;
+    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                  QStringLiteral("Download QtMeshEditor model"));
+    AIModelCatalog::instance()->downloadModel(item->data(Qt::UserRole).toString());
+    updateAIModelCatalogButtons();
+}
+
+void LLMSettingsWidget::onAIModelCatalogDownloadAllClicked()
+{
+    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                  QStringLiteral("Download all QtMeshEditor models"));
+    AIModelCatalog::instance()->downloadAllModels();
+    updateAIModelCatalogButtons();
+}
+
+void LLMSettingsWidget::onAIModelCatalogDeleteClicked()
+{
+    QListWidgetItem *item = m_aiModelCatalogList->currentItem();
+    if (!item)
+        return;
+
+    const QString modelName = item->data(Qt::UserRole + 4).toString();
+    QMessageBox::StandardButton reply = QMessageBox::question(
+        this, "Delete Model Files",
+        QString("Delete downloaded files for %1?").arg(modelName),
+        QMessageBox::Yes | QMessageBox::No);
+    if (reply == QMessageBox::No)
+        return;
+
+    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                  QStringLiteral("Delete QtMeshEditor model files"));
+    AIModelCatalog::instance()->deleteModel(item->data(Qt::UserRole).toString());
+}
+
+void LLMSettingsWidget::onAIModelCatalogDeleteAllClicked()
+{
+    QMessageBox::StandardButton reply = QMessageBox::question(
+        this, "Remove All Model Files",
+        "Remove all downloaded QtMeshEditor model files?",
+        QMessageBox::Yes | QMessageBox::No);
+    if (reply == QMessageBox::No)
+        return;
+
+    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                  QStringLiteral("Delete all QtMeshEditor model files"));
+    AIModelCatalog::instance()->deleteAllModels();
+}
+
+void LLMSettingsWidget::onAIModelCatalogRefreshClicked()
+{
+    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                  QStringLiteral("Refresh QtMeshEditor model catalog"));
+    AIModelCatalog::instance()->refresh();
+}
+
+void LLMSettingsWidget::onAIModelCatalogOpenFolderClicked()
+{
+    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+                                  QStringLiteral("Open QtMeshEditor models folder"));
+    const QString folderPath = QDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation))
+                                   .filePath(QStringLiteral("ai_models"));
+    QDir dir;
+    if (!dir.mkpath(folderPath)) {
+        QMessageBox::warning(this, "Open Folder Failed",
+                             QString("Could not create %1.").arg(folderPath));
+        return;
+    }
+    if (!QDesktopServices::openUrl(QUrl::fromLocalFile(folderPath))) {
+        QMessageBox::warning(this, "Open Folder Failed",
+                             QString("Could not open %1.").arg(folderPath));
+    }
 }
 
 // ============ SD Models Tab ============
@@ -883,6 +1105,6 @@ void LLMSettingsWidget::onSDApplySettings()
 
     QMessageBox::information(this, "Settings Applied", "SD settings have been saved.");
 }
-#endif // ENABLE_STABLE_DIFFUSION
+#endif
 
 // LCOV_EXCL_STOP

--- a/src/LLMSettingsWidget.h
+++ b/src/LLMSettingsWidget.h
@@ -14,10 +14,11 @@
 #include <QGroupBox>
 #include <QTabWidget>
 #include "LLMManager.h"
+#include "AIModelCatalog.h"
+#include "ModelDownloader.h"
 #ifdef ENABLE_STABLE_DIFFUSION
 #include "SDManager.h"
 #endif
-#include "ModelDownloader.h"
 
 class LLMSettingsWidget : public QDialog
 {
@@ -49,7 +50,6 @@ private slots:
     void onResetDefaults();
 
 #ifdef ENABLE_STABLE_DIFFUSION
-    // SD slots
     void onSDLoadModelClicked();
     void onSDUnloadModelClicked();
     void onSDRefreshModelsClicked();
@@ -61,11 +61,22 @@ private slots:
     void onSDApplySettings();
 #endif
 
+    // QtMeshEditor model catalog slots
+    void updateAIModelCatalogList();
+    void updateAIModelCatalogButtons();
+    void onAIModelCatalogDownloadClicked();
+    void onAIModelCatalogDownloadAllClicked();
+    void onAIModelCatalogDeleteClicked();
+    void onAIModelCatalogDeleteAllClicked();
+    void onAIModelCatalogRefreshClicked();
+    void onAIModelCatalogOpenFolderClicked();
+
 private:
     void setupUI();
     void setupModelsTab(QWidget *parent);
     void setupSettingsTab(QWidget *parent);
     void setupDownloadTab(QWidget *parent);
+    void setupAIModelCatalogTab(QWidget *parent);
 #ifdef ENABLE_STABLE_DIFFUSION
     void setupSDModelsTab(QWidget *parent);
     void setupSDSettingsTab(QWidget *parent);
@@ -117,8 +128,17 @@ private:
     QLabel *m_downloadStatusLabel;
     QLabel *m_downloadSpeedLabel;
 
+    // QtMeshEditor models tab
+    QListWidget *m_aiModelCatalogList;
+    QPushButton *m_aiModelCatalogDownloadButton;
+    QPushButton *m_aiModelCatalogDownloadAllButton;
+    QPushButton *m_aiModelCatalogDeleteButton;
+    QPushButton *m_aiModelCatalogDeleteAllButton;
+    QPushButton *m_aiModelCatalogRefreshButton;
+    QPushButton *m_aiModelCatalogOpenFolderButton;
+    QLabel *m_aiModelCatalogStatusLabel;
+
 #ifdef ENABLE_STABLE_DIFFUSION
-    // SD Models tab
     QComboBox *m_sdModelCombo;
     QPushButton *m_sdLoadButton;
     QPushButton *m_sdUnloadButton;

--- a/src/LLMSettingsWidget_test.cpp
+++ b/src/LLMSettingsWidget_test.cpp
@@ -35,9 +35,9 @@ TEST_F(LLMSettingsWidgetTest, HasTabWidget)
     QTabWidget* tabWidget = widget.findChild<QTabWidget*>();
     ASSERT_NE(tabWidget, nullptr);
 #ifdef ENABLE_STABLE_DIFFUSION
-    EXPECT_EQ(tabWidget->count(), 5); // LLM Models, LLM Settings, LLM Download, SD Models, SD Settings
+    EXPECT_EQ(tabWidget->count(), 6);
 #else
-    EXPECT_EQ(tabWidget->count(), 3);
+    EXPECT_EQ(tabWidget->count(), 4);
 #endif
 }
 
@@ -49,9 +49,10 @@ TEST_F(LLMSettingsWidgetTest, TabNames)
     EXPECT_EQ(tabWidget->tabText(0), "LLM Models");
     EXPECT_EQ(tabWidget->tabText(1), "LLM Settings");
     EXPECT_EQ(tabWidget->tabText(2), "LLM Download");
+    EXPECT_EQ(tabWidget->tabText(3), "QtMeshEditor Models");
 #ifdef ENABLE_STABLE_DIFFUSION
-    EXPECT_EQ(tabWidget->tabText(3), "SD Models");
-    EXPECT_EQ(tabWidget->tabText(4), "SD Settings");
+    EXPECT_EQ(tabWidget->tabText(4), "SD Models");
+    EXPECT_EQ(tabWidget->tabText(5), "SD Settings");
 #endif
 }
 

--- a/src/MaterialEditorQML.cpp
+++ b/src/MaterialEditorQML.cpp
@@ -36,6 +36,7 @@
 #endif
 #include "QMLMaterialHighlighter.h"
 #include "ModelDownloader.h"
+#include "AIModelCatalog.h"
 #include "RTShaderHelper.h"
 #include "TextureChannelPacker.h"
 #include "TextureAtlasPacker.h"
@@ -5593,6 +5594,13 @@ void MaterialEditorQML::openMaterialEditorWindow(const QString &materialName)
                 Q_UNUSED(engine)
                 Q_UNUSED(scriptEngine)
                 return ModelDownloader::qmlInstance(engine, scriptEngine);
+            });
+
+        qmlRegisterSingletonType<AIModelCatalog>("MaterialEditorQML", 1, 0, "AIModelCatalog",
+            [](QQmlEngine *engine, QJSEngine *scriptEngine) -> QObject* {
+                Q_UNUSED(engine)
+                Q_UNUSED(scriptEngine)
+                return AIModelCatalog::qmlInstance(engine, scriptEngine);
             });
 
         // Register QMLMaterialHighlighter for QML use

--- a/src/MaterialEditorQML_qml_test.cpp
+++ b/src/MaterialEditorQML_qml_test.cpp
@@ -15,6 +15,7 @@
 #include "MaterialEditorQML.h"
 #include "LLMManager.h"
 #include "ModelDownloader.h"
+#include "AIModelCatalog.h"
 #include "ImageTo3D/MeshGenController.h"
 #include "QMLMaterialHighlighter.h"
 #include "ThemeManager.h"
@@ -193,6 +194,11 @@ protected:
         qmlRegisterSingletonType<ModelDownloader>("MaterialEditorQML", 1, 0, "ModelDownloader",
             [](QQmlEngine *eng, QJSEngine *js) -> QObject * {
                 return ModelDownloader::qmlInstance(eng, js);
+            }
+        );
+        qmlRegisterSingletonType<AIModelCatalog>("MaterialEditorQML", 1, 0, "AIModelCatalog",
+            [](QQmlEngine *eng, QJSEngine *js) -> QObject * {
+                return AIModelCatalog::qmlInstance(eng, js);
             }
         );
         // AISettingsDialog.qml references MeshGenController (image-to-3D #764) under
@@ -669,4 +675,4 @@ TEST_F(QMLComponentLoadingTest, DynamicComponentCreation) {
 } 
 */
 
-// End of commented-out QML tests due to MaterialEditorQML singleton lifecycle issues 
+// End of commented-out QML tests due to MaterialEditorQML singleton lifecycle issues

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@
 #include "MaterialEditorQML.h"
 #include "QMLMaterialHighlighter.h"
 #include "LLMManager.h"
+#include "AIModelCatalog.h"
 #ifdef ENABLE_STABLE_DIFFUSION
 #include "SDManager.h"
 #endif
@@ -229,6 +230,11 @@ int main(int argc, char *argv[])
     qmlRegisterSingletonType<ModelDownloader>("MaterialEditorQML", 1, 0, "ModelDownloader",
         [](QQmlEngine *engine, QJSEngine *scriptEngine) -> QObject* {
             return ModelDownloader::qmlInstance(engine, scriptEngine);
+        });
+
+    qmlRegisterSingletonType<AIModelCatalog>("MaterialEditorQML", 1, 0, "AIModelCatalog",
+        [](QQmlEngine *engine, QJSEngine *scriptEngine) -> QObject* {
+            return AIModelCatalog::qmlInstance(engine, scriptEngine);
         });
 
 #ifdef ENABLE_STABLE_DIFFUSION

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -107,6 +107,7 @@
 #endif
 #include "QMLMaterialHighlighter.h"
 #include "ModelDownloader.h"
+#include "AIModelCatalog.h"
 #include "UndoManager.h"
 #include "commands/TransformCommands.h"
 #include "PropertiesPanelController.h"
@@ -4674,6 +4675,13 @@ void MainWindow::on_actionMaterial_Editor_triggered()
                 Q_UNUSED(engine)
                 Q_UNUSED(scriptEngine)
                 return ModelDownloader::qmlInstance(engine, scriptEngine);
+            });
+
+        qmlRegisterSingletonType<AIModelCatalog>("MaterialEditorQML", 1, 0, "AIModelCatalog",
+            [](QQmlEngine *engine, QJSEngine *scriptEngine) -> QObject* {
+                Q_UNUSED(engine)
+                Q_UNUSED(scriptEngine)
+                return AIModelCatalog::qmlInstance(engine, scriptEngine);
             });
 
         // Register QMLMaterialHighlighter for QML use

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,6 +71,8 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/LLMWorker.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/LLMSettingsWidget.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/ModelDownloader.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/SDManager.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/SDWorker.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/SentryReporter.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/BoneWeightOverlay.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/NormalVisualizer.cpp
@@ -210,6 +212,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/UvPipeline.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MeshValidator.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AIChatManager.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/AIModelCatalog.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/WelcomeScreenController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/WelcomeDialog.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/SubMeshTransform.cpp
@@ -336,6 +339,8 @@ ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/MeshReconstructorTexKeys.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/LLMWorker.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/LLMSettingsWidget.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/ModelDownloader.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/SDManager.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/SDWorker.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/SentryReporter.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/BoneWeightOverlay.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/NormalVisualizer.h
@@ -369,6 +374,7 @@ ${CMAKE_CURRENT_SOURCE_DIR}/../src/PS1/runtime/MeshReconstructorTexKeys.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/UvPipeline.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MeshValidator.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AIChatManager.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/AIModelCatalog.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/WelcomeScreenController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/WelcomeDialog.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/SubMeshTransform.h


### PR DESCRIPTION
## Summary
- Add a QtMeshEditor Models tab to AI settings with per-model download/delete controls and bulk Download All/Remove All actions.
- Surface the same model management tab in the top-menu AI Model Settings widget, alongside existing LLM controls and Stable Diffusion controls when SD support is compiled in.
- Add a shared AI model catalog covering current app-managed model files, including newly detected Mesh Segmentation category models and SkinTokens files.

## Features
- Lists each QtMeshEditor-managed AI model, installed status, present file count, size, feature area, and availability requirements.
- Allows per-model download/delete and bulk download/remove-all from both QML AI settings and the top-menu settings widget.
- Keeps deletion safer with confirmation prompts, shared-file preservation, and failure reporting.

## Bugfixes
- Fixes `MaterialEditorQML_test` linking by including Stable Diffusion manager sources in the shared test support target.
- Restores `ENABLE_STABLE_DIFFUSION` guards so SD tabs are hidden in non-SD builds.

## Technical Details
- Adds `AIModelCatalog` as a QML singleton backed by `ModelDownloader` and app data storage under `ai_models`.
- Deduplicates shared downloads and preserves shared artifacts when deleting a single model.
- Adds Sentry breadcrumbs for catalog UI actions and model download/delete lifecycle events.

## Verification
- `git diff --check`
- `cmake --build build --target MaterialEditorQML_test -j2`
- `QT_QPA_PLATFORM=offscreen ./build/debug/MaterialEditorQML_qml_test --gtest_filter=QMLComponentLoadingTest.AISettingsDialogLoadsWithoutErrors`
- `cmake --build build --target QtMeshEditor -j2`
- `cmake --build build_onnx_cpu --target QtMeshEditor -j2`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated QtMeshEditor Models tab for browsing available AI models.
  * Download, cancel, refresh, delete, download-all, remove-all, and open-folder actions are now available.
  * Model cards show availability, download progress, installation status, and build requirements.
  * Added confirmation dialogs for individual and bulk model removal.
  * Model management is available in both the QML and desktop settings interfaces.

* **Tests**
  * Updated settings-tab coverage for the new models tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->