### PR TITLE
fix(snap): enable Performance Capture webcam on Linux

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -854,7 +854,7 @@ jobs:
             cp ./bin/QtMeshEditor ./pack-deb/usr/share/qtmesheditor/qtmesheditor
 
             # Create proper launcher script
-            printf '#!/bin/sh\nexport LD_LIBRARY_PATH="/usr/lib/qtmesheditor:${LD_LIBRARY_PATH}"\nexport QT_PLUGIN_PATH="/usr/lib/qtmesheditor:/usr/share/qtmesheditor:${QT_PLUGIN_PATH}"\nexport QML2_IMPORT_PATH="/usr/share/qtmesheditor/qml:${QML2_IMPORT_PATH}"\n# Ogre requires X11 window handles; force XCB under Wayland\nexport QT_QPA_PLATFORM="${QT_QPA_PLATFORM:-xcb}"\nexec /usr/share/qtmesheditor/qtmesheditor "$@"\n' > ./pack-deb/usr/bin/qtmesheditor
+            printf '#!/bin/sh\nexport LD_LIBRARY_PATH="/usr/lib/qtmesheditor:${LD_LIBRARY_PATH}"\nexport QT_PLUGIN_PATH="/usr/lib/qtmesheditor/plugins:/usr/share/qtmesheditor:${QT_PLUGIN_PATH}"\nexport QML2_IMPORT_PATH="/usr/share/qtmesheditor/qml:${QML2_IMPORT_PATH}"\n# Ogre requires X11 window handles; force XCB under Wayland\nexport QT_QPA_PLATFORM="${QT_QPA_PLATFORM:-xcb}"\nexec /usr/share/qtmesheditor/qtmesheditor "$@"\n' > ./pack-deb/usr/bin/qtmesheditor
             chmod 755 ./pack-deb/usr/bin/qtmesheditor
 
             # Create qtmesh symlink for CLI mode (name starts with "qtmesh" but not "qtmesheditor")

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -854,7 +854,7 @@ jobs:
             cp ./bin/QtMeshEditor ./pack-deb/usr/share/qtmesheditor/qtmesheditor
 
             # Create proper launcher script
-            printf '#!/bin/sh\nexport LD_LIBRARY_PATH="/usr/lib/qtmesheditor:${LD_LIBRARY_PATH}"\nexport QML2_IMPORT_PATH="/usr/share/qtmesheditor/qml:${QML2_IMPORT_PATH}"\n# Ogre requires X11 window handles; force XCB under Wayland\nexport QT_QPA_PLATFORM="${QT_QPA_PLATFORM:-xcb}"\nexec /usr/share/qtmesheditor/qtmesheditor "$@"\n' > ./pack-deb/usr/bin/qtmesheditor
+            printf '#!/bin/sh\nexport LD_LIBRARY_PATH="/usr/lib/qtmesheditor:${LD_LIBRARY_PATH}"\nexport QT_PLUGIN_PATH="/usr/lib/qtmesheditor:/usr/share/qtmesheditor:${QT_PLUGIN_PATH}"\nexport QML2_IMPORT_PATH="/usr/share/qtmesheditor/qml:${QML2_IMPORT_PATH}"\n# Ogre requires X11 window handles; force XCB under Wayland\nexport QT_QPA_PLATFORM="${QT_QPA_PLATFORM:-xcb}"\nexec /usr/share/qtmesheditor/qtmesheditor "$@"\n' > ./pack-deb/usr/bin/qtmesheditor
             chmod 755 ./pack-deb/usr/bin/qtmesheditor
 
             # Create qtmesh symlink for CLI mode (name starts with "qtmesh" but not "qtmesheditor")
@@ -914,6 +914,19 @@ jobs:
                 mkdir -p ./pack-deb/usr/lib/qtmesheditor/plugins/multimedia
                 cp -R "$QT_DIR/plugins/multimedia/"*.so \
                     ./pack-deb/usr/lib/qtmesheditor/plugins/multimedia/ 2>/dev/null || true
+            fi
+
+            # Bundle FFmpeg libs required by libffmpegmediaplugin.so so confined
+            # Snap / minimal .deb installs can open webcams and video files.
+            FFMPEG_PLUGIN="./pack-deb/usr/lib/qtmesheditor/plugins/multimedia/libffmpegmediaplugin.so"
+            if [ -f "$FFMPEG_PLUGIN" ]; then
+              for lib in $(ldd "$FFMPEG_PLUGIN" | awk '/=> \// {print $3}'); do
+                case "$lib" in
+                  */libav*|*/libsw*)
+                    cp -L "$lib" ./pack-deb/usr/lib/qtmesheditor/
+                    ;;
+                esac
+              done
             fi
 
             dpkg-deb --build --root-owner-group pack-deb

