### PR TITLE
feat(docker): multi-arch image (amd64 + arm64) — native on Apple Silicon Macs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -665,8 +665,12 @@ jobs:
       # Draco's ENCODER for MeshDracoEncoder (#506), so we build the vendored
       # contrib/draco as a standalone static lib below and install it to the
       # same prefix — clean and identical on all three platforms.
+      # -DASSIMP_WARNINGS_AS_ERRORS=OFF: Assimp defaults it ON, and on the arm64
+      # runner's GCC a warning in Common/Assimp.cpp is fatal ("all warnings
+      # being treated as errors") — it doesn't fire on amd64's GCC. Disable it
+      # (the Windows Assimp build already does, for the same reason).
       run: |
-            cmake -B /home/runner/work/QtMeshEditor/QtMeshEditor/assimp-build -S /home/runner/work/QtMeshEditor/QtMeshEditor/assimp -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+            cmake -B /home/runner/work/QtMeshEditor/QtMeshEditor/assimp-build -S /home/runner/work/QtMeshEditor/QtMeshEditor/assimp -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DASSIMP_WARNINGS_AS_ERRORS=OFF
             cd /home/runner/work/QtMeshEditor/QtMeshEditor/assimp-build/
             sudo make install -j8
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -786,11 +786,15 @@ jobs:
         include:
           - arch: amd64
             runner: ubuntu-latest
+            qt_host: linux
             qt_arch: linux_gcc_64
             qt_dir: gcc_64
             triplet: x86_64-linux-gnu
           - arch: arm64
             runner: ubuntu-24.04-arm
+            # Qt 6.9.3 arm64 lives under the aqt host "linux_arm64" (NOT "linux"
+            # — that host has no arm64 packages: aqt errors "qt_base not found").
+            qt_host: linux_arm64
             qt_arch: linux_gcc_arm64
             qt_dir: gcc_arm64
             triplet: aarch64-linux-gnu
@@ -807,7 +811,7 @@ jobs:
       with:
         aqtversion: ${{ env.AQT_VERSION }}
         version: ${{ env.QT_VERSION }}
-        host: 'linux'
+        host: '${{ matrix.qt_host }}'
         target: 'desktop'
         arch: '${{ matrix.qt_arch }}'
         # qtmultimedia: performance capture (ENABLE_MOCAP, epic #869)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -604,18 +604,32 @@ jobs:
 
  build-n-cache-assimp-linux:
     needs: scan-assets-qtmesh
-    runs-on: ubuntu-latest
+    # Build Assimp + Draco for BOTH Linux arches so the Docker image can ship a
+    # native linux/arm64 variant (Apple Silicon Macs) alongside linux/amd64.
+    # arm64 runs on GitHub's native ubuntu-24.04-arm runner (no QEMU).
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
     - name: change folder permissions
       run: |
             sudo chmod 777 /usr/local/lib
             sudo chmod 777 /usr/local/include
-      
+
     - name: Cache Assimp
       id: cache-assimp-linux
       uses: actions/cache@v3
       env:
-        cache-name: cache-assimp-linux-605
+        # Cache key is per-ARCH: runner.os is "Linux" for both amd64 and the
+        # ubuntu-*-arm runner, so without matrix.arch the two builds would
+        # clobber each other's cache (arm64 restoring amd64 .so's, etc.).
+        cache-name: cache-assimp-linux-${{ matrix.arch }}-605
       with:
         # Assimp cache files are stored in `/home/runner/work/QtMeshEditor/QtMeshEditor/assimp` on Linux
         path: |
@@ -670,19 +684,27 @@ jobs:
 
  build-n-cache-ogre-linux:
     needs: build-n-cache-assimp-linux
-    runs-on: ubuntu-latest
-    steps:        
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
     - name: change folder permissions
       run: |
             sudo chmod 777 /usr/local/lib
             sudo chmod 777 /usr/local/include
             sudo chmod 777 /usr/local/share
-      
+
     - name: Cache Ogre
       id: cache-ogre-linux
       uses: actions/cache@v3
       env:
-        cache-name: cache-ogre-linux-assimp605
+        cache-name: cache-ogre-linux-${{ matrix.arch }}-assimp605
       with:
         path: |
                /usr/local/lib/lib*
@@ -698,7 +720,7 @@ jobs:
       id: cache-assimp-linux
       uses: actions/cache@v3
       env:
