### PR TITLE
feat(skeleton): rest pose authoring — Slice C (#557)

### DIFF
--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -3119,6 +3119,76 @@ Rectangle {
                     SkelToolButton { label: "Remove"; action: "remove" }
                     SkelToolButton { label: "Rename"; action: "rename" }
                 }
+
+                Text {
+                    text: "Rest Pose"
+                    color: PropertiesPanelController.textColor
+                    font.pixelSize: 11
+                    font.bold: true
+                }
+                Text {
+                    width: parent.width
+                    wrapMode: Text.Wrap
+                    font.pixelSize: 10
+                    color: PropertiesPanelController.borderColor
+                    text: "Capture the current pose as bind, or edit rest with the bone gizmo."
+                }
+
+                Flow {
+                    width: parent.width
+                    spacing: 4
+                    SkelToolButton { label: "Capture Rest"; action: "captureRest"; needsBone: false }
+                    SkelToolButton { label: "Reset Rest"; action: "resetRest"; needsBone: false }
+                    SkelToolButton { label: "Snap Bone"; action: "snapRest" }
+                }
+
+                Row {
+                    spacing: 12
+                    CheckBox {
+                        id: editRestCheck
+                        text: "Edit rest pose"
+                        checked: SkeletonEditor.editRestPoseMode
+                        onCheckedChanged: {
+                            if (checked !== SkeletonEditor.editRestPoseMode)
+                                SkeletonEditor.editRestPoseMode = checked
+                        }
+                        contentItem: Text {
+                            text: editRestCheck.text
+                            color: PropertiesPanelController.textColor
+                            font.pixelSize: 11
+                            leftPadding: editRestCheck.indicator.width + 4
+                            verticalAlignment: Text.AlignVCenter
+                        }
+                    }
+                    CheckBox {
+                        id: ghostRestCheck
+                        text: "Rest ghost"
+                        checked: SkeletonEditor.showRestPoseGhost
+                        onCheckedChanged: {
+                            if (checked !== SkeletonEditor.showRestPoseGhost)
+                                SkeletonEditor.showRestPoseGhost = checked
+                        }
+                        contentItem: Text {
+                            text: ghostRestCheck.text
+                            color: PropertiesPanelController.textColor
+                            font.pixelSize: 11
+                            leftPadding: ghostRestCheck.indicator.width + 4
+                            verticalAlignment: Text.AlignVCenter
+                        }
+                    }
+                }
+
+                Connections {
+                    target: SkeletonEditor
+                    function onEditRestPoseModeChanged() {
+                        if (editRestCheck.checked !== SkeletonEditor.editRestPoseMode)
+                            editRestCheck.checked = SkeletonEditor.editRestPoseMode
+                    }
+                    function onShowRestPoseGhostChanged() {
+                        if (ghostRestCheck.checked !== SkeletonEditor.showRestPoseGhost)
+                            ghostRestCheck.checked = SkeletonEditor.showRestPoseGhost
+                    }
+                }
             }
 
             Text {
@@ -7925,6 +7995,27 @@ Rectangle {
             }
         } else if (action === "attach") {
             root.openAttachBoneDialog()
+        } else if (action === "captureRest") {
+            if (SkeletonEditor.captureRestPoseForSelected()) {
+                root.boneEditStatus = "Rest pose captured."
+            } else {
+                root.boneEditError = true
+                root.boneEditStatus = "Capture rest pose failed."
+            }
+        } else if (action === "resetRest") {
+            if (SkeletonEditor.resetRestPoseForSelected()) {
+                root.boneEditStatus = "Rest pose reset to import."
+            } else {
+                root.boneEditError = true
+                root.boneEditStatus = "Reset rest pose failed."
+            }
+        } else if (action === "snapRest") {
+            if (SkeletonEditor.snapSelectedBonesToCurrentPose()) {
+                root.boneEditStatus = "Selected bone snapped to rest."
+            } else {
+                root.boneEditError = true
+                root.boneEditStatus = "Snap rest pose failed (select a bone)."
+            }
         } else if (action === "remove") {
             root.openRemoveBoneDialog()
         } else if (action === "rename") {

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -3130,7 +3130,8 @@ Rectangle {
                     width: parent.width
                     wrapMode: Text.Wrap
                     font.pixelSize: 10
-                    color: PropertiesPanelController.borderColor
+                    color: PropertiesPanelController.textColor
+                    opacity: 0.75
                     text: "Capture the current pose as bind, or edit rest with the bone gizmo."
                 }
 
@@ -3144,7 +3145,7 @@ Rectangle {
 
                 Row {
                     spacing: 12
-                    CheckBox {
+                    InspectorCheckBox {
                         id: editRestCheck
                         text: "Edit rest pose"
                         checked: SkeletonEditor.editRestPoseMode
@@ -3152,28 +3153,14 @@ Rectangle {
                             if (checked !== SkeletonEditor.editRestPoseMode)
                                 SkeletonEditor.editRestPoseMode = checked
                         }
-                        contentItem: Text {
-                            text: editRestCheck.text
-                            color: PropertiesPanelController.textColor
-                            font.pixelSize: 11
-                            leftPadding: editRestCheck.indicator.width + 4
-                            verticalAlignment: Text.AlignVCenter
-                        }
                     }
-                    CheckBox {
+                    InspectorCheckBox {
                         id: ghostRestCheck
                         text: "Rest ghost"
                         checked: SkeletonEditor.showRestPoseGhost
                         onCheckedChanged: {
                             if (checked !== SkeletonEditor.showRestPoseGhost)
                                 SkeletonEditor.showRestPoseGhost = checked
-                        }
-                        contentItem: Text {
-                            text: ghostRestCheck.text
-                            color: PropertiesPanelController.textColor
-                            font.pixelSize: 11
-                            leftPadding: ghostRestCheck.indicator.width + 4
-                            verticalAlignment: Text.AlignVCenter
                         }
                     }
                 }

--- a/src/AnimationWidget.cpp
+++ b/src/AnimationWidget.cpp
@@ -171,6 +171,14 @@ void AnimationWidget::rebuildSkeletonOverlays(Ogre::Entity* entity)
     updateSkeletonTable();
 }
 
+void AnimationWidget::setRestPoseGhostVisible(bool show)
+{
+    for (SkeletonDebug* sd : mShowSkeleton.values()) {
+        if (sd)
+            sd->showRestGhost(show);
+    }
+}
+
 SkeletonDebug* AnimationWidget::getSkeletonDebug(Ogre::Entity* entity) const
 {
     if (mShowSkeleton.contains(entity))

--- a/src/AnimationWidget.cpp
+++ b/src/AnimationWidget.cpp
@@ -187,6 +187,9 @@ void AnimationWidget::setRestPoseGhostVisible(bool show)
         for (Ogre::Entity* ent : mgr->getEntities()) {
             if (!ent || ent->getMovableType() != "Entity" || !ent->hasSkeleton())
                 continue;
+            // Skip rest-pose ghost mesh entities (name suffix from SkeletonDebug).
+            if (QString::fromStdString(ent->getName()).endsWith(QStringLiteral("_restGhostMesh")))
+                continue;
             SkeletonDebug* sd = nullptr;
             if (mShowSkeleton.contains(ent)) {
                 sd = mShowSkeleton.value(ent);

--- a/src/AnimationWidget.cpp
+++ b/src/AnimationWidget.cpp
@@ -72,7 +72,9 @@ bool AnimationWidget::isSkeletonShown(Ogre::Entity * entity) const
 
 bool AnimationWidget::isSkeletonDebugActive(Ogre::Entity* entity) const
 {
-    return mShowSkeleton.contains(entity);
+    // "Active" means the user-visible skeleton overlay (bones), not a
+    // rest-pose ghost host that happens to share SkeletonDebug.
+    return isSkeletonShown(entity);
 }
 
 bool AnimationWidget::isBoneWeightsShown(Ogre::Entity* entity) const
@@ -100,14 +102,17 @@ bool AnimationWidget::toggleSkeletonDebug(Ogre::Entity* entity, bool show)
     {
         sd->showAxes(false);
         sd->showNames(false);
-        mShowSkeleton.remove(entity);
-        // QMap of raw pointers doesn't own — delete explicitly. Without
-        // this, the SkeletonDebug + its QTimer (which fires every tick
-        // touching mBoneEntities) leaks. On the next enable, a *new*
-        // SkeletonDebug attaches new visuals, the leaked one's timer
-        // races with the new attachments via attachObjectToBone, and
-        // touches dangling Ogre::Entity pointers → SIGSEGV at 0xf8.
-        delete sd; // NOSONAR — manual delete needed since QMap doesn't own
+        // Keep the host alive when rest-pose ghost still needs it.
+        if (!sd->restGhostShown()) {
+            mShowSkeleton.remove(entity);
+            // QMap of raw pointers doesn't own — delete explicitly. Without
+            // this, the SkeletonDebug + its QTimer (which fires every tick
+            // touching mBoneEntities) leaks. On the next enable, a *new*
+            // SkeletonDebug attaches new visuals, the leaked one's timer
+            // races with the new attachments via attachObjectToBone, and
+            // touches dangling Ogre::Entity pointers → SIGSEGV at 0xf8.
+            delete sd; // NOSONAR — manual delete needed since QMap doesn't own
+        }
     }
     else if (show && mWeightOverlays.contains(entity))
     {
@@ -173,9 +178,40 @@ void AnimationWidget::rebuildSkeletonOverlays(Ogre::Entity* entity)
 
 void AnimationWidget::setRestPoseGhostVisible(bool show)
 {
-    for (SkeletonDebug* sd : mShowSkeleton.values()) {
-        if (sd)
-            sd->showRestGhost(show);
+    auto* mgr = Manager::getSingletonPtr();
+    if (!mgr) return;
+
+    if (show) {
+        // Create a SkeletonDebug host when needed, but do NOT enable bone
+        // visuals — rest ghost is independent of the Skeleton checkbox.
+        for (Ogre::Entity* ent : mgr->getEntities()) {
+            if (!ent || ent->getMovableType() != "Entity" || !ent->hasSkeleton())
+                continue;
+            SkeletonDebug* sd = nullptr;
+            if (mShowSkeleton.contains(ent)) {
+                sd = mShowSkeleton.value(ent);
+            } else {
+                sd = new SkeletonDebug(ent, mgr->getSceneMgr(), 0.1f, 0.01f);
+                mShowSkeleton.insert(ent, sd);
+            }
+            sd->showRestGhost(true);
+        }
+        return;
+    }
+
+    // Hide ghost only. Destroy hosts that exist solely for the ghost
+    // (bones never shown) so we don't leave invisible SkeletonDebug timers.
+    QList<Ogre::Entity*> toRemove;
+    for (auto it = mShowSkeleton.begin(); it != mShowSkeleton.end(); ++it) {
+        SkeletonDebug* sd = it.value();
+        if (!sd) continue;
+        sd->showRestGhost(false);
+        if (!sd->bonesShown())
+            toRemove.append(it.key());
+    }
+    for (Ogre::Entity* ent : toRemove) {
+        SkeletonDebug* sd = mShowSkeleton.take(ent);
+        delete sd; // NOSONAR — QMap doesn't own
     }
 }
 

--- a/src/AnimationWidget.h
+++ b/src/AnimationWidget.h
@@ -28,6 +28,8 @@ public:
     /// Recreate skeleton/weight overlays after rig structure edits
     /// (entity->_initialise invalidates TagPoint attachments).
     void rebuildSkeletonOverlays(Ogre::Entity* entity);
+    /// Rest-pose ghost overlay on all active SkeletonDebug instances (#557).
+    void setRestPoseGhostVisible(bool show);
     SkeletonDebug* getSkeletonDebug(Ogre::Entity* entity) const;
     BoneWeightOverlay* getBoneWeightOverlay(Ogre::Entity* entity) const;
 

--- a/src/BoneDragRelease.cpp
+++ b/src/BoneDragRelease.cpp
@@ -30,7 +30,7 @@ BoneDragRelease::Result BoneDragRelease::apply(Ogre::Bone* bone,
                                                const Ogre::Vector3& beforeScale,
                                                bool hasActiveAnim,
                                                bool autoKeyOn,
-                                               Ogre::Entity* entityForUpdate,
+                                               Ogre::Entity* /*entityForUpdate*/,
                                                bool editRestMode)
 {
     if (!bone) return Result::NoOp;
@@ -48,31 +48,15 @@ BoneDragRelease::Result BoneDragRelease::apply(Ogre::Bone* bone,
         return Result::NoOp;
     }
 
-    // Edit-rest (or no active animation): rest-pose authoring. Caller
-    // commits via SkeletonEditor::commitBoneRestPose / SetRestPoseCommand
-    // so animation tracks are re-baked against the prior bind.
-    if (editRestMode || !hasActiveAnim) {
-        bone->setManuallyControlled(false);
-        return Result::CommitBind;
-    }
-
-    if (autoKeyOn) {
-        // Caller writes the keyframe (via AnimationControlController) and
-        // pushes BoneTransformCommand. We just unfreeze the bone so the
-        // curve drives playback through the new key.
+    // Auto-key with an enabled clip: write a keyframe (caller). Edit-rest
+    // overrides this — rest authoring wins over keying.
+    if (autoKeyOn && hasActiveAnim && !editRestMode) {
         bone->setManuallyControlled(false);
         return Result::Commit;
     }
 
-    // Preview only: revert bone to its pre-drag local TRS so playback
-    // is unaffected. Don't call setInitialState — the curve stores
-    // deltas relative to initial; changing initial would double-apply
-    // the curve delta on next sample.
-    bone->setPosition(beforePos);
-    bone->setOrientation(beforeOrient);
-    bone->setScale(beforeScale);
+    // Rest-pose authoring (edit-rest, no clip, or auto-key off). Caller
+    // commits via SkeletonEditor::commitBoneRestPose / SetRestPoseCommand.
     bone->setManuallyControlled(false);
-    bone->needUpdate(true);
-    if (entityForUpdate) entityForUpdate->_updateAnimation();
-    return Result::Revert;
+    return Result::CommitBind;
 }

--- a/src/BoneDragRelease.cpp
+++ b/src/BoneDragRelease.cpp
@@ -30,7 +30,8 @@ BoneDragRelease::Result BoneDragRelease::apply(Ogre::Bone* bone,
                                                const Ogre::Vector3& beforeScale,
                                                bool hasActiveAnim,
                                                bool autoKeyOn,
-                                               Ogre::Entity* entityForUpdate)
+                                               Ogre::Entity* entityForUpdate,
+                                               bool editRestMode)
 {
     if (!bone) return Result::NoOp;
 
@@ -47,7 +48,15 @@ BoneDragRelease::Result BoneDragRelease::apply(Ogre::Bone* bone,
         return Result::NoOp;
     }
 
-    if (autoKeyOn && hasActiveAnim) {
+    // Edit-rest (or no active animation): rest-pose authoring. Caller
+    // commits via SkeletonEditor::commitBoneRestPose / SetRestPoseCommand
+    // so animation tracks are re-baked against the prior bind.
+    if (editRestMode || !hasActiveAnim) {
+        bone->setManuallyControlled(false);
+        return Result::CommitBind;
+    }
+
+    if (autoKeyOn) {
         // Caller writes the keyframe (via AnimationControlController) and
         // pushes BoneTransformCommand. We just unfreeze the bone so the
         // curve drives playback through the new key.
@@ -55,23 +64,15 @@ BoneDragRelease::Result BoneDragRelease::apply(Ogre::Bone* bone,
         return Result::Commit;
     }
 
-    if (hasActiveAnim) {
-        // Preview only: revert bone to its pre-drag local TRS so playback
-        // is unaffected. Don't call setInitialState — the curve stores
-        // deltas relative to initial; changing initial would double-apply
-        // the curve delta on next sample.
-        bone->setPosition(beforePos);
-        bone->setOrientation(beforeOrient);
-        bone->setScale(beforeScale);
-        bone->setManuallyControlled(false);
-        bone->needUpdate(true);
-        if (entityForUpdate) entityForUpdate->_updateAnimation();
-        return Result::Revert;
-    }
-
-    // No active animation: T-pose / bind-pose authoring. The dragged
-    // local TRS becomes the new bind pose.
-    bone->setInitialState();
+    // Preview only: revert bone to its pre-drag local TRS so playback
+    // is unaffected. Don't call setInitialState — the curve stores
+    // deltas relative to initial; changing initial would double-apply
+    // the curve delta on next sample.
+    bone->setPosition(beforePos);
+    bone->setOrientation(beforeOrient);
+    bone->setScale(beforeScale);
     bone->setManuallyControlled(false);
-    return Result::CommitBind;
+    bone->needUpdate(true);
+    if (entityForUpdate) entityForUpdate->_updateAnimation();
+    return Result::Revert;
 }

--- a/src/BoneDragRelease.h
+++ b/src/BoneDragRelease.h
@@ -14,23 +14,21 @@ class QUndoCommand;
 
 /// Pure-data helper that decides what to do with a bone at the end of a
 /// gizmo drag, based on (auto-key on/off, animation selected/not, bone
-/// changed/not). Extracted from TransformOperator::mouseReleaseEvent so
+/// changed/not, edit-rest mode). Extracted from TransformOperator::mouseReleaseEvent so
 /// the rules are testable in isolation — without an OgreWidget, mouse
 /// event, or QApplication.
 ///
-/// Three cases:
-/// 1. Animation active + auto-key ON + changed
+/// Cases:
+/// 1. Edit-rest mode + changed
+///      → keep dragged TRS; caller commits rest via SkeletonEditor (rebake).
+///        Returns Result::CommitBind. Does NOT call setInitialState.
+/// 2. Animation active + auto-key ON + changed
 ///      → keep dragged TRS, release manualControlled (curve drives playback
 ///        through the new key written by callback). Returns Result::Commit.
-///        Caller is responsible for writing the keyframe (via
-///        AnimationControlController::autoKeyOnTransform) and pushing the
-///        BoneTransformCommand.
-/// 2. Animation active + auto-key OFF + changed
-///      → revert bone to before-state. Returns Result::Revert. Caller does
-///        not push undo (no commit).
-/// 3. No active animation + changed
-///      → setInitialState (commits new bind pose). Returns Result::CommitBind.
-///        Caller pushes BoneTransformCommand for undo.
+/// 3. Animation active + auto-key OFF + changed
+///      → revert bone to before-state. Returns Result::Revert.
+/// 4. No active animation + changed
+///      → rest-pose authoring (same as edit-rest). Returns Result::CommitBind.
 ///
 /// "No change" returns Result::NoOp.
 class BoneDragRelease {
@@ -39,21 +37,23 @@ public:
         NoOp,          ///< Bone TRS is unchanged from before-state
         Commit,        ///< Animation + auto-key on: caller writes keyframe
         Revert,        ///< Animation + auto-key off: bone reverted in-place
-        CommitBind,    ///< No animation: bone's initial state updated
+        CommitBind,    ///< Rest-pose edit: caller commits bind + rebake
     };
 
     /// Apply the release-path rules to `bone`. The bone's current local TRS
     /// is treated as the after-state; `before*` describe what the bone was
     /// before the drag started.
-    /// @param hasActiveAnim true when an animation is selected in the panel
+    /// @param hasActiveAnim true when an animation is enabled on the entity
     /// @param autoKeyOn     true when auto-key toggle is on
+    /// @param editRestMode  true when Inspector edit-rest mode is active
     static Result apply(Ogre::Bone* bone,
                         const Ogre::Vector3& beforePos,
                         const Ogre::Quaternion& beforeOrient,
                         const Ogre::Vector3& beforeScale,
                         bool hasActiveAnim,
                         bool autoKeyOn,
-                        Ogre::Entity* entityForUpdate = nullptr);
+                        Ogre::Entity* entityForUpdate = nullptr,
+                        bool editRestMode = false);
 };
 
 #endif // BONE_DRAG_RELEASE_H

--- a/src/BoneDragRelease.h
+++ b/src/BoneDragRelease.h
@@ -19,16 +19,16 @@ class QUndoCommand;
 /// event, or QApplication.
 ///
 /// Cases:
-/// 1. Edit-rest mode + changed
-///      → keep dragged TRS; caller commits rest via SkeletonEditor (rebake).
-///        Returns Result::CommitBind. Does NOT call setInitialState.
-/// 2. Animation active + auto-key ON + changed
+/// 1. Auto-key ON + animation active + not edit-rest + changed
 ///      → keep dragged TRS, release manualControlled (curve drives playback
 ///        through the new key written by callback). Returns Result::Commit.
-/// 3. Animation active + auto-key OFF + changed
-///      → revert bone to before-state. Returns Result::Revert.
-/// 4. No active animation + changed
-///      → rest-pose authoring (same as edit-rest). Returns Result::CommitBind.
+/// 2. Otherwise + changed (edit-rest, no anim, or auto-key off)
+///      → rest-pose authoring. Returns Result::CommitBind. Caller commits
+///        bind via SkeletonEditor; does NOT call setInitialState here.
+///
+/// Auto-key off no longer reverts: the Inspector documents the bone gizmo
+/// as a rest-pose editor, and reverting made Mixamo-enabled meshes snap
+/// back on every release.
 ///
 /// "No change" returns Result::NoOp.
 class BoneDragRelease {
@@ -36,8 +36,8 @@ public:
     enum class Result {
         NoOp,          ///< Bone TRS is unchanged from before-state
         Commit,        ///< Animation + auto-key on: caller writes keyframe
-        Revert,        ///< Animation + auto-key off: bone reverted in-place
-        CommitBind,    ///< Rest-pose edit: caller commits bind + rebake
+        Revert,        ///< Deprecated — kept for ABI; apply() never returns this
+        CommitBind,    ///< Rest-pose edit: caller commits bind
     };
 
     /// Apply the release-path rules to `bone`. The bone's current local TRS

--- a/src/BoneDragRelease_test.cpp
+++ b/src/BoneDragRelease_test.cpp
@@ -1,5 +1,4 @@
 #include <gtest/gtest.h>
-#include <array>
 #include <QApplication>
 #include <QCoreApplication>
 #include <QThread>
@@ -55,53 +54,50 @@ TEST_F(BoneDragReleaseTest, NoChangeIsNoOp) {
     EXPECT_EQ(outcome, BoneDragRelease::Result::NoOp);
 }
 
-TEST_F(BoneDragReleaseTest, AutoKeyOffWithAnimReverts) {
-    // Drag with auto-key OFF + animation active: the bone must revert
-    // to its pre-drag local TRS. Without revert, accumulated drag
-    // offsets pile up across drags ("if I moved it down before, it
-    // goes further down on my second attempt").
-    Ogre::Entity* entity = createAnimatedTestEntity("BDR_RevertOnce");
+TEST_F(BoneDragReleaseTest, AutoKeyOffWithAnimCommitsBind) {
+    // Auto-key OFF: bone gizmo is rest-pose authoring (matches Inspector
+    // copy). Keep the dragged TRS; caller commits bind via SetRestPoseCommand.
+    Ogre::Entity* entity = createAnimatedTestEntity("BDR_CommitBindOnce");
     ASSERT_NE(entity, nullptr);
     Ogre::Bone* bone = entity->getSkeleton()->getBone("Child");
 
     const Ogre::Vector3 before = bone->getPosition();
-    simulateBoneDrag(bone, before + Ogre::Vector3(0.5f, -0.3f, 0.0f));
+    const Ogre::Vector3 after = before + Ogre::Vector3(0.5f, -0.3f, 0.0f);
+    simulateBoneDrag(bone, after);
 
     auto outcome = BoneDragRelease::apply(bone, before, bone->getInitialOrientation(),
                                           bone->getInitialScale(),
                                           /*hasAnim=*/true, /*autoKey=*/false,
                                           entity);
-    EXPECT_EQ(outcome, BoneDragRelease::Result::Revert);
-    EXPECT_EQ(bone->getPosition(), before);
+    EXPECT_EQ(outcome, BoneDragRelease::Result::CommitBind);
+    EXPECT_EQ(bone->getPosition(), after);
+    EXPECT_FALSE(bone->isManuallyControlled());
 }
 
-TEST_F(BoneDragReleaseTest, AutoKeyOffTwoDragsDoNotAccumulate) {
-    // Critical regression test for the user-reported "down before going
-    // right" teleport. Two consecutive drags with auto-key off must
-    // each leave the bone at its pre-drag pose — the second drag's
-    // before-state must be the SAME as the first drag's before-state,
-    // not the first drag's accumulated offset.
+TEST_F(BoneDragReleaseTest, AutoKeyOffTwoDragsKeepLatestPose) {
+    // With CommitBind, each drag keeps its after-TRS (caller then writes
+    // bind). Second drag's before-state is the first drag's after-state.
     Ogre::Entity* entity = createAnimatedTestEntity("BDR_TwoDrags");
     ASSERT_NE(entity, nullptr);
     Ogre::Bone* bone = entity->getSkeleton()->getBone("Child");
 
     const Ogre::Vector3 origLocal = bone->getPosition();
+    const Ogre::Vector3 after1 = origLocal + Ogre::Vector3(0, 0.5f, 0);
+    const Ogre::Vector3 after2 = after1 + Ogre::Vector3(0.5f, 0, 0);
 
-    // Drag 1: move +Y by 0.5
-    simulateBoneDrag(bone, origLocal + Ogre::Vector3(0, 0.5f, 0));
-    BoneDragRelease::apply(bone, origLocal, bone->getInitialOrientation(),
-                           bone->getInitialScale(),
-                           /*hasAnim=*/true, /*autoKey=*/false, entity);
-    const Ogre::Vector3 afterDrag1 = bone->getPosition();
-    EXPECT_EQ(afterDrag1, origLocal) << "Drag 1 did not revert";
+    simulateBoneDrag(bone, after1);
+    EXPECT_EQ(BoneDragRelease::apply(bone, origLocal, bone->getInitialOrientation(),
+                                     bone->getInitialScale(),
+                                     /*hasAnim=*/true, /*autoKey=*/false, entity),
+              BoneDragRelease::Result::CommitBind);
+    EXPECT_EQ(bone->getPosition(), after1);
 
-    // Drag 2: move +X by 0.5
-    simulateBoneDrag(bone, origLocal + Ogre::Vector3(0.5f, 0, 0));
-    BoneDragRelease::apply(bone, origLocal, bone->getInitialOrientation(),
-                           bone->getInitialScale(),
-                           /*hasAnim=*/true, /*autoKey=*/false, entity);
-    const Ogre::Vector3 afterDrag2 = bone->getPosition();
-    EXPECT_EQ(afterDrag2, origLocal) << "Drag 2 did not revert (accumulation bug)";
+    simulateBoneDrag(bone, after2);
+    EXPECT_EQ(BoneDragRelease::apply(bone, after1, bone->getInitialOrientation(),
+                                     bone->getInitialScale(),
+                                     /*hasAnim=*/true, /*autoKey=*/false, entity),
+              BoneDragRelease::Result::CommitBind);
+    EXPECT_EQ(bone->getPosition(), after2);
 }
 
 TEST_F(BoneDragReleaseTest, AutoKeyOnWithAnimKeepsDraggedPose) {
@@ -125,11 +121,8 @@ TEST_F(BoneDragReleaseTest, AutoKeyOnWithAnimKeepsDraggedPose) {
     EXPECT_FALSE(bone->isManuallyControlled());
 }
 
-// User report: "first moved Y down, then tried X — went down before
-// going right." Simulates that exact sequence at the helper level.
-// Without revert, the accumulated Y delta from drag 1 would leak into
-// drag 2's before-state, and the bone would re-show the Y offset.
-TEST_F(BoneDragReleaseTest, YThenXDragsDoNotLeakYIntoX) {
+// Derived-position drags with auto-key off keep the after-pose (CommitBind).
+TEST_F(BoneDragReleaseTest, YThenXDragsKeepEachAfterPose) {
     Ogre::Entity* entity = createAnimatedTestEntity("BDR_YThenX");
     ASSERT_NE(entity, nullptr);
     Ogre::Bone* bone = entity->getSkeleton()->getBone("Child");
@@ -137,43 +130,30 @@ TEST_F(BoneDragReleaseTest, YThenXDragsDoNotLeakYIntoX) {
     const Ogre::Vector3 origLocal = bone->getPosition();
     const Ogre::Vector3 origDerived = bone->_getDerivedPosition();
 
-    // Drag 1: Y axis down.
     bone->setManuallyControlled(true);
     bone->_setDerivedPosition(origDerived + Ogre::Vector3(0, -0.7f, 0));
-    BoneDragRelease::apply(bone, origLocal, bone->getInitialOrientation(),
-                           bone->getInitialScale(),
-                           /*hasAnim=*/true, /*autoKey=*/false, entity);
-    EXPECT_EQ(bone->getPosition(), origLocal);
-    EXPECT_LT((bone->_getDerivedPosition() - origDerived).length(), 1e-5f);
+    const Ogre::Vector3 after1 = bone->getPosition();
+    EXPECT_EQ(BoneDragRelease::apply(bone, origLocal, bone->getInitialOrientation(),
+                                     bone->getInitialScale(),
+                                     /*hasAnim=*/true, /*autoKey=*/false, entity),
+              BoneDragRelease::Result::CommitBind);
+    EXPECT_EQ(bone->getPosition(), after1);
 
-    // Drag 2: X axis right. The bone must start fresh from origLocal,
-    // not from any leaked Y offset.
     const Ogre::Vector3 drag2Before = bone->getPosition();
-    EXPECT_EQ(drag2Before, origLocal);
-
     bone->setManuallyControlled(true);
-    bone->_setDerivedPosition(origDerived + Ogre::Vector3(0.7f, 0, 0));
-    BoneDragRelease::apply(bone, drag2Before, bone->getInitialOrientation(),
-                           bone->getInitialScale(),
-                           /*hasAnim=*/true, /*autoKey=*/false, entity);
-    // Final state: same origLocal (revert), no leaked Y.
-    EXPECT_EQ(bone->getPosition(), origLocal);
-    EXPECT_NEAR(bone->_getDerivedPosition().y, origDerived.y, 1e-5f)
-        << "Y leaked from previous drag";
+    bone->_setDerivedPosition(bone->_getDerivedPosition() + Ogre::Vector3(0.7f, 0, 0));
+    const Ogre::Vector3 after2 = bone->getPosition();
+    EXPECT_EQ(BoneDragRelease::apply(bone, drag2Before, bone->getInitialOrientation(),
+                                     bone->getInitialScale(),
+                                     /*hasAnim=*/true, /*autoKey=*/false, entity),
+              BoneDragRelease::Result::CommitBind);
+    EXPECT_EQ(bone->getPosition(), after2);
 }
 
-// The critical regression test: simulate the actual TransformOperator
-// flow using _setDerivedPosition (not just setPosition), with parent
-// state matching the user's "head bone with rotated parent" case, and
-// assert that two consecutive drags don't accumulate when reverted.
-TEST_F(BoneDragReleaseTest, SetDerivedPositionDragRevertsCleanly) {
+TEST_F(BoneDragReleaseTest, SetDerivedPositionDragCommitsBind) {
     Ogre::Entity* entity = createAnimatedTestEntity("BDR_SetDerivedTwoDrags");
     ASSERT_NE(entity, nullptr);
 
-    // Use the child bone (parent = root). Apply a non-identity rotation
-    // to the root bone so _setDerivedPosition has to do real parent-frame
-    // math — matches the "head bone with rotated parent mid-animation"
-    // scenario where the bug shows up.
     Ogre::Bone* root = entity->getSkeleton()->getBone("Root");
     Ogre::Bone* child = entity->getSkeleton()->getBone("Child");
     root->setOrientation(Ogre::Quaternion(Ogre::Radian(0.5f), Ogre::Vector3::UNIT_Y));
@@ -182,40 +162,36 @@ TEST_F(BoneDragReleaseTest, SetDerivedPositionDragRevertsCleanly) {
     const Ogre::Vector3 origLocal = child->getPosition();
     const Ogre::Vector3 origDerived = child->_getDerivedPosition();
 
-    // Drag 1: move derived +Y by 0.5 in world space.
     child->setManuallyControlled(true);
     child->_setDerivedPosition(origDerived + Ogre::Vector3(0, 0.5f, 0));
     child->needUpdate(true);
-    // Local Y has changed (non-trivially) because of parent rotation.
-    EXPECT_NE(child->getPosition(), origLocal);
+    const Ogre::Vector3 after1 = child->getPosition();
+    EXPECT_NE(after1, origLocal);
 
-    auto outcome1 = BoneDragRelease::apply(child, origLocal, child->getInitialOrientation(),
-                                          child->getInitialScale(),
-                                          /*hasAnim=*/true, /*autoKey=*/false, entity);
-    EXPECT_EQ(outcome1, BoneDragRelease::Result::Revert);
-    EXPECT_EQ(child->getPosition(), origLocal) << "Drag 1 revert failed";
+    EXPECT_EQ(BoneDragRelease::apply(child, origLocal, child->getInitialOrientation(),
+                                     child->getInitialScale(),
+                                     /*hasAnim=*/true, /*autoKey=*/false, entity),
+              BoneDragRelease::Result::CommitBind);
+    EXPECT_EQ(child->getPosition(), after1);
 
-    // Drag 2 press: capture new before-state (which should equal origLocal).
-    const Ogre::Vector3 drag2Local  = child->getPosition();
-    EXPECT_EQ(drag2Local, origLocal) << "After drag 1 revert, child has shifted (accumulation)";
-
-    // Drag 2: move derived +X by 0.5
+    const Ogre::Vector3 drag2Local = child->getPosition();
     const Ogre::Vector3 drag2Derived = child->_getDerivedPosition();
     child->setManuallyControlled(true);
     child->_setDerivedPosition(drag2Derived + Ogre::Vector3(0.5f, 0, 0));
     child->needUpdate(true);
+    const Ogre::Vector3 after2 = child->getPosition();
 
-    auto outcome2 = BoneDragRelease::apply(child, drag2Local, child->getInitialOrientation(),
-                                          child->getInitialScale(),
-                                          /*hasAnim=*/true, /*autoKey=*/false, entity);
-    EXPECT_EQ(outcome2, BoneDragRelease::Result::Revert);
-    EXPECT_EQ(child->getPosition(), origLocal) << "Drag 2 revert failed (accumulation across drags)";
+    EXPECT_EQ(BoneDragRelease::apply(child, drag2Local, child->getInitialOrientation(),
+                                     child->getInitialScale(),
+                                     /*hasAnim=*/true, /*autoKey=*/false, entity),
+              BoneDragRelease::Result::CommitBind);
+    EXPECT_EQ(child->getPosition(), after2);
 }
 
 TEST_F(BoneDragReleaseTest, NoAnimSetsInitial) {
     // No active animation: drag returns CommitBind; caller (TransformOperator)
     // commits via SetRestPoseCommand. apply() itself does not call
-    // setInitialState — that belongs to the rest-pose rebake path.
+    // setInitialState — that belongs to the rest-pose path.
     Ogre::Entity* entity = createAnimatedTestEntity("BDR_BindPose");
     ASSERT_NE(entity, nullptr);
     Ogre::Bone* bone = entity->getSkeleton()->getBone("Child");
@@ -230,7 +206,7 @@ TEST_F(BoneDragReleaseTest, NoAnimSetsInitial) {
     EXPECT_EQ(outcome, BoneDragRelease::Result::CommitBind);
     EXPECT_EQ(bone->getPosition(), after);
     EXPECT_EQ(bone->getInitialPosition(), initialBefore)
-        << "apply() must leave initial unchanged for the rebake caller";
+        << "apply() must leave initial unchanged for the commit caller";
 }
 
 TEST_F(BoneDragReleaseTest, EditRestModeCommitsBindEvenWithAnim) {
@@ -249,100 +225,18 @@ TEST_F(BoneDragReleaseTest, EditRestModeCommitsBindEvenWithAnim) {
     EXPECT_EQ(bone->getPosition(), after);
 }
 
-// Drag-release-tick-drag-release: an animation tick between two drags
-// re-applies the curve via _updateAnimation. If the first drag's revert
-// path didn't fully restore TRS before clearing manualControlled, the
-// tick would re-apply the curve on top of leaked state and the second
-// drag's before-state would be wrong.
-TEST_F(BoneDragReleaseTest, EntityTickBetweenDragsDoesNotAccumulate) {
-    Ogre::Entity* entity = createAnimatedTestEntity("BDR_TickBetween");
-    ASSERT_NE(entity, nullptr);
-    Ogre::Bone* bone = entity->getSkeleton()->getBone("Child");
-
-    if (entity->hasAnimationState("TestAnim")) {
-        auto* state = entity->getAnimationState("TestAnim");
-        state->setEnabled(true);
-        state->setTimePosition(0.0f);
-    }
-
-    const Ogre::Vector3 origLocal = bone->getPosition();
-
-    simulateBoneDrag(bone, origLocal + Ogre::Vector3(0, 0.5f, 0));
-    BoneDragRelease::apply(bone, origLocal, bone->getInitialOrientation(),
-                           bone->getInitialScale(),
-                           /*hasAnim=*/true, /*autoKey=*/false, entity);
-    EXPECT_EQ(bone->getPosition(), origLocal);
-
-    // Frame tick: re-apply animation. Without a clean revert this
-    // re-applies the curve on top of leaked state.
-    entity->_updateAnimation();
-    entity->getSkeleton()->_updateTransforms();
-
-    const Ogre::Vector3 drag2Local = bone->getPosition();
-    EXPECT_EQ(drag2Local, origLocal) << "tick after revert leaked offset";
-
-    simulateBoneDrag(bone, origLocal + Ogre::Vector3(0.5f, 0, 0));
-    BoneDragRelease::apply(bone, drag2Local, bone->getInitialOrientation(),
-                           bone->getInitialScale(),
-                           /*hasAnim=*/true, /*autoKey=*/false, entity);
-    EXPECT_EQ(bone->getPosition(), origLocal) << "Drag 2 revert failed after mid-sequence tick";
-}
-
-// Force a derived-transform recompute via needUpdate(true) + _update
-// between drags so any cached state is flushed mid-sequence.
-TEST_F(BoneDragReleaseTest, NeedUpdateBetweenDragsDoesNotAccumulate) {
-    Ogre::Entity* entity = createAnimatedTestEntity("BDR_NeedUpdateBetween");
-    ASSERT_NE(entity, nullptr);
-    Ogre::Bone* bone = entity->getSkeleton()->getBone("Child");
-
-    const Ogre::Vector3 origLocal = bone->getPosition();
-    const Ogre::Vector3 origDerived = bone->_getDerivedPosition();
-
-    simulateBoneDrag(bone, origLocal + Ogre::Vector3(0, 0.5f, 0));
-    BoneDragRelease::apply(bone, origLocal, bone->getInitialOrientation(),
-                           bone->getInitialScale(),
-                           /*hasAnim=*/true, /*autoKey=*/false, entity);
-
-    bone->needUpdate(true);
-    bone->_update(true, true);
-    EXPECT_NEAR((bone->_getDerivedPosition() - origDerived).length(), 0.0f, 1e-5f)
-        << "derived position drifted after revert + needUpdate";
-
-    // Capture before-state for drag 2 BEFORE simulating the drag —
-    // passing bone->getPosition() AFTER the drag would feed the helper
-    // an after==before pair and short-circuit to NoOp instead of
-    // reverting.
-    const Ogre::Vector3 drag2Before = bone->getPosition();
-    simulateBoneDrag(bone, origLocal + Ogre::Vector3(0.5f, 0, 0));
-    BoneDragRelease::apply(bone, drag2Before, bone->getInitialOrientation(),
-                           bone->getInitialScale(),
-                           /*hasAnim=*/true, /*autoKey=*/false, entity);
-    EXPECT_EQ(bone->getPosition(), origLocal);
-}
-
-// Reproduces the actual TransformOperator drag flow: each mouse-move
-// event drives _setDerivedPosition + needUpdate(true) anchored to the
-// SAME press-time derived position with a different incremental delta.
-// A realistic drag is 5–20 such events before release. Without a clean
-// revert that uses the press-anchored before-state (not the
-// last-move-event state), the second drag would inherit micro-drift
-// accumulated across the first drag's update chain.
-TEST_F(BoneDragReleaseTest, MultiMoveSetUpdateSequenceRevertsCleanly) {
+TEST_F(BoneDragReleaseTest, MultiMoveSetUpdateSequenceCommitsBind) {
     Ogre::Entity* entity = createAnimatedTestEntity("BDR_MultiMoveSeq");
     ASSERT_NE(entity, nullptr);
     Ogre::Bone* root = entity->getSkeleton()->getBone("Root");
     Ogre::Bone* child = entity->getSkeleton()->getBone("Child");
 
-    // Rotate parent so derived/local math is non-trivial.
     root->setOrientation(Ogre::Quaternion(Ogre::Radian(0.5f), Ogre::Vector3::UNIT_Y));
     root->setManuallyControlled(true);
 
     const Ogre::Vector3 origLocal   = child->getPosition();
     const Ogre::Vector3 origDerived = child->_getDerivedPosition();
 
-    // Drag 1: 5 mouse-move events, each rewriting derived position to
-    // (anchor + frac * targetDelta) — same pattern as the TransformOperator
-    // move handler (anchored, not incremental).
     child->setManuallyControlled(true);
     const Ogre::Vector3 drag1Target(0.0f, 0.6f, 0.0f);
     for (int i = 1; i <= 5; ++i) {
@@ -350,92 +244,14 @@ TEST_F(BoneDragReleaseTest, MultiMoveSetUpdateSequenceRevertsCleanly) {
         child->_setDerivedPosition(origDerived + drag1Target * frac);
         child->needUpdate(true);
     }
-    auto outcome1 = BoneDragRelease::apply(child, origLocal,
-                                           child->getInitialOrientation(),
-                                           child->getInitialScale(),
-                                           /*hasAnim=*/true, /*autoKey=*/false,
-                                           entity);
-    EXPECT_EQ(outcome1, BoneDragRelease::Result::Revert);
-    EXPECT_EQ(child->getPosition(), origLocal)
-        << "5-event drag 1 did not revert to origLocal";
-
-    // Drag 2: another 5-event sequence on a different axis.
-    const Ogre::Vector3 drag2Before = child->getPosition();
-    EXPECT_EQ(drag2Before, origLocal)
-        << "After drag 1 revert, child's local pos leaked across the multi-event update chain";
-
-    const Ogre::Vector3 drag2DerivedAnchor = child->_getDerivedPosition();
-    child->setManuallyControlled(true);
-    const Ogre::Vector3 drag2Target(0.7f, 0.0f, 0.0f);
-    for (int i = 1; i <= 5; ++i) {
-        const float frac = static_cast<float>(i) / 5.0f;
-        child->_setDerivedPosition(drag2DerivedAnchor + drag2Target * frac);
-        child->needUpdate(true);
-    }
-    auto outcome2 = BoneDragRelease::apply(child, drag2Before,
-                                           child->getInitialOrientation(),
-                                           child->getInitialScale(),
-                                           /*hasAnim=*/true, /*autoKey=*/false,
-                                           entity);
-    EXPECT_EQ(outcome2, BoneDragRelease::Result::Revert);
-    EXPECT_EQ(child->getPosition(), origLocal)
-        << "5-event drag 2 did not revert to origLocal (accumulation across multi-event drags)";
-    EXPECT_NEAR((child->_getDerivedPosition() - origDerived).length(), 0.0f, 1e-4f)
-        << "derived position drifted across two 5-event drags";
-}
-
-// Stress variant: 20 setUpdate events per drag, three consecutive
-// auto-key-off drags. The local TRS must return to the press-time
-// baseline after each revert. Derived position is NOT asserted here:
-// BoneDragRelease::apply calls entity->_updateAnimation() which runs
-// Skeleton::reset() and wipes any pose we set up on other bones —
-// derived drift across iterations reflects that reset, not bone
-// accumulation. The local-equals-baseline invariant is what guards
-// against the reported "down before going right" teleport.
-TEST_F(BoneDragReleaseTest, ThreeStressDragsNoAccumulationAfterRevert) {
-    Ogre::Entity* entity = createAnimatedTestEntity("BDR_StressDrags");
-    ASSERT_NE(entity, nullptr);
-    Ogre::Bone* root = entity->getSkeleton()->getBone("Root");
-    Ogre::Bone* child = entity->getSkeleton()->getBone("Child");
-
-    const Ogre::Vector3 origLocal = child->getPosition();
-
-    const std::array<Ogre::Vector3, 3> targets = {
-        Ogre::Vector3(0.0f, -0.5f, 0.0f),  // drag down
-        Ogre::Vector3(0.5f,  0.0f, 0.0f),  // drag right
-        Ogre::Vector3(0.0f,  0.0f, 0.3f),  // drag forward
-    };
-
-    for (size_t d = 0; d < targets.size(); ++d) {
-        // Re-apply the parent rotation each iteration. _updateAnimation
-        // (called inside BoneDragRelease::apply) runs Skeleton::reset
-        // which wipes it; manualControlled keeps tracks from being
-        // re-played onto root but does NOT survive reset itself.
-        root->setOrientation(Ogre::Quaternion(Ogre::Radian(0.7f),
-                                              Ogre::Vector3::UNIT_Z));
-        root->setManuallyControlled(true);
-
-        const Ogre::Vector3 beforeLocal   = child->getPosition();
-        const Ogre::Vector3 beforeDerived = child->_getDerivedPosition();
-        ASSERT_EQ(beforeLocal, origLocal)
-            << "Drag " << d << " starting before-state shifted (accumulation across drags)";
-
-        child->setManuallyControlled(true);
-        for (int i = 1; i <= 20; ++i) {
-            const float frac = static_cast<float>(i) / 20.0f;
-            child->_setDerivedPosition(beforeDerived + targets[d] * frac);
-            child->needUpdate(true);
-        }
-        auto outcome = BoneDragRelease::apply(child, beforeLocal,
-                                              child->getInitialOrientation(),
-                                              child->getInitialScale(),
-                                              /*hasAnim=*/true, /*autoKey=*/false,
-                                              entity);
-        ASSERT_EQ(outcome, BoneDragRelease::Result::Revert)
-            << "Drag " << d << " did not produce Revert";
-        EXPECT_EQ(child->getPosition(), origLocal)
-            << "Drag " << d << " did not revert local to origLocal";
-    }
+    const Ogre::Vector3 after1 = child->getPosition();
+    EXPECT_EQ(BoneDragRelease::apply(child, origLocal,
+                                     child->getInitialOrientation(),
+                                     child->getInitialScale(),
+                                     /*hasAnim=*/true, /*autoKey=*/false,
+                                     entity),
+              BoneDragRelease::Result::CommitBind);
+    EXPECT_EQ(child->getPosition(), after1);
 }
 
 // Reproduces a subtle variant of the bug: a mouse-move event with a
@@ -487,3 +303,4 @@ TEST_F(BoneDragReleaseTest, OgreSetDerivedPositionIsNoOpOnParentlessBone) {
     root->setPosition(Ogre::Vector3(5, 0, 0));
     EXPECT_EQ(root->getPosition(), Ogre::Vector3(5, 0, 0));
 }
+

--- a/src/BoneDragRelease_test.cpp
+++ b/src/BoneDragRelease_test.cpp
@@ -213,24 +213,39 @@ TEST_F(BoneDragReleaseTest, SetDerivedPositionDragRevertsCleanly) {
 }
 
 TEST_F(BoneDragReleaseTest, NoAnimSetsInitial) {
-    // No active animation: drag commits to bind pose via setInitialState.
-    // Subsequent reset would land at the new bind pose — confirm by
-    // calling resetToInitialState afterwards.
+    // No active animation: drag returns CommitBind; caller (TransformOperator)
+    // commits via SetRestPoseCommand. apply() itself does not call
+    // setInitialState — that belongs to the rest-pose rebake path.
     Ogre::Entity* entity = createAnimatedTestEntity("BDR_BindPose");
     ASSERT_NE(entity, nullptr);
     Ogre::Bone* bone = entity->getSkeleton()->getBone("Child");
 
     const Ogre::Vector3 before = bone->getPosition();
     const Ogre::Vector3 after  = before + Ogre::Vector3(0.5f, 0, 0);
+    const Ogre::Vector3 initialBefore = bone->getInitialPosition();
     simulateBoneDrag(bone, after);
     auto outcome = BoneDragRelease::apply(bone, before, bone->getInitialOrientation(),
                                           bone->getInitialScale(),
                                           /*hasAnim=*/false, /*autoKey=*/false);
     EXPECT_EQ(outcome, BoneDragRelease::Result::CommitBind);
     EXPECT_EQ(bone->getPosition(), after);
-    // Reset to initial — should land back at `after` since we just rebound.
-    bone->setPosition(Ogre::Vector3::ZERO);
-    bone->resetToInitialState();
+    EXPECT_EQ(bone->getInitialPosition(), initialBefore)
+        << "apply() must leave initial unchanged for the rebake caller";
+}
+
+TEST_F(BoneDragReleaseTest, EditRestModeCommitsBindEvenWithAnim) {
+    Ogre::Entity* entity = createAnimatedTestEntity("BDR_EditRest");
+    ASSERT_NE(entity, nullptr);
+    Ogre::Bone* bone = entity->getSkeleton()->getBone("Child");
+
+    const Ogre::Vector3 before = bone->getPosition();
+    const Ogre::Vector3 after  = before + Ogre::Vector3(0.25f, 0, 0);
+    simulateBoneDrag(bone, after);
+    auto outcome = BoneDragRelease::apply(bone, before, bone->getOrientation(),
+                                          bone->getScale(),
+                                          /*hasAnim=*/true, /*autoKey=*/true,
+                                          entity, /*editRestMode=*/true);
+    EXPECT_EQ(outcome, BoneDragRelease::Result::CommitBind);
     EXPECT_EQ(bone->getPosition(), after);
 }
 

--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -865,7 +865,8 @@ bool Manager::isForbiddenNodeName(const QString &_name)
             ||_name=="QtMeshDepthCameraNode" //offscreen depth-render camera (MeshDepthRenderer)
             ||_name==SELECTIONBOX_OBJECT_NAME
             ||_name==TRANSFORM_OBJECT_NAME
-            ||_name.startsWith("Unnamed_")); //This is the cameras's nodes
+            ||_name.startsWith("Unnamed_") //This is the cameras's nodes
+            ||_name.endsWith("_restGhostRoot")); // SkeletonDebug rest-pose mesh ghost (#557)
 }
 
 bool Manager::hasAnimationName(Ogre::Entity *entity, const QString &_name)

--- a/src/PropertiesPanelController.cpp
+++ b/src/PropertiesPanelController.cpp
@@ -1208,20 +1208,8 @@ void PropertiesPanelController::refreshSkeletonOverlays(const QString& entityNam
 void PropertiesPanelController::setRestPoseGhostVisible(bool show)
 {
     if (!mAnimationWidget) return;
-    if (show) {
-        // Ghost lives on SkeletonDebug instances — ensure skinned entities
-        // have an overlay so the rest pose is visible even if the user
-        // hasn't toggled "Skeleton" yet.
-        auto* mgr = Manager::getSingletonPtr();
-        if (mgr) {
-            for (Ogre::Entity* ent : mgr->getEntities()) {
-                if (!ent || ent->getMovableType() != "Entity" || !ent->hasSkeleton())
-                    continue;
-                if (!mAnimationWidget->isSkeletonDebugActive(ent))
-                    mAnimationWidget->toggleSkeletonDebug(ent, true);
-            }
-        }
-    }
+    // Ghost is independent of the Skeleton debug checkbox — AnimationWidget
+    // creates bone-hidden hosts when needed and tears them down on hide.
     mAnimationWidget->setRestPoseGhostVisible(show);
 }
 

--- a/src/PropertiesPanelController.cpp
+++ b/src/PropertiesPanelController.cpp
@@ -1205,6 +1205,26 @@ void PropertiesPanelController::refreshSkeletonOverlays(const QString& entityNam
     emit animationStateChanged();
 }
 
+void PropertiesPanelController::setRestPoseGhostVisible(bool show)
+{
+    if (!mAnimationWidget) return;
+    if (show) {
+        // Ghost lives on SkeletonDebug instances — ensure skinned entities
+        // have an overlay so the rest pose is visible even if the user
+        // hasn't toggled "Skeleton" yet.
+        auto* mgr = Manager::getSingletonPtr();
+        if (mgr) {
+            for (Ogre::Entity* ent : mgr->getEntities()) {
+                if (!ent || ent->getMovableType() != "Entity" || !ent->hasSkeleton())
+                    continue;
+                if (!mAnimationWidget->isSkeletonDebugActive(ent))
+                    mAnimationWidget->toggleSkeletonDebug(ent, true);
+            }
+        }
+    }
+    mAnimationWidget->setRestPoseGhostVisible(show);
+}
+
 bool PropertiesPanelController::renameAnimation(const QString& entityName, const QString& oldName, const QString& newName)
 {
     if (newName.isEmpty() || oldName == newName) return false;

--- a/src/PropertiesPanelController.h
+++ b/src/PropertiesPanelController.h
@@ -256,6 +256,8 @@ public:
     void applySkeletonDebug(const QString& entityName, bool show);
     /// Rebuild skeleton/weight viewport overlays after bone CRUD.
     Q_INVOKABLE void refreshSkeletonOverlays(const QString& entityName);
+    /// Rest-pose ghost overlay (#557) across active skeleton debug instances.
+    void setRestPoseGhostVisible(bool show);
     Q_INVOKABLE bool renameAnimation(const QString& entityName, const QString& oldName, const QString& newName);
     /// Remove an animation from the entity's skeleton (irreversible). Disables
     /// debug overlays + playback first (rename-style safety) so stale pointers

--- a/src/SkeletonDebug.cpp
+++ b/src/SkeletonDebug.cpp
@@ -4,6 +4,8 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <functional>
+#include <unordered_map>
 
 namespace {
 constexpr const char* kBoneNameTag = "skeletonDebugBoneName";
@@ -115,6 +117,9 @@ void SkeletonDebug::onTimerTick()
         if (currentSelected >= 0)
             emit boneSelected(static_cast<unsigned short>(currentSelected));
     }
+
+    if (mShowRestGhost)
+        updateGhostVisuals();
 }
 
 void SkeletonDebug::rebuildVisuals()
@@ -125,8 +130,10 @@ void SkeletonDebug::rebuildVisuals()
     const bool wasAxes = mShowAxes;
     const bool wasBones = mShowBones;
     const bool wasNames = mShowNames;
+    const bool wasGhost = mShowRestGhost;
 
     mTimer.stop();
+    destroyGhostVisuals();
     mEntity->detachAllObjectsFromBone();
 
     for (auto* ent : mBoneEntities)
@@ -145,9 +152,11 @@ void SkeletonDebug::rebuildVisuals()
     mShowAxes = false;
     mShowBones = false;
     mShowNames = false;
+    mShowRestGhost = false;
     showAxes(wasAxes);
     showBones(wasBones);
     showNames(wasNames);
+    showRestGhost(wasGhost);
     mTimer.start(0);
 }
 
@@ -155,6 +164,8 @@ SkeletonDebug::~SkeletonDebug()
 {
     mTimer.stop();
     mTimer.disconnect();
+
+    destroyGhostVisuals();
 
     // Detach all bone-attached objects at once — this clears mChildObjectList
     // and frees TagPoints without leaving stale parent references.
@@ -309,6 +320,103 @@ void SkeletonDebug::showNames(bool show)
     mShowNames = show;
 }
 
+void SkeletonDebug::showRestGhost(bool show)
+{
+    if (mShowRestGhost == show)
+        return;
+    mShowRestGhost = show;
+    if (show) {
+        ensureGhostVisuals();
+        updateGhostVisuals();
+    } else {
+        destroyGhostVisuals();
+    }
+}
+
+void SkeletonDebug::destroyGhostVisuals()
+{
+    for (auto* ent : mGhostEntities) {
+        if (ent && ent->getParentSceneNode())
+            ent->detachFromParent();
+        if (ent)
+            mSceneMan->destroyEntity(ent);
+    }
+    mGhostEntities.clear();
+    mGhostNodes.clear();
+    mGhostBoneNames.clear();
+    if (mGhostRoot) {
+        mGhostRoot->removeAndDestroyAllChildren();
+        mSceneMan->destroySceneNode(mGhostRoot);
+        mGhostRoot = nullptr;
+    }
+}
+
+void SkeletonDebug::ensureGhostVisuals()
+{
+    if (!mEntity || !mEntity->hasSkeleton() || !mSceneMan)
+        return;
+    if (mGhostRoot)
+        return;
+
+    createBoneMaterial();
+    if (!mJointMeshPtr)
+        createJointMesh();
+
+    Ogre::SceneNode* entNode = mEntity->getParentSceneNode();
+    if (!entNode)
+        return;
+
+    mGhostRoot = entNode->createChildSceneNode(
+        mEntity->getName() + "_restGhostRoot");
+
+    Ogre::SkeletonInstance* skel = mEntity->getSkeleton();
+    for (auto* bone : skel->getBones()) {
+        const Ogre::String entName = mEntity->getName() + "_restGhostEnt_" + bone->getName();
+        Ogre::Entity* ghost = mSceneMan->createEntity(entName, "SkeletonDebug/JointMesh");
+        ghost->setMaterial(mBoneMatGhostPtr);
+        ghost->setQueryFlags(0);
+        ghost->setVisible(true);
+        Ogre::SceneNode* node = mGhostRoot->createChildSceneNode();
+        node->attachObject(ghost);
+        const float jointScale = std::max(mBoneSize * 0.9f, 0.02f);
+        node->setScale(jointScale, jointScale, jointScale);
+        mGhostEntities.push_back(ghost);
+        mGhostNodes.push_back(node);
+        mGhostBoneNames.push_back(bone->getName());
+    }
+}
+
+void SkeletonDebug::updateGhostVisuals()
+{
+    if (!mShowRestGhost || !mEntity || !mEntity->hasSkeleton() || !mGhostRoot)
+        return;
+
+    Ogre::SkeletonInstance* skel = mEntity->getSkeleton();
+
+    // Rest-pose transforms in skeleton/entity-local space from initial TRS.
+    std::unordered_map<std::string, std::pair<Ogre::Vector3, Ogre::Quaternion>> restLocal;
+    std::function<void(Ogre::Bone*, const Ogre::Vector3&, const Ogre::Quaternion&)> walk;
+    walk = [&](Ogre::Bone* bone, const Ogre::Vector3& parentPos, const Ogre::Quaternion& parentOri) {
+        const Ogre::Vector3 pos = parentPos + parentOri * bone->getInitialPosition();
+        const Ogre::Quaternion ori = parentOri * bone->getInitialOrientation();
+        restLocal[bone->getName()] = {pos, ori};
+        for (auto* child : bone->getChildren())
+            walk(static_cast<Ogre::Bone*>(child), pos, ori);
+    };
+    for (Ogre::Bone* root : skel->getRootBones())
+        walk(root, Ogre::Vector3::ZERO, Ogre::Quaternion::IDENTITY);
+
+    const size_t n = std::min(mGhostNodes.size(), mGhostBoneNames.size());
+    for (size_t i = 0; i < n; ++i) {
+        Ogre::SceneNode* node = mGhostNodes[i];
+        if (!node) continue;
+        auto it = restLocal.find(mGhostBoneNames[i]);
+        if (it == restLocal.end()) continue;
+        node->setPosition(it->second.first);
+        node->setOrientation(it->second.second);
+    }
+}
+
 void SkeletonDebug::createAxesMaterial()
 {
     Ogre::String matName = "SkeletonDebug/AxesMat";
@@ -413,6 +521,25 @@ void SkeletonDebug::createBoneMaterial()
         p->setCullingMode(Ogre::CULL_NONE);
         p->setDepthWriteEnabled(false);
         p->setDepthCheckEnabled(false);
+    }
+
+    // Translucent cyan ghost for rest-pose overlay (slice C #557).
+    Ogre::String ghostMatName = "SkeletonDebug/BoneMatGhost";
+    mBoneMatGhostPtr = Ogre::static_pointer_cast<Ogre::Material>(
+        Ogre::MaterialManager::getSingleton().getByName(ghostMatName));
+    if (!mBoneMatGhostPtr) {
+        mBoneMatGhostPtr = Ogre::static_pointer_cast<Ogre::Material>(
+            Ogre::MaterialManager::getSingleton().create(
+                ghostMatName, Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME));
+        Ogre::Pass* p = mBoneMatGhostPtr->getTechnique(0)->getPass(0);
+        p->setLightingEnabled(true);
+        p->setDepthWriteEnabled(false);
+        p->setDepthCheckEnabled(false);
+        p->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
+        p->setCullingMode(Ogre::CULL_ANTICLOCKWISE);
+        p->setDiffuse(0.2f, 0.85f, 0.95f, 0.35f);
+        p->setAmbient(0.1f, 0.4f, 0.5f);
+        p->setEmissive(0.05f, 0.25f, 0.3f);
     }
 }
 

--- a/src/SkeletonDebug.cpp
+++ b/src/SkeletonDebug.cpp
@@ -335,6 +335,19 @@ void SkeletonDebug::showRestGhost(bool show)
 
 void SkeletonDebug::destroyGhostVisuals()
 {
+    if (mGhostMeshEntity) {
+        if (mGhostMeshEntity->getParentSceneNode())
+            mGhostMeshEntity->detachFromParent();
+        mSceneMan->destroyEntity(mGhostMeshEntity);
+        mGhostMeshEntity = nullptr;
+    }
+    // Drop the private mesh clone so the next ghost enable re-snapshots rest.
+    if (mGhostMeshPtr) {
+        const Ogre::String name = mGhostMeshPtr->getName();
+        mGhostMeshPtr.reset();
+        if (Ogre::MeshManager::getSingleton().resourceExists(name))
+            Ogre::MeshManager::getSingleton().remove(name);
+    }
     for (auto* ent : mGhostEntities) {
         if (ent && ent->getParentSceneNode())
             ent->detachFromParent();
@@ -359,8 +372,6 @@ void SkeletonDebug::ensureGhostVisuals()
         return;
 
     createBoneMaterial();
-    if (!mJointMeshPtr)
-        createJointMesh();
 
     Ogre::SceneNode* entNode = mEntity->getParentSceneNode();
     if (!entNode)
@@ -369,51 +380,59 @@ void SkeletonDebug::ensureGhostVisuals()
     mGhostRoot = entNode->createChildSceneNode(
         mEntity->getName() + "_restGhostRoot");
 
-    Ogre::SkeletonInstance* skel = mEntity->getSkeleton();
-    for (auto* bone : skel->getBones()) {
-        const Ogre::String entName = mEntity->getName() + "_restGhostEnt_" + bone->getName();
-        Ogre::Entity* ghost = mSceneMan->createEntity(entName, "SkeletonDebug/JointMesh");
-        ghost->setMaterial(mBoneMatGhostPtr);
-        ghost->setQueryFlags(0);
-        ghost->setVisible(true);
-        Ogre::SceneNode* node = mGhostRoot->createChildSceneNode();
-        node->attachObject(ghost);
-        const float jointScale = std::max(mBoneSize * 0.9f, 0.02f);
-        node->setScale(jointScale, jointScale, jointScale);
-        mGhostEntities.push_back(ghost);
-        mGhostNodes.push_back(node);
-        mGhostBoneNames.push_back(bone->getName());
+    // Translucent blue MESH frozen at the rest pose when the ghost was enabled.
+    // Must NOT share the live mesh resource — rest-pose bake writes into that
+    // mesh and would make the ghost follow the new pose.
+    // Live skeleton joints keep their normal materials (never this blue).
+    try {
+        const Ogre::String ghostEntName = mEntity->getName() + "_restGhostMesh";
+        const Ogre::String ghostMeshRes = mEntity->getName() + "_restGhostMeshRes";
+        if (mSceneMan->hasEntity(ghostEntName))
+            mSceneMan->destroyEntity(ghostEntName);
+        if (Ogre::MeshManager::getSingleton().resourceExists(ghostMeshRes))
+            Ogre::MeshManager::getSingleton().remove(ghostMeshRes);
+
+        mGhostMeshPtr = mEntity->getMesh()->clone(ghostMeshRes);
+        mGhostMeshEntity = mSceneMan->createEntity(ghostEntName, ghostMeshRes);
+        mGhostMeshEntity->setQueryFlags(0);
+        mGhostMeshEntity->setCastShadows(false);
+        mGhostMeshEntity->setMaterial(mMeshGhostMatPtr);
+        for (unsigned short i = 0; i < mGhostMeshEntity->getNumSubEntities(); ++i)
+            mGhostMeshEntity->getSubEntity(i)->setMaterial(mMeshGhostMatPtr);
+        mGhostRoot->attachObject(mGhostMeshEntity);
+        // Keep ghost at its cloned bind: disable clips and reset to bind.
+        if (Ogre::AnimationStateSet* states = mGhostMeshEntity->getAllAnimationStates()) {
+            for (const auto& pair : states->getAnimationStates())
+                pair.second->setEnabled(false);
+        }
+        if (Ogre::SkeletonInstance* gSkel = mGhostMeshEntity->getSkeleton())
+            gSkel->reset(true);
+    } catch (const Ogre::Exception&) {
+        mGhostMeshEntity = nullptr;
+        if (mGhostMeshPtr) {
+            const Ogre::String name = mGhostMeshPtr->getName();
+            mGhostMeshPtr.reset();
+            if (Ogre::MeshManager::getSingleton().resourceExists(name))
+                Ogre::MeshManager::getSingleton().remove(name);
+        }
     }
 }
 
 void SkeletonDebug::updateGhostVisuals()
 {
-    if (!mShowRestGhost || !mEntity || !mEntity->hasSkeleton() || !mGhostRoot)
+    if (!mShowRestGhost || !mEntity || !mGhostRoot)
         return;
 
-    Ogre::SkeletonInstance* skel = mEntity->getSkeleton();
-
-    // Rest-pose transforms in skeleton/entity-local space from initial TRS.
-    std::unordered_map<std::string, std::pair<Ogre::Vector3, Ogre::Quaternion>> restLocal;
-    std::function<void(Ogre::Bone*, const Ogre::Vector3&, const Ogre::Quaternion&)> walk;
-    walk = [&](Ogre::Bone* bone, const Ogre::Vector3& parentPos, const Ogre::Quaternion& parentOri) {
-        const Ogre::Vector3 pos = parentPos + parentOri * bone->getInitialPosition();
-        const Ogre::Quaternion ori = parentOri * bone->getInitialOrientation();
-        restLocal[bone->getName()] = {pos, ori};
-        for (auto* child : bone->getChildren())
-            walk(static_cast<Ogre::Bone*>(child), pos, ori);
-    };
-    for (Ogre::Bone* root : skel->getRootBones())
-        walk(root, Ogre::Vector3::ZERO, Ogre::Quaternion::IDENTITY);
-
-    const size_t n = std::min(mGhostNodes.size(), mGhostBoneNames.size());
-    for (size_t i = 0; i < n; ++i) {
-        Ogre::SceneNode* node = mGhostNodes[i];
-        if (!node) continue;
-        auto it = restLocal.find(mGhostBoneNames[i]);
-        if (it == restLocal.end()) continue;
-        node->setPosition(it->second.first);
-        node->setOrientation(it->second.second);
+    // Force the ghost mesh to the bind pose every tick so it never
+    // picks up the live animated skeleton.
+    if (mGhostMeshEntity) {
+        if (Ogre::SkeletonInstance* gSkel = mGhostMeshEntity->getSkeleton())
+            gSkel->reset(true);
+        mGhostMeshEntity->setVisible(true);
+        if (mMeshGhostMatPtr) {
+            for (unsigned short i = 0; i < mGhostMeshEntity->getNumSubEntities(); ++i)
+                mGhostMeshEntity->getSubEntity(i)->setMaterial(mMeshGhostMatPtr);
+        }
     }
 }
 
@@ -523,7 +542,27 @@ void SkeletonDebug::createBoneMaterial()
         p->setDepthCheckEnabled(false);
     }
 
-    // Translucent cyan ghost for rest-pose overlay (slice C #557).
+    // Translucent blue for rest-pose MESH ghost (slice C #557).
+    // Live skeleton joints never use this — only the ghost mesh entity.
+    Ogre::String meshGhostMatName = "SkeletonDebug/MeshGhostMat";
+    mMeshGhostMatPtr = Ogre::static_pointer_cast<Ogre::Material>(
+        Ogre::MaterialManager::getSingleton().getByName(meshGhostMatName));
+    if (!mMeshGhostMatPtr) {
+        mMeshGhostMatPtr = Ogre::static_pointer_cast<Ogre::Material>(
+            Ogre::MaterialManager::getSingleton().create(
+                meshGhostMatName, Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME));
+        Ogre::Pass* p = mMeshGhostMatPtr->getTechnique(0)->getPass(0);
+        p->setLightingEnabled(true);
+        p->setDepthWriteEnabled(false);
+        p->setDepthCheckEnabled(true);
+        p->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
+        p->setCullingMode(Ogre::CULL_NONE);
+        p->setDiffuse(0.25f, 0.55f, 1.0f, 0.35f);
+        p->setAmbient(0.1f, 0.25f, 0.5f);
+        p->setEmissive(0.05f, 0.15f, 0.35f);
+    }
+
+    // Legacy joint-ghost material kept for any residual joint markers.
     Ogre::String ghostMatName = "SkeletonDebug/BoneMatGhost";
     mBoneMatGhostPtr = Ogre::static_pointer_cast<Ogre::Material>(
         Ogre::MaterialManager::getSingleton().getByName(ghostMatName));
@@ -537,9 +576,9 @@ void SkeletonDebug::createBoneMaterial()
         p->setDepthCheckEnabled(false);
         p->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
         p->setCullingMode(Ogre::CULL_ANTICLOCKWISE);
-        p->setDiffuse(0.2f, 0.85f, 0.95f, 0.35f);
-        p->setAmbient(0.1f, 0.4f, 0.5f);
-        p->setEmissive(0.05f, 0.25f, 0.3f);
+        p->setDiffuse(0.25f, 0.55f, 1.0f, 0.35f);
+        p->setAmbient(0.1f, 0.25f, 0.5f);
+        p->setEmissive(0.05f, 0.15f, 0.35f);
     }
 }
 

--- a/src/SkeletonDebug.h
+++ b/src/SkeletonDebug.h
@@ -22,9 +22,11 @@ public:
     void showAxes(bool show);
     void showNames(bool show);
     void showBones(bool show);
+    void showRestGhost(bool show);
     bool axesShown() const {return mShowAxes;}
     bool namesShown() const {return mShowNames;}
     bool bonesShown() const {return mShowBones;}
+    bool restGhostShown() const {return mShowRestGhost;}
 
     /// Rebuild bone/axis visuals after skeleton structure changes (bone CRUD / undo).
     void rebuildVisuals();
@@ -46,6 +48,10 @@ private:
     std::vector<Ogre::Entity*> mAxisEntities;
     std::vector<Ogre::Entity*> mBoneEntities;   // joints + hierarchy links
     std::map<std::string, Ogre::Entity*, std::less<>> mBoneVisualByName; // joint only
+    std::vector<Ogre::SceneNode*> mGhostNodes;
+    std::vector<Ogre::Entity*> mGhostEntities;
+    std::vector<std::string> mGhostBoneNames;
+    Ogre::SceneNode* mGhostRoot = nullptr;
 
     float mBoneSize;
 
@@ -54,6 +60,7 @@ private:
     Ogre::MaterialPtr mBoneMatPtr;
     Ogre::MaterialPtr mBoneMatSelectedPtr;
     Ogre::MaterialPtr mBoneMatRootPtr;
+    Ogre::MaterialPtr mBoneMatGhostPtr;
     Ogre::MaterialPtr mLinkMatPtr;
     Ogre::MeshPtr mBoneMeshPtr;
     Ogre::MeshPtr mJointMeshPtr;
@@ -66,6 +73,7 @@ private:
     bool mShowAxes = true;
     bool mShowBones = true;
     bool mShowNames = true;
+    bool mShowRestGhost = false;
 
     void createAxesMaterial();
     void createBoneMaterial();
@@ -75,6 +83,9 @@ private:
     void createLinkMesh();
     std::map<std::string, Ogre::Entity*, std::less<>> createBoneVisuals();
     void createChildLinks(const Ogre::Bone* pBone);
+    void ensureGhostVisuals();
+    void destroyGhostVisuals();
+    void updateGhostVisuals();
     void onTimerTick();
 
     QTimer mTimer;

--- a/src/SkeletonDebug.h
+++ b/src/SkeletonDebug.h
@@ -49,8 +49,10 @@ private:
     std::vector<Ogre::Entity*> mBoneEntities;   // joints + hierarchy links
     std::map<std::string, Ogre::Entity*, std::less<>> mBoneVisualByName; // joint only
     std::vector<Ogre::SceneNode*> mGhostNodes;
-    std::vector<Ogre::Entity*> mGhostEntities;
+    std::vector<Ogre::Entity*> mGhostEntities; ///< rest-pose joint markers (optional)
     std::vector<std::string> mGhostBoneNames;
+    Ogre::Entity* mGhostMeshEntity = nullptr; ///< translucent blue mesh at bind pose
+    Ogre::MeshPtr mGhostMeshPtr; ///< private mesh clone (frozen at ghost-enable rest)
     Ogre::SceneNode* mGhostRoot = nullptr;
 
     float mBoneSize;
@@ -61,6 +63,7 @@ private:
     Ogre::MaterialPtr mBoneMatSelectedPtr;
     Ogre::MaterialPtr mBoneMatRootPtr;
     Ogre::MaterialPtr mBoneMatGhostPtr;
+    Ogre::MaterialPtr mMeshGhostMatPtr;
     Ogre::MaterialPtr mLinkMatPtr;
     Ogre::MeshPtr mBoneMeshPtr;
     Ogre::MeshPtr mJointMeshPtr;

--- a/src/SkeletonEditor.cpp
+++ b/src/SkeletonEditor.cpp
@@ -168,6 +168,99 @@ void worldToNewParentLocal(Ogre::Bone* bone,
         cScale.z / std::max(pScale.z, Ogre::Real(1e-8)));
 }
 
+struct RestPoseTRS {
+    Ogre::Vector3 position = Ogre::Vector3::ZERO;
+    Ogre::Quaternion orientation = Ogre::Quaternion::IDENTITY;
+    Ogre::Vector3 scale = Ogre::Vector3::UNIT_SCALE;
+};
+
+struct ImportedRestCache {
+    std::vector<std::pair<std::string, RestPoseTRS>> bones;
+};
+
+// Keyed by mesh name so skeleton resource rebuilds keep the original import.
+std::unordered_map<std::string, ImportedRestCache>& importedRestCaches()
+{
+    static std::unordered_map<std::string, ImportedRestCache> caches;
+    return caches;
+}
+
+std::string restCacheKey(Ogre::Entity* entity)
+{
+    if (!entity || !entity->getMesh()) return {};
+    return entity->getMesh()->getName();
+}
+
+void rebakeTrackKeyframes(Ogre::NodeAnimationTrack* track,
+                          const RestPoseTRS& oldRest,
+                          const RestPoseTRS& newRest)
+{
+    if (!track) return;
+    for (unsigned short k = 0; k < track->getNumKeyFrames(); ++k) {
+        auto* kf = track->getNodeKeyFrame(k);
+        const Ogre::Vector3 posePos = oldRest.position + kf->getTranslate();
+        const Ogre::Quaternion poseOri = oldRest.orientation * kf->getRotation();
+        const Ogre::Vector3 poseScl(
+            oldRest.scale.x * kf->getScale().x,
+            oldRest.scale.y * kf->getScale().y,
+            oldRest.scale.z * kf->getScale().z);
+
+        kf->setTranslate(posePos - newRest.position);
+        kf->setRotation(newRest.orientation.Inverse() * poseOri);
+        kf->setScale(Ogre::Vector3(
+            poseScl.x / std::max(newRest.scale.x, Ogre::Real(1e-8)),
+            poseScl.y / std::max(newRest.scale.y, Ogre::Real(1e-8)),
+            poseScl.z / std::max(newRest.scale.z, Ogre::Real(1e-8))));
+    }
+}
+
+void rebakeAnimationsForBone(Ogre::Skeleton* skel,
+                             const std::string& boneName,
+                             const RestPoseTRS& oldRest,
+                             const RestPoseTRS& newRest)
+{
+    if (!skel) return;
+    for (unsigned short ai = 0; ai < skel->getNumAnimations(); ++ai) {
+        Ogre::Animation* anim = skel->getAnimation(ai);
+        if (!anim) continue;
+        for (const auto& [handle, track] : anim->_getNodeTrackList()) {
+            if (!track) continue;
+            Ogre::Node* node = track->getAssociatedNode();
+            if (!node || node->getName() != boneName) continue;
+            rebakeTrackKeyframes(track, oldRest, newRest);
+        }
+    }
+}
+
+bool applyRestPoseMap(Ogre::Entity* entity,
+                      const std::unordered_map<std::string, RestPoseTRS>& newRests,
+                      QString* error)
+{
+    Ogre::SkeletonPtr skel = skeletonResource(entity);
+    if (!skel || newRests.empty()) {
+        if (error) *error = QStringLiteral("No skeleton or bones to update");
+        return false;
+    }
+
+    for (const auto& [name, newRest] : newRests) {
+        if (!skel->hasBone(name)) {
+            if (error) *error = QStringLiteral("Bone not found: %1").arg(QString::fromStdString(name));
+            return false;
+        }
+        Ogre::Bone* bone = skel->getBone(name);
+        RestPoseTRS oldRest{bone->getInitialPosition(), bone->getInitialOrientation(),
+                            bone->getInitialScale()};
+        rebakeAnimationsForBone(skel.get(), name, oldRest, newRest);
+        bone->setPosition(newRest.position);
+        bone->setOrientation(newRest.orientation);
+        bone->setScale(newRest.scale);
+        bone->setInitialState();
+    }
+    skel->setBindingPose();
+    entity->_initialise(true);
+    return true;
+}
+
 } // namespace
 
 SkeletonEditor* SkeletonEditor::s_singleton = nullptr;
@@ -191,8 +284,14 @@ SkeletonEditor* SkeletonEditor::qmlInstance(QQmlEngine* engine, QJSEngine*)
 
 void SkeletonEditor::kill()
 {
+    if (s_singleton) {
+        if (s_singleton->m_editRestPoseMode)
+            s_singleton->setEditRestPoseMode(false);
+        s_singleton->setShowRestPoseGhost(false);
+    }
     delete s_singleton;
     s_singleton = nullptr;
+    clearImportedRestCache();
 }
 
 SkeletonEditor::SkeletonEditor(QObject* parent) : QObject(parent) {}
@@ -1203,6 +1302,186 @@ QVariantList SkeletonEditor::attachTargetEntities() const
     return out;
 }
 
+void SkeletonEditor::ensureImportedRestCache(Ogre::Entity* entity)
+{
+    const std::string key = restCacheKey(entity);
+    if (key.empty()) return;
+    auto& caches = importedRestCaches();
+    if (caches.find(key) != caches.end()) return;
+
+    Ogre::SkeletonPtr skel = skeletonResource(entity);
+    if (!skel) return;
+
+    ImportedRestCache cache;
+    auto boneIt = skel->getBoneIterator();
+    while (boneIt.hasMoreElements()) {
+        Ogre::Bone* bone = boneIt.getNext();
+        cache.bones.push_back({bone->getName(),
+                               {bone->getInitialPosition(), bone->getInitialOrientation(),
+                                bone->getInitialScale()}});
+    }
+    caches.emplace(key, std::move(cache));
+}
+
+void SkeletonEditor::clearImportedRestCache(Ogre::Entity* entity)
+{
+    auto& caches = importedRestCaches();
+    if (!entity) {
+        caches.clear();
+        return;
+    }
+    const std::string key = restCacheKey(entity);
+    if (!key.empty())
+        caches.erase(key);
+}
+
+SkeletonEditor::Result SkeletonEditor::captureRestPose(Ogre::Entity* entity, const QStringList& boneNames)
+{
+    Result result;
+    Ogre::SkeletonPtr skel = skeletonResource(entity);
+    if (!skel) {
+        result.error = QStringLiteral("Entity has no skeleton");
+        return result;
+    }
+    ensureImportedRestCache(entity);
+
+    Ogre::SkeletonInstance* inst = entity->getSkeleton();
+    std::unordered_map<std::string, RestPoseTRS> newRests;
+
+    auto addBone = [&](const std::string& name) {
+        if (!skel->hasBone(name)) return;
+        Ogre::Bone* src = nullptr;
+        if (inst && inst->hasBone(name))
+            src = inst->getBone(name);
+        else
+            src = skel->getBone(name);
+        newRests[name] = {src->getPosition(), src->getOrientation(), src->getScale()};
+    };
+
+    if (boneNames.isEmpty()) {
+        auto boneIt = skel->getBoneIterator();
+        while (boneIt.hasMoreElements())
+            addBone(boneIt.getNext()->getName());
+    } else {
+        for (const QString& n : boneNames)
+            addBone(n.toStdString());
+    }
+
+    QString err;
+    if (!applyRestPoseMap(entity, newRests, &err)) {
+        result.error = err;
+        return result;
+    }
+    result.ok = true;
+    return result;
+}
+
+SkeletonEditor::Result SkeletonEditor::resetRestPose(Ogre::Entity* entity)
+{
+    Result result;
+    ensureImportedRestCache(entity);
+    const std::string key = restCacheKey(entity);
+    auto& caches = importedRestCaches();
+    auto it = caches.find(key);
+    if (it == caches.end() || it->second.bones.empty()) {
+        result.error = QStringLiteral("No imported rest pose cached");
+        return result;
+    }
+
+    std::unordered_map<std::string, RestPoseTRS> newRests;
+    for (const auto& [name, trs] : it->second.bones)
+        newRests[name] = trs;
+
+    QString err;
+    if (!applyRestPoseMap(entity, newRests, &err)) {
+        result.error = err;
+        return result;
+    }
+    result.ok = true;
+    return result;
+}
+
+SkeletonEditor::Result SkeletonEditor::commitBoneRestPose(Ogre::Entity* entity,
+                                                         const QString& boneName,
+                                                         const Ogre::Vector3& pos,
+                                                         const Ogre::Quaternion& orient,
+                                                         const Ogre::Vector3& scale)
+{
+    Result result;
+    if (!entity || boneName.isEmpty()) {
+        result.error = QStringLiteral("Invalid entity or bone");
+        return result;
+    }
+    ensureImportedRestCache(entity);
+    std::unordered_map<std::string, RestPoseTRS> newRests;
+    newRests[boneName.toStdString()] = {pos, orient, scale};
+    QString err;
+    if (!applyRestPoseMap(entity, newRests, &err)) {
+        result.error = err;
+        return result;
+    }
+    result.ok = true;
+    result.boneName = boneName;
+    return result;
+}
+
+void SkeletonEditor::setEditRestPoseMode(bool on)
+{
+    if (m_editRestPoseMode == on) return;
+    m_editRestPoseMode = on;
+    applyEditRestAnimMute(on);
+    emit editRestPoseModeChanged();
+}
+
+void SkeletonEditor::setShowRestPoseGhost(bool on)
+{
+    if (m_showRestPoseGhost == on) return;
+    m_showRestPoseGhost = on;
+    syncRestPoseGhostOverlay();
+    emit showRestPoseGhostChanged();
+}
+
+void SkeletonEditor::applyEditRestAnimMute(bool mute)
+{
+    auto* animCtrl = AnimationControlController::instance();
+    if (!mute) {
+        if (!m_editRestMutedEntity.isEmpty() && animCtrl) {
+            Ogre::Entity* ent = resolveEntityByName(m_editRestMutedEntity.toStdString());
+            if (ent) {
+                for (const QString& name : m_editRestMutedAnims) {
+                    if (!ent->hasAnimationState(name.toStdString())) continue;
+                    ent->getAnimationState(name.toStdString())->setEnabled(true);
+                }
+            }
+        }
+        m_editRestMutedEntity.clear();
+        m_editRestMutedAnims.clear();
+        return;
+    }
+
+    Ogre::Entity* ent = selectedSkinnedEntity();
+    if (!ent) return;
+    m_editRestMutedEntity = QString::fromStdString(ent->getName());
+    m_editRestMutedAnims.clear();
+    if (Ogre::AnimationStateSet* states = ent->getAllAnimationStates()) {
+        for (const auto& pair : states->getAnimationStates()) {
+            if (!pair.second->getEnabled()) continue;
+            m_editRestMutedAnims.append(QString::fromStdString(pair.first));
+            pair.second->setEnabled(false);
+        }
+    }
+    // Settle bones at bind so the gizmo edits rest, not a frozen anim frame.
+    if (Ogre::SkeletonInstance* skel = ent->getSkeleton())
+        skel->reset(true);
+    ent->_updateAnimation();
+}
+
+void SkeletonEditor::syncRestPoseGhostOverlay()
+{
+    if (auto* ppc = PropertiesPanelController::instance())
+        ppc->setRestPoseGhostVisible(m_showRestPoseGhost);
+}
+
 bool SkeletonEditor::createBoneForSelected(const QString& parentBoneName)
 {
     Ogre::Entity* entity = selectedSkinnedEntity();
@@ -1328,6 +1607,36 @@ bool SkeletonEditor::attachSelectedBoneToEntity(const QString& dstEntityName)
 
     auto* cmd = new AttachBoneToEntityCommand(
         src->getName(), QStringList{bone}, dstEntityName.toStdString(), {});
+    UndoManager::getSingleton()->push(cmd);
+    return cmd->applied();
+}
+
+bool SkeletonEditor::captureRestPoseForSelected()
+{
+    Ogre::Entity* entity = selectedSkinnedEntity();
+    if (!entity) return false;
+    auto* cmd = new SetRestPoseCommand(entity->getName(), SetRestPoseCommand::Op::CaptureAll);
+    UndoManager::getSingleton()->push(cmd);
+    return cmd->applied();
+}
+
+bool SkeletonEditor::resetRestPoseForSelected()
+{
+    Ogre::Entity* entity = selectedSkinnedEntity();
+    if (!entity) return false;
+    auto* cmd = new SetRestPoseCommand(entity->getName(), SetRestPoseCommand::Op::Reset);
+    UndoManager::getSingleton()->push(cmd);
+    return cmd->applied();
+}
+
+bool SkeletonEditor::snapSelectedBonesToCurrentPose()
+{
+    Ogre::Entity* entity = selectedSkinnedEntity();
+    if (!entity) return false;
+    const QString bone = selectedBoneName();
+    if (bone.isEmpty()) return false;
+    auto* cmd = new SetRestPoseCommand(entity->getName(), SetRestPoseCommand::Op::SnapSelected,
+                                       QStringList{bone});
     UndoManager::getSingleton()->push(cmd);
     return cmd->applied();
 }

--- a/src/SkeletonEditor.cpp
+++ b/src/SkeletonEditor.cpp
@@ -11,9 +11,13 @@
 
 #include <OgreBone.h>
 #include <OgreEntity.h>
+#include <OgreHardwareBuffer.h>
 #include <OgreSkeleton.h>
 #include <OgreSkeletonInstance.h>
 #include <OgreSkeletonManager.h>
+#include <OgreAnimationState.h>
+#include <OgreSubMesh.h>
+#include <OgreSubEntity.h>
 
 #include <QSet>
 #include <QStringList>
@@ -23,6 +27,7 @@
 #include <limits>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 namespace {
 
@@ -176,6 +181,7 @@ struct RestPoseTRS {
 
 struct ImportedRestCache {
     std::vector<std::pair<std::string, RestPoseTRS>> bones;
+    std::vector<SkeletonEditor::Snapshot::BindVertexBuffer> bindVertexBuffers;
 };
 
 // Keyed by mesh name so skeleton resource rebuilds keep the original import.
@@ -189,6 +195,206 @@ std::string restCacheKey(Ogre::Entity* entity)
 {
     if (!entity || !entity->getMesh()) return {};
     return entity->getMesh()->getName();
+}
+
+void readBindVertexBuffer(const Ogre::VertexData* vd,
+                          SkeletonEditor::Snapshot::BindVertexBuffer& out)
+{
+    out.positions.clear();
+    out.normals.clear();
+    if (!vd || vd->vertexCount == 0) return;
+
+    const size_t n = vd->vertexCount;
+    out.positions.resize(n * 3, 0.f);
+
+    const auto* posElem = vd->vertexDeclaration->findElementBySemantic(Ogre::VES_POSITION);
+    if (posElem) {
+        auto vbuf = vd->vertexBufferBinding->getBuffer(posElem->getSource());
+        auto* base = static_cast<unsigned char*>(
+            vbuf->lock(Ogre::HardwareBuffer::HBL_READ_ONLY));
+        for (size_t i = 0; i < n; ++i) {
+            float* p = nullptr;
+            posElem->baseVertexPointerToElement(base + i * vbuf->getVertexSize(), &p);
+            out.positions[i * 3 + 0] = p[0];
+            out.positions[i * 3 + 1] = p[1];
+            out.positions[i * 3 + 2] = p[2];
+        }
+        vbuf->unlock();
+    }
+
+    const auto* normElem = vd->vertexDeclaration->findElementBySemantic(Ogre::VES_NORMAL);
+    if (normElem) {
+        out.normals.resize(n * 3, 0.f);
+        auto vbuf = vd->vertexBufferBinding->getBuffer(normElem->getSource());
+        auto* base = static_cast<unsigned char*>(
+            vbuf->lock(Ogre::HardwareBuffer::HBL_READ_ONLY));
+        for (size_t i = 0; i < n; ++i) {
+            float* p = nullptr;
+            normElem->baseVertexPointerToElement(base + i * vbuf->getVertexSize(), &p);
+            out.normals[i * 3 + 0] = p[0];
+            out.normals[i * 3 + 1] = p[1];
+            out.normals[i * 3 + 2] = p[2];
+        }
+        vbuf->unlock();
+    }
+}
+
+void writeBindVertexBuffer(Ogre::VertexData* vd,
+                           const SkeletonEditor::Snapshot::BindVertexBuffer& in)
+{
+    if (!vd || in.positions.size() < vd->vertexCount * 3) return;
+    const size_t n = vd->vertexCount;
+
+    const auto* posElem = vd->vertexDeclaration->findElementBySemantic(Ogre::VES_POSITION);
+    if (posElem) {
+        auto vbuf = vd->vertexBufferBinding->getBuffer(posElem->getSource());
+        auto* base = static_cast<unsigned char*>(
+            vbuf->lock(Ogre::HardwareBuffer::HBL_NORMAL));
+        for (size_t i = 0; i < n; ++i) {
+            float* p = nullptr;
+            posElem->baseVertexPointerToElement(base + i * vbuf->getVertexSize(), &p);
+            p[0] = in.positions[i * 3 + 0];
+            p[1] = in.positions[i * 3 + 1];
+            p[2] = in.positions[i * 3 + 2];
+        }
+        vbuf->unlock();
+    }
+
+    const auto* normElem = vd->vertexDeclaration->findElementBySemantic(Ogre::VES_NORMAL);
+    if (normElem && in.normals.size() >= n * 3) {
+        auto vbuf = vd->vertexBufferBinding->getBuffer(normElem->getSource());
+        auto* base = static_cast<unsigned char*>(
+            vbuf->lock(Ogre::HardwareBuffer::HBL_NORMAL));
+        for (size_t i = 0; i < n; ++i) {
+            float* p = nullptr;
+            normElem->baseVertexPointerToElement(base + i * vbuf->getVertexSize(), &p);
+            p[0] = in.normals[i * 3 + 0];
+            p[1] = in.normals[i * 3 + 1];
+            p[2] = in.normals[i * 3 + 2];
+        }
+        vbuf->unlock();
+    }
+}
+
+std::vector<SkeletonEditor::Snapshot::BindVertexBuffer> captureMeshBindVertices(Ogre::Mesh* mesh)
+{
+    std::vector<SkeletonEditor::Snapshot::BindVertexBuffer> out;
+    if (!mesh) return out;
+    if (mesh->sharedVertexData) {
+        SkeletonEditor::Snapshot::BindVertexBuffer b;
+        b.submeshIndex = -1;
+        readBindVertexBuffer(mesh->sharedVertexData, b);
+        out.push_back(std::move(b));
+    }
+    for (unsigned short si = 0; si < mesh->getNumSubMeshes(); ++si) {
+        Ogre::SubMesh* sub = mesh->getSubMesh(si);
+        if (!sub || sub->useSharedVertices || !sub->vertexData) continue;
+        SkeletonEditor::Snapshot::BindVertexBuffer b;
+        b.submeshIndex = static_cast<int>(si);
+        readBindVertexBuffer(sub->vertexData, b);
+        out.push_back(std::move(b));
+    }
+    return out;
+}
+
+void restoreMeshBindVertices(Ogre::Mesh* mesh,
+                             const std::vector<SkeletonEditor::Snapshot::BindVertexBuffer>& buffers)
+{
+    if (!mesh) return;
+    Ogre::AxisAlignedBox box;
+    bool any = false;
+    for (const auto& b : buffers) {
+        Ogre::VertexData* vd = nullptr;
+        if (b.submeshIndex < 0)
+            vd = mesh->sharedVertexData;
+        else if (static_cast<unsigned short>(b.submeshIndex) < mesh->getNumSubMeshes()) {
+            Ogre::SubMesh* sub = mesh->getSubMesh(static_cast<unsigned short>(b.submeshIndex));
+            if (sub && !sub->useSharedVertices)
+                vd = sub->vertexData;
+        }
+        if (!vd) continue;
+        writeBindVertexBuffer(vd, b);
+        for (size_t i = 0; i + 2 < b.positions.size(); i += 3) {
+            box.merge(Ogre::Vector3(b.positions[i], b.positions[i + 1], b.positions[i + 2]));
+            any = true;
+        }
+    }
+    if (any) {
+        mesh->_setBounds(box, false);
+        mesh->_setBoundingSphereRadius(
+            std::max(box.getMaximum().length(), box.getMinimum().length()));
+    }
+}
+
+/// Copy software-skinned positions/normals into the mesh bind buffers so the
+/// visible posed shape becomes the new rest geometry. Required because LBS at
+/// the binding pose is identity — changing bone initials alone always shows
+/// the authored T-pose verts again.
+///
+/// Caller must: disable animation states, reset non-target bones to the current
+/// bind, and pose target bones with setManuallyControlled(true). This function
+/// does not re-enable clips (setBindingPose must run while they stay muted).
+bool bakeSkinnedPoseIntoBindMesh(Ogre::Entity* entity, QString* error)
+{
+    if (!entity || !entity->hasSkeleton() || !entity->getMesh()) {
+        if (error) *error = QStringLiteral("No skinned entity to bake");
+        return false;
+    }
+
+    Ogre::Mesh* mesh = entity->getMesh().get();
+
+    if (Ogre::SkeletonInstance* inst = entity->getSkeleton()) {
+        for (Ogre::Bone* root : inst->getRootBones())
+            root->_update(true, true);
+    }
+
+    // Skip setAnimationState inside cacheBoneMatrices — a reset() there would
+    // fight our manually posed bones if the dirty-frame gate re-enters it.
+    const bool prevSkip = entity->getSkipAnimationStateUpdate();
+    entity->setSkipAnimationStateUpdate(true);
+    entity->addSoftwareAnimationRequest(true);
+    entity->_updateAnimation();
+
+    auto copySkinnedToBind = [](Ogre::VertexData* bind, const Ogre::VertexData* skinned) -> bool {
+        if (!bind || !skinned || bind->vertexCount != skinned->vertexCount)
+            return false;
+        SkeletonEditor::Snapshot::BindVertexBuffer tmp;
+        readBindVertexBuffer(skinned, tmp);
+        writeBindVertexBuffer(bind, tmp);
+        return true;
+    };
+
+    bool ok = true;
+    bool any = false;
+    if (mesh->sharedVertexData) {
+        any = true;
+        Ogre::VertexData* skinned = entity->_getSkelAnimVertexData();
+        if (!copySkinnedToBind(mesh->sharedVertexData, skinned))
+            ok = false;
+    }
+    for (unsigned short si = 0; si < mesh->getNumSubMeshes(); ++si) {
+        Ogre::SubMesh* sub = mesh->getSubMesh(si);
+        if (!sub || sub->useSharedVertices || !sub->vertexData) continue;
+        any = true;
+        Ogre::VertexData* skinned = entity->getSubEntity(si)->_getSkelAnimVertexData();
+        if (!copySkinnedToBind(sub->vertexData, skinned))
+            ok = false;
+    }
+
+    entity->removeSoftwareAnimationRequest(true);
+    entity->setSkipAnimationStateUpdate(prevSkip);
+
+    if (!any || !ok) {
+        if (error) *error = QStringLiteral("Failed to read software-skinned vertices");
+        return false;
+    }
+
+    // Refresh AABB from the newly baked bind verts.
+    // Do NOT call mesh->_dirtyState(): that bumps getStateCount() and forces
+    // Entity::_initialise(true) on the next frame, which destroys TagPoints and
+    // makes the Skeleton overlay disappear while the checkbox stays checked.
+    restoreMeshBindVertices(mesh, captureMeshBindVertices(mesh));
+    return true;
 }
 
 void rebakeTrackKeyframes(Ogre::NodeAnimationTrack* track,
@@ -219,14 +425,17 @@ void rebakeAnimationsForBone(Ogre::Skeleton* skel,
                              const RestPoseTRS& oldRest,
                              const RestPoseTRS& newRest)
 {
-    if (!skel) return;
+    if (!skel || !skel->hasBone(boneName)) return;
+    const unsigned short boneHandle = skel->getBone(boneName)->getHandle();
     for (unsigned short ai = 0; ai < skel->getNumAnimations(); ++ai) {
         Ogre::Animation* anim = skel->getAnimation(ai);
         if (!anim) continue;
         for (const auto& [handle, track] : anim->_getNodeTrackList()) {
             if (!track) continue;
             Ogre::Node* node = track->getAssociatedNode();
-            if (!node || node->getName() != boneName) continue;
+            const bool nameMatch = node && node->getName() == boneName;
+            const bool handleMatch = handle == boneHandle;
+            if (!nameMatch && !handleMatch) continue;
             rebakeTrackKeyframes(track, oldRest, newRest);
         }
     }
@@ -234,7 +443,9 @@ void rebakeAnimationsForBone(Ogre::Skeleton* skel,
 
 bool applyRestPoseMap(Ogre::Entity* entity,
                       const std::unordered_map<std::string, RestPoseTRS>& newRests,
-                      QString* error)
+                      QString* error,
+                      bool rebakeAnimations,
+                      bool bakeMesh)
 {
     Ogre::SkeletonPtr skel = skeletonResource(entity);
     if (!skel || newRests.empty()) {
@@ -251,18 +462,105 @@ bool applyRestPoseMap(Ogre::Entity* entity,
         }
     }
 
+    // Mute clips for the whole bind write. Re-enabling mid-bake used to let
+    // setAnimationState()/setBindingPose capture mid-clip locals as the new
+    // bind, and the mesh bake never stuck visually.
+    struct AnimMute {
+        Ogre::Entity* ent = nullptr;
+        std::vector<std::pair<std::string, bool>> saved;
+        explicit AnimMute(Ogre::Entity* e) : ent(e)
+        {
+            if (!ent) return;
+            if (Ogre::AnimationStateSet* states = ent->getAllAnimationStates()) {
+                for (const auto& pair : states->getAnimationStates()) {
+                    saved.push_back({pair.first, pair.second->getEnabled()});
+                    pair.second->setEnabled(false);
+                }
+            }
+        }
+        ~AnimMute()
+        {
+            if (!ent) return;
+            if (Ogre::AnimationStateSet* states = ent->getAllAnimationStates()) {
+                for (const auto& [name, enabled] : saved) {
+                    if (!states->hasAnimationState(name)) continue;
+                    states->getAnimationState(name)->setEnabled(enabled);
+                }
+            }
+        }
+    } animMute(entity);
+
+    // Pose from a clean bind: reset every bone, then apply only the new rests.
+    // Baking on top of a mid-clip body pose would freeze that clip into the mesh.
+    if (Ogre::SkeletonInstance* inst = entity->getSkeleton()) {
+        for (unsigned short i = 0; i < inst->getNumBones(); ++i)
+            inst->getBone(i)->setManuallyControlled(false);
+        inst->reset(true);
+        for (const auto& [name, newRest] : newRests) {
+            if (!inst->hasBone(name)) continue;
+            Ogre::Bone* ib = inst->getBone(name);
+            ib->setManuallyControlled(true);
+            ib->setPosition(newRest.position);
+            ib->setOrientation(newRest.orientation);
+            ib->setScale(newRest.scale);
+        }
+        for (Ogre::Bone* root : inst->getRootBones())
+            root->_update(true, true);
+    }
+
+    // LBS at the binding pose is identity — without baking the posed
+    // skinned verts into the mesh, changing bone initials alone always
+    // shows the authored T-pose geometry again (bones look posed, mesh
+    // snaps back). Capture/gizmo commits bake; reset restores cached verts.
+    if (bakeMesh) {
+        QString bakeErr;
+        if (!bakeSkinnedPoseIntoBindMesh(entity, &bakeErr)) {
+            if (error) *error = bakeErr;
+            return false;
+        }
+    }
+
     for (const auto& [name, newRest] : newRests) {
         Ogre::Bone* bone = skel->getBone(name);
         RestPoseTRS oldRest{bone->getInitialPosition(), bone->getInitialOrientation(),
                             bone->getInitialScale()};
-        rebakeAnimationsForBone(skel.get(), name, oldRest, newRest);
+        // Capture Rest / Reset: rebake so clip world motion is unchanged.
+        // Gizmo CommitBind: do NOT rebake — preserving absolute poses would
+        // immediately undo the user's rest edit once the clip is re-applied.
+        if (rebakeAnimations)
+            rebakeAnimationsForBone(skel.get(), name, oldRest, newRest);
         bone->setPosition(newRest.position);
         bone->setOrientation(newRest.orientation);
         bone->setScale(newRest.scale);
         bone->setInitialState();
     }
     skel->setBindingPose();
-    entity->_initialise(true);
+
+    // Sync the LIVE SkeletonInstance in place. Do NOT call entity->_initialise(true):
+    // that destroys TagPoints and leaves SkeletonDebug joint entities floating.
+    // Copy EVERY bone's new initial from the resource so setBindingPose does not
+    // freeze leftover clip locals into inverse-bind matrices.
+    if (Ogre::SkeletonInstance* inst = entity->getSkeleton()) {
+        for (unsigned short i = 0; i < inst->getNumBones(); ++i) {
+            Ogre::Bone* ib = inst->getBone(i);
+            if (!skel->hasBone(ib->getName())) continue;
+            Ogre::Bone* rb = skel->getBone(ib->getName());
+            ib->setManuallyControlled(true);
+            ib->setPosition(rb->getInitialPosition());
+            ib->setOrientation(rb->getInitialOrientation());
+            ib->setScale(rb->getInitialScale());
+        }
+        for (Ogre::Bone* root : inst->getRootBones())
+            root->_update(true, true);
+        inst->setBindingPose();
+        for (unsigned short i = 0; i < inst->getNumBones(); ++i)
+            inst->getBone(i)->setManuallyControlled(false);
+        inst->reset(true);
+        for (Ogre::Bone* root : inst->getRootBones())
+            root->_update(true, true);
+    }
+
+    entity->_updateAnimation();
     return true;
 }
 
@@ -411,6 +709,7 @@ SkeletonEditor::Snapshot SkeletonEditor::captureSnapshot(Ogre::Entity* entity)
     }
 
     gatherBoneAssignments(mesh, snap);
+    snap.bindVertexBuffers = captureMeshBindVertices(mesh);
     return snap;
 }
 
@@ -494,6 +793,8 @@ bool SkeletonEditor::restoreSnapshot(Ogre::Entity* entity, const Snapshot& snaps
     Ogre::Mesh* mesh = entity->getMesh().get();
     mesh->_notifySkeleton(skel);
     applyBoneAssignments(mesh, snapshot);
+    if (!snapshot.bindVertexBuffers.empty())
+        restoreMeshBindVertices(mesh, snapshot.bindVertexBuffers);
     entity->_initialise(true);
     return true;
 }
@@ -583,6 +884,7 @@ bool SkeletonEditor::rebuildSkeletonWithoutBones(Ogre::Entity* entity,
     filtered.skeletonName = snap.skeletonName;
     filtered.meshName = snap.meshName;
     filtered.submeshAssignments = snap.submeshAssignments;
+    filtered.bindVertexBuffers = snap.bindVertexBuffers;
 
     std::unordered_map<unsigned short, unsigned short> oldToNew;
     unsigned short nextHandle = 0;
@@ -1339,6 +1641,7 @@ void SkeletonEditor::ensureImportedRestCache(Ogre::Entity* entity)
                                {bone->getInitialPosition(), bone->getInitialOrientation(),
                                 bone->getInitialScale()}});
     }
+    cache.bindVertexBuffers = captureMeshBindVertices(entity->getMesh().get());
     caches.emplace(key, std::move(cache));
 }
 
@@ -1387,7 +1690,8 @@ SkeletonEditor::Result SkeletonEditor::captureRestPose(Ogre::Entity* entity, con
     }
 
     QString err;
-    if (!applyRestPoseMap(entity, newRests, &err)) {
+    if (!applyRestPoseMap(entity, newRests, &err, /*rebakeAnimations=*/true,
+                          /*bakeMesh=*/true)) {
         result.error = err;
         return result;
     }
@@ -1424,8 +1728,13 @@ SkeletonEditor::Result SkeletonEditor::resetRestPose(Ogre::Entity* entity)
         return result;
     }
 
+    // Restore authored bind-pose verts before re-applying imported bone TRS.
+    if (!it->second.bindVertexBuffers.empty())
+        restoreMeshBindVertices(entity->getMesh().get(), it->second.bindVertexBuffers);
+
     QString err;
-    if (!applyRestPoseMap(entity, newRests, &err)) {
+    if (!applyRestPoseMap(entity, newRests, &err, /*rebakeAnimations=*/true,
+                          /*bakeMesh=*/false)) {
         result.error = err;
         return result;
     }
@@ -1448,7 +1757,10 @@ SkeletonEditor::Result SkeletonEditor::commitBoneRestPose(Ogre::Entity* entity,
     std::unordered_map<std::string, RestPoseTRS> newRests;
     newRests[boneName.toStdString()] = {pos, orient, scale};
     QString err;
-    if (!applyRestPoseMap(entity, newRests, &err)) {
+    // Bake posed mesh into bind + update bone bind. Do not rebake clips to
+    // preserve absolute poses (that snaps the mesh back to the pre-edit look).
+    if (!applyRestPoseMap(entity, newRests, &err, /*rebakeAnimations=*/false,
+                          /*bakeMesh=*/true)) {
         result.error = err;
         return result;
     }

--- a/src/SkeletonEditor.cpp
+++ b/src/SkeletonEditor.cpp
@@ -242,11 +242,16 @@ bool applyRestPoseMap(Ogre::Entity* entity,
         return false;
     }
 
+    // Validate every target bone exists before mutating any tracks/bind.
     for (const auto& [name, newRest] : newRests) {
+        Q_UNUSED(newRest);
         if (!skel->hasBone(name)) {
             if (error) *error = QStringLiteral("Bone not found: %1").arg(QString::fromStdString(name));
             return false;
         }
+    }
+
+    for (const auto& [name, newRest] : newRests) {
         Ogre::Bone* bone = skel->getBone(name);
         RestPoseTRS oldRest{bone->getInitialPosition(), bone->getInitialOrientation(),
                             bone->getInitialScale()};
@@ -295,6 +300,20 @@ void SkeletonEditor::kill()
 }
 
 SkeletonEditor::SkeletonEditor(QObject* parent) : QObject(parent) {}
+
+void SkeletonEditor::ensureEditRestSelectionHook()
+{
+    if (m_editRestSelectionHooked) return;
+    auto* sel = SelectionSet::getSingletonPtr();
+    if (!sel) return;
+    connect(sel, &SelectionSet::selectionChanged, this, [this]() {
+        if (!m_editRestPoseMode) return;
+        // Remute for the newly selected entity; unmute the previous one.
+        applyEditRestAnimMute(false);
+        applyEditRestAnimMute(true);
+    });
+    m_editRestSelectionHooked = true;
+}
 
 Ogre::Entity* SkeletonEditor::selectedSkinnedEntity()
 {
@@ -1388,9 +1407,22 @@ SkeletonEditor::Result SkeletonEditor::resetRestPose(Ogre::Entity* entity)
         return result;
     }
 
+    Ogre::SkeletonPtr skel = skeletonResource(entity);
+    if (!skel) {
+        result.error = QStringLiteral("Entity has no skeleton");
+        return result;
+    }
+
     std::unordered_map<std::string, RestPoseTRS> newRests;
-    for (const auto& [name, trs] : it->second.bones)
+    for (const auto& [name, trs] : it->second.bones) {
+        if (!skel->hasBone(name))
+            continue; // renamed/removed since import — skip stale cache entries
         newRests[name] = trs;
+    }
+    if (newRests.empty()) {
+        result.error = QStringLiteral("Cached rest pose has no matching bones");
+        return result;
+    }
 
     QString err;
     if (!applyRestPoseMap(entity, newRests, &err)) {
@@ -1428,8 +1460,12 @@ SkeletonEditor::Result SkeletonEditor::commitBoneRestPose(Ogre::Entity* entity,
 void SkeletonEditor::setEditRestPoseMode(bool on)
 {
     if (m_editRestPoseMode == on) return;
+    if (on)
+        ensureEditRestSelectionHook();
     m_editRestPoseMode = on;
     applyEditRestAnimMute(on);
+    SentryReporter::addBreadcrumb(QStringLiteral("scene.skel.rest_pose.edit_mode"),
+                                  on ? QStringLiteral("on") : QStringLiteral("off"));
     emit editRestPoseModeChanged();
 }
 
@@ -1438,14 +1474,15 @@ void SkeletonEditor::setShowRestPoseGhost(bool on)
     if (m_showRestPoseGhost == on) return;
     m_showRestPoseGhost = on;
     syncRestPoseGhostOverlay();
+    SentryReporter::addBreadcrumb(QStringLiteral("scene.skel.rest_pose.ghost"),
+                                  on ? QStringLiteral("on") : QStringLiteral("off"));
     emit showRestPoseGhostChanged();
 }
 
 void SkeletonEditor::applyEditRestAnimMute(bool mute)
 {
-    auto* animCtrl = AnimationControlController::instance();
     if (!mute) {
-        if (!m_editRestMutedEntity.isEmpty() && animCtrl) {
+        if (!m_editRestMutedEntity.isEmpty()) {
             Ogre::Entity* ent = resolveEntityByName(m_editRestMutedEntity.toStdString());
             if (ent) {
                 for (const QString& name : m_editRestMutedAnims) {

--- a/src/SkeletonEditor.h
+++ b/src/SkeletonEditor.h
@@ -23,13 +23,17 @@ class Mesh;
 class Skeleton;
 }
 
-/// Bone-level CRUD + hierarchy editing for skeletal rigs
-/// (epic #554: slice A #555 CRUD, slice B #556 hierarchy).
+/// Bone-level CRUD + hierarchy + rest-pose editing for skeletal rigs
+/// (epic #554: slice A #555 CRUD, slice B #556 hierarchy, slice C #557 rest pose).
 class SkeletonEditor : public QObject
 {
     Q_OBJECT
     QML_ELEMENT
     QML_SINGLETON
+    Q_PROPERTY(bool editRestPoseMode READ editRestPoseMode WRITE setEditRestPoseMode
+               NOTIFY editRestPoseModeChanged)
+    Q_PROPERTY(bool showRestPoseGhost READ showRestPoseGhost WRITE setShowRestPoseGhost
+               NOTIFY showRestPoseGhostChanged)
 
 public:
     struct CreateOptions {
@@ -138,6 +142,25 @@ public:
     static Result setBoneConnected(Ogre::Entity* entity, const QString& boneName, bool connected);
     static bool isBoneConnected(Ogre::Entity* entity, const QString& boneName);
 
+    /// Cache the mesh skeleton's current bind pose as the "imported" rest
+    /// (first call wins per mesh). Used by resetRestPose.
+    static void ensureImportedRestCache(Ogre::Entity* entity);
+    /// Clear cached imported rest for a mesh (tests / mesh destroy).
+    static void clearImportedRestCache(Ogre::Entity* entity = nullptr);
+
+    /// Set rest pose of the listed bones (empty list = all) to their current
+    /// evaluated local TRS, rebake animation tracks so world motion is
+    /// unchanged, and refresh inverse binds. Mutates the mesh skeleton.
+    static Result captureRestPose(Ogre::Entity* entity, const QStringList& boneNames = {});
+    /// Restore bind pose (+ rebaked tracks) to the cached imported rest.
+    static Result resetRestPose(Ogre::Entity* entity);
+    /// Commit an explicit new rest TRS for one bone (edit-rest gizmo path).
+    static Result commitBoneRestPose(Ogre::Entity* entity,
+                                     const QString& boneName,
+                                     const Ogre::Vector3& pos,
+                                     const Ogre::Quaternion& orient,
+                                     const Ogre::Vector3& scale);
+
     static void refreshAfterEdit(const std::string& entityName, const QString& selectBone = {});
 
     /// Push undo commands — used by QML and tests.
@@ -152,6 +175,10 @@ public:
     Q_INVOKABLE bool isSelectedBoneConnected() const;
     Q_INVOKABLE bool attachSelectedBoneToEntity(const QString& dstEntityName);
 
+    Q_INVOKABLE bool captureRestPoseForSelected();
+    Q_INVOKABLE bool resetRestPoseForSelected();
+    Q_INVOKABLE bool snapSelectedBonesToCurrentPose();
+
     Q_INVOKABLE bool hasSkeletonSelection() const;
     Q_INVOKABLE QString selectedBoneName() const;
     /// Current parent of the selected bone; empty string if root / none.
@@ -161,7 +188,12 @@ public:
     /// Other scene entities that can receive an attached bone.
     Q_INVOKABLE QVariantList attachTargetEntities() const;
 
-/// Request the floating bone context menu at a global screen position
+    bool editRestPoseMode() const { return m_editRestPoseMode; }
+    void setEditRestPoseMode(bool on);
+    bool showRestPoseGhost() const { return m_showRestPoseGhost; }
+    void setShowRestPoseGhost(bool on);
+
+    /// Request the floating bone context menu at a global screen position
     /// (viewport right-click or Inspector bone picker).
     void requestBoneContextMenu(int globalX, int globalY);
 
@@ -172,6 +204,9 @@ signals:
     void boneDuplicated(const QString& entityName, const QString& boneName);
     void skeletonStructureChanged();
     void boneContextMenuRequested(int globalX, int globalY);
+    void editRestPoseModeChanged();
+    void showRestPoseGhostChanged();
+    void restPoseChanged();
 
 private:
     explicit SkeletonEditor(QObject* parent = nullptr);
@@ -185,5 +220,12 @@ private:
                                             QString* error);
     static bool ensureEntitySkeleton(Ogre::Entity* entity, QString* error);
 
+    void applyEditRestAnimMute(bool mute);
+    void syncRestPoseGhostOverlay();
+
     static SkeletonEditor* s_singleton;
+    bool m_editRestPoseMode = false;
+    bool m_showRestPoseGhost = false;
+    QString m_editRestMutedEntity;
+    QStringList m_editRestMutedAnims;
 };

--- a/src/SkeletonEditor.h
+++ b/src/SkeletonEditor.h
@@ -222,10 +222,12 @@ private:
 
     void applyEditRestAnimMute(bool mute);
     void syncRestPoseGhostOverlay();
+    void ensureEditRestSelectionHook();
 
     static SkeletonEditor* s_singleton;
     bool m_editRestPoseMode = false;
     bool m_showRestPoseGhost = false;
+    bool m_editRestSelectionHooked = false;
     QString m_editRestMutedEntity;
     QStringList m_editRestMutedAnims;
 };

--- a/src/SkeletonEditor.h
+++ b/src/SkeletonEditor.h
@@ -100,6 +100,14 @@ public:
         std::vector<AnimationData> animations;
         std::vector<Ogre::VertexBoneAssignment> meshAssignments;
         std::vector<std::vector<Ogre::VertexBoneAssignment>> submeshAssignments;
+        /// Bind-pose mesh positions/normals (for rest-pose bake undo/reset).
+        /// submeshIndex -1 = shared VertexData; else dedicated submesh verts.
+        struct BindVertexBuffer {
+            int submeshIndex = -1;
+            std::vector<float> positions; ///< xyz packed
+            std::vector<float> normals;   ///< xyz packed (empty if none)
+        };
+        std::vector<BindVertexBuffer> bindVertexBuffers;
     };
 
     static SkeletonEditor* getSingleton();

--- a/src/SkeletonEditor_test.cpp
+++ b/src/SkeletonEditor_test.cpp
@@ -6,6 +6,7 @@
 #include <QThread>
 
 #include "SkeletonEditor.h"
+#include "SkeletonDebug.h"
 #include "UndoManager.h"
 #include "commands/SkeletonBoneCommands.h"
 #include "AnimationControlController.h"
@@ -15,6 +16,7 @@
 
 #include <OgreBone.h>
 #include <OgreEntity.h>
+#include <OgreHardwareBuffer.h>
 #include <OgreSkeleton.h>
 
 class SkeletonEditorTest : public ::testing::Test {
@@ -552,3 +554,193 @@ TEST_F(SkeletonEditorTest, SetRestPoseCommandUndoRedo) {
     EXPECT_NEAR(entity->getMesh()->getSkeleton()->getBone("Child")->getInitialPosition().x,
                 0.5f, 1e-4f);
 }
+
+// Gizmo CommitBind must use the captured after-TRS, not re-read the instance
+// bone — an animation tick can reset the bone to the old bind between drag
+// end and undo-push, which previously made the mesh snap back to rest while
+// debug joints looked posed.
+TEST_F(SkeletonEditorTest, ExplicitPoseCommitIgnoresStaleInstanceBone) {
+    Ogre::Entity* entity = createThreeBoneAnimatedEntity("SkelEd_RestExplicit");
+    ASSERT_NE(entity, nullptr);
+    SkeletonEditor::ensureImportedRestCache(entity);
+
+    const Ogre::Vector3 capturedPos(0.4f, 1.0f, 0.0f);
+    const Ogre::Quaternion capturedOri = Ogre::Quaternion::IDENTITY;
+    const Ogre::Vector3 capturedScale = Ogre::Vector3::UNIT_SCALE;
+
+    // Simulate post-drag reset: instance bone already back at old bind.
+    Ogre::SkeletonInstance* inst = entity->getSkeleton();
+    ASSERT_NE(inst, nullptr);
+    Ogre::Bone* child = inst->getBone("Child");
+    ASSERT_NE(child, nullptr);
+    child->setPosition(Ogre::Vector3::ZERO);
+    child->setOrientation(Ogre::Quaternion::IDENTITY);
+    child->setScale(Ogre::Vector3::UNIT_SCALE);
+    child->setManuallyControlled(false);
+
+    SetRestPoseCommand::ExplicitPose pose;
+    pose.boneName = QStringLiteral("Child");
+    pose.position = capturedPos;
+    pose.orientation = capturedOri;
+    pose.scale = capturedScale;
+
+    auto* cmd = new SetRestPoseCommand(entity->getName(), std::vector{pose});
+    UndoManager::getSingleton()->push(cmd);
+    ASSERT_TRUE(cmd->applied());
+    EXPECT_NEAR(entity->getMesh()->getSkeleton()->getBone("Child")->getInitialPosition().x,
+                0.4f, 1e-4f);
+
+    UndoManager::getSingleton()->undo();
+    EXPECT_NEAR(entity->getMesh()->getSkeleton()->getBone("Child")->getInitialPosition().x,
+                0.0f, 1e-4f);
+}
+
+// Rest commit must bake skinned verts into the mesh bind buffers.
+// Changing bone initials alone leaves LBS as identity at the new bind,
+// so the mesh would always show the authored T-pose geometry again.
+TEST_F(SkeletonEditorTest, CommitBoneRestPoseBakesMeshVertices) {
+    Ogre::Entity* entity = createThreeBoneAnimatedEntity("SkelEd_RestBakeMesh");
+    ASSERT_NE(entity, nullptr);
+    SkeletonEditor::ensureImportedRestCache(entity);
+
+    Ogre::Mesh* mesh = entity->getMesh().get();
+    ASSERT_NE(mesh->sharedVertexData, nullptr);
+    const auto* posElem =
+        mesh->sharedVertexData->vertexDeclaration->findElementBySemantic(Ogre::VES_POSITION);
+    ASSERT_NE(posElem, nullptr);
+    auto vbuf = mesh->sharedVertexData->vertexBufferBinding->getBuffer(posElem->getSource());
+    auto* base = static_cast<unsigned char*>(vbuf->lock(Ogre::HardwareBuffer::HBL_READ_ONLY));
+    float* p0 = nullptr;
+    posElem->baseVertexPointerToElement(base, &p0);
+    const Ogre::Vector3 before(p0[0], p0[1], p0[2]);
+    vbuf->unlock();
+
+    // Rotate Child 90° so weighted verts must move when baked.
+    const Ogre::Quaternion rot(Ogre::Radian(Ogre::Degree(90)), Ogre::Vector3::UNIT_Z);
+    const auto result = SkeletonEditor::commitBoneRestPose(
+        entity, QStringLiteral("Child"),
+        entity->getMesh()->getSkeleton()->getBone("Child")->getInitialPosition(),
+        rot, Ogre::Vector3::UNIT_SCALE);
+    ASSERT_TRUE(result.ok) << result.error.toStdString();
+
+    base = static_cast<unsigned char*>(vbuf->lock(Ogre::HardwareBuffer::HBL_READ_ONLY));
+    posElem->baseVertexPointerToElement(base, &p0);
+    const Ogre::Vector3 after(p0[0], p0[1], p0[2]);
+    vbuf->unlock();
+
+    EXPECT_GT(before.distance(after), 1e-3f)
+        << "Bind-pose mesh verts should move after rest-pose bake";
+
+    // At the new bind, skinning is identity — mesh must still show the baked pose.
+    entity->getSkeleton()->reset(true);
+    entity->_updateAnimation();
+    base = static_cast<unsigned char*>(vbuf->lock(Ogre::HardwareBuffer::HBL_READ_ONLY));
+    posElem->baseVertexPointerToElement(base, &p0);
+    const Ogre::Vector3 atBind(p0[0], p0[1], p0[2]);
+    vbuf->unlock();
+    EXPECT_NEAR(atBind.distance(after), 0.0f, 1e-4f);
+}
+
+// Bake must not bump mesh state count — that forces Entity::_initialise(true)
+// and destroys SkeletonDebug TagPoints (overlay vanishes, checkbox stays on).
+TEST_F(SkeletonEditorTest, CommitBoneRestPoseDoesNotDirtyMeshState) {
+    Ogre::Entity* entity = createThreeBoneAnimatedEntity("SkelEd_RestNoDirty");
+    ASSERT_NE(entity, nullptr);
+    SkeletonEditor::ensureImportedRestCache(entity);
+    Ogre::Mesh* mesh = entity->getMesh().get();
+    const size_t stateBefore = mesh->getStateCount();
+
+    const auto result = SkeletonEditor::commitBoneRestPose(
+        entity, QStringLiteral("Child"),
+        Ogre::Vector3(0.2f, 1.0f, 0.0f),
+        Ogre::Quaternion::IDENTITY, Ogre::Vector3::UNIT_SCALE);
+    ASSERT_TRUE(result.ok) << result.error.toStdString();
+    EXPECT_EQ(mesh->getStateCount(), stateBefore);
+}
+
+// Gizmo rest commit must NOT rebake clips to preserve absolute poses —
+// that made Mixamo-enabled meshes snap back to the pre-edit look on release.
+TEST_F(SkeletonEditorTest, CommitBoneRestPoseKeepsNewBindWithEnabledAnim) {
+    Ogre::Entity* entity = createThreeBoneAnimatedEntity("SkelEd_RestCommitNoRebake");
+    ASSERT_NE(entity, nullptr);
+    SkeletonEditor::ensureImportedRestCache(entity);
+
+    ASSERT_TRUE(entity->hasAnimationState("TestAnim"));
+    auto* state = entity->getAnimationState("TestAnim");
+    state->setEnabled(true);
+    state->setTimePosition(0.0f);
+
+    const Ogre::Vector3 newPos(0.35f, 1.0f, 0.0f);
+    const auto result = SkeletonEditor::commitBoneRestPose(
+        entity, QStringLiteral("Child"), newPos,
+        Ogre::Quaternion::IDENTITY, Ogre::Vector3::UNIT_SCALE);
+    ASSERT_TRUE(result.ok) << result.error.toStdString();
+
+    EXPECT_NEAR(entity->getMesh()->getSkeleton()->getBone("Child")->getInitialPosition().x,
+                0.35f, 1e-4f);
+
+    // Clip must still be enabled, and evaluating at t=0 (identity keys in
+    // this fixture) must land on the new bind — not the old.
+    ASSERT_TRUE(entity->hasAnimationState("TestAnim"));
+    EXPECT_TRUE(entity->getAnimationState("TestAnim")->getEnabled());
+    entity->getAnimationState("TestAnim")->setTimePosition(0.0f);
+    entity->_updateAnimation();
+    entity->getSkeleton()->_updateTransforms();
+    EXPECT_NEAR(entity->getSkeleton()->getBone("Child")->getPosition().x, 0.35f, 1e-3f);
+}
+
+// Rest ghost must keep a private mesh clone so a rest bake does not move it.
+TEST_F(SkeletonEditorTest, RestGhostMeshStaysAtEnableTimePoseAfterBake) {
+    Ogre::Entity* entity = createThreeBoneAnimatedEntity("SkelEd_RestGhostFreeze");
+    ASSERT_NE(entity, nullptr);
+    SkeletonEditor::ensureImportedRestCache(entity);
+
+    auto* sceneMgr = Manager::getSingleton()->getSceneMgr();
+    ASSERT_NE(sceneMgr, nullptr);
+    SkeletonDebug ghostHost(entity, sceneMgr, 0.1f, 0.01f);
+    ghostHost.showBones(true);
+    ghostHost.showRestGhost(true);
+    ASSERT_TRUE(ghostHost.restGhostShown());
+    ASSERT_TRUE(ghostHost.bonesShown());
+
+    const Ogre::String ghostMeshName = entity->getName() + "_restGhostMeshRes";
+    Ogre::MeshPtr ghostMesh = Ogre::static_pointer_cast<Ogre::Mesh>(
+        Ogre::MeshManager::getSingleton().getByName(ghostMeshName));
+    ASSERT_NE(ghostMesh, nullptr);
+    ASSERT_NE(ghostMesh->sharedVertexData, nullptr);
+
+    auto readFirstPos = [](Ogre::Mesh* mesh) -> Ogre::Vector3 {
+        const auto* posElem =
+            mesh->sharedVertexData->vertexDeclaration->findElementBySemantic(Ogre::VES_POSITION);
+        auto vbuf = mesh->sharedVertexData->vertexBufferBinding->getBuffer(posElem->getSource());
+        auto* base = static_cast<unsigned char*>(vbuf->lock(Ogre::HardwareBuffer::HBL_READ_ONLY));
+        float* p0 = nullptr;
+        posElem->baseVertexPointerToElement(base, &p0);
+        Ogre::Vector3 v(p0[0], p0[1], p0[2]);
+        vbuf->unlock();
+        return v;
+    };
+
+    const Ogre::Vector3 ghostBefore = readFirstPos(ghostMesh.get());
+    const Ogre::Vector3 liveBefore = readFirstPos(entity->getMesh().get());
+    EXPECT_NEAR(ghostBefore.distance(liveBefore), 0.0f, 1e-4f);
+
+    const Ogre::Quaternion rot(Ogre::Radian(Ogre::Degree(90)), Ogre::Vector3::UNIT_Z);
+    const auto result = SkeletonEditor::commitBoneRestPose(
+        entity, QStringLiteral("Child"),
+        entity->getMesh()->getSkeleton()->getBone("Child")->getInitialPosition(),
+        rot, Ogre::Vector3::UNIT_SCALE);
+    ASSERT_TRUE(result.ok) << result.error.toStdString();
+
+    const Ogre::Vector3 ghostAfter = readFirstPos(ghostMesh.get());
+    const Ogre::Vector3 liveAfter = readFirstPos(entity->getMesh().get());
+    EXPECT_NEAR(ghostBefore.distance(ghostAfter), 0.0f, 1e-4f)
+        << "Ghost mesh clone must stay at the enable-time rest";
+    EXPECT_GT(liveBefore.distance(liveAfter), 1e-3f)
+        << "Live mesh should bake to the new rest";
+
+    // Skeleton overlay flag must survive the bake (no mesh-state reinit).
+    EXPECT_TRUE(ghostHost.bonesShown());
+    EXPECT_TRUE(ghostHost.restGhostShown());
+}
+

--- a/src/SkeletonEditor_test.cpp
+++ b/src/SkeletonEditor_test.cpp
@@ -421,3 +421,134 @@ TEST_F(SkeletonEditorTest, ReparentAndSplitUndoViaCommand) {
     UndoManager::getSingleton()->undo();
     EXPECT_EQ(entity->getMesh()->getSkeleton()->getNumBones(), 2u);
 }
+
+namespace {
+
+Ogre::Entity* createThreeBoneAnimatedEntity(const std::string& name)
+{
+    Ogre::Entity* entity = createAnimatedTestEntity(name);
+    if (!entity) return nullptr;
+    Ogre::SkeletonPtr skel = entity->getMesh()->getSkeleton();
+    Ogre::Bone* child = skel->getBone("Child");
+    Ogre::Bone* tip = skel->createBone("Tip", 2);
+    tip->setPosition(Ogre::Vector3(0, 1, 0));
+    child->addChild(tip);
+    tip->setInitialState();
+    skel->setBindingPose();
+    entity->_initialise(true);
+    return entity;
+}
+
+Ogre::Vector3 sampleBoneDerived(Ogre::Entity* entity, const char* boneName, float time)
+{
+    Ogre::SkeletonInstance* skel = entity->getSkeleton();
+    Ogre::SkeletonPtr meshSkel = entity->getMesh()->getSkeleton();
+    if (!skel || !meshSkel || !meshSkel->hasAnimation("TestAnim"))
+        return Ogre::Vector3::ZERO;
+
+    // Apply the mesh skeleton's animation directly onto the instance.
+    // Entity::_updateAnimation can leave bones at bind after a prior t=0
+    // sample on this fixture; Animation::apply is deterministic.
+    skel->reset(true);
+    Ogre::Animation* anim = meshSkel->getAnimation("TestAnim");
+    anim->apply(skel, time, 1.0f, Ogre::Real(1.0f));
+    for (Ogre::Bone* root : skel->getRootBones())
+        root->_update(true, false);
+    return skel->getBone(boneName)->_getDerivedPosition();
+}
+
+} // namespace
+
+TEST_F(SkeletonEditorTest, CaptureRestPoseRebasesAnimation) {
+    Ogre::Entity* entity = createThreeBoneAnimatedEntity("SkelEd_RestCapture");
+    ASSERT_NE(entity, nullptr);
+    ASSERT_EQ(entity->getMesh()->getSkeleton()->getNumBones(), 3u);
+
+    // Pose samples for world-motion preservation checks.
+    const Ogre::Vector3 beforeT0 = sampleBoneDerived(entity, "Child", 0.0f);
+    const Ogre::Vector3 beforeT05 = sampleBoneDerived(entity, "Child", 0.5f);
+    const Ogre::Vector3 beforeT1 = sampleBoneDerived(entity, "Child", 1.0f);
+    // Mid-frame must actually move — otherwise the fixture/anim is broken.
+    ASSERT_GT(beforeT05.distance(beforeT0), 0.1f);
+
+    sampleBoneDerived(entity, "Child", 0.5f);
+    const auto result = SkeletonEditor::captureRestPose(entity);
+    ASSERT_TRUE(result.ok) << result.error.toStdString();
+
+    Ogre::Bone* meshChild = entity->getMesh()->getSkeleton()->getBone("Child");
+    EXPECT_NEAR(meshChild->getInitialPosition().x, 0.5f, 1e-4f);
+
+    Ogre::Animation* anim = entity->getMesh()->getSkeleton()->getAnimation("TestAnim");
+    Ogre::NodeAnimationTrack* track = nullptr;
+    for (const auto& [handle, t] : anim->_getNodeTrackList()) {
+        if (t->getAssociatedNode() && t->getAssociatedNode()->getName() == "Child") {
+            track = t;
+            break;
+        }
+    }
+    ASSERT_NE(track, nullptr);
+    const auto* kfMid = track->getNodeKeyFrame(1);
+    EXPECT_NEAR(kfMid->getTranslate().length(), 0.0f, 1e-3f);
+
+    EXPECT_NEAR(sampleBoneDerived(entity, "Child", 0.0f).distance(beforeT0), 0.0f, 1e-3f);
+    EXPECT_NEAR(sampleBoneDerived(entity, "Child", 0.5f).distance(beforeT05), 0.0f, 1e-3f);
+    EXPECT_NEAR(sampleBoneDerived(entity, "Child", 1.0f).distance(beforeT1), 0.0f, 1e-3f);
+}
+
+TEST_F(SkeletonEditorTest, ResetRestPoseRestoresImportedBind) {
+    Ogre::Entity* entity = createThreeBoneAnimatedEntity("SkelEd_RestReset");
+    ASSERT_NE(entity, nullptr);
+
+    SkeletonEditor::ensureImportedRestCache(entity);
+    const Ogre::Vector3 imported =
+        entity->getMesh()->getSkeleton()->getBone("Child")->getInitialPosition();
+
+    sampleBoneDerived(entity, "Child", 0.5f);
+    ASSERT_TRUE(SkeletonEditor::captureRestPose(entity).ok);
+    EXPECT_NEAR(entity->getMesh()->getSkeleton()->getBone("Child")->getInitialPosition().x,
+                0.5f, 1e-4f);
+
+    const auto reset = SkeletonEditor::resetRestPose(entity);
+    ASSERT_TRUE(reset.ok) << reset.error.toStdString();
+    EXPECT_EQ(entity->getMesh()->getSkeleton()->getBone("Child")->getInitialPosition(),
+              imported);
+}
+
+TEST_F(SkeletonEditorTest, SnapSelectedBoneLeavesOthersUnchanged) {
+    Ogre::Entity* entity = createThreeBoneAnimatedEntity("SkelEd_RestSnap");
+    ASSERT_NE(entity, nullptr);
+
+    const Ogre::Vector3 tipInitial =
+        entity->getMesh()->getSkeleton()->getBone("Tip")->getInitialPosition();
+
+    sampleBoneDerived(entity, "Child", 0.5f);
+    const auto result = SkeletonEditor::captureRestPose(
+        entity, QStringList{QStringLiteral("Child")});
+    ASSERT_TRUE(result.ok) << result.error.toStdString();
+
+    EXPECT_NEAR(entity->getMesh()->getSkeleton()->getBone("Child")->getInitialPosition().x,
+                0.5f, 1e-4f);
+    EXPECT_EQ(entity->getMesh()->getSkeleton()->getBone("Tip")->getInitialPosition(),
+              tipInitial);
+}
+
+TEST_F(SkeletonEditorTest, SetRestPoseCommandUndoRedo) {
+    Ogre::Entity* entity = createThreeBoneAnimatedEntity("SkelEd_RestUndo");
+    ASSERT_NE(entity, nullptr);
+    SkeletonEditor::ensureImportedRestCache(entity);
+
+    sampleBoneDerived(entity, "Child", 0.5f);
+    auto* cmd = new SetRestPoseCommand(entity->getName(), SetRestPoseCommand::Op::CaptureAll);
+    UndoManager::getSingleton()->push(cmd);
+    ASSERT_TRUE(cmd->applied());
+    EXPECT_NEAR(entity->getMesh()->getSkeleton()->getBone("Child")->getInitialPosition().x,
+                0.5f, 1e-4f);
+
+    UndoManager::getSingleton()->undo();
+    EXPECT_NEAR(entity->getMesh()->getSkeleton()->getBone("Child")->getInitialPosition().x,
+                0.0f, 1e-4f);
+
+    UndoManager::getSingleton()->redo();
+    EXPECT_NEAR(entity->getMesh()->getSkeleton()->getBone("Child")->getInitialPosition().x,
+                0.5f, 1e-4f);
+}

--- a/src/TransformOperator.cpp
+++ b/src/TransformOperator.cpp
@@ -2035,12 +2035,9 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
                         || (afterScale  != mBoneStartScale);
             const bool autoKeyOn = AnimationControlController::instance()->autoKey();
             // Active = an animation state is currently ENABLED (driving
-            // bones), not just selected in the panel. With no enabled
-            // animation, the bone is at its bind pose and the user is
-            // doing T-pose authoring → setInitialState. With at least
-            // one enabled animation, the curve writes the bone each
-            // frame and a setInitialState would shift the whole curve
-            // → revert instead.
+            // bones), not just selected in the panel. Auto-key ON + active
+            // anim → write a keyframe. Otherwise the bone gizmo commits
+            // rest pose (Inspector: "edit rest with the bone gizmo").
             bool hasActiveAnim = false;
             if (Ogre::Entity* dragEnt = AnimationControlController::instance()->selectedEntity()) {
                 if (Ogre::AnimationStateSet* states = dragEnt->getAllAnimationStates()) {
@@ -2050,27 +2047,23 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
                 }
             }
 
-            // Restore the per-state BlendMask values we captured at
-            // press, BEFORE calling apply(). The Revert path calls
-            // _updateAnimation which runs Skeleton::reset (bone →
-            // initial) then animation tracks (initial + curve sample).
-            // With the BlendMask still muted, the curve contributes
-            // zero and the bone settles at initial (T-pose) instead
-            // of the press-time pose. Restoring before apply() lets
-            // the curve drive the bone correctly. Restore exactly the
-            // pre-drag weights — not a hardcoded 1.0 — to preserve
-            // any layered/masked setup the user had.
-            if (Ogre::Entity* dragEnt = AnimationControlController::instance()->selectedEntity()) {
-                if (Ogre::AnimationStateSet* states = dragEnt->getAllAnimationStates()) {
-                    for (const auto& [stateName, weight] : mBoneDragSavedMaskWeights) {
-                        if (!states->hasAnimationState(stateName)) continue;
-                        Ogre::AnimationState* st = states->getAnimationState(stateName);
-                        if (st->hasBlendMask())
-                            st->setBlendMaskEntry(bone->getHandle(), weight);
+            // Keep the per-bone blend mask MUTED through CommitBind so an
+            // enabled clip cannot overwrite the dragged pose before the rest
+            // commit lands. Restore after. For Commit (auto-key), restore
+            // first so the keyframe samples the intended curve-driven pose.
+            auto restoreBoneBlendMasks = [&]() {
+                if (Ogre::Entity* dragEnt = AnimationControlController::instance()->selectedEntity()) {
+                    if (Ogre::AnimationStateSet* states = dragEnt->getAllAnimationStates()) {
+                        for (const auto& [stateName, weight] : mBoneDragSavedMaskWeights) {
+                            if (!states->hasAnimationState(stateName)) continue;
+                            Ogre::AnimationState* st = states->getAnimationState(stateName);
+                            if (st->hasBlendMask())
+                                st->setBlendMaskEntry(bone->getHandle(), weight);
+                        }
                     }
                 }
-            }
-            mBoneDragSavedMaskWeights.clear();
+                mBoneDragSavedMaskWeights.clear();
+            };
 
             const bool editRestMode = SkeletonEditor::getSingletonPtr()
                 && SkeletonEditor::getSingletonPtr()->editRestPoseMode();
@@ -2080,6 +2073,7 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
                 AnimationControlController::instance()->selectedEntity(),
                 editRestMode);
             if (outcome == BoneDragRelease::Result::Commit) {
+                restoreBoneBlendMasks();
                 // autoKeyOnTransform → addKeyframe → AddKeyframeCommand
                 // captures the durable artifact (the keyframe). The
                 // bone's live local TRS is fully determined by the
@@ -2088,17 +2082,29 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
                 // undoing the keyframe is enough.
                 AnimationControlController::instance()->autoKeyOnTransform();
             } else if (outcome == BoneDragRelease::Result::CommitBind) {
-                // Rest-pose commit with animation re-bake (slice C #557).
+                // Rest-pose commit: keep blend mask muted until after the
+                // bind write so the mesh cannot snap to the old clip pose
+                // mid-commit. Pass the after-TRS captured above.
                 const std::string entityName =
                     AnimationControlController::instance()->selectedEntityName().toStdString();
+                SetRestPoseCommand::ExplicitPose pose;
+                pose.boneName = QString::fromStdString(bone->getName());
+                pose.position = afterPos;
+                pose.orientation = afterOrient;
+                pose.scale = afterScale;
                 UndoManager::getSingleton()->push(
-                    new SetRestPoseCommand(entityName,
-                                           SetRestPoseCommand::Op::SnapSelected,
-                                           QStringList{QString::fromStdString(bone->getName())}));
+                    new SetRestPoseCommand(entityName, std::vector{pose}));
+                restoreBoneBlendMasks();
+                // Force one skinning tick with the new bind + restored masks.
+                if (Ogre::Entity* dragEnt = AnimationControlController::instance()->selectedEntity())
+                    dragEnt->_updateAnimation();
             } else if (outcome == BoneDragRelease::Result::Revert) {
+                restoreBoneBlendMasks();
                 // Restore the gizmo to the press-time anchor so the
                 // viewport visually returns to the start of the drag.
                 m_pTransformNode->setPosition(mBoneDragGizmoOrigin);
+            } else {
+                restoreBoneBlendMasks();
             }
         }
         // Restore playback if we paused it on press.

--- a/src/TransformOperator.cpp
+++ b/src/TransformOperator.cpp
@@ -26,6 +26,7 @@
 #include "UndoManager.h"
 #include "commands/TransformCommands.h"
 #include "commands/BoneTransformCommand.h"
+#include "commands/SkeletonBoneCommands.h"
 #include "BoneDragRelease.h"
 #include "EditModeController.h"
 #include "AutoRigController.h"
@@ -2071,10 +2072,13 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
             }
             mBoneDragSavedMaskWeights.clear();
 
+            const bool editRestMode = SkeletonEditor::getSingletonPtr()
+                && SkeletonEditor::getSingletonPtr()->editRestPoseMode();
             const auto outcome = BoneDragRelease::apply(
                 bone, mBoneStartPos, mBoneStartOrient, mBoneStartScale,
                 hasActiveAnim, autoKeyOn,
-                AnimationControlController::instance()->selectedEntity());
+                AnimationControlController::instance()->selectedEntity(),
+                editRestMode);
             if (outcome == BoneDragRelease::Result::Commit) {
                 // autoKeyOnTransform → addKeyframe → AddKeyframeCommand
                 // captures the durable artifact (the keyframe). The
@@ -2084,16 +2088,13 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
                 // undoing the keyframe is enough.
                 AnimationControlController::instance()->autoKeyOnTransform();
             } else if (outcome == BoneDragRelease::Result::CommitBind) {
-                // bindMode=true so undo also reverts the bone's initial
-                // (bind) state — otherwise Skeleton::reset would snap
-                // back to the new bind on the next animation update.
+                // Rest-pose commit with animation re-bake (slice C #557).
                 const std::string entityName =
                     AnimationControlController::instance()->selectedEntityName().toStdString();
                 UndoManager::getSingleton()->push(
-                    new BoneTransformCommand(entityName, bone->getName(),
-                        mBoneStartPos, mBoneStartOrient, mBoneStartScale,
-                        afterPos,      afterOrient,      afterScale,
-                        /*bindMode=*/true));
+                    new SetRestPoseCommand(entityName,
+                                           SetRestPoseCommand::Op::SnapSelected,
+                                           QStringList{QString::fromStdString(bone->getName())}));
             } else if (outcome == BoneDragRelease::Result::Revert) {
                 // Restore the gizmo to the press-time anchor so the
                 // viewport visually returns to the start of the drag.

--- a/src/commands/SkeletonBoneCommands.cpp
+++ b/src/commands/SkeletonBoneCommands.cpp
@@ -457,6 +457,19 @@ SetRestPoseCommand::SetRestPoseCommand(std::string entityName,
     }
 }
 
+SetRestPoseCommand::SetRestPoseCommand(std::string entityName,
+                                       std::vector<ExplicitPose> explicitPoses,
+                                       QUndoCommand* parent)
+    : QUndoCommand(parent)
+    , m_entityName(std::move(entityName))
+    , m_op(Op::SnapSelected)
+    , m_explicitPoses(std::move(explicitPoses))
+{
+    setText(QStringLiteral("Edit bone rest pose"));
+    for (const auto& p : m_explicitPoses)
+        m_boneNames.append(p.boneName);
+}
+
 void SetRestPoseCommand::redo()
 {
     Ogre::Entity* entity = resolveEntityByName(m_entityName);
@@ -465,16 +478,28 @@ void SetRestPoseCommand::redo()
     if (m_firstRedo) {
         m_before = SkeletonEditor::captureSnapshot(entity);
         SkeletonEditor::Result result;
-        switch (m_op) {
-        case Op::CaptureAll:
-            result = SkeletonEditor::captureRestPose(entity);
-            break;
-        case Op::SnapSelected:
-            result = SkeletonEditor::captureRestPose(entity, m_boneNames);
-            break;
-        case Op::Reset:
-            result = SkeletonEditor::resetRestPose(entity);
-            break;
+        if (!m_explicitPoses.empty()) {
+            result.ok = true;
+            for (const auto& pose : m_explicitPoses) {
+                const auto one = SkeletonEditor::commitBoneRestPose(
+                    entity, pose.boneName, pose.position, pose.orientation, pose.scale);
+                if (!one.ok) {
+                    result = one;
+                    break;
+                }
+            }
+        } else {
+            switch (m_op) {
+            case Op::CaptureAll:
+                result = SkeletonEditor::captureRestPose(entity);
+                break;
+            case Op::SnapSelected:
+                result = SkeletonEditor::captureRestPose(entity, m_boneNames);
+                break;
+            case Op::Reset:
+                result = SkeletonEditor::resetRestPose(entity);
+                break;
+            }
         }
         if (!result.ok) return;
         m_after = SkeletonEditor::captureSnapshot(entity);
@@ -487,16 +512,20 @@ void SetRestPoseCommand::redo()
 
     m_applied = true;
     QString crumb;
-    switch (m_op) {
-    case Op::CaptureAll:
-        crumb = QStringLiteral("scene.skel.rest_pose.capture");
-        break;
-    case Op::SnapSelected:
-        crumb = QStringLiteral("scene.skel.rest_pose.snap");
-        break;
-    case Op::Reset:
-        crumb = QStringLiteral("scene.skel.rest_pose.reset");
-        break;
+    if (!m_explicitPoses.empty()) {
+        crumb = QStringLiteral("scene.skel.rest_pose.edit");
+    } else {
+        switch (m_op) {
+        case Op::CaptureAll:
+            crumb = QStringLiteral("scene.skel.rest_pose.capture");
+            break;
+        case Op::SnapSelected:
+            crumb = QStringLiteral("scene.skel.rest_pose.snap");
+            break;
+        case Op::Reset:
+            crumb = QStringLiteral("scene.skel.rest_pose.reset");
+            break;
+        }
     }
     SentryReporter::addBreadcrumb(crumb,
         QStringLiteral("%1 (%2 bone(s))")

--- a/src/commands/SkeletonBoneCommands.cpp
+++ b/src/commands/SkeletonBoneCommands.cpp
@@ -434,3 +434,91 @@ void AttachBoneToEntityCommand::undo()
     }
     m_applied = false;
 }
+
+SetRestPoseCommand::SetRestPoseCommand(std::string entityName,
+                                       Op op,
+                                       QStringList boneNames,
+                                       QUndoCommand* parent)
+    : QUndoCommand(parent)
+    , m_entityName(std::move(entityName))
+    , m_op(op)
+    , m_boneNames(std::move(boneNames))
+{
+    switch (m_op) {
+    case Op::CaptureAll:
+        setText(QStringLiteral("Capture rest pose"));
+        break;
+    case Op::SnapSelected:
+        setText(QStringLiteral("Snap bones to rest pose"));
+        break;
+    case Op::Reset:
+        setText(QStringLiteral("Reset rest pose"));
+        break;
+    }
+}
+
+void SetRestPoseCommand::redo()
+{
+    Ogre::Entity* entity = resolveEntityByName(m_entityName);
+    if (!entity) return;
+
+    if (m_firstRedo) {
+        m_before = SkeletonEditor::captureSnapshot(entity);
+        SkeletonEditor::Result result;
+        switch (m_op) {
+        case Op::CaptureAll:
+            result = SkeletonEditor::captureRestPose(entity);
+            break;
+        case Op::SnapSelected:
+            result = SkeletonEditor::captureRestPose(entity, m_boneNames);
+            break;
+        case Op::Reset:
+            result = SkeletonEditor::resetRestPose(entity);
+            break;
+        }
+        if (!result.ok) return;
+        m_after = SkeletonEditor::captureSnapshot(entity);
+        m_firstRedo = false;
+    } else {
+        QString err;
+        if (!SkeletonEditor::restoreSnapshot(entity, m_after, &err))
+            return;
+    }
+
+    m_applied = true;
+    QString crumb;
+    switch (m_op) {
+    case Op::CaptureAll:
+        crumb = QStringLiteral("scene.skel.rest_pose.capture");
+        break;
+    case Op::SnapSelected:
+        crumb = QStringLiteral("scene.skel.rest_pose.snap");
+        break;
+    case Op::Reset:
+        crumb = QStringLiteral("scene.skel.rest_pose.reset");
+        break;
+    }
+    SentryReporter::addBreadcrumb(crumb,
+        QStringLiteral("%1 (%2 bone(s))")
+            .arg(QString::fromStdString(m_entityName))
+            .arg(m_boneNames.isEmpty() ? QStringLiteral("all")
+                                       : QString::number(m_boneNames.size())));
+    SkeletonEditor::refreshAfterEdit(m_entityName);
+    if (auto* editor = SkeletonEditor::getSingletonPtr())
+        emit editor->restPoseChanged();
+}
+
+void SetRestPoseCommand::undo()
+{
+    Ogre::Entity* entity = resolveEntityByName(m_entityName);
+    if (!entity || m_before.bones.empty()) return;
+    QString err;
+    if (!SkeletonEditor::restoreSnapshot(entity, m_before, &err))
+        return;
+    m_applied = false;
+    SentryReporter::addBreadcrumb(QStringLiteral("scene.skel.rest_pose.undo"),
+        QString::fromStdString(m_entityName));
+    SkeletonEditor::refreshAfterEdit(m_entityName);
+    if (auto* editor = SkeletonEditor::getSingletonPtr())
+        emit editor->restPoseChanged();
+}

--- a/src/commands/SkeletonBoneCommands.h
+++ b/src/commands/SkeletonBoneCommands.h
@@ -5,6 +5,8 @@
 #include <QUndoCommand>
 #include <QString>
 
+#include <vector>
+
 /// Undoable bone create (epic #554 slice A).
 class CreateBoneCommand : public QUndoCommand
 {
@@ -209,9 +211,23 @@ class SetRestPoseCommand : public QUndoCommand
 public:
     enum class Op { CaptureAll, SnapSelected, Reset };
 
+    struct ExplicitPose {
+        QString boneName;
+        Ogre::Vector3 position = Ogre::Vector3::ZERO;
+        Ogre::Quaternion orientation = Ogre::Quaternion::IDENTITY;
+        Ogre::Vector3 scale = Ogre::Vector3::UNIT_SCALE;
+    };
+
     SetRestPoseCommand(std::string entityName,
                        Op op,
                        QStringList boneNames = {},
+                       QUndoCommand* parent = nullptr);
+
+    /// Gizmo CommitBind path: commit these exact local TRS values as rest
+    /// (do not re-read the skeleton — the instance may already have been
+    /// reset by an animation tick between drag end and undo-push).
+    SetRestPoseCommand(std::string entityName,
+                       std::vector<ExplicitPose> explicitPoses,
                        QUndoCommand* parent = nullptr);
 
     void undo() override;
@@ -223,6 +239,7 @@ private:
     std::string m_entityName;
     Op m_op = Op::CaptureAll;
     QStringList m_boneNames;
+    std::vector<ExplicitPose> m_explicitPoses;
     SkeletonEditor::Snapshot m_before;
     SkeletonEditor::Snapshot m_after;
     bool m_applied = false;

--- a/src/commands/SkeletonBoneCommands.h
+++ b/src/commands/SkeletonBoneCommands.h
@@ -202,3 +202,29 @@ private:
     bool m_applied = false;
     bool m_firstRedo = true;
 };
+
+/// Undoable rest-pose capture / snap / reset (epic #554 slice C #557).
+class SetRestPoseCommand : public QUndoCommand
+{
+public:
+    enum class Op { CaptureAll, SnapSelected, Reset };
+
+    SetRestPoseCommand(std::string entityName,
+                       Op op,
+                       QStringList boneNames = {},
+                       QUndoCommand* parent = nullptr);
+
+    void undo() override;
+    void redo() override;
+
+    bool applied() const { return m_applied; }
+
+private:
+    std::string m_entityName;
+    Op m_op = Op::CaptureAll;
+    QStringList m_boneNames;
+    SkeletonEditor::Snapshot m_before;
+    SkeletonEditor::Snapshot m_after;
+    bool m_applied = false;
+    bool m_firstRedo = true;
+};


### PR DESCRIPTION
## Summary
- Capture / reset / snap rest pose with animation track re-bake so world motion stays the same when the bind pose changes (`SkeletonEditor` + undoable `SetRestPoseCommand`)
- Edit-rest mode mutes playback and routes bone-gizmo commits through rest rebake; translucent rest-pose ghost overlay on `SkeletonDebug`
- Inspector Rest Pose controls (Capture / Reset / Snap + Edit rest / Rest ghost); Sentry breadcrumbs `scene.skel.rest_pose.*`
- Headless tests on a 3-bone fixture for capture / reset / snap / undo

Deferred: A-pose / T-pose helpers (need Slice E L/R naming).

Closes #557

## Test plan
- [ ] UnitTests: `SkeletonEditorTest.*` + `BoneDragReleaseTest.*` (incl. CaptureRestPoseRebasesAnimation, Reset, Snap, UndoRedo, EditRestMode)
- [ ] GUI: skinned mesh → Animation mode → Skeleton Tools → Capture Rest at a mid-frame pose; scrub anim — motion should match pre-capture
- [ ] Reset Rest returns to imported bind
- [ ] Snap Bone updates only the selected bone
- [ ] Edit rest pose: drag bone gizmo (no auto-key) updates bind; undo restores
- [ ] Rest ghost: cyan translucent joints at rest alongside animated skeleton
- [ ] Export glTF/FBX after capture and verify bind pose in Blender (optional smoke)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Rest Pose workflow for skeleton editing (capture, reset, snap) with an Edit Rest Pose mode.
  * Added a “rest-pose ghost” overlay with global visibility controls, plus UI toggles to edit rest pose and show the ghost.
  * Rest-pose edits are now undoable/redoable via a dedicated rest-pose command.

* **Bug Fixes**
  * Improved bone drag release behavior in edit-rest mode to produce the correct commit result and undo/redo bind outcomes.
  * Refined skeleton debug activation and rest-ghost lifecycle so visuals are preserved/cleaned correctly.

* **Tests**
  * Added/updated coverage for rest-pose capture/reset/snap, animation rebasing, ghost behavior, and commit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->