### PR TITLE
fix(mocap): stop high-knee landmark aims from flipping Mixamo legs

### DIFF
--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -2139,6 +2139,33 @@ bool legLandmarksReliable(int role, const float* visibility33)
     }
 }
 
+// Clamp an aim direction to a max swing from `from` (radians). When `to` is
+// nearly antiparallel, getRotationTo's axis is arbitrary and Mixamo thighs
+// fold up the back — prefer swinging toward `fallbackAxis` (torso forward).
+Ogre::Vector3 clampAimSwing(const Ogre::Vector3& from,
+                            const Ogre::Vector3& to,
+                            float maxAngleRad,
+                            const Ogre::Vector3& fallbackAxis)
+{
+    if (from.squaredLength() < 1e-12f || to.squaredLength() < 1e-12f)
+        return from;
+    Ogre::Vector3 a = from.normalisedCopy();
+    Ogre::Vector3 b = to.normalisedCopy();
+    float cosA = a.dotProduct(b);
+    cosA = std::max(-1.f, std::min(1.f, cosA));
+    const float angle = std::acos(cosA);
+    if (angle <= maxAngleRad + 1e-4f)
+        return b;
+    Ogre::Vector3 axis = a.crossProduct(b);
+    if (axis.squaredLength() < 1e-10f) {
+        axis = a.crossProduct(fallbackAxis);
+        if (axis.squaredLength() < 1e-10f)
+            axis = a.perpendicular();
+    }
+    axis.normalise();
+    return Ogre::Quaternion(Ogre::Radian(maxAngleRad), axis) * a;
+}
+
 void collectFingerDirsFromPoseLandmarks(
     const float* world33, const float* visibility33,
     std::array<std::array<float, 3>, AnimationMerger::kFingerSlots>& out,
@@ -2506,10 +2533,9 @@ BodyRetargeter::evaluateFrame(
                 continue;
             }
             Ogre::Quaternion local;
-            // Leg landmark directions are often wrong (standing hallucination when
-            // knees are occluded). Prefer PoseIK quats for legs when resolved.
-            // Hip stays on bind/direction path — quat hip rotation breaks W
-            // propagation and distorts arms/torso direction retarget.
+            // Legs: clamp landmark aims (avoids 180° thigh flips on high knee)
+            // and fall back to PoseIK quats when landmarks look stuck at
+            // neutral. Hip stays on bind/direction — quat hip breaks W.
             const bool isLegRole =
                 (c >= PoseIK::RButtock && c <= PoseIK::LFoot);
             const bool isHandRole =
@@ -2549,19 +2575,60 @@ BodyRetargeter::evaluateFrame(
                 }
                 local = localDir;
             } else if (isLegRole) {
+                // High-knee / occlusion: raw landmark getRotationTo can swing
+                // ~180° and fold Mixamo thighs up the back. Prefer clamped
+                // landmark aims for real leg motion; when the landmark looks
+                // stuck at neutral (seated occlusion), use PoseIK quats — but
+                // refuse a quat that would invert the thigh.
+                const Ogre::Vector3& dref =
+                    d->neutralDref[static_cast<size_t>(c)];
+                Ogre::Vector3 dsLeg = Ogre::Vector3::ZERO;
+                bool haveLmAim = false;
                 if (legDirOk) {
-                    Ogre::Vector3 ds =
-                        CtInv * liveCanon[static_cast<size_t>(c)];
-                    ds.normalise();
-                    const Ogre::Quaternion R =
-                        d->neutralDref[static_cast<size_t>(c)].getRotationTo(ds);
+                    dsLeg = CtInv * liveCanon[static_cast<size_t>(c)];
+                    if (dsLeg.squaredLength() > 1e-12f) {
+                        dsLeg.normalise();
+                        haveLmAim = true;
+                    }
+                }
+                const bool dirNearNeutral =
+                    haveLmAim && dref.dotProduct(dsLeg) > 0.9995f;
+                const Ogre::Vector3 torsoFwd =
+                    (CtInv * Ogre::Vector3::UNIT_Z).normalisedCopy();
+                constexpr float kMaxLegSwing = 115.f * (Ogre::Math::PI / 180.f);
+
+                auto applyClampedDir = [&](const Ogre::Vector3& aim) {
+                    const Ogre::Vector3 clamped =
+                        clampAimSwing(dref, aim, kMaxLegSwing, torsoFwd);
+                    const Ogre::Quaternion R = dref.getRotationTo(clamped);
                     const Ogre::Quaternion Wt =
                         R * d->dirQbase[static_cast<size_t>(i)];
                     local = Wp.Inverse() * Wt;
                     W[static_cast<size_t>(i)] = Wt;
+                };
+
+                if (haveLmAim && !dirNearNeutral) {
+                    applyClampedDir(dsLeg);
                 } else if (legQuatResolved) {
                     local = quatDeltaArtic(i, c, base);
                     W[static_cast<size_t>(i)] = Wp * local;
+                    if (tb.tgtBindDir[static_cast<size_t>(c)].squaredLength()
+                        > 1e-12f) {
+                        const Ogre::Vector3 thigh =
+                            (W[static_cast<size_t>(i)]
+                             * tb.tgtBindDir[static_cast<size_t>(c)])
+                                .normalisedCopy();
+                        if (dref.dotProduct(thigh) < -0.15f) {
+                            if (haveLmAim)
+                                applyClampedDir(dsLeg);
+                            else {
+                                local = base;
+                                W[static_cast<size_t>(i)] = Wp * local;
+                            }
+                        }
+                    }
+                } else if (haveLmAim) {
+                    applyClampedDir(dsLeg);
                 } else {
                     local = base;
                     W[static_cast<size_t>(i)] = Wp * local;

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -2610,7 +2610,21 @@ BodyRetargeter::evaluateFrame(
                 if (haveLmAim && !dirNearNeutral) {
                     applyClampedDir(dsLeg);
                 } else if (legQuatResolved) {
-                    local = quatDeltaArtic(i, c, base);
+                    // Near-neutral landmarks: compose the PoseIK delta onto the
+                    // calibrated landmark aim, not bind `base`. Otherwise a
+                    // seated/raised-leg calibration (live ≈ dref → identity
+                    // delta) snaps the leg back to standing bind.
+                    Ogre::Quaternion articBase = base;
+                    if (haveLmAim) {
+                        const Ogre::Vector3 clamped = clampAimSwing(
+                            dref, dsLeg, kMaxLegSwing, torsoFwd);
+                        const Ogre::Quaternion R =
+                            dref.getRotationTo(clamped);
+                        const Ogre::Quaternion Wt =
+                            R * d->dirQbase[static_cast<size_t>(i)];
+                        articBase = Wp.Inverse() * Wt;
+                    }
+                    local = quatDeltaArtic(i, c, articBase);
                     W[static_cast<size_t>(i)] = Wp * local;
                     if (tb.tgtBindDir[static_cast<size_t>(c)].squaredLength()
                         > 1e-12f) {

--- a/src/AnimationMerger_test.cpp
+++ b/src/AnimationMerger_test.cpp
@@ -1355,6 +1355,131 @@ TEST_F(AnimationMergerTest, BodyRetargeterLandmarkDirectionMovesArm)
 
     EXPECT_GT(raisedMotion, 25.0f);
 }
+
+TEST_F(AnimationMergerTest, BodyRetargeterHighKneeDoesNotFlipThigh)
+{
+    // High knee: MediaPipe thigh can aim antiparallel to the standing neutral
+    // (knee above the hip in world-up). Landmark getRotationTo then flips the
+    // Mixamo thigh 180° up the back. Prefer PoseIK quats + reject unsafe
+    // direction aims so the thigh stays forward/down, matching the capture.
+    auto skel = Ogre::SkeletonManager::getSingleton().create(
+        "body_rt_knee_skel",
+        Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+    unsigned short h = 0;
+    auto bone = [&](const char* n, const Ogre::Vector3& p, Ogre::Bone* parent) {
+        auto* b = skel->createBone(n, h++);
+        b->setPosition(p);
+        if (parent) parent->addChild(b);
+        return b;
+    };
+    auto* hips = bone("Hips", {0, 1.0f, 0}, nullptr);
+    auto* spine = bone("Spine", {0, 0.2f, 0}, hips);
+    auto* chest = bone("Spine2", {0, 0.25f, 0}, spine);
+    bone("Neck", {0, 0.15f, 0}, chest);
+    bone("Head", {0, 0.15f, 0}, chest);
+    auto* lArm = bone("LeftArm", {0.25f, 0.05f, 0}, chest);
+    bone("LeftForeArm", {0.25f, 0, 0}, lArm);
+    bone("LeftHand", {0.15f, 0, 0}, lArm);
+    auto* rArm = bone("RightArm", {-0.25f, 0.05f, 0}, chest);
+    bone("RightForeArm", {-0.25f, 0, 0}, rArm);
+    bone("RightHand", {-0.15f, 0, 0}, rArm);
+    auto* lUp = bone("LeftUpLeg", {0.12f, -0.05f, 0}, hips);
+    auto* lKnee = bone("LeftLeg", {0, -0.40f, 0}, lUp);
+    bone("LeftFoot", {0, -0.40f, 0.05f}, lKnee);
+    auto* rUp = bone("RightUpLeg", {-0.12f, -0.05f, 0}, hips);
+    auto* rKnee = bone("RightLeg", {0, -0.40f, 0}, rUp);
+    bone("RightFoot", {0, -0.40f, 0.05f}, rKnee);
+    skel->setBindingPose();
+    auto mesh = createInMemoryMesh("body_rt_knee_mesh", skel);
+    Ogre::Entity* ent = Manager::getSingleton()->getSceneMgr()->createEntity(
+        "body_rt_knee_ent", mesh);
+    ASSERT_NE(ent, nullptr);
+    Ogre::SkeletonInstance* skelInst = ent->getSkeleton();
+    BodyRetargeter rt(skelInst);
+    ASSERT_TRUE(rt.valid());
+
+    using Landmarks = std::array<float, PoseIK::kLandmarkCount * 3>;
+    auto setLm = [](Landmarks& l, int lm, float x, float y, float z) {
+        l[lm * 3 + 0] = x;
+        l[lm * 3 + 1] = y;
+        l[lm * 3 + 2] = z;
+    };
+    auto standLm = [&]() {
+        Landmarks l{};
+        setLm(l, 11, 0.18f, -0.45f, 0.f);
+        setLm(l, 12, -0.18f, -0.45f, 0.f);
+        setLm(l, 13, 0.45f, -0.45f, 0.f);
+        setLm(l, 14, -0.45f, -0.45f, 0.f);
+        setLm(l, 15, 0.70f, -0.45f, 0.f);
+        setLm(l, 16, -0.70f, -0.45f, 0.f);
+        setLm(l, 23, 0.10f, 0.f, 0.f);
+        setLm(l, 24, -0.10f, 0.f, 0.f);
+        setLm(l, 25, 0.10f, 0.40f, 0.f);
+        setLm(l, 26, -0.10f, 0.40f, 0.f);
+        setLm(l, 27, 0.10f, 0.80f, 0.f);
+        setLm(l, 28, -0.10f, 0.80f, 0.f);
+        setLm(l, 0, 0.f, -0.65f, -0.10f);
+        setLm(l, 7, 0.08f, -0.62f, 0.02f);
+        setLm(l, 8, -0.08f, -0.62f, 0.02f);
+        return l;
+    };
+
+    auto thighDir = [&]() -> Ogre::Vector3 {
+        skelInst->_updateTransforms();
+        return (skelInst->getBone("LeftLeg")->_getDerivedPosition()
+                - skelInst->getBone("LeftUpLeg")->_getDerivedPosition())
+            .normalisedCopy();
+    };
+    auto applyLocals =
+        [&](const std::vector<std::pair<unsigned short, Ogre::Quaternion>>&
+                locals) {
+            skelInst->reset(true);
+            for (const auto& [handle, local] : locals) {
+                Ogre::Bone* b = skelInst->getBone(handle);
+                b->setManuallyControlled(true);
+                b->setOrientation(local);
+            }
+            for (Ogre::Bone* root : skelInst->getRootBones())
+                root->_update(true, true);
+        };
+
+    std::array<float, PoseIK::kLandmarkCount> vis{};
+    vis.fill(1.f);
+
+    PoseIK::Solver solver;
+    Landmarks neutralLm = standLm();
+    const auto neutralFr = solver.solveFrame(neutralLm.data(), vis.data());
+    ASSERT_TRUE(neutralFr.resolved(PoseIK::LHip));
+    ASSERT_TRUE(neutralFr.resolved(PoseIK::LKnee));
+
+    rt.setNeutralReference(neutralFr.quats, neutralFr.resolvedMask,
+                           neutralLm.data(), vis.data());
+    applyLocals(rt.evaluateFrame(neutralFr.quats, neutralFr.resolvedMask, 0,
+                                 neutralLm.data(), vis.data()));
+    const Ogre::Vector3 standThigh = thighDir();
+    EXPECT_LT(standThigh.y, -0.5f);  // standing thigh points down
+
+    // Extreme high left knee: knee nearly straight above the hip (image-y up)
+    // with a tiny forward offset. After canonicalize the live thigh is nearly
+    // antiparallel to the standing-down neutral — landmark getRotationTo then
+    // picks an arbitrary 180° axis and folds the Mixamo thigh up the back.
+    Landmarks highKnee = standLm();
+    setLm(highKnee, 25, 0.10f, -0.35f, 0.05f);  // knee almost above hip
+    setLm(highKnee, 27, 0.10f, -0.10f, 0.10f);  // ankle still above hip line
+    const auto highFr = solver.solveFrame(highKnee.data(), vis.data());
+    ASSERT_TRUE(highFr.resolved(PoseIK::LHip));
+    applyLocals(rt.evaluateFrame(highFr.quats, highFr.resolvedMask, 0,
+                                 highKnee.data(), vis.data()));
+    const Ogre::Vector3 lifted = thighDir();
+
+    // The upside-down bug is a ~180° flip: thigh ≈ -standThigh (straight up
+    // the spine / shoe behind the head). Clamped landmark aim must not.
+    EXPECT_LT(lifted.dotProduct(-standThigh), 0.85f)
+        << "thigh flipped antiparallel to standing: lifted=" << lifted
+        << " stand=" << standThigh;
+    // Still a real high-knee: leave the standing-down pose.
+    EXPECT_GT(degBetween(standThigh, lifted), 20.0f) << lifted;
+}
 #endif  // ENABLE_MOCAP
 
 // ── #857: twist transport in the bind-referenced direction retarget ─────────

--- a/src/AnimationMerger_test.cpp
+++ b/src/AnimationMerger_test.cpp
@@ -1480,6 +1480,116 @@ TEST_F(AnimationMergerTest, BodyRetargeterHighKneeDoesNotFlipThigh)
     // Still a real high-knee: leave the standing-down pose.
     EXPECT_GT(degBetween(standThigh, lifted), 20.0f) << lifted;
 }
+
+TEST_F(AnimationMergerTest, BodyRetargeterSeatedNeutralDoesNotSnapToStanding)
+{
+    // Calibrate while seated (thighs forward). Replaying the same pose used to
+    // hit the near-neutral quat path with identity delta on bind `base`, which
+    // snapped the legs back to standing. Landmark-aligned articBase must keep
+    // the calibrated seated aim.
+    auto skel = Ogre::SkeletonManager::getSingleton().create(
+        "body_rt_seat_skel",
+        Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+    unsigned short h = 0;
+    auto bone = [&](const char* n, const Ogre::Vector3& p, Ogre::Bone* parent) {
+        auto* b = skel->createBone(n, h++);
+        b->setPosition(p);
+        if (parent) parent->addChild(b);
+        return b;
+    };
+    auto* hips = bone("Hips", {0, 1.0f, 0}, nullptr);
+    auto* spine = bone("Spine", {0, 0.2f, 0}, hips);
+    auto* chest = bone("Spine2", {0, 0.25f, 0}, spine);
+    bone("Neck", {0, 0.15f, 0}, chest);
+    bone("Head", {0, 0.15f, 0}, chest);
+    auto* lArm = bone("LeftArm", {0.25f, 0.05f, 0}, chest);
+    bone("LeftForeArm", {0.25f, 0, 0}, lArm);
+    bone("LeftHand", {0.15f, 0, 0}, lArm);
+    auto* rArm = bone("RightArm", {-0.25f, 0.05f, 0}, chest);
+    bone("RightForeArm", {-0.25f, 0, 0}, rArm);
+    bone("RightHand", {-0.15f, 0, 0}, rArm);
+    auto* lUp = bone("LeftUpLeg", {0.12f, -0.05f, 0}, hips);
+    auto* lKnee = bone("LeftLeg", {0, -0.40f, 0}, lUp);
+    bone("LeftFoot", {0, -0.40f, 0.05f}, lKnee);
+    auto* rUp = bone("RightUpLeg", {-0.12f, -0.05f, 0}, hips);
+    auto* rKnee = bone("RightLeg", {0, -0.40f, 0}, rUp);
+    bone("RightFoot", {0, -0.40f, 0.05f}, rKnee);
+    skel->setBindingPose();
+    auto mesh = createInMemoryMesh("body_rt_seat_mesh", skel);
+    Ogre::Entity* ent = Manager::getSingleton()->getSceneMgr()->createEntity(
+        "body_rt_seat_ent", mesh);
+    ASSERT_NE(ent, nullptr);
+    Ogre::SkeletonInstance* skelInst = ent->getSkeleton();
+    BodyRetargeter rt(skelInst);
+    ASSERT_TRUE(rt.valid());
+
+    using Landmarks = std::array<float, PoseIK::kLandmarkCount * 3>;
+    auto setLm = [](Landmarks& l, int lm, float x, float y, float z) {
+        l[lm * 3 + 0] = x;
+        l[lm * 3 + 1] = y;
+        l[lm * 3 + 2] = z;
+    };
+    auto seatedLm = [&]() {
+        Landmarks l{};
+        setLm(l, 11, 0.18f, -0.45f, 0.f);
+        setLm(l, 12, -0.18f, -0.45f, 0.f);
+        setLm(l, 13, 0.45f, -0.45f, 0.f);
+        setLm(l, 14, -0.45f, -0.45f, 0.f);
+        setLm(l, 15, 0.70f, -0.45f, 0.f);
+        setLm(l, 16, -0.70f, -0.45f, 0.f);
+        setLm(l, 23, 0.10f, 0.f, 0.f);
+        setLm(l, 24, -0.10f, 0.f, 0.f);
+        // Knees forward of the hips (seated), not below (standing).
+        setLm(l, 25, 0.10f, 0.05f, 0.40f);
+        setLm(l, 26, -0.10f, 0.05f, 0.40f);
+        setLm(l, 27, 0.10f, 0.40f, 0.45f);
+        setLm(l, 28, -0.10f, 0.40f, 0.45f);
+        setLm(l, 0, 0.f, -0.65f, -0.10f);
+        setLm(l, 7, 0.08f, -0.62f, 0.02f);
+        setLm(l, 8, -0.08f, -0.62f, 0.02f);
+        return l;
+    };
+
+    auto thighDir = [&]() -> Ogre::Vector3 {
+        skelInst->_updateTransforms();
+        return (skelInst->getBone("LeftLeg")->_getDerivedPosition()
+                - skelInst->getBone("LeftUpLeg")->_getDerivedPosition())
+            .normalisedCopy();
+    };
+    auto applyLocals =
+        [&](const std::vector<std::pair<unsigned short, Ogre::Quaternion>>&
+                locals) {
+            skelInst->reset(true);
+            for (const auto& [handle, local] : locals) {
+                Ogre::Bone* b = skelInst->getBone(handle);
+                b->setManuallyControlled(true);
+                b->setOrientation(local);
+            }
+            for (Ogre::Bone* root : skelInst->getRootBones())
+                root->_update(true, true);
+        };
+
+    std::array<float, PoseIK::kLandmarkCount> vis{};
+    vis.fill(1.f);
+
+    PoseIK::Solver solver;
+    Landmarks neutralLm = seatedLm();
+    const auto neutralFr = solver.solveFrame(neutralLm.data(), vis.data());
+    ASSERT_TRUE(neutralFr.resolved(PoseIK::LHip));
+
+    rt.setNeutralReference(neutralFr.quats, neutralFr.resolvedMask,
+                           neutralLm.data(), vis.data());
+    applyLocals(rt.evaluateFrame(neutralFr.quats, neutralFr.resolvedMask, 0,
+                                 neutralLm.data(), vis.data()));
+    const Ogre::Vector3 seatedThigh = thighDir();
+
+    // Must not snap to standing (thigh straight down). Seated calib keeps a
+    // forward-ish thigh when replaying the neutral frame.
+    EXPECT_GT(seatedThigh.z, 0.25f)
+        << "seated neutral snapped toward standing: " << seatedThigh;
+    EXPECT_GT(seatedThigh.y, -0.75f)
+        << "seated thigh collapsed to standing-down: " << seatedThigh;
+}
 #endif  // ENABLE_MOCAP
 
 // ── #857: twist transport in the bind-referenced direction retarget ─────────


### PR DESCRIPTION
## Summary
- Live mocap detection (MediaPipe overlay) looked correct, but Mixamo thighs sometimes flipped 180° up the back on high knees / brief antiparallel aims because leg retarget used unconstrained landmark `getRotationTo`.
- Clamp leg aim swing to 115° (prefer torso-forward when antiparallel), keep PoseIK quats only when landmarks look stuck at neutral, and refuse quats that would invert the thigh.
- Add `BodyRetargeterHighKneeDoesNotFlipThigh` regression covering the extreme high-knee singularity.

## Test plan
- [x] `UnitTests --gtest_filter='AnimationMergerTest.BodyRetargeter*'` (3/3 pass)
- [ ] Live mocap with Face+Head+Body on a Mixamo character: march / high-knee like the screencast — legs should lift forward, not fold behind the back
- [ ] Seated capture still drives legs (landmarks near-neutral → PoseIK quat path)
- [ ] Arms/torso unchanged in the same session


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved motion capture leg retargeting for high-knee and seated poses.
  * Prevented thigh rotations from flipping backward or snapping incorrectly during neutral calibration.
  * Limited extreme aim-direction rotations for more stable animation results.

* **Tests**
  * Added regression coverage for high-knee poses and seated neutral calibration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->