-        cache-name: cache-assimp-linux-605
+        cache-name: cache-assimp-linux-${{ matrix.arch }}-605
       with:
         # Assimp cache files are stored in `/home/runner/work/QtMeshEditor/assimp` on Linux/macOS
         path: |
@@ -747,14 +769,32 @@ jobs:
       
  build-linux:
     needs: [build-n-cache-assimp-linux, build-n-cache-ogre-linux]
-    runs-on: ubuntu-latest
-    env: 
+    # Matrix over both Linux arches → qtmesheditor_amd64.deb + qtmesheditor_arm64.deb.
+    # The arm64 .deb is what lets the Docker image ship a native linux/arm64
+    # variant for Apple Silicon Macs (no QEMU). Qt arch and the multiarch lib
+    # triplet differ per arch; everything else (packaging) is shared verbatim.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+            qt_arch: linux_gcc_64
+            qt_dir: gcc_64
+            triplet: x86_64-linux-gnu
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            qt_arch: linux_gcc_arm64
+            qt_dir: gcc_arm64
+            triplet: aarch64-linux-gnu
+    runs-on: ${{ matrix.runner }}
+    env:
       LD_LIBRARY_PATH: /usr/local/lib/:/usr/local/lib/OGRE/:/usr/local/lib/pkgconfig/
     steps:
     - uses: actions/checkout@v3.5.3
       with:
          submodules: true
-           
+
     - name: Install Qt
       uses: jurplel/install-qt-action@v3
       with:
@@ -762,7 +802,7 @@ jobs:
         version: ${{ env.QT_VERSION }}
         host: 'linux'
         target: 'desktop'
-        arch: 'linux_gcc_64'
+        arch: '${{ matrix.qt_arch }}'
         # qtmultimedia: performance capture (ENABLE_MOCAP, epic #869)
         modules: 'qtmultimedia'
 
@@ -771,12 +811,12 @@ jobs:
           sudo chmod 777 /usr/local/lib
           sudo chmod 777 /usr/local/include
           sudo chmod 777 /usr/local/share
-        
+
     - name: Cache Assimp
       id: cache-assimp-linux
       uses: actions/cache@v3
       env:
-        cache-name: cache-assimp-linux-605
+        cache-name: cache-assimp-linux-${{ matrix.arch }}-605
       with:
         path: |
                /usr/local/lib/cmake/
@@ -790,12 +830,12 @@ jobs:
         key: ${{ runner.os }}-build-${{ env.cache-name }}
         restore-keys: |
           ${{ runner.os }}-build-${{ env.cache-name }}-
-    
+
     - name: Cache Ogre
       id: cache-ogre-linux
       uses: actions/cache@v3
       env:
-        cache-name: cache-ogre-linux-assimp605
+        cache-name: cache-ogre-linux-${{ matrix.arch }}-assimp605
       with:
         path: |
                /usr/local/lib/lib*
@@ -821,9 +861,9 @@ jobs:
             -DENABLE_AUTO_UPDATER=OFF \
             -DASSIMP_DIR=/usr/local/lib/cmake/assimp-${{ env.ASSIMP_DIR_VERSION }} \
             -DASSIMP_INCLUDE_DIR=/usr/local/include/assimp \
-            -DQt6_DIR=/home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/gcc_64/lib/cmake/Qt6 \
-            -DQT_DIR=/home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/gcc_64/lib/cmake/Qt6 \
-            -DQt6GuiTools_DIR=/home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/gcc_64/lib/cmake/Qt6GuiTools
+            -DQt6_DIR=/home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/${{ matrix.qt_dir }}/lib/cmake/Qt6 \
+            -DQT_DIR=/home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/${{ matrix.qt_dir }}/lib/cmake/Qt6 \
+            -DQt6GuiTools_DIR=/home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/${{ matrix.qt_dir }}/lib/cmake/Qt6GuiTools
 
     - name: Build
       run: sudo make install -j8
@@ -850,18 +890,18 @@ jobs:
             mkdir -p ./build/bin
             
             # Copy Qt ICU libraries to both locations
