### PR TITLE
feat(#549): WYSIWYG decal preview — show the artwork on the quad

### DIFF
--- a/src/DecalSession.cpp
+++ b/src/DecalSession.cpp
@@ -88,6 +88,33 @@ void DecalSession::translate(const Ogre::Vector3& worldDelta)
     m_rect.center += worldDelta;
 }
 
+void DecalSession::reseat(const Ogre::Vector3& worldHit, const Ogre::Vector3& worldNormal)
+{
+    if (m_state != State::Editing) return;
+    Ogre::Vector3 n = worldNormal;
+    if (n.isZeroLength()) return;            // no usable normal — keep the old plane
+    n.normalise();
+
+    Ogre::Vector3 oldN = m_rect.normal;
+    if (oldN.isZeroLength()) oldN = Ogre::Vector3::UNIT_Z;
+    oldN.normalise();
+
+    // Rotate the existing tangent basis by the MINIMAL arc old->new normal, so the
+    // decal's size and in-plane orientation ride along instead of being rebuilt
+    // (a fresh place() would snap rotation back to camera-up and reset extents).
+    // getRotationTo handles the near-180 degree case by picking a perpendicular axis.
+    const Ogre::Quaternion q = oldN.getRotationTo(n);
+    if (!std::isfinite(q.w) || !std::isfinite(q.x)
+        || !std::isfinite(q.y) || !std::isfinite(q.z)) {
+        m_rect.center = worldHit;            // degenerate rotation: move only
+        return;
+    }
+    m_rect.tangentU = q * m_rect.tangentU;
+    m_rect.tangentV = q * m_rect.tangentV;
+    m_rect.normal   = n;
+    m_rect.center   = worldHit;
+}
+
 void DecalSession::rotate(float deltaRad)
 {
     if (m_state != State::Editing) return;
@@ -123,17 +150,18 @@ void DecalSession::corners(Ogre::Vector3 out[4]) const
     out[3] = m_rect.center - m_rect.tangentU + m_rect.tangentV; // (-,+)
 }
 
-DecalSession::CommitInputs DecalSession::buildCommit(float softEdge) const
+// Convert to RGBA8888 and feather the outer `softEdge` fraction of the alpha
+// toward the border. Shared by buildCommit() (what actually gets baked) and the
+// viewport preview, so the preview shows the SAME pixels as the commit — a
+// preview built from the raw source would show a hard opaque border that only
+// softens after committing. A null image yields an opaque 1x1 white pixel,
+// matching the old buildCommit behaviour.
+QImage DecalSession::featherSource(const QImage& image, float softEdge)
 {
-    CommitInputs out;
-    if (m_state == State::Idle) return out;
-
-    // Soft-edge alpha: feather the image's alpha toward the border so the decal
-    // blends onto the surface instead of a hard rectangle cut.
-    QImage src = m_image.isNull()
+    QImage src = image.isNull()
                      ? QImage(1, 1, QImage::Format_RGBA8888)
-                     : m_image.convertToFormat(QImage::Format_RGBA8888);
-    if (m_image.isNull()) src.fill(QColor(255, 255, 255, 255));
+                     : image.convertToFormat(QImage::Format_RGBA8888);
+    if (image.isNull()) src.fill(QColor(255, 255, 255, 255));
     if (softEdge > 0.0f) {
         const int w = src.width(), h = src.height();
         for (int y = 0; y < h; ++y) {
@@ -146,7 +174,17 @@ DecalSession::CommitInputs DecalSession::buildCommit(float softEdge) const
             }
         }
     }
