### PR TITLE
Improve Sentry product telemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ docs/*
 !docs/MESH_SEGMENTATION_STRATEGY.md
 !docs/FACE_RIG.md
 !docs/FACE_RIG_SPIKE.md
+!docs/TELEMETRY.md
 
 # minisign — never commit secret keys
 minisign.key

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -1,0 +1,154 @@
+# QtMeshEditor Sentry Telemetry
+
+QtMeshEditor uses the existing `SentryReporter` wrapper for both crash reporting and anonymous product telemetry. Do not add another analytics SDK or emit telemetry directly from feature code.
+
+## Privacy Rules
+
+- Default PII collection is not enabled. The bundled sentry-native SDK has no `sendDefaultPii` option, and QtMeshEditor only sets an opaque `user.id`.
+- The installation identifier is a random UUID created only after telemetry is enabled and stored at `telemetry/anonymousInstallationId` in `QSettings`.
+- Sentry `user.id` is `install:<uuid>`. The UUID is never derived from MAC address, disk serial, hostname, username, account data, IP address, hardware fingerprint, file content, prompts or model data.
+- If telemetry is disabled, QtMeshEditor does not generate or submit the anonymous installation ID.
+- Reset mechanism: call `SentryReporter::resetAnonymousInstallationId()` or remove the `telemetry/anonymousInstallationId` QSettings key. Disabling telemetry through `SentryReporter::setEnabled(false)` also removes it.
+- Breadcrumbs and event contexts are sanitized by `SentryReporter`; paths, filenames, prompts, emails, GitHub identifiers and tokens are redacted.
+- `QTMESH_TELEMETRY_ROLE` may be `developer`, `ci` or `tester`. Any other value is submitted as `user`. This appears as `telemetry.role` so internal activity can be filtered without location data.
+
+## Session Context
+
+Every process creates a fresh random `session.id`; multiple GUI, CLI and MCP sessions on the same machine reuse the same anonymous installation ID when telemetry remains enabled. Common tags on telemetry events include:
+
+- `app.version` and `release`
+- `launch_mode`: `gui`, `gui+mcp`, `cli` or `mcp`
+- `source_surface`: `gui`, `cli` or `mcp` when applicable
+- `telemetry.role`
+- `session.id`
+- `os`, `arch`, `qt_version`
+- `capability` for feature-specific events
+
+Numeric values such as durations and counts live in event context rather than tags.
+
+## Events
+
+Application lifecycle:
+
+- `app.startup`: emitted once after Sentry session configuration.
+- `app.shutdown`: emitted on clean shutdown with `duration_ms`.
+
+File workflow:
+
+- `file.import.started`, `file.import.completed`, `file.import.failed`
+- `file.export.started`, `file.export.completed`, `file.export.failed`
+
+Properties: `source_surface`, `input_format`, `output_format`, `asset_kind`, `duration_ms`, `success`, `failure_category`, `model_count`, `animation_count`, `size_bucket`. Formats are extensions only; paths and filenames are never sent.
+
+CLI and MCP:
+
+- `cli.command.started`, `cli.command.completed`, `cli.command.failed`
+- `mcp.tool.started`, `mcp.tool.completed`, `mcp.tool.failed`
+
+Properties: `command` or `tool`, `phase`, `invocation.id`, `duration_ms`, `changed_scene`, `success`, `failure_category`, `source_surface`. MCP arguments are not submitted.
+
+AI model management:
+
+- `ai.model_catalog.opened`
+- `ai.model_download.started`, `ai.model_download.completed`, `ai.model_download.failed`
+- `ai.model_delete.completed`, `ai.model_delete.failed`
+- `ai.model_download_all.completed`
+- `ai.feature_model_missing`
+
+Properties: `model_id`, `capability`, `source`, `duration_ms`, `byte_size_bucket`, `failure_category`, `build_available`. Model IDs are stable catalog IDs, not paths.
+
+Editing adoption:
+
+- `edit.mode.entered`
+- `selection.mesh`
+- `selection.bone`
+- `transform.completed`
+- `segmentation.started`, `segmentation.completed`, `segmentation.failed`
+- `animation.played`
+- `animation.exported`
+
+`transform.completed` records `transform_type` and `target_kind` only after a committed edit. It does not emit continuous mouse-move telemetry.
+
+Segmentation properties: `requested_category`, `resolved_category`, `automatic`, `manual`, `ai`, `geometric_fallback`, `result_part_count`, `duration_ms`, `success`, `failure_category`.
+
+## Crash Diagnostics
+
+Release workflow symbol upload currently exists for all release platforms:
+
+- Windows: copies `QtMeshEditor.exe`, strips the shipped binary, uploads the unstripped debug executable with `sentry-cli debug-files upload --include-sources`.
+- Linux: creates `QtMeshEditor.debug` with `objcopy --only-keep-debug`, strips the binary, adds a GNU debug link, uploads the debug file.
+- macOS: runs `dsymutil` for `QtMeshEditor.app/Contents/MacOS/QtMeshEditor`, strips the binary, uploads the `.dSYM` bundle.
+
+Crashes are associated with release by `sentry_options_set_release`, anonymous installation by Sentry `user.id`, and session by `session.id`. Breadcrumbs are capped by Sentry SDK defaults and sanitized before submission. Handled operational failures use telemetry events or `captureMessage(..., "error")`; fatal crashes remain native Sentry crash events.
+
+Historical issues like `QTMESHEDITOR-D` showing only `BaseThreadInitThunk` and `QTMESHEDITOR-2` showing mostly unknown frames are most likely from one of these conditions: the crash came from a build predating debug-file upload, debug files were not uploaded because the event was not from a GitHub `release.published` workflow, the uploaded debug file did not match the binary build ID, or the Sentry event release did not match the finalized release name. Verify the event's debug image IDs against uploaded debug files in Sentry, and compare the event release to `qtmesheditor@<applicationVersion>`.
+
+## Example Sentry Queries
+
+Exclude internal activity in all product dashboards:
+
+```text
+!telemetry.role:developer !telemetry.role:ci
+```
+
+Weekly active anonymous installations:
+
+```text
+event.type:default message:"app.startup" !telemetry.role:developer !telemetry.role:ci
+```
+
+Group by `user.id` and use a 7-day interval.
+
+New versus returning installations:
+
+```text
+message:"app.startup" !telemetry.role:developer !telemetry.role:ci
+```
+
+Group by `user.id`; classify first-seen users as new and users with previous `app.startup` events as returning.
+
+Sessions per installation:
+
+```text
+message:"app.startup" !telemetry.role:developer !telemetry.role:ci
+```
+
+Group by `user.id` and count unique `session.id`.
+
+Import to edit to export funnel:
+
+```text
+message:["file.import.completed", "edit.mode.entered", "file.export.completed"] !telemetry.role:developer !telemetry.role:ci
+```
+
+Group by `user.id` or `session.id` and use Sentry Discover or Funnels if available.
+
+GUI versus CLI versus MCP adoption:
+
+```text
+message:["app.startup", "cli.command.completed", "mcp.tool.completed"] !telemetry.role:developer !telemetry.role:ci
+```
+
+Group by `launch_mode` and `source_surface`.
+
+Model-download success rate:
+
+```text
+message:["ai.model_download.completed", "ai.model_download.failed"] !telemetry.role:developer !telemetry.role:ci
+```
+
+Group by `model_id` and `capability`; compute completed / (completed + failed).
+
+Crashes per release and affected installations:
+
+```text
+event.type:error level:fatal !telemetry.role:developer !telemetry.role:ci
+```
+
+Group by `release`; count unique `user.id` for affected installations.
+
+Exclude developer and CI traffic explicitly:
+
+```text
+!telemetry.role:developer !telemetry.role:ci
+```

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -50,9 +50,9 @@ Properties: `command` or `tool`, `phase`, `invocation.id`, `duration_ms`, `chang
 AI model management:
 
 - `ai.model_catalog.opened`
-- `ai.model_download.started`, `ai.model_download.completed`, `ai.model_download.failed`
-- `ai.model_delete.completed`, `ai.model_delete.failed`
-- `ai.model_download_all.completed`
+- `ai.model_download.started`, `ai.model_download.completed`, `ai.model_download.failed`, `ai.model_download.canceled`
+- `ai.model_delete.started`, `ai.model_delete.completed`, `ai.model_delete.failed`
+- `ai.model_download_all.started`, `ai.model_download_all.completed`
 - `ai.feature_model_missing`
 
 Properties: `model_id`, `capability`, `source`, `duration_ms`, `byte_size_bucket`, `failure_category`, `build_available`. Model IDs are stable catalog IDs, not paths.
@@ -134,10 +134,10 @@ Group by `launch_mode` and `source_surface`.
 Model-download success rate:
 
 ```text
-message:["ai.model_download.completed", "ai.model_download.failed"] !telemetry.role:developer !telemetry.role:ci
+message:["ai.model_download.completed", "ai.model_download.failed", "ai.model_download.canceled"] !telemetry.role:developer !telemetry.role:ci
 ```
 
-Group by `model_id` and `capability`; compute completed / (completed + failed).
+Group by `model_id` and `capability`; compute completed / (completed + failed + canceled).
 
 Crashes per release and affected installations:
 

--- a/src/AIModelCatalog.cpp
+++ b/src/AIModelCatalog.cpp
@@ -3,9 +3,11 @@
 #include "ModelDownloader.h"
 #include "SentryReporter.h"
 
+#include <QDateTime>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QJsonObject>
 #include <QSettings>
 #include <QStandardPaths>
 #include <QSet>
@@ -22,6 +24,23 @@ QString joinUrl(QString base, const QString& fileName)
     if (!base.endsWith('/'))
         base += '/';
     return base + fileName;
+}
+
+QString capabilityForFeature(const QString& feature)
+{
+    const QString f = feature.toLower();
+    if (f.contains(QStringLiteral("mesh tools"))) return QStringLiteral("segmentation");
+    if (f.contains(QStringLiteral("image to 3d"))) return QStringLiteral("generation");
+    if (f.contains(QStringLiteral("animation"))) return QStringLiteral("mocap");
+    if (f.contains(QStringLiteral("texture"))) return QStringLiteral("material");
+    return QStringLiteral("other");
+}
+
+QString sourceForModelId(const QString& id)
+{
+    if (id.startsWith(QStringLiteral("tripos")) || id.contains(QStringLiteral("caption")))
+        return QStringLiteral("huggingface");
+    return QStringLiteral("bundled");
 }
 }
 
@@ -50,8 +69,8 @@ AIModelCatalog::AIModelCatalog(QObject* parent)
                 if (m_pendingFiles.first().label != name)
                     return;
                 m_pendingFiles.removeFirst();
-                SentryReporter::addBreadcrumb(QStringLiteral("file.import"),
-                                              tr("Downloaded %1").arg(name));
+                SentryReporter::addBreadcrumb(QStringLiteral("ai.model_download"),
+                                              QStringLiteral("downloaded catalog file"));
                 emit modelsChanged();
                 QTimer::singleShot(0, this, &AIModelCatalog::startNextQueuedFile);
             });
@@ -61,8 +80,14 @@ AIModelCatalog::AIModelCatalog(QObject* parent)
                     return;
                 if (m_pendingFiles.first().label != name)
                     return;
-                SentryReporter::addBreadcrumb(QStringLiteral("file.import"),
-                                              tr("Download failed for %1: %2").arg(name, error),
+                QList<ModelSpec> owner;
+                const ModelSpec* spec = findSpec(m_activeModelId, &owner);
+                captureModelTelemetry(QStringLiteral("ai.model_download.failed"), spec,
+                                      m_activeDownloadStartedMs > 0
+                                          ? QDateTime::currentMSecsSinceEpoch() - m_activeDownloadStartedMs : -1,
+                                      SentryReporter::sanitizedErrorCategory(error));
+                SentryReporter::addBreadcrumb(QStringLiteral("ai.model_download"),
+                                              QStringLiteral("download failed"),
                                               QStringLiteral("error"));
                 m_pendingFiles.clear();
                 setStatusMessage(tr("Download failed: %1").arg(error));
@@ -76,8 +101,8 @@ AIModelCatalog::AIModelCatalog(QObject* parent)
                     return;
                 if (m_pendingFiles.first().label != name)
                     return;
-                SentryReporter::addBreadcrumb(QStringLiteral("file.import"),
-                                              tr("Download canceled for %1").arg(name),
+                SentryReporter::addBreadcrumb(QStringLiteral("ai.model_download"),
+                                              QStringLiteral("download canceled"),
                                               QStringLiteral("warning"));
                 m_pendingFiles.clear();
                 setStatusMessage(tr("Download canceled."));
@@ -371,7 +396,29 @@ qint64 AIModelCatalog::installedBytes(const ModelSpec& spec) const
 
 void AIModelCatalog::refresh()
 {
+    SentryReporter::captureTelemetryEvent(QStringLiteral("ai.model_catalog.opened"),
+        QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("gui")}});
     emit modelsChanged();
+}
+
+
+void AIModelCatalog::captureModelTelemetry(const QString& eventName, const ModelSpec* spec,
+                                           qint64 durationMs, const QString& failureCategory) const
+{
+    QJsonObject props;
+    props["source_surface"] = QStringLiteral("gui");
+    props["model_id"] = spec ? spec->id : m_activeModelId;
+    props["capability"] = spec ? capabilityForFeature(spec->feature) : QStringLiteral("other");
+    props["source"] = spec ? sourceForModelId(spec->id) : QStringLiteral("custom");
+    props["build_available"] = spec ? spec->available : false;
+    if (durationMs >= 0)
+        props["duration_ms"] = durationMs;
+    const qint64 bytes = spec ? installedBytes(*spec) : 0;
+    props["byte_size_bucket"] = SentryReporter::sizeBucket(bytes);
+    if (!failureCategory.isEmpty())
+        props["failure_category"] = SentryReporter::sanitizedErrorCategory(failureCategory);
+    SentryReporter::captureTelemetryEvent(eventName, props,
+        eventName.endsWith(QStringLiteral(".failed")) ? QStringLiteral("error") : QStringLiteral("info"));
 }
 
 void AIModelCatalog::downloadModel(const QString& id)
@@ -386,6 +433,7 @@ void AIModelCatalog::downloadModel(const QString& id)
     if (!spec)
         return;
     if (!spec->available) {
+        captureModelTelemetry(QStringLiteral("ai.feature_model_missing"), spec, -1, QStringLiteral("build_unavailable"));
         setStatusMessage(spec->buildRequirement);
         return;
     }
@@ -404,9 +452,11 @@ void AIModelCatalog::downloadModel(const QString& id)
 
     m_activeModelId = spec->id;
     m_activeModelName = spec->name;
+    m_activeDownloadStartedMs = QDateTime::currentMSecsSinceEpoch();
     emit activeModelChanged();
-    SentryReporter::addBreadcrumb(QStringLiteral("file.import"),
-                                  tr("Started download for %1").arg(spec->name));
+    captureModelTelemetry(QStringLiteral("ai.model_download.started"), spec);
+    SentryReporter::addBreadcrumb(QStringLiteral("ai.model_download"),
+                                  QStringLiteral("started"));
     setBusy(true);
     setStatusMessage(tr("Downloading %1...").arg(spec->name));
     emit modelsChanged();
@@ -446,12 +496,19 @@ void AIModelCatalog::downloadAllModels()
     }
 
     m_activeModelId = QStringLiteral("__all__");
+    m_activeDownloadStartedMs = QDateTime::currentMSecsSinceEpoch();
     m_activeModelName = unavailable > 0
         ? tr("all available QtMeshEditor models")
         : tr("all QtMeshEditor models");
     emit activeModelChanged();
-    SentryReporter::addBreadcrumb(QStringLiteral("file.import"),
-                                  tr("Started download for %1").arg(m_activeModelName));
+    SentryReporter::captureTelemetryEvent(QStringLiteral("ai.model_download.started"),
+        QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("gui")},
+                    {QStringLiteral("model_id"), QStringLiteral("__all__")},
+                    {QStringLiteral("capability"), QStringLiteral("other")},
+                    {QStringLiteral("source"), QStringLiteral("bundled")},
+                    {QStringLiteral("build_available"), true}});
+    SentryReporter::addBreadcrumb(QStringLiteral("ai.model_download"),
+                                  QStringLiteral("started all"));
     setBusy(true);
     setStatusMessage(tr("Downloading %1...").arg(m_activeModelName));
     emit modelsChanged();
@@ -470,8 +527,9 @@ void AIModelCatalog::deleteModel(const QString& id)
     if (!spec)
         return;
 
-    SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
-                                  tr("Deleting files for %1").arg(spec->name));
+    const qint64 deleteStartedMs = QDateTime::currentMSecsSinceEpoch();
+    SentryReporter::addBreadcrumb(QStringLiteral("ai.model_delete"),
+                                  QStringLiteral("started"));
 
     QSet<QString> sharedPaths;
     for (const ModelSpec& other : std::as_const(owner)) {
@@ -509,17 +567,20 @@ void AIModelCatalog::deleteModel(const QString& id)
         setStatusMessage(tr("Could not delete %1 file(s) for %2.")
                              .arg(failedPaths.size())
                              .arg(spec->name));
-        SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
-                                      tr("Failed to delete %1 file(s) for %2")
-                                          .arg(failedPaths.size())
-                                          .arg(spec->name),
+        captureModelTelemetry(QStringLiteral("ai.model_delete.failed"), spec,
+                              QDateTime::currentMSecsSinceEpoch() - deleteStartedMs,
+                              QStringLiteral("delete_failed"));
+        SentryReporter::addBreadcrumb(QStringLiteral("ai.model_delete"),
+                                      QStringLiteral("failed"),
                                       QStringLiteral("error"));
     } else if (removedAny) {
         setStatusMessage(keptSharedPaths.isEmpty()
             ? tr("Deleted %1.").arg(spec->name)
             : tr("Deleted %1. Shared files used by other models were kept.").arg(spec->name));
-        SentryReporter::addBreadcrumb(QStringLiteral("file.export"),
-                                      tr("Deleted files for %1").arg(spec->name));
+        captureModelTelemetry(QStringLiteral("ai.model_delete.completed"), spec,
+                              QDateTime::currentMSecsSinceEpoch() - deleteStartedMs);
+        SentryReporter::addBreadcrumb(QStringLiteral("ai.model_delete"),
+                                      QStringLiteral("completed"));
     } else if (!keptSharedPaths.isEmpty()) {
         setStatusMessage(tr("No exclusive downloaded files found for %1; shared files were kept.")
                              .arg(spec->name));
@@ -586,8 +647,21 @@ void AIModelCatalog::deleteAllModels()
 void AIModelCatalog::startNextQueuedFile()
 {
     if (m_pendingFiles.isEmpty()) {
-        SentryReporter::addBreadcrumb(QStringLiteral("file.import"),
-                                      tr("Completed download for %1").arg(m_activeModelName));
+        const qint64 durationMs = m_activeDownloadStartedMs > 0
+            ? QDateTime::currentMSecsSinceEpoch() - m_activeDownloadStartedMs : -1;
+        if (m_activeModelId == QStringLiteral("__all__")) {
+            SentryReporter::captureTelemetryEvent(QStringLiteral("ai.model_download_all.completed"),
+                QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("gui")},
+                            {QStringLiteral("model_id"), QStringLiteral("__all__")},
+                            {QStringLiteral("capability"), QStringLiteral("other")},
+                            {QStringLiteral("duration_ms"), durationMs}});
+        } else {
+            QList<ModelSpec> owner;
+            captureModelTelemetry(QStringLiteral("ai.model_download.completed"),
+                                  findSpec(m_activeModelId, &owner), durationMs);
+        }
+        SentryReporter::addBreadcrumb(QStringLiteral("ai.model_download"),
+                                      QStringLiteral("completed"));
         setStatusMessage(tr("%1 downloaded.").arg(m_activeModelName));
         clearActive();
         setBusy(false);
@@ -598,8 +672,14 @@ void AIModelCatalog::startNextQueuedFile()
     const FileSpec f = m_pendingFiles.first();
     if (f.url.isEmpty()) {
         m_pendingFiles.clear();
-        SentryReporter::addBreadcrumb(QStringLiteral("file.import"),
-                                      tr("No download URL configured for %1").arg(m_activeModelName),
+        QList<ModelSpec> owner;
+        captureModelTelemetry(QStringLiteral("ai.model_download.failed"),
+                              findSpec(m_activeModelId, &owner),
+                              m_activeDownloadStartedMs > 0
+                                  ? QDateTime::currentMSecsSinceEpoch() - m_activeDownloadStartedMs : -1,
+                              QStringLiteral("missing_url"));
+        SentryReporter::addBreadcrumb(QStringLiteral("ai.model_download"),
+                                      QStringLiteral("missing url"),
                                       QStringLiteral("error"));
         setStatusMessage(tr("No download URL configured for %1.").arg(m_activeModelName));
         clearActive();

--- a/src/AIModelCatalog.cpp
+++ b/src/AIModelCatalog.cpp
@@ -85,7 +85,7 @@ AIModelCatalog::AIModelCatalog(QObject* parent)
                 captureModelTelemetry(QStringLiteral("ai.model_download.failed"), spec,
                                       m_activeDownloadStartedMs > 0
                                           ? QDateTime::currentMSecsSinceEpoch() - m_activeDownloadStartedMs : -1,
-                                      SentryReporter::sanitizedErrorCategory(error));
+                                      error);
                 SentryReporter::addBreadcrumb(QStringLiteral("ai.model_download"),
                                               QStringLiteral("download failed"),
                                               QStringLiteral("error"));
@@ -101,6 +101,11 @@ AIModelCatalog::AIModelCatalog(QObject* parent)
                     return;
                 if (m_pendingFiles.first().label != name)
                     return;
+                QList<ModelSpec> owner;
+                captureModelTelemetry(QStringLiteral("ai.model_download.canceled"),
+                                      findSpec(m_activeModelId, &owner),
+                                      m_activeDownloadStartedMs > 0
+                                          ? QDateTime::currentMSecsSinceEpoch() - m_activeDownloadStartedMs : -1);
                 SentryReporter::addBreadcrumb(QStringLiteral("ai.model_download"),
                                               QStringLiteral("download canceled"),
                                               QStringLiteral("warning"));
@@ -501,7 +506,7 @@ void AIModelCatalog::downloadAllModels()
         ? tr("all available QtMeshEditor models")
         : tr("all QtMeshEditor models");
     emit activeModelChanged();
-    SentryReporter::captureTelemetryEvent(QStringLiteral("ai.model_download.started"),
+    SentryReporter::captureTelemetryEvent(QStringLiteral("ai.model_download_all.started"),
         QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("gui")},
                     {QStringLiteral("model_id"), QStringLiteral("__all__")},
                     {QStringLiteral("capability"), QStringLiteral("other")},
@@ -528,6 +533,7 @@ void AIModelCatalog::deleteModel(const QString& id)
         return;
 
     const qint64 deleteStartedMs = QDateTime::currentMSecsSinceEpoch();
+    captureModelTelemetry(QStringLiteral("ai.model_delete.started"), spec);
     SentryReporter::addBreadcrumb(QStringLiteral("ai.model_delete"),
                                   QStringLiteral("started"));
 

--- a/src/AIModelCatalog.h
+++ b/src/AIModelCatalog.h
@@ -74,6 +74,8 @@ private:
     void startNextQueuedFile();
     void clearActive();
     const ModelSpec* findSpec(const QString& id, QList<ModelSpec>* owner = nullptr) const;
+    void captureModelTelemetry(const QString& eventName, const ModelSpec* spec,
+                               qint64 durationMs = -1, const QString& failureCategory = {}) const;
 
     static AIModelCatalog* s_instance;
 
@@ -82,6 +84,7 @@ private:
     QString m_activeModelName;
     QString m_statusMessage;
     QList<FileSpec> m_pendingFiles;
+    qint64 m_activeDownloadStartedMs = 0;
 };
 
 #endif // AIMODELCATALOG_H

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -406,6 +406,7 @@ bool AnimationControlController::boneCanTranslate(const Ogre::Bone* bone) const
 
 void AnimationControlController::selectBone(const QString& boneName)
 {
+    const bool changedSelection = m_selectedBone != boneName.toStdString();
     m_selectedTrack   = nullptr;
     m_currentKeyframe = nullptr;
     m_selectedBone    = boneName.toStdString();
@@ -444,6 +445,11 @@ void AnimationControlController::selectBone(const QString& boneName)
         }
     }
 
+    if (changedSelection) {
+        SentryReporter::captureTelemetryEvent(QStringLiteral("selection.bone"),
+            QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("gui")},
+                        {QStringLiteral("target_kind"), QStringLiteral("bone")}});
+    }
     emit boneListChanged();
     refreshSliderTicks();
     setAnimationFrame(m_sliderValue);

--- a/src/AnimationWidget.cpp
+++ b/src/AnimationWidget.cpp
@@ -3,6 +3,7 @@
 #include <QInputDialog>
 #include <QFileDialog>
 #include <QMessageBox>
+#include <QJsonObject>
 #include <QPointer>
 
 #include <OgreAnimationState.h>
@@ -275,6 +276,10 @@ void AnimationWidget::updateSkeletonTable()
 void AnimationWidget::on_PlayPauseButton_toggled(bool checked)
 {
     SentryReporter::addBreadcrumb("ui.animation", "Toggle animation playback");
+    if (checked) {
+        SentryReporter::captureTelemetryEvent(QStringLiteral("animation.played"),
+            QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("gui")}});
+    }
     setAnimationState(checked);
 }
 

--- a/src/AppSettingsKeys.h
+++ b/src/AppSettingsKeys.h
@@ -52,7 +52,7 @@ inline const QString& telemetryEnabled()
 /** @brief Opaque random telemetry installation UUID. Never machine-derived. */
 inline const QString& anonymousInstallationId()
 {
-    static const QString k(QStringLiteral("telemetry/anonymousInstallationId"));
+    static const auto k(QStringLiteral("telemetry/anonymousInstallationId"));
     return k;
 }
 

