### PR TITLE
fix(anim): finger/hand retarget quality + V2 library upgrade path + retarget diagnostics (#838)

### DIFF
--- a/scripts/build-motion-library-v6.py
+++ b/scripts/build-motion-library-v6.py
@@ -101,14 +101,6 @@ def norm_anim_name(name):
 # Fold verbatim-word actions onto a canonical base so we don't split a
 # handful of clips across near-duplicate labels ("waving"→"wave"). Keeps the
 # runtime kSynonyms table and these labels consistent.
-# Sources whose rigs have BLOCK/UNAUTHORED hands: their finger bones carry
-# junk (never polished — the mesh shows no fingers), which splays a real
-# hand's fingers on retarget. Zero the finger joints (22..51) for these so
-# targets hold their bind hands. Substring match on the asset title.
-FINGERLESS_SOURCES = [
-    "Animated Human Low Poly",
-]
-
 CANON_ACTION = {
     "waving": "wave", "singing": "sing", "walking": "walk",
     "running": "run", "jumping": "jump", "dancing": "dance",
@@ -736,19 +728,6 @@ def main():
                         # `quats`/`restWorld`/`restDir` already — no separate
                         # `fingers` side-channel. (The V1 builder copied
                         # c["fingers"] here; V2 dumps don't emit it.)
-                        # Block-hand rigs ship WITHOUT finger data (targets
-                        # hold their bind hands — see FINGERLESS_SOURCES).
-                        if any(fs.lower() in title.lower()
-                               for fs in FINGERLESS_SOURCES):
-                            for fr in clip["quats"]:
-                                for j in range(22, min(52, len(fr))):
-                                    fr[j] = [0.0, 0.0, 0.0, 0.0]
-                            for key in ("restWorld", "restDir"):
-                                arr = clip.get(key)
-                                if arr and len(arr) == 52:
-                                    zero = [0.0]*len(arr[22])
-                                    for j in range(22, 52):
-                                        arr[j] = list(zero)
                         clips.append(clip)
                         print(f"  + {action:<10} {title[:38]:<40}"
                               f" {c.get('animation')} ({len(w)}f, q={quality:.2f})")

--- a/scripts/build-motion-library-v6.py
+++ b/scripts/build-motion-library-v6.py
@@ -585,23 +585,40 @@ def main():
     # to let user curation override heuristic drops during extraction).
     def _find_curation():
         if args.curation:
+            # Fail CLOSED: an explicit path that doesn't exist is an operator
+            # error — silently building with an empty approval set would drop
+            # approved clips unnoticed.
+            if not os.path.exists(args.curation):
+                sys.exit(f"--curation: file not found: {args.curation}")
             return args.curation
         home = os.path.expanduser("~")
+        xdg = os.environ.get("XDG_DATA_HOME",
+                             os.path.join(home, ".local/share"))
+        local_appdata = os.environ.get("LOCALAPPDATA",
+                                       os.path.join(home, "AppData/Local"))
+        # Mirror MotionLibrary::curationPath()'s AppDataLocation resolution
+        # per platform (macOS nested org/app layout first, then Linux XDG,
+        # then Windows LOCALAPPDATA).
         for cand in (
             os.path.join(home, "Library/Application Support/QtMeshEditor/"
                                "QtMeshEditor/ai_models/motion/curation.json"),
             os.path.join(home, "Library/Application Support/QtMeshEditor/"
                                "ai_models/motion/curation.json"),
-            os.path.join(home, ".local/share/QtMeshEditor/QtMeshEditor/"
-                               "ai_models/motion/curation.json"),
+            os.path.join(xdg, "QtMeshEditor/QtMeshEditor/"
+                              "ai_models/motion/curation.json"),
+            os.path.join(xdg, "QtMeshEditor/ai_models/motion/curation.json"),
+            os.path.join(local_appdata, "QtMeshEditor/QtMeshEditor/"
+                                        "ai_models/motion/curation.json"),
         ):
             if os.path.exists(cand):
                 return cand
         return None
     _cur_path = _find_curation()
     user_approved = set()
-    if _cur_path and os.path.exists(_cur_path):
-        user_approved = set(json.load(open(_cur_path)).get("approved", []))
+    if _cur_path:
+        raw = json.load(open(_cur_path)).get("approved", [])
+        # keep only string entries (the MotionLibrary::loadCuration schema)
+        user_approved = {v for v in raw if isinstance(v, str)}
         print(f"curation: {len(user_approved)} approved sources "
               f"(heuristic-drop override) from {_cur_path}")
 

--- a/scripts/build-motion-library-v6.py
+++ b/scripts/build-motion-library-v6.py
@@ -581,6 +581,30 @@ def main():
     ap.add_argument("--max-per-action", type=int, default=12)
     args = ap.parse_args()
 
+    # Approved clip sources (used BOTH for the --approved-only ship gate and
+    # to let user curation override heuristic drops during extraction).
+    def _find_curation():
+        if args.curation:
+            return args.curation
+        home = os.path.expanduser("~")
+        for cand in (
+            os.path.join(home, "Library/Application Support/QtMeshEditor/"
+                               "QtMeshEditor/ai_models/motion/curation.json"),
+            os.path.join(home, "Library/Application Support/QtMeshEditor/"
+                               "ai_models/motion/curation.json"),
+            os.path.join(home, ".local/share/QtMeshEditor/QtMeshEditor/"
+                               "ai_models/motion/curation.json"),
+        ):
+            if os.path.exists(cand):
+                return cand
+        return None
+    _cur_path = _find_curation()
+    user_approved = set()
+    if _cur_path and os.path.exists(_cur_path):
+        user_approved = set(json.load(open(_cur_path)).get("approved", []))
+        print(f"curation: {len(user_approved)} approved sources "
+              f"(heuristic-drop override) from {_cur_path}")
+
     qtmesh = find_qtmesh(args.qtmesh)
     corpus = os.path.expanduser(args.corpus)
     manifest = {}
@@ -685,6 +709,18 @@ def main():
                             action, w, rest_world, rest_dir,
                             c.get("resolvedRoles", 0),
                             sum(e) / max(1, len(e)), args.min_energy)
+                        # USER CURATION OVERRIDES HEURISTICS: a clip the user
+                        # explicitly approved in the app must not be dropped
+                        # by a style/quality guess (the arm-hanging gate
+                        # rejected 4 approved clips after the importer fixes
+                        # changed the measured posture). License drops
+                        # (_excluded, earlier) still apply.
+                        src_key = f"{title} — {c.get('animation')}"
+                        if drop and src_key in user_approved:
+                            print(f"  ~ {action:<10} {title[:38]:<40}"
+                                  f" {c.get('animation')} KEPT (user-approved;"
+                                  f" heuristic said: {drop})")
+                            quality, drop = max(quality, 0.5), None
                         if drop:
                             print(f"  - {action:<10} {title[:38]:<40}"
                                   f" {c.get('animation')} DROPPED: {drop}")

--- a/scripts/build-motion-library-v6.py
+++ b/scripts/build-motion-library-v6.py
@@ -101,6 +101,14 @@ def norm_anim_name(name):
 # Fold verbatim-word actions onto a canonical base so we don't split a
 # handful of clips across near-duplicate labels ("waving"→"wave"). Keeps the
 # runtime kSynonyms table and these labels consistent.
+# Sources whose rigs have BLOCK/UNAUTHORED hands: their finger bones carry
+# junk (never polished — the mesh shows no fingers), which splays a real
+# hand's fingers on retarget. Zero the finger joints (22..51) for these so
+# targets hold their bind hands. Substring match on the asset title.
+FINGERLESS_SOURCES = [
+    "Animated Human Low Poly",
+]
+
 CANON_ACTION = {
     "waving": "wave", "singing": "sing", "walking": "walk",
     "running": "run", "jumping": "jump", "dancing": "dance",
@@ -728,6 +736,19 @@ def main():
                         # `quats`/`restWorld`/`restDir` already — no separate
                         # `fingers` side-channel. (The V1 builder copied
                         # c["fingers"] here; V2 dumps don't emit it.)
+                        # Block-hand rigs ship WITHOUT finger data (targets
+                        # hold their bind hands — see FINGERLESS_SOURCES).
+                        if any(fs.lower() in title.lower()
+                               for fs in FINGERLESS_SOURCES):
+                            for fr in clip["quats"]:
+                                for j in range(22, min(52, len(fr))):
+                                    fr[j] = [0.0, 0.0, 0.0, 0.0]
+                            for key in ("restWorld", "restDir"):
+                                arr = clip.get(key)
+                                if arr and len(arr) == 52:
+                                    zero = [0.0]*len(arr[22])
+                                    for j in range(22, 52):
+                                        arr[j] = list(zero)
                         clips.append(clip)
                         print(f"  + {action:<10} {title[:38]:<40}"
                               f" {c.get('animation')} ({len(w)}f, q={quality:.2f})")

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -3715,50 +3715,6 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
                     dref[static_cast<size_t>(c)] = CtInv * v;
                 }
             }
