### PR TITLE
fix(mocap): plantarflex feet on raised legs (no sole-to-camera)

### DIFF
--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -2190,6 +2190,26 @@ TargetBindFrame readTargetBindFrame(Ogre::Skeleton* skel,
                 if (v.squaredLength() > 1e-12f) return v;
             }
         }
+        // Feet (and other leaves) often have no canonical child — Mixamo
+        // ToeBase isn't a CMU role. Prefer a real Ogre child so Foot aims
+        // along the toes, NOT back along the shin (parent fallback).
+        if (a >= 0) {
+            Ogre::Bone* bone =
+                skel->getBone(static_cast<unsigned short>(a));
+            if (bone) {
+                for (unsigned short ci = 0; ci < bone->numChildren(); ++ci) {
+                    auto* ch = dynamic_cast<Ogre::Bone*>(bone->getChild(ci));
+                    if (!ch)
+                        continue;
+                    const unsigned short chH = ch->getHandle();
+                    if (chH >= static_cast<unsigned short>(nBones))
+                        continue;
+                    Ogre::Vector3 v = tb.bindPos[chH] - tb.bindPos[static_cast<size_t>(a)];
+                    if (v.squaredLength() > 1e-12f)
+                        return v;
+                }
+            }
+        }
         if (a >= 0 && parent >= 0) {
             const int pIdx = tb.roleBoneIdx[static_cast<size_t>(parent)];
             if (pIdx >= 0) {
@@ -2375,9 +2395,11 @@ bool legLandmarksReliable(int role, const float* visibility33)
     }
 }
 
-// Plantarflexion / plantigrade foot aim. Project torso-forward onto the plane
-// ⊥ shin so the result is continuous (no ±torsoFwd flip from a tiny vertical
-// cross product). When forward ‖ shin (raised calf), fall back toward ground.
+// Plantarflexion aim: direction ⊥ shin toward ground. When shin ‖ ground
+// (standing / hanging), fall back to torso forward so feet stay plantigrade.
+// Prefer the torso-forward hemisphere when the cross product is nearly
+// antiparallel to forward — avoids ±torsoFwd snaps from vertical shin noise
+// without an early-return threshold that mis-classifies hanging shins.
 Ogre::Vector3 plantarFlexAim(const Ogre::Vector3& shin,
                              const Ogre::Vector3& groundDown,
                              const Ogre::Vector3& torsoFwd)
@@ -2392,28 +2414,21 @@ Ogre::Vector3 plantarFlexAim(const Ogre::Vector3& shin,
     if (s.squaredLength() < 1e-12f)
         return f;
     s.normalise();
-
     Ogre::Vector3 g = groundDown;
     if (g.squaredLength() < 1e-12f)
         g = -Ogre::Vector3::UNIT_Y;
     else
         g.normalise();
-
-    // Plantigrade: keep as much torso-forward as possible while staying ⊥ shin.
-    Ogre::Vector3 aim = f - s * f.dotProduct(s);
-    if (aim.squaredLength() < 1e-6f) {
-        // Forward lies along the shin (e.g. calf kicked forward) — swing
-        // toward ground in the shin–ground plane.
-        aim = s.crossProduct(g).crossProduct(s);
-        if (aim.squaredLength() < 1e-6f)
-            return f;
-        aim.normalise();
-        if (aim.dotProduct(g) < 0.f)
-            aim = -aim;
-        return aim;
-    }
-    aim.normalise();
-    return aim;
+    Ogre::Vector3 axis = s.crossProduct(g);
+    if (axis.squaredLength() < 1e-6f)
+        return f;
+    Ogre::Vector3 plantar = axis.crossProduct(s);
+    if (plantar.squaredLength() < 1e-12f)
+        return f;
+    plantar.normalise();
+    if (plantar.dotProduct(f) < -0.5f)
+        plantar = -plantar;
+    return plantar;
 }
 
 // Foot aim in canonical (+Y up) space. Never returns the shin — that is what
@@ -2987,7 +3002,14 @@ BodyRetargeter::evaluateFrame(
                 };
 
                 if (haveLmAim && !dirNearNeutral) {
-                    applyClampedDir(dsLeg);
+                    Ogre::Vector3 aim = dsLeg;
+                    // Hanging-shin plantar is often ~antiparallel to the standing
+                    // toe aim (+Z vs −Z). clampAimSwing's axis then degenerates
+                    // (fallback ‖ dref) and a.perpendicular() can swing toes to
+                    // +Y (ceiling / sole-to-camera). Prefer plantigrade forward.
+                    if (isFootRole && dref.dotProduct(aim) < -0.5f)
+                        aim = torsoFwd;
+                    applyClampedDir(aim);
                 } else if (allowLegQuat) {
                     // Near-neutral landmarks: compose the PoseIK delta onto the
                     // calibrated landmark aim, not bind `base`. Otherwise a
@@ -3021,7 +3043,10 @@ BodyRetargeter::evaluateFrame(
                         }
                     }
                 } else if (haveLmAim) {
-                    applyClampedDir(dsLeg);
+                    Ogre::Vector3 aim = dsLeg;
+                    if (isFootRole && dref.dotProduct(aim) < -0.5f)
+                        aim = torsoFwd;
+                    applyClampedDir(aim);
                 } else {
                     local = base;
                     W[static_cast<size_t>(i)] = Wp * local;

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -2375,9 +2375,9 @@ bool legLandmarksReliable(int role, const float* visibility33)
     }
 }
 
