### PR TITLE
fix(mocap): stop body Neck drive from tipping FaceCap head

### DIFF
--- a/src/Mocap/MocapController.cpp
+++ b/src/Mocap/MocapController.cpp
@@ -1051,7 +1051,8 @@ bool MocapController::beginPreviewWithLiveSource(
     d->savedAlwaysUpdateMainSkeleton = entity->getAlwaysUpdateMainSkeleton();
     entity->setAlwaysUpdateMainSkeleton(true);
     // Head-bone drive uses FaceCap (dense landmarks) even when Body is on —
-    // PoseIK's head role is coarse and fights the face solve.
+    // PoseIK's Neck/Head roles aim at the nose and tip the head down if
+    // left enabled alongside FaceCap.
     const bool headBoneDrive =
         d->headEnabled && !d->headBone.isEmpty();
     const std::string headBoneStd =
@@ -1548,12 +1549,17 @@ void MocapController::onSample(const FaceSample& sample,
         }
         d->bodyNeutralReady = d->bodyRetargeter->hasNeutralReference();
 
-        const uint32_t skipHead =
+        // FaceCap owns Head. Body must not also aim Neck/Neck1 at the nose —
+        // that webcam look-down stacks with FaceCap and leaves the head tipped
+        // after calibration (head-only mode stays fine because Neck stays bind).
+        const uint32_t skipFaceHeadChain =
             (d->headEnabled && !d->headBone.isEmpty())
-                ? (1u << static_cast<unsigned>(PoseIK::Head))
+                ? ((1u << static_cast<unsigned>(PoseIK::Neck))
+                   | (1u << static_cast<unsigned>(PoseIK::Neck1))
+                   | (1u << static_cast<unsigned>(PoseIK::Head)))
                 : 0u;
         const auto locals = d->bodyRetargeter->evaluateFrame(
-            canonQuats, body.resolvedMask, skipHead, body.world.data(),
+            canonQuats, body.resolvedMask, skipFaceHeadChain, body.world.data(),
             body.visibility.data());
         Ogre::SkeletonInstance* skel = entity->getSkeleton();
         const auto boneSmooth = boneOutputSmoothParams(d->smoothingCutoff);
@@ -1740,7 +1746,9 @@ void MocapController::stopRecording()
             bopts.algorithmUsed = QStringLiteral("pose-ik-landmarks");
             if (d->headEnabled && !d->headBone.isEmpty())
                 bopts.skipRolesMask =
-                    (1u << static_cast<unsigned>(PoseIK::Head));
+                    (1u << static_cast<unsigned>(PoseIK::Neck))
+                    | (1u << static_cast<unsigned>(PoseIK::Neck1))
+                    | (1u << static_cast<unsigned>(PoseIK::Head));
             const int fps =
                 (d->liveFps >= 5.0)
                     ? std::max(1, static_cast<int>(std::lround(d->liveFps)))

--- a/src/Mocap/MocapController.cpp
+++ b/src/Mocap/MocapController.cpp
@@ -353,6 +353,18 @@ signals:
 
 namespace {
 
+// When FaceCap owns the Head bone, body retarget must not also aim Neck/Neck1
+// at the nose — webcam look-down stacks with FaceCap and tips the head after
+// calibration. Shared by live preview and body-clip bake.
+uint32_t faceHeadChainSkipMask(bool faceCapOwnsHead)
+{
+    if (!faceCapOwnsHead)
+        return 0u;
+    return (1u << static_cast<unsigned>(PoseIK::Neck))
+           | (1u << static_cast<unsigned>(PoseIK::Neck1))
+           | (1u << static_cast<unsigned>(PoseIK::Head));
+}
+
 int countFingerScreen2dSlots(
     const std::array<std::array<float, 2>, AnimationMerger::kFingerSlots>& dirs)
 {
@@ -1549,15 +1561,9 @@ void MocapController::onSample(const FaceSample& sample,
         }
         d->bodyNeutralReady = d->bodyRetargeter->hasNeutralReference();
 
-        // FaceCap owns Head. Body must not also aim Neck/Neck1 at the nose —
-        // that webcam look-down stacks with FaceCap and leaves the head tipped
-        // after calibration (head-only mode stays fine because Neck stays bind).
-        const uint32_t skipFaceHeadChain =
-            (d->headEnabled && !d->headBone.isEmpty())
-                ? ((1u << static_cast<unsigned>(PoseIK::Neck))
-                   | (1u << static_cast<unsigned>(PoseIK::Neck1))
-                   | (1u << static_cast<unsigned>(PoseIK::Head)))
-                : 0u;
+        // FaceCap owns Head — skip Neck|Neck1|Head so body does not tip them.
+        const uint32_t skipFaceHeadChain = faceHeadChainSkipMask(
+            d->headEnabled && !d->headBone.isEmpty());
         const auto locals = d->bodyRetargeter->evaluateFrame(
             canonQuats, body.resolvedMask, skipFaceHeadChain, body.world.data(),
             body.visibility.data());
@@ -1744,11 +1750,8 @@ void MocapController::stopRecording()
             MocapRecorder::BodyRecordOptions bopts;
             bopts.clipName = d->clipName + QStringLiteral("_Body");
             bopts.algorithmUsed = QStringLiteral("pose-ik-landmarks");
-            if (d->headEnabled && !d->headBone.isEmpty())
-                bopts.skipRolesMask =
-                    (1u << static_cast<unsigned>(PoseIK::Neck))
-                    | (1u << static_cast<unsigned>(PoseIK::Neck1))
-                    | (1u << static_cast<unsigned>(PoseIK::Head));
+            bopts.skipRolesMask = faceHeadChainSkipMask(
+                d->headEnabled && !d->headBone.isEmpty());
             const int fps =
                 (d->liveFps >= 5.0)
                     ? std::max(1, static_cast<int>(std::lround(d->liveFps)))

--- a/src/Mocap/MocapRecorder.h
+++ b/src/Mocap/MocapRecorder.h
@@ -81,7 +81,10 @@ struct BodyRecordOptions {
     bool replaceExisting = true;
     QString algorithmUsed = QStringLiteral("pose-ik");  // for the report
     QString fallbackReason;                             // why not sam3dbody
-    uint32_t skipRolesMask = 0;  // e.g. Head role when head bone is driven separately
+    // Roles body bake must not write (FaceCap owns the head chain when Head
+    // is enabled — typically Neck | Neck1 | Head so webcam look-down does not
+    // stack with the face solve).
+    uint32_t skipRolesMask = 0;
 };
 
 struct BodyRecordReport {


### PR DESCRIPTION
## Summary
- When **Head + Body** are both enabled, FaceCap owns the Head bone, but body retarget still aimed **Neck / Neck1** at the nose (webcam look-down). That pitch stacked with FaceCap and left the head tipped after calibration; head-only mode was fine because Neck stayed at bind.
- Skip the full face chain — `Neck | Neck1 | Head` — in live body retarget and body-clip bake whenever FaceCap drives the head.

## Test plan
- [ ] Enable Head only → calibrate → head stays level / tracks face as before
- [ ] Enable Head + Body → Recalibrate facing the camera → head no longer tips down after calibration
- [ ] Body limbs / torso still track; neck bones stay at bind while FaceCap drives Head
- [ ] Record a take with Head + Body and confirm the baked `_Body` clip does not include neck/head tracks that fight the face head clip


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented body tracking from overriding FaceCap head and neck positioning when head drive is enabled.
  * Fixed head tilting downward after calibration when combining body and facial tracking.
  * Ensured recorded body clips preserve the facial tracking head and neck pose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->