--- a/src/AppSettingsKeys.h
+++ b/src/AppSettingsKeys.h
@@ -49,6 +49,13 @@ inline const QString& telemetryEnabled()
     return k;
 }
 
+/** @brief Opaque random telemetry installation UUID. Never machine-derived. */
+inline const QString& anonymousInstallationId()
+{
+    static const QString k(QStringLiteral("telemetry/anonymousInstallationId"));
+    return k;
+}
+
 /** @brief Light/dark/system from Preferences. */
 inline const QString& appearanceTheme()
 {

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -1572,7 +1572,6 @@ int CLIPipeline::run(int argc, char* argv[])
     if (SentryReporter::isEnabled()) {
         SentryReporter::configureSession(QStringLiteral("cli"));
         SentryReporter::initialize();
-        SentryReporter::configureSession(QStringLiteral("cli"));
     }
 
     SentryReporter::captureTelemetryEvent(QStringLiteral("app.startup"),
@@ -10097,16 +10096,6 @@ int CLIPipeline::cmdSegment(int argc, char* argv[])
         QString("segment .%1 noModel=%2 category=%3")
             .arg(fi.suffix()).arg(noModel)
             .arg(MeshSegmenter::categoryName(category)));
-    QElapsedTimer segmentTimer;
-    segmentTimer.start();
-    const QString requestedCategory = MeshSegmenter::categoryName(category);
-    SentryReporter::captureTelemetryEvent(QStringLiteral("segmentation.started"),
-        QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("cli")},
-                    {QStringLiteral("requested_category"), requestedCategory},
-                    {QStringLiteral("automatic"), category == MeshSegmenter::Category::Auto},
-                    {QStringLiteral("manual"), category != MeshSegmenter::Category::Auto},
-                    {QStringLiteral("capability"), QStringLiteral("segmentation")}});
-
     MeshImporterExporter::importer({fi.absoluteFilePath()});
     Ogre::Entity* entity = nullptr;
     for (Ogre::Entity* e : Manager::getSingleton()->getEntities()) {
@@ -10188,6 +10177,16 @@ int CLIPipeline::cmdSegment(int argc, char* argv[])
                      .arg(100.0 * rigResolved / std::max(1, vertexCount), 0, 'f', 1));
         return 0;
     }
+
+    QElapsedTimer segmentTimer;
+    segmentTimer.start();
+    const QString requestedCategory = MeshSegmenter::categoryName(category);
+    SentryReporter::captureTelemetryEvent(QStringLiteral("segmentation.started"),
+        QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("cli")},
+                    {QStringLiteral("requested_category"), requestedCategory},
+                    {QStringLiteral("automatic"), category == MeshSegmenter::Category::Auto},
+                    {QStringLiteral("manual"), category != MeshSegmenter::Category::Auto},
+                    {QStringLiteral("capability"), QStringLiteral("segmentation")}});
 
     MeshSegmenter::Options opts;
     opts.upAxis = upAxis;

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -1570,13 +1570,18 @@ int CLIPipeline::run(int argc, char* argv[])
     }
 
     if (SentryReporter::isEnabled()) {
+        SentryReporter::configureSession(QStringLiteral("cli"));
         SentryReporter::initialize();
-        SentryReporter::setTag("os", QSysInfo::prettyProductName());
-        SentryReporter::setTag("arch", QSysInfo::currentCpuArchitecture());
-        SentryReporter::setTag("qt_version", qVersion());
-        SentryReporter::setTag("launch_mode", "cli");
+        SentryReporter::configureSession(QStringLiteral("cli"));
     }
 
+    SentryReporter::captureTelemetryEvent(QStringLiteral("app.startup"),
+        QJsonObject{{QStringLiteral("launch_mode"), QStringLiteral("cli")}});
+    QElapsedTimer cliTimer;
+    cliTimer.start();
+    const QString cliInvocationId = QUuid::createUuid().toString(QUuid::WithoutBraces);
+    SentryReporter::captureInvocationEvent(QStringLiteral("cli"), cmd, QStringLiteral("started"),
+        -1, false, QString(), cliInvocationId);
     auto cliTxn = SentryReporter::startTransaction("cli." + cmd, "cli.command");
     SentryReporter::addBreadcrumb("cli", QString("CLI command: %1").arg(cmd));
 
@@ -1660,6 +1665,9 @@ int CLIPipeline::run(int argc, char* argv[])
         GamificationManager::instance()->flushBlocking(4000);
     }
 
+    SentryReporter::captureInvocationEvent(QStringLiteral("cli"), cmd,
+        rc == 0 ? QStringLiteral("completed") : QStringLiteral("failed"),
+        cliTimer.elapsed(), rc == 0, rc == 0 ? QString() : QStringLiteral("nonzero_exit"), cliInvocationId);
     SentryReporter::finishTransaction(cliTxn);
     SentryReporter::shutdown();
     _exit(rc);
@@ -3899,6 +3907,12 @@ int CLIPipeline::cmdPose(int argc, char* argv[])
             return 1;
         }
 
+        SentryReporter::captureTelemetryEvent(QStringLiteral("animation.exported"), QJsonObject{
+            {QStringLiteral("source_surface"), QStringLiteral("cli")},
+            {QStringLiteral("output_format"), SentryReporter::extensionOnly(outputPath)},
+            {QStringLiteral("frame_count"), exported},
+            {QStringLiteral("success"), true}
+        });
         return 0;
 
     } else {
@@ -3916,6 +3930,12 @@ int CLIPipeline::cmdPose(int argc, char* argv[])
             return 1;
         }
 