-            // LIMB STANCE CORRECTION (#951): collars/arms/legs/feet (6..21)
-            // pre-rotate the transported direction trajectory by a constant
-            // per-bone offset S so the clip's REST direction lands on the
-            // TARGET's bind direction:
-            //     S      = slerp(w; I → arc(dref → dt_bind))   (once per bone)
-            //     dir(f) = S · ds(f)
-            // Aiming a wide-shouldered/wide-hipped rig at a narrow rig's raw
-            // ABSOLUTE limb directions splays the arms and crosses the legs
-            // (user-reported on the low-poly jump → Rumba). But the source's
-            // restDir is its RIG BIND, which is NOT guaranteed to be a
-            // T-pose: game assets are sometimes authored with an action-pose
-            // bind (Gregorio's rig binds crouched — the buildloop legs stay
-            // 0–3° from rest for the whole clip), and anchoring that rest to
-            // the target bind would cancel the pose itself. The reliable
-            // per-bone separator is the clip's own ARTICULATION RANGE from
-            // rest: a bone that HOLDS near its rest is showing a pose (keep
-            // absolute aim — w→0 below kStanceHoldDeg), while a bone that
-            // swings far away treats rest as a stance reference (anchor it —
-            // w→1 above kStanceMoveDeg). Spine/neck/head (0..5) always keep
-            // absolute aim: torso posture and lean must be faithful to the
-            // clip.
-            auto isLimbRole = [](int c) { return c >= 6 && c <= 21; };
-            constexpr float kStanceHoldDeg = 15.0f;
-            constexpr float kStanceMoveDeg = 40.0f;
-            std::vector<Ogre::Quaternion> stanceS(
-                static_cast<size_t>(Jc), Ogre::Quaternion::IDENTITY);
-            std::vector<float> roleMaxDevDeg(static_cast<size_t>(Jc), 0.0f);
-            for (int c = 0; c < Jc; ++c) {
-                if (!isLimbRole(c)
-                    || srcLocalAxis[static_cast<size_t>(c)].squaredLength()
-                           <= 1e-8f)
-                    continue;
-                const auto& sd = clipRestDir[static_cast<size_t>(c)];
-                Ogre::Vector3 rest(sd[0], sd[1], sd[2]);
-                rest.normalise();
-                float maxDev = 0.0f;
-                for (int f = 0; f < frames; ++f) {
-                    const Ogre::Vector3 d =
-                        clipQ(f, c) * srcLocalAxis[static_cast<size_t>(c)];
-                    maxDev = std::max(
-                        maxDev, d.angleBetween(rest).valueDegrees());
-                }
-                roleMaxDevDeg[static_cast<size_t>(c)] = maxDev;
-            }
             std::vector<Ogre::Quaternion> Qbase(static_cast<size_t>(nBones),
                                                 Ogre::Quaternion::IDENTITY);
             for (int i = 0; i < nBones; ++i) {
@@ -3770,23 +3726,6 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
                         tb.tgtBindDir[static_cast<size_t>(c)]
                             .getRotationTo(dref[static_cast<size_t>(c)])
                         * tb.bindWorld[static_cast<size_t>(i)];
-                    if (isLimbRole(c)) {
-                        const float w = std::clamp(
-                            (roleMaxDevDeg[static_cast<size_t>(c)]
-                             - kStanceHoldDeg)
-                                / (kStanceMoveDeg - kStanceHoldDeg),
-                            0.0f, 1.0f);
-                        if (w > 1e-4f)
-                            stanceS[static_cast<size_t>(c)] =
-                                Ogre::Quaternion::Slerp(
-                                    w, Ogre::Quaternion::IDENTITY,
-                                    dref[static_cast<size_t>(c)]
-                                        .getRotationTo(
-                                            tb.tgtBindDir
-                                                [static_cast<size_t>(c)]
-                                                    .normalisedCopy()),
-                                    true);
-                    }
                     // NOTE (2026-08-02 investigation): this minimal-arc baseline
                     // keeps the TARGET-BIND's roll about the bone axis, dropping
                     // the roll of the source's bind→reference rotation — the
@@ -4027,13 +3966,8 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
                              * srcLocalAxis[static_cast<size_t>(c)]);
                         const Ogre::Quaternion R =
                             dref[static_cast<size_t>(c)].getRotationTo(ds);
-                        // Limb stance correction (see stanceS above): the
-                        // graded offset composes OUTSIDE the matched-pole
-                        // swing, so dir = S·ds and S=I degrades to the plain
-                        // absolute aim.
                         Ogre::Quaternion Wt =
-                            stanceS[static_cast<size_t>(c)] * R
-                            * Qbase[static_cast<size_t>(i)];
+                            R * Qbase[static_cast<size_t>(i)];
                         // #857: re-apply the source's roll about the aimed
                         // direction (the swing above deliberately dropped it).
                         // (A hierarchical "exact twist" hybrid and a source-
@@ -4047,11 +3981,7 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
                                                    [static_cast<size_t>(c)]
                                          * twistGainAt(c);
                         if (std::abs(th) > 1e-5f) {
-                            // Limb stance correction: the bone's actual
-                            // direction is S·ds — twist about the real axis
-                            // (S is identity for non-limb roles).
-                            Ogre::Vector3 axis =
-                                stanceS[static_cast<size_t>(c)] * ds;
+                            Ogre::Vector3 axis = ds;
                             axis.normalise();
                             Wt = Ogre::Quaternion(Ogre::Radian(th), axis) * Wt;
                         }

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -3808,25 +3808,44 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
                         // HANDS via the self-calibrated hand-basis map. The
                         // aim+twist path transports the hand's DIRECTION but
                         // its ROLL rides the C≠Ct frame mismatch — the raised
-                        // arm renders palm-out ("rotated arm"). The hand-basis
-                        // map M (validated by the finger transport) carries
-                        // the FULL source hand orientation frame-safely:
-                        //     Wt(f) = M · [clipQ(f,c)·restQ(c)⁻¹] · M⁻¹ · Wbind
-                        // ABSOLUTE (not parent-relative) on purpose: the palm
-                        // must land where the source intended even when the
-                        // forearm chain carries residual roll — the wrist
-                        // skinning absorbs the difference, exactly like real
-                        // forearm-twist rigs do. Fingers (below) ride this
-                        // corrected hand as their parent.
+                        // arm renders palm-out ("rotated arm"). Transport the
+                        // hand's WRIST articulation (delta RELATIVE to the
+                        // forearm) through the basis map M, riding the
+                        // target's animated forearm — the same pattern the
+                        // fingers use one level down:
+                        //   Drel = Dp(forearm)⁻¹·Df(hand)     (source wrist)
+                        //   Wt   = forearmDelta·(M·Drel·M⁻¹)·Wbind
+                        // Parent-RELATIVE on purpose: an absolute palm pins
+                        // the hand to the source's world orientation and
+                        // fights the target's arm as it moves (broken wrists
+                        // in mid-motion frames). Relative keeps the wrist
+                        // faithful and smooth; fingers ride this hand.
                         const int side = (c == 9) ? 0 : 1;
                         const auto& rq = cmuRestWorld[static_cast<size_t>(c)];
                         const Ogre::Quaternion refQ(rq[3], rq[0], rq[1],
                                                     rq[2]);
-                        const Ogre::Quaternion Dsrc =
+                        const Ogre::Quaternion Df =
                             clipQ(f, c) * refQ.Inverse();
+                        Ogre::Quaternion Dp = Ogre::Quaternion::IDENTITY;
+                        const int pcArm = (c == 9) ? 8 : 12;   // elbow
+                        const auto& prq =
+                            cmuRestWorld[static_cast<size_t>(pcArm)];
+                        if (prq[0]*prq[0] + prq[1]*prq[1] + prq[2]*prq[2]
+                                + prq[3]*prq[3] > 0.25f) {
+                            const Ogre::Quaternion prefQ(prq[3], prq[0],
+                                                         prq[1], prq[2]);
+                            Dp = clipQ(f, pcArm) * prefQ.Inverse();
+                        }
+                        const Ogre::Quaternion Drel = Dp.Inverse() * Df;
+                        const Ogre::Quaternion WpBind = (pi >= 0)
+                            ? tb.bindWorld[static_cast<size_t>(pi)]
+                            : Ogre::Quaternion::IDENTITY;
+                        const Ogre::Quaternion forearmDelta =
+                            Wp * WpBind.Inverse();
                         const Ogre::Quaternion Wt =