-// Plantarflexion aim: direction ⊥ shin toward ground. Near-vertical shins
-// (standing) must return a stable torso-forward — a tiny cross product from
-// forward/back noise would otherwise flip between ±torsoFwd (~180° snap).
+// Plantarflexion / plantigrade foot aim. Project torso-forward onto the plane
+// ⊥ shin so the result is continuous (no ±torsoFwd flip from a tiny vertical
+// cross product). When forward ‖ shin (raised calf), fall back toward ground.
 Ogre::Vector3 plantarFlexAim(const Ogre::Vector3& shin,
                              const Ogre::Vector3& groundDown,
                              const Ogre::Vector3& torsoFwd)
@@ -2392,29 +2392,28 @@ Ogre::Vector3 plantarFlexAim(const Ogre::Vector3& shin,
     if (s.squaredLength() < 1e-12f)
         return f;
     s.normalise();
+
     Ogre::Vector3 g = groundDown;
     if (g.squaredLength() < 1e-12f)
         g = -Ogre::Vector3::UNIT_Y;
     else
         g.normalise();
 
-    // |shin · ground| ≈ 1 → standing; prefer torso forward (no noisy cross).
-    const float align = std::abs(s.dotProduct(g));
-    if (align > 0.92f)
-        return f;
-
-    Ogre::Vector3 axis = s.crossProduct(g);
-    if (axis.squaredLength() < 1e-8f)
-        return f;
-    Ogre::Vector3 plantar = axis.crossProduct(s);
-    if (plantar.squaredLength() < 1e-12f)
-        return f;
-    plantar.normalise();
-    // Still mostly upright: keep the hemisphere toward torso forward so a
-    // shallow lean cannot pick −torsoFwd from noise.
-    if (align > 0.7f && plantar.dotProduct(f) < 0.f)
-        plantar = -plantar;
-    return plantar;
+    // Plantigrade: keep as much torso-forward as possible while staying ⊥ shin.
+    Ogre::Vector3 aim = f - s * f.dotProduct(s);
+    if (aim.squaredLength() < 1e-6f) {
+        // Forward lies along the shin (e.g. calf kicked forward) — swing
+        // toward ground in the shin–ground plane.
+        aim = s.crossProduct(g).crossProduct(s);
+        if (aim.squaredLength() < 1e-6f)
+            return f;
+    }
+    aim.normalise();
+    // Never pick the hemisphere away from ground when the shin is clearly
+    // off-vertical (raised leg); standing (shin ‖ ground) keeps forward.
+    if (std::abs(s.dotProduct(g)) < 0.85f && aim.dotProduct(g) < 0.f)
+        aim = -aim;
+    return aim;
 }
 
 // Foot aim in canonical (+Y up) space. Never returns the shin — that is what

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -2407,12 +2407,12 @@ Ogre::Vector3 plantarFlexAim(const Ogre::Vector3& shin,
         aim = s.crossProduct(g).crossProduct(s);
         if (aim.squaredLength() < 1e-6f)
             return f;
+        aim.normalise();
+        if (aim.dotProduct(g) < 0.f)
+            aim = -aim;
+        return aim;
     }
     aim.normalise();
-    // Never pick the hemisphere away from ground when the shin is clearly
-    // off-vertical (raised leg); standing (shin ‖ ground) keeps forward.
-    if (std::abs(s.dotProduct(g)) < 0.85f && aim.dotProduct(g) < 0.f)
-        aim = -aim;
     return aim;
 }
 

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -2190,10 +2190,12 @@ TargetBindFrame readTargetBindFrame(Ogre::Skeleton* skel,
                 if (v.squaredLength() > 1e-12f) return v;
             }
         }