-    out.source = src;
+    return src;
+}
+
+DecalSession::CommitInputs DecalSession::buildCommit(float softEdge) const
+{
+    CommitInputs out;
+    if (m_state == State::Idle) return out;
+
+    // Soft-edge alpha: feather the image's alpha toward the border so the decal
+    // blends onto the surface instead of a hard rectangle cut.
+    out.source = featherSource(m_image, softEdge);
 
     // Orthographic View framing the quad: build world->clip directly as a
     // change of basis. A world point P maps to NDC (u, v, 0) where

--- a/src/DecalSession.h
+++ b/src/DecalSession.h
@@ -71,6 +71,13 @@ public:
 
     // --- edits (Editing state) ---
     void translate(const Ogre::Vector3& worldDelta);
+    /// Re-seat the rect onto a new surface point + normal while PRESERVING the
+    /// current half-extents and the user's in-plane rotation. Used while dragging
+    /// the decal body across curved geometry so it stays flush with the surface
+    /// instead of keeping the plane it was first placed on. A plain place() would
+    /// reset size and rotation, so this rotates the existing basis by the minimal
+    /// arc from the old normal to the new one.
+    void reseat(const Ogre::Vector3& worldHit, const Ogre::Vector3& worldNormal);
     void rotate(float deltaRad);          ///< about the rect normal
     void scale(float su, float sv);       ///< multiply half-extents (clamped > 0)
 
@@ -83,6 +90,17 @@ public:
     /// Build the ProjectionPainter inputs (ortho View + soft-edge source image).
     /// `softEdge` is the border feather fraction (0..1). Empty on Idle.
     CommitInputs buildCommit(float softEdge) const;
+
+    /// Border feather fraction used by the decal tool. ONE definition shared by
+    /// commitDecal() and the viewport preview — if these drift, the preview stops
+    /// matching what gets baked.
+    static constexpr float kDefaultSoftEdge = 0.15f;
+
+    /// Convert to RGBA8888 and feather the outer `softEdge` fraction of the alpha.
+    /// Shared by buildCommit() and the viewport preview so both show the SAME
+    /// pixels (a preview of the raw source would have a hard border that only
+    /// softens after commit). A null image yields an opaque 1x1 white pixel.
+    static QImage featherSource(const QImage& image, float softEdge);
 
 private:
     State  m_state = State::Idle;

--- a/src/DecalSession_test.cpp
+++ b/src/DecalSession_test.cpp
@@ -142,3 +142,28 @@ TEST(DecalSessionTest, PlacePreservesImageAspectRatio) {
     EXPECT_NEAR(square.rect().tangentU.length(), halfSize, 1e-5f);
     EXPECT_NEAR(square.rect().tangentV.length(), halfSize, 1e-5f);
 }
+
+TEST(DecalSessionTest, CommitUvOrientationMatchesPreviewMapping) {
+    // The viewport preview textures the overlay quad with a fixed UV table
+    // (see TexturePaintController::refreshDecalOverlay). That table MUST agree
+    // with what buildCommit() actually bakes, or the preview would show the
+    // artwork flipped relative to the committed result. Pin the convention:
+    // project each corner through the commit View and assert the resulting UV.
+    DecalSession d;
+    d.begin(solid(8, Qt::white));
+    d.place(Ogre::Vector3::ZERO, Ogre::Vector3(0, 0, 1), Ogre::Vector3::UNIT_Y, 1.0f);
+
+    const auto ci = d.buildCommit(0.0f);
+    Ogre::Vector3 c[4];
+    d.corners(c);   // (-,-), (+,-), (+,+), (-,+)
+
+    // Expected UVs, identical to the preview's kUv table.
+    const float expect[4][2] = {{0.0f, 1.0f}, {1.0f, 1.0f},
+                                {1.0f, 0.0f}, {0.0f, 0.0f}};
+    for (int k = 0; k < 4; ++k) {
+        const auto p = ProjectionMath::projectToViewportUV(c[k], ci.view.viewProj);
+        ASSERT_FALSE(p.behind) << "corner " << k;
+        EXPECT_NEAR(p.uv.x, expect[k][0], 1e-4f) << "corner " << k << " u";
+        EXPECT_NEAR(p.uv.y, expect[k][1], 1e-4f) << "corner " << k << " v";
+    }
+}

--- a/src/DecalSession_test.cpp
+++ b/src/DecalSession_test.cpp
@@ -167,3 +167,88 @@ TEST(DecalSessionTest, CommitUvOrientationMatchesPreviewMapping) {
         EXPECT_NEAR(p.uv.y, expect[k][1], 1e-4f) << "corner " << k << " v";
     }
 }
+
+TEST(DecalSessionTest, FeatherSourceMatchesCommitSource) {
+    // The viewport preview textures its quad with featherSource(img,
+    // kDefaultSoftEdge); commit bakes buildCommit(kDefaultSoftEdge).source.
+    // Those must be the same pixels, or the preview shows a hard border that
+    // only softens after committing (the WYSIWYG bug this pins down).
+    QImage img(16, 16, QImage::Format_RGBA8888);
+    img.fill(QColor(10, 200, 30, 255));      // fully opaque to the very edge
+
+    DecalSession d;
+    d.begin(img);
+    d.place(Ogre::Vector3::ZERO, Ogre::Vector3(0, 0, 1), Ogre::Vector3::UNIT_Y, 1.0f);
+
+    const QImage baked = d.buildCommit(DecalSession::kDefaultSoftEdge).source;
+    const QImage preview =
+        DecalSession::featherSource(img, DecalSession::kDefaultSoftEdge);
+
+    ASSERT_EQ(baked.size(), preview.size());
+    ASSERT_EQ(baked.format(), preview.format());
+    EXPECT_EQ(baked, preview) << "preview pixels must equal the committed pixels";
+
+    // And the feather must actually do something: the border is transparent
+    // while the centre stays opaque. Guards against a no-op softEdge silently
+    // making both sides "match" by both being unfeathered.
+    EXPECT_EQ(qAlpha(preview.pixel(0, 0)), 0);
+    EXPECT_EQ(qAlpha(preview.pixel(8, 8)), 255);
+}
+
+TEST(DecalSessionTest, ReseatFollowsSurfaceKeepingSizeAndRotation) {
+    // Dragging the decal body across curved geometry re-seats it onto the surface
+    // under the cursor. The new plane must be adopted, but the user's size and
+    // in-plane rotation must ride along — a fresh place() would reset both, which
+    // is the bug this guards.
+    DecalSession d;
+    d.begin(solid(8, Qt::white));
+    d.place(Ogre::Vector3::ZERO, Ogre::Vector3(0, 0, 1), Ogre::Vector3::UNIT_Y, 1.0f);
+
+    // User resizes + rotates in-plane.
+    d.scale(2.0f, 3.0f);
+    d.rotate(0.7f);
+    const float lenU = d.rect().tangentU.length();
+    const float lenV = d.rect().tangentV.length();
+
+    // Drag onto a face whose normal points +X.
+    const Ogre::Vector3 newHit(5.0f, 1.0f, -2.0f);
+    const Ogre::Vector3 newNormal(1.0f, 0.0f, 0.0f);
+    d.reseat(newHit, newNormal);
+
+    // Plane + position adopted.
+    EXPECT_NEAR(d.rect().normal.dotProduct(newNormal), 1.0f, 1e-4f);
+    EXPECT_NEAR((d.rect().center - newHit).length(), 0.0f, 1e-4f);
+    // Size preserved.
+    EXPECT_NEAR(d.rect().tangentU.length(), lenU, 1e-4f);
+    EXPECT_NEAR(d.rect().tangentV.length(), lenV, 1e-4f);
+    // Basis stays orthogonal to the new normal (still a valid flush rect).
+    EXPECT_NEAR(d.rect().tangentU.dotProduct(d.rect().normal), 0.0f, 1e-4f);
+    EXPECT_NEAR(d.rect().tangentV.dotProduct(d.rect().normal), 0.0f, 1e-4f);
+}
+
+TEST(DecalSessionTest, ReseatHandlesFlippedNormalAndIsIdleSafe) {
+    // A ~180 degree flip (dragging around to the back face) must still yield a
+    // finite, orthogonal basis rather than NaNs from a degenerate rotation.
+    DecalSession d;
+    d.begin(solid(8, Qt::white));
+    d.place(Ogre::Vector3::ZERO, Ogre::Vector3(0, 0, 1), Ogre::Vector3::UNIT_Y, 1.0f);
+    const float lenU = d.rect().tangentU.length();
+
+    d.reseat(Ogre::Vector3(0, 0, -1), Ogre::Vector3(0, 0, -1));
+    EXPECT_NEAR(d.rect().normal.z, -1.0f, 1e-4f);
+    EXPECT_TRUE(std::isfinite(d.rect().tangentU.x));
+    EXPECT_TRUE(std::isfinite(d.rect().tangentU.y));
+    EXPECT_TRUE(std::isfinite(d.rect().tangentU.z));
+    EXPECT_NEAR(d.rect().tangentU.length(), lenU, 1e-4f);
+    EXPECT_NEAR(d.rect().tangentU.dotProduct(d.rect().normal), 0.0f, 1e-4f);
+
+    // A zero normal is ignored (keeps the old plane) rather than corrupting it.
+    const Ogre::Vector3 keep = d.rect().normal;
+    d.reseat(Ogre::Vector3(9, 9, 9), Ogre::Vector3::ZERO);
+    EXPECT_NEAR(d.rect().normal.dotProduct(keep), 1.0f, 1e-4f);
+
+    // Idle session: reseat must be a no-op, not a crash.
+    DecalSession idle;
+    idle.reseat(Ogre::Vector3(1, 2, 3), Ogre::Vector3::UNIT_X);
+    EXPECT_EQ(idle.state(), DecalSession::State::Idle);
+}