-                            fingerBasisMap[side] * Dsrc
-                            * fingerBasisMap[side].Inverse()
+                            forearmDelta
+                            * (fingerBasisMap[side] * Drel
+                               * fingerBasisMap[side].Inverse())
                             * tb.bindWorld[static_cast<size_t>(i)];
                         local = Wp.Inverse() * Wt;
                         W[static_cast<size_t>(i)] = Wt;

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -3341,22 +3341,21 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
             bool fingerBasisOk[2] = {false, false};
             if (clipIsV2 && !clipRestDir.empty()
                 && static_cast<int>(clipRestDir.size()) >= canonN) {
-                auto basisQuat = [](const Ogre::Vector3& dIn,
-                                    const Ogre::Vector3& tIn,
+                // Basis from a hand direction + a flexion axis: x = hand
+                // direction, y = flexion axis (orthogonalized), z = x×y.
+                auto basisQuat = [](Ogre::Vector3 d, Ogre::Vector3 fl,
                                     Ogre::Quaternion& out) -> bool {
-                    Ogre::Vector3 d = dIn, t = tIn;
-                    if (d.squaredLength() < 1e-8f || t.squaredLength() < 1e-8f)
+                    if (d.squaredLength() < 1e-8f || fl.squaredLength() < 1e-8f)
                         return false;
                     d.normalise();
-                    Ogre::Vector3 p = t - d * t.dotProduct(d);
-                    if (p.squaredLength() < 1e-6f)
-                        return false;   // thumb ~parallel to hand: degenerate
-                    p.normalise();
-                    const Ogre::Vector3 b = d.crossProduct(p);
+                    fl = fl - d * fl.dotProduct(d);
+                    if (fl.squaredLength() < 1e-6f)
+                        return false;
+                    fl.normalise();
                     Ogre::Matrix3 m;
                     m.SetColumn(0, d);
-                    m.SetColumn(1, p);
-                    m.SetColumn(2, b);
+                    m.SetColumn(1, fl);
+                    m.SetColumn(2, d.crossProduct(fl));
                     out = Ogre::Quaternion(m);
                     return true;
                 };
@@ -3369,14 +3368,184 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
                         || thumb0 >= static_cast<int>(tb.tgtBindDir.size()))
                         continue;
                     const auto& hd = clipRestDir[static_cast<size_t>(hand)];
-                    const auto& td = clipRestDir[static_cast<size_t>(thumb0)];
+                    const Ogre::Vector3 dS(hd[0], hd[1], hd[2]);
+
+                    // SOURCE flexion axis: SELF-CALIBRATED from the curl data
+                    // itself — the dominant rotation axis of the non-thumb
+                    // finger deltas (power-iterated axis covariance). Rigs
+                    // whose thumb rest points oddly (block-hand exports) fool
+                    // a thumb-based palmward guess, but the fingers' own curl
+                    // axis is ground truth (measured 0.99+ concentration on
+                    // such rigs). Sign: fingers FLEX far more than they
+                    // extend, so the net signed curl points along +flexion.
+                    Ogre::Matrix3 cov(0, 0, 0, 0, 0, 0, 0, 0, 0);
+                    float totW = 0.0f;
+                    for (int fgr = 1; fgr < 5; ++fgr)
+                        for (int seg = 0; seg < 3; ++seg) {
+                            const int c = MotionInbetween::fingerJointIndexV2(
+                                side, fgr, seg);
+                            const int pc =
+                                MotionInbetween::canonicalParentOfV2(c);
+                            if (c < 0 || c >= canonN || pc < 0) continue;
+                            const auto& rq =
+                                cmuRestWorld[static_cast<size_t>(c)];
+                            const auto& prq =
+                                cmuRestWorld[static_cast<size_t>(pc)];
+                            if (rq[0]*rq[0] + rq[1]*rq[1] + rq[2]*rq[2]
+                                    + rq[3]*rq[3] < 0.25f) continue;
+                            const Ogre::Quaternion refQ(rq[3], rq[0], rq[1],
+                                                        rq[2]);
+                            const Ogre::Quaternion prefQ(prq[3], prq[0],
+                                                         prq[1], prq[2]);
+                            for (int f = 0; f < frames; ++f) {
+                                const Ogre::Quaternion Df =
+                                    clipQ(f, c) * refQ.Inverse();
+                                const Ogre::Quaternion Dp =
+                                    clipQ(f, pc) * prefQ.Inverse();
+                                Ogre::Quaternion Drel = Dp.Inverse() * Df;
+                                if (Drel.w < 0) Drel = -Drel;
+                                Ogre::Vector3 ax(Drel.x, Drel.y, Drel.z);
+                                const float deg = 2.0f * Ogre::Math::ACos(
+                                    std::min(1.0f, Drel.w)).valueDegrees();
+                                if (deg < 10.0f
+                                    || ax.squaredLength() < 1e-10f)
+                                    continue;
+                                ax.normalise();
+                                for (int r = 0; r < 3; ++r)
+                                    for (int cc = 0; cc < 3; ++cc)
+                                        cov[r][cc] += deg * ax[r] * ax[cc];
+                                totW += deg;
+                            }
+                        }
+                    Ogre::Vector3 flexS = Ogre::Vector3::ZERO;
+                    float concentration = 0.0f;
+                    if (totW > 30.0f) {   // enough articulation to calibrate
+                        Ogre::Vector3 v(1, 1, 1);
+                        for (int it = 0; it < 40; ++it) {
+                            v = cov * v;
+                            if (v.squaredLength() < 1e-20f) break;
+                            v.normalise();
+                        }
+                        // concentration + net sign in one pass
+                        float aligned = 0.0f, net = 0.0f;
+                        for (int fgr = 1; fgr < 5; ++fgr)
+                            for (int seg = 0; seg < 3; ++seg) {
+                                const int c =
+                                    MotionInbetween::fingerJointIndexV2(
+                                        side, fgr, seg);
+                                const int pc =
+                                    MotionInbetween::canonicalParentOfV2(c);
+                                if (c < 0 || c >= canonN || pc < 0) continue;
+                                const auto& rq =
+                                    cmuRestWorld[static_cast<size_t>(c)];
+                                const auto& prq =
+                                    cmuRestWorld[static_cast<size_t>(pc)];
+                                if (rq[0]*rq[0] + rq[1]*rq[1] + rq[2]*rq[2]
+                                        + rq[3]*rq[3] < 0.25f) continue;
+                                const Ogre::Quaternion refQ(rq[3], rq[0],
+                                                            rq[1], rq[2]);
+                                const Ogre::Quaternion prefQ(prq[3], prq[0],
+                                                             prq[1], prq[2]);
+                                for (int f = 0; f < frames; ++f) {
+                                    const Ogre::Quaternion Df =
+                                        clipQ(f, c) * refQ.Inverse();
+                                    const Ogre::Quaternion Dp =
+                                        clipQ(f, pc) * prefQ.Inverse();
+                                    Ogre::Quaternion Drel =
+                                        Dp.Inverse() * Df;
+                                    if (Drel.w < 0) Drel = -Drel;
+                                    Ogre::Vector3 ax(Drel.x, Drel.y, Drel.z);
+                                    const float deg = 2.0f * Ogre::Math::ACos(
+                                        std::min(1.0f, Drel.w))
+                                            .valueDegrees();
+                                    if (deg < 10.0f
+                                        || ax.squaredLength() < 1e-10f)
+                                        continue;
+                                    ax.normalise();
+                                    const float d = ax.dotProduct(v);
+                                    aligned += deg * std::abs(d);
+                                    net += deg * (d >= 0 ? 1.0f : -1.0f);
+                                }
+                            }
+                        concentration = aligned / totW;
+                        flexS = (net >= 0.0f) ? v : -v;
+                    }
+
+                    // TARGET flexion axis: the KNUCKLE LINE (seg0 bone
+                    // positions of index..pinky) — anatomically the axis
+                    // fingers flex about; sign chosen so +rotation curls
+                    // toward the palm (thumb side).
+                    Ogre::Vector3 flexT = Ogre::Vector3::ZERO;
+                    {
+                        std::vector<Ogre::Vector3> kn;
+                        for (int fgr = 1; fgr < 5; ++fgr) {
+                            const int c = MotionInbetween::fingerJointIndexV2(
+                                side, fgr, 0);
+                            if (c < 0 || c >= canonN) continue;
+                            const int bi =
+                                tb.roleBoneIdx[static_cast<size_t>(c)];
+                            if (bi >= 0)
+                                kn.push_back(
+                                    tb.bindPos[static_cast<size_t>(bi)]);
+                        }
+                        const int hb =
+                            tb.roleBoneIdx[static_cast<size_t>(hand)];
+                        const int tbi =
+                            tb.roleBoneIdx[static_cast<size_t>(thumb0)];
+                        if (kn.size() >= 2 && hb >= 0 && tbi >= 0) {
+                            Ogre::Vector3 line = kn.back() - kn.front();
+                            const Ogre::Vector3 dT =
+                                tb.tgtBindDir[static_cast<size_t>(hand)]
+                                    .normalisedCopy();
+                            line = line - dT * line.dotProduct(dT);
+                            if (line.squaredLength() > 1e-10f) {
+                                line.normalise();
+                                // palm side = where the thumb sits
+                                Ogre::Vector3 palm =
+                                    tb.bindPos[static_cast<size_t>(tbi)]
+                                    - tb.bindPos[static_cast<size_t>(hb)];
+                                palm = palm - dT * palm.dotProduct(dT);
+                                // +rotation about `line` moves fingertips
+                                // toward line×dT — require that to be the
+                                // palm side.
+                                if (line.crossProduct(dT).dotProduct(palm)
+                                        < 0.0f)
+                                    line = -line;
+                                flexT = line;
+                            }
+                        }
+                    }
+
                     Ogre::Quaternion qs, qt;
-                    const bool okS = basisQuat(
-                        Ogre::Vector3(hd[0], hd[1], hd[2]),
-                        Ogre::Vector3(td[0], td[1], td[2]), qs);
-                    const bool okT = basisQuat(
-                        tb.tgtBindDir[static_cast<size_t>(hand)],
-                        tb.tgtBindDir[static_cast<size_t>(thumb0)], qt);
+                    bool okS = false, okT = false;
+                    if (concentration > 0.8f
+                        && flexS.squaredLength() > 0.5f)
+                        okS = basisQuat(dS, flexS, qs);
+                    if (flexT.squaredLength() > 0.5f)
+                        okT = basisQuat(
+                            tb.tgtBindDir[static_cast<size_t>(hand)], flexT,
+                            qt);
+                    if (!okS || !okT) {
+                        // Fallback: thumb-direction palmward on both sides
+                        // (the previous construction — fine for rigs with a
+                        // sane thumb rest, e.g. Gregorio).
+                        const auto& td =
+                            clipRestDir[static_cast<size_t>(thumb0)];
+                        Ogre::Vector3 tS(td[0], td[1], td[2]);
+                        // flexion ≈ d × palmward: build via palmward and
+                        // rotate: basis (d, palmward, d×palmward) is the same
+                        // family — reuse it directly on both sides.
+                        okS = basisQuat(dS, dS.crossProduct(
+                                  tS - dS * tS.dotProduct(
+                                      dS.normalisedCopy())), qs);
+                        const Ogre::Vector3 dT =
+                            tb.tgtBindDir[static_cast<size_t>(hand)];
+                        const Ogre::Vector3 tT =
+                            tb.tgtBindDir[static_cast<size_t>(thumb0)];
+                        okT = basisQuat(dT, dT.crossProduct(
+                                  tT - dT * tT.dotProduct(
+                                      dT.normalisedCopy())), qt);
+                    }
                     if (okS && okT) {
                         fingerBasisMap[side] = qt * qs.Inverse();
                         fingerBasisOk[side] = true;

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -1013,6 +1013,98 @@ AnimationMerger::extractCanonicalClips(Ogre::Entity* entity, int fps,
         }
     }
 
+    // ── NAME-vs-ANATOMY chirality check (#951) ─────────────────────────
+    // Some rigs ship with MIRRORED bone naming (Blender FBX −X-scale
+    // exports: bones named "Left*" sit on the anatomical RIGHT — the
+    // Quaternius "Animated Human" is the canonical case). The extraction
+    // trusts names for the L/R roles AND derives its facing from the
+    // named hip line (left = rhip→lhip), so a mirrored rig yields clips
+    // canonically yawed 180°: invisible on self-retarget (rigid whole-clip
+    // yaw) but cross-rig every punch goes backward-overhead and arm swings
+    // mirror (user-reported). Detect chirality NAME-INDEPENDENTLY from the
+    // TOES: toes point forward, so for correct naming the signed volume
+    // det[named-left, up, toe-forward] = hipLine·(up×toe) is POSITIVE
+    // (left×up=fwd convention ⇒ up×fwd=left). The toe is found
+    // STRUCTURALLY (the foot bone's child with the largest horizontal
+    // offset — no names), and the test is averaged over sampled frames of
+    // every animation so a single odd pose can't flip it. (A knee-hinge
+    // test was tried first and REVERTED: thigh turnout — dance! — rotates
+    // the flexion axis, flipping the sign even on correctly-named rigs.)
+    // Negative ⇒ names are mirrored ⇒ swap every L/R role and finger side,
+    // making names match anatomy for everything downstream.
+    {
+        double chirality = 0.0;
+        Ogre::Bone* feet[2] = {roleBone[17], roleBone[21]};
+        Ogre::Bone* hipsLR[2] = {roleBone[15], roleBone[19]};
+        Ogre::Bone* hipB = roleBone[0];
+        Ogre::Bone* headB = roleBone[5] ? roleBone[5] : roleBone[3];
+        if (hipsLR[0] && hipsLR[1] && hipB && headB
+            && (feet[0] || feet[1])) {
+            auto accumulate = [&]() {
+                Ogre::Vector3 up = headB->_getDerivedPosition()
+                                   - hipB->_getDerivedPosition();
+                Ogre::Vector3 hipLine = hipsLR[1]->_getDerivedPosition()
+                                        - hipsLR[0]->_getDerivedPosition();
+                if (up.squaredLength() < 1e-12f
+                    || hipLine.squaredLength() < 1e-12f)
+                    return;
+                up.normalise();
+                hipLine.normalise();
+                for (Ogre::Bone* foot : feet) {
+                    if (!foot || foot->numChildren() == 0) continue;
+                    // structural toe: the child with the largest offset
+                    // component perpendicular to up
+                    Ogre::Vector3 best = Ogre::Vector3::ZERO;
+                    float bestH = 0.0f;
+                    for (unsigned short ci = 0; ci < foot->numChildren();
+                         ++ci) {
+                        auto* ch = static_cast<Ogre::Bone*>(
+                            foot->getChild(ci));
+                        Ogre::Vector3 off = ch->_getDerivedPosition()
+                                            - foot->_getDerivedPosition();
+                        const Ogre::Vector3 h =
+                            off - up * off.dotProduct(up);
+                        if (h.squaredLength() > bestH) {
+                            bestH = h.squaredLength();
+                            best = h;
+                        }
+                    }
+                    if (bestH < 1e-12f) continue;
+                    best.normalise();
+                    chirality += up.crossProduct(best).dotProduct(hipLine);
+                }
+            };
+            for (unsigned short a = 0; a < skel->getNumAnimations(); ++a) {
+                Ogre::Animation* anim = skel->getAnimation(a);
+                if (!anim || anim->getLength() <= 0.0f) continue;
+                const int nS = 8;
+                for (int f = 0; f < nS; ++f) {
+                    skel->reset(true);
+                    anim->apply(skel, anim->getLength()
+                                          * static_cast<float>(f)
+                                          / static_cast<float>(nS - 1));
+                    skel->_updateTransforms();
+                    accumulate();
+                }
+            }
+            skel->reset(true);
+            skel->_updateTransforms();
+        }
+        // MEASUREMENT RESULT (2026-08-20): every tested rig (Mixamo Rumba,
+        // Quaternius lowpoly, Gregorio) measures NEGATIVE — the Ogre import
+        // presents ALL humanoids with the same mirrored named-left/anatomy
+        // relationship, so naming is CONSISTENT across rigs and cancels in
+        // cross-rig retargets. A one-sided swap here would therefore BREAK
+        // retargets (source mirrored vs target) — keep this as a
+        // diagnostic-only check that flags a rig whose chirality DIFFERS
+        // from the fleet norm (positive = odd one out).
+        if (qEnvironmentVariableIsSet("QTMESH_EXTRACT_DEBUG"))
+            fprintf(stderr,
+                    "[extract] toe chirality %.3f (fleet norm: negative; "
+                    "positive would mean this rig mirrors differently)\n",
+                    chirality);
+    }
+
     // ── source-frame → canonical-frame conjugation ─────────────────────
     // Scraped rigs live in arbitrary file frames (Blender FBX armatures are
     // commonly Z-up), while the motion library's world convention is Y-up,
@@ -1365,6 +1457,34 @@ AnimationMerger::extractCanonicalClips(Ogre::Entity* entity, int fps,
                 }
             }
         }