--- a/docs/MOCAP.md
+++ b/docs/MOCAP.md
@@ -98,6 +98,23 @@ ad-hoc dev build will NOT get the prompt. If you hit that on a dev build, use
 the file-based capture (`qtmesh mocap <video>`) instead — it needs no camera
 permission and exercises the identical pipeline.
 
+## Linux Snap camera access
+
+The Snap is strictly confined, so webcam access needs two things:
+
+1. **Connect the camera interface** (one-time, not auto-connected on install):
+
+   ```bash
+   snap connect qtmesheditor:camera
+   ```
+
+2. **Use a build that bundles the Qt Multimedia FFmpeg backend** (3.24.3+).
+   The Performance Capture panel will suggest the `snap connect` command if no
+   cameras appear or permission is denied.
+
+On desktop Linux outside Snap, allow camera access via your desktop portal /
+privacy settings when prompted.
+
 ## Known limitations (v1)
 
 - Single person per frame; the highest-scoring detection wins.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -56,11 +56,13 @@ apps:
       - home
       - network
       - removable-media
+      - camera
     environment:
       LD_LIBRARY_PATH: $SNAP/usr/lib/qtmesheditor:$SNAP/usr/share/qtmesheditor/platforms:$SNAP/usr/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu/pulseaudio:$LD_LIBRARY_PATH
       QML2_IMPORT_PATH: $SNAP/usr/share/qtmesheditor/qml:$QML2_IMPORT_PATH
       QT_QPA_PLATFORM: xcb
-      QT_PLUGIN_PATH: $SNAP/usr/share/qtmesheditor
+      # Multimedia FFmpeg backend lives under usr/lib/qtmesheditor/plugins/multimedia/
+      QT_PLUGIN_PATH: $SNAP/usr/lib/qtmesheditor:$SNAP/usr/share/qtmesheditor
       OGRE_PLUGIN_DIR: $SNAP/usr/lib/qtmesheditor
       FONTCONFIG_PATH: $SNAP/etc/fonts
       FONTCONFIG_FILE: $SNAP/etc/fonts/fonts.conf

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -61,8 +61,8 @@ apps:
       LD_LIBRARY_PATH: $SNAP/usr/lib/qtmesheditor:$SNAP/usr/share/qtmesheditor/platforms:$SNAP/usr/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu/pulseaudio:$LD_LIBRARY_PATH
       QML2_IMPORT_PATH: $SNAP/usr/share/qtmesheditor/qml:$QML2_IMPORT_PATH
       QT_QPA_PLATFORM: xcb
-      # Multimedia FFmpeg backend lives under usr/lib/qtmesheditor/plugins/multimedia/
-      QT_PLUGIN_PATH: $SNAP/usr/lib/qtmesheditor:$SNAP/usr/share/qtmesheditor
+      # Multimedia FFmpeg backend: plugins/multimedia/ under this root.
+      QT_PLUGIN_PATH: $SNAP/usr/lib/qtmesheditor/plugins:$SNAP/usr/share/qtmesheditor
       OGRE_PLUGIN_DIR: $SNAP/usr/lib/qtmesheditor
       FONTCONFIG_PATH: $SNAP/etc/fonts
       FONTCONFIG_FILE: $SNAP/etc/fonts/fonts.conf

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -185,6 +185,7 @@ Mocap/PoseCapPredictor.cpp
 Mocap/PoseIKSolver.cpp
 Mocap/MocapCLI.cpp
 Mocap/MocapController.cpp
+Mocap/MocapCameraHints.cpp
 commands/RecordMocapClipCommand.cpp
 ApplyAtlas.cpp
 EmbeddedTextureCache.cpp

