### PR TITLE
feat(ui): lights-overlay toggle in the viewport title bar

### DIFF
--- a/src/EditorViewport.cpp
+++ b/src/EditorViewport.cpp
@@ -72,7 +72,9 @@ EditorViewport::EditorViewport(MainWindow* parent, int index)
     QAction* normalsAction  = m_pMainWindow ? m_pMainWindow->actionShowNormals()  : nullptr;
     QAction* meshInfoAction = m_pMainWindow ? m_pMainWindow->actionShowMeshInfo() : nullptr;
     QAction* viewCubeAction = m_pMainWindow ? m_pMainWindow->actionShowViewCube() : nullptr;
-    m_titleBar = new ViewportTitleBar(this, gridAction, normalsAction, meshInfoAction, viewCubeAction, this);
+    QAction* lightsAction   = m_pMainWindow ? m_pMainWindow->actionShowLightIcons() : nullptr;
+    m_titleBar = new ViewportTitleBar(this, gridAction, normalsAction, meshInfoAction,
+                                      viewCubeAction, lightsAction, this);
     setTitleBarWidget(m_titleBar);
     if (layout())
         layout()->setContentsMargins(0, 0, 0, 0);

--- a/src/ViewportTitleBar.cpp
+++ b/src/ViewportTitleBar.cpp
@@ -88,6 +88,7 @@ ViewportTitleBar::ViewportTitleBar(QDockWidget* dock,
                                    QAction* normalsAction,
                                    QAction* meshInfoAction,
                                    QAction* viewCubeAction,
+                                   QAction* lightsAction,
                                    QWidget* parent)
     : QWidget(parent ? parent : dock)
     , m_dock(dock)
@@ -123,10 +124,12 @@ ViewportTitleBar::ViewportTitleBar(QDockWidget* dock,
     m_normalsButton  = makeActionButton(normalsAction,  QStringLiteral("N"));
     m_meshInfoButton = makeActionButton(meshInfoAction, QStringLiteral("I"));
     m_viewCubeButton = makeActionButton(viewCubeAction, QStringLiteral("C"));
+    m_lightsButton   = makeActionButton(lightsAction,   QStringLiteral("L"));
     if (m_gridButton)     layout->addWidget(m_gridButton);
     if (m_normalsButton)  layout->addWidget(m_normalsButton);
     if (m_meshInfoButton) layout->addWidget(m_meshInfoButton);
     if (m_viewCubeButton) layout->addWidget(m_viewCubeButton);
+    if (m_lightsButton)   layout->addWidget(m_lightsButton);
 
     if (m_dock) {
         // Re-implement the float/close buttons that `setTitleBarWidget`

--- a/src/ViewportTitleBar.h
+++ b/src/ViewportTitleBar.h
@@ -39,7 +39,8 @@ class QToolButton;
 /// Custom title-bar widget used by `EditorViewport` (a `QDockWidget`).
 ///
 /// Replaces Qt's default dock title bar so the per-viewport display
-/// controls (Show Grid / Show Normals / Show Mesh Info / Show View Cube) live
+/// controls (Show Grid / Show Normals / Show Mesh Info / Show View Cube /
+/// Show Lights) live
 /// directly in the title strip instead of as a separate floating widget. This avoids the
 /// long-standing compositing issue with `OgreWidget` (which uses
 /// `WA_PaintOnScreen` and produced black rectangles for any overlapping Qt
@@ -63,6 +64,7 @@ public:
                      QAction* normalsAction,
                      QAction* meshInfoAction,
                      QAction* viewCubeAction,
+                     QAction* lightsAction = nullptr,
                      QWidget* parent = nullptr);
 
     /// Returns the toolbutton bound to the corresponding QAction (or nullptr
@@ -71,6 +73,7 @@ public:
     QToolButton* normalsButton() const { return m_normalsButton; }
     QToolButton* meshInfoButton() const { return m_meshInfoButton; }
     QToolButton* viewCubeButton() const { return m_viewCubeButton; }
+    QToolButton* lightsButton() const { return m_lightsButton; }
     QToolButton* floatButton() const { return m_floatButton; }
     QToolButton* closeButton() const { return m_closeButton; }
     QLabel* titleLabel() const { return m_titleLabel; }
@@ -93,6 +96,7 @@ private:
     QToolButton* m_normalsButton = nullptr;
     QToolButton* m_meshInfoButton = nullptr;
     QToolButton* m_viewCubeButton = nullptr;
+    QToolButton* m_lightsButton = nullptr;
     QToolButton* m_floatButton = nullptr;
     QToolButton* m_closeButton = nullptr;
 

--- a/src/ViewportTitleBar_test.cpp
+++ b/src/ViewportTitleBar_test.cpp
@@ -150,3 +150,25 @@ TEST_F(ViewportTitleBarTest, EmptyTooltipFallsBackToActionText)
     ASSERT_NE(bar.viewCubeButton(), nullptr);
     EXPECT_EQ(bar.viewCubeButton()->toolTip(), QStringLiteral("View Cube"));
 }
