### PR TITLE
fix(anim): Blender-rig FBX animation space — isometric --animation empty frames + turntable --animation (#936)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,8 @@ qtmesh pose model.fbx --animation "Walk" --time 0.5 -o posed.stl  # export singl
 qtmesh pose model.fbx --animation "Dance" --count 4 -o pose_%02d.stl  # export N evenly spaced frames
 qtmesh turntable model.fbx -o turntable.png  # PNG sprite sheet (12 frames default)
 qtmesh turntable model.fbx -o frame_%02d.png --frames 24 --axis y --camera-height 25
+qtmesh turntable model.fbx --animation "Walk" --frames 8 -o walk.png  # #936: sample the clip over time, fixed front camera (--orbit combines rotation+animation)
+qtmesh turntable model.fbx --at 0.5 -o pose.png  # #936: normal orbit of the pose at t=0.5s
 qtmesh isometric model.fbx -o iso.png  # 8-direction static sprite grid (rows=directions)
 qtmesh isometric model.fbx --resolution 256 -o iso.png  # square 256px cells
 qtmesh isometric model.fbx --animation "Walk" --frames 8 -o iso.png  # 8×8 animated atlas

--- a/src/Assimp/AnimationProcessor.cpp
+++ b/src/Assimp/AnimationProcessor.cpp
@@ -1,6 +1,7 @@
 #include "AnimationProcessor.h"
 
 #include <cmath>
+#include <cstdlib>
 #include <string>
 
 AnimationProcessor::AnimationProcessor(Ogre::SkeletonPtr skeleton): skeleton(skeleton) {}
@@ -205,6 +206,23 @@ void AnimationProcessor::processAnimationChannel(aiNodeAnim* nodeAnim, Ogre::Ani
     // Get the bone's T-pose position and orientation
     auto boneTPosePosition = bone->getPosition();
     Ogre::Quaternion boneTPoseInverseRotation = bone->getOrientation().Inverse();
+    // The channel's keys live in the source NODE's local space, so the bind
+    // reference for scale keys is the aiNode's own bind scale — NOT the Ogre
+    // bone's (the two differ when the bind chain was re-rooted, e.g. the
+    // mesh-node-relative root bind). Blender-style FBX rigs re-express the
+    // armature's static ×100 scale in every animation curve; dividing by the
+    // node bind scale turns that into the identity it really is (#936).
+    // Guard degenerate components so a zero scale can't divide by zero.
+    Ogre::Vector3 nodeBindScale = Ogre::Vector3::UNIT_SCALE;
+    if (scene && scene->mRootNode) {
+        if (const aiNode* channelNode = scene->mRootNode->FindNode(nodeAnim->mNodeName)) {
+            aiVector3D ns, np; aiQuaternion nr;
+            channelNode->mTransformation.Decompose(ns, nr, np);
+            nodeBindScale = Ogre::Vector3(ns.x, ns.y, ns.z);
+        }
+    }
+    for (int c = 0; c < 3; ++c)
+        if (std::abs(nodeBindScale[c]) < 1e-8f) nodeBindScale[c] = 1.0f;
 
     // Process the position keys.
     // Ogre applies translation keyframes in bone-local space (TS_LOCAL):
@@ -241,10 +259,17 @@ void AnimationProcessor::processAnimationChannel(aiNodeAnim* nodeAnim, Ogre::Ani
         }
     }
 
-    // Process the scaling keys
+    // Process the scaling keys.
+    // Ogre applies keyframe scale MULTIPLICATIVELY on top of the bind pose
+    // (bones reset to bind each frame), so the key must hold the scale
+    // RELATIVE to the T-pose — like position/rotation above. Blender-style
+    // FBX rigs re-express the armature's static scale (e.g. ×100) in every
+    // animation curve; storing it raw double-applied it (bind ×100 × key
+    // ×100), blowing the skinned mesh up 100× and out of frame (#936).
     for(auto i = 0u; i < nodeAnim->mNumScalingKeys; i++) {
         aiVectorKey scalingKey = nodeAnim->mScalingKeys[i];
         Ogre::Vector3 scale(scalingKey.mValue.x, scalingKey.mValue.y, scalingKey.mValue.z);
+        scale = scale / nodeBindScale;
         if (keyframes.find(scalingKey.mTime) == keyframes.end()) {
             keyframes[scalingKey.mTime] = std::make_tuple(
                 Ogre::Vector3::ZERO,

--- a/src/Assimp/AnimationProcessor.cpp
+++ b/src/Assimp/AnimationProcessor.cpp
@@ -230,19 +230,27 @@ void AnimationProcessor::processAnimationChannel(aiNodeAnim* nodeAnim, Ogre::Ani
             channelNode->mTransformation.Decompose(ns, nr, np);
             nodeBindScale = Ogre::Vector3(ns.x, ns.y, ns.z);
 
-            Ogre::Affine3 nodeBind;
-            nodeBind.makeTransform(Ogre::Vector3(np.x, np.y, np.z),
-                                   Ogre::Vector3(ns.x, ns.y, ns.z),
-                                   Ogre::Quaternion(nr.w, nr.x, nr.y, nr.z));
-            Ogre::Affine3 ogreBind;
-            ogreBind.makeTransform(bone->getPosition(), bone->getScale(),
-                                   bone->getOrientation());
-            const Ogre::Affine3 c = ogreBind * nodeBind.inverse();
-            c.decomposition(cPos, cScale, cRot);
-            haveSpaceChange =
-                !cPos.positionEquals(Ogre::Vector3::ZERO, 1e-5f) ||
-                !cRot.equals(Ogre::Quaternion::IDENTITY, Ogre::Radian(1e-4f)) ||
-                !cScale.positionEquals(Ogre::Vector3::UNIT_SCALE, 1e-4f);
+            // A zero bind-scale component makes the node transform singular —
+            // skip the space-change mapping rather than invert it (keys then
+            // apply in node space, the pre-#936 behavior for that bone).
+            const bool invertible = std::abs(ns.x) > 1e-8f &&
+                                    std::abs(ns.y) > 1e-8f &&
+                                    std::abs(ns.z) > 1e-8f;
+            if (invertible) {
+                Ogre::Affine3 nodeBind;
+                nodeBind.makeTransform(Ogre::Vector3(np.x, np.y, np.z),
+                                       Ogre::Vector3(ns.x, ns.y, ns.z),
+                                       Ogre::Quaternion(nr.w, nr.x, nr.y, nr.z));
+                Ogre::Affine3 ogreBind;
+                ogreBind.makeTransform(bone->getPosition(), bone->getScale(),
+                                       bone->getOrientation());
+                const Ogre::Affine3 c = ogreBind * nodeBind.inverse();
+                c.decomposition(cPos, cScale, cRot);
+                haveSpaceChange =
+                    !cPos.positionEquals(Ogre::Vector3::ZERO, 1e-5f) ||
+                    !cRot.equals(Ogre::Quaternion::IDENTITY, Ogre::Radian(1e-4f)) ||
+                    !cScale.positionEquals(Ogre::Vector3::UNIT_SCALE, 1e-4f);
+            }
         }
     }
     for (int c = 0; c < 3; ++c)

--- a/src/Assimp/AnimationProcessor.cpp
+++ b/src/Assimp/AnimationProcessor.cpp
@@ -214,15 +214,47 @@ void AnimationProcessor::processAnimationChannel(aiNodeAnim* nodeAnim, Ogre::Ani
     // node bind scale turns that into the identity it really is (#936).
     // Guard degenerate components so a zero scale can't divide by zero.
     Ogre::Vector3 nodeBindScale = Ogre::Vector3::UNIT_SCALE;
+    // Space-change prefix for POSITION/ROTATION keys: the Ogre bind can be
+    // RE-ROOTED relative to the node bind (BoneProcessor's mesh-node-relative
+    // root, #936), so a key equal to the node's bind transform must still
+    // produce an IDENTITY delta. C = OgreBindLocal · NodeBindLocal⁻¹ maps
+    // node-local keys into the Ogre bind space; it is exactly identity for
+    // every bone whose two binds agree (all non-re-rooted bones, Mixamo rigs).
+    bool haveSpaceChange = false;
+    Ogre::Vector3 cPos = Ogre::Vector3::ZERO;
+    Ogre::Quaternion cRot = Ogre::Quaternion::IDENTITY;
+    Ogre::Vector3 cScale = Ogre::Vector3::UNIT_SCALE;
     if (scene && scene->mRootNode) {
         if (const aiNode* channelNode = scene->mRootNode->FindNode(nodeAnim->mNodeName)) {
             aiVector3D ns, np; aiQuaternion nr;
             channelNode->mTransformation.Decompose(ns, nr, np);
             nodeBindScale = Ogre::Vector3(ns.x, ns.y, ns.z);
+
+            Ogre::Affine3 nodeBind;
+            nodeBind.makeTransform(Ogre::Vector3(np.x, np.y, np.z),
+                                   Ogre::Vector3(ns.x, ns.y, ns.z),
+                                   Ogre::Quaternion(nr.w, nr.x, nr.y, nr.z));
+            Ogre::Affine3 ogreBind;
+            ogreBind.makeTransform(bone->getPosition(), bone->getScale(),
+                                   bone->getOrientation());
+            const Ogre::Affine3 c = ogreBind * nodeBind.inverse();
+            c.decomposition(cPos, cScale, cRot);
+            haveSpaceChange =
+                !cPos.positionEquals(Ogre::Vector3::ZERO, 1e-5f) ||
+                !cRot.equals(Ogre::Quaternion::IDENTITY, Ogre::Radian(1e-4f)) ||
+                !cScale.positionEquals(Ogre::Vector3::UNIT_SCALE, 1e-4f);
         }
     }
     for (int c = 0; c < 3; ++c)
         if (std::abs(nodeBindScale[c]) < 1e-8f) nodeBindScale[c] = 1.0f;
+    // Map a node-local key transform into the Ogre bind space (no-op for the
+    // common consistent-bind case).
+    auto mapPos = [&](const Ogre::Vector3& p) {
+        return haveSpaceChange ? cRot * (cScale * p) + cPos : p;
+    };
+    auto mapRot = [&](const Ogre::Quaternion& q) {
+        return haveSpaceChange ? cRot * q : q;
+    };
 
     // Process the position keys.
     // Ogre applies translation keyframes in bone-local space (TS_LOCAL):
@@ -232,8 +264,9 @@ void AnimationProcessor::processAnimationChannel(aiNodeAnim* nodeAnim, Ogre::Ani
     for(auto i = 0u; i < nodeAnim->mNumPositionKeys; i++) {
         aiVectorKey positionKey = nodeAnim->mPositionKeys[i];
         Ogre::Vector3 position(positionKey.mValue.x, positionKey.mValue.y, positionKey.mValue.z);
-        // Compute delta in parent-local space, then rotate into bone-local space
-        position = boneTPoseInverseRotation * (position - boneTPosePosition);
+        // Map into the Ogre bind space first (#936 re-rooted roots), then
+        // compute the delta in parent-local space and rotate it bone-local.
+        position = boneTPoseInverseRotation * (mapPos(position) - boneTPosePosition);
 
         keyframes[positionKey.mTime] = std::make_tuple(
             position,
@@ -246,7 +279,7 @@ void AnimationProcessor::processAnimationChannel(aiNodeAnim* nodeAnim, Ogre::Ani
     for(auto i = 0u; i < nodeAnim->mNumRotationKeys; i++) {
         aiQuatKey rotationKey = nodeAnim->mRotationKeys[i];
         Ogre::Quaternion rot(rotationKey.mValue.w, rotationKey.mValue.x, rotationKey.mValue.y, rotationKey.mValue.z);
-        rot = boneTPoseInverseRotation * rot; // Convert from local space to model space
+        rot = boneTPoseInverseRotation * mapRot(rot); // node-local → Ogre bind space → bind-relative delta
         rot.normalise(); // Normalize the quaternion
         if (keyframes.find(rotationKey.mTime) == keyframes.end()) {
             keyframes[rotationKey.mTime] = std::make_tuple(

--- a/src/Assimp/AnimationProcessor_test.cpp
+++ b/src/Assimp/AnimationProcessor_test.cpp
@@ -24,3 +24,53 @@ TEST(AnimationProcessorTest, ProcessAllAnimations) {
     EXPECT_EQ(mockSkeleton->getAnimation(0)->getName(), "Animation1");
     EXPECT_EQ(mockSkeleton->getAnimation(1)->getName(), "Animation2");
 }
+
+// #936: scale keys must be stored RELATIVE to the channel node's bind scale.
+// Blender-style FBX rigs re-express the armature's static scale (e.g. ×100)
+// in every animation curve; Ogre applies keyframe scale multiplicatively on
+// the bind pose, so a raw key double-applies the scale and blows the skinned
+// mesh out of frame. A key equal to the node's bind scale must become 1.
+TEST(AnimationProcessorTest, ScaleKeysAreRelativeToNodeBindScale) {
+    auto ogreRoot = std::make_unique<Ogre::Root>();
+    auto skel = Ogre::SkeletonManager::getSingleton().create(
+        "ScaleRelSkeleton", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME, true);
+    Ogre::Bone* bone = skel->createBone("Armature");
+    bone->setScale(Ogre::Vector3::UNIT_SCALE);   // re-rooted Ogre bind: scale 1
+
+    aiScene scene;
+    scene.mRootNode = new aiNode("Scene");
+    aiNode* arm = new aiNode("Armature");
+    aiMatrix4x4::Scaling(aiVector3D(100.f, 100.f, 100.f), arm->mTransformation);
+    arm->mParent = scene.mRootNode;
+    scene.mRootNode->mNumChildren = 1;
+    scene.mRootNode->mChildren = new aiNode*[1]{arm};
+
+    auto* channel = new aiNodeAnim;
+    channel->mNodeName = aiString(std::string("Armature"));
+    channel->mNumScalingKeys = 1;
+    channel->mScalingKeys = new aiVectorKey[1];
+    channel->mScalingKeys[0] = aiVectorKey(0.0, aiVector3D(100.f, 100.f, 100.f));
+
+    auto* anim = new aiAnimation;
+    anim->mName = aiString(std::string("Clip"));
+    anim->mDuration = 1.0;
+    anim->mTicksPerSecond = 1.0;
+    anim->mNumChannels = 1;
+    anim->mChannels = new aiNodeAnim*[1]{channel};
+    scene.mNumAnimations = 1;
+    scene.mAnimations = new aiAnimation*[1]{anim};
+
+    AnimationProcessor processor(skel);
+    processor.processAnimations(&scene);
+
+    ASSERT_EQ(skel->getNumAnimations(), 1);
+    Ogre::NodeAnimationTrack* track =
+        skel->getAnimation(0)->getNodeTrack(bone->getHandle());
+    ASSERT_NE(track, nullptr);
+    ASSERT_GE(track->getNumKeyFrames(), 1);
+    auto* kf = static_cast<Ogre::TransformKeyFrame*>(track->getKeyFrame(0));
+    // key(100) / nodeBindScale(100) → identity: the pose stays at bind size.
+    EXPECT_NEAR(kf->getScale().x, 1.0f, 1e-4f);
+    EXPECT_NEAR(kf->getScale().y, 1.0f, 1e-4f);
+    EXPECT_NEAR(kf->getScale().z, 1.0f, 1e-4f);
+}

--- a/src/Assimp/BoneProcessor.cpp
+++ b/src/Assimp/BoneProcessor.cpp
@@ -13,14 +13,30 @@ void BoneProcessor::processBones(Ogre::SkeletonPtr skeleton, const aiScene *scen
         }
     }
 
-    // Create the root bones
+    // Create the root bones.
+    // The root bind must be the armature node's transform RELATIVE TO THE
+    // MESH NODE (meshNodeWorld⁻¹ · armatureNodeWorld), not its raw local
+    // mTransformation: children's binds are derived from the offset matrices
+    // (offset⁻¹ = meshNodeWorld⁻¹ · boneBindWorld), so the whole chain lives
+    // in mesh-node space. With a raw local root the two spaces disagree by
+    // every ancestor transform above the armature — for Blender FBX rigs
+    // (scene-root unit conversion + armature ×100) that skewed every bone's
+    // bind local ×100 vs the node-local ANIMATION keys, exploding animated
+    // poses out of frame (#936). For Mixamo-style rigs (mesh node local ==
+    // identity, armature directly under the root) this reduces to the old
+    // value, so typical assets are bit-identical.
     for(auto i = 0u; i < scene->mNumMeshes; i++) {
         aiMesh* mesh = scene->mMeshes[i];
+        if (mesh->mNumBones == 0) continue;
+        const aiNode* meshNode = findMeshNode(scene->mRootNode, i);
+        const Ogre::Matrix4 meshWorldInv = meshNode
+            ? nodeWorldTransform(meshNode).inverse() : Ogre::Matrix4::IDENTITY;
         for(auto j = 0u; j < mesh->mNumBones; j++) {
             aiBone* bone = mesh->mBones[j];
             if(bone->mNode && bone->mNode->mParent && !skeleton->hasBone(bone->mNode->mParent->mName.C_Str())) {
                 createBone(bone->mNode->mParent->mName.C_Str());
-                Ogre::Matrix4 rootBoneGlobalTransformation = convertToOgreMatrix4(bone->mNode->mParent->mTransformation);
+                const Ogre::Matrix4 rootBoneGlobalTransformation =
+                    meshWorldInv * nodeWorldTransform(bone->mNode->mParent);
                 applyTransformation(bone->mNode->mParent->mName.C_Str(), rootBoneGlobalTransformation);
             }
         }
@@ -95,6 +111,28 @@ void BoneProcessor::createBone(const std::string& boneName) {
         // If the bone does not exist, create it
         skeleton->createBone(boneName);
     }
+}
+
+Ogre::Matrix4 BoneProcessor::nodeWorldTransform(const aiNode* node) const {
+    Ogre::Matrix4 world = Ogre::Matrix4::IDENTITY;
+    for (const aiNode* n = node; n; n = n->mParent)
+        world = Ogre::Matrix4(
+                    n->mTransformation.a1, n->mTransformation.a2, n->mTransformation.a3, n->mTransformation.a4,
+                    n->mTransformation.b1, n->mTransformation.b2, n->mTransformation.b3, n->mTransformation.b4,
+                    n->mTransformation.c1, n->mTransformation.c2, n->mTransformation.c3, n->mTransformation.c4,
+                    n->mTransformation.d1, n->mTransformation.d2, n->mTransformation.d3, n->mTransformation.d4)
+                * world;
+    return world;
+}
+
+const aiNode* BoneProcessor::findMeshNode(const aiNode* node, unsigned meshIndex) {
+    if (!node) return nullptr;
+    for (unsigned i = 0; i < node->mNumMeshes; ++i)
+        if (node->mMeshes[i] == meshIndex) return node;
+    for (unsigned i = 0; i < node->mNumChildren; ++i)
+        if (const aiNode* hit = findMeshNode(node->mChildren[i], meshIndex))
+            return hit;
+    return nullptr;
 }
 
 Ogre::Matrix4 BoneProcessor::convertToOgreMatrix4(const aiMatrix4x4& aiMat) {

--- a/src/Assimp/BoneProcessor.h
+++ b/src/Assimp/BoneProcessor.h
@@ -19,6 +19,11 @@ class BoneProcessor {
         void processBoneNode(aiBone *bone);
         void processNonSkinnedBone(aiNode* node);
         void processAnimationOnlyHierarchy(aiNode* node, const std::set<std::string>& animatedNodes);
+        // World (scene-root-relative) transform of a node: product of
+        // mTransformation from the scene root down to `node`.
+        Ogre::Matrix4 nodeWorldTransform(const aiNode* node) const;
+        // Node that references mesh index `meshIndex` (nullptr if none).
+        static const aiNode* findMeshNode(const aiNode* node, unsigned meshIndex);
         Ogre::Matrix4 convertToOgreMatrix4(const aiMatrix4x4& aiMat);
         void applyTransformation(const std::string& boneName, const Ogre::Matrix4 &transform);
 

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -4567,7 +4567,13 @@ int CLIPipeline::cmdTurntable(int argc, char* argv[])
             axis = parsed;
             continue;
         }
-        if (arg == "--animation" && i + 1 < argc) {
+        if (arg == "--animation") {
+            // A missing value must be a usage error — silently falling through
+            // would render the static pose and still return success.
+            if (i + 1 >= argc || QString(argv[i + 1]).startsWith(QLatin1Char('-'))) {
+                err() << "Error: --animation requires an animation name." << Qt::endl;
+                return 2;
+            }
             animationName = QString(argv[++i]);
             continue;
         }
@@ -4575,9 +4581,10 @@ int CLIPipeline::cmdTurntable(int argc, char* argv[])
             orbitWithAnimation = true;
             continue;
         }
-        if (arg == "--at" && i + 1 < argc) {
-            if (!parseCliFloat(QString(argv[++i]), &atSeconds) || atSeconds < 0.0f) {
-                err() << "Error: Invalid value for --at (seconds >= 0)." << Qt::endl;
+        if (arg == "--at") {
+            if (i + 1 >= argc ||
+                !parseCliFloat(QString(argv[++i]), &atSeconds) || atSeconds < 0.0f) {
+                err() << "Error: --at requires a time in seconds (>= 0)." << Qt::endl;
                 return 2;
             }
             continue;

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -4474,7 +4474,8 @@ int CLIPipeline::cmdPose(int argc, char* argv[])
 int CLIPipeline::cmdTurntable(int argc, char* argv[])
 {
     // turntable <file> -o <output> [--frames N] [--size WxH] [--width W] [--height H]
-    //                     [--columns C] [--axis y|x|z] [--elevation deg] [--camera-height deg] [--json]
+    //                     [--columns C] [--axis y|x|z] [--elevation deg] [--camera-height deg]
+    //                     [--animation NAME [--orbit]] [--at SECONDS] [--json]
     QString inputPath, outputPath;
     int frameCount = 12;
     int width = 512;
@@ -4483,6 +4484,9 @@ int CLIPipeline::cmdTurntable(int argc, char* argv[])
     float elevation = 20.0f;
     bool jsonOutput = false;
     TurntableAxis axis = TurntableAxis::Y;
+    QString animationName;          // #936: sample a clip over time
+    bool orbitWithAnimation = false;   // #936: combine rotation + animation
+    float atSeconds = -1.0f;           // #936: single posed frame, normal orbit
 
     for (int i = 1; i < argc; ++i) {
         QString arg(argv[i]);
@@ -4563,6 +4567,21 @@ int CLIPipeline::cmdTurntable(int argc, char* argv[])
             axis = parsed;
             continue;
         }
+        if (arg == "--animation" && i + 1 < argc) {
+            animationName = QString(argv[++i]);
+            continue;
+        }
+        if (arg == "--orbit") {
+            orbitWithAnimation = true;
+            continue;
+        }
+        if (arg == "--at" && i + 1 < argc) {
+            if (!parseCliFloat(QString(argv[++i]), &atSeconds) || atSeconds < 0.0f) {
+                err() << "Error: Invalid value for --at (seconds >= 0)." << Qt::endl;
+                return 2;
+            }
+            continue;
+        }
         if (!arg.startsWith(QLatin1Char('-')) && inputPath.isEmpty()) {
             inputPath = arg;
             continue;
@@ -4622,6 +4641,9 @@ int CLIPipeline::cmdTurntable(int argc, char* argv[])
     options.frameCount = qBound(1, frameCount, 360);
     options.axis = axis;
     options.elevationDegrees = elevation;
+    options.animationName = animationName;       // #936
+    options.orbitWithAnimation = orbitWithAnimation;
+    options.atSeconds = atSeconds;
 
     QList<QImage> frames;
     QString renderError;

--- a/src/ModelTurntableRenderer.cpp
+++ b/src/ModelTurntableRenderer.cpp
@@ -581,6 +581,8 @@ bool ModelTurntableRenderer::renderToImages(const QList<Ogre::Entity *> &entitie
     return true;
   } catch (const Ogre::Exception &e) {
     outFrames->clear();
+    if (animState)
+      animState->setEnabled(false);   // don't leak the sampled clip's state
     restoreTurntableLighting(sm);
     if (errorOut)
       *errorOut = QString::fromStdString(e.getFullDescription());
@@ -588,6 +590,8 @@ bool ModelTurntableRenderer::renderToImages(const QList<Ogre::Entity *> &entitie
     return false;
   } catch (...) {
     outFrames->clear();
+    if (animState)
+      animState->setEnabled(false);
     restoreTurntableLighting(sm);
     if (errorOut)
       *errorOut = QStringLiteral("Turntable render failed");

--- a/src/ModelTurntableRenderer.cpp
+++ b/src/ModelTurntableRenderer.cpp
@@ -430,6 +430,29 @@ void ModelTurntableRenderer::shutdown()
   st.pivotNode = nullptr;
 }
 
+namespace {
+
+// #936: pose `entity` at `time` of `animState` — same recipe as the isometric
+// renderer (enable + set time + notify + fire queued so software/hardware
+// animation state updates, then force the entity update).
+void applyTurntableAnimationFrame(Ogre::Entity *entity, Ogre::AnimationState *animState, float time)
+{
+  if (!entity || !animState)
+    return;
+  animState->setEnabled(true);
+  animState->setTimePosition(time);
+  if (Ogre::AnimationStateSet *states = entity->getAllAnimationStates())
+    states->_notifyDirty();
+  Ogre::FrameEvent ev{};
+  ev.timeSinceLastFrame = 0.0f;
+  ev.timeSinceLastEvent = 0.0f;
+  if (Ogre::Root *root = Ogre::Root::getSingletonPtr())
+    root->_fireFrameRenderingQueued(ev);
+  entity->_updateAnimation();
+}
+
+} // namespace
+
 bool ModelTurntableRenderer::renderToImages(const QList<Ogre::Entity *> &entities,
                                             const TurntableOptions &options, QList<QImage> *outFrames,
                                             QString *errorOut)
@@ -458,6 +481,48 @@ bool ModelTurntableRenderer::renderToImages(const QList<Ogre::Entity *> &entitie
   const int height = std::max(16, options.height);
   const int frameCount = std::clamp(options.frameCount, 1, 360);
 
+  // #936: resolve the animated entity + state up front so a bad name fails
+  // with a clear error instead of silently rendering the bind pose.
+  const bool wantsAnimation = !options.animationName.isEmpty();
+  Ogre::Entity *animatedEntity = nullptr;
+  Ogre::AnimationState *animState = nullptr;
+  float animLength = 0.0f;
+  if (wantsAnimation || options.atSeconds >= 0.0f) {
+    const std::string wanted = options.animationName.toStdString();
+    for (Ogre::Entity *entity : entities) {
+      if (!entity || !entity->hasSkeleton())
+        continue;
+      Ogre::AnimationStateSet *states = entity->getAllAnimationStates();
+      if (!states)
+        continue;
+      if (wantsAnimation) {
+        if (states->hasAnimationState(wanted)) {
+          animatedEntity = entity;
+          animState = states->getAnimationState(wanted);
+          break;
+        }
+      } else if (!states->getAnimationStates().empty()) {
+        // --at with no name: pose the first animation found.
+        animatedEntity = entity;
+        animState = states->getAnimationStates().begin()->second;
+        break;
+      }
+    }
+    if (!animState) {
+      if (errorOut)
+        *errorOut = wantsAnimation
+            ? QStringLiteral("Animation '%1' not found").arg(options.animationName)
+            : QStringLiteral("--at needs a skeletal animation, none found");
+      return false;
+    }
+    animLength = animState->getLength();
+    // Only the sampled clip drives the pose — disable everything else.
+    if (Ogre::AnimationStateSet *states = animatedEntity->getAllAnimationStates())
+      for (const auto &entry : states->getAnimationStates())
+        if (entry.second)
+          entry.second->setEnabled(false);
+  }
+
   if (!ensureRenderTarget(width, height, options.background, errorOut))
     return false;
 
@@ -484,14 +549,32 @@ bool ModelTurntableRenderer::renderToImages(const QList<Ogre::Entity *> &entitie
   SentryReporter::addBreadcrumb("cli.turntable",
                                 QStringLiteral("render start frames=%1").arg(frameCount));
 
+  // #936: --at poses once, before framing bounds matter for the orbit.
+  if (animState && !wantsAnimation && options.atSeconds >= 0.0f)
+    applyTurntableAnimationFrame(animatedEntity, animState,
+                                 std::min(options.atSeconds, animLength));
+
   outFrames->reserve(frameCount);
   try {
     for (int i = 0; i < frameCount; ++i) {
-      const float angle = Ogre::Math::TWO_PI * static_cast<float>(i) / static_cast<float>(frameCount);
+      if (wantsAnimation) {
+        // Frame i at `length * i/(frames-1)` — the issue's sampling contract.
+        const float t = frameCount > 1
+            ? animLength * static_cast<float>(i) / static_cast<float>(frameCount - 1)
+            : 0.0f;
+        applyTurntableAnimationFrame(animatedEntity, animState, t);
+      }
+      // Animation sampling keeps the camera FIXED at the front unless the
+      // caller combines both via --orbit.
+      const float angle = (wantsAnimation && !options.orbitWithAnimation)
+          ? 0.0f
+          : Ogre::Math::TWO_PI * static_cast<float>(i) / static_cast<float>(frameCount);
       placeCameraOnAxis(bounds, angle, options.axis, elevationRad, 1.25f);
       state().renderTarget->update();
       outFrames->append(readRenderTarget(width, height));
     }
+    if (animState)
+      animState->setEnabled(false);
     restoreTurntableLighting(sm);
     SentryReporter::addBreadcrumb("cli.turntable",
                                   QStringLiteral("render ok frames=%1").arg(outFrames->size()));

--- a/src/ModelTurntableRenderer.h
+++ b/src/ModelTurntableRenderer.h
@@ -27,6 +27,15 @@ struct TurntableOptions {
   /// Camera angle above the orbit plane, in degrees (see axis).
   float elevationDegrees = 20.0f;
   Ogre::ColourValue background{0.12f, 0.12f, 0.13f, 1.0f};
+  /// #936: sample this skeletal animation across its duration instead of
+  /// rotating the pose — frame i at time `length * i/(frameCount-1)`, camera
+  /// FIXED at the front unless `orbitWithAnimation` combines both.
+  QString animationName;
+  bool orbitWithAnimation = false;
+  /// #936: pose the model at this time (seconds) for every frame — a normal
+  /// orbit of a single posed frame (thumbnail of a specific pose). Ignored
+  /// when < 0 or when `animationName` is set.
+  float atSeconds = -1.0f;
 };
 
 class ModelTurntableRenderer


### PR DESCRIPTION
## Summary

Fixes #936 on both fronts.

### The bug — animated renders empty while static works

Blender-exported rigs (Quaternius `KnightCharacter.fbx`, `Trex.fbx`) carry a static **×100 scale on the armature node**, and the exporter re-expresses that scale in every animation curve. Two import bugs compounded so the animated pose blew up ~100× and left the camera frame (static bind renders were self-consistent and fine):

1. **`AnimationProcessor` stored scale keys raw.** Ogre applies keyframe scale *multiplicatively* on the bind pose, so a key equal to the node's bind scale double-applies it (bind ×100 × key ×100). Scale keys are now stored **relative to the channel node's bind scale** — the space the keys actually live in — mirroring the existing position/rotation delta conversion. Regression unit test included.
2. **`BoneProcessor` mixed bind spaces.** The root bone's bind used the armature node's raw local `mTransformation`, while every child bind derives from the offset matrices (which are **mesh-node-relative**). The root bind is now `meshNodeWorld⁻¹ · armatureNodeWorld`, making the whole chain agree with the node-local animation keys. For Mixamo-style rigs this reduces to the old value (verified bit-identical output).

### The feature — `turntable --animation` (the issue's original ask)

- `--animation <name>`: frame *i* sampled at `length·i/(frames−1)`, camera fixed at the front; `--orbit` combines rotation + animation.
- `--at <seconds>`: normal orbit of a single posed frame (pose thumbnail).
- Clear error (exit 1) for an unknown animation name.

### Verification

| check | before | after |
|---|---|---|
| Knight `HumanArmature\|Walking` isometric (4×4) | **0** non-bg px | 290,386 px, walk cycle visible in all directions |
| Trex `Armature\|TRex_Attack` isometric (4×4) | 228 stray px | 771,756 px (169,709 at final) |
| Rumba Dancing (Mixamo) animated isometric | 458,438 px | **458,438 px — bit-identical** |
| Knight posed bounds (`qtmesh pose`) | 6.6 units, −20 Z off-frame | matches bind bounds |
| Quaternius woman + Hip Hop Dancing renders | — | non-empty, sane |
| Pure-data unit tests (incl. new scale-space test) | — | 62/62 green |

White silhouettes in headless sheets are the separate shaded-rendering issue (#933).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added animation sampling for turntable renders, including selecting an animation, rendering at a specific timestamp, and sampling across its duration.
  * Added an option to combine animation playback with camera orbiting or keep the camera fixed.
  * Added usage examples for animated and timestamp-based turntable rendering.
* **Bug Fixes**
  * Improved skeletal animation transforms for models with scaled nodes.
  * Corrected root bone positioning relative to mesh placement.
* **Tests**
  * Added regression coverage for animation scale handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->