--- a/src/Mocap/MocapCameraHints.cpp
+++ b/src/Mocap/MocapCameraHints.cpp
@@ -1,0 +1,59 @@
+#ifdef ENABLE_MOCAP
+
+#include "MocapCameraHints.h"
+
+#include <QCoreApplication>
+
+namespace MocapCameraHints {
+
+bool runningAsSnap()
+{
+#ifdef Q_OS_LINUX
+    return qEnvironmentVariable("SNAP") == QLatin1String("qtmesheditor");
+#else
+    return false;
+#endif
+}
+
+QString snapConnectHint()
+{
+    if (!runningAsSnap())
+        return {};
+    return QCoreApplication::translate(
+        "MocapCameraHints",
+        "\n\nIf you installed via Snap, connect the camera interface:\n"
+        "  snap connect qtmesheditor:camera");
+}
+
+QString permissionDeniedMessage()
+{
+#ifdef Q_OS_MACOS
+    return QCoreApplication::translate(
+        "MocapCameraHints",
+        "Camera access was not granted. If no prompt appeared, enable it for "
+        "QtMeshEditor in System Settings → Privacy & Security → Camera, then "
+        "click Preview again.");
+#elif defined(Q_OS_LINUX)
+    if (runningAsSnap()) {
+        return QCoreApplication::translate(
+            "MocapCameraHints",
+            "Camera access was not granted. Connect the camera interface, then "
+            "click Preview again:\n"
+            "  snap connect qtmesheditor:camera");
+    }
+    return QCoreApplication::translate(
+        "MocapCameraHints",
+        "Camera access was not granted. Allow camera access for QtMeshEditor "
+        "in your system privacy settings (or via xdg-desktop-portal), then "
+        "click Preview again.");
+#else
+    return QCoreApplication::translate(
+        "MocapCameraHints",
+        "Camera access was not granted. Allow camera access for QtMeshEditor, "
+        "then click Preview again.");
+#endif
+}
+
+}  // namespace MocapCameraHints
+
+#endif  // ENABLE_MOCAP

--- a/src/Mocap/MocapCameraHints.h
+++ b/src/Mocap/MocapCameraHints.h
@@ -1,60 +1,15 @@
 #ifndef MOCAPCAMERAHINTS_H
 #define MOCAPCAMERAHINTS_H
 
-#include "../updater/InstallFlavor.h"
-
-#include <QCoreApplication>
 #include <QString>
-
-#ifdef Q_OS_LINUX
-#include <QtGlobal>
-#endif
 
 namespace MocapCameraHints {
 
-inline bool runningAsSnap()
-{
-#ifdef Q_OS_LINUX
-    return InstallFlavor::detect(QCoreApplication::applicationFilePath())
-        == InstallFlavor::Flavor::Snap;
-#else
-    return false;
-#endif
-}
+bool runningAsSnap();
 
-inline QString snapConnectHint()
-{
-    if (!runningAsSnap())
-        return {};
-    return QStringLiteral(
-        "\n\nIf you installed via Snap, connect the camera interface:\n"
-        "  snap connect qtmesheditor:camera");
-}
+QString snapConnectHint();
 
-inline QString permissionDeniedMessage()
-{
-#ifdef Q_OS_MACOS
-    return QStringLiteral(
-        "Camera access was not granted. If no prompt appeared, enable it for "
-        "QtMeshEditor in System Settings → Privacy & Security → Camera, then "
-        "click Preview again.");
-#elif defined(Q_OS_LINUX)
-    if (runningAsSnap()) {
-        return QStringLiteral(
-            "Camera access was not granted. Connect the camera interface, then "
-            "click Preview again:\n"
-            "  snap connect qtmesheditor:camera");
-    }
-    return QStringLiteral(
-        "Camera access was not granted. Allow camera access for QtMeshEditor "
-        "in your system privacy settings (or via xdg-desktop-portal), then "
-        "click Preview again.");
-#else
-    return QStringLiteral(
-        "Camera access was not granted. Allow camera access for QtMeshEditor, "
-        "then click Preview again.");
-#endif
-}
+QString permissionDeniedMessage();
 
 }  // namespace MocapCameraHints
 

