### PR TITLE
chore: bump version to 3.35.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 3.34.0 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 3.35.0 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Available on the [GitHub Actions Marketplace](https://github.com/marketplace/act
 **Versioning**
 
 - **Always follow the latest GitHub release** — use the Marketplace floating tag `fernandotonon/QtMeshEditor@v1` (same pattern as the [Marketplace example](https://github.com/marketplace/actions/qtmesheditor)). The composite action defaults to `image-tag: latest`, so the Docker CLI tracks the newest published `ghcr.io/fernandotonon/qtmesh` image.
-- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.34.0**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
+- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.35.0**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
 
 Pinned workflow template (action + `ghcr.io` image aligned):
 
@@ -48,10 +48,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run QtMesh scan
-        uses: fernandotonon/QtMeshEditor@3.34.0
+        uses: fernandotonon/QtMeshEditor@3.35.0
         with:
           command: scan
-          image-tag: "3.34.0"
+          image-tag: "3.35.0"
         env:
           QTMESH_CLOUD_TOKEN: ${{ secrets.QTMESH_CLOUD_TOKEN }}
 ```
@@ -76,37 +76,37 @@ Release tags are listed on the [releases page](https://github.com/fernandotonon/
 
 ```yaml
 # Validate a specific mesh
-- uses: fernandotonon/QtMeshEditor@3.34.0
+- uses: fernandotonon/QtMeshEditor@3.35.0
   with:
     command: validate
     input-file: ./models/character.fbx
-    image-tag: "3.34.0"
+    image-tag: "3.35.0"
 
 # Convert FBX → glTF
-- uses: fernandotonon/QtMeshEditor@3.34.0
+- uses: fernandotonon/QtMeshEditor@3.35.0
   with:
     command: convert
     input-file: ./models/character.fbx
     output-file: ./output/character.gltf2
-    image-tag: "3.34.0"
+    image-tag: "3.35.0"
 
 # Resample Mixamo animations (200+ keyframes → 30)
-- uses: fernandotonon/QtMeshEditor@3.34.0
+- uses: fernandotonon/QtMeshEditor@3.35.0
   with:
     command: anim
     input-file: ./animations/dance.fbx
     output-file: ./output/dance_optimized.fbx
     options: --resample 30
-    image-tag: "3.34.0"
+    image-tag: "3.35.0"
 
 # Get mesh info as JSON
-- uses: fernandotonon/QtMeshEditor@3.34.0
+- uses: fernandotonon/QtMeshEditor@3.35.0
   id: info
   with:
     command: info
     input-file: ./models/character.fbx
     options: --json
-    image-tag: "3.34.0"
+    image-tag: "3.35.0"
 
 # Docker (alternative — :latest tracks newest image; pin :3.4.0 to match semver action ref)
 # The image is multi-arch (linux/amd64 + linux/arm64), so it runs natively on

--- a/website/src/hooks/useQtmeshActionRef.js
+++ b/website/src/hooks/useQtmeshActionRef.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 const QTMESH_RELEASES_LATEST_API = 'https://api.github.com/repos/fernandotonon/QtMeshEditor/releases/latest';
-const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.34.0';
+const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.35.0';
 const CACHE_KEY = 'qtmesh.actionRef.cache.v1';
 const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 


### PR DESCRIPTION
Release bump for the text-to-motion v8.0 work merged in #963.

Ships:
- **t2m v8.0** — trained on the curated template clips instead of the CMU corpus, which never carried the correct facing convention. Generated clips now face the right way.
- **Leg-chain fix** — a walk's bend stays in the knee rather than the ankle (the defect that rendered as a false second knee). Knee/ankle 41°/8° vs a real reference walk's 38°/10°; leg-chain penalty 0.359 → 0.0003.
- **Data gates** — anatomical ankle gate and a minimum-resolved-roles floor drop four actions whose source clips were broken (march/throw/hey/confession); those prompts fall back to the curated templates.

Model and the 150-clip training library are published on HuggingFace; the app downloads the model on first use.

Version synced across README and the website action ref via `scripts/sync-doc-versions-from-cmake.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated QtMeshEditor to version 3.35.0 across the application and related resources.
  * Updated documentation, CI examples, container references, and reproducible-build instructions to reflect version 3.35.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->