+        SentryReporter::captureTelemetryEvent(QStringLiteral("animation.exported"), QJsonObject{
+            {QStringLiteral("source_surface"), QStringLiteral("cli")},
+            {QStringLiteral("output_format"), SentryReporter::extensionOnly(outputPath)},
+            {QStringLiteral("frame_count"), 1},
+            {QStringLiteral("success"), true}
+        });
         cliWrite(QString("Exported pose (t=%1s): %2\n")
             .arg(time, 0, 'f', 3)
             .arg(QFileInfo(outputPath).fileName()));
@@ -10077,6 +10097,15 @@ int CLIPipeline::cmdSegment(int argc, char* argv[])
         QString("segment .%1 noModel=%2 category=%3")
             .arg(fi.suffix()).arg(noModel)
             .arg(MeshSegmenter::categoryName(category)));
+    QElapsedTimer segmentTimer;
+    segmentTimer.start();
+    const QString requestedCategory = MeshSegmenter::categoryName(category);
+    SentryReporter::captureTelemetryEvent(QStringLiteral("segmentation.started"),
+        QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("cli")},
+                    {QStringLiteral("requested_category"), requestedCategory},
+                    {QStringLiteral("automatic"), category == MeshSegmenter::Category::Auto},
+                    {QStringLiteral("manual"), category != MeshSegmenter::Category::Auto},
+                    {QStringLiteral("capability"), QStringLiteral("segmentation")}});
 
     MeshImporterExporter::importer({fi.absoluteFilePath()});
     Ogre::Entity* entity = nullptr;
@@ -10179,6 +10208,19 @@ int CLIPipeline::cmdSegment(int argc, char* argv[])
         verts.data(), vertexCount, indices.data(), static_cast<int>(indices.size()),
         modelPath, opts, rigLabels.empty() ? nullptr : rigLabels.data());
     if (!r.ok) {
+        SentryReporter::captureTelemetryEvent(QStringLiteral("segmentation.failed"),
+            QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("cli")},
+                        {QStringLiteral("requested_category"), requestedCategory},
+                        {QStringLiteral("resolved_category"), MeshSegmenter::categoryName(opts.category)},
+                        {QStringLiteral("automatic"), category == MeshSegmenter::Category::Auto},
+                        {QStringLiteral("manual"), category != MeshSegmenter::Category::Auto},
+                        {QStringLiteral("ai"), !noModel},
+                        {QStringLiteral("geometric_fallback"), noModel},
+                        {QStringLiteral("duration_ms"), segmentTimer.elapsed()},
+                        {QStringLiteral("success"), false},
+                        {QStringLiteral("failure_category"), SentryReporter::sanitizedErrorCategory(r.error)},
+                        {QStringLiteral("capability"), QStringLiteral("segmentation")}},
+            QStringLiteral("error"));
         err() << "Error: " << (r.error.isEmpty() ? QStringLiteral("segmentation failed") : r.error)
               << Qt::endl;
         return 1;
@@ -10189,6 +10231,23 @@ int CLIPipeline::cmdSegment(int argc, char* argv[])
     std::vector<int> vCount(P, 0), fCount(P, 0);
     for (int l : r.vertexLabels) if (l >= 0 && l < P) ++vCount[l];
     for (int l : r.faceLabels)   if (l >= 0 && l < P) ++fCount[l];
+
+    int resultPartCount = 0;
+    for (int p = 0; p < P; ++p)
+        if (vCount[p] > 0 || fCount[p] > 0)
+            ++resultPartCount;
+    SentryReporter::captureTelemetryEvent(QStringLiteral("segmentation.completed"),
+        QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("cli")},
+                    {QStringLiteral("requested_category"), requestedCategory},
+                    {QStringLiteral("resolved_category"), MeshSegmenter::categoryName(r.category)},
+                    {QStringLiteral("automatic"), category == MeshSegmenter::Category::Auto},
+                    {QStringLiteral("manual"), category != MeshSegmenter::Category::Auto},
+                    {QStringLiteral("ai"), r.usedModel},
+                    {QStringLiteral("geometric_fallback"), !r.usedModel},
+                    {QStringLiteral("result_part_count"), resultPartCount},
+                    {QStringLiteral("duration_ms"), segmentTimer.elapsed()},
+                    {QStringLiteral("success"), true},
+                    {QStringLiteral("capability"), QStringLiteral("segmentation")}});
 
     if (jsonOutput) {
         QJsonObject root;

--- a/src/EditModeController.cpp
+++ b/src/EditModeController.cpp
@@ -567,6 +567,11 @@ bool EditModeController::enterEditMode()
             .arg(m_editableMesh->totalVertexCount())
             .arg(m_editableMesh->totalTriangleCount())
             .arg(m_editableMesh->subMeshCount()));
+    SentryReporter::captureTelemetryEvent(QStringLiteral("edit.mode.entered"),
+        QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("gui")},
+                    {QStringLiteral("target_kind"), QStringLiteral("mesh")},
+                    {QStringLiteral("vertex_count"), static_cast<int>(m_editableMesh->totalVertexCount())},
+                    {QStringLiteral("submesh_count"), static_cast<int>(m_editableMesh->subMeshCount())}});
 
     // Run initial validation
     validateMesh();

--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -839,7 +839,7 @@ QJsonObject MCPServer::callTool(const QString &name, const QJsonObject &args)
     }
 
     const bool failed = toolResult.contains("isError") && toolResult["isError"].toBool();
-    static const QSet<QString> sceneChangingTools = {
+    static const auto sceneChangingTools = QSet{
         QStringLiteral("load_mesh"), QStringLiteral("transform_mesh"), QStringLiteral("transform_submesh"),
         QStringLiteral("apply_material"), QStringLiteral("create_material"), QStringLiteral("modify_material"),
         QStringLiteral("export_mesh"), QStringLiteral("auto_uv_unwrap"), QStringLiteral("uv_project"),

--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -67,6 +67,7 @@
 #include "SceneLightsIO.h"
 #include "RTShaderHelper.h"
 #include <QEventLoop>
+#include <QElapsedTimer>
 #include <QThread>
 #ifdef ENABLE_PS1_RIP
 #include "PS1/runtime/PS1RipManager.h"
@@ -92,6 +93,7 @@
 #include <QMetaObject>
 #include <QPixmap>
 #include <QSet>
+#include <QUuid>
 #include <optional>
 #include <OgreException.h>
 #include <OgreLight.h>
@@ -756,8 +758,13 @@ bool MCPServer::isHeavyTool(const QString &name)
 
 QJsonObject MCPServer::callTool(const QString &name, const QJsonObject &args)
 {
-    qDebug() << "MCP Tool Call:" << name << args;
+    qDebug() << "MCP Tool Call:" << name;
 
+    const QString invocationId = QUuid::createUuid().toString(QUuid::WithoutBraces);
+    QElapsedTimer telemetryTimer;
+    telemetryTimer.start();
+    SentryReporter::captureInvocationEvent(QStringLiteral("mcp"), name, QStringLiteral("started"),
+        -1, false, QString(), invocationId);
     SentryReporter::addBreadcrumb("ai.tool_call", QStringLiteral("Tool call: %1").arg(name));
 
     uintptr_t txn = 0;
@@ -768,6 +775,8 @@ QJsonObject MCPServer::callTool(const QString &name, const QJsonObject &args)
     // Lazily initialize Ogre/Manager on first scene-dependent tool call
     if (!name.startsWith(QStringLiteral("cloud_")) && !ensureOgreInitialized()) {
         if (txn) SentryReporter::finishTransaction(txn);
+        SentryReporter::captureInvocationEvent(QStringLiteral("mcp"), name, QStringLiteral("failed"),
+            telemetryTimer.elapsed(), false, QStringLiteral("renderer"), invocationId);
         return makeErrorResult("Error: Ogre 3D engine could not be initialized (no OpenGL available)");
     }
 
@@ -775,6 +784,8 @@ QJsonObject MCPServer::callTool(const QString &name, const QJsonObject &args)
     const auto handlerIt = handlers.constFind(name);
     if (handlerIt == handlers.constEnd()) {
         if (txn) SentryReporter::finishTransaction(txn);
+        SentryReporter::captureInvocationEvent(QStringLiteral("mcp"), name, QStringLiteral("failed"),
+            telemetryTimer.elapsed(), false, QStringLiteral("unknown_tool"), invocationId);
         return makeErrorResult(QString("Unknown tool: %1").arg(name));
     }
 
@@ -826,6 +837,33 @@ QJsonObject MCPServer::callTool(const QString &name, const QJsonObject &args)
         if (!feature.isEmpty())
             GamificationManager::noteFeature(feature, GamificationManager::Surface::Mcp);
     }
+
+    const bool failed = toolResult.contains("isError") && toolResult["isError"].toBool();
+    static const QSet<QString> sceneChangingTools = {
+        QStringLiteral("load_mesh"), QStringLiteral("transform_mesh"), QStringLiteral("transform_submesh"),
+        QStringLiteral("apply_material"), QStringLiteral("create_material"), QStringLiteral("modify_material"),
+        QStringLiteral("export_mesh"), QStringLiteral("auto_uv_unwrap"), QStringLiteral("uv_project"),
+        QStringLiteral("uv_set_seams"), QStringLiteral("uv_unwrap_selection"), QStringLiteral("retopologize"),
+        QStringLiteral("compute_skin_weights"), QStringLiteral("auto_rig"), QStringLiteral("generate_mesh_texture"),
+        QStringLiteral("generate_pbr_maps"), QStringLiteral("upscale_texture"), QStringLiteral("create_primitive"),
+        QStringLiteral("animate"), QStringLiteral("add_keyframe"), QStringLiteral("remove_keyframe"),
+        QStringLiteral("merge_animations"), QStringLiteral("resample_animation"), QStringLiteral("simplify_animation"),
+        QStringLiteral("bake_animation_fps"), QStringLiteral("motion_in_between"), QStringLiteral("generate_motion"),
+        QStringLiteral("adjust_arm_space"), QStringLiteral("segment_mesh"), QStringLiteral("generate_mesh_from_image"),
+        QStringLiteral("save_scene"), QStringLiteral("open_scene"), QStringLiteral("generate_lods"),
+        QStringLiteral("generate_auto_lods"), QStringLiteral("remove_lods"), QStringLiteral("decimate_mesh"),
+        QStringLiteral("delete_entity"), QStringLiteral("create_light"), QStringLiteral("delete_light"),
+        QStringLiteral("set_light_property"), QStringLiteral("apply_light_rig"), QStringLiteral("duplicate_entity"),
+        QStringLiteral("group_nodes"), QStringLiteral("ungroup_node"), QStringLiteral("reparent_node"),
+        QStringLiteral("apply_atlas"), QStringLiteral("optimize_mesh"), QStringLiteral("bake_vat"),
+        QStringLiteral("set_morph_weight"), QStringLiteral("import_alembic"), QStringLiteral("set_node_keyframe"),
+        QStringLiteral("apply_pose"), QStringLiteral("delete_pose"), QStringLiteral("mirror_pose"),
+        QStringLiteral("load_pose_library")
+    };
+    SentryReporter::captureInvocationEvent(QStringLiteral("mcp"), name,
+        failed ? QStringLiteral("failed") : QStringLiteral("completed"),
+        telemetryTimer.elapsed(), sceneChangingTools.contains(name) && !failed,
+        failed ? QStringLiteral("tool_error") : QString(), invocationId);
 
     if (txn) SentryReporter::finishTransaction(txn);
 
@@ -4341,6 +4379,8 @@ QJsonObject MCPServer::toolSegmentMesh(const QJsonObject &args)
     try {
         SentryReporter::addBreadcrumb(QStringLiteral("ai.assist.segment"),
             QStringLiteral("MCP segment_mesh"));
+        QElapsedTimer segmentTimer;
+        segmentTimer.start();
 
         Manager* mgr = Manager::getSingletonPtr();
         if (!mgr) return makeErrorResult("Error: Manager not available");
@@ -4378,6 +4418,7 @@ QJsonObject MCPServer::toolSegmentMesh(const QJsonObject &args)
             else return makeErrorResult("Error: up_axis must be 'x', 'y', or 'z'");
         }
         const QString categoryStr = args.value("category").toString();
+        QString requestedCategory = categoryStr.isEmpty() ? QStringLiteral("auto") : categoryStr.toLower();
         if (!categoryStr.isEmpty()) {
             bool okCat = false;
             opts.category = MeshSegmenter::categoryFromName(categoryStr, &okCat);
@@ -4385,6 +4426,13 @@ QJsonObject MCPServer::toolSegmentMesh(const QJsonObject &args)
                 return makeErrorResult("Error: category must be 'auto', 'body', "
                                        "'vegetation', 'vehicle', or 'building'");
         }
+        SentryReporter::captureTelemetryEvent(QStringLiteral("segmentation.started"),
+            QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("mcp")},
+                        {QStringLiteral("requested_category"), requestedCategory},
+                        {QStringLiteral("automatic"), categoryStr.isEmpty() || requestedCategory == QStringLiteral("auto")},
+                        {QStringLiteral("manual"), !(categoryStr.isEmpty() || requestedCategory == QStringLiteral("auto"))},
+                        {QStringLiteral("capability"), QStringLiteral("segmentation")}});
+
         // Auto → classifier (first-use download); offline/no_model → body.
         if (!noModel)
             opts.category = MeshSegmenter::resolveCategoryBlocking(
@@ -4399,15 +4447,46 @@ QJsonObject MCPServer::toolSegmentMesh(const QJsonObject &args)
             verts.data(), vertexCount, indices.data(),
             static_cast<int>(indices.size()), modelPath, opts,
             rigLabels.empty() ? nullptr : rigLabels.data());
-        if (!r.ok)
+        if (!r.ok) {
+            SentryReporter::captureTelemetryEvent(QStringLiteral("segmentation.failed"),
+                QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("mcp")},
+                            {QStringLiteral("requested_category"), requestedCategory},
+                            {QStringLiteral("resolved_category"), MeshSegmenter::categoryName(opts.category)},
+                            {QStringLiteral("automatic"), categoryStr.isEmpty() || requestedCategory == QStringLiteral("auto")},
+                            {QStringLiteral("manual"), !(categoryStr.isEmpty() || requestedCategory == QStringLiteral("auto"))},
+                            {QStringLiteral("ai"), !noModel},
+                            {QStringLiteral("geometric_fallback"), noModel},
+                            {QStringLiteral("duration_ms"), segmentTimer.elapsed()},
+                            {QStringLiteral("success"), false},
+                            {QStringLiteral("failure_category"), SentryReporter::sanitizedErrorCategory(r.error)},
+                            {QStringLiteral("capability"), QStringLiteral("segmentation")}},
+                QStringLiteral("error"));
             return makeErrorResult(QString("Error: %1")
                 .arg(r.error.isEmpty() ? QStringLiteral("segmentation failed") : r.error));
+        }
 
         const int P = MeshSegmenter::partCount();
         std::vector<int> vCount(P, 0);
         for (int l : r.vertexLabels) if (l >= 0 && l < P) ++vCount[l];
         std::vector<int> fCount(P, 0);
         for (int l : r.faceLabels) if (l >= 0 && l < P) ++fCount[l];
