### PR TITLE
ci: give build-linux a stable matrix check name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -775,6 +775,15 @@ jobs:
             sudo make install -j8
       
  build-linux:
+    # Explicit name: without it GitHub derives the check name from EVERY matrix
+    # parameter, so this job reported as
+    #   "build-linux (amd64, ubuntu-latest, linux, linux_gcc_64, gcc_64, x86_64-linux-gnu)".
+    # Branch protection required a context called plain "build-linux", which a
+    # matrix job never produces, so that context sat pending forever and every
+    # PR showed BLOCKED with nothing actually failing. Pinning a short stable
+    # name keeps the required contexts working even if the matrix gains or
+    # loses parameters later.
+    name: build-linux (${{ matrix.arch }})
     needs: [build-n-cache-assimp-linux, build-n-cache-ogre-linux]
     # Matrix over both Linux arches → qtmesheditor_amd64.deb + qtmesheditor_arm64.deb.
     # The arm64 .deb is what lets the Docker image ship a native linux/arm64


### PR DESCRIPTION
## Problem

Branch protection on `master` requires a status context named plain `build-linux`. That job is a `strategy.matrix`, and without an explicit `name:` GitHub derives the check name from **every** matrix parameter:

```
build-linux (amd64, ubuntu-latest, linux, linux_gcc_64, gcc_64, x86_64-linux-gnu)
build-linux (arm64, ubuntu-24.04-arm, linux_arm64, linux_gcc_arm64, gcc_arm64, aarch64-linux-gnu)
```

So a context called `build-linux` is never reported, stays pending forever, and **every PR shows `BLOCKED` while nothing is actually failing**. #963 and #964 each had 18 passing checks and 0 failures, and both still had to be merged by hand.

## Fix

Pin `name: build-linux (${{ matrix.arch }})`, so the checks report as `build-linux (amd64)` and `build-linux (arm64)` — short, stable, and unaffected if the matrix gains or loses parameters later.

## Follow-up (repo settings, not code)

After this merges and the new names have reported once, the required contexts should change from:

```
build-linux, build-macos, build-windows, unit-tests-linux
```

to:

```
build-linux (amd64), build-linux (arm64), build-macos, build-windows, unit-tests-linux
```

`build-macos`, `build-windows` and `unit-tests-linux` are not matrix jobs and already report correctly.

## Test plan

- [x] `deploy.yml` parses as valid YAML (18 jobs)
- [ ] This PR's own checks report `build-linux (amd64)` / `build-linux (arm64)` — visible on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment workflow check naming for clearer, more consistent status reporting.
  * Preserved compatibility with branch protection requirements when build matrix settings change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->