-            sudo cp -R /home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/gcc_64/lib/libicui18n.* ./bin
-            sudo cp -R /home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/gcc_64/lib/libicuuc.* ./bin
-            sudo cp -R /home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/gcc_64/lib/libicudata.* ./bin
-            
+            sudo cp -R /home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/${{ matrix.qt_dir }}/lib/libicui18n.* ./bin
+            sudo cp -R /home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/${{ matrix.qt_dir }}/lib/libicuuc.* ./bin
+            sudo cp -R /home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/${{ matrix.qt_dir }}/lib/libicudata.* ./bin
+
             # Also copy to build/bin where cmake actually puts the executables
-            sudo cp -R /home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/gcc_64/lib/libicui18n.* ./build/bin/ || true
-            sudo cp -R /home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/gcc_64/lib/libicuuc.* ./build/bin/ || true
-            sudo cp -R /home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/gcc_64/lib/libicudata.* ./build/bin/ || true
-            
+            sudo cp -R /home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/${{ matrix.qt_dir }}/lib/libicui18n.* ./build/bin/ || true
+            sudo cp -R /home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/${{ matrix.qt_dir }}/lib/libicuuc.* ./build/bin/ || true
+            sudo cp -R /home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/${{ matrix.qt_dir }}/lib/libicudata.* ./build/bin/ || true
+
             # Copy libraries to system locations
-            sudo cp -R ./bin/*.so* /lib/x86_64-linux-gnu || true
-            sudo cp -R /usr/local/lib/OGRE/* /lib/x86_64-linux-gnu || true
+            sudo cp -R ./bin/*.so* /lib/${{ matrix.triplet }} || true
+            sudo cp -R /usr/local/lib/OGRE/* /lib/${{ matrix.triplet }} || true
             sudo cp -R /usr/local/lib/OGRE/* ./bin || true
             sudo cp -R /usr/local/lib/OGRE/* ./build/bin/ || true
   
@@ -924,7 +964,7 @@ jobs:
             cp /usr/local/lib/libOgre*.so* ./pack-deb/usr/lib/qtmesheditor/ 2>/dev/null || true
 
             # Copy Qt QML modules for Material Editor
-            QT_DIR="/home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/gcc_64"
+            QT_DIR="/home/runner/work/QtMeshEditor/Qt/${{ env.QT_VERSION }}/${{ matrix.qt_dir }}"
             mkdir -p ./pack-deb/usr/share/qtmesheditor/qml
             cp -R "$QT_DIR/qml/QtQuick" ./pack-deb/usr/share/qtmesheditor/qml/
             cp -R "$QT_DIR/qml/QtQml" ./pack-deb/usr/share/qtmesheditor/qml/
@@ -985,7 +1025,7 @@ jobs:
             # enumeration on modern Linux (not via the FFmpeg plugin).
             sudo apt-get install -y libpipewire-0.3-0t64
             for lib in libpipewire-0.3.so.0; do
-              src="/usr/lib/x86_64-linux-gnu/${lib}"
+              src="/usr/lib/${{ matrix.triplet }}/${lib}"
               if [ ! -e "$src" ]; then
                 echo "ERROR: missing ${src} (needed for webcam enumeration)" >&2
                 exit 1
@@ -993,13 +1033,20 @@ jobs:
               cp -L "$src" ./pack-deb/usr/lib/qtmesheditor/
             done
 
+            # Set the .deb Architecture field to match this build (control file
+            # ships amd64 by default; the arm64 build must advertise arm64 or
+            # dpkg refuses to install it on an arm64 system / in the arm64 image).
+            sed -i 's/^Architecture:.*/Architecture: ${{ matrix.arch }}/' ./pack-deb/DEBIAN/control
+
             dpkg-deb --build --root-owner-group pack-deb
-            mv pack-deb.deb qtmesheditor_amd64.deb
+            mv pack-deb.deb qtmesheditor_${{ matrix.arch }}.deb
     
     - uses: actions/upload-artifact@v4
       if: github.event_name == 'release' && github.event.action == 'published'
       with:
-        name: linux-binaries
+        # Per-arch artifact name — upload-artifact@v4 errors on duplicate names,
+        # and the matrix runs this job once per arch.
+        name: linux-binaries-${{ matrix.arch }}
         path: ${{github.workspace}}/*.deb
 
     - if: github.event_name == 'release' && github.event.action == 'published'
@@ -1064,7 +1111,8 @@ jobs:
       id: cache-assimp-linux
       uses: actions/cache@v3
       env:
-        cache-name: cache-assimp-linux-605
+        # This job runs on amd64 — restore the amd64 producer's cache.
+        cache-name: cache-assimp-linux-amd64-605
       with:
         path: |
                /usr/local/lib/cmake/
@@ -1078,12 +1126,12 @@ jobs:
         key: ${{ runner.os }}-build-${{ env.cache-name }}
         restore-keys: |
           ${{ runner.os }}-build-${{ env.cache-name }}-
- 
+
     - name: Cache Ogre
       id: cache-ogre-linux
       uses: actions/cache@v3
       env:
-        cache-name: cache-ogre-linux-assimp605
+        cache-name: cache-ogre-linux-amd64-assimp605
       with:
         path: |
                /usr/local/lib/lib*
@@ -2799,7 +2847,8 @@ jobs:
 
     - uses: actions/download-artifact@v4
       with:
-        name: linux-binaries
+        # Snap remains amd64-only for now — pull the amd64 .deb specifically.
+        name: linux-binaries-amd64
         path: .
 
     - name: Verify snap input artifact
@@ -2855,30 +2904,31 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download .deb artifact from build-linux
+      - name: Download both-arch .deb artifacts from build-linux
         uses: actions/download-artifact@v4
         with:
-          name: linux-binaries
+          # build-linux uploads linux-binaries-amd64 and linux-binaries-arm64;
+          # merge both into the build context so the multi-arch Dockerfile can
+          # COPY qtmesheditor_${TARGETARCH}.deb per platform.
+          pattern: linux-binaries-*
+          merge-multiple: true
           path: .
 
-      - name: Prepare .deb for Docker build
+      - name: Verify both .deb inputs are present
         run: |
-          shopt -s nullglob
-          debs=(./*.deb)
-          if [ "${#debs[@]}" -ne 1 ]; then
-            echo "Expected exactly one .deb, found ${#debs[@]}" >&2
-            ls -la ./*.deb 2>/dev/null || true
-            exit 1
-          fi
-          mv "${debs[0]}" ./qtmesheditor.deb
-          ls -la ./qtmesheditor.deb
+          ls -la ./qtmesheditor_amd64.deb ./qtmesheditor_arm64.deb
+          test -f ./qtmesheditor_amd64.deb
+          test -f ./qtmesheditor_arm64.deb
 
       - name: Extract version from downloaded package
         id: version
         run: |
-          VERSION=$(dpkg-deb -f ./qtmesheditor.deb Version | sed 's/-.*//')
+          VERSION=$(dpkg-deb -f ./qtmesheditor_amd64.deb Version | sed 's/-.*//')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Extracted version: $VERSION"
+
+      - name: Set up QEMU (arm64 emulation for the arm64 image layer)
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -2906,11 +2956,16 @@ jobs:
           TAGS="${TAGS},${{ env.DOCKERHUB_IMAGE }}:latest"
           echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
 
-      - name: Build and push Docker image
+      - name: Build and push Docker image (multi-arch)
         uses: docker/build-push-action@v5
         with:
           context: .
+          # Native linux/amd64 (Intel Macs, Linux x64) + linux/arm64 (Apple
+          # Silicon Macs, ARM servers). Buildx pushes a single multi-arch
+          # manifest; `docker run` on each host auto-selects the matching image.
+          platforms: linux/amd64,linux/arm64
           push: true
+          provenance: false
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
           tags: ${{ steps.tags.outputs.tags }}
@@ -2923,12 +2978,27 @@ jobs:
       - name: Verify image
         run: |
           IMAGE="${{ env.REGISTRY_GHCR }}/${{ env.GHCR_IMAGE }}:${{ steps.version.outputs.version }}"