+
+        int resultPartCount = 0;
+        for (int p = 0; p < P; ++p)
+            if (vCount[p] > 0 || fCount[p] > 0)
+                ++resultPartCount;
+        SentryReporter::captureTelemetryEvent(QStringLiteral("segmentation.completed"),
+            QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("mcp")},
+                        {QStringLiteral("requested_category"), requestedCategory},
+                        {QStringLiteral("resolved_category"), MeshSegmenter::categoryName(r.category)},
+                        {QStringLiteral("automatic"), categoryStr.isEmpty() || requestedCategory == QStringLiteral("auto")},
+                        {QStringLiteral("manual"), !(categoryStr.isEmpty() || requestedCategory == QStringLiteral("auto"))},
+                        {QStringLiteral("ai"), r.usedModel},
+                        {QStringLiteral("geometric_fallback"), !r.usedModel},
+                        {QStringLiteral("result_part_count"), resultPartCount},
+                        {QStringLiteral("duration_ms"), segmentTimer.elapsed()},
+                        {QStringLiteral("success"), true},
+                        {QStringLiteral("capability"), QStringLiteral("segmentation")}});
 
         QString summary = QString("Segmented '%1' (%2 verts, category %3) via %4:")
             .arg(QString::fromStdString(entity->getName())).arg(vertexCount)

--- a/src/SelectionSet.cpp
+++ b/src/SelectionSet.cpp
@@ -2,10 +2,12 @@
 
 #include <Ogre.h>
 #include <QSet>
+#include <QJsonObject>
 
 #include "Euler.h"
 #include "Manager.h"
 #include "SelectionSet.h"
+#include "SentryReporter.h"
 
 namespace {
 
@@ -141,12 +143,19 @@ void SelectionSet::append(Ogre::SceneNode* const& obj)
 
 void SelectionSet::append(Ogre::Entity* const& obj)
 {
+    bool added = false;
     if(!mEntitiesSelected.contains(obj))
     {
         obj->getParentSceneNode()->showBoundingBox(true);
         mEntitiesSelected.append(obj);
+        added = true;
     }
 
+    if (added) {
+        SentryReporter::captureTelemetryEvent(QStringLiteral("selection.mesh"),
+            QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("gui")},
+                        {QStringLiteral("selection_count"), mEntitiesSelected.size()}});
+    }
     emit entitySelectionChanged();
     emit selectionChanged();
 }
@@ -223,6 +232,9 @@ void SelectionSet::selectOne(Ogre::Entity* const& obj)
     obj->getParentSceneNode()->showBoundingBox(true);
     mEntitiesSelected.append(obj);
 
+    SentryReporter::captureTelemetryEvent(QStringLiteral("selection.mesh"),
+        QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("gui")},
+                    {QStringLiteral("selection_count"), 1}});
     emit entitySelectionChanged();
     emit selectionChanged();
 }

--- a/src/SentryReporter.cpp
+++ b/src/SentryReporter.cpp
@@ -7,12 +7,93 @@
 #include <QStandardPaths>
 #include <QDir>
 #include <QDebug>
+#include <QDateTime>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QRegularExpression>
+#include <QSet>
+#include <QSysInfo>
+#include <QUuid>
 
 #ifdef ENABLE_SENTRY
 #include <sentry.h>
 #endif
 
 bool SentryReporter::s_initialized = false;
+QString SentryReporter::s_sessionId;
+QString SentryReporter::s_launchMode = QStringLiteral("unknown");
+qint64 SentryReporter::s_sessionStartedMs = 0;
+QVector<SentryReporter::CapturedTelemetryEvent> SentryReporter::s_capturedTelemetryEvents;
+
+namespace {
+QString normalizedRole(QString role)
+{
+    role = role.trimmed().toLower();
+    if (role == QStringLiteral("developer") || role == QStringLiteral("ci")
+        || role == QStringLiteral("tester"))
+        return role;
+    return QStringLiteral("user");
+}
+
+QJsonObject sanitizedObject(const QJsonObject& in)
+{
+    QJsonObject out;
+    for (auto it = in.constBegin(); it != in.constEnd(); ++it) {
+        const QString key = it.key();
+        const QString lower = key.toLower();
+        if (lower.contains(QStringLiteral("prompt"))
+            || lower.contains(QStringLiteral("path"))
+            || lower.contains(QStringLiteral("filename"))
+            || lower.contains(QStringLiteral("file_name"))
+            || lower.contains(QStringLiteral("email"))
+            || lower.contains(QStringLiteral("github"))
+            || lower.contains(QStringLiteral("token"))) {
+            out.insert(key, QStringLiteral("[redacted]"));
+            continue;
+        }
+        if (it.value().isString())
+            out.insert(key, SentryReporter::sanitizedValue(it.value().toString()));
+        else if (it.value().isObject())
+            out.insert(key, sanitizedObject(it.value().toObject()));
+        else
+            out.insert(key, it.value());
+    }
+    return out;
+}
+
+#ifdef ENABLE_SENTRY
+sentry_level_t sentryLevelFromString(const QString& level)
+{
+    if (level == "warning") return SENTRY_LEVEL_WARNING;
+    if (level == "error") return SENTRY_LEVEL_ERROR;
+    if (level == "fatal") return SENTRY_LEVEL_FATAL;
+    if (level == "debug") return SENTRY_LEVEL_DEBUG;
+    return SENTRY_LEVEL_INFO;
+}
+
+sentry_value_t jsonToSentryValue(const QJsonValue& value)
+{
+    if (value.isBool()) return sentry_value_new_bool(value.toBool());
+    if (value.isDouble()) return sentry_value_new_double(value.toDouble());
+    if (value.isString()) return sentry_value_new_string(value.toString().toUtf8().constData());
+    if (value.isArray()) {
+        sentry_value_t arr = sentry_value_new_list();
+        const QJsonArray json = value.toArray();
+        for (const QJsonValue& item : json)
+            sentry_value_append(arr, jsonToSentryValue(item));
+        return arr;
+    }
+    if (value.isObject()) {
+        sentry_value_t obj = sentry_value_new_object();
+        const QJsonObject json = value.toObject();
+        for (auto it = json.constBegin(); it != json.constEnd(); ++it)
+            sentry_value_set_by_key(obj, it.key().toUtf8().constData(), jsonToSentryValue(it.value()));
+        return obj;
+    }
+    return sentry_value_new_null();
+}
+#endif
+} // namespace
 
 void SentryReporter::initialize()
 {
@@ -23,25 +104,24 @@ void SentryReporter::initialize()
     sentry_options_t *options = sentry_options_new();
     sentry_options_set_dsn(options,
         "https://51f59f98ea62a3b7523ce52de2b2387d@o4509454943322112.ingest.us.sentry.io/4510896994254848");
+    // sentry-native versions bundled by this project do not collect default PII
+    // through a sendDefaultPii option. Keep identity limited to opaque user.id.
 
-    // Set database path for crash report persistence
     QString dbPath = QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation)
                      + "/sentry-db";
     QDir().mkpath(dbPath);
     QByteArray dbPathUtf8 = dbPath.toUtf8();
     sentry_options_set_database_path(options, dbPathUtf8.constData());
 
-    // Set release version (keep QByteArray alive for constData pointer)
     QByteArray release = QStringLiteral("qtmesheditor@%1")
         .arg(QCoreApplication::applicationVersion()).toUtf8();
     sentry_options_set_release(options, release.constData());
-
-    // Sample rate for performance transactions (1.0 = 100%)
     sentry_options_set_traces_sample_rate(options, 1.0);
 
     int result = sentry_init(options);
     if (result == 0) {
         s_initialized = true;
+        configureSession(s_launchMode);
         qDebug() << "Sentry initialized successfully (db:" << dbPath << ")";
     } else {
         qWarning() << "Sentry initialization failed with code:" << result;
@@ -51,10 +131,41 @@ void SentryReporter::initialize()
 
 void SentryReporter::shutdown()
 {
+    if (!s_sessionId.isEmpty() && s_sessionStartedMs > 0) {
+        QJsonObject props;
+        props["duration_ms"] = QDateTime::currentMSecsSinceEpoch() - s_sessionStartedMs;
+        captureTelemetryEvent(QStringLiteral("app.shutdown"), props);
+    }
 #ifdef ENABLE_SENTRY
     if (!s_initialized) return;
     sentry_close();
     s_initialized = false;
+#endif
+}
+
+void SentryReporter::configureSession(const QString &launchMode)
+{
+    s_launchMode = launchMode;
+    if (!isEnabled())
+        return;
+    if (s_sessionId.isEmpty()) {
+        s_sessionId = QUuid::createUuid().toString(QUuid::WithoutBraces);
+        s_sessionStartedMs = QDateTime::currentMSecsSinceEpoch();
+    }
+    setTag(QStringLiteral("os"), QSysInfo::prettyProductName());
+    setTag(QStringLiteral("arch"), QSysInfo::currentCpuArchitecture());
+    setTag(QStringLiteral("qt_version"), qVersion());
+    setTag(QStringLiteral("launch_mode"), launchMode);
+    setTag(QStringLiteral("telemetry.role"), telemetryRole());
+    setTag(QStringLiteral("session.id"), s_sessionId);
+    setTag(QStringLiteral("app.version"), QCoreApplication::applicationVersion());
+#ifdef ENABLE_SENTRY
+    if (s_initialized) {
+        sentry_value_t user = sentry_value_new_object();
+        const QString id = QStringLiteral("install:%1").arg(anonymousInstallationId());
+        sentry_value_set_by_key(user, "id", sentry_value_new_string(id.toUtf8().constData()));
+        sentry_set_user(user);
+    }
 #endif
 }
 
@@ -68,6 +179,8 @@ void SentryReporter::setEnabled(bool enabled)
 {
     QSettings settings;
     settings.setValue(AppSettingsKeys::sentryEnabled(), enabled);
+    if (!enabled)
+        resetAnonymousInstallationId();
 }
 
 bool SentryReporter::isFirstLaunch()
@@ -91,11 +204,47 @@ void SentryReporter::showConsentDialog()
     setEnabled(true);
 }
 
+QString SentryReporter::anonymousInstallationId()
+{
+    if (!isEnabled())
+        return {};
+    QSettings settings;
+    const QString key = AppSettingsKeys::anonymousInstallationId();
+    QString id = settings.value(key).toString();
+    if (QUuid(id).isNull()) {
+        id = QUuid::createUuid().toString(QUuid::WithoutBraces);
+        settings.setValue(key, id);
+    }
+    return id;
+}
+
+void SentryReporter::resetAnonymousInstallationId()
+{
+    QSettings settings;
+    settings.remove(AppSettingsKeys::anonymousInstallationId());
+}
+
+QString SentryReporter::sessionId()
+{
+    if (!isEnabled())
+        return {};
+    if (s_sessionId.isEmpty()) {
+        s_sessionId = QUuid::createUuid().toString(QUuid::WithoutBraces);
+        s_sessionStartedMs = QDateTime::currentMSecsSinceEpoch();
+    }
+    return s_sessionId;
+}
+
+QString SentryReporter::telemetryRole()
+{
+    return normalizedRole(QString::fromUtf8(qgetenv("QTMESH_TELEMETRY_ROLE")));
+}
+
 void SentryReporter::setTag(const QString &key, const QString &value)
 {
 #ifdef ENABLE_SENTRY
     if (!s_initialized) return;
-    sentry_set_tag(key.toUtf8().constData(), value.toUtf8().constData());
+    sentry_set_tag(key.toUtf8().constData(), sanitizedValue(value).toUtf8().constData());
 #else
     Q_UNUSED(key);
     Q_UNUSED(value);
@@ -105,21 +254,21 @@ void SentryReporter::setTag(const QString &key, const QString &value)
 void SentryReporter::addBreadcrumb(const QString &category, const QString &message,
                                    const QString &level)
 {
-    FeedbackDiagnostics::recordRecentEvent(category, message);
+    const QString safeCategory = sanitizedValue(category);
+    const QString safeMessage = sanitizedValue(message);
+    FeedbackDiagnostics::recordRecentEvent(safeCategory, safeMessage);
 
 #ifdef ENABLE_SENTRY
     if (!s_initialized) return;
 
     sentry_value_t crumb = sentry_value_new_breadcrumb("default",
-        message.toUtf8().constData());
+        safeMessage.toUtf8().constData());
     sentry_value_set_by_key(crumb, "category",
-        sentry_value_new_string(category.toUtf8().constData()));
+        sentry_value_new_string(safeCategory.toUtf8().constData()));
     sentry_value_set_by_key(crumb, "level",
         sentry_value_new_string(level.toUtf8().constData()));
     sentry_add_breadcrumb(crumb);
 #else
-    Q_UNUSED(category);
-    Q_UNUSED(message);
     Q_UNUSED(level);
 #endif
 }