+        if (qEnvironmentVariableIsSet("QTMESH_EXTRACT_DEBUG")) {
+            // RAW world anatomy at a few frames — no canonical conjugation.
+            for (int f : {0, frames / 3, frames / 2, (2 * frames) / 3}) {
+                skel->reset(true);
+                anim->apply(skel, std::min(length,
+                    static_cast<float>(f) / static_cast<float>(fps)));
+                skel->_updateTransforms();
+                auto pos = [&](int role) -> Ogre::Vector3 {
+                    Ogre::Bone* b = roleBone[static_cast<size_t>(role)];
+                    return b ? b->_getDerivedPosition() : Ogre::Vector3::ZERO;
+                };
+                const Ogre::Vector3 relbow = pos(8), rhand = pos(9);
+                const Ogre::Vector3 lhip = pos(19), rhip = pos(15);
+                const Ogre::Vector3 hip = pos(0), head = pos(5);
+                Ogre::Vector3 fore = (rhand - relbow).normalisedCopy();
+                Ogre::Vector3 hl = (lhip - rhip).normalisedCopy();
+                Ogre::Vector3 up = (head - hip).normalisedCopy();
+                const Ogre::Vector3 fwd = hl.crossProduct(up).normalisedCopy();
+                fprintf(stderr,
+                        "[extract-raw] %s f=%d foreW=(%5.2f %5.2f %5.2f) "
+                        "hipL=(%5.2f %5.2f %5.2f) up=(%5.2f %5.2f %5.2f) "
+                        "fore-dot-fwd=%5.2f fore-dot-up=%5.2f\n",
+                        anim->getName().c_str(), f,
+                        fore.x, fore.y, fore.z, hl.x, hl.y, hl.z,
+                        up.x, up.y, up.z,
+                        fore.dotProduct(fwd), fore.dotProduct(up));
+            }
+        }
         // re-pose at the reference frame for the restWorld/restDir sampling below
         skel->reset(true);
         if (refFrame >= 0)