-        // Feet (and other leaves) often have no canonical child — Mixamo
-        // ToeBase isn't a CMU role. Prefer a real Ogre child so Foot aims
-        // along the toes, NOT back along the shin (parent fallback).
-        if (a >= 0) {
+        // Feet have no canonical child — Mixamo ToeBase isn't a CMU role.
+        // Prefer a real Ogre toe child so Foot aims along the toes, NOT back
+        // along the shin (parent fallback). Hands/head keep the parent-leaf
+        // contract (finger children must not redefine Hand bind aim).
+        if (a >= 0
+            && (role == PoseIK::RFoot || role == PoseIK::LFoot)) {
             Ogre::Bone* bone =
                 skel->getBone(static_cast<unsigned short>(a));
             if (bone) {
@@ -2204,7 +2206,8 @@ TargetBindFrame readTargetBindFrame(Ogre::Skeleton* skel,
                     const unsigned short chH = ch->getHandle();
                     if (chH >= static_cast<unsigned short>(nBones))
                         continue;
-                    Ogre::Vector3 v = tb.bindPos[chH] - tb.bindPos[static_cast<size_t>(a)];
+                    Ogre::Vector3 v = tb.bindPos[chH]
+                                      - tb.bindPos[static_cast<size_t>(a)];
                     if (v.squaredLength() > 1e-12f)
                         return v;
                 }

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -2360,16 +2360,90 @@ bool legLandmarksReliable(int role, const float* visibility33)
     case PoseIK::RKnee:
         return vis(26) && vis(28);
     case PoseIK::RFoot:
-        return vis(28);
+        // Toe tip preferred; heel+ankle is enough for a flat-foot guess.
+        // Never treat ankle-only as OK — PoseIK's shin fallback aims Foot
+        // bones up the leg.
+        return (vis(28) && vis(32)) || (vis(28) && vis(30));
     case PoseIK::LHip:
         return vis(23) && vis(25);
     case PoseIK::LKnee:
         return vis(25) && vis(27);
     case PoseIK::LFoot:
-        return vis(27);
+        return (vis(27) && vis(31)) || (vis(27) && vis(29));
     default:
         return false;
     }
+}
+
+// Plantarflexion aim: direction ⊥ shin toward ground. When shin ‖ ground
+// (standing), fall back to torso forward so standing feet stay flat.
+Ogre::Vector3 plantarFlexAim(const Ogre::Vector3& shin,
+                             const Ogre::Vector3& groundDown,
+                             const Ogre::Vector3& torsoFwd)
+{
+    Ogre::Vector3 s = shin;
+    if (s.squaredLength() < 1e-12f)
+        return torsoFwd;
+    s.normalise();
+    Ogre::Vector3 g = groundDown;
+    if (g.squaredLength() < 1e-12f)
+        g = -Ogre::Vector3::UNIT_Y;
+    else
+        g.normalise();
+    Ogre::Vector3 axis = s.crossProduct(g);
+    if (axis.squaredLength() < 1e-8f) {
+        Ogre::Vector3 f = torsoFwd;
+        if (f.squaredLength() < 1e-12f)
+            return g;
+        f.normalise();
+        return f;
+    }
+    return axis.crossProduct(s).normalisedCopy();
+}
+
+// Foot aim in canonical (+Y up) space. Never returns the shin — that is what
+// made Mixamo Foot bones point toes at the ceiling.
+bool footAimCanonical(int role, const float* world33, const float* visibility33,
+                      Ogre::Vector3& outDir)
+{
+    if (!world33 || (role != PoseIK::RFoot && role != PoseIK::LFoot))
+        return false;
+    std::array<std::array<float, 3>, PoseIK::kLandmarkCount> canon{};
+    PoseIK::Solver::canonicalizeMediaPipeWorld(world33, canon);
+    auto vis = [&](int lm) {
+        return !visibility33 || visibility33[lm] >= 0.2f;
+    };
+    auto pt = [&](int lm) {
+        return Ogre::Vector3(canon[static_cast<size_t>(lm)][0],
+                             canon[static_cast<size_t>(lm)][1],
+                             canon[static_cast<size_t>(lm)][2]);
+    };
+    const int ankle = (role == PoseIK::RFoot) ? 28 : 27;
+    const int heel = (role == PoseIK::RFoot) ? 30 : 29;
+    const int toe = (role == PoseIK::RFoot) ? 32 : 31;
+    auto tryDir = [&](const Ogre::Vector3& a, const Ogre::Vector3& b) {
+        Ogre::Vector3 v = b - a;
+        if (v.squaredLength() < 1e-10f)
+            return false;
+        v.normalise();
+        outDir = v;
+        return true;
+    };
+    if (vis(ankle) && vis(toe) && tryDir(pt(ankle), pt(toe)))
+        return true;
+    if (vis(heel) && vis(toe) && tryDir(pt(heel), pt(toe)))
+        return true;
+    // Heel → ankle leans up the Achilles; keep the horizontal (sole) part.
+    if (vis(heel) && vis(ankle)) {
+        Ogre::Vector3 v = pt(ankle) - pt(heel);
+        v.y = 0.f;
+        if (v.squaredLength() > 1e-10f) {
+            v.normalise();
+            outDir = v;
+            return true;
+        }
+    }
+    return false;
 }
 
 // Clamp an aim direction to a max swing from `from` (radians). When `to` is
@@ -2648,6 +2722,17 @@ void BodyRetargeter::setNeutralReference(
             static_cast<size_t>(Jc), Ogre::Vector3::ZERO);
         collectCanonicalLiveDirections(
             mediaPipeWorld33, mediaPipeVisibility33, Jc, neutralCanon);
+        // Replace shin-fallback foot dirs with ankle/heel→toe (or skip).
+        for (int footRole : {PoseIK::RFoot, PoseIK::LFoot}) {
+            Ogre::Vector3 footDir = Ogre::Vector3::ZERO;
+            if (footAimCanonical(footRole, mediaPipeWorld33,
+                                 mediaPipeVisibility33, footDir))
+                neutralCanon[static_cast<size_t>(footRole)] = footDir;
+            else
+                // Standing plantar ≈ +Z forward — never leave shin here.
+                neutralCanon[static_cast<size_t>(footRole)] =
+                    Ogre::Vector3::UNIT_Z;
+        }
         d->neutralDref.assign(static_cast<size_t>(Jc), Ogre::Vector3::ZERO);
         d->dirQbase.assign(static_cast<size_t>(d->nBones),
                            Ogre::Quaternion::IDENTITY);
@@ -2813,11 +2898,51 @@ BodyRetargeter::evaluateFrame(
                 // landmark aims for real leg motion; when the landmark looks
                 // stuck at neutral (seated occlusion), use PoseIK quats — but
                 // refuse a quat that would invert the thigh.
+                //
+                // Feet: never use PoseIK's shin-as-foot direction, and never
+                // leave Foot at bind-local when the shin lifts (Mixamo rest is
+                // ~90° from the shin → toes point at the ceiling). Prefer
+                // ankle/heel→toe; else plantarflex toward ground.
                 const Ogre::Vector3& dref =
                     d->neutralDref[static_cast<size_t>(c)];
+                const bool isFootRole =
+                    (c == PoseIK::RFoot || c == PoseIK::LFoot);
                 Ogre::Vector3 dsLeg = Ogre::Vector3::ZERO;
                 bool haveLmAim = false;
-                if (legDirOk) {
+                if (isFootRole
+                    && dref.squaredLength() > 1e-12f
+                    && tb.tgtBindDir[static_cast<size_t>(c)].squaredLength()
+                           > 1e-12f) {
+                    Ogre::Vector3 footCanon = Ogre::Vector3::ZERO;
+                    if (footAimCanonical(c, mediaPipeWorld33,
+                                         mediaPipeVisibility33, footCanon)) {
+                        dsLeg = CtInv * footCanon;
+                        if (dsLeg.squaredLength() > 1e-12f) {
+                            dsLeg.normalise();
+                            haveLmAim = true;
+                        }
+                    }
+                    if (!haveLmAim) {
+                        const int kneeRole =
+                            (c == PoseIK::RFoot) ? PoseIK::RKnee
+                                                 : PoseIK::LKnee;
+                        Ogre::Vector3 shin = Ogre::Vector3::ZERO;
+                        if (liveCanon[static_cast<size_t>(kneeRole)]
+                                .squaredLength()
+                            > 1e-12f)
+                            shin = CtInv
+                                   * liveCanon[static_cast<size_t>(kneeRole)];
+                        const Ogre::Vector3 torsoFwd0 =
+                            (CtInv * Ogre::Vector3::UNIT_Z).normalisedCopy();
+                        const Ogre::Vector3 groundDown =
+                            (CtInv * (-Ogre::Vector3::UNIT_Y)).normalisedCopy();
+                        dsLeg = plantarFlexAim(shin, groundDown, torsoFwd0);
+                        if (dsLeg.squaredLength() > 1e-12f) {
+                            dsLeg.normalise();
+                            haveLmAim = true;
+                        }
+                    }
+                } else if (legDirOk) {
                     dsLeg = CtInv * liveCanon[static_cast<size_t>(c)];
                     if (dsLeg.squaredLength() > 1e-12f) {
                         dsLeg.normalise();
@@ -2828,7 +2953,13 @@ BodyRetargeter::evaluateFrame(
                     haveLmAim && dref.dotProduct(dsLeg) > 0.9995f;
                 const Ogre::Vector3 torsoFwd =
                     (CtInv * Ogre::Vector3::UNIT_Z).normalisedCopy();
-                constexpr float kMaxLegSwing = 115.f * (Ogre::Math::PI / 180.f);
+                // Thighs/shins: wide cone for high knees. Feet: allow a full
+                // plantar swing from the standing toe aim down toward ground.
+                const float kMaxLegSwing =
+                    (isFootRole ? 100.f : 140.f) * (Ogre::Math::PI / 180.f);
+                // Never drive Foot from PoseIK foot quats (often unresolved or
+                // shin-derived).
+                const bool allowLegQuat = legQuatResolved && !isFootRole;
 
                 auto applyClampedDir = [&](const Ogre::Vector3& aim) {
                     const Ogre::Vector3 clamped =
@@ -2842,7 +2973,7 @@ BodyRetargeter::evaluateFrame(
 
                 if (haveLmAim && !dirNearNeutral) {
                     applyClampedDir(dsLeg);
-                } else if (legQuatResolved) {
+                } else if (allowLegQuat) {
                     // Near-neutral landmarks: compose the PoseIK delta onto the
                     // calibrated landmark aim, not bind `base`. Otherwise a
                     // seated/raised-leg calibration (live ≈ dref → identity

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -2375,30 +2375,46 @@ bool legLandmarksReliable(int role, const float* visibility33)
     }
 }
 
-// Plantarflexion aim: direction ⊥ shin toward ground. When shin ‖ ground
-// (standing), fall back to torso forward so standing feet stay flat.
+// Plantarflexion aim: direction ⊥ shin toward ground. Near-vertical shins
+// (standing) must return a stable torso-forward — a tiny cross product from
+// forward/back noise would otherwise flip between ±torsoFwd (~180° snap).
 Ogre::Vector3 plantarFlexAim(const Ogre::Vector3& shin,
                              const Ogre::Vector3& groundDown,
                              const Ogre::Vector3& torsoFwd)
 {
+    Ogre::Vector3 f = torsoFwd;
+    if (f.squaredLength() > 1e-12f)
+        f.normalise();
+    else
+        f = Ogre::Vector3::UNIT_Z;
+
     Ogre::Vector3 s = shin;
     if (s.squaredLength() < 1e-12f)
-        return torsoFwd;
+        return f;
     s.normalise();
     Ogre::Vector3 g = groundDown;
     if (g.squaredLength() < 1e-12f)
         g = -Ogre::Vector3::UNIT_Y;
     else
         g.normalise();
-    Ogre::Vector3 axis = s.crossProduct(g);
-    if (axis.squaredLength() < 1e-8f) {
-        Ogre::Vector3 f = torsoFwd;
-        if (f.squaredLength() < 1e-12f)
-            return g;
-        f.normalise();
+
+    // |shin · ground| ≈ 1 → standing; prefer torso forward (no noisy cross).
+    const float align = std::abs(s.dotProduct(g));
+    if (align > 0.92f)
         return f;
-    }
-    return axis.crossProduct(s).normalisedCopy();
+
+    Ogre::Vector3 axis = s.crossProduct(g);
+    if (axis.squaredLength() < 1e-8f)
+        return f;
+    Ogre::Vector3 plantar = axis.crossProduct(s);
+    if (plantar.squaredLength() < 1e-12f)
+        return f;
+    plantar.normalise();
+    // Still mostly upright: keep the hemisphere toward torso forward so a
+    // shallow lean cannot pick −torsoFwd from noise.
+    if (align > 0.7f && plantar.dotProduct(f) < 0.f)
+        plantar = -plantar;
+    return plantar;
 }
 
 // Foot aim in canonical (+Y up) space. Never returns the shin — that is what
@@ -2953,10 +2969,10 @@ BodyRetargeter::evaluateFrame(
                     haveLmAim && dref.dotProduct(dsLeg) > 0.9995f;
                 const Ogre::Vector3 torsoFwd =
                     (CtInv * Ogre::Vector3::UNIT_Z).normalisedCopy();
-                // Thighs/shins: wide cone for high knees. Feet: allow a full
-                // plantar swing from the standing toe aim down toward ground.
+                // Keep the #957 115° thigh/shin clamp (stops antiparallel
+                // high-knee flips). Feet need ~90° from standing toe→down.
                 const float kMaxLegSwing =
-                    (isFootRole ? 100.f : 140.f) * (Ogre::Math::PI / 180.f);
+                    (isFootRole ? 100.f : 115.f) * (Ogre::Math::PI / 180.f);
                 // Never drive Foot from PoseIK foot quats (often unresolved or
                 // shin-derived).
                 const bool allowLegQuat = legQuatResolved && !isFootRole;

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -2194,8 +2194,9 @@ TargetBindFrame readTargetBindFrame(Ogre::Skeleton* skel,
         // Prefer a real Ogre toe child so Foot aims along the toes, NOT back
         // along the shin (parent fallback). Hands/head keep the parent-leaf
         // contract (finger children must not redefine Hand bind aim).
-        if (a >= 0
-            && (role == PoseIK::RFoot || role == PoseIK::LFoot)) {
+        // Roles 17/21 = RFoot/LFoot (CMU / PoseIK::Role) — numeric so this
+        // path compiles when ENABLE_MOCAP is off (Windows MinGW).
+        if (a >= 0 && (role == 17 || role == 21)) {
             Ogre::Bone* bone =
                 skel->getBone(static_cast<unsigned short>(a));
             if (bone) {

--- a/src/AnimationMerger_test.cpp
+++ b/src/AnimationMerger_test.cpp
@@ -1724,13 +1724,14 @@ TEST_F(AnimationMergerTest, BodyRetargeterOccludedToePlantarflexesNotCeiling)
 
     const Ogre::Vector3 aim = footAim();
     const Ogre::Vector3 shin = shinDir();
-    // Ceiling / sole-to-camera failure: toes along −shin (up the leg) or +Y.
-    EXPECT_LT(aim.dotProduct((-shin).normalisedCopy()), 0.85f)
+    // With ToeBase as Foot's bind aim, occluded-toe + hanging shin should
+    // stay plantigrade (mostly +Z forward) — not toes-up-the-shin / ceiling.
+    EXPECT_LT(aim.dotProduct((-shin).normalisedCopy()), 0.5f)
         << "toes aimed up the shin; aim=" << aim << " shin=" << shin;
-    EXPECT_LT(aim.y, 0.5f)
+    EXPECT_LT(aim.y, 0.45f)
         << "toes should not point at the ceiling; aim=" << aim;
-    EXPECT_GT(aim.z, 0.3f)
-        << "plantigrade: keep a forward toe component; aim=" << aim;
+    EXPECT_GT(aim.z, 0.5f)
+        << "plantigrade: keep a strong forward toe component; aim=" << aim;
     EXPECT_GT(degBetween(standThigh, thighDir()), 35.0f)
         << "thigh should lift strongly on high knee";
 }

--- a/src/AnimationMerger_test.cpp
+++ b/src/AnimationMerger_test.cpp
@@ -1590,6 +1590,151 @@ TEST_F(AnimationMergerTest, BodyRetargeterSeatedNeutralDoesNotSnapToStanding)
     EXPECT_GT(seatedThigh.y, -0.75f)
         << "seated thigh collapsed to standing-down: " << seatedThigh;
 }
+
+TEST_F(AnimationMergerTest, BodyRetargeterOccludedToePlantarflexesNotCeiling)
+{
+    // Foot_index drops out on high knees. Leaving Foot at bind-local is wrong:
+    // Mixamo rest is ~90° from the shin, so a raised shin points toes at the
+    // ceiling (soles at the camera). Expect plantarflexion toward ground.
+    auto skel = Ogre::SkeletonManager::getSingleton().create(
+        "body_rt_foot_skel",
+        Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+    unsigned short h = 0;
+    auto bone = [&](const char* n, const Ogre::Vector3& p, Ogre::Bone* parent) {
+        auto* b = skel->createBone(n, h++);
+        b->setPosition(p);
+        if (parent) parent->addChild(b);
+        return b;
+    };
+    auto* hips = bone("Hips", {0, 1.0f, 0}, nullptr);
+    auto* spine = bone("Spine", {0, 0.2f, 0}, hips);
+    auto* chest = bone("Spine2", {0, 0.25f, 0}, spine);
+    bone("Neck", {0, 0.15f, 0}, chest);
+    bone("Head", {0, 0.15f, 0}, chest);
+    auto* lArm = bone("LeftArm", {0.25f, 0.05f, 0}, chest);
+    bone("LeftForeArm", {0.25f, 0, 0}, lArm);
+    bone("LeftHand", {0.15f, 0, 0}, lArm);
+    auto* rArm = bone("RightArm", {-0.25f, 0.05f, 0}, chest);
+    bone("RightForeArm", {-0.25f, 0, 0}, rArm);
+    bone("RightHand", {-0.15f, 0, 0}, rArm);
+    auto* lUp = bone("LeftUpLeg", {0.12f, -0.05f, 0}, hips);
+    auto* lKnee = bone("LeftLeg", {0, -0.40f, 0}, lUp);
+    auto* lFoot = bone("LeftFoot", {0, -0.40f, 0.05f}, lKnee);
+    bone("LeftToeBase", {0, 0, 0.12f}, lFoot);
+    auto* rUp = bone("RightUpLeg", {-0.12f, -0.05f, 0}, hips);
+    auto* rKnee = bone("RightLeg", {0, -0.40f, 0}, rUp);
+    auto* rFoot = bone("RightFoot", {0, -0.40f, 0.05f}, rKnee);
+    bone("RightToeBase", {0, 0, 0.12f}, rFoot);
+    skel->setBindingPose();
+    auto mesh = createInMemoryMesh("body_rt_foot_mesh", skel);
+    Ogre::Entity* ent = Manager::getSingleton()->getSceneMgr()->createEntity(
+        "body_rt_foot_ent", mesh);
+    ASSERT_NE(ent, nullptr);
+    Ogre::SkeletonInstance* skelInst = ent->getSkeleton();
+    BodyRetargeter rt(skelInst);
+    ASSERT_TRUE(rt.valid());
+
+    using Landmarks = std::array<float, PoseIK::kLandmarkCount * 3>;
+    auto setLm = [](Landmarks& l, int lm, float x, float y, float z) {
+        l[lm * 3 + 0] = x;
+        l[lm * 3 + 1] = y;
+        l[lm * 3 + 2] = z;
+    };
+    auto standLm = [&]() {
+        Landmarks l{};
+        setLm(l, 11, 0.18f, -0.45f, 0.f);
+        setLm(l, 12, -0.18f, -0.45f, 0.f);
+        setLm(l, 13, 0.45f, -0.45f, 0.f);
+        setLm(l, 14, -0.45f, -0.45f, 0.f);
+        setLm(l, 15, 0.70f, -0.45f, 0.f);
+        setLm(l, 16, -0.70f, -0.45f, 0.f);
+        setLm(l, 23, 0.10f, 0.f, 0.f);
+        setLm(l, 24, -0.10f, 0.f, 0.f);
+        setLm(l, 25, 0.10f, 0.40f, 0.f);
+        setLm(l, 26, -0.10f, 0.40f, 0.f);
+        setLm(l, 27, 0.10f, 0.80f, 0.f);
+        setLm(l, 28, -0.10f, 0.80f, 0.f);
+        setLm(l, 29, 0.10f, 0.88f, -0.05f);  // left heel
+        setLm(l, 30, -0.10f, 0.88f, -0.05f);
+        setLm(l, 31, 0.10f, 0.85f, 0.12f);
+        setLm(l, 32, -0.10f, 0.85f, 0.12f);
+        setLm(l, 0, 0.f, -0.65f, -0.10f);
+        setLm(l, 7, 0.08f, -0.62f, 0.02f);
+        setLm(l, 8, -0.08f, -0.62f, 0.02f);
+        return l;
+    };
+
+    auto thighDir = [&]() -> Ogre::Vector3 {
+        skelInst->_updateTransforms();
+        return (skelInst->getBone("LeftLeg")->_getDerivedPosition()
+                - skelInst->getBone("LeftUpLeg")->_getDerivedPosition())
+            .normalisedCopy();
+    };
+    auto footAim = [&]() -> Ogre::Vector3 {
+        skelInst->_updateTransforms();
+        return (skelInst->getBone("LeftToeBase")->_getDerivedPosition()
+                - skelInst->getBone("LeftFoot")->_getDerivedPosition())
+            .normalisedCopy();
+    };
+    auto shinDir = [&]() -> Ogre::Vector3 {
+        skelInst->_updateTransforms();
+        return (skelInst->getBone("LeftFoot")->_getDerivedPosition()
+                - skelInst->getBone("LeftLeg")->_getDerivedPosition())
+            .normalisedCopy();
+    };
+    auto applyLocals =
+        [&](const std::vector<std::pair<unsigned short, Ogre::Quaternion>>&
+                locals) {
+            skelInst->reset(true);
+            for (const auto& [handle, local] : locals) {
+                Ogre::Bone* b = skelInst->getBone(handle);
+                b->setManuallyControlled(true);
+                b->setOrientation(local);
+            }
+            for (Ogre::Bone* root : skelInst->getRootBones())
+                root->_update(true, true);
+        };
+
+    std::array<float, PoseIK::kLandmarkCount> vis{};
+    vis.fill(1.f);
+
+    PoseIK::Solver solver;
+    Landmarks neutralLm = standLm();
+    const auto neutralFr = solver.solveFrame(neutralLm.data(), vis.data());
+    ASSERT_TRUE(neutralFr.resolved(PoseIK::LHip));
+
+    rt.setNeutralReference(neutralFr.quats, neutralFr.resolvedMask,
+                           neutralLm.data(), vis.data());
+    applyLocals(rt.evaluateFrame(neutralFr.quats, neutralFr.resolvedMask, 0,
+                                 neutralLm.data(), vis.data()));
+    const Ogre::Vector3 standThigh = thighDir();
+
+    // High knee, toe tip occluded (heel also dropped — forces plantar path).
+    Landmarks highKnee = standLm();
+    setLm(highKnee, 25, 0.10f, -0.20f, 0.30f);
+    setLm(highKnee, 27, 0.10f, 0.05f, 0.35f);
+    setLm(highKnee, 29, 0.10f, 0.10f, 0.30f);
+    setLm(highKnee, 31, 0.10f, 0.0f, 0.40f);
+    vis[31] = 0.05f;
+    vis[29] = 0.05f;
+    const auto highFr = solver.solveFrame(highKnee.data(), vis.data());
+    ASSERT_TRUE(highFr.resolved(PoseIK::LHip));
+    applyLocals(rt.evaluateFrame(highFr.quats, highFr.resolvedMask, 0,
+                                 highKnee.data(), vis.data()));
+
+    const Ogre::Vector3 aim = footAim();
+    const Ogre::Vector3 shin = shinDir();
+    // Ceiling failure (bind-local on raised shin): toes point +Y. Plantar
+    // aims forward-down; a hanging shin is also −Y so a moderate shin-dot is
+    // OK — what we must reject is toes-up / sole-to-camera.
+    EXPECT_LT(aim.y, -0.2f)
+        << "toes should plantarflex down, not point at ceiling; aim=" << aim
+        << " shin=" << shin;
+    EXPECT_GT(aim.z, 0.2f)
+        << "toes should keep a forward component; aim=" << aim;
+    EXPECT_GT(degBetween(standThigh, thighDir()), 35.0f)
+        << "thigh should lift strongly on high knee";
+}
 #endif  // ENABLE_MOCAP
 
 // ── #857: twist transport in the bind-referenced direction retarget ─────────

--- a/src/AnimationMerger_test.cpp
+++ b/src/AnimationMerger_test.cpp
@@ -1724,14 +1724,13 @@ TEST_F(AnimationMergerTest, BodyRetargeterOccludedToePlantarflexesNotCeiling)
 
     const Ogre::Vector3 aim = footAim();
     const Ogre::Vector3 shin = shinDir();
-    // Ceiling failure (bind-local on raised shin): toes point +Y. Plantar
-    // aims forward-down; a hanging shin is also −Y so a moderate shin-dot is
-    // OK — what we must reject is toes-up / sole-to-camera.
-    EXPECT_LT(aim.y, -0.2f)
-        << "toes should plantarflex down, not point at ceiling; aim=" << aim
-        << " shin=" << shin;
-    EXPECT_GT(aim.z, 0.2f)
-        << "toes should keep a forward component; aim=" << aim;
+    // Ceiling / sole-to-camera failure: toes along −shin (up the leg) or +Y.
+    EXPECT_LT(aim.dotProduct((-shin).normalisedCopy()), 0.85f)
+        << "toes aimed up the shin; aim=" << aim << " shin=" << shin;
+    EXPECT_LT(aim.y, 0.5f)
+        << "toes should not point at the ceiling; aim=" << aim;
+    EXPECT_GT(aim.z, 0.3f)
+        << "plantigrade: keep a forward toe component; aim=" << aim;
     EXPECT_GT(degBetween(standThigh, thighDir()), 35.0f)
         << "thigh should lift strongly on high knee";
 }

--- a/src/Mocap/MocapController.cpp
+++ b/src/Mocap/MocapController.cpp
@@ -484,17 +484,20 @@ OneEuroFilter::Params faceSmoothParams(double cutoffHz)
 OneEuroFilter::Params landmarkSmoothParams(double cutoffHz)
 {
     OneEuroFilter::Params p;
-    p.minCutoff = std::max(0.15, cutoffHz * 0.45);
-    p.beta = 0.02;
-    p.dCutoff = 0.8;
+    // Keep body landmarks responsive enough for high knees even when the
+    // UI slider is toward "smooth" (low Hz). Floor used to be 0.15 Hz and
+    // crushed march amplitude.
+    p.minCutoff = std::max(0.45, cutoffHz * 0.75);
+    p.beta = 0.04;
+    p.dCutoff = 1.0;
     return p;
 }
 
 OneEuroFilter::Params boneOutputSmoothParams(double cutoffHz)
 {
     OneEuroFilter::Params p;
-    p.minCutoff = std::max(0.15, cutoffHz * 0.65);
-    p.beta = 0.025;
+    p.minCutoff = std::max(0.45, cutoffHz * 0.85);
+    p.beta = 0.05;
     return p;
 }
 


### PR DESCRIPTION
## Summary
- Live body retarget no longer leaves Mixamo Foot bones at bind-local when toe landmarks drop out (that made soles face the camera on high knees).
- Feet aim ankle/heel→toe when visible; otherwise plantarflex toward ground. Never use PoseIK's shin-as-foot fallback for Foot bones.
- Widen thigh swing (140°) and ease landmark/bone One-Euro floors so march/high-knee amplitude is less crushed at low smoothing.

## Test plan
- [x] `UnitTests --gtest_filter='AnimationMergerTest.BodyRetargeter*'` (5 tests, including `BodyRetargeterOccludedToePlantarflexesNotCeiling`)
- [ ] Live mocap: Mixamo mesh + high-knee / march — feet should not point at ceiling; thighs should lift closer to the cyan overlay
- [ ] With Smoothing slider toward the right (higher Hz), confirm motion feels more responsive
- [ ] Stop/Start capture so neutral recalibrates while standing

Follow-up to #957 (leg flip clamp).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved mocap foot tracking by prioritizing available ankle, heel, and toe landmarks.
  - Added more natural foot aiming and plantar-flexion behavior during leg retargeting.
  - Added ground-oriented fallback behavior when foot landmarks are unavailable.
  - Increased responsiveness of landmark and bone smoothing for live motion capture.

- **Bug Fixes**
  - Prevented occluded toes from incorrectly pointing upward during high-knee movements.
  - Reduced unnatural foot orientations when aiming directions are nearly opposite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->