@@ -129,19 +278,186 @@ void SentryReporter::captureMessage(const QString &message, const QString &level
 #ifdef ENABLE_SENTRY
     if (!s_initialized) return;
 
-    sentry_level_t sentryLevel = SENTRY_LEVEL_INFO;
-    if (level == "warning") sentryLevel = SENTRY_LEVEL_WARNING;
-    else if (level == "error") sentryLevel = SENTRY_LEVEL_ERROR;
-    else if (level == "fatal") sentryLevel = SENTRY_LEVEL_FATAL;
-    else if (level == "debug") sentryLevel = SENTRY_LEVEL_DEBUG;
-
-    sentry_value_t event = sentry_value_new_message_event(sentryLevel,
-        "qtmesheditor", message.toUtf8().constData());
+    sentry_value_t event = sentry_value_new_message_event(sentryLevelFromString(level),
+        "qtmesheditor", sanitizedValue(message).toUtf8().constData());
     sentry_capture_event(event);
 #else
     Q_UNUSED(message);
     Q_UNUSED(level);
 #endif
+}
+
+void SentryReporter::captureTelemetryEvent(const QString &eventName,
+                                           const QJsonObject &properties,
+                                           const QString &level)
+{
+    if (!isEnabled() || eventName.isEmpty() || !isKnownTelemetryEvent(eventName))
+        return;
+    sessionId();
+    anonymousInstallationId();
+
+    QJsonObject tags;
+    tags["app.version"] = QCoreApplication::applicationVersion();
+    tags["release"] = QStringLiteral("qtmesheditor@%1").arg(QCoreApplication::applicationVersion());
+    tags["launch_mode"] = s_launchMode;
+    tags["telemetry.role"] = telemetryRole();
+    tags["session.id"] = s_sessionId;
+    tags["os"] = QSysInfo::prettyProductName();
+    tags["arch"] = QSysInfo::currentCpuArchitecture();
+    tags["qt_version"] = qVersion();
+    if (properties.contains("source_surface"))
+        tags["source_surface"] = properties.value("source_surface").toString();
+    if (properties.contains("capability"))
+        tags["capability"] = properties.value("capability").toString();
+
+    QJsonObject context = sanitizedObject(properties);
+    context["event_name"] = eventName;
+    s_capturedTelemetryEvents.push_back({eventName, level, tags, context});
+
+#ifdef ENABLE_SENTRY
+    if (!s_initialized)
+        return;
+    sentry_value_t event = sentry_value_new_message_event(
+        sentryLevelFromString(level), "qtmesheditor.telemetry", eventName.toUtf8().constData());
+    sentry_value_set_by_key(event, "tags", jsonToSentryValue(tags));
+    sentry_value_set_by_key(event, "contexts",
+                            jsonToSentryValue(QJsonObject{{QStringLiteral("telemetry"), context}}));
+    sentry_capture_event(event);
+#endif
+}
+
+void SentryReporter::captureInvocationEvent(const QString &surface, const QString &name,
+                                            const QString &phase, qint64 durationMs,
+                                            bool changedScene,
+                                            const QString &failureCategory,
+                                            const QString &invocationId)
+{
+    QJsonObject props;
+    props["source_surface"] = surface;
+    props["command"] = sanitizedValue(name);
+    props["tool"] = sanitizedValue(name);
+    props["phase"] = phase;
+    props["invocation.id"] = invocationId.isEmpty()
+        ? QUuid::createUuid().toString(QUuid::WithoutBraces) : invocationId;
+    props["changed_scene"] = changedScene;
+    props["success"] = phase != QStringLiteral("failed");
+    if (durationMs >= 0)
+        props["duration_ms"] = durationMs;
+    if (!failureCategory.isEmpty())
+        props["failure_category"] = sanitizedErrorCategory(failureCategory);
+    captureTelemetryEvent(QStringLiteral("%1.%2.%3").arg(surface, surface == "mcp" ? "tool" : "command", phase),
+                          props, phase == QStringLiteral("failed") ? QStringLiteral("error") : QStringLiteral("info"));
+}
+
+void SentryReporter::captureFileWorkflowEvent(const QString &operation, const QString &phase,
+                                              const QString &sourceSurface,
+                                              const QString &inputPath,
+                                              const QString &outputPath,
+                                              qint64 durationMs,
+                                              bool success,
+                                              const QString &failureCategory,
+                                              int modelCount,
+                                              int animationCount,
+                                              qint64 approximateBytes)
+{
+    QJsonObject props;
+    props["source_surface"] = sourceSurface;
+    props["input_format"] = extensionOnly(inputPath);
+    props["output_format"] = extensionOnly(outputPath);
+    props["asset_kind"] = QStringLiteral("unknown");
+    props["success"] = success;
+    props["phase"] = phase;
+    if (durationMs >= 0)
+        props["duration_ms"] = durationMs;
+    if (!failureCategory.isEmpty())
+        props["failure_category"] = sanitizedErrorCategory(failureCategory);
+    if (modelCount >= 0)
+        props["model_count"] = modelCount;
+    if (animationCount >= 0)
+        props["animation_count"] = animationCount;
+    if (approximateBytes >= 0)
+        props["size_bucket"] = sizeBucket(approximateBytes);
+    captureTelemetryEvent(QStringLiteral("file.%1.%2").arg(operation, phase), props,
+                          success ? QStringLiteral("info") : QStringLiteral("error"));
+}
+
+QString SentryReporter::sanitizedValue(const QString &value)
+{
+    QString out = value;
+    static const QRegularExpression pathRe(
+        QStringLiteral(R"((?:[A-Za-z]:[\\/]|/|~[/\\])(?:[^\\/\s]+[\\/])*[^\\/\s]+)"));
+    static const QRegularExpression fileRe(
+        QStringLiteral(R"(\b[\w .-]+\.(fbx|obj|dae|gltf|glb|mesh|skeleton|png|jpg|jpeg|tga|hdr|exr|onnx|bin|json|txt|ply|stl|tmd|rsd)\b)"),
+        QRegularExpression::CaseInsensitiveOption);
+    out.replace(pathRe, QStringLiteral("[redacted-path]"));
+    out.replace(fileRe, QStringLiteral("[redacted-file]"));
+    if (out.size() > 160)
+        out = out.left(160) + QStringLiteral("...");
+    return out;
+}
+
+QString SentryReporter::sanitizedErrorCategory(const QString &error)
+{
+    const QString e = error.toLower();
+    if (e.contains("permission")) return QStringLiteral("permission");
+    if (e.contains("not found") || e.contains("missing")) return QStringLiteral("not_found");
+    if (e.contains("network") || e.contains("host") || e.contains("timeout")) return QStringLiteral("network");
+    if (e.contains("parse") || e.contains("invalid")) return QStringLiteral("invalid_input");
+    if (e.contains("download")) return QStringLiteral("download");
+    if (e.contains("export")) return QStringLiteral("export");
+    if (e.contains("import")) return QStringLiteral("import");
+    if (e.contains("ogre") || e.contains("renderer")) return QStringLiteral("renderer");
+    return QStringLiteral("other");
+}
+
+QString SentryReporter::extensionOnly(const QString &path)
+{
+    const QString suffix = QFileInfo(path).suffix().toLower();
+    return suffix.isEmpty() ? QStringLiteral("unknown") : suffix;
+}
+
+QString SentryReporter::sizeBucket(qint64 bytes)
+{
+    if (bytes < 0) return QStringLiteral("unknown");
+    if (bytes < 1024 * 1024) return QStringLiteral("<1mb");
+    if (bytes < 10 * 1024 * 1024) return QStringLiteral("1-10mb");
+    if (bytes < 100 * 1024 * 1024) return QStringLiteral("10-100mb");
+    return QStringLiteral("100mb+");
+}
+
+bool SentryReporter::isKnownTelemetryEvent(const QString &eventName)
+{
+    static const QSet<QString> events = {
+        QStringLiteral("app.startup"), QStringLiteral("app.shutdown"),
+        QStringLiteral("file.import.started"), QStringLiteral("file.import.completed"),
+        QStringLiteral("file.import.failed"), QStringLiteral("file.export.started"),
+        QStringLiteral("file.export.completed"), QStringLiteral("file.export.failed"),
+        QStringLiteral("cli.command.started"), QStringLiteral("cli.command.completed"),
+        QStringLiteral("cli.command.failed"), QStringLiteral("mcp.tool.started"),
+        QStringLiteral("mcp.tool.completed"), QStringLiteral("mcp.tool.failed"),
+        QStringLiteral("ai.model_catalog.opened"), QStringLiteral("ai.model_download.started"),
+        QStringLiteral("ai.model_download.completed"), QStringLiteral("ai.model_download.failed"),
+        QStringLiteral("ai.model_delete.completed"), QStringLiteral("ai.model_delete.failed"),
+        QStringLiteral("ai.model_download_all.completed"), QStringLiteral("ai.feature_model_missing"),
+        QStringLiteral("edit.mode.entered"), QStringLiteral("selection.mesh"),
+        QStringLiteral("selection.bone"), QStringLiteral("transform.completed"),
+        QStringLiteral("segmentation.started"), QStringLiteral("segmentation.completed"),
+        QStringLiteral("segmentation.failed"), QStringLiteral("animation.played"),
+        QStringLiteral("animation.exported")
+    };
+    return events.contains(eventName);
+}
+
+void SentryReporter::clearCapturedTelemetryEventsForTest()
+{
+    s_capturedTelemetryEvents.clear();
+    s_sessionId.clear();
+    s_sessionStartedMs = 0;
+}
+
+QVector<SentryReporter::CapturedTelemetryEvent> SentryReporter::capturedTelemetryEventsForTest()
+{
+    return s_capturedTelemetryEvents;
 }
 
 uintptr_t SentryReporter::startTransaction(const QString &name, const QString &op)