@@ -1645,6 +1765,48 @@ AnimationMerger::extractCanonicalClips(Ogre::Entity* entity, int fps,
     skel->reset(true);
     skel->_updateTransforms();
     return out;
+}
+
+void AnimationMerger::debugDumpAnatomy(Ogre::Skeleton* skel,
+                                       const std::string& animName,
+                                       const char* tag)
+{
+    if (!skel || !skel->hasAnimation(animName)) return;
+    Ogre::Animation* anim = skel->getAnimation(animName);
+    const float len = anim->getLength();
+    if (len <= 0.0f) return;
+    Ogre::Bone* role[22] = {nullptr};
+    for (auto* b : skel->getBones()) {
+        const int c = MotionInbetween::canonicalIndexForBone(
+            QString::fromStdString(b->getName()));
+        if (c >= 0 && c < 22 && !role[c]) role[c] = b;
+    }
+    if (!role[8] || !role[9] || !role[15] || !role[19] || !role[0]
+        || !(role[5] || role[3]))
+        return;
+    Ogre::Bone* headB = role[5] ? role[5] : role[3];
+    for (int k = 0; k < 4; ++k) {
+        skel->reset(true);
+        anim->apply(skel, len * (0.05f + 0.3f * k));
+        skel->_updateTransforms();
+        const Ogre::Vector3 fore =
+            (role[9]->_getDerivedPosition() - role[8]->_getDerivedPosition())
+                .normalisedCopy();
+        const Ogre::Vector3 hl =
+            (role[19]->_getDerivedPosition()
+             - role[15]->_getDerivedPosition()).normalisedCopy();
+        const Ogre::Vector3 up =
+            (headB->_getDerivedPosition() - role[0]->_getDerivedPosition())
+                .normalisedCopy();
+        const Ogre::Vector3 fwd = hl.crossProduct(up).normalisedCopy();
+        fprintf(stderr,
+                "[anat:%s] t=%.2f foreW=(%5.2f %5.2f %5.2f) "
+                "fore-dot-fwd=%5.2f fore-dot-up=%5.2f\n",
+                tag, len * (0.05f + 0.3f * k), fore.x, fore.y, fore.z,
+                fore.dotProduct(fwd), fore.dotProduct(up));
+    }
+    skel->reset(true);
+    skel->_updateTransforms();
 }
 
 bool AnimationMerger::detectBackwardFacing(Ogre::Entity* entity)

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -3387,12 +3387,18 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
                             const int pc =
                                 MotionInbetween::canonicalParentOfV2(c);
                             if (c < 0 || c >= canonN || pc < 0) continue;
+                            // Chains the plausibility gate rejected must not
+                            // calibrate the axis either.
+                            if (fingerChainUntrusted[static_cast<size_t>(c)])
+                                continue;
                             const auto& rq =
                                 cmuRestWorld[static_cast<size_t>(c)];
                             const auto& prq =
                                 cmuRestWorld[static_cast<size_t>(pc)];
                             if (rq[0]*rq[0] + rq[1]*rq[1] + rq[2]*rq[2]
-                                    + rq[3]*rq[3] < 0.25f) continue;
+                                    + rq[3]*rq[3] < 0.25f ||
+                                prq[0]*prq[0] + prq[1]*prq[1] + prq[2]*prq[2]
+                                    + prq[3]*prq[3] < 0.25f) continue;
                             const Ogre::Quaternion refQ(rq[3], rq[0], rq[1],
                                                         rq[2]);
                             const Ogre::Quaternion prefQ(prq[3], prq[0],
@@ -3436,12 +3442,17 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
                                 const int pc =
                                     MotionInbetween::canonicalParentOfV2(c);
                                 if (c < 0 || c >= canonN || pc < 0) continue;
+                                if (fingerChainUntrusted
+                                        [static_cast<size_t>(c)]) continue;
                                 const auto& rq =
                                     cmuRestWorld[static_cast<size_t>(c)];
                                 const auto& prq =
                                     cmuRestWorld[static_cast<size_t>(pc)];
                                 if (rq[0]*rq[0] + rq[1]*rq[1] + rq[2]*rq[2]
-                                        + rq[3]*rq[3] < 0.25f) continue;
+                                        + rq[3]*rq[3] < 0.25f ||
+                                    prq[0]*prq[0] + prq[1]*prq[1]
+                                        + prq[2]*prq[2] + prq[3]*prq[3]
+                                        < 0.25f) continue;
                                 const Ogre::Quaternion refQ(rq[3], rq[0],
                                                             rq[1], rq[2]);
                                 const Ogre::Quaternion prefQ(prq[3], prq[0],

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -3249,6 +3249,136 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
                 const auto& q = clipQuats[frame][joint];
                 return Ogre::Quaternion(q[3], q[0], q[1], q[2]);   // (w,x,y,z)
             };
