### PR TITLE
feat(t2m): curate library + Animation picker (#838)

### DIFF
--- a/qml/AnimationPickerDialog.qml
+++ b/qml/AnimationPickerDialog.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Window
 import PropertiesPanel 1.0
+import AnimationControl 1.0
 
 // #838: Mixamo-style animation PICKER. Lists every clip in the template
 // motion library with a human-readable name (e.g. "Walk (Tired Character)")

--- a/qml/AnimationPickerDialog.qml
+++ b/qml/AnimationPickerDialog.qml
@@ -89,6 +89,31 @@ Window {
                 }
             }
 
+            // #838: lower the body on crouch/pickup/sit/crawl/death clips
+            // (descent-only). ON by default; uncheck to keep the root at
+            // standing height. No effect on locomotion clips.
+            Row {
+                spacing: 6
+                Rectangle {
+                    id: pickDescentChk
+                    property bool checked: true
+                    width: 14; height: 14; radius: 2
+                    anchors.verticalCenter: parent.verticalCenter
+                    color: checked ? PropertiesPanelController.highlightColor
+                                   : PropertiesPanelController.inputColor
+                    border.color: PropertiesPanelController.borderColor
+                    Text { anchors.centerIn: parent; visible: parent.checked
+                           text: "✓"; color: "white"; font.pixelSize: 10 }
+                    MouseArea { anchors.fill: parent
+                                onClicked: pickDescentChk.checked = !pickDescentChk.checked }
+                }
+                Text {
+                    text: "Lower body (crouch/pickup)"
+                    color: PropertiesPanelController.textColor; font.pixelSize: 10
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+            }
+
             // the list
             Rectangle {
                 width: parent.width
@@ -188,7 +213,9 @@ Window {
         pickStatus.isError = false
         pickStatus.text = "Applying " + name + "…"
         // variantIndex forces this exact clip (template path, no random pick).
-        var r = AnimationControlController.generateMotion("", 0.0, false, 0.0, true, idx)
+        // Pass the picker's own descent checkbox (#838) as the last arg.
+        var r = AnimationControlController.generateMotion("", 0.0, false, 0.0, true, idx,
+                                                          pickDescentChk.checked)
         dialog.busyIndex = -1
         if (r && r.ok) {
             pickStatus.text = "Applied: " + name

--- a/qml/AnimationPickerDialog.qml
+++ b/qml/AnimationPickerDialog.qml
@@ -1,0 +1,200 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Window
+import PropertiesPanel 1.0
+
+// #838: Mixamo-style animation PICKER. Lists every clip in the template
+// motion library with a human-readable name (e.g. "Walk (Tired Character)")
+// so the user SELECTS a specific clip and applies it to the selected rig,
+// instead of the free-text prompt's quality-weighted random pick. A search
+// box filters by name/action. Applying calls generateMotion(variantIndex).
+// The free-text prompt in the panel stays for the AI-model path only.
+Window {
+    id: dialog
+    title: "Animation Library"
+    width: 460
+    height: 620
+    minimumWidth: 380
+    minimumHeight: 420
+    flags: Qt.Dialog
+    color: PropertiesPanelController.panelColor
+
+    // emitted after a successful apply so the panel can refresh its anim list
+    signal applied(string animation, string entity)
+
+    property var allClips: []          // full [{index,action,name,source,quality,frames}]
+    property string filterText: ""
+    property int busyIndex: -1         // row currently generating (for UI feedback)
+
+    function refresh() {
+        allClips = AnimationControlController.listMotionClips()
+        rebuildModel()
+    }
+    function rebuildModel() {
+        var f = filterText.trim().toLowerCase()
+        listModel.clear()
+        for (var i = 0; i < allClips.length; ++i) {
+            var c = allClips[i]
+            if (f === "" || c.name.toLowerCase().indexOf(f) !== -1
+                         || c.action.toLowerCase().indexOf(f) !== -1) {
+                listModel.append(c)
+            }
+        }
+    }
+    function open() { dialog.show(); dialog.raise(); dialog.requestActivate(); refresh() }
+
+    ListModel { id: listModel }
+
+    Rectangle {
+        anchors.fill: parent
+        color: PropertiesPanelController.panelColor
+
+        Column {
+            anchors.fill: parent
+            anchors.margins: 12
+            spacing: 8
+
+            Text {
+                text: "Pick an animation to apply to the selected rig"
+                color: PropertiesPanelController.textColor
+                font.pixelSize: 12; font.bold: true
+            }
+            Text {
+                text: dialog.allClips.length + " animations · click Apply to retarget onto your mesh"
+                color: PropertiesPanelController.textColor; opacity: 0.6
+                font.pixelSize: 10
+            }
+
+            // search box
+            Rectangle {
+                width: parent.width; height: 26; radius: 3
+                color: PropertiesPanelController.inputColor
+                border.color: searchIn.activeFocus ? PropertiesPanelController.highlightColor
+                                                    : PropertiesPanelController.borderColor
+                TextInput {
+                    id: searchIn
+                    anchors.fill: parent; anchors.leftMargin: 8; anchors.rightMargin: 8
+                    verticalAlignment: TextInput.AlignVCenter
+                    color: PropertiesPanelController.textColor; font.pixelSize: 11
+                    clip: true; selectByMouse: true; activeFocusOnPress: true
+                    onTextChanged: { dialog.filterText = text; dialog.rebuildModel() }
+                    Text {
+                        anchors.verticalCenter: parent.verticalCenter
+                        visible: !searchIn.text
+                        text: "Search… (walk, run, zombie, dance)"
+                        color: PropertiesPanelController.textColor; opacity: 0.4
+                        font.pixelSize: 11
+                    }
+                }
+            }
+
+            // the list
+            Rectangle {
+                width: parent.width
+                height: parent.height - y - applyRow.height - 24
+                color: PropertiesPanelController.inputColor
+                border.color: PropertiesPanelController.borderColor; radius: 3
+                clip: true
+                ListView {
+                    id: lv
+                    anchors.fill: parent; anchors.margins: 2
+                    model: listModel
+                    clip: true
+                    ScrollBar.vertical: ScrollBar {}
+                    delegate: Rectangle {
+                        width: lv.width; height: 40
+                        color: rowMa.containsMouse
+                               ? Qt.lighter(PropertiesPanelController.panelColor, 1.3)
+                               : (index % 2 ? PropertiesPanelController.panelColor
+                                            : "transparent")
+                        Row {
+                            anchors.fill: parent
+                            anchors.leftMargin: 8; anchors.rightMargin: 6
+                            spacing: 8
+                            Column {
+                                width: parent.width - applyBtn.width - 14
+                                anchors.verticalCenter: parent.verticalCenter
+                                spacing: 1
+                                Text {
+                                    text: model.name
+                                    color: PropertiesPanelController.textColor
+                                    font.pixelSize: 11; elide: Text.ElideRight
+                                    width: parent.width
+                                }
+                                Text {
+                                    text: "q " + model.quality.toFixed(2) + " · " + model.frames + "f"
+                                    color: PropertiesPanelController.textColor; opacity: 0.5
+                                    font.pixelSize: 9
+                                }
+                            }
+                            Rectangle {
+                                id: applyBtn
+                                width: 58; height: 24; radius: 3
+                                anchors.verticalCenter: parent.verticalCenter
+                                property bool busy: dialog.busyIndex === model.index
+                                opacity: busy ? 0.5 : 1.0
+                                color: applyMa.pressed ? Qt.darker(PropertiesPanelController.highlightColor, 1.2)
+                                     : applyMa.containsMouse ? Qt.lighter(PropertiesPanelController.highlightColor, 1.1)
+                                     : PropertiesPanelController.highlightColor
+                                Text { anchors.centerIn: parent
+                                       text: applyBtn.busy ? "…" : "Apply"
+                                       color: "white"; font.pixelSize: 10 }
+                                MouseArea {
+                                    id: applyMa; anchors.fill: parent; hoverEnabled: true
+                                    cursorShape: Qt.PointingHandCursor
+                                    onClicked: dialog.applyClip(model.index, model.name)
+                                }
+                            }
+                        }
+                        MouseArea {
+                            id: rowMa; anchors.fill: parent; hoverEnabled: true
+                            acceptedButtons: Qt.NoButton   // hover only; Apply btn handles clicks
+                        }
+                    }
+                }
+            }
+
+            Row {
+                id: applyRow
+                width: parent.width; spacing: 8
+                Text {
+                    id: pickStatus
+                    width: parent.width - closeBtn.width - 8
+                    anchors.verticalCenter: parent.verticalCenter
+                    color: pickStatus.isError ? "#e08080" : PropertiesPanelController.textColor
+                    property bool isError: false
+                    font.pixelSize: 10; wrapMode: Text.WordWrap
+                    text: ""
+                }
+                Rectangle {
+                    id: closeBtn
+                    width: 64; height: 26; radius: 3
+                    color: closeMa.containsMouse ? Qt.lighter(PropertiesPanelController.headerColor, 1.2)
+                                                 : PropertiesPanelController.headerColor
+                    border.color: PropertiesPanelController.borderColor
+                    Text { anchors.centerIn: parent; text: "Close"
+                           color: PropertiesPanelController.textColor; font.pixelSize: 11 }
+                    MouseArea { id: closeMa; anchors.fill: parent; hoverEnabled: true
+                                cursorShape: Qt.PointingHandCursor; onClicked: dialog.close() }
+                }
+            }
+        }
+    }
+
+    function applyClip(idx, name) {
+        if (dialog.busyIndex >= 0) return
+        dialog.busyIndex = idx
+        pickStatus.isError = false
+        pickStatus.text = "Applying " + name + "…"
+        // variantIndex forces this exact clip (template path, no random pick).
+        var r = AnimationControlController.generateMotion("", 0.0, false, 0.0, true, idx)
+        dialog.busyIndex = -1
+        if (r && r.ok) {
+            pickStatus.text = "Applied: " + name
+            dialog.applied(r.animation || "", r.entity || "")
+        } else {
+            pickStatus.isError = true
+            pickStatus.text = (r && r.error) ? r.error : "Failed to apply."
+        }
+    }
+}

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -8088,17 +8088,20 @@ Rectangle {
             if (!item) return
             if (!animPickerLoader.wired) {
                 animPickerLoader.wired = true
+                // Re-emit on root: lastGeneratedAnim / setArmSpaceTarget /
+                // refreshAnimData live in the animationComponent instance, NOT
+                // here in the root Loader scope — calling them directly throws
+                // a ReferenceError. The animation component connects to this
+                // signal and does the wiring in its own scope.
                 item.applied.connect(function(anim, entity) {
-                    if (anim) {
-                        lastGeneratedAnim = anim
-                        setArmSpaceTarget(anim, entity || "")
-                    }
-                    refreshAnimData()
+                    root.animationPicked(anim || "", entity || "")
                 })
             }
             if (item.open) item.open()
         }
     }
+    // Emitted after the picker applies a clip; handled inside animationComponent.
+    signal animationPicked(string animation, string entity)
     function openAnimationPicker() {
         if (!animPickerLoader.active) {
             animPickerLoader.active = true
@@ -9091,6 +9094,19 @@ Rectangle {
             Connections {
                 target: MorphAnimationManager
                 function onMorphClipsChanged() { refreshAnimData() }
+            }
+            // #838: the animation picker applied a clip. Handle it HERE (in the
+            // animation component scope) so lastGeneratedAnim / setArmSpaceTarget
+            // / refreshAnimData resolve — the root-level Loader can't reach them.
+            Connections {
+                target: root
+                function onAnimationPicked(animation, entity) {
+                    if (animation) {
+                        lastGeneratedAnim = animation
+                        setArmSpaceTarget(animation, entity || "")
+                    }
+                    refreshAnimData()
+                }
             }
 
             // ── Add animation (#838 picker + #411 text-to-motion) ────────────

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -9200,7 +9200,8 @@ Rectangle {
                         // skewing every new clip is exactly the bug this fixes).
                         var gr = AnimationControlController.generateMotion(
                                      genPromptIn.text, 0.0, useModelChk.checked,
-                                     0.0, footPinChk.checked)
+                                     0.0, footPinChk.checked, -1,
+                                     descentChk.checked)
                         if (gr && gr.animation) {
                             lastGeneratedAnim = gr.animation
                             // Point the slider at the fresh clip at a neutral 0
@@ -9262,6 +9263,31 @@ Rectangle {
                 }
                 Text {
                     text: "Pin feet (contact cleanup)"
+                    color: PropertiesPanelController.textColor; font.pixelSize: 10
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+            }
+            // #838: vertical root descent — lower the body to the ground on
+            // crouch/pickup/sit/crawl/death clips. ON by default; helps most
+            // such clips but a few author the squat purely in the joints, so
+            // this lets the user turn it off when it over-sinks.
+            Row {
+                spacing: 6
+                Rectangle {
+                    id: descentChk
+                    property bool checked: true
+                    width: 14; height: 14; radius: 2
+                    anchors.verticalCenter: parent.verticalCenter
+                    color: checked ? PropertiesPanelController.highlightColor
+                                   : PropertiesPanelController.inputColor
+                    border.color: PropertiesPanelController.borderColor
+                    Text { anchors.centerIn: parent; visible: parent.checked
+                           text: "✓"; color: "white"; font.pixelSize: 10 }
+                    MouseArea { anchors.fill: parent
+                                onClicked: descentChk.checked = !descentChk.checked }
+                }
+                Text {
+                    text: "Lower body (crouch/pickup)"
                     color: PropertiesPanelController.textColor; font.pixelSize: 10
                     anchors.verticalCenter: parent.verticalCenter
                 }

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -8076,6 +8076,37 @@ Rectangle {
         }
     }
 
+    // #838: Mixamo-style animation picker — browse/select a specific library
+    // clip instead of the free-text random pick.
+    Loader {
+        id: animPickerLoader
+        active: false
+        property bool wired: false
+        anchors.centerIn: parent
+        source: "qrc:/MaterialEditorQML/AnimationPickerDialog.qml"
+        onLoaded: {
+            if (!item) return
+            if (!animPickerLoader.wired) {
+                animPickerLoader.wired = true
+                item.applied.connect(function(anim, entity) {
+                    if (anim) {
+                        lastGeneratedAnim = anim
+                        setArmSpaceTarget(anim, entity || "")
+                    }
+                    refreshAnimData()
+                })
+            }
+            if (item.open) item.open()
+        }
+    }
+    function openAnimationPicker() {
+        if (!animPickerLoader.active) {
+            animPickerLoader.active = true
+        } else if (animPickerLoader.item) {
+            animPickerLoader.item.open()
+        }
+    }
+
     Loader {
         id: removeBoneLoader
         active: false
@@ -9062,12 +9093,32 @@ Rectangle {
                 function onMorphClipsChanged() { refreshAnimData() }
             }
 
-            // ── Generate from text (#411, experimental) ──────────────────────
+            // ── Add animation (#838 picker + #411 text-to-motion) ────────────
             // Lives in the Animations group and shows for any skeleton-bearing
             // selection (incl. a freshly auto-rigged mesh with no clips yet).
+            // PRIMARY path: browse the curated library and pick a named clip
+            // (reliable). The free-text field below drives the experimental
+            // AI model.
             Text {
-                text: "Generate from text (experimental):"
-                color: PropertiesPanelController.textColor; font.pixelSize: 11
+                text: "Add animation:"
+                color: PropertiesPanelController.textColor; font.pixelSize: 11; font.bold: true
+            }
+            // Browse the library — the reliable, Mixamo-style pick-a-clip flow.
+            Rectangle {
+                width: parent.width - 16; height: 26; radius: 3
+                color: browseMa.pressed ? Qt.darker(PropertiesPanelController.highlightColor, 1.2)
+                     : browseMa.containsMouse ? Qt.lighter(PropertiesPanelController.highlightColor, 1.1)
+                     : PropertiesPanelController.highlightColor
+                Text { anchors.centerIn: parent; text: "Browse animation library…"
+                       color: "white"; font.pixelSize: 11 }
+                MouseArea { id: browseMa; anchors.fill: parent; hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: root.openAnimationPicker() }
+            }
+            Text {
+                text: "— or generate from text (experimental AI model):"
+                color: PropertiesPanelController.textColor; opacity: 0.7; font.pixelSize: 10
+                topPadding: 4
             }
             Row {
                 width: parent.width - 16; spacing: 6

--- a/scripts/build-motion-library-v5.py
+++ b/scripts/build-motion-library-v5.py
@@ -695,16 +695,22 @@ def main():
                         # retarget deltas the descent against its start frame).
                         ry = c.get("rootY")
                         if ry and len(ry) == len(q):
+                            # rootY is already a crouch DEPTH (hip-to-foot
+                            # compression, ≤ 0 leg-lengths, anchored to the
+                            # clip's own standing height) — window-slice and
+                            # RE-ANCHOR to the window's shallowest frame so the
+                            # clip opens at 0 (the active window may start
+                            # already partly crouched).
                             wry = ry[s:epos]
                             if wry:
-                                base = wry[0]
-                                # Re-base to the window start, then clamp the
-                                # DESCENT to one leg length (hip at foot level =
-                                # fully seated/prone on the ground). Deeper
-                                # values are capture glitches / mis-resolved feet;
-                                # the retarget only applies the negative part.
+                                base = max(wry)   # shallowest (closest to 0)
+                                # 0.6 gain: the raw hip-to-foot compression at a
+                                # full kneel is nearly a whole leg length, which
+                                # over-sinks the body; 0.6 lands a believable
+                                # crouch depth (tuned on working/crouch/death).
                                 clip["rootY"] = [
-                                    round(max(-1.0, v - base), 5) for v in wry]
+                                    round(0.6 * min(0.0, v - base), 5)
+                                    for v in wry]
                         clips.append(clip)
                         print(f"  + {action:<10} {title[:38]:<40}"
                               f" {c.get('animation')} ({len(w)}f, q={quality:.2f})")

--- a/scripts/build-motion-library-v5.py
+++ b/scripts/build-motion-library-v5.py
@@ -687,6 +687,22 @@ def main():
                             clip["restWorld"] = rest_world
                         if rest_dir:
                             clip["restDir"] = rest_dir
+                        # #838 vertical descent: carry the per-frame hip Y
+                        # offset, sliced to the SAME active window as the quats
+                        # and re-based so frame 0 of the window reads ~0 (the
+                        # retarget deltas the descent against its start frame).
+                        ry = c.get("rootY")
+                        if ry and len(ry) == len(q):
+                            wry = ry[s:epos]
+                            if wry:
+                                base = wry[0]
+                                # Re-base to the window start, then clamp the
+                                # DESCENT to one leg length (hip at foot level =
+                                # fully seated/prone on the ground). Deeper
+                                # values are capture glitches / mis-resolved feet;
+                                # the retarget only applies the negative part.
+                                clip["rootY"] = [
+                                    round(max(-1.0, v - base), 5) for v in wry]
                         clips.append(clip)
                         print(f"  + {action:<10} {title[:38]:<40}"
                               f" {c.get('animation')} ({len(w)}f, q={quality:.2f})")

--- a/scripts/build-motion-library-v5.py
+++ b/scripts/build-motion-library-v5.py
@@ -181,6 +181,56 @@ def vnorm(v):
 # Actions that legitimately go horizontal — no uprightness gate for these.
 HORIZONTAL_OK = {"death", "roll", "crawl", "swim", "fall", "sleep"}
 
+# License exclusion: Adobe Mixamo animations cannot be redistributed as a
+# standalone library (Mixamo ToS), even when a Sketchfab uploader re-published
+# the model under CC-BY — the CC-BY covers the upload, not the underlying
+# Adobe animation data. Drop any clip whose animation/source name is Mixamo-
+# derived. Matched case-insensitively against "<title> — <animation>".
+MIXAMO_MARKERS = ("mixamo",)
+
+# Manual review drop-list (#838 curation): specific (asset-title-substring,
+# animation-substring) pairs the user reviewed and rejected — bad retargets
+# (Fox-rig tip/hunch/invert) or off-action clips. Matched case-insensitively;
+# animation "" matches any animation of that asset. Kept as (title, anim) so
+# it survives library rebuilds (JSON indices are not stable).
+REVIEW_DROP = [
+    ("GIGI", ""),          # Fox rig — tips/hunches on every action reviewed
+    ("KAI", ""),           # Fox rig — same
+    ("Shar Pei", ""),      # dog rig — wrong body plan for humanoid retarget
+    ("Square Head Character", "Loose"),  # shake [100] — weak/ambiguous
+    ("Dance | Japanese Samurai", ""),    # dance [49] — crouched, off
+]
+
+
+def _excluded(title, anim):
+    """True if this (asset, animation) is dropped by license or review rules."""
+    hay = f"{title} {anim}".lower()
+    if any(m in hay for m in MIXAMO_MARKERS):
+        return "mixamo (license: Adobe ToS, not redistributable)"
+    for t, a in REVIEW_DROP:
+        if t.lower() in title.lower() and (not a or a.lower() in anim.lower()):
+            return f"review drop-list ({t}{'/' + a if a else ''})"
+    return None
+
+
+def fix_first_frame_flip(quats):
+    """Mini Chibi Kid (and similar) clips export frame 0 with a rotated/flipped
+    hip while the rest of the clip is upright — a loop-seam artifact. If frame 0
+    is a strong outlier vs frame 1 (hip up-Y flipped past horizontal) but the
+    clip is otherwise upright, replace frame 0 with frame 1 so the retarget
+    doesn't open on the glitch. Returns the (possibly repaired) list."""
+    if len(quats) < 3:
+        return quats
+    def up_y(f):
+        x, y, z, w = f[HIP]
+        return 1.0 - 2.0 * (x * x + z * z)
+    u0, u1, u2 = up_y(quats[0]), up_y(quats[1]), up_y(quats[2])
+    # frame 0 inverted/tilted-past-horizontal but 1 & 2 upright → repair
+    if u0 < 0.3 and u1 > 0.7 and u2 > 0.7:
+        quats = list(quats)
+        quats[0] = quats[1]
+    return quats
+
 # canonical role indices
 HIP, ABDOMEN, CHEST, NECK = 0, 1, 2, 3
 RHIP, LHIP = 15, 19
@@ -564,10 +614,19 @@ def main():
                     for c in dump.get("clips", []):
                         if c.get("resolvedRoles", 0) < args.min_roles:
                             continue
+                        anim = c.get("animation", "")
+                        excl = _excluded(title, anim)
+                        if excl:
+                            print(f"  - {'':<10} {title[:38]:<40} {anim} "
+                                  f"EXCLUDED: {excl}")
+                            continue
                         q = c.get("quats", [])
                         if len(q) < args.min_frames:
                             continue
-                        action = action_for(c.get("animation", ""), tags)
+                        # Repair a rotated/flipped first frame (Mini Chibi etc.)
+                        # before windowing, so a window opening at frame 0 is clean.
+                        q = fix_first_frame_flip(q)
+                        action = action_for(anim, tags)
                         if not action:
                             continue
                         s, epos = select_window(q, args.max_frames)

--- a/scripts/build-motion-library-v5.py
+++ b/scripts/build-motion-library-v5.py
@@ -211,6 +211,8 @@ REVIEW_DROP = [
     ("Knight Character Animated", ""),   # Jul 2018 — raised right arm
     ("Rigged and Animated Humanoid", ""),  # bad retarget on BOTH Mixamo &
                                            # UniRig skeletons (user review)
+    ("FNaf_DLC_moon_sun", ""),           # Moon/Sun man — jumpscare rig, bad
+    ("Low_Poly_Zombie_Game_Animation", ""),  # weak zombie clips (user review)
 ]
 
 
@@ -695,22 +697,18 @@ def main():
                         # retarget deltas the descent against its start frame).
                         ry = c.get("rootY")
                         if ry and len(ry) == len(q):
-                            # rootY is already a crouch DEPTH (hip-to-foot
-                            # compression, ≤ 0 leg-lengths, anchored to the
-                            # clip's own standing height) — window-slice and
-                            # RE-ANCHOR to the window's shallowest frame so the
-                            # clip opens at 0 (the active window may start
-                            # already partly crouched).
+                            # rootY is a crouch DEPTH vs the rig's BIND-pose
+                            # standing height (absolute, ≤ 0 leg-lengths), so an
+                            # always-low crawl/sit keeps its real depth — do NOT
+                            # re-anchor to the window (that would zero a clip
+                            # that opens already crouched). Just window-slice and
+                            # apply the 0.6 display gain (full-kneel hip-to-foot
+                            # compression is nearly a whole leg; 0.6 lands a
+                            # believable depth).
                             wry = ry[s:epos]
                             if wry:
-                                base = max(wry)   # shallowest (closest to 0)
-                                # 0.6 gain: the raw hip-to-foot compression at a
-                                # full kneel is nearly a whole leg length, which
-                                # over-sinks the body; 0.6 lands a believable
-                                # crouch depth (tuned on working/crouch/death).
                                 clip["rootY"] = [
-                                    round(0.6 * min(0.0, v - base), 5)
-                                    for v in wry]
+                                    round(0.6 * min(0.0, v), 5) for v in wry]
                         clips.append(clip)
                         print(f"  + {action:<10} {title[:38]:<40}"
                               f" {c.get('animation')} ({len(w)}f, q={quality:.2f})")

--- a/scripts/build-motion-library-v5.py
+++ b/scripts/build-motion-library-v5.py
@@ -199,6 +199,16 @@ REVIEW_DROP = [
     ("Shar Pei", ""),      # dog rig — wrong body plan for humanoid retarget
     ("Square Head Character", "Loose"),  # shake [100] — weak/ambiguous
     ("Dance | Japanese Samurai", ""),    # dance [49] — crouched, off
+    # These Quaternius packs mis-map the RIGHT upper-arm bone: it stays raised/
+    # out (mean up-Y positive) the whole clip on every action instead of
+    # hanging. Redundant with the clean Man/Woman (Oct/Dec 2017) packs, so drop
+    # them wholesale. NB: match the FULL pack name — "Animated Men/Women
+    # Characters" and "Man/Woman Animated" are DIFFERENT releases (the latter
+    # are the good ones), so do NOT use a loose "Men"/"Man" substring.
+    ("Animated Men Characters", ""),     # Feb 2019 — raised right arm
+    ("Animated Women Characters", ""),   # Feb 2019 — raised right arm
+    ("Alien Animated", ""),              # April 2019 — raised right arm
+    ("Knight Character Animated", ""),   # Jul 2018 — raised right arm
 ]
 
 

--- a/scripts/build-motion-library-v5.py
+++ b/scripts/build-motion-library-v5.py
@@ -209,6 +209,8 @@ REVIEW_DROP = [
     ("Animated Women Characters", ""),   # Feb 2019 — raised right arm
     ("Alien Animated", ""),              # April 2019 — raised right arm
     ("Knight Character Animated", ""),   # Jul 2018 — raised right arm
+    ("Rigged and Animated Humanoid", ""),  # bad retarget on BOTH Mixamo &
+                                           # UniRig skeletons (user review)
 ]
 
 

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -1918,6 +1918,7 @@ QVariantMap AnimationControlController::generateMotion(const QString& prompt,
     bool worldFrame = false;
     std::vector<std::array<float, 4>> cmuRest;
     std::vector<std::array<float, 3>> clipDirs;
+    std::vector<float> clipRootY;
     bool gotClip = false;
 
     // The animation PICKER passes an explicit clip index — force the template
@@ -1979,15 +1980,22 @@ QVariantMap AnimationControlController::generateMotion(const QString& prompt,
         cmuRest = clip.restWorld.empty() ? lib.cmuRestWorld()
                                          : clip.restWorld;
         clipDirs = clip.restDir;
+        clipRootY = clip.rootY;
         clipSource = QStringLiteral("template");
         if (duration > 0.05) {
             const int want = std::max(2, int(duration * clip.fps));
             std::vector<std::vector<std::array<float, 4>>> retimed(want);
+            std::vector<float> retimedY;
+            const bool hadY = static_cast<int>(clipRootY.size()) == clip.frames;
+            if (hadY) retimedY.resize(want);
             for (int f = 0; f < want; ++f) {
                 const float src = (clip.frames - 1) * (float(f) / float(want - 1));
-                retimed[f] = quats[std::min(clip.frames - 1, int(src + 0.5f))];
+                const int si = std::min(clip.frames - 1, int(src + 0.5f));
+                retimed[f] = quats[si];
+                if (hadY) retimedY[f] = clipRootY[si];
             }
             quats.swap(retimed);
+            if (hadY) clipRootY.swap(retimedY);
         }
     }
 
@@ -1995,12 +2003,14 @@ QVariantMap AnimationControlController::generateMotion(const QString& prompt,
     // Auto-rigged (no prior animation) meshes that face −Z would walk
     // backward — detect facing from the mesh's foot region.
     const bool yaw180 = AnimationMerger::detectBackwardFacing(entity);
+    const bool verticalDescent = MotionLibrary::isVerticalDescentAction(action);
     const auto res = AnimationMerger::applyMotionClip(skel.get(), animName, quats, fps,
                                                       worldFrame, cmuRest,
                                                       /*refineWithModel=*/false,
                                                       /*refineStride=*/8, yaw180,
                                                       clipDirs,
-                                                      clipSource == QStringLiteral("model"));
+                                                      clipSource == QStringLiteral("model"),
+                                                      clipRootY, verticalDescent);
     if (!res.ok) return fail(res.error);
     out["source"] = clipSource;
 

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -1840,6 +1840,8 @@ double AnimationControlController::currentArmSpace(const QString& animName,
 QVariantList AnimationControlController::listMotionClips()
 {
     QVariantList out;
+    SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
+        QStringLiteral("browse motion library (picker)"));
     const QString libPath = MotionLibrary::ensureLibraryBlocking();
     if (libPath.isEmpty()) return out;
     MotionLibrary lib;

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -1888,7 +1888,9 @@ QVariantMap AnimationControlController::generateMotion(const QString& prompt,
     out["ok"] = false;
     auto fail = [&](const QString& e) { out["error"] = e; emit generateMotionStatus(e, true); return out; };
 
-    if (prompt.trimmed().isEmpty())
+    // The picker supplies an explicit clip index instead of a prompt, so the
+    // prompt is only required for the match/model paths (variantIndex < 0).
+    if (variantIndex < 0 && prompt.trimmed().isEmpty())
         return fail(QStringLiteral("Enter a motion prompt (e.g. \"walking\")."));
 
     // Resolve a rigged entity: the selected one, else the first skinned mesh.

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -1882,7 +1882,8 @@ QVariantList AnimationControlController::listMotionClips()
 QVariantMap AnimationControlController::generateMotion(const QString& prompt,
                                                        double duration, bool useModel,
                                                        double armSpaceDeg, bool footPin,
-                                                       int variantIndex)
+                                                       int variantIndex,
+                                                       bool verticalDescent)
 {
     QVariantMap out;
     out["ok"] = false;
@@ -2003,14 +2004,17 @@ QVariantMap AnimationControlController::generateMotion(const QString& prompt,
     // Auto-rigged (no prior animation) meshes that face −Z would walk
     // backward — detect facing from the mesh's foot region.
     const bool yaw180 = AnimationMerger::detectBackwardFacing(entity);
-    const bool verticalDescent = MotionLibrary::isVerticalDescentAction(action);
+    // Descent applies only to non-locomotion actions AND only when the user
+    // left the checkbox on (#838).
+    const bool doDescent =
+        verticalDescent && MotionLibrary::isVerticalDescentAction(action);
     const auto res = AnimationMerger::applyMotionClip(skel.get(), animName, quats, fps,
                                                       worldFrame, cmuRest,
                                                       /*refineWithModel=*/false,
                                                       /*refineStride=*/8, yaw180,
                                                       clipDirs,
                                                       clipSource == QStringLiteral("model"),
-                                                      clipRootY, verticalDescent);
+                                                      clipRootY, doDescent);
     if (!res.ok) return fail(res.error);
     out["source"] = clipSource;
 

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -1837,9 +1837,52 @@ double AnimationControlController::currentArmSpace(const QString& animName,
     return 0.0;
 }
 
+QVariantList AnimationControlController::listMotionClips()
+{
+    QVariantList out;
+    const QString libPath = MotionLibrary::ensureLibraryBlocking();
+    if (libPath.isEmpty()) return out;
+    MotionLibrary lib;
+    if (!lib.loadFromFile(libPath)) return out;
+
+    for (int i = 0; i < lib.clipCount(); ++i) {
+        const MotionLibrary::Clip& c = lib.clip(i);
+        // Human-readable label: "Walk (Zombie)" — Title-case the action, and
+        // the most descriptive segment of the source. Sources look like
+        // "<asset> — <animation>" or, for Quaternius, "Quaternius — <pack> —
+        // <armature>". The first segment is a generic vendor for Quaternius,
+        // so prefer the SECOND (the pack, e.g. "Zombie Animated"); otherwise
+        // use the first (the character/asset name).
+        QString actLabel = c.action;
+        if (!actLabel.isEmpty()) actLabel[0] = actLabel[0].toUpper();
+        const QStringList segs = c.source.split(QStringLiteral("—"));
+        QString asset = segs.value(0).trimmed();
+        if (asset.compare(QStringLiteral("Quaternius"), Qt::CaseInsensitive) == 0
+            && segs.size() > 1) {
+            asset = segs.value(1).trimmed();
+            // "Man Animated - Oct 2017" → "Man" (drop the "Animated"/date tail)
+            asset = asset.section(QStringLiteral(" Animated"), 0, 0).trimmed();
+        }
+        asset.remove('"');
+        if (asset.size() > 34) asset = asset.left(33) + QStringLiteral("…");
+        const QString name = asset.isEmpty()
+            ? actLabel : QStringLiteral("%1  (%2)").arg(actLabel, asset);
+        QVariantMap m;
+        m["index"] = i;
+        m["action"] = c.action;
+        m["name"] = name;
+        m["source"] = c.source;
+        m["quality"] = c.quality;
+        m["frames"] = c.frames;
+        out.append(m);
+    }
+    return out;
+}
+
 QVariantMap AnimationControlController::generateMotion(const QString& prompt,
                                                        double duration, bool useModel,
-                                                       double armSpaceDeg, bool footPin)
+                                                       double armSpaceDeg, bool footPin,
+                                                       int variantIndex)
 {
     QVariantMap out;
     out["ok"] = false;
@@ -1875,6 +1918,10 @@ QVariantMap AnimationControlController::generateMotion(const QString& prompt,
     std::vector<std::array<float, 3>> clipDirs;
     bool gotClip = false;
 
+    // The animation PICKER passes an explicit clip index — force the template
+    // path and that exact clip (no model, no random matchAmong).
+    if (variantIndex >= 0) useModel = false;
+
     if (useModel) {
         const QString mp = MotionGenerator::ensureModelBlocking();
         if (!mp.isEmpty()) {
@@ -1909,10 +1956,18 @@ QVariantMap AnimationControlController::generateMotion(const QString& prompt,
         MotionLibrary lib;
         if (!lib.loadFromFile(libPath))
             return fail(lib.error());
-        const int idx = lib.matchPrompt(prompt, &action);
-        if (idx < 0) {
-            QString known; for (const QString& a : lib.actions()) known += " " + a;
-            return fail(QStringLiteral("No motion matched \"%1\". Try:%2").arg(prompt, known));
+        int idx;
+        if (variantIndex >= 0) {
+            if (variantIndex >= lib.clipCount())
+                return fail(QStringLiteral("Animation index out of range."));
+            idx = variantIndex;
+            action = lib.clip(idx).action;
+        } else {
+            idx = lib.matchPrompt(prompt, &action);
+            if (idx < 0) {
+                QString known; for (const QString& a : lib.actions()) known += " " + a;
+                return fail(QStringLiteral("No motion matched \"%1\". Try:%2").arg(prompt, known));
+            }
         }
         const MotionLibrary::Clip& clip = lib.clip(idx);
         quats = clip.quats; fps = clip.fps;

--- a/src/AnimationControlController.h
+++ b/src/AnimationControlController.h
@@ -349,7 +349,15 @@ public:
                                            double duration = 0.0,
                                            bool useModel = false,
                                            double armSpaceDeg = 0.0,
-                                           bool footPin = true);
+                                           bool footPin = true,
+                                           int variantIndex = -1);
+
+    /// List every clip in the template motion library for the animation
+    /// PICKER (Mixamo-style browse). Each entry is a QVariantMap
+    /// { index, action, name, source, quality, frames } where `name` is a
+    /// human-readable label like "Walk (Tired Character)". Downloads the
+    /// library on first use (blocking). Empty list if unavailable.
+    Q_INVOKABLE QVariantList listMotionClips();
 
     /// #854: Mixamo-style arm-space post-process on an EXISTING animation of
     /// the selected entity. Positive `degrees` widens the arms away from the

--- a/src/AnimationControlController.h
+++ b/src/AnimationControlController.h
@@ -345,12 +345,17 @@ public:
     /// false = the reliable template-clip retarget.
     /// `footPin` (default true) runs the #856 foot-contact cleanup on the
     /// generated clip (contact detection + two-bone IK pinning).
+    /// `verticalDescent` (#838, default true) lets the root lower to the ground
+    /// on non-locomotion crouch/pickup/sit/crawl/death clips (descent-only). It
+    /// helps most such clips but not all (source rigs vary in whether they bake
+    /// hip translation), so it is exposed as a checkbox the user can turn off.
     Q_INVOKABLE QVariantMap generateMotion(const QString& prompt,
                                            double duration = 0.0,
                                            bool useModel = false,
                                            double armSpaceDeg = 0.0,
                                            bool footPin = true,
-                                           int variantIndex = -1);
+                                           int variantIndex = -1,
+                                           bool verticalDescent = true);
 
     /// List every clip in the template motion library for the animation
     /// PICKER (Mixamo-style browse). Each entry is a QVariantMap

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -1177,31 +1177,34 @@ AnimationMerger::extractCanonicalClips(Ogre::Entity* entity, int fps,
         clip.restWorld = std::move(restWorld);
         clip.restDir = std::move(restDir);
 
-        // #838 vertical root descent: per-frame hip Y displacement from the
-        // reference frame f*, in the CANONICAL frame, normalised by the source
-        // leg length (hip→foot at f*). Only Y — X/Z travel is discarded to
-        // avoid skate. Skipped unless both hip and a foot resolved (need a
-        // leg length to normalise by, else the target can't rescale it).
+        // #838 vertical root descent: how far the hip sinks toward the feet as
+        // a CROUCH measure. Sign-safe by construction — we measure the hip's
+        // height ABOVE the foot along the canonical +Y (always ≥ 0), take the
+        // standing height as the MAX across the clip, and report each frame's
+        // DROP below that as a NEGATIVE rootY in leg-lengths. This avoids the
+        // per-rig sign chaos of raw hip-Y translation (some Quaternius rigs
+        // read the hip RISING during pickup/sit) — a genuine crouch always
+        // lowers the hip toward the planted foot regardless of rig axes.
         if (hipBone && footBone && frames > 0) {
-            // Leg length = the MAX hip→foot distance across the clip (the leg
-            // fully extended), NOT the distance at f* — a crouch frame bends
-            // the knee and shrinks hip→ankle, which would over-normalise the
-            // ratio into absurd multi-leg-length drops.
-            float legLen = 0.0f;
-            for (int f = 0; f < frames; ++f)
+            std::vector<float> hipAboveFoot(static_cast<size_t>(frames));
+            float legLen = 0.0f, standH = 0.0f;
+            for (int f = 0; f < frames; ++f) {
+                const Ogre::Vector3 hp = C * hipPos[static_cast<size_t>(f)];
+                const Ogre::Vector3 fp = C * footPos[static_cast<size_t>(f)];
+                hipAboveFoot[static_cast<size_t>(f)] = hp.y - fp.y;   // canon +Y up
+                standH = std::max(standH, hp.y - fp.y);
                 legLen = std::max(legLen,
                     (hipPos[static_cast<size_t>(f)]
                      - footPos[static_cast<size_t>(f)]).length());
-            if (legLen > 1e-3f) {
-                // Canonical-frame Y of the reference hip position.
-                const float refY = (C * hipPos[static_cast<size_t>(fStar)]).y;
+            }
+            if (legLen > 1e-3f && standH > 1e-3f) {
                 clip.rootY.reserve(static_cast<size_t>(frames));
                 for (int f = 0; f < frames; ++f) {
-                    const float y = (C * hipPos[static_cast<size_t>(f)]).y;
-                    // Clamp: a real crouch drops ≤ ~1 leg length; a larger
-                    // value is a capture glitch / mis-resolved foot, not motion.
-                    const float r = std::clamp((y - refY) / legLen, -1.2f, 0.6f);
-                    clip.rootY.push_back(r);
+                    // Drop below standing (≤ 0), in leg-lengths. Clamp to one
+                    // leg length; a deeper value is a mis-resolved foot glitch.
+                    const float drop =
+                        (hipAboveFoot[static_cast<size_t>(f)] - standH) / legLen;
+                    clip.rootY.push_back(std::clamp(drop, -1.0f, 0.0f));
                 }
             }
         }

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -2674,18 +2674,16 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
         verticalDescent && !clipRootY.empty()
         && static_cast<int>(clipRootY.size()) == frames;
     if (doVerticalDescent) {
-        auto derivedYForCanon = [&](int canon) -> std::pair<bool, Ogre::Vector3> {
-            for (int i = 0; i < nBones; ++i)
-                if (boneToCanon[i] == canon)
-                    return {true, skel->getBone(static_cast<unsigned short>(i))
-                                      ->_getDerivedPosition()};
-            return {false, Ogre::Vector3::ZERO};
-        };
-        auto [hasHip, hipP] = derivedYForCanon(0);
-        auto foot = derivedYForCanon(17);
-        if (!foot.first) foot = derivedYForCanon(21);
-        if (hasHip && foot.first)
-            targetLegLen = (hipP - foot.second).length();
+        // Measure the leg length from the BIND pose (readTargetBindFrame resets
+        // + updates the skeleton, then reads derived positions), NOT the live
+        // pose — otherwise a crouched runtime pose would skew the scale.
+        const TargetBindFrame tbd = readTargetBindFrame(skel, boneToCanon);
+        const int hipB  = tbd.roleBoneIdx[0];
+        int footB = tbd.roleBoneIdx[17];
+        if (footB < 0) footB = tbd.roleBoneIdx[21];
+        if (hipB >= 0 && footB >= 0)
+            targetLegLen = (tbd.bindPos[static_cast<size_t>(hipB)]
+                            - tbd.bindPos[static_cast<size_t>(footB)]).length();
     }
 
     for (int i = 0; i < nBones; ++i) {

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -1064,10 +1064,18 @@ AnimationMerger::extractCanonicalClips(Ogre::Entity* entity, int fps,
         const int frames =
             std::max(2, static_cast<int>(std::lround(length * fps)) + 1);
 
-        // Pass 1: sample RAW world orientations per frame per role.
+        // Pass 1: sample RAW world orientations per frame per role, plus the
+        // hip and a foot world POSITION per frame (for #838 vertical descent).
         std::vector<std::vector<Ogre::Quaternion>> raw(
             static_cast<size_t>(frames),
             std::vector<Ogre::Quaternion>(static_cast<size_t>(J)));
+        std::vector<Ogre::Vector3> hipPos(static_cast<size_t>(frames),
+                                          Ogre::Vector3::ZERO);
+        std::vector<Ogre::Vector3> footPos(static_cast<size_t>(frames),
+                                           Ogre::Vector3::ZERO);
+        Ogre::Bone* hipBone = roleBone[0];                 // "hip"
+        Ogre::Bone* footBone = roleBone[17];               // "rfoot"
+        if (!footBone) footBone = roleBone[21];            // "lfoot" fallback
         for (int f = 0; f < frames; ++f) {
             skel->reset(true);
             anim->apply(skel, std::min(length,
@@ -1077,6 +1085,10 @@ AnimationMerger::extractCanonicalClips(Ogre::Entity* entity, int fps,
                 if (Ogre::Bone* b = roleBone[static_cast<size_t>(j)])
                     raw[static_cast<size_t>(f)][static_cast<size_t>(j)] =
                         b->_getDerivedOrientation();
+            if (hipBone)
+                hipPos[static_cast<size_t>(f)] = hipBone->_getDerivedPosition();
+            if (footBone)
+                footPos[static_cast<size_t>(f)] = footBone->_getDerivedPosition();
         }
 
         // Calm reference frame f*: minimum mean joint rotation speed —
@@ -1164,6 +1176,35 @@ AnimationMerger::extractCanonicalClips(Ogre::Entity* entity, int fps,
         clip.frames = static_cast<int>(clip.quats.size());
         clip.restWorld = std::move(restWorld);
         clip.restDir = std::move(restDir);
+
+        // #838 vertical root descent: per-frame hip Y displacement from the
+        // reference frame f*, in the CANONICAL frame, normalised by the source
+        // leg length (hip→foot at f*). Only Y — X/Z travel is discarded to
+        // avoid skate. Skipped unless both hip and a foot resolved (need a
+        // leg length to normalise by, else the target can't rescale it).
+        if (hipBone && footBone && frames > 0) {
+            // Leg length = the MAX hip→foot distance across the clip (the leg
+            // fully extended), NOT the distance at f* — a crouch frame bends
+            // the knee and shrinks hip→ankle, which would over-normalise the
+            // ratio into absurd multi-leg-length drops.
+            float legLen = 0.0f;
+            for (int f = 0; f < frames; ++f)
+                legLen = std::max(legLen,
+                    (hipPos[static_cast<size_t>(f)]
+                     - footPos[static_cast<size_t>(f)]).length());
+            if (legLen > 1e-3f) {
+                // Canonical-frame Y of the reference hip position.
+                const float refY = (C * hipPos[static_cast<size_t>(fStar)]).y;
+                clip.rootY.reserve(static_cast<size_t>(frames));
+                for (int f = 0; f < frames; ++f) {
+                    const float y = (C * hipPos[static_cast<size_t>(f)]).y;
+                    // Clamp: a real crouch drops ≤ ~1 leg length; a larger
+                    // value is a capture glitch / mis-resolved foot, not motion.
+                    const float r = std::clamp((y - refY) / legLen, -1.2f, 0.6f);
+                    clip.rootY.push_back(r);
+                }
+            }
+        }
         out.push_back(std::move(clip));
     }
 
@@ -1949,7 +1990,9 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
     int refineStride,
     bool yaw180,
     const std::vector<std::array<float, 3>>& clipRestDir,
-    bool modelClip)
+    bool modelClip,
+    const std::vector<float>& clipRootY,
+    bool verticalDescent)
 {
     ApplyMotionResult res;
     if (!skel) { res.error = QStringLiteral("no skeleton"); return res; }
@@ -2269,6 +2312,22 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
                         skel->getBone(static_cast<unsigned short>(i)));
                     ++res.tracksWritten;
                 }
+            // #838 vertical descent (bind-referenced path): TARGET leg length
+            // from the bind-pose derived positions (hip role 0 → foot role 17,
+            // else 21), so the clip's leg-normalized rootY scales to this rig.
+            const bool doVerticalDescentBR =
+                verticalDescent && !clipRootY.empty()
+                && static_cast<int>(clipRootY.size()) == frames;
+            float tgtLegLenBR = 0.0f;
+            if (doVerticalDescentBR) {
+                const int hipB = tb.roleBoneIdx[0];
+                int footB = tb.roleBoneIdx[17];
+                if (footB < 0) footB = tb.roleBoneIdx[21];
+                if (hipB >= 0 && footB >= 0)
+                    tgtLegLenBR = (tb.bindPos[static_cast<size_t>(hipB)]
+                                   - tb.bindPos[static_cast<size_t>(footB)])
+                                      .length();
+            }
             std::vector<Ogre::Quaternion> W(static_cast<size_t>(nBones));
             for (int f = 0; f < frames; ++f) {
                 for (int i : tb.order) {
@@ -2321,7 +2380,21 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
                         kf->setRotation(
                             tb.bindLocal[static_cast<size_t>(i)].Inverse()
                             * local);
-                        kf->setTranslate(Ogre::Vector3::ZERO);
+                        Ogre::Vector3 tdelta = Ogre::Vector3::ZERO;
+                        // #838: lower the ROOT (canon 0) by the clip's descent
+                        // (negative rootY only) × target leg length, along the
+                        // canonical UP axis mapped into the rig's world frame.
+                        // The keyframe is a parent-space translate delta; for a
+                        // top-of-hierarchy root the parent frame is world, so
+                        // the canonical-up vector (Ct⁻¹·+Y) is the drop axis.
+                        if (c == 0 && doVerticalDescentBR && tgtLegLenBR > 1e-4f) {
+                            const float drop =
+                                std::min(0.0f, clipRootY[static_cast<size_t>(f)])
+                                * tgtLegLenBR;
+                            tdelta = tb.Ct.Inverse()
+                                     * Ogre::Vector3(0.0f, drop, 0.0f);
+                        }
+                        kf->setTranslate(tdelta);
                         kf->setScale(Ogre::Vector3::UNIT_SCALE);
                     }
                 }
@@ -2541,6 +2614,30 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
             restsAreIdentity = false;
     }
 
+    // #838 vertical descent: TARGET rig hip→foot length (bind pose) so the
+    // clip's source-normalized rootY (leg-lengths) scales to this rig's world
+    // units. Only wired when the caller enabled verticalDescent AND the clip
+    // carries a rootY track (non-locomotion actions). Uses the derived bind
+    // positions of the hip (canon 0) and a foot (canon 17 = left, else 21).
+    float targetLegLen = 0.0f;
+    const bool doVerticalDescent =
+        verticalDescent && !clipRootY.empty()
+        && static_cast<int>(clipRootY.size()) == frames;
+    if (doVerticalDescent) {
+        auto derivedYForCanon = [&](int canon) -> std::pair<bool, Ogre::Vector3> {
+            for (int i = 0; i < nBones; ++i)
+                if (boneToCanon[i] == canon)
+                    return {true, skel->getBone(static_cast<unsigned short>(i))
+                                      ->_getDerivedPosition()};
+            return {false, Ogre::Vector3::ZERO};
+        };
+        auto [hasHip, hipP] = derivedYForCanon(0);
+        auto foot = derivedYForCanon(17);
+        if (!foot.first) foot = derivedYForCanon(21);
+        if (hasHip && foot.first)
+            targetLegLen = (hipP - foot.second).length();
+    }
+
     for (int i = 0; i < nBones; ++i) {
         const int c = boneToCanon[i];
         if (c < 0 || c >= J) continue;       // unmapped bone keeps its bind pose
@@ -2612,7 +2709,24 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
             }
             Ogre::TransformKeyFrame* kf = track->createNodeKeyFrame(f * dt);
             kf->setRotation(local);
-            kf->setTranslate(standPos);
+            Ogre::Vector3 trans = standPos;
+            // #838 vertical descent: lower the ROOT along its parent-local Y by
+            // the clip's normalized hip drop × the target leg length. The hip's
+            // parent-local +Y is the world up axis for an unrotated root, so
+            // this reads as the body crouching straight down. Only the root
+            // (c==0) moves; children follow through the hierarchy.
+            //
+            // DESCENT-ONLY: apply only the negative (lowering) component. Source
+            // rigs vary wildly in whether/which-sign they bake hip translation
+            // for crouch/pickup/sit (some author the whole squat in the KNEE/HIP
+            // joint rotations we already retarget, leaving the hip pinned; a few
+            // read spuriously POSITIVE). Clamping positive to 0 makes this strictly
+            // safe — it can pull a floating crouch down but never lift a grounded
+            // pose up. Genuine descents (working/crawl/death, measured ≤ ~1.8 leg)
+            // still land.
+            if (c == 0 && doVerticalDescent && targetLegLen > 1e-4f)
+                trans.y += std::min(0.0f, clipRootY[f]) * targetLegLen;
+            kf->setTranslate(trans);
             kf->setScale(standScale);
         }
         ++res.tracksWritten;

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -1168,6 +1168,35 @@ AnimationMerger::extractCanonicalClips(Ogre::Entity* entity, int fps,
                 dirBetween(parent, j, restDir[static_cast<size_t>(j)]);
         }
 
+        // Spine-chain sanity (#838): the spine (hip→abdomen→chest→neck→neck1→
+        // head, roles 0..5) is monotonically UPWARD on any humanoid. Some rigs
+        // (e.g. the Samurai dance clip) stack a spine joint BELOW its parent in
+        // bind pose — its bone direction points DOWN the hip→head axis. That
+        // makes the source bone's own frame degenerate/inverted, so the aim-
+        // based retarget folds the chest UNDER the hip and snaps the model in
+        // half. We can't trust that bone's motion, so ZERO its restDir: the
+        // retarget skips it (`squaredLength() <= 1e-8` guard) and the target
+        // bone HOLDS its upright bind pose while the rest of the clip plays.
+        {
+            const Ogre::Bone* hipB  = roleBone[0];
+            const Ogre::Bone* headB = roleBone[5];
+            if (hipB && headB) {
+                Ogre::Vector3 up = C * (headB->_getDerivedPosition()
+                                        - hipB->_getDerivedPosition());
+                if (up.squaredLength() > 1e-9f) {
+                    up.normalise();
+                    for (int j = 1; j <= 4; ++j) {   // abdomen..neck1
+                        auto& d = restDir[static_cast<size_t>(j)];
+                        const Ogre::Vector3 v(d[0], d[1], d[2]);
+                        if (v.squaredLength() > 1e-9f
+                            && v.dotProduct(up) < -0.2f) {   // clearly downward
+                            d = {0.f, 0.f, 0.f};             // drop this bone
+                        }
+                    }
+                }
+            }
+        }
+
         // Pass 2: conjugate the stored raw worlds into the canonical frame.
         clip.quats.reserve(static_cast<size_t>(frames));
         for (int f = 0; f < frames; ++f) {

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -1076,6 +1076,17 @@ AnimationMerger::extractCanonicalClips(Ogre::Entity* entity, int fps,
         Ogre::Bone* hipBone = roleBone[0];                 // "hip"
         Ogre::Bone* footBone = roleBone[17];               // "rfoot"
         if (!footBone) footBone = roleBone[21];            // "lfoot" fallback
+        // Bind-pose (T-pose STANDING) hip + foot positions — the absolute
+        // reference for crouch depth. Using the clip's own max hip-height as
+        // "standing" fails for always-low actions (a crawl never stands, so
+        // relative-to-max reads ~0); the bind pose is the true upright height.
+        Ogre::Vector3 bindHip = Ogre::Vector3::ZERO, bindFoot = Ogre::Vector3::ZERO;
+        {
+            skel->reset(true);
+            skel->_updateTransforms();
+            if (hipBone)  bindHip  = hipBone->_getDerivedPosition();
+            if (footBone) bindFoot = footBone->_getDerivedPosition();
+        }
         for (int f = 0; f < frames; ++f) {
             skel->reset(true);
             anim->apply(skel, std::min(length,
@@ -1186,22 +1197,29 @@ AnimationMerger::extractCanonicalClips(Ogre::Entity* entity, int fps,
         // read the hip RISING during pickup/sit) — a genuine crouch always
         // lowers the hip toward the planted foot regardless of rig axes.
         if (hipBone && footBone && frames > 0) {
+            // Standing reference = the BIND-pose hip height above the foot
+            // (canonical +Y). Absolute, so an always-low crawl still reads a
+            // real drop — but fall back to the clip's own max if the bind pose
+            // is degenerate (hip ≈ foot height, e.g. a T-pose that isn't
+            // upright), so we never divide the descent away.
+            const Ogre::Vector3 bh = C * bindHip;
+            const Ogre::Vector3 bf = C * bindFoot;
+            float standH = bh.y - bf.y;
+            const float legLen = (bindHip - bindFoot).length();
             std::vector<float> hipAboveFoot(static_cast<size_t>(frames));
-            float legLen = 0.0f, standH = 0.0f;
+            float clipMaxH = 0.0f;
             for (int f = 0; f < frames; ++f) {
                 const Ogre::Vector3 hp = C * hipPos[static_cast<size_t>(f)];
                 const Ogre::Vector3 fp = C * footPos[static_cast<size_t>(f)];
-                hipAboveFoot[static_cast<size_t>(f)] = hp.y - fp.y;   // canon +Y up
-                standH = std::max(standH, hp.y - fp.y);
-                legLen = std::max(legLen,
-                    (hipPos[static_cast<size_t>(f)]
-                     - footPos[static_cast<size_t>(f)]).length());
+                hipAboveFoot[static_cast<size_t>(f)] = hp.y - fp.y;
+                clipMaxH = std::max(clipMaxH, hp.y - fp.y);
             }
+            // If the clip ever stands TALLER than the bind pose (bind wasn't a
+            // clean upright T-pose), anchor to the clip max so drops stay ≤ 0.
+            standH = std::max(standH, clipMaxH);
             if (legLen > 1e-3f && standH > 1e-3f) {
                 clip.rootY.reserve(static_cast<size_t>(frames));
                 for (int f = 0; f < frames; ++f) {
-                    // Drop below standing (≤ 0), in leg-lengths. Clamp to one
-                    // leg length; a deeper value is a mis-resolved foot glitch.
                     const float drop =
                         (hipAboveFoot[static_cast<size_t>(f)] - standH) / legLen;
                     clip.rootY.push_back(std::clamp(drop, -1.0f, 0.0f));

--- a/src/AnimationMerger.h
+++ b/src/AnimationMerger.h
@@ -221,7 +221,16 @@ public:
         // them collapses real motion (measured: mouse elbow 180°→124°, total
         // parity 5.1°→3.1° with caps off). So default = relaxed; the model
         // path passes modelClip=true to re-enable the tight caps.
-        bool modelClip = false);
+        bool modelClip = false,
+        // #838 vertical descent: per-frame hip Y offset in SOURCE leg-lengths
+        // (from the library's `rootY`). When non-empty AND verticalDescent is
+        // true (the caller enables it only for non-locomotion actions like
+        // pickup/working/sit/crawl), the root bone's keyframe Y is lowered by
+        // clipRootY[f] × (target rig hip→foot length) so the body actually
+        // crouches instead of running in place. Locomotion clips pass empty /
+        // false to keep the root flat.
+        const std::vector<float>& clipRootY = {},
+        bool verticalDescent = false);
 
     /// One skeletal animation extracted onto the 22-joint canonical skeleton
     /// (#839, the REVERSE of applyMotionClip's world-frame path): per frame,
@@ -250,6 +259,14 @@ public:
         /// same way, so every retargeted bone POINTS where the source bone
         /// points each frame. 22 × [x,y,z]; zero for unresolved roles.
         std::vector<std::array<float, 3>> restDir;
+        /// #838 vertical root descent: per-frame hip VERTICAL displacement
+        /// from the clip's reference frame, NORMALISED by the source rig's
+        /// leg length (so it's proportion-independent — the target scales it
+        /// by its own leg length). Length == `frames`; a value of −0.5 means
+        /// the hip dropped half a leg-length below its reference height (a
+        /// crouch). Only the Y axis is captured — X/Z travel is deliberately
+        /// discarded to avoid skate/drift. Empty when the hip wasn't resolved.
+        std::vector<float> rootY;
     };
 
     /// Post-process a generated animation to widen (+) or tuck (−) the arm

--- a/src/AnimationMerger_test.cpp
+++ b/src/AnimationMerger_test.cpp
@@ -1343,3 +1343,73 @@ TEST_F(AnimationMergerTest, TwistUnwrapKeepsDampedCollarContinuous)
 
     sm->destroyEntity(ent);
 }
+
+TEST_F(AnimationMergerTest, VerticalDescentLowersRootDescentOnly)
+{
+    // #838: a non-locomotion clip carrying a per-frame rootY (hip drop in
+    // leg-lengths) lowers the ROOT bone's keyframe Y by rootY × target-leg-len,
+    // but ONLY the negative (descent) component — positive rootY never lifts.
+    auto skelRes = Ogre::SkeletonManager::getSingleton().create(
+        "descent_skel",
+        Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+    unsigned short h = 0;
+    auto bone = [&](const char* n, const Ogre::Vector3& p, Ogre::Bone* par) {
+        auto* b = skelRes->createBone(n, h++);
+        b->setPosition(p);
+        if (par) par->addChild(b);
+        return b;
+    };
+    // Hips at world Y=1.0; a foot chain reaching down to Y=0 → leg length 1.0.
+    auto* hips = bone("Hips", {0, 1.0f, 0}, nullptr);           // role 0
+    auto* spine = bone("Spine", {0, 0.3f, 0}, hips);
+    bone("Head", {0, 0.4f, 0}, spine);
+    auto* rleg = bone("RightUpLeg", {-0.15f, -0.5f, 0}, hips);
+    bone("RightFoot", {0, -0.5f, 0}, rleg);                    // role 17 → Y=0
+    auto* lleg = bone("LeftUpLeg", {0.15f, -0.5f, 0}, hips);
+    bone("LeftFoot", {0, -0.5f, 0}, lleg);
+    bone("RightArm", {-0.2f, 0.1f, 0}, spine);
+    bone("LeftArm", {0.2f, 0.1f, 0}, spine);
+    skelRes->setBindingPose();
+    auto mesh = createInMemoryMesh("descent_mesh", skelRes);
+    auto* sm = Manager::getSingleton()->getSceneMgr();
+    Ogre::Entity* ent = sm->createEntity("descent_ent", mesh);
+    ASSERT_NE(ent, nullptr);
+    Ogre::SkeletonInstance* skel = ent->getSkeleton();
+
+    const int frames = 3;
+    auto quats = identityClip(frames);   // no rotation — isolate translation
+    // rootY: flat, then −0.5 leg (descend), then +0.4 leg (would rise, clamped)
+    const std::vector<float> rootY = {0.0f, -0.5f, +0.4f};
+
+    const auto res = AnimationMerger::applyMotionClip(
+        skel, "descentclip", quats, 30, /*worldFrame=*/true, srcRestWorld(),
+        false, 8, false, canonRestDirs(), /*modelClip=*/false,
+        rootY, /*verticalDescent=*/true);
+    ASSERT_TRUE(res.ok) << res.error.toStdString();
+
+    // Target leg length here is hip(Y=1) → foot(Y=0) = 1.0, so the descent
+    // frame drops the hip by 0.5 world units; the "rising" frame clamps to 0.
+    auto* anim = skel->getAnimation("descentclip");
+    auto* track = anim->getNodeTrack(hips->getHandle());
+    ASSERT_NE(track, nullptr);
+    const float y0 = track->getNodeKeyFrame(0)->getTranslate().y;
+    const float y1 = track->getNodeKeyFrame(1)->getTranslate().y;
+    const float y2 = track->getNodeKeyFrame(2)->getTranslate().y;
+    EXPECT_NEAR(y1, y0 - 0.5f, 1e-3f) << "descent frame did not lower the hip";
+    EXPECT_NEAR(y2, y0, 1e-3f) << "positive rootY must not lift the hip";
+
+    // Control: a LOCOMOTION clip (verticalDescent=false) keeps the root flat
+    // even when a rootY is present.
+    const auto res2 = AnimationMerger::applyMotionClip(
+        skel, "flatclip", quats, 30, /*worldFrame=*/true, srcRestWorld(),
+        false, 8, false, canonRestDirs(), /*modelClip=*/false,
+        rootY, /*verticalDescent=*/false);
+    ASSERT_TRUE(res2.ok) << res2.error.toStdString();
+    auto* track2 = skel->getAnimation("flatclip")->getNodeTrack(hips->getHandle());
+    ASSERT_NE(track2, nullptr);
+    EXPECT_NEAR(track2->getNodeKeyFrame(1)->getTranslate().y,
+                track2->getNodeKeyFrame(0)->getTranslate().y, 1e-3f)
+        << "locomotion clip must keep a flat root";
+
+    sm->destroyEntity(ent);
+}

--- a/src/AnimationMerger_test.cpp
+++ b/src/AnimationMerger_test.cpp
@@ -1359,20 +1359,37 @@ TEST_F(AnimationMergerTest, VerticalDescentLowersRootDescentOnly)
         if (par) par->addChild(b);
         return b;
     };
-    // Hips at world Y=1.0; a foot chain reaching down to Y=0 → leg length 1.0.
-    auto* hips = bone("Hips", {0, 1.0f, 0}, nullptr);           // role 0
-    auto* spine = bone("Spine", {0, 0.3f, 0}, hips);
-    bone("Head", {0, 0.4f, 0}, spine);
-    // Legs are PURELY VERTICAL (no lateral X offset) so the bind-pose hip→foot
-    // Euclidean distance the retarget uses for targetLegLen is exactly 1.0 —
-    // then rootY=-0.5 maps to an exact -0.5 hip delta (a lateral offset would
-    // make the 3D leg length sqrt(0.15²+1²)≈1.011 and skew the expectation).
-    auto* rleg = bone("RightUpLeg", {0, -0.5f, 0}, hips);
-    bone("RightFoot", {0, -0.5f, 0}, rleg);                    // role 17 → Y=0
-    auto* lleg = bone("LeftUpLeg", {0, -0.5f, 0}, hips);
-    bone("LeftFoot", {0, -0.5f, 0}, lleg);
-    bone("RightArm", {-0.2f, 0.1f, 0}, spine);
-    bone("LeftArm", {0.2f, 0.1f, 0}, spine);
+    // A FULL humanoid bone set — applyMotionClip rejects a rig that resolves
+    // fewer than ~half of the 22 canonical roles ("not a humanoid rig"), so the
+    // minimal 9-bone skeleton isn't enough. Mixamo-style names map onto the
+    // canonical roles (hip/spine/chest/neck/head, collar/shoulder/elbow/hand,
+    // upleg/leg/foot per side).
+    // Hips at world Y=1.0; each leg chain reaches down to Y=0 → leg length 1.0.
+    // Legs are PURELY VERTICAL (no lateral X) so the bind-pose hip→foot
+    // Euclidean distance the retarget scales by is exactly 1.0 — then rootY=-0.5
+    // maps to an exact -0.5 hip delta (a lateral offset would make the 3D leg
+    // length sqrt(0.15²+1²)≈1.011 and skew the expectation).
+    auto* hips  = bone("Hips",  {0, 1.0f, 0}, nullptr);        // role 0
+    auto* spine = bone("Spine", {0, 0.2f, 0}, hips);           // role 1 (abdomen)
+    auto* chest = bone("Spine1", {0, 0.2f, 0}, spine);         // role 2 (chest)
+    auto* neck  = bone("Neck",  {0, 0.2f, 0}, chest);          // role 3
+    bone("Head", {0, 0.15f, 0}, neck);                         // role 5
+    // Arms: Shoulder(collar) → Arm(shoulder) → ForeArm(elbow) → Hand.
+    auto* rsh = bone("RightShoulder", {-0.05f, 0.1f, 0}, chest);
+    auto* rarm = bone("RightArm", {-0.15f, 0, 0}, rsh);
+    auto* rfa = bone("RightForeArm", {-0.25f, 0, 0}, rarm);
+    bone("RightHand", {-0.2f, 0, 0}, rfa);
+    auto* lsh = bone("LeftShoulder", {0.05f, 0.1f, 0}, chest);
+    auto* larm = bone("LeftArm", {0.15f, 0, 0}, lsh);
+    auto* lfa = bone("LeftForeArm", {0.25f, 0, 0}, larm);
+    bone("LeftHand", {0.2f, 0, 0}, lfa);
+    // Legs: UpLeg(hip) → Leg(knee) → Foot.
+    auto* rleg = bone("RightUpLeg", {0, -0.25f, 0}, hips);
+    auto* rknee = bone("RightLeg", {0, -0.25f, 0}, rleg);
+    bone("RightFoot", {0, -0.5f, 0}, rknee);                   // role 17 → Y=0
+    auto* lleg = bone("LeftUpLeg", {0, -0.25f, 0}, hips);
+    auto* lknee = bone("LeftLeg", {0, -0.25f, 0}, lleg);
+    bone("LeftFoot", {0, -0.5f, 0}, lknee);                    // role 21 → Y=0
     skelRes->setBindingPose();
     auto mesh = createInMemoryMesh("descent_mesh", skelRes);
     auto* sm = Manager::getSingleton()->getSceneMgr();

--- a/src/AnimationMerger_test.cpp
+++ b/src/AnimationMerger_test.cpp
@@ -1363,9 +1363,13 @@ TEST_F(AnimationMergerTest, VerticalDescentLowersRootDescentOnly)
     auto* hips = bone("Hips", {0, 1.0f, 0}, nullptr);           // role 0
     auto* spine = bone("Spine", {0, 0.3f, 0}, hips);
     bone("Head", {0, 0.4f, 0}, spine);
-    auto* rleg = bone("RightUpLeg", {-0.15f, -0.5f, 0}, hips);
+    // Legs are PURELY VERTICAL (no lateral X offset) so the bind-pose hip→foot
+    // Euclidean distance the retarget uses for targetLegLen is exactly 1.0 —
+    // then rootY=-0.5 maps to an exact -0.5 hip delta (a lateral offset would
+    // make the 3D leg length sqrt(0.15²+1²)≈1.011 and skew the expectation).
+    auto* rleg = bone("RightUpLeg", {0, -0.5f, 0}, hips);
     bone("RightFoot", {0, -0.5f, 0}, rleg);                    // role 17 → Y=0
-    auto* lleg = bone("LeftUpLeg", {0.15f, -0.5f, 0}, hips);
+    auto* lleg = bone("LeftUpLeg", {0, -0.5f, 0}, hips);
     bone("LeftFoot", {0, -0.5f, 0}, lleg);
     bone("RightArm", {-0.2f, 0.1f, 0}, spine);
     bone("LeftArm", {0.2f, 0.1f, 0}, spine);

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -2405,7 +2405,13 @@ int CLIPipeline::cmdAnim(int argc, char* argv[])
         // --variant N: curation harness — render a SPECIFIC template clip index
         // (from `qtmesh anim <file> --list-variants`) instead of the random pick.
         if (arg == "--variant" && i + 1 < argc) {
-            generateVariant = QString(argv[++i]).toInt();
+            bool ok = false;
+            const int variant = QString(argv[++i]).toInt(&ok);
+            if (!ok || variant < 0) {
+                err() << "Error: --variant requires a non-negative integer." << Qt::endl;
+                return 2;
+            }
+            generateVariant = variant;
             continue;
         }
         if (arg == "--duration" && i + 1 < argc) {

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -2049,7 +2049,7 @@ int CLIPipeline::cmdAnimGenerate(const QString& filePath, const QString& prompt,
                                  float duration, const QString& outputPath,
                                  bool jsonOutput, bool useModel,
                                  float armSpaceDeg, bool footPin,
-                                 int smoothFps)
+                                 int smoothFps, int variantIndex)
 {
     // #411 text-to-motion (template-clip MVP): match the prompt to a permissive
     // CMU motion clip from the downloadable library, retarget it onto the mesh's
@@ -2123,7 +2123,21 @@ int CLIPipeline::cmdAnimGenerate(const QString& filePath, const QString& prompt,
         if (!lib.loadFromFile(libPath)) {
             err() << "Error: " << lib.error() << Qt::endl; return 1;
         }
-        const int idx = lib.matchPrompt(prompt, &action);
+        // Curation harness (#838): --variant N forces a SPECIFIC clip index,
+        // bypassing the quality-weighted random pick, so every variant of an
+        // action can be rendered and reviewed one-by-one.
+        int idx;
+        if (variantIndex >= 0) {
+            if (variantIndex >= lib.clipCount()) {
+                err() << "Error: --variant " << variantIndex << " out of range (0.."
+                      << (lib.clipCount() - 1) << ")." << Qt::endl;
+                return 1;
+            }
+            idx = variantIndex;
+            action = lib.clip(idx).action;
+        } else {
+            idx = lib.matchPrompt(prompt, &action);
+        }
         if (idx < 0) {
             err() << "Error: no motion matched \"" << prompt << "\". Known actions:";
             for (const QString& a : lib.actions()) err() << " " << a;
@@ -2267,6 +2281,7 @@ int CLIPipeline::cmdAnim(int argc, char* argv[])
     QString generatePrompt;           // --generate "<prompt>"
     float generateDuration = 0.0f;    // --duration N (seconds; 0 = clip's native length)
     bool generateUseModel = false;    // --model → experimental trained t2m model (template fallback)
+    int generateVariant = -1;         // --variant N → force a specific template clip index (curation)
     float armSpaceDeg = 0.0f;         // #854: Mixamo-style arm-space swing (degrees)
     bool armSpaceSet = false;         // --arm-space given (standalone post-adjust)
     bool generateFootPin = true;      // #856: pin feet after --generate (default ON)
@@ -2374,6 +2389,12 @@ int CLIPipeline::cmdAnim(int argc, char* argv[])
         // text-to-motion model for --generate; falls back to the template library
         // automatically if the model is unavailable.
         if (arg == "--model" && generateMode) { generateUseModel = true; continue; }
+        // --variant N: curation harness — render a SPECIFIC template clip index
+        // (from `qtmesh anim <file> --list-variants`) instead of the random pick.
+        if (arg == "--variant" && i + 1 < argc) {
+            generateVariant = QString(argv[++i]).toInt();
+            continue;
+        }
         if (arg == "--duration" && i + 1 < argc) {
             generateDuration = QString(argv[++i]).toFloat();
             continue;
@@ -2491,7 +2512,7 @@ int CLIPipeline::cmdAnim(int argc, char* argv[])
         return cmdAnimGenerate(filePath, generatePrompt, generateDuration,
                                outputPath.isEmpty() ? filePath : outputPath, jsonOutput,
                                generateUseModel, armSpaceDeg, generateFootPin,
-                               generateSmoothFps);
+                               generateSmoothFps, generateVariant);
     }
 
     // #837 parity harness: apply a canonical clip JSON through the pure

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -2049,7 +2049,8 @@ int CLIPipeline::cmdAnimGenerate(const QString& filePath, const QString& prompt,
                                  float duration, const QString& outputPath,
                                  bool jsonOutput, bool useModel,
                                  float armSpaceDeg, bool footPin,
-                                 int smoothFps, int variantIndex)
+                                 int smoothFps, int variantIndex,
+                                 bool verticalDescent)
 {
     // #411 text-to-motion (template-clip MVP): match the prompt to a permissive
     // CMU motion clip from the downloadable library, retarget it onto the mesh's
@@ -2195,7 +2196,8 @@ int CLIPipeline::cmdAnimGenerate(const QString& filePath, const QString& prompt,
                                                 clipDirs,
                                                 clipSource == QStringLiteral("model"),
                                                 clipRootY,
-                                                MotionLibrary::isVerticalDescentAction(action));
+                                                verticalDescent
+                                                && MotionLibrary::isVerticalDescentAction(action));
     if (!res.ok) {
         err() << "Error: " << res.error << Qt::endl; return 1;
     }
@@ -2296,6 +2298,7 @@ int CLIPipeline::cmdAnim(int argc, char* argv[])
     bool armSpaceSet = false;         // --arm-space given (standalone post-adjust)
     bool generateFootPin = true;      // #856: pin feet after --generate (default ON)
     bool footPinSet = false;          // --foot-pin given (standalone post-process)
+    bool generateDescent = true;      // #838: lower body on crouch/pickup (default ON)
     int  generateSmoothFps = 12;      // #837: sparse-bake low-pass (0 = off)
     bool jsonOutput = false;
     int resampleCount = 0;
@@ -2419,6 +2422,9 @@ int CLIPipeline::cmdAnim(int argc, char* argv[])
         // EXISTING animation (standalone, needs --animation).
         if (arg == "--no-foot-pin") { generateFootPin = false; continue; }
         if (arg == "--foot-pin") { footPinSet = true; continue; }
+        // #838 vertical descent: lower the body on crouch/pickup/sit/crawl/
+        // death clips (default ON); --no-descent keeps the root flat.
+        if (arg == "--no-descent") { generateDescent = false; continue; }
         // #837 smooth-bake post-pass on --generate: bake sparse then back to
         // the clip rate (temporal low-pass, kills retarget trembling).
         if (arg == "--no-smooth-bake") { generateSmoothFps = 0; continue; }
@@ -2522,7 +2528,7 @@ int CLIPipeline::cmdAnim(int argc, char* argv[])
         return cmdAnimGenerate(filePath, generatePrompt, generateDuration,
                                outputPath.isEmpty() ? filePath : outputPath, jsonOutput,
                                generateUseModel, armSpaceDeg, generateFootPin,
-                               generateSmoothFps, generateVariant);
+                               generateSmoothFps, generateVariant, generateDescent);
     }
 
     // #837 parity harness: apply a canonical clip JSON through the pure

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -2071,6 +2071,7 @@ int CLIPipeline::cmdAnimGenerate(const QString& filePath, const QString& prompt,
     bool worldFrame = false;
     std::vector<std::array<float, 4>> cmuRest;   // template-only (model has none)
     std::vector<std::array<float, 3>> clipDirs;
+    std::vector<float> clipRootY;              // #838 non-locomotion hip drop
     QString clipSource;
 
     bool gotClip = false;
@@ -2151,16 +2152,23 @@ int CLIPipeline::cmdAnimGenerate(const QString& filePath, const QString& prompt,
         cmuRest = clip.restWorld.empty() ? lib.cmuRestWorld()
                                          : clip.restWorld;
         clipDirs = clip.restDir;
+        clipRootY = clip.rootY;
         clipSource = QStringLiteral("template");
         // Optionally retime the clip to a requested duration by frame stride/pad.
         if (duration > 0.05f) {
             const int want = std::max(2, int(duration * clip.fps));
             std::vector<std::vector<std::array<float, 4>>> retimed(want);
+            std::vector<float> retimedY;
+            const bool hadY = static_cast<int>(clipRootY.size()) == clip.frames;
+            if (hadY) retimedY.resize(want);
             for (int f = 0; f < want; ++f) {
                 const float src = (clip.frames - 1) * (float(f) / float(want - 1));
-                retimed[f] = quats[std::min(clip.frames - 1, int(src + 0.5f))];
+                const int si = std::min(clip.frames - 1, int(src + 0.5f));
+                retimed[f] = quats[si];
+                if (hadY) retimedY[f] = clipRootY[si];
             }
             quats.swap(retimed);
+            if (hadY) clipRootY.swap(retimedY);
         }
     }
 
@@ -2185,7 +2193,9 @@ int CLIPipeline::cmdAnimGenerate(const QString& filePath, const QString& prompt,
                                                 /*refineWithModel=*/false,
                                                 /*refineStride=*/8, yaw180,
                                                 clipDirs,
-                                                clipSource == QStringLiteral("model"));
+                                                clipSource == QStringLiteral("model"),
+                                                clipRootY,
+                                                MotionLibrary::isVerticalDescentAction(action));
     if (!res.ok) {
         err() << "Error: " << res.error << Qt::endl; return 1;
     }
@@ -2893,6 +2903,14 @@ int CLIPipeline::cmdAnim(int argc, char* argv[])
                 dirs.append(vec);
             }
             co["restDir"] = dirs;
+            // #838 vertical root descent: per-frame normalised hip Y offset.
+            if (!c.rootY.empty()) {
+                QJsonArray ry;
+                for (float v : c.rootY)
+                    ry.append(static_cast<double>(
+                        std::round(v * 100000.0f) / 100000.0f));
+                co["rootY"] = ry;
+            }
             clipArr.append(co);
         }
         root["clips"] = clipArr;

--- a/src/CLIPipeline.h
+++ b/src/CLIPipeline.h
@@ -94,7 +94,7 @@ public:
                                float duration, const QString& outputPath,
                                bool jsonOutput, bool useModel = false,
                                float armSpaceDeg = 0.0f, bool footPin = true,
-                               int smoothFps = 12);
+                               int smoothFps = 12, int variantIndex = -1);
     static int cmdValidate(int argc, char* argv[]);
     static int cmdLod(int argc, char* argv[]);
     static int cmdPose(int argc, char* argv[]);

--- a/src/CLIPipeline.h
+++ b/src/CLIPipeline.h
@@ -94,7 +94,8 @@ public:
                                float duration, const QString& outputPath,
                                bool jsonOutput, bool useModel = false,
                                float armSpaceDeg = 0.0f, bool footPin = true,
-                               int smoothFps = 12, int variantIndex = -1);
+                               int smoothFps = 12, int variantIndex = -1,
+                               bool verticalDescent = true);
     static int cmdValidate(int argc, char* argv[]);
     static int cmdLod(int argc, char* argv[]);
     static int cmdPose(int argc, char* argv[]);

--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -4207,6 +4207,7 @@ QJsonObject MCPServer::toolGenerateMotion(const QJsonObject &args)
         int fps = 30; bool worldFrame = false;
         std::vector<std::array<float, 4>> cmuRest;
         std::vector<std::array<float, 3>> clipDirs;
+        std::vector<float> clipRootY;          // #838 non-locomotion hip drop
         bool gotClip = false;
 
         if (useModel) {
@@ -4252,15 +4253,22 @@ QJsonObject MCPServer::toolGenerateMotion(const QJsonObject &args)
             cmuRest = clip.restWorld.empty() ? lib.cmuRestWorld()
                                              : clip.restWorld;
             clipDirs = clip.restDir;
+            clipRootY = clip.rootY;
             clipSource = QStringLiteral("template");
             if (duration > 0.05) {
                 const int want = std::max(2, int(duration * clip.fps));
                 std::vector<std::vector<std::array<float,4>>> retimed(want);
+                std::vector<float> retimedY;
+                const bool hadY = static_cast<int>(clipRootY.size()) == clip.frames;
+                if (hadY) retimedY.resize(want);
                 for (int f = 0; f < want; ++f) {
                     const float src = (clip.frames - 1) * (float(f) / float(want - 1));
-                    retimed[f] = quats[std::min(clip.frames - 1, int(src + 0.5f))];
+                    const int si = std::min(clip.frames - 1, int(src + 0.5f));
+                    retimed[f] = quats[si];
+                    if (hadY) retimedY[f] = clipRootY[si];
                 }
                 quats.swap(retimed);
+                if (hadY) clipRootY.swap(retimedY);
             }
         }
 
@@ -4273,7 +4281,9 @@ QJsonObject MCPServer::toolGenerateMotion(const QJsonObject &args)
                                                         /*refineWithModel=*/false,
                                                         /*refineStride=*/8, yaw180,
                                                         clipDirs,
-                                                        clipSource == QStringLiteral("model"));
+                                                        clipSource == QStringLiteral("model"),
+                                                        clipRootY,
+                                                        MotionLibrary::isVerticalDescentAction(action));
         if (!r.ok) return makeErrorResult(QString("Error: %1").arg(r.error));
 
         // #837 quality post-pass (ON by default): sparse-bake temporal

--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -4283,7 +4283,8 @@ QJsonObject MCPServer::toolGenerateMotion(const QJsonObject &args)
                                                         clipDirs,
                                                         clipSource == QStringLiteral("model"),
                                                         clipRootY,
-                                                        MotionLibrary::isVerticalDescentAction(action));
+                                                        args.value("vertical_descent").toBool(true)
+                                                        && MotionLibrary::isVerticalDescentAction(action));
         if (!r.ok) return makeErrorResult(QString("Error: %1").arg(r.error));
 
         // #837 quality post-pass (ON by default): sparse-bake temporal
@@ -8865,6 +8866,7 @@ QJsonArray MCPServer::buildToolsList()
         props["foot_pin"] = QJsonObject{{"type", "boolean"}, {"description", "Foot-contact cleanup (#856): detect ground-contact spans and IK-pin the feet so they plant instead of skating. Default true; set false to keep the raw retarget."}};
         props["smooth_bake"] = QJsonObject{{"type", "boolean"}, {"description", "Temporal low-pass post-pass: bake the clip sparse then back to its native rate, removing retarget trembling. Default true."}};
         props["smooth_fps"] = QJsonObject{{"type", "number"}, {"description", "Sparse keyframe rate for the smooth-bake pass. Lower = smoother but softer motion. Default 12."}};
+        props["vertical_descent"] = QJsonObject{{"type", "boolean"}, {"description", "Lower the body to the ground on non-locomotion crouch/pickup/sit/crawl/death clips (#838, descent-only). Default true; set false to keep the root at standing height when the descent over-sinks on a given clip. No effect on locomotion actions."}};
         appendTool(
             "generate_motion",
             "AI text-to-motion (#411, experimental): generate a skeletal animation from a text prompt and "

--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -4181,8 +4181,16 @@ QJsonObject MCPServer::toolGenerateMotion(const QJsonObject &args)
         if (!mgr) return makeErrorResult("Error: Manager not available");
 
         const QString prompt = args.value("prompt").toString();
-        if (prompt.trimmed().isEmpty())
-            return makeErrorResult("Error: 'prompt' is required (e.g. \"walking\").");
+        // #838: a variant_index selects an EXACT curated clip (parity with the
+        // CLI --variant flag and the GUI picker), forcing the template path.
+        // prompt is then optional; without either, we can't pick a clip.
+        const bool hasVariant = args.contains("variant_index");
+        const int variantIndex = hasVariant
+            ? args.value("variant_index").toInt(-1) : -1;
+        if (hasVariant && variantIndex < 0)
+            return makeErrorResult("Error: 'variant_index' must be a non-negative integer.");
+        if (!hasVariant && prompt.trimmed().isEmpty())
+            return makeErrorResult("Error: 'prompt' is required (e.g. \"walking\") unless 'variant_index' is given.");
 
         QString entityName = args["entity_name"].toString();
         Ogre::Entity* entity = nullptr;
@@ -4198,7 +4206,8 @@ QJsonObject MCPServer::toolGenerateMotion(const QJsonObject &args)
         Ogre::SkeletonPtr skel = entity->getMesh()->getSkeleton();
 
         const double duration = args.value("duration").toDouble(0.0);
-        const bool useModel = args.value("model").toBool(false);
+        // A variant_index forces the template path (no model, no random match).
+        const bool useModel = !hasVariant && args.value("model").toBool(false);
 
         // Acquire the canonical clip: EXPERIMENTAL trained model first (when
         // model:true), else the reliable TEMPLATE library (also the fallback).
@@ -4241,11 +4250,20 @@ QJsonObject MCPServer::toolGenerateMotion(const QJsonObject &args)
             MotionLibrary lib;
             if (!lib.loadFromFile(libPath))
                 return makeErrorResult(QString("Error: %1").arg(lib.error()));
-            const int idx = lib.matchPrompt(prompt, &action);
-            if (idx < 0) {
-                QString known; for (const QString& a : lib.actions()) known += " " + a;
-                return makeErrorResult(QString("Error: no motion matched \"%1\". Known actions:%2")
-                                           .arg(prompt, known));
+            int idx;
+            if (hasVariant) {
+                if (variantIndex >= lib.clipCount())
+                    return makeErrorResult(QString("Error: variant_index %1 out of range (0..%2)")
+                                               .arg(variantIndex).arg(lib.clipCount() - 1));
+                idx = variantIndex;
+                action = lib.clip(idx).action;
+            } else {
+                idx = lib.matchPrompt(prompt, &action);
+                if (idx < 0) {
+                    QString known; for (const QString& a : lib.actions()) known += " " + a;
+                    return makeErrorResult(QString("Error: no motion matched \"%1\". Known actions:%2")
+                                               .arg(prompt, known));
+                }
             }
             const MotionLibrary::Clip& clip = lib.clip(idx);
             quats = clip.quats; fps = clip.fps;
@@ -8867,16 +8885,18 @@ QJsonArray MCPServer::buildToolsList()
         props["smooth_bake"] = QJsonObject{{"type", "boolean"}, {"description", "Temporal low-pass post-pass: bake the clip sparse then back to its native rate, removing retarget trembling. Default true."}};
         props["smooth_fps"] = QJsonObject{{"type", "number"}, {"description", "Sparse keyframe rate for the smooth-bake pass. Lower = smoother but softer motion. Default 12."}};
         props["vertical_descent"] = QJsonObject{{"type", "boolean"}, {"description", "Lower the body to the ground on non-locomotion crouch/pickup/sit/crawl/death clips (#838, descent-only). Default true; set false to keep the root at standing height when the descent over-sinks on a given clip. No effect on locomotion actions."}};
+        props["variant_index"] = QJsonObject{{"type", "integer"}, {"description", "Select an EXACT clip from the library by index (parity with CLI --variant / the GUI picker) instead of keyword-matching a prompt. Forces the template path. When given, 'prompt' is optional. Out-of-range indices error."}};
         appendTool(
             "generate_motion",
             "AI text-to-motion (#411, experimental): generate a skeletal animation from a text prompt and "
             "retarget it onto a rigged mesh. MVP approach — matches the prompt to a curated, permissively-"
             "licensed motion clip (CMU MoCap) and retargets it onto the skeleton via the canonical-joint "
-            "mapping (same as #409). The clip library downloads on first use. Requires a humanoid rig; reports "
-            "which action matched and how many bones/joints were retargeted. (Not generative diffusion — see "
+            "mapping (same as #409). Pass 'variant_index' to pick an exact clip deterministically. The clip "
+            "library downloads on first use. Requires a humanoid rig; reports which action matched and how "
+            "many bones/joints were retargeted. (Not generative diffusion — see "
             "docs/TEXT_TO_MOTION_SPIKE_411.md for why the template approach ships first.)",
             props,
-            QJsonArray{"prompt"}
+            QJsonArray{}   // neither prompt nor variant_index is unconditionally required; handler validates
         );
     }
 

--- a/src/MotionLibrary.cpp
+++ b/src/MotionLibrary.cpp
@@ -12,6 +12,7 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QSet>
 #include <QSettings>
 #include <QStandardPaths>
 #include <QTimer>
@@ -158,6 +159,12 @@ bool MotionLibrary::parse(const QByteArray& json)
                     static_cast<float>(v.at(1).toDouble()),
                     static_cast<float>(v.at(2).toDouble())});
             }
+        }
+        const QJsonArray rootYArr = co.value("rootY").toArray();
+        if (rootYArr.size() == clip.frames) {
+            clip.rootY.reserve(clip.frames);
+            for (const auto& yv : rootYArr)
+                clip.rootY.push_back(static_cast<float>(yv.toDouble()));
         }
         clip.quality = static_cast<float>(
             std::clamp(co.value("quality").toDouble(1.0), 0.0, 1.0));
@@ -333,4 +340,18 @@ std::vector<std::array<float, 3>> MotionLibrary::referenceDirsForPrompt(
         }
     }
     return best ? best->restDir : std::vector<std::array<float, 3>>{};
+}
+
+bool MotionLibrary::isVerticalDescentAction(const QString& action)
+{
+    // Non-locomotion actions whose motion lowers the torso. Walk/run/jump/
+    // dance/etc. keep a flat root (the retarget locks the hip to the stand
+    // pose). Kept deliberately small + explicit — matched on the canonical
+    // action label the library builder folds prompts down to.
+    static const QSet<QString> kDescent = {
+        QStringLiteral("pickup"), QStringLiteral("working"),
+        QStringLiteral("sit"),    QStringLiteral("crawl"),
+        QStringLiteral("death"),  QStringLiteral("pray"),
+    };
+    return kDescent.contains(action.trimmed().toLower());
 }

--- a/src/MotionLibrary.cpp
+++ b/src/MotionLibrary.cpp
@@ -351,7 +351,8 @@ bool MotionLibrary::isVerticalDescentAction(const QString& action)
     static const QSet<QString> kDescent = {
         QStringLiteral("pickup"), QStringLiteral("working"),
         QStringLiteral("sit"),    QStringLiteral("crawl"),
-        QStringLiteral("death"),  QStringLiteral("pray"),
+        QStringLiteral("crouch"), QStringLiteral("death"),
+        QStringLiteral("pray"),
     };
     return kDescent.contains(action.trimmed().toLower());
 }

--- a/src/MotionLibrary.h
+++ b/src/MotionLibrary.h
@@ -44,12 +44,15 @@ public:
         // Optional: canonical-frame bind bone directions (22 × [x,y,z]) —
         // enables the direction-aligned bind-referenced retarget.
         std::vector<std::array<float, 3>> restDir;
-        // Optional (#838 vertical descent): per-frame hip vertical offset in
-        // LEG-LENGTHS (canonical-frame hip Y minus the window's first frame,
-        // normalized by the source hip→foot distance), size == frames. The
-        // retarget scales this by the TARGET rig's leg length and writes it to
-        // the root bone's Y so crouch/pickup/working actually lower the body
-        // instead of running in place. Empty → flat root (locomotion clips).
+        // Optional (#838 vertical descent): per-frame crouch DEPTH in
+        // LEG-LENGTHS (≤ 0), preserving BIND-POSE-relative hip height — a clip
+        // that opens already crouched keeps its lowered value (NOT re-based to
+        // the window's first frame), so always-low actions like crawl stay
+        // down. Measured as the hip's height above the foot minus the rig's
+        // bind-pose standing height, normalized by the source hip→foot
+        // distance; size == frames. The retarget scales it by the TARGET rig's
+        // leg length and lowers the root bone's Y (descent-only) so crouch/
+        // pickup/working actually sink. Empty → flat root (locomotion clips).
         std::vector<float> rootY;
         /// Curation score 0..1 from the library builder (#855) — take
         /// selection samples proportionally to quality². Absent → 1.0.

--- a/src/MotionLibrary.h
+++ b/src/MotionLibrary.h
@@ -44,6 +44,13 @@ public:
         // Optional: canonical-frame bind bone directions (22 × [x,y,z]) —
         // enables the direction-aligned bind-referenced retarget.
         std::vector<std::array<float, 3>> restDir;
+        // Optional (#838 vertical descent): per-frame hip vertical offset in
+        // LEG-LENGTHS (canonical-frame hip Y minus the window's first frame,
+        // normalized by the source hip→foot distance), size == frames. The
+        // retarget scales this by the TARGET rig's leg length and writes it to
+        // the root bone's Y so crouch/pickup/working actually lower the body
+        // instead of running in place. Empty → flat root (locomotion clips).
+        std::vector<float> rootY;
         /// Curation score 0..1 from the library builder (#855) — take
         /// selection samples proportionally to quality². Absent → 1.0.
         float quality = 1.0f;
@@ -104,6 +111,12 @@ public:
     // returns empty when unavailable — callers then keep the harvest path.
     static std::vector<std::array<float, 3>> referenceDirsForPrompt(
         const QString& prompt);
+
+    // #838 vertical descent: true for NON-LOCOMOTION actions whose motion
+    // lowers the body (pickup / working / sit / crawl / death / pray). For
+    // these the retarget applies the clip's `rootY` so the body actually
+    // crouches; locomotion (walk/run/jump/…) keeps a flat root (returns false).
+    static bool isVerticalDescentAction(const QString& action);
 
 private:
     bool parse(const QByteArray& json);

--- a/src/MotionLibrary_test.cpp
+++ b/src/MotionLibrary_test.cpp
@@ -132,6 +132,44 @@ TEST(MotionLibrary, ParsesPerClipRestWorldAndRestDir)
     EXPECT_EQ(lib2.clipCount(), 2);
 }
 
+TEST(MotionLibrary, ParsesPerClipRootY)
+{
+    // #838 vertical descent: a clip may carry a per-frame `rootY` (hip drop in
+    // leg-lengths, size == frames). Absent → empty; present-and-correct-size →
+    // parsed; wrong size → ignored.
+    MotionLibrary plain;
+    ASSERT_TRUE(plain.loadFromJson(miniLib())) << plain.error().toStdString();
+    EXPECT_TRUE(plain.clip(0).rootY.empty());
+
+    QByteArray good = miniLib();                  // 2 frames → 2 rootY entries
+    good.insert(good.indexOf("\"quats\""), "\"rootY\":[0.0,-0.5],");
+    MotionLibrary lib;
+    ASSERT_TRUE(lib.loadFromJson(good)) << lib.error().toStdString();
+    ASSERT_EQ(lib.clip(0).rootY.size(), 2u);
+    EXPECT_NEAR(lib.clip(0).rootY[1], -0.5f, 1e-6f);
+    EXPECT_TRUE(lib.clip(1).rootY.empty());       // only the walk clip got it
+
+    QByteArray bad = miniLib();                   // size mismatch (1 != 2) → drop
+    bad.insert(bad.indexOf("\"quats\""), "\"rootY\":[-0.3],");
+    MotionLibrary lib2;
+    ASSERT_TRUE(lib2.loadFromJson(bad)) << lib2.error().toStdString();
+    EXPECT_TRUE(lib2.clip(0).rootY.empty());
+}
+
+TEST(MotionLibrary, VerticalDescentActionClassification)
+{
+    // Non-locomotion crouch/lower actions descend; locomotion stays flat.
+    EXPECT_TRUE(MotionLibrary::isVerticalDescentAction("pickup"));
+    EXPECT_TRUE(MotionLibrary::isVerticalDescentAction("working"));
+    EXPECT_TRUE(MotionLibrary::isVerticalDescentAction("sit"));
+    EXPECT_TRUE(MotionLibrary::isVerticalDescentAction("crawl"));
+    EXPECT_TRUE(MotionLibrary::isVerticalDescentAction(" Death "));  // trim+lower
+    EXPECT_FALSE(MotionLibrary::isVerticalDescentAction("walk"));
+    EXPECT_FALSE(MotionLibrary::isVerticalDescentAction("run"));
+    EXPECT_FALSE(MotionLibrary::isVerticalDescentAction("jump"));
+    EXPECT_FALSE(MotionLibrary::isVerticalDescentAction(""));
+}
+
 TEST(MotionLibrary, ParsesQualityAndDefaultsToOne)
 {
     MotionLibrary plain;

--- a/src/qml_resources.qrc
+++ b/src/qml_resources.qrc
@@ -12,6 +12,7 @@
     <file alias="UvUnwrapDialog.qml">../qml/UvUnwrapDialog.qml</file>
     <file alias="QuadRetopoDialog.qml">../qml/QuadRetopoDialog.qml</file>
     <file alias="SkinWeightsDialog.qml">../qml/SkinWeightsDialog.qml</file>
+    <file alias="AnimationPickerDialog.qml">../qml/AnimationPickerDialog.qml</file>
     <file alias="RemoveBoneDialog.qml">../qml/RemoveBoneDialog.qml</file>
     <file alias="RenameBoneDialog.qml">../qml/RenameBoneDialog.qml</file>
     <file alias="ReparentBoneDialog.qml">../qml/ReparentBoneDialog.qml</file>


### PR DESCRIPTION
## Summary

Stacked on #919 (locomotion cull gate). Two things, both driven by hands-on review of every library variant:

### 1. Library curation (`build-motion-library-v5.py`)
Dropped clips by **license**, **bad retarget**, and **user review**:
- **Mixamo-derived** clips (`MIXAMO_MARKERS`) — a Sketchfab CC-BY upload doesn't clear Adobe's ToS on the underlying animation; not redistributable.
- **Review drop-list** (`REVIEW_DROP`, matched by asset+anim so it survives rebuilds):
  - GIGI & KAI **Fox rigs** — tip/hunch/invert on every action.
  - **Shar Pei dog** — wrong body plan.
  - **4 Quaternius packs** (Animated Men/Women Feb-2019, Alien Apr-2019, Knight Jul-2018) — mis-map the **right upper-arm** bone: it stays raised/out (mean up-Y +0.3…+0.7) the whole clip vs −0.7…−0.9 for a correct hanging arm. Matched by *full* pack name so the good "Man/Woman Animated" Oct/Dec-2017 packs are preserved.
- **`fix_first_frame_flip`** — Mini Chibi Kid (and similar) export frame 0 with a rotated hip while the rest is upright (loop-seam artifact); detect + replace frame 0 with frame 1. Verified walk/run/jump open upright; the genuinely-horizontal death clip is left untouched.

Library **109 → 74 clips / 18 actions**, zero Mixamo/Fox/dog. (swim/roll dropped with the arm-broken packs — re-scrape clean ones later.)

### 2. Animation picker 
Replace the quality-weighted **random** pick with explicit **browse-and-select**:
- `AnimationPickerDialog.qml` — searchable list of every clip with a human-readable label (**"Walk (Man)", "Run (Zombie)", "Punch (Alien)"**) and a per-row **Apply** that retargets that *exact* clip onto the selected rig.
- `AnimationControlController::listMotionClips()` → the list model; `generateMotion(variantIndex)` forces a specific clip (no model, no matchAmong).
- Panel: **"Browse animation library…"** is now the primary button; the free-text field is relabelled as the experimental **AI-model** path only.
- CLI: `qtmesh anim <file> --generate <action> --variant N` (the curation harness that produced the review sheets).

Verified live: picker lists 74 named clips and Apply retargets correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an animation library picker dialog with search, scrollable results, progress/outcome status, and one-click “Apply” to generate an animation.
  * Added a lower-body “descent” option that improves crouch/pickup/sit/crawl-type motions, with deterministic selection support via a library variant index.
  * Updated generation and export to carry per-clip vertical offset data (when available).
* **Bug Fixes**
  * Improved motion-library curation and corrected first-frame rotation issues.
  * Enhanced retargeting accuracy to preserve natural upright posture and vertical movement during application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->