@@ -150,8 +466,8 @@ uintptr_t SentryReporter::startTransaction(const QString &name, const QString &o
     if (!s_initialized) return 0;
 
     sentry_transaction_context_t *txn_ctx =
-        sentry_transaction_context_new(name.toUtf8().constData(),
-                                       op.toUtf8().constData());
+        sentry_transaction_context_new(sanitizedValue(name).toUtf8().constData(),
+                                       sanitizedValue(op).toUtf8().constData());
     sentry_transaction_t *txn = sentry_transaction_start(txn_ctx, sentry_value_new_null());
     return reinterpret_cast<uintptr_t>(txn);
 #else
@@ -169,7 +485,7 @@ uintptr_t SentryReporter::startSpan(uintptr_t transaction, const QString &op,
 
     auto *txn = reinterpret_cast<sentry_transaction_t *>(transaction);
     sentry_span_t *span = sentry_transaction_start_child(txn,
-        op.toUtf8().constData(), description.toUtf8().constData());
+        sanitizedValue(op).toUtf8().constData(), sanitizedValue(description).toUtf8().constData());
     return reinterpret_cast<uintptr_t>(span);
 #else
     Q_UNUSED(transaction);

--- a/src/SentryReporter.cpp
+++ b/src/SentryReporter.cpp
@@ -23,7 +23,9 @@ bool SentryReporter::s_initialized = false;
 QString SentryReporter::s_sessionId;
 QString SentryReporter::s_launchMode = QStringLiteral("unknown");
 qint64 SentryReporter::s_sessionStartedMs = 0;
+#ifdef QTMESH_UNIT_TESTS
 QVector<SentryReporter::CapturedTelemetryEvent> SentryReporter::s_capturedTelemetryEvents;
+#endif
 
 namespace {
 QString normalizedRole(QString role)
@@ -222,6 +224,15 @@ void SentryReporter::resetAnonymousInstallationId()
 {
     QSettings settings;
     settings.remove(AppSettingsKeys::anonymousInstallationId());
+    s_sessionId.clear();
+    s_sessionStartedMs = 0;
+#ifdef ENABLE_SENTRY
+    if (s_initialized) {
+        sentry_set_user(sentry_value_new_object());
+        sentry_close();
+        s_initialized = false;
+    }
+#endif
 }
 
 QString SentryReporter::sessionId()
@@ -243,7 +254,7 @@ QString SentryReporter::telemetryRole()
 void SentryReporter::setTag(const QString &key, const QString &value)
 {
 #ifdef ENABLE_SENTRY
-    if (!s_initialized) return;
+    if (!isEnabled() || !s_initialized) return;
     sentry_set_tag(key.toUtf8().constData(), sanitizedValue(value).toUtf8().constData());
 #else
     Q_UNUSED(key);
@@ -276,7 +287,7 @@ void SentryReporter::addBreadcrumb(const QString &category, const QString &messa
 void SentryReporter::captureMessage(const QString &message, const QString &level)
 {
 #ifdef ENABLE_SENTRY
-    if (!s_initialized) return;
+    if (!isEnabled() || !s_initialized) return;
 
     sentry_value_t event = sentry_value_new_message_event(sentryLevelFromString(level),
         "qtmesheditor", sanitizedValue(message).toUtf8().constData());
@@ -312,7 +323,9 @@ void SentryReporter::captureTelemetryEvent(const QString &eventName,
 
     QJsonObject context = sanitizedObject(properties);
     context["event_name"] = eventName;
+#ifdef QTMESH_UNIT_TESTS
     s_capturedTelemetryEvents.push_back({eventName, level, tags, context});
+#endif
 
 #ifdef ENABLE_SENTRY
     if (!s_initialized)
@@ -334,8 +347,10 @@ void SentryReporter::captureInvocationEvent(const QString &surface, const QStrin
 {
     QJsonObject props;
     props["source_surface"] = surface;
-    props["command"] = sanitizedValue(name);
-    props["tool"] = sanitizedValue(name);
+    if (surface == QStringLiteral("mcp"))
+        props["tool"] = sanitizedValue(name);
+    else
+        props["command"] = sanitizedValue(name);
     props["phase"] = phase;
     props["invocation.id"] = invocationId.isEmpty()
         ? QUuid::createUuid().toString(QUuid::WithoutBraces) : invocationId;
@@ -349,36 +364,27 @@ void SentryReporter::captureInvocationEvent(const QString &surface, const QStrin
                           props, phase == QStringLiteral("failed") ? QStringLiteral("error") : QStringLiteral("info"));
 }
 
-void SentryReporter::captureFileWorkflowEvent(const QString &operation, const QString &phase,
-                                              const QString &sourceSurface,
-                                              const QString &inputPath,
-                                              const QString &outputPath,
-                                              qint64 durationMs,
-                                              bool success,
-                                              const QString &failureCategory,
-                                              int modelCount,
-                                              int animationCount,
-                                              qint64 approximateBytes)
+void SentryReporter::captureFileWorkflowEvent(const FileWorkflowTelemetry &telemetry)
 {
     QJsonObject props;
-    props["source_surface"] = sourceSurface;
-    props["input_format"] = extensionOnly(inputPath);
-    props["output_format"] = extensionOnly(outputPath);
+    props["source_surface"] = telemetry.sourceSurface;
+    props["input_format"] = extensionOnly(telemetry.inputPath);
+    props["output_format"] = extensionOnly(telemetry.outputPath);
     props["asset_kind"] = QStringLiteral("unknown");
-    props["success"] = success;
-    props["phase"] = phase;
-    if (durationMs >= 0)
-        props["duration_ms"] = durationMs;
-    if (!failureCategory.isEmpty())
-        props["failure_category"] = sanitizedErrorCategory(failureCategory);
-    if (modelCount >= 0)
-        props["model_count"] = modelCount;
-    if (animationCount >= 0)
-        props["animation_count"] = animationCount;
-    if (approximateBytes >= 0)
-        props["size_bucket"] = sizeBucket(approximateBytes);
-    captureTelemetryEvent(QStringLiteral("file.%1.%2").arg(operation, phase), props,
-                          success ? QStringLiteral("info") : QStringLiteral("error"));
+    props["success"] = telemetry.success;
+    props["phase"] = telemetry.phase;
+    if (telemetry.durationMs >= 0)
+        props["duration_ms"] = telemetry.durationMs;
+    if (!telemetry.failureCategory.isEmpty())
+        props["failure_category"] = sanitizedErrorCategory(telemetry.failureCategory);
+    if (telemetry.modelCount >= 0)
+        props["model_count"] = telemetry.modelCount;
+    if (telemetry.animationCount >= 0)
+        props["animation_count"] = telemetry.animationCount;
+    if (telemetry.approximateBytes >= 0)
+        props["size_bucket"] = sizeBucket(telemetry.approximateBytes);
+    captureTelemetryEvent(QStringLiteral("file.%1.%2").arg(telemetry.operation, telemetry.phase), props,
+                          telemetry.success ? QStringLiteral("info") : QStringLiteral("error"));
 }
 
 QString SentryReporter::sanitizedValue(const QString &value)
@@ -437,8 +443,10 @@ bool SentryReporter::isKnownTelemetryEvent(const QString &eventName)
         QStringLiteral("mcp.tool.completed"), QStringLiteral("mcp.tool.failed"),
         QStringLiteral("ai.model_catalog.opened"), QStringLiteral("ai.model_download.started"),
         QStringLiteral("ai.model_download.completed"), QStringLiteral("ai.model_download.failed"),
+        QStringLiteral("ai.model_download.canceled"), QStringLiteral("ai.model_delete.started"),
         QStringLiteral("ai.model_delete.completed"), QStringLiteral("ai.model_delete.failed"),
-        QStringLiteral("ai.model_download_all.completed"), QStringLiteral("ai.feature_model_missing"),
+        QStringLiteral("ai.model_download_all.started"), QStringLiteral("ai.model_download_all.completed"),
+        QStringLiteral("ai.feature_model_missing"),
         QStringLiteral("edit.mode.entered"), QStringLiteral("selection.mesh"),
         QStringLiteral("selection.bone"), QStringLiteral("transform.completed"),
         QStringLiteral("segmentation.started"), QStringLiteral("segmentation.completed"),
@@ -450,14 +458,20 @@ bool SentryReporter::isKnownTelemetryEvent(const QString &eventName)
 
 void SentryReporter::clearCapturedTelemetryEventsForTest()
 {
+#ifdef QTMESH_UNIT_TESTS
     s_capturedTelemetryEvents.clear();
+#endif
     s_sessionId.clear();
     s_sessionStartedMs = 0;
 }
 
 QVector<SentryReporter::CapturedTelemetryEvent> SentryReporter::capturedTelemetryEventsForTest()
 {
+#ifdef QTMESH_UNIT_TESTS
     return s_capturedTelemetryEvents;
+#else
+    return {};
+#endif
 }
 
 uintptr_t SentryReporter::startTransaction(const QString &name, const QString &op)

--- a/src/SentryReporter.cpp
+++ b/src/SentryReporter.cpp
@@ -42,8 +42,8 @@ QJsonObject sanitizedObject(const QJsonObject& in)
     QJsonObject out;
     for (auto it = in.constBegin(); it != in.constEnd(); ++it) {
         const QString key = it.key();
-        const QString lower = key.toLower();
-        if (lower.contains(QStringLiteral("prompt"))
+        if (const QString lower = key.toLower();
+            lower.contains(QStringLiteral("prompt"))
             || lower.contains(QStringLiteral("path"))
             || lower.contains(QStringLiteral("filename"))
             || lower.contains(QStringLiteral("file_name"))
@@ -433,7 +433,7 @@ QString SentryReporter::sizeBucket(qint64 bytes)
 
 bool SentryReporter::isKnownTelemetryEvent(const QString &eventName)
 {
-    static const QSet<QString> events = {
+    static const auto events = QSet{
         QStringLiteral("app.startup"), QStringLiteral("app.shutdown"),
         QStringLiteral("file.import.started"), QStringLiteral("file.import.completed"),
         QStringLiteral("file.import.failed"), QStringLiteral("file.export.started"),

--- a/src/SentryReporter.h
+++ b/src/SentryReporter.h
@@ -1,27 +1,43 @@
 #ifndef SENTRYREPORTER_H
 #define SENTRYREPORTER_H
 
+#include <QJsonObject>
 #include <QString>
+#include <QVector>
 #include <cstdint>
 
 /**
  * @brief Thin static wrapper isolating all Sentry SDK usage behind ENABLE_SENTRY.
  *
  * All methods are no-ops when Sentry is disabled at compile time or when the
- * user has opted out via QSettings.
+ * user has opted out via QSettings. Product telemetry must go through this
+ * wrapper so event names, privacy filtering, session tags and the anonymous
+ * installation ID stay consistent across GUI, CLI and MCP.
  */
 class SentryReporter
 {
 public:
+    struct CapturedTelemetryEvent {
+        QString name;
+        QString level;
+        QJsonObject tags;
+        QJsonObject context;
+    };
+
     // Lifecycle
     static void initialize();
     static void shutdown();
+    static void configureSession(const QString &launchMode);
 
     // Opt-in / opt-out (persisted in QSettings)
     static bool isEnabled();
     static void setEnabled(bool enabled);
     static bool isFirstLaunch();
     static void showConsentDialog();
+    static QString anonymousInstallationId();
+    static void resetAnonymousInstallationId();
+    static QString sessionId();
+    static QString telemetryRole();
 
     // Breadcrumbs
     static void addBreadcrumb(const QString &category, const QString &message,
@@ -32,6 +48,32 @@ public:
 
     // Manual events
     static void captureMessage(const QString &message, const QString &level = "info");
+    static void captureTelemetryEvent(const QString &eventName,
+                                      const QJsonObject &properties = {},
+                                      const QString &level = "info");
+    static void captureInvocationEvent(const QString &surface, const QString &name,
+                                       const QString &phase, qint64 durationMs = -1,
+                                       bool changedScene = false,
+                                       const QString &failureCategory = {},
+                                       const QString &invocationId = {});
+    static void captureFileWorkflowEvent(const QString &operation, const QString &phase,
+                                         const QString &sourceSurface,
+                                         const QString &inputPath = {},
+                                         const QString &outputPath = {},
+                                         qint64 durationMs = -1,
+                                         bool success = true,
+                                         const QString &failureCategory = {},
+                                         int modelCount = -1,
+                                         int animationCount = -1,
+                                         qint64 approximateBytes = -1);
+
+    static QString sanitizedValue(const QString &value);
+    static QString sanitizedErrorCategory(const QString &error);
+    static QString extensionOnly(const QString &path);
+    static QString sizeBucket(qint64 bytes);
+    static bool isKnownTelemetryEvent(const QString &eventName);
+    static void clearCapturedTelemetryEventsForTest();
+    static QVector<CapturedTelemetryEvent> capturedTelemetryEventsForTest();
 
     // Performance monitoring (opaque handles)
     static uintptr_t startTransaction(const QString &name, const QString &op);
@@ -42,6 +84,10 @@ public:
 private:
     SentryReporter() = delete;
     static bool s_initialized;
+    static QString s_sessionId;
+    static QString s_launchMode;
+    static qint64 s_sessionStartedMs;
+    static QVector<CapturedTelemetryEvent> s_capturedTelemetryEvents;
 };
 
 #endif // SENTRYREPORTER_H

--- a/src/SentryReporter.h
+++ b/src/SentryReporter.h
@@ -24,6 +24,20 @@ public:
         QJsonObject context;
     };
 
+    struct FileWorkflowTelemetry {
+        QString operation;
+        QString phase;
+        QString sourceSurface;
+        QString inputPath;
+        QString outputPath;
+        qint64 durationMs = -1;
+        bool success = true;
+        QString failureCategory;
+        int modelCount = -1;
+        int animationCount = -1;
+        qint64 approximateBytes = -1;
+    };
+
     // Lifecycle
     static void initialize();
     static void shutdown();
@@ -56,16 +70,7 @@ public:
                                        bool changedScene = false,
                                        const QString &failureCategory = {},
                                        const QString &invocationId = {});
-    static void captureFileWorkflowEvent(const QString &operation, const QString &phase,
-                                         const QString &sourceSurface,
-                                         const QString &inputPath = {},
-                                         const QString &outputPath = {},
-                                         qint64 durationMs = -1,
-                                         bool success = true,
-                                         const QString &failureCategory = {},
-                                         int modelCount = -1,
-                                         int animationCount = -1,
-                                         qint64 approximateBytes = -1);
+    static void captureFileWorkflowEvent(const FileWorkflowTelemetry &telemetry);
 
     static QString sanitizedValue(const QString &value);
     static QString sanitizedErrorCategory(const QString &error);
@@ -87,7 +92,9 @@ private:
     static QString s_sessionId;
     static QString s_launchMode;
     static qint64 s_sessionStartedMs;
+#ifdef QTMESH_UNIT_TESTS
     static QVector<CapturedTelemetryEvent> s_capturedTelemetryEvents;
+#endif
 };
 
 #endif // SENTRYREPORTER_H

--- a/src/SentryReporter_test.cpp
+++ b/src/SentryReporter_test.cpp
@@ -1,19 +1,28 @@
 #include <gtest/gtest.h>
+#include <QJsonObject>
 #include <QSettings>
+#include <QUuid>
 #include "AppSettingsKeys.h"
 #include "SentryReporter.h"
 
 class SentryReporterTest : public ::testing::Test {
 protected:
     void SetUp() override {
-        // Clear any previous Sentry settings
+        SentryReporter::shutdown();
+        SentryReporter::clearCapturedTelemetryEventsForTest();
         QSettings settings;
         settings.remove(AppSettingsKeys::sentryEnabled());
+        settings.remove(AppSettingsKeys::anonymousInstallationId());
+        qunsetenv("QTMESH_TELEMETRY_ROLE");
     }
 
     void TearDown() override {
+        SentryReporter::shutdown();
+        SentryReporter::clearCapturedTelemetryEventsForTest();
         QSettings settings;
         settings.remove(AppSettingsKeys::sentryEnabled());
+        settings.remove(AppSettingsKeys::anonymousInstallationId());
+        qunsetenv("QTMESH_TELEMETRY_ROLE");
     }
 };
 
@@ -75,4 +84,124 @@ TEST_F(SentryReporterTest, InitializeRespectsDisabledSetting)
     // Should be a no-op since disabled
     SentryReporter::initialize();
     SentryReporter::shutdown();
+}
+
+TEST_F(SentryReporterTest, AnonymousInstallationIdCreatedReusedAndReset)
+{
+    SentryReporter::setEnabled(true);
+    const QString first = SentryReporter::anonymousInstallationId();
+    EXPECT_FALSE(first.isEmpty());
+    EXPECT_FALSE(QUuid(first).isNull());
+
+    const QString second = SentryReporter::anonymousInstallationId();
+    EXPECT_EQ(first, second);
+
+    SentryReporter::resetAnonymousInstallationId();
+    QSettings settings;
+    EXPECT_FALSE(settings.contains(AppSettingsKeys::anonymousInstallationId()));
+
+    const QString third = SentryReporter::anonymousInstallationId();
+    EXPECT_FALSE(third.isEmpty());
+    EXPECT_NE(first, third);
+}
+
+TEST_F(SentryReporterTest, OptOutDoesNotGenerateInstallationIdOrEvents)
+{
+    SentryReporter::setEnabled(false);
+    EXPECT_TRUE(SentryReporter::anonymousInstallationId().isEmpty());
+    EXPECT_TRUE(SentryReporter::sessionId().isEmpty());
+    SentryReporter::captureTelemetryEvent(QStringLiteral("app.startup"));
+    EXPECT_TRUE(SentryReporter::capturedTelemetryEventsForTest().isEmpty());
+
+    QSettings settings;
+    EXPECT_FALSE(settings.contains(AppSettingsKeys::anonymousInstallationId()));
+}
+
+TEST_F(SentryReporterTest, SessionsShareInstallationIdButHaveDifferentSessionIds)
+{
+    SentryReporter::setEnabled(true);
+    SentryReporter::configureSession(QStringLiteral("gui"));
+    const QString installation = SentryReporter::anonymousInstallationId();
+    const QString firstSession = SentryReporter::sessionId();
+
+    SentryReporter::shutdown();
+    SentryReporter::clearCapturedTelemetryEventsForTest();
+    SentryReporter::configureSession(QStringLiteral("cli"));
+    const QString secondInstallation = SentryReporter::anonymousInstallationId();
+    const QString secondSession = SentryReporter::sessionId();
+
+    EXPECT_EQ(installation, secondInstallation);
+    EXPECT_NE(firstSession, secondSession);
+}
+
+TEST_F(SentryReporterTest, SanitizesPathsFilenamesAndPrompts)
+{
+    const QString unsafe = QStringLiteral(
+        "Open /home/alice/secret/model.fbx and C:\\Users\\Bob\\Desktop\\dragon.obj prompt: make it blue");
+    const QString safe = SentryReporter::sanitizedValue(unsafe);
+    EXPECT_FALSE(safe.contains(QStringLiteral("/home/alice")));
+    EXPECT_FALSE(safe.contains(QStringLiteral("C:\\Users")));
+    EXPECT_FALSE(safe.contains(QStringLiteral("model.fbx")));
+    EXPECT_FALSE(safe.contains(QStringLiteral("dragon.obj")));
+
+    SentryReporter::setEnabled(true);
+    SentryReporter::configureSession(QStringLiteral("mcp"));
+    SentryReporter::captureTelemetryEvent(QStringLiteral("mcp.tool.started"),
+        QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("mcp")},
+                    {QStringLiteral("prompt"), QStringLiteral("make a private character")},
+                    {QStringLiteral("path"), QStringLiteral("/tmp/private/model.fbx")}});
+    const auto events = SentryReporter::capturedTelemetryEventsForTest();
+    ASSERT_EQ(events.size(), 1);
+    EXPECT_EQ(events[0].context.value(QStringLiteral("prompt")).toString(), QStringLiteral("[redacted]"));
+    EXPECT_EQ(events[0].context.value(QStringLiteral("path")).toString(), QStringLiteral("[redacted]"));
+}
+
+TEST_F(SentryReporterTest, EventNamesAreAllowListedAndRequiredTagsArePresent)
+{
+    SentryReporter::setEnabled(true);
+    SentryReporter::configureSession(QStringLiteral("cli"));
+    SentryReporter::captureTelemetryEvent(QStringLiteral("mcp.argument.leak"),
+                                          QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("mcp")}});
+    EXPECT_TRUE(SentryReporter::capturedTelemetryEventsForTest().isEmpty());
+
+    SentryReporter::captureTelemetryEvent(QStringLiteral("file.import.completed"),
+        QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("cli")},
+                    {QStringLiteral("duration_ms"), 42}});
+    const auto events = SentryReporter::capturedTelemetryEventsForTest();
+    ASSERT_EQ(events.size(), 1);
+    const QJsonObject tags = events[0].tags;
+    EXPECT_EQ(events[0].name, QStringLiteral("file.import.completed"));
+    EXPECT_TRUE(tags.contains(QStringLiteral("app.version")));
+    EXPECT_TRUE(tags.contains(QStringLiteral("release")));
+    EXPECT_EQ(tags.value(QStringLiteral("launch_mode")).toString(), QStringLiteral("cli"));
+    EXPECT_EQ(tags.value(QStringLiteral("source_surface")).toString(), QStringLiteral("cli"));
+    EXPECT_EQ(tags.value(QStringLiteral("telemetry.role")).toString(), QStringLiteral("user"));
+    EXPECT_FALSE(tags.value(QStringLiteral("session.id")).toString().isEmpty());
+    EXPECT_TRUE(tags.contains(QStringLiteral("os")));
+    EXPECT_TRUE(tags.contains(QStringLiteral("arch")));
+}
+
+TEST_F(SentryReporterTest, TelemetryRoleDefaultsAndHonorsAllowedValues)
+{
+    EXPECT_EQ(SentryReporter::telemetryRole(), QStringLiteral("user"));
+    qputenv("QTMESH_TELEMETRY_ROLE", "developer");
+    EXPECT_EQ(SentryReporter::telemetryRole(), QStringLiteral("developer"));
+    qputenv("QTMESH_TELEMETRY_ROLE", "ci");
+    EXPECT_EQ(SentryReporter::telemetryRole(), QStringLiteral("ci"));
+    qputenv("QTMESH_TELEMETRY_ROLE", "tester");
+    EXPECT_EQ(SentryReporter::telemetryRole(), QStringLiteral("tester"));
+    qputenv("QTMESH_TELEMETRY_ROLE", "fernando");
+    EXPECT_EQ(SentryReporter::telemetryRole(), QStringLiteral("user"));
+}
+
+TEST_F(SentryReporterTest, FileWorkflowUsesExtensionsOnly)
+{
+    SentryReporter::setEnabled(true);
+    SentryReporter::configureSession(QStringLiteral("gui"));
+    SentryReporter::captureFileWorkflowEvent(QStringLiteral("import"), QStringLiteral("completed"),
+        QStringLiteral("gui"), QStringLiteral("/Users/me/Secret Character.fbx"), QString(), 5, true);
+    const auto events = SentryReporter::capturedTelemetryEventsForTest();
+    ASSERT_EQ(events.size(), 1);
+    EXPECT_EQ(events[0].context.value(QStringLiteral("input_format")).toString(), QStringLiteral("fbx"));
+    EXPECT_FALSE(events[0].context.contains(QStringLiteral("input_path")));
 }

--- a/src/SentryReporter_test.cpp
+++ b/src/SentryReporter_test.cpp
@@ -107,6 +107,10 @@ TEST_F(SentryReporterTest, AnonymousInstallationIdCreatedReusedAndReset)
 
 TEST_F(SentryReporterTest, OptOutDoesNotGenerateInstallationIdOrEvents)
 {
+    SentryReporter::setEnabled(true);
+    SentryReporter::configureSession(QStringLiteral("gui"));
+    EXPECT_FALSE(SentryReporter::sessionId().isEmpty());
+
     SentryReporter::setEnabled(false);
     EXPECT_TRUE(SentryReporter::anonymousInstallationId().isEmpty());
     EXPECT_TRUE(SentryReporter::sessionId().isEmpty());
@@ -179,6 +183,29 @@ TEST_F(SentryReporterTest, EventNamesAreAllowListedAndRequiredTagsArePresent)
     EXPECT_FALSE(tags.value(QStringLiteral("session.id")).toString().isEmpty());
     EXPECT_TRUE(tags.contains(QStringLiteral("os")));
     EXPECT_TRUE(tags.contains(QStringLiteral("arch")));
+
+    EXPECT_TRUE(SentryReporter::isKnownTelemetryEvent(QStringLiteral("ai.model_download.canceled")));
+    EXPECT_TRUE(SentryReporter::isKnownTelemetryEvent(QStringLiteral("ai.model_delete.started")));
+    EXPECT_TRUE(SentryReporter::isKnownTelemetryEvent(QStringLiteral("ai.model_download_all.started")));
+}
+
+TEST_F(SentryReporterTest, InvocationEventsUseSurfaceSpecificIdentifier)
+{
+    SentryReporter::setEnabled(true);
+    SentryReporter::configureSession(QStringLiteral("cli"));
+    SentryReporter::captureInvocationEvent(QStringLiteral("cli"), QStringLiteral("segment"),
+                                           QStringLiteral("started"), -1, false, QString(),
+                                           QStringLiteral("invocation-1"));
+    SentryReporter::captureInvocationEvent(QStringLiteral("mcp"), QStringLiteral("load_mesh"),
+                                           QStringLiteral("started"), -1, false, QString(),
+                                           QStringLiteral("invocation-2"));
+
+    const auto events = SentryReporter::capturedTelemetryEventsForTest();
+    ASSERT_EQ(events.size(), 2);
+    EXPECT_EQ(events[0].context.value(QStringLiteral("command")).toString(), QStringLiteral("segment"));
+    EXPECT_FALSE(events[0].context.contains(QStringLiteral("tool")));
+    EXPECT_EQ(events[1].context.value(QStringLiteral("tool")).toString(), QStringLiteral("load_mesh"));
+    EXPECT_FALSE(events[1].context.contains(QStringLiteral("command")));
 }
 
 TEST_F(SentryReporterTest, TelemetryRoleDefaultsAndHonorsAllowedValues)
@@ -198,8 +225,8 @@ TEST_F(SentryReporterTest, FileWorkflowUsesExtensionsOnly)
 {
     SentryReporter::setEnabled(true);
     SentryReporter::configureSession(QStringLiteral("gui"));
-    SentryReporter::captureFileWorkflowEvent(QStringLiteral("import"), QStringLiteral("completed"),
-        QStringLiteral("gui"), QStringLiteral("/Users/me/Secret Character.fbx"), QString(), 5, true);
+    SentryReporter::captureFileWorkflowEvent({QStringLiteral("import"), QStringLiteral("completed"),
+        QStringLiteral("gui"), QStringLiteral("/Users/me/Secret Character.fbx"), QString(), 5, true});
     const auto events = SentryReporter::capturedTelemetryEventsForTest();
     ASSERT_EQ(events.size(), 1);
     EXPECT_EQ(events[0].context.value(QStringLiteral("input_format")).toString(), QStringLiteral("fbx"));

--- a/src/TransformOperator.cpp
+++ b/src/TransformOperator.cpp
@@ -45,6 +45,22 @@
 TransformOperator* TransformOperator:: m_pSingleton = nullptr;
 const QPoint  TransformOperator::invalidPosition(-1,-1);
 
+namespace {
+QString telemetryTransformType(TransformOperator::TransformState state)
+{
+    switch (state) {
+    case TransformOperator::TS_TRANSLATE:
+        return QStringLiteral("translate");
+    case TransformOperator::TS_ROTATE:
+        return QStringLiteral("rotate");
+    case TransformOperator::TS_SCALE:
+        return QStringLiteral("scale");
+    default:
+        return QStringLiteral("other");
+    }
+}
+}
+
 ////////////////////////////////////////
 /// Static Member to build & destroy
 
@@ -2101,12 +2117,9 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
                 m_pTransformNode->setPosition(mBoneDragGizmoOrigin);
             }
             if (changed && outcome != BoneDragRelease::Result::Revert) {
-                const QString transformType = mTransformState == TS_TRANSLATE ? QStringLiteral("translate")
-                    : mTransformState == TS_ROTATE ? QStringLiteral("rotate")
-                    : mTransformState == TS_SCALE ? QStringLiteral("scale") : QStringLiteral("other");
                 SentryReporter::captureTelemetryEvent(QStringLiteral("transform.completed"),
                     QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("gui")},
-                                {QStringLiteral("transform_type"), transformType},
+                                {QStringLiteral("transform_type"), telemetryTransformType(mTransformState)},
                                 {QStringLiteral("target_kind"), QStringLiteral("bone")}});
             }
         }
@@ -2150,12 +2163,9 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
                 UndoManager::getSingleton()->push(
                     new EditVertexTransformCommand(mEditModeUndoSnapshot, newPositions, desc));
 
-                const QString transformType = mTransformState == TS_TRANSLATE ? QStringLiteral("translate")
-                    : mTransformState == TS_ROTATE ? QStringLiteral("rotate")
-                    : mTransformState == TS_SCALE ? QStringLiteral("scale") : QStringLiteral("other");
                 SentryReporter::captureTelemetryEvent(QStringLiteral("transform.completed"),
                     QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("gui")},
-                                {QStringLiteral("transform_type"), transformType},
+                                {QStringLiteral("transform_type"), telemetryTransformType(mTransformState)},
                                 {QStringLiteral("target_kind"), QStringLiteral("mesh")}});
 
                 // Validate mesh after edit
