### PR TITLE
ci: skip SonarCloud scan on Dependabot PRs (unblocks #918)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1526,7 +1526,12 @@ jobs:
           ls -la coverage.xml 2>/dev/null || echo "coverage.xml not found"
 
     - name: Run sonar-scanner
-      uses: SonarSource/sonarqube-scan-action@v4
+      # Dependabot PRs run without access to repository secrets, so SONAR_TOKEN
+      # is empty there and the scan fails with a 401 that blocks the PR through
+      # no fault of its own. Skip the scan for Dependabot; the analysis still
+      # runs on branch pushes and same-repo PRs, which is where the quality gate
+      # matters.
+      if: ${{ github.actor != 'dependabot[bot]' }}
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1532,6 +1532,7 @@ jobs:
       # runs on branch pushes and same-repo PRs, which is where the quality gate
       # matters.
       if: ${{ github.actor != 'dependabot[bot]' }}
+      uses: SonarSource/sonarqube-scan-action@v4
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Problem

Dependabot PRs (e.g. #918, bumping `SonarSource/sonarqube-scan-action` v4→v6) are permanently `BLOCKED` because the `unit-tests-linux` job's **Run sonar-scanner** step fails with:

```
401 Not authorized. Please check the 'SONAR_TOKEN' environment variable...
Action failed: sonar-scanner failed with exit code 3
```

This is **not a code problem** — the tests all pass (`FAILED_SUITES: 0`). GitHub deliberately withholds repository secrets from Dependabot-triggered workflow runs, so `SONAR_TOKEN` is empty and the scan 401s. This blocks *every* Dependabot PR the same way.

(The v4→v6 bump itself is safe for us: our `args:` values contain no spaces, so the v6 arg-quoting breaking change doesn't apply.)

## Fix

Gate the sonar-scanner step on `github.actor != 'dependabot[bot]'`. The SonarCloud quality gate still runs on branch pushes and same-repo PRs — where it actually matters — and simply skips in the secret-less Dependabot context instead of hard-failing.

## Effect

- Unblocks #918 and all future Dependabot PRs.
- No change to analysis coverage on real branches/PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated validation workflows to skip SonarCloud analysis for Dependabot pull requests when required credentials are unavailable.
  * Prevented unnecessary scan failures during automated dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->