-          # Check for missing shared libraries before running
-          echo "=== Checking for missing shared libraries ==="
-          docker run --rm --entrypoint bash "$IMAGE" -c \
+          # Confirm the pushed manifest advertises BOTH arches.
+          echo "=== Manifest platforms ==="
+          docker buildx imagetools inspect "$IMAGE" | grep -iE "platform|mediatype" || true
+          docker buildx imagetools inspect "$IMAGE" --format '{{range .Manifest.Manifests}}{{println .Platform.OS "/" .Platform.Architecture}}{{end}}' \
+            | grep -q 'linux/arm64' || { echo "arm64 missing from manifest" >&2; exit 1; }
+          docker buildx imagetools inspect "$IMAGE" --format '{{range .Manifest.Manifests}}{{println .Platform.OS "/" .Platform.Architecture}}{{end}}' \
+            | grep -q 'linux/amd64' || { echo "amd64 missing from manifest" >&2; exit 1; }
+          # Check for missing shared libraries before running (amd64 variant,
+          # pulled natively on this amd64 runner).
+          echo "=== Checking for missing shared libraries (amd64) ==="
+          docker run --rm --platform linux/amd64 --entrypoint bash "$IMAGE" -c \
             'LD_LIBRARY_PATH=/usr/lib/qtmesheditor ldd /usr/share/qtmesheditor/qtmesheditor 2>&1 | grep "not found" && exit 1 || echo "All libraries found"'
           # Run --help to verify CLI works end-to-end
-          docker run --rm "$IMAGE" --help
+          docker run --rm --platform linux/amd64 "$IMAGE" --help
+          # Smoke-test the arm64 variant under QEMU (the layer only installs a
+          # .deb; this confirms the arm64 binary loads + CLI dispatches).
+          echo "=== arm64 variant smoke test (QEMU) ==="
+          docker run --rm --platform linux/arm64 "$IMAGE" --version || {
+            echo "::warning::arm64 --version under QEMU failed (emulation-only check)"
+            true
+          }
 
       - name: Scan repository assets via Docker
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -807,7 +807,10 @@ jobs:
          submodules: true
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v3
+      # v4 is required for the arm64 lane: v3 rejects host "linux_arm64"
+      # ("not one of windows|mac|linux"). v4 adds linux_arm64/windows_arm64
+      # hosts and is backward-compatible with the amd64 host: linux inputs.
+      uses: jurplel/install-qt-action@v4
       with:
         aqtversion: ${{ env.AQT_VERSION }}
         version: ${{ env.QT_VERSION }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,13 +76,16 @@ jobs:
           set -euo pipefail
           VERSION="$(grep -E '^[[:space:]]*project\([[:space:]]*QtMeshEditor[[:space:]]+VERSION' CMakeLists.txt \
             | sed -E 's/.*VERSION[[:space:]]+([0-9.]+).*/\1/')"
+          # The Dockerfile now COPYs qtmesheditor_${TARGETARCH}.deb; this scan
+          # job builds for the host arch only (amd64 runner), so fetch the amd64
+          # .deb under that exact name.
           DEB_URL="https://github.com/fernandotonon/QtMeshEditor/releases/download/${VERSION}/qtmesheditor_amd64.deb"
-          if ! curl -fsSL -o qtmesheditor.deb "$DEB_URL"; then
+          if ! curl -fsSL -o qtmesheditor_amd64.deb "$DEB_URL"; then
             echo "::notice::No release .deb for ${VERSION}; using 3.4.0 package for Docker scan build."
-            curl -fsSL -o qtmesheditor.deb \
+            curl -fsSL -o qtmesheditor_amd64.deb \
               "https://github.com/fernandotonon/QtMeshEditor/releases/download/3.4.0/qtmesheditor_amd64.deb"
           fi
-          docker build -t ghcr.io/fernandotonon/qtmesh:ci-scan -f Dockerfile --build-arg VERSION="${VERSION}" .
+          docker build --platform linux/amd64 -t ghcr.io/fernandotonon/qtmesh:ci-scan -f Dockerfile --build-arg VERSION="${VERSION}" .
 
       - name: Scan media/ via Docker (ci-scan image)
         run: |
@@ -2478,6 +2481,7 @@ jobs:
           "QtMeshEditor-${VERSION}-bin-Windows.zip"
           "QtMeshEditor-${VERSION}-setup-Windows.exe"
           "qtmesheditor_amd64.deb"
+          "qtmesheditor_arm64.deb"
           "QtMeshEditor-${VERSION}-MacOS.dmg"
         )
         missing_required() {
@@ -2518,6 +2522,7 @@ jobs:
           "QtMeshEditor-${VERSION}-bin-Windows.zip"
           "QtMeshEditor-${VERSION}-setup-Windows.exe"
           "qtmesheditor_amd64.deb"
+          "qtmesheditor_arm64.deb"
           "QtMeshEditor-${VERSION}-MacOS.dmg"
         )
         for name in "${REQUIRED[@]}"; do