@@ -2201,12 +2211,9 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
             }
         }
         if (subMeshTransformCommitted) {
-            const QString transformType = mTransformState == TS_TRANSLATE ? QStringLiteral("translate")
-                : mTransformState == TS_ROTATE ? QStringLiteral("rotate")
-                : mTransformState == TS_SCALE ? QStringLiteral("scale") : QStringLiteral("other");
             SentryReporter::captureTelemetryEvent(QStringLiteral("transform.completed"),
                 QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("gui")},
-                            {QStringLiteral("transform_type"), transformType},
+                            {QStringLiteral("transform_type"), telemetryTransformType(mTransformState)},
                             {QStringLiteral("target_kind"), QStringLiteral("mesh")}});
         }
         mUndoSubEntities.clear();
@@ -2300,12 +2307,9 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
         // Auto-key only when an actual transform was committed — plain clicks
         // and zero-delta releases must not pollute tracks with duplicate keys.
         if (nodeTransformCommitted) {
-            const QString transformType = mTransformState == TS_TRANSLATE ? QStringLiteral("translate")
-                : mTransformState == TS_ROTATE ? QStringLiteral("rotate")
-                : mTransformState == TS_SCALE ? QStringLiteral("scale") : QStringLiteral("other");
             SentryReporter::captureTelemetryEvent(QStringLiteral("transform.completed"),
                 QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("gui")},
-                            {QStringLiteral("transform_type"), transformType},
+                            {QStringLiteral("transform_type"), telemetryTransformType(mTransformState)},
                             {QStringLiteral("target_kind"), QStringLiteral("mesh")}});
             AnimationControlController::instance()->autoKeyOnTransform();
         }

--- a/src/TransformOperator.cpp
+++ b/src/TransformOperator.cpp
@@ -1,6 +1,7 @@
 #include <QtDebug>
 #include <QSettings>
 #include <QApplication>
+#include <QJsonObject>
 #include <cmath>
 #include <limits>
 
@@ -2099,6 +2100,15 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
                 // viewport visually returns to the start of the drag.
                 m_pTransformNode->setPosition(mBoneDragGizmoOrigin);
             }
+            if (changed && outcome != BoneDragRelease::Result::Revert) {
+                const QString transformType = mTransformState == TS_TRANSLATE ? QStringLiteral("translate")
+                    : mTransformState == TS_ROTATE ? QStringLiteral("rotate")
+                    : mTransformState == TS_SCALE ? QStringLiteral("scale") : QStringLiteral("other");
+                SentryReporter::captureTelemetryEvent(QStringLiteral("transform.completed"),
+                    QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("gui")},
+                                {QStringLiteral("transform_type"), transformType},
+                                {QStringLiteral("target_kind"), QStringLiteral("bone")}});
+            }
         }
         // Restore playback if we paused it on press.
         if (mBoneDragWasPlaying) {
@@ -2140,6 +2150,14 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
                 UndoManager::getSingleton()->push(
                     new EditVertexTransformCommand(mEditModeUndoSnapshot, newPositions, desc));
 
+                const QString transformType = mTransformState == TS_TRANSLATE ? QStringLiteral("translate")
+                    : mTransformState == TS_ROTATE ? QStringLiteral("rotate")
+                    : mTransformState == TS_SCALE ? QStringLiteral("scale") : QStringLiteral("other");
+                SentryReporter::captureTelemetryEvent(QStringLiteral("transform.completed"),
+                    QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("gui")},
+                                {QStringLiteral("transform_type"), transformType},
+                                {QStringLiteral("target_kind"), QStringLiteral("mesh")}});
+
                 // Validate mesh after edit
                 editCtrl->validateMesh();
             }
@@ -2162,6 +2180,7 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
     if (SelectionSet::getSingleton()->hasSubEntities() && !mUndoSubEntities.isEmpty()
         && (e->button() == Qt::LeftButton))
     {
+        bool subMeshTransformCommitted = false;
         for (int i = 0; i < mUndoSubEntities.size(); ++i)
         {
             Ogre::SubEntity* sub = mUndoSubEntities[i];
@@ -2178,7 +2197,17 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
                 QString desc = QString("SubMesh %1 Transform").arg(subIdx);
                 UndoManager::getSingleton()->push(
                     new SubMeshTransformCommand(sub, mUndoSubMeshPositions[i], desc));
+                subMeshTransformCommitted = true;
             }
+        }
+        if (subMeshTransformCommitted) {
+            const QString transformType = mTransformState == TS_TRANSLATE ? QStringLiteral("translate")
+                : mTransformState == TS_ROTATE ? QStringLiteral("rotate")
+                : mTransformState == TS_SCALE ? QStringLiteral("scale") : QStringLiteral("other");
+            SentryReporter::captureTelemetryEvent(QStringLiteral("transform.completed"),
+                QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("gui")},
+                            {QStringLiteral("transform_type"), transformType},
+                            {QStringLiteral("target_kind"), QStringLiteral("mesh")}});
         }
         mUndoSubEntities.clear();
         mUndoSubMeshPositions.clear();
@@ -2270,8 +2299,16 @@ void TransformOperator::mouseReleaseEvent(QMouseEvent *e)
 
         // Auto-key only when an actual transform was committed — plain clicks
         // and zero-delta releases must not pollute tracks with duplicate keys.
-        if (nodeTransformCommitted)
+        if (nodeTransformCommitted) {
+            const QString transformType = mTransformState == TS_TRANSLATE ? QStringLiteral("translate")
+                : mTransformState == TS_ROTATE ? QStringLiteral("rotate")
+                : mTransformState == TS_SCALE ? QStringLiteral("scale") : QStringLiteral("other");
+            SentryReporter::captureTelemetryEvent(QStringLiteral("transform.completed"),
+                QJsonObject{{QStringLiteral("source_surface"), QStringLiteral("gui")},
+                            {QStringLiteral("transform_type"), transformType},
+                            {QStringLiteral("target_kind"), QStringLiteral("mesh")}});
             AnimationControlController::instance()->autoKeyOnTransform();
+        }
     }
 
     if(m_pSelectionBox->isVisible())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@
 #include <QLibraryInfo>
 #include <QDir>
 #include <QCommandLineParser>
+#include <QJsonObject>
 #include <QScopeGuard>
 #include <QtQml/qqmlengine.h>
 #include <QtQml/qjsengine.h>
@@ -57,10 +58,7 @@ static void forceX11PlatformIfNeeded()
 
 static void setSentrySessionTags(const QString& launchMode)
 {
-    SentryReporter::setTag("os", QSysInfo::prettyProductName());
-    SentryReporter::setTag("arch", QSysInfo::currentCpuArchitecture());
-    SentryReporter::setTag("qt_version", qVersion());
-    SentryReporter::setTag("launch_mode", launchMode);
+    SentryReporter::configureSession(launchMode);
 }
 
 int main(int argc, char *argv[])
@@ -128,6 +126,8 @@ int main(int argc, char *argv[])
         auto sentryClose = qScopeGuard([] { SentryReporter::shutdown(); });
 
         setSentrySessionTags("mcp");
+        SentryReporter::captureTelemetryEvent(QStringLiteral("app.startup"),
+            QJsonObject{{QStringLiteral("launch_mode"), QStringLiteral("mcp")}});
 
         MCPServer server;
         // Note: In standalone MCP mode, we don't have a MainWindow
@@ -203,6 +203,8 @@ int main(int argc, char *argv[])
     auto sentryClose = qScopeGuard([] { SentryReporter::shutdown(); });
 
     setSentrySessionTags(mcpWithGuiMode ? "gui+mcp" : "gui");
+    SentryReporter::captureTelemetryEvent(QStringLiteral("app.startup"),
+        QJsonObject{{QStringLiteral("launch_mode"), mcpWithGuiMode ? QStringLiteral("gui+mcp") : QStringLiteral("gui")}});
 
 #ifdef ENABLE_AUTO_UPDATER
     for (int i = 1; i < argc; ++i) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -4421,14 +4421,24 @@ void MainWindow::importMeshs(const QStringList &_uriList)
             entityNamesBefore.insert(QString::fromStdString(obj->getName()));
     }
 
+    QElapsedTimer importTimer;
+    importTimer.start();
+    const QString firstImportPath = _uriList.isEmpty() ? QString() : _uriList.first();
+    SentryReporter::captureFileWorkflowEvent(QStringLiteral("import"), QStringLiteral("started"),
+        QStringLiteral("gui"), firstImportPath);
     auto txn = SentryReporter::startTransaction("ui.import", "file.import");
     QList<Ogre::SkeletonPtr> animOnlySkeletons;
     try {
         MeshImporterExporter::importer(_uriList, 0, &animOnlySkeletons);
     } catch (...) {
+        SentryReporter::captureFileWorkflowEvent(QStringLiteral("import"), QStringLiteral("failed"),
+            QStringLiteral("gui"), firstImportPath, QString(), importTimer.elapsed(), false, QStringLiteral("exception"));
         SentryReporter::finishTransaction(txn);
         throw;
     }
+    SentryReporter::captureFileWorkflowEvent(QStringLiteral("import"), QStringLiteral("completed"),
+        QStringLiteral("gui"), firstImportPath, QString(), importTimer.elapsed(), true, QString(),
+        Manager::getSingleton()->getEntities().size(), animOnlySkeletons.size(), QFileInfo(firstImportPath).size());
     SentryReporter::finishTransaction(txn);
 
     // Material rebinding (texture hydration + per-material RTSS sync + a
@@ -4519,6 +4529,10 @@ void MainWindow::on_actionOpen_Scene_triggered()
                                                     nullptr, QFileDialog::DontUseNativeDialog);
     if (fileName.isEmpty()) return;
 
+    QElapsedTimer sceneImportTimer;
+    sceneImportTimer.start();
+    SentryReporter::captureFileWorkflowEvent(QStringLiteral("import"), QStringLiteral("started"),
+        QStringLiteral("gui"), fileName);
     auto txn = SentryReporter::startTransaction("ui.import", "scene.import");
     try {
         if (!MeshImporterExporter::sceneImporter(fileName)) {
@@ -4526,13 +4540,20 @@ void MainWindow::on_actionOpen_Scene_triggered()
                 this, tr("Open Scene"), tr("Could not import scene file."),
                 FeedbackReportHelper::importFailurePrefill(
                     QFileInfo(fileName).suffix(), tr("Could not import scene file.")));
+            SentryReporter::captureFileWorkflowEvent(QStringLiteral("import"), QStringLiteral("failed"),
+                QStringLiteral("gui"), fileName, QString(), sceneImportTimer.elapsed(), false, QStringLiteral("import_failed"));
             SentryReporter::finishTransaction(txn);
             return;
         }
     } catch (...) {
+        SentryReporter::captureFileWorkflowEvent(QStringLiteral("import"), QStringLiteral("failed"),
+            QStringLiteral("gui"), fileName, QString(), sceneImportTimer.elapsed(), false, QStringLiteral("exception"));
         SentryReporter::finishTransaction(txn);
         throw;
     }
+    SentryReporter::captureFileWorkflowEvent(QStringLiteral("import"), QStringLiteral("completed"),
+        QStringLiteral("gui"), fileName, QString(), sceneImportTimer.elapsed(), true, QString(),
+        Manager::getSingleton()->getEntities().size(), -1, QFileInfo(fileName).size());
     SentryReporter::finishTransaction(txn);
     addToRecentFiles(fileName);
 }