+            // FINGER PLAUSIBILITY GATE (V2). Some source rigs carry garbage
+            // finger data — e.g. "Animated Human Low Poly": the index chain
+            // articulates up to 176° RELATIVE TO THE HAND (folds through the
+            // palm; a full fist is ~100°), and the one-finger-drives-four
+            // replication copies it to every finger. Transporting impossible
+            // curls onto a realistic hand splays the fingers backwards, so
+            // when ANY segment of a chain exceeds the anatomical limit at any
+            // frame, HOLD THE WHOLE CHAIN AT BIND (neutral beats broken).
+            // Per-chain: a rig with a good thumb but bad fingers keeps the
+            // thumb animation.
+            std::vector<char> fingerChainUntrusted(
+                static_cast<size_t>(canonN), 0);
+            if (clipIsV2 && haveRestWorld) {
+                constexpr float kMaxFingerArticulationDeg = 120.0f;
+                int droppedChains = 0;
+                for (int side = 0; side < 2; ++side)
+                    for (int fgr = 0; fgr < 5; ++fgr) {
+                        float maxDeg = 0.0f;
+                        for (int seg = 0; seg < 3; ++seg) {
+                            const int c = MotionInbetween::fingerJointIndexV2(
+                                side, fgr, seg);
+                            const int pc =
+                                MotionInbetween::canonicalParentOfV2(c);
+                            if (c < 0 || c >= canonN || pc < 0) continue;
+                            const auto& rq =
+                                cmuRestWorld[static_cast<size_t>(c)];
+                            const auto& prq =
+                                cmuRestWorld[static_cast<size_t>(pc)];
+                            if (rq[0]*rq[0] + rq[1]*rq[1] + rq[2]*rq[2]
+                                    + rq[3]*rq[3] < 0.25f ||
+                                prq[0]*prq[0] + prq[1]*prq[1] + prq[2]*prq[2]
+                                    + prq[3]*prq[3] < 0.25f)
+                                continue;   // unpopulated → holds bind anyway
+                            const Ogre::Quaternion refQ(rq[3], rq[0], rq[1],
+                                                        rq[2]);
+                            const Ogre::Quaternion prefQ(prq[3], prq[0],
+                                                         prq[1], prq[2]);
+                            for (int f = 0; f < frames; ++f) {
+                                const auto& cq =
+                                    clipQuats[static_cast<size_t>(f)]
+                                             [static_cast<size_t>(c)];
+                                if (cq[0]*cq[0] + cq[1]*cq[1] + cq[2]*cq[2]
+                                        + cq[3]*cq[3] < 0.25f)
+                                    continue;
+                                const Ogre::Quaternion Df =
+                                    clipQ(f, c) * refQ.Inverse();
+                                const Ogre::Quaternion Dp =
+                                    clipQ(f, pc) * prefQ.Inverse();
+                                const Ogre::Quaternion Drel =
+                                    Dp.Inverse() * Df;
+                                const float deg = 2.0f * Ogre::Math::ACos(
+                                    std::min(1.0f, std::abs(Drel.w)))
+                                        .valueDegrees();
+                                if (deg > maxDeg) maxDeg = deg;
+                            }
+                        }
+                        if (maxDeg > kMaxFingerArticulationDeg) {
+                            ++droppedChains;
+                            for (int seg = 0; seg < 3; ++seg) {
+                                const int c =
+                                    MotionInbetween::fingerJointIndexV2(
+                                        side, fgr, seg);
+                                if (c >= 0 && c < canonN)
+                                    fingerChainUntrusted
+                                        [static_cast<size_t>(c)] = 1;
+                            }
+                        }
+                    }
+                if (droppedChains > 0)
+                    Ogre::LogManager::getSingleton().logMessage(
+                        "applyMotionClip: dropped " +
+                        std::to_string(droppedChains) +
+                        " implausible finger chain(s) (>120deg articulation)"
+                        " — holding bind");
+            }
+            // HAND-BASIS finger transport frames. The canonical-frame
+            // conjugation (Ct⁻¹·Drel·Ct) assumes the source's extraction
+            // frame C equals the target bind frame Ct; when they disagree
+            // (the documented C≠Ct class) the curl AXIS lands wrong on the
+            // target — fingers bend sideways/backward instead of toward the
+            // palm ("Animated Human Low Poly" jump). Fingers articulate
+            // relative to the HAND, so re-express the curl in each side's
+            // hand basis instead: d = hand/finger direction, p = palmward
+            // (thumb direction orthogonalized against d — the thumb is on
+            // the palm side in any bind), b = d×p. B = R_target·R_source⁻¹
+            // then replaces the Ct conjugation — no dependence on C at all.
+            // Falls back to the Ct conjugation when either basis degenerates.
+            Ogre::Quaternion fingerBasisMap[2] = {Ogre::Quaternion::IDENTITY,
+                                                  Ogre::Quaternion::IDENTITY};
+            bool fingerBasisOk[2] = {false, false};
+            if (clipIsV2 && !clipRestDir.empty()
+                && static_cast<int>(clipRestDir.size()) >= canonN) {
+                auto basisQuat = [](const Ogre::Vector3& dIn,
+                                    const Ogre::Vector3& tIn,
+                                    Ogre::Quaternion& out) -> bool {
+                    Ogre::Vector3 d = dIn, t = tIn;
+                    if (d.squaredLength() < 1e-8f || t.squaredLength() < 1e-8f)
+                        return false;
+                    d.normalise();
+                    Ogre::Vector3 p = t - d * t.dotProduct(d);
+                    if (p.squaredLength() < 1e-6f)
+                        return false;   // thumb ~parallel to hand: degenerate
+                    p.normalise();
+                    const Ogre::Vector3 b = d.crossProduct(p);
+                    Ogre::Matrix3 m;
+                    m.SetColumn(0, d);
+                    m.SetColumn(1, p);
+                    m.SetColumn(2, b);
+                    out = Ogre::Quaternion(m);
+                    return true;
+                };
+                for (int side = 0; side < 2; ++side) {
+                    const int hand = side == 0 ? 9 : 13;
+                    const int thumb0 =
+                        MotionInbetween::fingerJointIndexV2(side, 0, 0);
+                    const auto& hd = clipRestDir[static_cast<size_t>(hand)];
+                    const auto& td = clipRestDir[static_cast<size_t>(thumb0)];
+                    Ogre::Quaternion qs, qt;
+                    const bool okS = basisQuat(
+                        Ogre::Vector3(hd[0], hd[1], hd[2]),
+                        Ogre::Vector3(td[0], td[1], td[2]), qs);
+                    const bool okT = basisQuat(
+                        tb.tgtBindDir[static_cast<size_t>(hand)],
+                        tb.tgtBindDir[static_cast<size_t>(thumb0)], qt);
+                    if (okS && okT) {
+                        fingerBasisMap[side] = qt * qs.Inverse();
+                        fingerBasisOk[side] = true;
+                    }
+                }
+            }
             // #857: STABILIZED TWIST TRANSPORT. The aim above transports the
             // bone's DIRECTION but inherits the target bind's roll — gesture-
             // heavy clips (dance, wave) lose forearm/spine roll and read
@@ -3518,7 +3648,8 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
                             || std::abs(cq[0]) + std::abs(cq[1])
                                    + std::abs(cq[2]) > 1e-4f;
                         if (haveRestWorld && populated
-                            && rn > 0.25f && cn > 0.25f) {
+                            && rn > 0.25f && cn > 0.25f
+                            && !fingerChainUntrusted[static_cast<size_t>(c)]) {
                             const Ogre::Quaternion refQ(rq[3], rq[0], rq[1],
                                                         rq[2]);
                             const Ogre::Quaternion Df =
@@ -3551,8 +3682,21 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
                                 : Ogre::Quaternion::IDENTITY;
                             const Ogre::Quaternion handDelta =
                                 Wp * WpBind.Inverse();
+                            // Re-express the curl in the target frame: prefer
+                            // the HAND-BASIS map (frame-independent, see
+                            // fingerBasisMap above); fall back to the
+                            // canonical Ct conjugation.
+                            const int fSide =
+                                (c - MotionInbetween::canonicalJointCount())
+                                    / 15;
+                            const Ogre::Quaternion DrelT =
+                                (fSide >= 0 && fSide < 2
+                                 && fingerBasisOk[fSide])
+                                    ? fingerBasisMap[fSide] * Drel
+                                          * fingerBasisMap[fSide].Inverse()
+                                    : CtInv * Drel * tb.Ct;
                             const Ogre::Quaternion Wt =
-                                handDelta * (CtInv * Drel * tb.Ct)
+                                handDelta * DrelT
                                 * tb.bindWorld[static_cast<size_t>(i)];
                             local = Wp.Inverse() * Wt;
                             W[static_cast<size_t>(i)] = Wt;

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -3793,6 +3793,43 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
                             srcDelta * Qbase[static_cast<size_t>(i)];
                         local = Wp.Inverse() * Wt;   // Wp == identity (root)
                         W[static_cast<size_t>(i)] = Wt;
+                    } else if (clipIsV2 && (c == 9 || c == 13)
+                        && fingerBasisOk[c == 9 ? 0 : 1]
+                        && haveRestWorld
+                        && cmuRestWorld[static_cast<size_t>(c)][0]
+                                * cmuRestWorld[static_cast<size_t>(c)][0]
+                            + cmuRestWorld[static_cast<size_t>(c)][1]
+                                * cmuRestWorld[static_cast<size_t>(c)][1]
+                            + cmuRestWorld[static_cast<size_t>(c)][2]
+                                * cmuRestWorld[static_cast<size_t>(c)][2]
+                            + cmuRestWorld[static_cast<size_t>(c)][3]
+                                * cmuRestWorld[static_cast<size_t>(c)][3]
+                            > 0.25f) {
+                        // HANDS via the self-calibrated hand-basis map. The
+                        // aim+twist path transports the hand's DIRECTION but
+                        // its ROLL rides the C≠Ct frame mismatch — the raised
+                        // arm renders palm-out ("rotated arm"). The hand-basis
+                        // map M (validated by the finger transport) carries
+                        // the FULL source hand orientation frame-safely:
+                        //     Wt(f) = M · [clipQ(f,c)·restQ(c)⁻¹] · M⁻¹ · Wbind
+                        // ABSOLUTE (not parent-relative) on purpose: the palm
+                        // must land where the source intended even when the
+                        // forearm chain carries residual roll — the wrist
+                        // skinning absorbs the difference, exactly like real
+                        // forearm-twist rigs do. Fingers (below) ride this
+                        // corrected hand as their parent.
+                        const int side = (c == 9) ? 0 : 1;
+                        const auto& rq = cmuRestWorld[static_cast<size_t>(c)];
+                        const Ogre::Quaternion refQ(rq[3], rq[0], rq[1],
+                                                    rq[2]);
+                        const Ogre::Quaternion Dsrc =
+                            clipQ(f, c) * refQ.Inverse();
+                        const Ogre::Quaternion Wt =
+                            fingerBasisMap[side] * Dsrc
+                            * fingerBasisMap[side].Inverse()
+                            * tb.bindWorld[static_cast<size_t>(i)];
+                        local = Wp.Inverse() * Wt;
+                        W[static_cast<size_t>(i)] = Wt;
                     } else if (clipIsV2
                         && c >= MotionInbetween::canonicalJointCount()) {
                         // #838 V2 FINGERS: STANDARD HIERARCHICAL bind-referenced

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -3715,6 +3715,50 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
                     dref[static_cast<size_t>(c)] = CtInv * v;
                 }
             }