--- a/src/Mocap/MocapCameraHints.h
+++ b/src/Mocap/MocapCameraHints.h
@@ -1,0 +1,61 @@
+#ifndef MOCAPCAMERAHINTS_H
+#define MOCAPCAMERAHINTS_H
+
+#include "../updater/InstallFlavor.h"
+
+#include <QCoreApplication>
+#include <QString>
+
+#ifdef Q_OS_LINUX
+#include <QtGlobal>
+#endif
+
+namespace MocapCameraHints {
+
+inline bool runningAsSnap()
+{
+#ifdef Q_OS_LINUX
+    return InstallFlavor::detect(QCoreApplication::applicationFilePath())
+        == InstallFlavor::Flavor::Snap;
+#else
+    return false;
+#endif
+}
+
+inline QString snapConnectHint()
+{
+    if (!runningAsSnap())
+        return {};
+    return QStringLiteral(
+        "\n\nIf you installed via Snap, connect the camera interface:\n"
+        "  snap connect qtmesheditor:camera");
+}
+
+inline QString permissionDeniedMessage()
+{
+#ifdef Q_OS_MACOS
+    return QStringLiteral(
+        "Camera access was not granted. If no prompt appeared, enable it for "
+        "QtMeshEditor in System Settings → Privacy & Security → Camera, then "
+        "click Preview again.");
+#elif defined(Q_OS_LINUX)
+    if (runningAsSnap()) {
+        return QStringLiteral(
+            "Camera access was not granted. Connect the camera interface, then "
+            "click Preview again:\n"
+            "  snap connect qtmesheditor:camera");
+    }
+    return QStringLiteral(
+        "Camera access was not granted. Allow camera access for QtMeshEditor "
+        "in your system privacy settings (or via xdg-desktop-portal), then "
+        "click Preview again.");
+#else
+    return QStringLiteral(
+        "Camera access was not granted. Allow camera access for QtMeshEditor, "
+        "then click Preview again.");
+#endif
+}
+
+}  // namespace MocapCameraHints
+
+#endif  // MOCAPCAMERAHINTS_H

--- a/src/Mocap/MocapController.cpp
+++ b/src/Mocap/MocapController.cpp
@@ -426,25 +426,7 @@ bool MocapController::startPreview(const QString& deviceId)
             if (result.status() == Qt::PermissionStatus::Granted) {
                 beginPreview(deviceId);
             } else {
-                setStatusMessage(
-#ifdef Q_OS_MACOS
-                    tr("Camera access was not granted. If no prompt appeared, "
-                       "enable it for QtMeshEditor in System Settings → "
-                       "Privacy & Security → Camera, then click Preview again.")
-#elif defined(Q_OS_LINUX)
-                    MocapCameraHints::runningAsSnap()
-                        ? tr("Camera access was not granted. Connect the camera "
-                             "interface, then click Preview again:\n"
-                             "  snap connect qtmesheditor:camera")
-                        : tr("Camera access was not granted. Allow camera access "
-                             "for QtMeshEditor in your system privacy settings "
-                             "(or via xdg-desktop-portal), then click Preview "
-                             "again.")
-#else
-                    tr("Camera access was not granted. Allow camera access for "
-                       "QtMeshEditor, then click Preview again.")
-#endif
-                );
+                setStatusMessage(MocapCameraHints::permissionDeniedMessage());
                 emit errorOccurred(d->status);
             }
         });

--- a/src/Mocap/MocapController.cpp
+++ b/src/Mocap/MocapController.cpp
@@ -6,6 +6,7 @@
 #include "PoseCapPredictor.h"
 #include "PoseIKSolver.h"
 #include "VideoFrameSource.h"
+#include "MocapCameraHints.h"
 #include "../AnimationMerger.h"
 #include "../MotionInbetween.h"
 #include "../Manager.h"
@@ -426,9 +427,24 @@ bool MocapController::startPreview(const QString& deviceId)
                 beginPreview(deviceId);
             } else {
                 setStatusMessage(
+#ifdef Q_OS_MACOS
                     tr("Camera access was not granted. If no prompt appeared, "
                        "enable it for QtMeshEditor in System Settings → "
-                       "Privacy & Security → Camera, then click Preview again."));
+                       "Privacy & Security → Camera, then click Preview again.")
+#elif defined(Q_OS_LINUX)
+                    MocapCameraHints::runningAsSnap()
+                        ? tr("Camera access was not granted. Connect the camera "
+                             "interface, then click Preview again:\n"
+                             "  snap connect qtmesheditor:camera")
+                        : tr("Camera access was not granted. Allow camera access "
+                             "for QtMeshEditor in your system privacy settings "
+                             "(or via xdg-desktop-portal), then click Preview "
+                             "again.")
+#else
+                    tr("Camera access was not granted. Allow camera access for "
+                       "QtMeshEditor, then click Preview again.")
+#endif
+                );
                 emit errorOccurred(d->status);
             }
         });