+
+TEST_F(ViewportTitleBarTest, LightsToggleButtonBindsToAction)
+{
+    // The lights-overlay toggle lives in the viewport title strip like
+    // Grid/Normals/Info — toggling the button drives the action and the
+    // action's state reflects back onto the button.
+    QDockWidget dock;
+    QAction lights(QStringLiteral("Show Light Icons"), nullptr);
+    lights.setCheckable(true);
+    lights.setChecked(true);
+    ViewportTitleBar bar(&dock, nullptr, nullptr, nullptr, nullptr, &lights);
+    ASSERT_NE(bar.lightsButton(), nullptr);
+    EXPECT_TRUE(bar.lightsButton()->isChecked());
+    bar.lightsButton()->click();
+    EXPECT_FALSE(lights.isChecked());
+    lights.setChecked(true);
+    EXPECT_TRUE(bar.lightsButton()->isChecked());
+
+    // Omitting the action (old ctor shape) creates no button.
+    ViewportTitleBar bare(&dock, nullptr, nullptr, nullptr, nullptr);
+    EXPECT_EQ(bare.lightsButton(), nullptr);
+}

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -4532,6 +4532,11 @@ QAction* MainWindow::actionShowViewCube() const
     return ui ? ui->actionShow_View_Cube : nullptr;
 }
 
+QAction* MainWindow::actionShowLightIcons() const
+{
+    return ui ? ui->actionShow_Light_Icons : nullptr;
+}
+
 void MainWindow::revealBottomTool(const QString& toolId)
 {
     QDockWidget* dock = nullptr;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -169,6 +169,7 @@ public:
     QAction* actionShowNormals() const;
     QAction* actionShowMeshInfo() const;
     QAction* actionShowViewCube() const;
+    QAction* actionShowLightIcons() const;
     Q_INVOKABLE void revealBottomTool(const QString& toolId);
 
 private:


### PR DESCRIPTION
## Summary
- The light icons/gizmos overlay is noise when not working on lights; hiding it required the Options menu. The existing **Show Light Icons** action now also appears as an **L** toggle button in each viewport's title strip, next to Grid (G) / Normals (N) / Info (I) / View Cube (C).
- Same `makeActionButton` binding as the other toggles, so the menu item and the button stay in sync both ways; toggling off tears down all light overlays (icons + wire gizmos) via `LightVisualizer::setIconsVisible(false)`.

## Test plan
- [x] New `ViewportTitleBarTest.LightsToggleButtonBindsToAction`: button↔action two-way sync + null-action produces no button (old ctor shape untouched — the param is defaulted)
- [x] Full ViewportTitleBar suite passes (11 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Show Lights** control to each viewport title bar.
  * The new button stays synchronized with the light-icons display setting and supports toggling it directly.

* **Tests**
  * Added coverage verifying the Show Lights button correctly reflects and updates its associated setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->