+            // LIMB STANCE CORRECTION (#951): collars/arms/legs/feet (6..21)
+            // pre-rotate the transported direction trajectory by a constant
+            // per-bone offset S so the clip's REST direction lands on the
+            // TARGET's bind direction:
+            //     S      = slerp(w; I → arc(dref → dt_bind))   (once per bone)
+            //     dir(f) = S · ds(f)
+            // Aiming a wide-shouldered/wide-hipped rig at a narrow rig's raw
+            // ABSOLUTE limb directions splays the arms and crosses the legs
+            // (user-reported on the low-poly jump → Rumba). But the source's
+            // restDir is its RIG BIND, which is NOT guaranteed to be a
+            // T-pose: game assets are sometimes authored with an action-pose
+            // bind (Gregorio's rig binds crouched — the buildloop legs stay
+            // 0–3° from rest for the whole clip), and anchoring that rest to
+            // the target bind would cancel the pose itself. The reliable
+            // per-bone separator is the clip's own ARTICULATION RANGE from
+            // rest: a bone that HOLDS near its rest is showing a pose (keep
+            // absolute aim — w→0 below kStanceHoldDeg), while a bone that
+            // swings far away treats rest as a stance reference (anchor it —
+            // w→1 above kStanceMoveDeg). Spine/neck/head (0..5) always keep
+            // absolute aim: torso posture and lean must be faithful to the
+            // clip.
+            auto isLimbRole = [](int c) { return c >= 6 && c <= 21; };
+            constexpr float kStanceHoldDeg = 15.0f;
+            constexpr float kStanceMoveDeg = 40.0f;
+            std::vector<Ogre::Quaternion> stanceS(
+                static_cast<size_t>(Jc), Ogre::Quaternion::IDENTITY);
+            std::vector<float> roleMaxDevDeg(static_cast<size_t>(Jc), 0.0f);
+            for (int c = 0; c < Jc; ++c) {
+                if (!isLimbRole(c)
+                    || srcLocalAxis[static_cast<size_t>(c)].squaredLength()
+                           <= 1e-8f)
+                    continue;
+                const auto& sd = clipRestDir[static_cast<size_t>(c)];
+                Ogre::Vector3 rest(sd[0], sd[1], sd[2]);
+                rest.normalise();
+                float maxDev = 0.0f;
+                for (int f = 0; f < frames; ++f) {
+                    const Ogre::Vector3 d =
+                        clipQ(f, c) * srcLocalAxis[static_cast<size_t>(c)];
+                    maxDev = std::max(
+                        maxDev, d.angleBetween(rest).valueDegrees());
+                }
+                roleMaxDevDeg[static_cast<size_t>(c)] = maxDev;
+            }
             std::vector<Ogre::Quaternion> Qbase(static_cast<size_t>(nBones),
                                                 Ogre::Quaternion::IDENTITY);
             for (int i = 0; i < nBones; ++i) {
@@ -3726,6 +3770,23 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
                         tb.tgtBindDir[static_cast<size_t>(c)]
                             .getRotationTo(dref[static_cast<size_t>(c)])
                         * tb.bindWorld[static_cast<size_t>(i)];
+                    if (isLimbRole(c)) {
+                        const float w = std::clamp(
+                            (roleMaxDevDeg[static_cast<size_t>(c)]
+                             - kStanceHoldDeg)
+                                / (kStanceMoveDeg - kStanceHoldDeg),
+                            0.0f, 1.0f);
+                        if (w > 1e-4f)
+                            stanceS[static_cast<size_t>(c)] =
+                                Ogre::Quaternion::Slerp(
+                                    w, Ogre::Quaternion::IDENTITY,
+                                    dref[static_cast<size_t>(c)]
+                                        .getRotationTo(
+                                            tb.tgtBindDir
+                                                [static_cast<size_t>(c)]
+                                                    .normalisedCopy()),
+                                    true);
+                    }
                     // NOTE (2026-08-02 investigation): this minimal-arc baseline
                     // keeps the TARGET-BIND's roll about the bone axis, dropping
                     // the roll of the source's bind→reference rotation — the
@@ -3966,8 +4027,13 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
                              * srcLocalAxis[static_cast<size_t>(c)]);
                         const Ogre::Quaternion R =
                             dref[static_cast<size_t>(c)].getRotationTo(ds);
+                        // Limb stance correction (see stanceS above): the
+                        // graded offset composes OUTSIDE the matched-pole
+                        // swing, so dir = S·ds and S=I degrades to the plain
+                        // absolute aim.
                         Ogre::Quaternion Wt =
-                            R * Qbase[static_cast<size_t>(i)];
+                            stanceS[static_cast<size_t>(c)] * R
+                            * Qbase[static_cast<size_t>(i)];
                         // #857: re-apply the source's roll about the aimed
                         // direction (the swing above deliberately dropped it).
                         // (A hierarchical "exact twist" hybrid and a source-
@@ -3981,7 +4047,11 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
                                                    [static_cast<size_t>(c)]
                                          * twistGainAt(c);
                         if (std::abs(th) > 1e-5f) {
-                            Ogre::Vector3 axis = ds;
+                            // Limb stance correction: the bone's actual
+                            // direction is S·ds — twist about the real axis
+                            // (S is identity for non-limb roles).
+                            Ogre::Vector3 axis =
+                                stanceS[static_cast<size_t>(c)] * ds;
                             axis.normalise();
                             Wt = Ogre::Quaternion(Ogre::Radian(th), axis) * Wt;
                         }

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -1,5 +1,6 @@
 #include "AnimationMerger.h"
 #include "AutoRig.h"
+#include "SentryReporter.h"
 #include "FootContact.h"
 #include "MotionInbetween.h"
 #include <OgreSkeleton.h>
@@ -3317,12 +3318,18 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
                             }
                         }
                     }
-                if (droppedChains > 0)
+                if (droppedChains > 0) {
                     Ogre::LogManager::getSingleton().logMessage(
                         "applyMotionClip: dropped " +
                         std::to_string(droppedChains) +
                         " implausible finger chain(s) (>120deg articulation)"
                         " — holding bind");
+                    SentryReporter::addBreadcrumb(
+                        QStringLiteral("ai.assist.text_to_motion"),
+                        QStringLiteral("finger plausibility gate: %1 chain(s)"
+                                       " held at bind")
+                            .arg(droppedChains));
+                }
             }
             // HAND-BASIS finger transport frames. The canonical-frame
             // conjugation (Ct⁻¹·Drel·Ct) assumes the source's extraction

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -3364,6 +3364,10 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
                     const int hand = side == 0 ? 9 : 13;
                     const int thumb0 =
                         MotionInbetween::fingerJointIndexV2(side, 0, 0);
+                    if (thumb0 < 0 || thumb0 >= canonN
+                        || hand >= static_cast<int>(tb.tgtBindDir.size())
+                        || thumb0 >= static_cast<int>(tb.tgtBindDir.size()))
+                        continue;
                     const auto& hd = clipRestDir[static_cast<size_t>(hand)];
                     const auto& td = clipRestDir[static_cast<size_t>(thumb0)];
                     Ogre::Quaternion qs, qt;

--- a/src/AnimationMerger.h
+++ b/src/AnimationMerger.h
@@ -251,6 +251,15 @@ public:
         // anatomically — leave this false for qtmesh mocap / live drive.
         bool cmuLibraryHandedness = true);
 