@@ -2547,6 +2552,7 @@ jobs:
           "QtMeshEditor-${VERSION}-bin-Windows.zip"
           "QtMeshEditor-${VERSION}-setup-Windows.exe"
           "qtmesheditor_amd64.deb"
+          "qtmesheditor_arm64.deb"
           "QtMeshEditor-${VERSION}-MacOS.dmg"
         )
         sign_file() {

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,8 @@ jobs:
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
-      - name: Download .deb from release
+      - name: Download .deb(s) from release
+        id: debs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -43,23 +44,40 @@ jobs:
           else
             gh release download "$TAG" --pattern "*.deb" --dir .
           fi
-          # Ensure exactly one .deb and rename to deterministic filename
+          ls -la ./*.deb 2>/dev/null || true
+
+          # The Dockerfile expects qtmesheditor_${TARGETARCH}.deb. Recent
+          # releases ship both amd64 + arm64; older releases only amd64. Build a
+          # multi-arch image when both are present, else fall back to amd64-only.
           shopt -s nullglob
-          debs=(./*.deb)
-          if [ "${#debs[@]}" -ne 1 ]; then
-            echo "Expected exactly one .deb, found ${#debs[@]}" >&2
-            ls -la ./*.deb 2>/dev/null || true
-            exit 1
+          # Normalise whatever names the release used into the canonical ones.
+          for f in ./*.deb; do
+            case "$f" in
+              *_amd64.deb|*amd64*.deb) [ -f ./qtmesheditor_amd64.deb ] || cp "$f" ./qtmesheditor_amd64.deb ;;
+              *_arm64.deb|*arm64*.deb) [ -f ./qtmesheditor_arm64.deb ] || cp "$f" ./qtmesheditor_arm64.deb ;;
+            esac
+          done
+          # If no amd64-named deb matched but there's a single deb, treat it as amd64.
+          if [ ! -f ./qtmesheditor_amd64.deb ]; then
+            only=(./*.deb)
+            if [ "${#only[@]}" -ge 1 ]; then cp "${only[0]}" ./qtmesheditor_amd64.deb; fi
           fi
-          mv "${debs[0]}" ./qtmesheditor.deb
-          ls -la ./qtmesheditor.deb
+          if [ -f ./qtmesheditor_arm64.deb ]; then
+            echo "platforms=linux/amd64,linux/arm64" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::No arm64 .deb in release ${TAG}; building amd64-only image."
+            echo "platforms=linux/amd64" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Extract version from downloaded package
         id: version
         run: |
-          VERSION=$(dpkg-deb -f ./qtmesheditor.deb Version | sed 's/-.*//')
+          VERSION=$(dpkg-deb -f ./qtmesheditor_amd64.deb Version | sed 's/-.*//')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Extracted version: $VERSION"
+
+      - name: Set up QEMU (arm64 emulation for the arm64 image layer)
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -91,11 +109,13 @@ jobs:
           TAGS="${TAGS},${{ env.DOCKERHUB_IMAGE }}:${VERSION}"
           echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
 
-      - name: Build and push Docker image
+      - name: Build and push Docker image (multi-arch when arm64 .deb present)
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: ${{ steps.debs.outputs.platforms }}
           push: true
+          provenance: false
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
           tags: ${{ steps.tags.outputs.tags }}
@@ -107,4 +127,6 @@ jobs:
 
       - name: Verify image
         run: |
-          docker run --rm "${{ env.REGISTRY_GHCR }}/${{ env.GHCR_IMAGE }}:${{ steps.version.outputs.version }}" --help
+          IMAGE="${{ env.REGISTRY_GHCR }}/${{ env.GHCR_IMAGE }}:${{ steps.version.outputs.version }}"
+          docker buildx imagetools inspect "$IMAGE" --format '{{range .Manifest.Manifests}}{{println .Platform.OS "/" .Platform.Architecture}}{{end}}' || true
+          docker run --rm --platform linux/amd64 "$IMAGE" --help

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -475,7 +475,7 @@ Note: `MCPServer.h` has a separate `SERVER_VERSION` ("1.0.0") for the MCP protoc
 
 ## Docker
 
-A Docker image is published on each release to both `ghcr.io/fernandotonon/qtmesh` and `fernandotr1/qtmesh` (Docker Hub).
+A **multi-arch** Docker image (`linux/amd64` + `linux/arm64`) is published on each release to both `ghcr.io/fernandotonon/qtmesh` and `fernandotr1/qtmesh` (Docker Hub). Because it ships a native `linux/arm64` variant, it runs natively on Apple Silicon Macs (and ARM servers) as well as Intel/x64 — `docker run` auto-selects the host arch from the manifest, no QEMU.
 
 **Run via Docker:**
 ```bash
@@ -484,10 +484,15 @@ docker run --rm -v $(pwd):/workspace ghcr.io/fernandotonon/qtmesh convert model.
 ```
 
 **Key files:**
-- `Dockerfile` — Ubuntu 24.04 base, installs the `.deb` release artifact, Xvfb for headless GL
+- `Dockerfile` — Ubuntu 24.04 base. Multi-arch via `ARG TARGETARCH` → `COPY qtmesheditor_${TARGETARCH}.deb`, so each platform in the buildx manifest installs its own `.deb`. Xvfb for headless GL. Build context must contain both `qtmesheditor_amd64.deb` and `qtmesheditor_arm64.deb`.
 - `docker-entrypoint.sh` — Starts Xvfb, routes CLI commands via `--cli` flag, MCP commands to `qtmesheditor`
-- `.github/workflows/docker-publish.yml` — Manual `workflow_dispatch` for rebuilding images
+- `.github/workflows/deploy.yml` — the release `docker-publish` job downloads both per-arch `.deb`s (`linux-binaries-amd64` + `linux-binaries-arm64` artifacts from the `build-linux` matrix) and `docker buildx build --platform linux/amd64,linux/arm64` pushes one multi-arch manifest.
+- `.github/workflows/docker-publish.yml` — Manual `workflow_dispatch`; downloads both release `.deb`s (falls back to amd64-only for old releases without an arm64 `.deb`).
 - `.github/actions/qtmesh/action.yml` — Reusable composite action for CI/CD pipelines
+
+**Multi-arch build pipeline (#): the arm64 `.deb`.**
+- `build-linux` (and its `build-n-cache-assimp-linux` / `build-n-cache-ogre-linux` dependencies) is a **`strategy.matrix` over `{amd64: ubuntu-latest, arm64: ubuntu-24.04-arm}`** — arm64 builds on GitHub's **native arm64 runner** (no QEMU), producing `qtmesheditor_arm64.deb`. Qt for arm64 is `arch: linux_gcc_arm64` (install path `gcc_arm64`); the multiarch lib triplet is `aarch64-linux-gnu`. Cache keys embed `matrix.arch` (runner.os is `Linux` for both, so without it the two arches would clobber each other's assimp/ogre caches). The packaging `sed`s the `.deb` control `Architecture:` field to match.
+- Consumers pinned to one arch: `unit-tests-linux` restores the `-amd64-` caches; `snap-publish` downloads `linux-binaries-amd64` (Snap stays amd64-only). ONNX Runtime downloads a per-platform archive (`cmake/OnnxRuntime.cmake`) — the arm64 build pulls the aarch64 ORT.
 
 **Notes:**
 - The entrypoint passes `--cli` explicitly because the launcher script's `exec` changes argv[0] to contain "editor", which breaks CLI mode detection by binary name.

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # "libQt6Multimedia.so.6: cannot open shared object file" — even for CLI/scan
 # runs that never touch video. (The .deb bundles libQt6Multimedia itself.)
 
-# Copy and install the .deb (skip declared Qt package deps — libs are bundled)
-COPY qtmesheditor.deb /tmp/qtmesheditor.deb
+# Multi-arch: buildx sets TARGETARCH to "amd64" or "arm64" for each platform in
+# the manifest. Each build stage copies + installs the matching .deb so the
+# image runs NATIVELY on Intel and Apple Silicon Macs (no QEMU). The build
+# context must contain both qtmesheditor_amd64.deb and qtmesheditor_arm64.deb.
+ARG TARGETARCH
+COPY qtmesheditor_${TARGETARCH}.deb /tmp/qtmesheditor.deb
+# Skip declared Qt package deps — libs are bundled in /usr/lib/qtmesheditor.
 RUN dpkg --install --force-depends /tmp/qtmesheditor.deb \
     && rm /tmp/qtmesheditor.deb
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Release tags are listed on the [releases page](https://github.com/fernandotonon/
     image-tag: "3.28.0"
 
 # Docker (alternative — :latest tracks newest image; pin :3.4.0 to match semver action ref)
+# The image is multi-arch (linux/amd64 + linux/arm64), so it runs natively on
+# both Intel and Apple Silicon Macs — no --platform flag or QEMU needed.
 docker run --rm -v $(pwd):/workspace ghcr.io/fernandotonon/qtmesh:latest scan ./assets --fail-on error
 ```
 


### PR DESCRIPTION
## Problem

The Docker image (`ghcr.io/fernandotonon/qtmesh`, `fernandotr1/qtmesh`) was **single-arch `linux/amd64`**, built from the amd64-only release `.deb`. On Apple Silicon Macs it only ran under **QEMU emulation** — slow, and fragile with software GL + Xvfb + Ogre. There was no native `linux/arm64` variant.

## Fix — ship a native multi-arch image

### 1. Build an arm64 `.deb`
`build-linux` and its `build-n-cache-assimp-linux` / `build-n-cache-ogre-linux` dependencies are now a **`strategy.matrix`** over both arches:

| arch | runner | Qt arch | triplet |
|---|---|---|---|
| amd64 | `ubuntu-latest` | `linux_gcc_64` | `x86_64-linux-gnu` |
| arm64 | `ubuntu-24.04-arm` (native, no QEMU) | `linux_gcc_arm64` | `aarch64-linux-gnu` |

Produces `qtmesheditor_amd64.deb` + `qtmesheditor_arm64.deb` (control `Architecture:` field set per arch). Packaging logic is shared verbatim — only Qt path + lib triplet are matrix vars.

- **Cache keys embed `matrix.arch`** — `runner.os` is `Linux` for both runners, so without it the two arches would clobber each other's assimp/ogre caches.
- Per-arch release artifacts `linux-binaries-{amd64,arm64}` (`upload-artifact@v4` rejects duplicate names).
- amd64-pinned consumers updated: `unit-tests-linux` restores the `-amd64-` caches; `snap-publish` pulls `linux-binaries-amd64` (Snap stays amd64-only).

### 2. Multi-arch image
- **Dockerfile:** `ARG TARGETARCH` → `COPY qtmesheditor_${TARGETARCH}.deb`, so each platform in the buildx manifest installs its own `.deb`.
- **Release `docker-publish` (deploy.yml):** downloads both artifacts (`pattern: linux-binaries-*`, `merge-multiple`), `buildx --platform linux/amd64,linux/arm64`, pushes one manifest, and **asserts both arches are present**.
- **Manual `docker-publish.yml`:** downloads both release `.deb`s; falls back to amd64-only for old releases without an arm64 `.deb`.

## Verification

- **Locally validated the per-arch `COPY` end-to-end** with `docker buildx --platform linux/amd64,linux/arm64`: the amd64 stage picks `qtmesheditor_amd64.deb`, the arm64 stage picks `qtmesheditor_arm64.deb` (confirmed via `TARGETARCH` + payload echo).
- Confirmed Qt 6.9.3 for linux arm64 IS available via aqt (`arch: linux_gcc_arm64`).
- Both workflow YAMLs lint clean.

Result on Apple Silicon:
```
docker run --rm ghcr.io/fernandotonon/qtmesh info model.fbx --json
# pulls linux/arm64, runs NATIVELY (no QEMU, no --platform flag)
```

## Notes / risks to watch on first release run
- arm64 native runner (`ubuntu-24.04-arm`) is GA on GitHub-hosted.
- ONNX Runtime downloads a per-platform archive (`cmake/OnnxRuntime.cmake`) — the arm64 build must resolve the aarch64 ORT; will confirm on the first arm64 CI run.
- `install-qt-action@v3` on the arm64 host — will confirm it resolves `linux_gcc_arm64` on the native runner.

The heavy CI (arm64 assimp/ogre/draco builds) only runs on `release: published`, so it validates on the next release; happy to iterate on that run like we did for the Draco PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native Docker image support for Linux amd64 and arm64, including Apple Silicon Macs.
  * Added architecture-specific Linux packages and multi-architecture image publishing.
  * Added platform verification and smoke testing for published images.

* **Documentation**
  * Updated Docker usage and release instructions for architecture-specific packages, runners, and builds.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->