@@ -4555,6 +4576,10 @@ void MainWindow::on_actionSave_Scene_triggered()
     progressDialog.setMinimumDuration(0);
     progressDialog.setValue(0);
 
+    QElapsedTimer sceneExportTimer;
+    sceneExportTimer.start();
+    SentryReporter::captureFileWorkflowEvent(QStringLiteral("export"), QStringLiteral("started"),
+        QStringLiteral("gui"), QString(), fileName);
     auto txn = SentryReporter::startTransaction("ui.export", "scene.export");
     try {
         int result = MeshImporterExporter::sceneExporter(fileName,
@@ -4564,16 +4589,25 @@ void MainWindow::on_actionSave_Scene_triggered()
                 QApplication::processEvents();
             });
         if (result != 0) {
+            SentryReporter::captureFileWorkflowEvent(QStringLiteral("export"), QStringLiteral("failed"),
+                QStringLiteral("gui"), QString(), fileName, sceneExportTimer.elapsed(), false, QStringLiteral("export_failed"));
             FeedbackReportHelper::showFailureWithReportOption(
                 this, tr("Save Scene"), tr("Failed to save scene."),
                 FeedbackReportHelper::exportFailurePrefill(
                     QFileInfo(fileName).suffix(), tr("Failed to save scene."),
                     QString::number(result)));
+            SentryReporter::finishTransaction(txn);
+            return;
         }
     } catch (...) {
+        SentryReporter::captureFileWorkflowEvent(QStringLiteral("export"), QStringLiteral("failed"),
+            QStringLiteral("gui"), QString(), fileName, sceneExportTimer.elapsed(), false, QStringLiteral("exception"));
         SentryReporter::finishTransaction(txn);
         throw;
     }
+    SentryReporter::captureFileWorkflowEvent(QStringLiteral("export"), QStringLiteral("completed"),
+        QStringLiteral("gui"), QString(), fileName, sceneExportTimer.elapsed(), true, QString(),
+        Manager::getSingleton()->getEntities().size(), -1, QFileInfo(fileName).size());
     SentryReporter::finishTransaction(txn);
 }
 // LCOV_EXCL_STOP
@@ -4582,6 +4616,10 @@ void MainWindow::on_actionSave_Scene_triggered()
 void MainWindow::on_actionExport_Selected_triggered()
 {
     SentryReporter::addBreadcrumb("ui.action", "Export selected mesh");
+    QElapsedTimer exportTimer;
+    exportTimer.start();
+    SentryReporter::captureFileWorkflowEvent(QStringLiteral("export"), QStringLiteral("started"),
+        QStringLiteral("gui"));
     auto txn = SentryReporter::startTransaction("ui.export", "file.export");
 
     // Stop EVERY timer that could mutate the mesh / skeleton state
@@ -4630,11 +4668,16 @@ void MainWindow::on_actionExport_Selected_triggered()
     } catch (...) {
         AnimationControlController::instance()->resumePollTimer();
         if (wasRendering) m_pTimer->start();
+        SentryReporter::captureFileWorkflowEvent(QStringLiteral("export"), QStringLiteral("failed"),
+            QStringLiteral("gui"), QString(), QString(), exportTimer.elapsed(), false, QStringLiteral("exception"));
         SentryReporter::finishTransaction(txn);
         throw;
     }
     AnimationControlController::instance()->resumePollTimer();
     if (wasRendering) m_pTimer->start();
+    SentryReporter::captureFileWorkflowEvent(QStringLiteral("export"), QStringLiteral("completed"),
+        QStringLiteral("gui"), QString(), QString(), exportTimer.elapsed(), true, QString(),
+        Manager::getSingleton()->getEntities().size());
     SentryReporter::finishTransaction(txn);
 }
 // LCOV_EXCL_STOP

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -4423,6 +4423,8 @@ void MainWindow::importMeshs(const QStringList &_uriList)
 
     QElapsedTimer importTimer;
     importTimer.start();
+    SentryReporter::addBreadcrumb(QStringLiteral("file.import"),
+                                  QStringLiteral("Importing meshes"));
     const QString firstImportPath = _uriList.isEmpty() ? QString() : _uriList.first();
     SentryReporter::captureFileWorkflowEvent(
         {QStringLiteral("import"), QStringLiteral("started"), QStringLiteral("gui"), firstImportPath});

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -4424,21 +4424,22 @@ void MainWindow::importMeshs(const QStringList &_uriList)
     QElapsedTimer importTimer;
     importTimer.start();
     const QString firstImportPath = _uriList.isEmpty() ? QString() : _uriList.first();
-    SentryReporter::captureFileWorkflowEvent(QStringLiteral("import"), QStringLiteral("started"),
-        QStringLiteral("gui"), firstImportPath);
+    SentryReporter::captureFileWorkflowEvent(
+        {QStringLiteral("import"), QStringLiteral("started"), QStringLiteral("gui"), firstImportPath});
     auto txn = SentryReporter::startTransaction("ui.import", "file.import");
     QList<Ogre::SkeletonPtr> animOnlySkeletons;
     try {
         MeshImporterExporter::importer(_uriList, 0, &animOnlySkeletons);
     } catch (...) {
-        SentryReporter::captureFileWorkflowEvent(QStringLiteral("import"), QStringLiteral("failed"),
-            QStringLiteral("gui"), firstImportPath, QString(), importTimer.elapsed(), false, QStringLiteral("exception"));
+        SentryReporter::captureFileWorkflowEvent({QStringLiteral("import"), QStringLiteral("failed"),
+            QStringLiteral("gui"), firstImportPath, QString(), importTimer.elapsed(), false, QStringLiteral("exception")});
         SentryReporter::finishTransaction(txn);
         throw;
     }
-    SentryReporter::captureFileWorkflowEvent(QStringLiteral("import"), QStringLiteral("completed"),
+    SentryReporter::captureFileWorkflowEvent({QStringLiteral("import"), QStringLiteral("completed"),
         QStringLiteral("gui"), firstImportPath, QString(), importTimer.elapsed(), true, QString(),
-        Manager::getSingleton()->getEntities().size(), animOnlySkeletons.size(), QFileInfo(firstImportPath).size());
+        static_cast<int>(Manager::getSingleton()->getEntities().size()),
+        static_cast<int>(animOnlySkeletons.size()), QFileInfo(firstImportPath).size()});
     SentryReporter::finishTransaction(txn);
 
     // Material rebinding (texture hydration + per-material RTSS sync + a
@@ -4531,8 +4532,8 @@ void MainWindow::on_actionOpen_Scene_triggered()
 
     QElapsedTimer sceneImportTimer;
     sceneImportTimer.start();
-    SentryReporter::captureFileWorkflowEvent(QStringLiteral("import"), QStringLiteral("started"),
-        QStringLiteral("gui"), fileName);
+    SentryReporter::captureFileWorkflowEvent(
+        {QStringLiteral("import"), QStringLiteral("started"), QStringLiteral("gui"), fileName});
     auto txn = SentryReporter::startTransaction("ui.import", "scene.import");
     try {
         if (!MeshImporterExporter::sceneImporter(fileName)) {
@@ -4540,20 +4541,20 @@ void MainWindow::on_actionOpen_Scene_triggered()
                 this, tr("Open Scene"), tr("Could not import scene file."),
                 FeedbackReportHelper::importFailurePrefill(
                     QFileInfo(fileName).suffix(), tr("Could not import scene file.")));
-            SentryReporter::captureFileWorkflowEvent(QStringLiteral("import"), QStringLiteral("failed"),
-                QStringLiteral("gui"), fileName, QString(), sceneImportTimer.elapsed(), false, QStringLiteral("import_failed"));
+            SentryReporter::captureFileWorkflowEvent({QStringLiteral("import"), QStringLiteral("failed"),
+                QStringLiteral("gui"), fileName, QString(), sceneImportTimer.elapsed(), false, QStringLiteral("import_failed")});
             SentryReporter::finishTransaction(txn);
             return;
         }
     } catch (...) {
-        SentryReporter::captureFileWorkflowEvent(QStringLiteral("import"), QStringLiteral("failed"),
-            QStringLiteral("gui"), fileName, QString(), sceneImportTimer.elapsed(), false, QStringLiteral("exception"));
+        SentryReporter::captureFileWorkflowEvent({QStringLiteral("import"), QStringLiteral("failed"),
+            QStringLiteral("gui"), fileName, QString(), sceneImportTimer.elapsed(), false, QStringLiteral("exception")});
         SentryReporter::finishTransaction(txn);
         throw;
     }
-    SentryReporter::captureFileWorkflowEvent(QStringLiteral("import"), QStringLiteral("completed"),
+    SentryReporter::captureFileWorkflowEvent({QStringLiteral("import"), QStringLiteral("completed"),
         QStringLiteral("gui"), fileName, QString(), sceneImportTimer.elapsed(), true, QString(),
-        Manager::getSingleton()->getEntities().size(), -1, QFileInfo(fileName).size());
+        static_cast<int>(Manager::getSingleton()->getEntities().size()), -1, QFileInfo(fileName).size()});
     SentryReporter::finishTransaction(txn);
     addToRecentFiles(fileName);
 }
@@ -4578,8 +4579,8 @@ void MainWindow::on_actionSave_Scene_triggered()
 
     QElapsedTimer sceneExportTimer;
     sceneExportTimer.start();
-    SentryReporter::captureFileWorkflowEvent(QStringLiteral("export"), QStringLiteral("started"),
-        QStringLiteral("gui"), QString(), fileName);
+    SentryReporter::captureFileWorkflowEvent(
+        {QStringLiteral("export"), QStringLiteral("started"), QStringLiteral("gui"), QString(), fileName});
     auto txn = SentryReporter::startTransaction("ui.export", "scene.export");
     try {
         int result = MeshImporterExporter::sceneExporter(fileName,
@@ -4589,8 +4590,8 @@ void MainWindow::on_actionSave_Scene_triggered()
                 QApplication::processEvents();
             });
         if (result != 0) {
-            SentryReporter::captureFileWorkflowEvent(QStringLiteral("export"), QStringLiteral("failed"),
-                QStringLiteral("gui"), QString(), fileName, sceneExportTimer.elapsed(), false, QStringLiteral("export_failed"));
+            SentryReporter::captureFileWorkflowEvent({QStringLiteral("export"), QStringLiteral("failed"),
+                QStringLiteral("gui"), QString(), fileName, sceneExportTimer.elapsed(), false, QStringLiteral("export_failed")});
             FeedbackReportHelper::showFailureWithReportOption(
                 this, tr("Save Scene"), tr("Failed to save scene."),
                 FeedbackReportHelper::exportFailurePrefill(
@@ -4600,14 +4601,14 @@ void MainWindow::on_actionSave_Scene_triggered()
             return;
         }
     } catch (...) {
-        SentryReporter::captureFileWorkflowEvent(QStringLiteral("export"), QStringLiteral("failed"),
-            QStringLiteral("gui"), QString(), fileName, sceneExportTimer.elapsed(), false, QStringLiteral("exception"));
+        SentryReporter::captureFileWorkflowEvent({QStringLiteral("export"), QStringLiteral("failed"),
+            QStringLiteral("gui"), QString(), fileName, sceneExportTimer.elapsed(), false, QStringLiteral("exception")});
         SentryReporter::finishTransaction(txn);
         throw;
     }
-    SentryReporter::captureFileWorkflowEvent(QStringLiteral("export"), QStringLiteral("completed"),
+    SentryReporter::captureFileWorkflowEvent({QStringLiteral("export"), QStringLiteral("completed"),
         QStringLiteral("gui"), QString(), fileName, sceneExportTimer.elapsed(), true, QString(),
-        Manager::getSingleton()->getEntities().size(), -1, QFileInfo(fileName).size());
+        static_cast<int>(Manager::getSingleton()->getEntities().size()), -1, QFileInfo(fileName).size()});
     SentryReporter::finishTransaction(txn);
 }
 // LCOV_EXCL_STOP
@@ -4618,8 +4619,8 @@ void MainWindow::on_actionExport_Selected_triggered()
     SentryReporter::addBreadcrumb("ui.action", "Export selected mesh");
     QElapsedTimer exportTimer;
     exportTimer.start();
-    SentryReporter::captureFileWorkflowEvent(QStringLiteral("export"), QStringLiteral("started"),
-        QStringLiteral("gui"));
+    SentryReporter::captureFileWorkflowEvent(
+        {QStringLiteral("export"), QStringLiteral("started"), QStringLiteral("gui")});
     auto txn = SentryReporter::startTransaction("ui.export", "file.export");
 
     // Stop EVERY timer that could mutate the mesh / skeleton state
@@ -4668,16 +4669,16 @@ void MainWindow::on_actionExport_Selected_triggered()
     } catch (...) {
         AnimationControlController::instance()->resumePollTimer();
         if (wasRendering) m_pTimer->start();
-        SentryReporter::captureFileWorkflowEvent(QStringLiteral("export"), QStringLiteral("failed"),
-            QStringLiteral("gui"), QString(), QString(), exportTimer.elapsed(), false, QStringLiteral("exception"));
+        SentryReporter::captureFileWorkflowEvent({QStringLiteral("export"), QStringLiteral("failed"),
+            QStringLiteral("gui"), QString(), QString(), exportTimer.elapsed(), false, QStringLiteral("exception")});
         SentryReporter::finishTransaction(txn);
         throw;
     }
     AnimationControlController::instance()->resumePollTimer();
     if (wasRendering) m_pTimer->start();
-    SentryReporter::captureFileWorkflowEvent(QStringLiteral("export"), QStringLiteral("completed"),
+    SentryReporter::captureFileWorkflowEvent({QStringLiteral("export"), QStringLiteral("completed"),
         QStringLiteral("gui"), QString(), QString(), exportTimer.elapsed(), true, QString(),
-        Manager::getSingleton()->getEntities().size());
+        static_cast<int>(Manager::getSingleton()->getEntities().size())});
     SentryReporter::finishTransaction(txn);
 }
 // LCOV_EXCL_STOP


### PR DESCRIPTION
## Summary
- centralize Sentry product telemetry with anonymous installation/session identity, role tags, event allow-listing, sanitization, and test capture support
- instrument GUI/CLI/MCP lifecycle, invocation, file workflow, model management, edit/selection/transform/segmentation, and animation adoption events
- document telemetry events, privacy rules, reset behavior, crash symbolication notes, and Sentry query examples

## Privacy
- keeps telemetry opt-out behavior and does not generate an anonymous installation ID while disabled
- uses a random QSettings UUID at `telemetry/anonymousInstallationId`; never derives identity from machine/user/hardware data
- sets Sentry `user.id` only to `install:<uuid>` and sanitizes paths, filenames, prompts, emails, GitHub identifiers, and tokens
- adds `QTMESH_TELEMETRY_ROLE` with `developer`, `ci`, `tester`, defaulting to `user`

## Validation
- `cmake --build build_smoke --target UnitTests -j2`
- `build_smoke/bin/UnitTests --gtest_filter='SentryReporterTest.*'`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added `docs/TELEMETRY.md` covering crash diagnostics, anonymous telemetry behavior, privacy controls, allowed telemetry roles, event taxonomy, and example queries.

* **Enhancements**
  * Expanded and standardized telemetry across GUI, CLI, MCP, file import/export, AI model catalog/download/delete, selections, animation, edit-mode/transforms, and segmentation.
  * Improved privacy safeguards with stronger redaction/sanitization, anonymous install/session identifiers, and telemetry allow-list enforcement.

* **Tests**
  * Updated telemetry tests for opt-out behavior, event allow-list rules, sanitized context, invocation/session behavior, and file workflow shaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->