--- a/src/Mocap/VideoFrameSource.cpp
+++ b/src/Mocap/VideoFrameSource.cpp
@@ -232,7 +232,7 @@ bool CameraFrameSource::open(QString* error)
     }
     if (device.isNull()) {
         if (error) {
-            if (devices.isEmpty()) {
+            if (m_deviceId.isEmpty()) {
                 *error = tr("no camera available") + MocapCameraHints::snapConnectHint();
             } else {
                 *error = tr("camera not found: %1").arg(m_deviceId);
@@ -258,9 +258,7 @@ bool CameraFrameSource::open(QString* error)
             [this](QCamera::Error err, const QString& message) {
                 if (err == QCamera::CameraError && message.contains(
                         QStringLiteral("permission"), Qt::CaseInsensitive)) {
-                    emit errorOccurred(
-                        tr("camera permission denied — %1")
-                            .arg(MocapCameraHints::permissionDeniedMessage()));
+                    emit errorOccurred(MocapCameraHints::permissionDeniedMessage());
                 } else {
                     emit errorOccurred(tr("camera error: %1").arg(message));
                 }

--- a/src/Mocap/VideoFrameSource.cpp
+++ b/src/Mocap/VideoFrameSource.cpp
@@ -1,6 +1,7 @@
 #ifdef ENABLE_MOCAP
 
 #include "VideoFrameSource.h"
+#include "MocapCameraHints.h"
 
 #include <QCamera>
 #include <QCameraDevice>
@@ -230,10 +231,13 @@ bool CameraFrameSource::open(QString* error)
         }
     }
     if (device.isNull()) {
-        if (error)
-            *error = devices.isEmpty()
-                         ? tr("no camera available")
-                         : tr("camera not found: %1").arg(m_deviceId);
+        if (error) {
+            if (devices.isEmpty()) {
+                *error = tr("no camera available") + MocapCameraHints::snapConnectHint();
+            } else {
+                *error = tr("camera not found: %1").arg(m_deviceId);
+            }
+        }
         return false;
     }
 
@@ -254,9 +258,9 @@ bool CameraFrameSource::open(QString* error)
             [this](QCamera::Error err, const QString& message) {
                 if (err == QCamera::CameraError && message.contains(
                         QStringLiteral("permission"), Qt::CaseInsensitive)) {
-                    emit errorOccurred(tr("camera permission denied — allow "
-                                          "camera access for QtMeshEditor in "
-                                          "the system settings"));
+                    emit errorOccurred(
+                        tr("camera permission denied — %1")
+                            .arg(MocapCameraHints::permissionDeniedMessage()));
                 } else {
                     emit errorOccurred(tr("camera error: %1").arg(message));
                 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -94,6 +94,7 @@ if(BUILD_TESTS)
         # ENABLE_MOCAP (empty TU when off), so listing them unconditionally is
         # safe and keeps the per-suite test executables linking either way.
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Mocap/VideoFrameSource.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/Mocap/MocapCameraHints.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Mocap/OneEuroFilter.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Mocap/FaceCapMapper.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Mocap/FaceCapPose.cpp


### PR DESCRIPTION
## Summary
Enable Performance Capture webcam access on Linux Snap and `.deb` installs by declaring the camera interface, bundling FFmpeg runtime libraries, and fixing Qt multimedia plugin discovery.

## Technical Details
- Snap: add `camera` plug; set `QT_PLUGIN_PATH` to `usr/lib/qtmesheditor/plugins` (Qt searches category subdirs there) plus `usr/share/qtmesheditor` for platform plugins
- CI `.deb` pack: copy FFmpeg libs required by `libffmpegmediaplugin.so` via `ldd`; export `QT_PLUGIN_PATH` in the launcher script
- Snap detection for hints uses `SNAP=qtmesheditor` (no dependency on `InstallFlavor`, which is omitted when `ENABLE_AUTO_UPDATER=OFF`)

## Features
- Performance Capture shows `snap connect qtmesheditor:camera` when running as Snap and no camera is available or permission is denied
- Document Linux Snap camera setup in `docs/MOCAP.md`

## Bugfixes
- Strict Snap confinement could not load the FFmpeg multimedia backend (wrong plugin path, missing bundled libs, missing camera interface)
- Default-camera failure could show `camera not found:` with an empty id when `defaultVideoInput()` is null but devices exist

## Test plan
- [ ] Release `.deb` contains `plugins/multimedia/libffmpegmediaplugin.so` and bundled `libav*`/`libsw*` libs
- [ ] Snap install + `snap connect qtmesheditor:camera` → Performance Capture Preview shows webcam
- [ ] Without `snap connect`, status line suggests the connect command
- [ ] `.deb` install works without manual `QT_PLUGIN_PATH` export

**Note:** The `camera` interface is not auto-connected on install — users must run `snap connect qtmesheditor:camera` once.