+    /// Debug (#951): print raw world anatomy (forearm vs hip-line forward)
+    /// of an animation at a few sampled frames — env-gated by the caller
+    /// (QTMESH_T2M_DEBUG). The instrument that diagnosed #954: sample the
+    /// SAME quantities on the source rig and on the retargeted output and
+    /// the fore-dot-fwd sequences must match.
+    static void debugDumpAnatomy(Ogre::Skeleton* skel,
+                                 const std::string& animName,
+                                 const char* tag);
+
     /// One skeletal animation extracted onto the 22-joint canonical skeleton
     /// (#839, the REVERSE of applyMotionClip's world-frame path): per frame,
     /// per canonical role, the source bone's WORLD orientation — exactly the

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -2343,11 +2343,16 @@ int CLIPipeline::cmdAnimGenerate(const QString& filePath, const QString& prompt,
     // --smooth-fps N tunes): bake sparse -> re-bake at clip rate. A temporal
     // low-pass that removes retarget trembling; runs BEFORE arm-space and
     // foot pinning so the pin targets stay exact.
+    if (qEnvironmentVariableIsSet("QTMESH_T2M_DEBUG"))
+        AnimationMerger::debugDumpAnatomy(skel.get(), animName, "pre-post");
     if (smoothFps > 0) {
         if (AnimationMerger::smoothBakeAnimation(skel.get(), animName,
                                                  smoothFps, fps) > 0)
             err() << "(smooth-bake: " << smoothFps << " -> " << fps
                   << " fps)" << Qt::endl;
+        if (qEnvironmentVariableIsSet("QTMESH_T2M_DEBUG"))
+            AnimationMerger::debugDumpAnatomy(skel.get(), animName,
+                                              "post-smooth");
     }
 
     // #838: ground crouch/kneel/work clips (drop the root so the lowest foot
@@ -2376,6 +2381,8 @@ int CLIPipeline::cmdAnimGenerate(const QString& filePath, const QString& prompt,
                   << Qt::endl;
     }
 
+    if (qEnvironmentVariableIsSet("QTMESH_T2M_DEBUG"))
+        AnimationMerger::debugDumpAnatomy(skel.get(), animName, "pre-footpin");
     // #856: foot-contact cleanup — ON by default (--no-foot-pin disables).
     if (footPin) {
         const auto fp = AnimationMerger::pinFeet(skel.get(), animName);

--- a/src/MotionLibrary.cpp
+++ b/src/MotionLibrary.cpp
@@ -357,9 +357,17 @@ bool MotionLibrary::saveCuration(const QSet<QString>& approved)
 QString MotionLibrary::ensureLibraryBlocking()
 {
     const QString dest = libraryPath();
-    if (QFileInfo::exists(dest)) return dest;
+    const bool haveLocal = QFileInfo::exists(dest);
+    // Already on the V2 library (libraryPath prefers it when present) — done.
+    if (haveLocal && dest.endsWith(QLatin1String(kLibraryFileV2)))
+        return dest;
+    // UPGRADE GAP: a pre-V2 install has only the legacy V1 file, and the old
+    // early-return here meant the V2 (52-joint, curated) library NEVER
+    // downloaded — those users kept the V1 side-channel finger path and its
+    // artifacts. When only V1 exists, still attempt the V2 download (once per
+    // process — see below); offline/404 keeps the local V1 working.
     if (!qEnvironmentVariableIsEmpty("QTMESH_MOTION_NO_DOWNLOAD"))
-        return {};
+        return haveLocal ? dest : QString();
 
     QString base;
     {
@@ -371,11 +379,18 @@ QString MotionLibrary::ensureLibraryBlocking()
                                  : QString::fromUtf8(env);
         }
     }
-    if (base.isEmpty()) return {};
+    if (base.isEmpty()) return haveLocal ? dest : QString();
     if (!base.endsWith('/')) base += '/';
 
     auto* dl = ModelDownloader::instance();
-    if (!dl) return {};
+    if (!dl) return haveLocal ? dest : QString();
+
+    // One V2-upgrade attempt per process: a v1-only install must not re-hit
+    // the network for every generate call in a session when offline.
+    static bool s_v2UpgradeAttempted = false;
+    if (haveLocal && s_v2UpgradeAttempted)
+        return dest;
+    s_v2UpgradeAttempted = true;
 
     // Try the V2 library (schema v4, fingers-as-joints — the curated shipped
     // set) FIRST; fall back to the V1 file so overridden base URLs / older
@@ -414,6 +429,8 @@ QString MotionLibrary::ensureLibraryBlocking()
     };
     const QString v2 = tryDownload(kLibraryFileV2);
     if (!v2.isEmpty()) return v2;
+    // V2 unavailable: keep the legacy local V1 when we have one.
+    if (haveLocal) return dest;
     // A TIMEOUT means the connection stalled, not that the V2 file is absent —
     // retrying the V1 name would block the (GUI/CLI) caller for up to another
     // 5 minutes for nothing. Only fall back on a fast failure (404 / older

--- a/src/MotionLibrary.cpp
+++ b/src/MotionLibrary.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cmath>
 #include "ModelDownloader.h"
+#include "SentryReporter.h"
 
 #include <QDir>
 #include <QEventLoop>
@@ -391,13 +392,17 @@ QString MotionLibrary::ensureLibraryBlocking()
     if (haveLocal && s_v2UpgradeAttempted)
         return dest;
     s_v2UpgradeAttempted = true;
+    SentryReporter::addBreadcrumb(
+        QStringLiteral("ai.motion_library"),
+        haveLocal ? QStringLiteral("attempt V2 upgrade from local V1 library")
+                  : QStringLiteral("download V2 motion library"));
 
     // Try the V2 library (schema v4, fingers-as-joints — the curated shipped
     // set) FIRST; fall back to the V1 file so overridden base URLs / older
     // hosted repos keep working. Old app builds only request the V1 name and
     // their loader rejects the v4 schema, so hosting both is non-breaking.
     bool stalled = false;
-    auto tryDownload = [&](const char* fileName) -> QString {
+    auto tryDownload = [&](const char* fileName, int timeoutMs) -> QString {
         const QDir dir(QFileInfo(libraryPath()).absolutePath());
         const QString fdest = dir.filePath(QString::fromLatin1(fileName));
         const QString url = base + QString::fromLatin1(fileName);
@@ -416,7 +421,7 @@ QString MotionLibrary::ensureLibraryBlocking()
         timeout.setSingleShot(true);
         QObject::connect(&timeout, &QTimer::timeout, &loop,
                          [&]() { timedOut = true; loop.quit(); });
-        timeout.start(300000);   // 5 min — the library is small (~8 MB)
+        timeout.start(timeoutMs);
         dl->startDownload(url, fdest, label);
         loop.exec();
         QObject::disconnect(onDone);
@@ -427,16 +432,27 @@ QString MotionLibrary::ensureLibraryBlocking()
         QFile::remove(fdest);   // don't leave a partial/404 body behind
         return QString();
     };
-    const QString v2 = tryDownload(kLibraryFileV2);
+    // The UPGRADE attempt (a working V1 exists) uses a SHORT timeout: the
+    // caller blocks synchronously (GUI generate / listMotionClips), and a
+    // stalled connection must not freeze a functional V1 user for the full
+    // 5 minutes — 20s covers the ~8 MB file on a sane connection, and the
+    // attempt runs only once per process. Fresh installs (no local library)
+    // keep the long timeout since there is nothing to fall back to.
+    const QString v2 = tryDownload(kLibraryFileV2, haveLocal ? 20000 : 300000);
     if (!v2.isEmpty()) return v2;
     // V2 unavailable: keep the legacy local V1 when we have one.
-    if (haveLocal) return dest;
+    if (haveLocal) {
+        SentryReporter::addBreadcrumb(
+            QStringLiteral("ai.motion_library"),
+            QStringLiteral("V2 upgrade unavailable — keeping local V1"));
+        return dest;
+    }
     // A TIMEOUT means the connection stalled, not that the V2 file is absent —
     // retrying the V1 name would block the (GUI/CLI) caller for up to another
     // 5 minutes for nothing. Only fall back on a fast failure (404 / older
     // hosted repo without the V2 file).
     if (stalled) return {};
-    return tryDownload(kLibraryFile);
+    return tryDownload(kLibraryFile, 300000);
 }
 
 std::vector<std::array<float, 3>> MotionLibrary::referenceDirsForPrompt(


### PR DESCRIPTION
## What this PR actually changes

### 1. Finger/hand retarget quality (the user-visible fix)
- **Hand-basis finger transport**: finger curl is re-expressed through a per-side hand basis `M = R_t·R_s⁻¹` (frame-independent), with a **self-calibrating flexion basis** — the source flexion axis is estimated from the clip's own curl data (articulation-weighted PCA over non-thumb deltas, sign from net curl) and the target axis from the knuckle line, so rigs with odd thumb/finger rest conventions no longer splay or over-bend fingers.
- **Parent-relative wrist transport**: the hand follows the forearm's animated delta instead of an absolute frame (kills wrist fighting mid-motion).
- **Finger plausibility gate**: source rigs with garbage finger data (e.g. "Animated Human Low Poly" — chains articulating 176° through the palm) hold the whole chain at bind instead of transporting impossible curls (neutral beats broken); emits an `ai.assist.text_to_motion` breadcrumb.

### 2. V1→V2 motion-library upgrade path
`MotionLibrary::ensureLibraryBlocking` now attempts a V2 (52-joint, fingers-as-joints) library download once per process when only a local V1 exists — users upgraded from older versions get finger data without a manual purge.

### 3. Library builder (curation) fixes
- User curation **overrides** builder heuristics (an approved clip is never dropped by a quality gate).
- Portable curation-file discovery (macOS nested AppData, `XDG_DATA_HOME`, `LOCALAPPDATA`); explicit `--curation` fails closed.

### 4. Retarget-anatomy diagnostics (env-gated, zero effect on normal runs)
`AnimationMerger::debugDumpAnatomy` + extraction raw-anatomy dumps + a toe-based naming-chirality check (`QTMESH_T2M_DEBUG` / `QTMESH_EXTRACT_DEBUG`). These instruments proved the retarget is transport-exact end to end and isolated the two real defects behind the "punch overhead / arms wide / legs crossing" reports:
- **#954** — the post-#936/#933 FBX importer pitches Blender-rig arm chains ~90°, which had poisoned a library re-extraction (the hosted library has been rolled back to the validated July extractions).
- The pre-existing **glb export inversion** that mirrors every exported animation (tracked separately).

### Explicitly NOT in this PR
A stance-correction experiment was committed and reverted in-branch (net zero). The schema-v5 bind-relative transport research is parked on `feat/t2m-schema-v5-bind` pending #954.

## Verification
- Render-verified on Rumba: fingers correct on the low-poly jump, buildloop crouch preserved, chibi jump unchanged.
- Ground-truth self-parity harness + in-process anatomy dumps: retargeted output matches the source's forearm-direction sequences through every post-pass.
- 39/39 pure-data Motion tests pass; full suite on Linux CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