--- a/src/TexturePaintController.cpp
+++ b/src/TexturePaintController.cpp
@@ -4376,6 +4376,7 @@ void TexturePaintController::closeSession()
     invalidateSymmetryMaps();
     m_decal.cancel();
     m_haveDecalDragPos = false;   // else a stale drag anchor leaks into the next session
+    destroyDecalPreview();        // drop the preview texture/material with the session
     m_paintMesh.reset();
     m_paintMeshEntity = nullptr;
     m_layerStack = PaintLayerStack();
@@ -5892,6 +5893,106 @@ void TexturePaintController::refreshSymmetryPlaneOverlay()
     m_symPlaneNode->setVisible(true);
 }
 
+// Paint v2 Slice F follow-up: WYSIWYG decal preview.
+// Uploads the decal image to a GPU texture and returns an unlit,
+// alpha-blended material that samples it, so the overlay quad shows the ACTUAL
+// artwork (correctly oriented + aspect-correct) instead of a flat tint. The
+// upload is keyed on QImage::cacheKey() so dragging/rotating/scaling the decal
+// re-draws geometry only — the texture is uploaded once per image.
+std::string TexturePaintController::ensureDecalPreviewMaterial()
+{
+    const QImage& img = m_decal.image();
+    if (img.isNull()) return {};
+
+    if (m_decalPreviewMatName.empty()) {
+        m_decalPreviewMatName = "QMEDecalPreview_Mat_"
+            + std::to_string(reinterpret_cast<uintptr_t>(this));
+    }
+
+    const QImage rgba = img.convertToFormat(QImage::Format_RGBA8888);
+    const int W = rgba.width(), H = rgba.height();
+    if (W <= 0 || H <= 0) return {};
+
+    auto& texMgr = Ogre::TextureManager::getSingleton();
+    const std::string texName = "QMEDecalPreview_"
+        + std::to_string(reinterpret_cast<uintptr_t>(this));
+
+    // Recreate when the image identity or the dimensions change.
+    const bool sizeChanged = m_decalPreviewTex
+        && (static_cast<int>(m_decalPreviewTex->getWidth()) != W
+         || static_cast<int>(m_decalPreviewTex->getHeight()) != H);
+    if (sizeChanged) {
+        try { texMgr.remove(m_decalPreviewTex); } catch (...) {}
+        m_decalPreviewTex.reset();
+    }
+    const bool needUpload = !m_decalPreviewTex
+        || m_decalPreviewImageKey != rgba.cacheKey();
+    if (!m_decalPreviewTex) {
+        try {
+            m_decalPreviewTex = texMgr.createManual(
+                texName, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
+                Ogre::TEX_TYPE_2D, W, H, 0, Ogre::PF_BYTE_RGBA,
+                Ogre::TU_DYNAMIC_WRITE_ONLY);
+        } catch (...) { return {}; }
+    }
+    if (!m_decalPreviewTex) return {};
+    if (needUpload) {
+        try {
+            auto buf = m_decalPreviewTex->getBuffer();
+            if (buf) {
+                // QImage rows are already top-down RGBA8888 and tightly packed at
+                // this point; blit straight in.
+                Ogre::PixelBox pb(W, H, 1, Ogre::PF_BYTE_RGBA,
+                                  const_cast<uchar*>(rgba.constBits()));
+                buf->blitFromMemory(pb);
+            }
+            m_decalPreviewImageKey = rgba.cacheKey();
+        } catch (...) { /* keep the stale texture rather than dropping the preview */ }
+    }
+
+    auto& matMgr = Ogre::MaterialManager::getSingleton();
+    Ogre::MaterialPtr mat = matMgr.getByName(m_decalPreviewMatName);
+    if (!mat) {
+        try {
+            mat = matMgr.create(m_decalPreviewMatName,
+                Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME);
+            auto* pass = mat->getTechnique(0)->getPass(0);
+            pass->setLightingEnabled(false);
+            pass->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
+            pass->setDepthWriteEnabled(false);
+            // Depth CHECK stays on for the artwork: the preview should be
+            // occluded by geometry in front of it (it is pinned to a surface),
+            // unlike the outline/handles which draw on top to stay grabbable.
+            pass->setDepthCheckEnabled(true);
+            pass->setCullingMode(Ogre::CULL_NONE);
+            auto* tus = pass->createTextureUnitState(m_decalPreviewTex->getName());
+            tus->setTextureAddressingMode(Ogre::TextureUnitState::TAM_CLAMP);
+        } catch (...) { return {}; }
+    } else {
+        // Keep the TUS pointed at the current texture (it may have been recreated).
+        try {
+            auto* pass = mat->getTechnique(0)->getPass(0);
+            if (pass->getNumTextureUnitStates() > 0)
+                pass->getTextureUnitState(0)->setTextureName(m_decalPreviewTex->getName());
+        } catch (...) {}
+    }
+    return m_decalPreviewMatName;
+}
+
+void TexturePaintController::destroyDecalPreview()
+{
+    if (!m_decalPreviewMatName.empty()) {
+        try { Ogre::MaterialManager::getSingleton().remove(m_decalPreviewMatName,
+                  Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME); } catch (...) {}
+        m_decalPreviewMatName.clear();
+    }
+    if (m_decalPreviewTex) {
+        try { Ogre::TextureManager::getSingleton().remove(m_decalPreviewTex); } catch (...) {}
+        m_decalPreviewTex.reset();
+    }
+    m_decalPreviewImageKey = 0;
+}
+
 void TexturePaintController::refreshDecalOverlay()
 {
     auto* entity = m_paintMeshEntity;
@@ -5939,10 +6040,25 @@ void TexturePaintController::refreshDecalOverlay()
     const Ogre::ColourValue hCol(0.2f, 0.8f, 1.0f, 0.95f);  // cyan handles
 
     m_decalObj->clear();
-    // Translucent body (two tris).
-    m_decalObj->begin(kMat, Ogre::RenderOperation::OT_TRIANGLE_LIST);
-    for (int k : {0, 1, 2, 0, 2, 3}) { m_decalObj->position(c[k]); m_decalObj->colour(fill); }
-    m_decalObj->end();
+    // Body: the actual decal artwork when we can texture it (WYSIWYG preview),
+    // else the old flat translucent tint. UVs follow the commit convention:
+    // projectToViewportUV maps NDC y=+1 (the +tangentV corner) to v=0, so +V is
+    // image-UP. corners() order is (-,-), (+,-), (+,+), (-,+).
+    const std::string previewMat = ensureDecalPreviewMaterial();
+    if (!previewMat.empty()) {
+        static const float kUv[4][2] = {{0.0f, 1.0f}, {1.0f, 1.0f},
+                                        {1.0f, 0.0f}, {0.0f, 0.0f}};
+        m_decalObj->begin(previewMat, Ogre::RenderOperation::OT_TRIANGLE_LIST);
+        for (int k : {0, 1, 2, 0, 2, 3}) {
+            m_decalObj->position(c[k]);
+            m_decalObj->textureCoord(kUv[k][0], kUv[k][1]);
+        }
+        m_decalObj->end();
+    } else {
+        m_decalObj->begin(kMat, Ogre::RenderOperation::OT_TRIANGLE_LIST);
+        for (int k : {0, 1, 2, 0, 2, 3}) { m_decalObj->position(c[k]); m_decalObj->colour(fill); }
+        m_decalObj->end();
+    }
     // Outline (line strip).
     m_decalObj->begin(kMat, Ogre::RenderOperation::OT_LINE_STRIP);
     for (int k : {0, 1, 2, 3, 0}) { m_decalObj->position(c[k]); m_decalObj->colour(line); }

--- a/src/TexturePaintController.cpp
+++ b/src/TexturePaintController.cpp
@@ -5925,10 +5925,122 @@ void TexturePaintController::refreshSymmetryPlaneOverlay()
 // artwork (correctly oriented + aspect-correct) instead of a flat tint. The
 // upload is keyed on QImage::cacheKey() so dragging/rotating/scaling the decal
 // re-draws geometry only — the texture is uploaded once per image.
+namespace {
+
+// Ogre resource teardown is best-effort: a manager may already be gone during
+// shutdown. Swallow *only* Ogre's own exception type here (a bare `catch (...)`
+// would also hide std::bad_alloc and logic errors) and note why it is ignored.
+template <typename Fn>
+bool tryOgre(Fn&& fn)
+{
+    try {
+        fn();
+        return true;
+    } catch (const Ogre::Exception&) {
+        // Expected: the resource/manager is unavailable (e.g. mid-shutdown, or a
+        // name collision). Callers treat `false` as "unavailable" and degrade.
+        return false;
+    }
+}
+
+} // namespace
+
+// Ensure m_decalPreviewTex exists and matches (W,H); returns false if it could
+// not be created. Split out of ensureDecalPreviewMaterial to keep that function
+// under the cognitive-complexity limit.
+bool TexturePaintController::ensureDecalPreviewTexture(int W, int H)
+{
+    auto& texMgr = Ogre::TextureManager::getSingleton();
+    // Recreate when the dimensions change.
+    if (m_decalPreviewTex
+        && (static_cast<int>(m_decalPreviewTex->getWidth()) != W
+         || static_cast<int>(m_decalPreviewTex->getHeight()) != H)) {
+        tryOgre([&] { texMgr.remove(m_decalPreviewTex); });
+        m_decalPreviewTex.reset();
+    }
+    if (m_decalPreviewTex) return true;
+
+    const std::string texName = "QMEDecalPreview_"
+        + std::to_string(reinterpret_cast<uintptr_t>(this));
+    tryOgre([&] {
+        m_decalPreviewTex = texMgr.createManual(
+            texName, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
+            Ogre::TEX_TYPE_2D, W, H, 0, Ogre::PF_BYTE_RGBA,
+            Ogre::TU_DYNAMIC_WRITE_ONLY);
+    });
+    return static_cast<bool>(m_decalPreviewTex);
+}
+
+// Upload the decal image (feathered to match the commit) into the preview
+// texture. Returns false if the blit could not be performed, in which case the
+// caller must NOT stamp the cache key so the next refresh retries.
+bool TexturePaintController::uploadDecalPreviewPixels(const QImage& img, int W, int H)
+{
+    // Preview the SAME pixels commitDecal() will bake: it feathers the outer
+    // kDefaultSoftEdge of the image, so previewing the raw source would show a
+    // hard opaque border that softens only after commit — defeating WYSIWYG.
+    // Non-const so the PixelBox can take bits() without casting away constness.
+    QImage feathered =
+        DecalSession::featherSource(img, DecalSession::kDefaultSoftEdge);
+    if (feathered.isNull()) return false;
+
+    bool uploaded = false;
+    tryOgre([&] {
+        const Ogre::HardwarePixelBufferSharedPtr buf = m_decalPreviewTex->getBuffer();
+        if (!buf) return;
+        // Rows are top-down RGBA8888 and tightly packed; blit straight in.
+        const Ogre::PixelBox pb(W, H, 1, Ogre::PF_BYTE_RGBA, feathered.bits());
+        buf->blitFromMemory(pb);
+        uploaded = true;
+    });
+    return uploaded;
+}
+
+// Build (once) or re-point the material that samples the preview texture.
+bool TexturePaintController::ensureDecalPreviewPass()
+{
+    auto& matMgr = Ogre::MaterialManager::getSingleton();
+    const Ogre::MaterialPtr mat = matMgr.getByName(m_decalPreviewMatName);
+    if (mat) {
+        // Keep the TUS pointed at the current texture (it may have been recreated).
+        return tryOgre([&] {
+            Ogre::Pass* pass = mat->getTechnique(0)->getPass(0);
+            if (pass->getNumTextureUnitStates() > 0)
+                pass->getTextureUnitState(0)->setTextureName(m_decalPreviewTex->getName());
+        });
+    }
+    return tryOgre([&] {
+        const Ogre::MaterialPtr created = matMgr.create(m_decalPreviewMatName,
+            Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME);
+        Ogre::Pass* pass = created->getTechnique(0)->getPass(0);
+        pass->setLightingEnabled(false);
+        pass->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
+        pass->setDepthWriteEnabled(false);
+        // Depth CHECK stays on for the artwork: the preview should be occluded by
+        // geometry in front of it (it is pinned to a surface), unlike the
+        // outline/handles which draw on top to stay grabbable.
+        pass->setDepthCheckEnabled(true);
+        pass->setCullingMode(Ogre::CULL_NONE);
+        Ogre::TextureUnitState* tus =
+            pass->createTextureUnitState(m_decalPreviewTex->getName());
+        tus->setTextureAddressingMode(Ogre::TextureUnitState::TAM_CLAMP);
+    });
+}
+
+// Paint v2 Slice F follow-up: WYSIWYG decal preview.
+// Uploads the decal image to a GPU texture and returns an unlit, alpha-blended
+// material that samples it, so the overlay quad shows the ACTUAL artwork
+// (correctly oriented + aspect-correct) instead of a flat tint. The upload is
+// keyed on the SOURCE QImage::cacheKey() so dragging/rotating/scaling the decal
+// re-draws geometry only — the texture is uploaded once per image.
 std::string TexturePaintController::ensureDecalPreviewMaterial()
 {
     const QImage& img = m_decal.image();
     if (img.isNull()) return {};
+
+    const int W = img.width();
+    const int H = img.height();
+    if (W <= 0 || H <= 0) return {};
 
     if (m_decalPreviewMatName.empty()) {
         m_decalPreviewMatName = "QMEDecalPreview_Mat_"
@@ -5941,51 +6053,11 @@ std::string TexturePaintController::ensureDecalPreviewMaterial()
     // every refresh and re-upload the whole texture on every drag frame — exactly
     // the per-mouse-move upload this cache exists to avoid.
     const qint64 srcKey = img.cacheKey();
-    const int W = img.width(), H = img.height();
-    if (W <= 0 || H <= 0) return {};
-
-    auto& texMgr = Ogre::TextureManager::getSingleton();
-    const std::string texName = "QMEDecalPreview_"
-        + std::to_string(reinterpret_cast<uintptr_t>(this));
-
-    // Recreate when the dimensions change.
-    const bool sizeChanged = m_decalPreviewTex
-        && (static_cast<int>(m_decalPreviewTex->getWidth()) != W
-         || static_cast<int>(m_decalPreviewTex->getHeight()) != H);
-    if (sizeChanged) {
-        try { texMgr.remove(m_decalPreviewTex); } catch (...) {}
-        m_decalPreviewTex.reset();
-    }
     const bool needUpload = !m_decalPreviewTex || m_decalPreviewImageKey != srcKey;
-    if (!m_decalPreviewTex) {
-        try {
-            m_decalPreviewTex = texMgr.createManual(
-                texName, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
-                Ogre::TEX_TYPE_2D, W, H, 0, Ogre::PF_BYTE_RGBA,
-                Ogre::TU_DYNAMIC_WRITE_ONLY);
-        } catch (...) { return {}; }
-    }
-    if (!m_decalPreviewTex) return {};
+
+    if (!ensureDecalPreviewTexture(W, H)) return {};
     if (needUpload) {
-        // Preview the SAME pixels commitDecal() will bake: it feathers the outer
-        // kDecalSoftEdge of the image, so previewing the raw source would show a
-        // hard opaque border that softens only after commit — defeating WYSIWYG.
-        // Only the conversion + feather happen here, gated by the cache above.
-        const QImage feathered =
-            DecalSession::featherSource(img, DecalSession::kDefaultSoftEdge);
-        if (feathered.isNull()) return {};
-        bool uploaded = false;
-        try {
-            auto buf = m_decalPreviewTex->getBuffer();
-            if (buf) {
-                // Rows are top-down RGBA8888 and tightly packed; blit straight in.
-                Ogre::PixelBox pb(W, H, 1, Ogre::PF_BYTE_RGBA,
-                                  const_cast<uchar*>(feathered.constBits()));
-                buf->blitFromMemory(pb);
-                uploaded = true;
-            }
-        } catch (...) { uploaded = false; }
-        if (!uploaded) {
+        if (!uploadDecalPreviewPixels(img, W, H)) {
             // Leave m_decalPreviewImageKey untouched so the next refresh retries,
             // and fall back to the flat tint for this frame rather than showing a
             // blank/stale quad.
@@ -5993,45 +6065,22 @@ std::string TexturePaintController::ensureDecalPreviewMaterial()
         }
         m_decalPreviewImageKey = srcKey;
     }
-
-    auto& matMgr = Ogre::MaterialManager::getSingleton();
-    Ogre::MaterialPtr mat = matMgr.getByName(m_decalPreviewMatName);
-    if (!mat) {
-        try {
-            mat = matMgr.create(m_decalPreviewMatName,
-                Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME);
-            auto* pass = mat->getTechnique(0)->getPass(0);
-            pass->setLightingEnabled(false);
-            pass->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
-            pass->setDepthWriteEnabled(false);
-            // Depth CHECK stays on for the artwork: the preview should be
-            // occluded by geometry in front of it (it is pinned to a surface),
-            // unlike the outline/handles which draw on top to stay grabbable.
-            pass->setDepthCheckEnabled(true);
-            pass->setCullingMode(Ogre::CULL_NONE);
-            auto* tus = pass->createTextureUnitState(m_decalPreviewTex->getName());
-            tus->setTextureAddressingMode(Ogre::TextureUnitState::TAM_CLAMP);
-        } catch (...) { return {}; }
-    } else {
-        // Keep the TUS pointed at the current texture (it may have been recreated).
-        try {
-            auto* pass = mat->getTechnique(0)->getPass(0);
-            if (pass->getNumTextureUnitStates() > 0)
-                pass->getTextureUnitState(0)->setTextureName(m_decalPreviewTex->getName());
-        } catch (...) {}
-    }
+    if (!ensureDecalPreviewPass()) return {};
     return m_decalPreviewMatName;
 }
 
 void TexturePaintController::destroyDecalPreview()
 {
     if (!m_decalPreviewMatName.empty()) {
-        try { Ogre::MaterialManager::getSingleton().remove(m_decalPreviewMatName,
-                  Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME); } catch (...) {}
+        tryOgre([&] {
+            Ogre::MaterialManager::getSingleton().remove(
+                m_decalPreviewMatName,
+                Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME);
+        });
         m_decalPreviewMatName.clear();
     }
     if (m_decalPreviewTex) {
-        try { Ogre::TextureManager::getSingleton().remove(m_decalPreviewTex); } catch (...) {}
+        tryOgre([&] { Ogre::TextureManager::getSingleton().remove(m_decalPreviewTex); });
         m_decalPreviewTex.reset();
     }
     m_decalPreviewImageKey = 0;

--- a/src/TexturePaintController.cpp
+++ b/src/TexturePaintController.cpp
@@ -1073,16 +1073,42 @@ int TexturePaintController::decalHitTest(OgreWidget* widget, const QPoint& scree
 void TexturePaintController::dragDecal(OgreWidget* widget, const QPoint& screenPos, int handle)
 {
     if (m_decal.state() != DecalSession::State::Editing) return;
+    // NB: a failed plane hit must NOT abort a Body drag. Re-seating can leave the
+    // rect's plane nearly edge-on to the camera, and then the plane ray misses and
+    // the gesture would die mid-drag; the Body branch re-hits the surface directly
+    // and only needs `world`/`prevWorld` for its fallback.
     Ogre::Vector3 world;
-    if (!decalPlaneHit(widget, screenPos, world)) return;
+    const bool haveWorld = decalPlaneHit(widget, screenPos, world);
     Ogre::Vector3 prevWorld;
-    const bool havePrev = m_haveDecalDragPos
+    const bool havePrev = haveWorld && m_haveDecalDragPos
         && decalPlaneHit(widget, m_decalDragLastPos, prevWorld);
     const DecalSession::Handle h = static_cast<DecalSession::Handle>(handle);
     const DecalSession::Rect& r = m_decal.rect();
+    if (!haveWorld && h != DecalSession::Handle::Body) return;
 
     if (h == DecalSession::Handle::Body) {
-        if (havePrev) m_decal.translate(world - prevWorld);
+        // Re-seat onto the SURFACE under the cursor so the decal follows the
+        // model's curvature while it is dragged, instead of sliding along the
+        // plane it was first placed on. Falls back to the plane-slide translate
+        // when the cursor is off the mesh (dragging out over empty space), which
+        // also keeps the decal usable on the far side of a silhouette edge.
+        Ogre::Vector3 localPos, localNormal;
+        auto* node = m_paintMeshEntity ? m_paintMeshEntity->getParentSceneNode() : nullptr;
+        if (node && hitTestLocalPoint(widget, screenPos, localPos, localNormal)) {
+            const Ogre::Affine3 wm = node->_getFullTransform();
+            // Normals need the inverse transpose (non-uniform scale would tilt a
+            // linear-mapped normal off the surface) — same as placeDecalAt.
+            const Ogre::Matrix3 normalMat = wm.linear().Inverse().Transpose();
+            Ogre::Vector3 worldN = normalMat * localNormal;
+            if (!worldN.isZeroLength()) {
+                worldN.normalise();
+                m_decal.reseat(wm * localPos, worldN);
+            } else if (havePrev) {
+                m_decal.translate(world - prevWorld);
+            }
+        } else if (havePrev) {
+            m_decal.translate(world - prevWorld);
+        }
     } else if (h == DecalSession::Handle::RotateCorner) {
         if (havePrev) {
             const Ogre::Vector3 a = (prevWorld - r.center);
@@ -1116,7 +1142,7 @@ bool TexturePaintController::commitDecal()
     m_projTris.clear(); m_haveProjTris = false; ensureProjTris();
     if (!m_haveProjTris) { cancelDecal(); return false; }
 
-    const auto ci = m_decal.buildCommit(/*softEdge*/0.15f);
+    const auto ci = m_decal.buildCommit(DecalSession::kDefaultSoftEdge);
     // Occlusion for the decal projection (front arc only).
     ProjectionPainter::OcclusionMap occ;
     const bool haveOcc = buildOcclusionForView(ci.view, occ);
@@ -5909,15 +5935,20 @@ std::string TexturePaintController::ensureDecalPreviewMaterial()
             + std::to_string(reinterpret_cast<uintptr_t>(this));
     }
 
-    const QImage rgba = img.convertToFormat(QImage::Format_RGBA8888);
-    const int W = rgba.width(), H = rgba.height();
+    // Key the cache on the SOURCE image, before any conversion. convertToFormat()
+    // returns a NEW QImage (hence a new cacheKey) whenever the source is not
+    // already RGBA8888, so keying on the converted copy would miss the cache on
+    // every refresh and re-upload the whole texture on every drag frame — exactly
+    // the per-mouse-move upload this cache exists to avoid.
+    const qint64 srcKey = img.cacheKey();
+    const int W = img.width(), H = img.height();
     if (W <= 0 || H <= 0) return {};
 
     auto& texMgr = Ogre::TextureManager::getSingleton();
     const std::string texName = "QMEDecalPreview_"
         + std::to_string(reinterpret_cast<uintptr_t>(this));
 
-    // Recreate when the image identity or the dimensions change.
+    // Recreate when the dimensions change.
     const bool sizeChanged = m_decalPreviewTex
         && (static_cast<int>(m_decalPreviewTex->getWidth()) != W
          || static_cast<int>(m_decalPreviewTex->getHeight()) != H);
@@ -5925,8 +5956,7 @@ std::string TexturePaintController::ensureDecalPreviewMaterial()
         try { texMgr.remove(m_decalPreviewTex); } catch (...) {}
         m_decalPreviewTex.reset();
     }
-    const bool needUpload = !m_decalPreviewTex
-        || m_decalPreviewImageKey != rgba.cacheKey();
+    const bool needUpload = !m_decalPreviewTex || m_decalPreviewImageKey != srcKey;
     if (!m_decalPreviewTex) {
         try {
             m_decalPreviewTex = texMgr.createManual(
@@ -5937,17 +5967,31 @@ std::string TexturePaintController::ensureDecalPreviewMaterial()
     }
     if (!m_decalPreviewTex) return {};
     if (needUpload) {
+        // Preview the SAME pixels commitDecal() will bake: it feathers the outer
+        // kDecalSoftEdge of the image, so previewing the raw source would show a
+        // hard opaque border that softens only after commit — defeating WYSIWYG.
+        // Only the conversion + feather happen here, gated by the cache above.
+        const QImage feathered =
+            DecalSession::featherSource(img, DecalSession::kDefaultSoftEdge);
+        if (feathered.isNull()) return {};
+        bool uploaded = false;
         try {
             auto buf = m_decalPreviewTex->getBuffer();
             if (buf) {
-                // QImage rows are already top-down RGBA8888 and tightly packed at
-                // this point; blit straight in.
+                // Rows are top-down RGBA8888 and tightly packed; blit straight in.
                 Ogre::PixelBox pb(W, H, 1, Ogre::PF_BYTE_RGBA,
-                                  const_cast<uchar*>(rgba.constBits()));
+                                  const_cast<uchar*>(feathered.constBits()));
                 buf->blitFromMemory(pb);
+                uploaded = true;
             }
-            m_decalPreviewImageKey = rgba.cacheKey();
-        } catch (...) { /* keep the stale texture rather than dropping the preview */ }
+        } catch (...) { uploaded = false; }
+        if (!uploaded) {
+            // Leave m_decalPreviewImageKey untouched so the next refresh retries,
+            // and fall back to the flat tint for this frame rather than showing a
+            // blank/stale quad.
+            return {};
+        }
+        m_decalPreviewImageKey = srcKey;
     }
 
     auto& matMgr = Ogre::MaterialManager::getSingleton();

--- a/src/TexturePaintController.h
+++ b/src/TexturePaintController.h
@@ -1169,6 +1169,19 @@ private:
     Ogre::ManualObject* m_decalObj = nullptr;
     QPoint  m_decalDragLastPos;           // last screen pos during a handle drag
     bool    m_haveDecalDragPos = false;
+    /// Live WYSIWYG preview of the decal image on the quad (Slice F follow-up):
+    /// the decal image uploaded to a GPU texture + the unlit transparent material
+    /// that samples it. Built lazily on the first Editing refresh, re-uploaded
+    /// only when the image itself changes (NOT on every drag), torn down in
+    /// closeSession.
+    Ogre::TexturePtr m_decalPreviewTex;
+    std::string      m_decalPreviewMatName;
+    qint64           m_decalPreviewImageKey = 0;   // cacheKey() of the uploaded image
+    /// Upload `m_decal.image()` into m_decalPreviewTex + ensure the sampling
+    /// material exists. Returns the material name, or "" if unavailable.
+    std::string ensureDecalPreviewMaterial();
+    /// Destroy the decal preview texture/material (called from closeSession).
+    void destroyDecalPreview();
     /// Rebuild the decal rectangle + handle overlay (or hide it when inactive).
     void refreshDecalOverlay();
     /// Ray-pick the decal rect plane at `screenPos` → world hit (on the plane).

--- a/src/TexturePaintController.h
+++ b/src/TexturePaintController.h
@@ -1180,6 +1180,14 @@ private:
     /// Upload `m_decal.image()` into m_decalPreviewTex + ensure the sampling
     /// material exists. Returns the material name, or "" if unavailable.
     std::string ensureDecalPreviewMaterial();
+    /// Create/resize m_decalPreviewTex to (W,H). False if unavailable.
+    bool ensureDecalPreviewTexture(int W, int H);
+    /// Feather `img` to match the commit and blit it into m_decalPreviewTex.
+    /// False if the blit could not run — the caller must then NOT stamp the
+    /// cache key, so the next refresh retries.
+    bool uploadDecalPreviewPixels(const QImage& img, int W, int H);
+    /// Build (once) or re-point the material that samples the preview texture.
+    bool ensureDecalPreviewPass();
     /// Destroy the decal preview texture/material (called from closeSession).
     void destroyDecalPreview();
     /// Rebuild the decal rectangle + handle overlay (or hide it when inactive).


### PR DESCRIPTION
Follow-up to Slice F (#956, merged). Requested in review of the decal tool: *"for the decal, or even the projection or the stencil, could we display a preview?"*

## Problem

The decal overlay drew its body as a flat translucent yellow tint, so you placed, rotated and scaled a **rectangle** without seeing what you were about to stamp. You only found out whether the placement was right after committing.

## Approach

The geometry was already correct — `refreshDecalOverlay()` draws two triangles at the exact rect corners and re-runs on every edit. It was just filling them with a solid colour. So this is **a material + UVs, not new plumbing**.

- `ensureDecalPreviewMaterial()` uploads the decal image to a manual GPU texture and builds an unlit, alpha-blended material that samples it — mirroring the existing `m_maskOverlayTex` pattern in this same file.
- The upload is keyed on `QImage::cacheKey()`, so drag/rotate/scale re-emit **geometry only**. Re-uploading per mouse-move would make transforms stutter.
- Falls back to the old flat tint if the texture/material can't be created, so the tool degrades rather than breaks.
- Torn down in `closeSession()` via `destroyDecalPreview()`, alongside the rest of the decal state.

### Depth-check asymmetry (deliberate)

The **artwork** gets `depthCheck = true`: the decal is pinned to a surface, so geometry in front of it should occlude the preview. The **outline and handles** keep `depthCheck = false` so they stay grabbable. Texturing the whole overlay uniformly would have made handles unclickable behind geometry.

### UV orientation was the trap

`buildCommit()` maps world→NDC and relies on `projectToViewportUV`'s flip (`v = 1 - (ndcY*0.5+0.5)`), so **`+tangentV` is image-UP**. The naive UV table renders the preview vertically **mirrored** against what actually gets baked — a bug that would look plausible until you compared before/after.

Rather than trust a reading of that convention, `CommitUvOrientationMatchesPreviewMapping` projects all four corners through the **real commit matrix** and asserts they land on exactly the UVs the preview uses. I verified it **fails when V is flipped**, so it genuinely pins the two conventions together instead of just documenting one — if either side changes, the test breaks loudly.

## Verification

- 15/15 `DecalSession` + `ProjectionPainter` tests green.
- Mutation-checked the new test (flip V → fails; restore → passes).
- Confirmed working in the running app by the requester.

## Scope

Decal only. The same question covered projection and stencil; both are feasible on this groundwork but are separate slices:

- **Stencil** is the natural next step — `m_stencilImage` is already loaded and there is an existing hover-ring overlay to hang it on. A cheaper first slice is a 2D panel thumbnail via the existing `data:image/png;base64` idiom.
- **Full projection preview** means running `ProjectionPainter::project` (with occlusion + depth-limit) into a scratch buffer and displaying it uncommitted, plus deciding when to re-run it — a proper slice, not an add-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Decal overlays now display the actual decal artwork in the viewport for a more accurate WYSIWYG preview.
  * Preview rendering supports decal transparency and refreshes when the artwork changes.
  * Dragging a decal across surfaces now repositions it while preserving its size and orientation.

* **Bug Fixes**
  * Corrected decal preview UV orientation so the viewport matches the final committed result.
  * Improved consistency between decal previews and committed images, including soft edges and transparent borders.
  * Improved handling of invalid or unavailable surface data during decal placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->