### PR TITLE
feat(ai): TRELLIS.2 GGUF weights downloadable from AI Model Settings

### DIFF
--- a/src/AIModelCatalog.cpp
+++ b/src/AIModelCatalog.cpp
@@ -195,6 +195,9 @@ QList<AIModelCatalog::ModelSpec> AIModelCatalog::specs() const
     const QString t2mBase = resolveBaseUrl(
         "ai/t2mModelBaseUrl", "QTMESH_T2M_MODEL_BASE_URL",
         "https://huggingface.co/fernandotonon/QtMeshEditor-models/resolve/main/motion/");
+    const QString trellis2Base = resolveBaseUrl(
+        "ai/trellis2GgufBaseUrl", "QTMESH_TRELLIS2_GGUF_BASE_URL",
+        "https://huggingface.co/fernandotonon/QtMeshEditor-trellis2-gguf/resolve/main/");
     const QString segmentBase = resolveBaseUrl(
         "ai/segmentModelBaseUrl", "QTMESH_SEGMENT_MODEL_BASE_URL",
         "https://huggingface.co/fernandotonon/QtMeshEditor-models/resolve/main/segment/");
@@ -236,6 +239,24 @@ QList<AIModelCatalog::ModelSpec> AIModelCatalog::specs() const
         QStringLiteral("Medium"), onnxAvailable ? QString() : tr("Requires an ONNX-enabled build"),
         onnxAvailable,
         { file(QStringLiteral("pbr"), QStringLiteral("RealESRGAN_x4plus.onnx"), pbrBase, QStringLiteral("Upscale 4x")) }};
+    out << ModelSpec{
+        QStringLiteral("trellis2-gguf"), tr("TRELLIS.2 (trellis.cpp)"), tr("Image to 3D"),
+        tr("Microsoft TRELLIS.2-4B GGUF weights for the trellis.cpp runtime — the "
+           "highest-quality image-to-3D backend, with real PBR attributes. Runs on "
+           "Apple Silicon (Metal), Vulkan and CUDA; no ONNX or Python needed. Also "
+           "install the trellis-cli binary and point ai/trellis2Cli at it (see "
+           "docs/TRELLIS2.md); these models are found automatically once downloaded."),
+        QStringLiteral("~10.4 GB"), QString(),
+        true,
+        {
+            file(QStringLiteral("trellis2"), QStringLiteral("dinov3.gguf"), trellis2Base, QStringLiteral("TRELLIS.2 DINOv3 conditioning encoder")),
+            file(QStringLiteral("trellis2"), QStringLiteral("ss_flow.gguf"), trellis2Base, QStringLiteral("TRELLIS.2 sparse-structure flow")),
+            file(QStringLiteral("trellis2"), QStringLiteral("ss_dec.gguf"), trellis2Base, QStringLiteral("TRELLIS.2 sparse-structure decoder")),
+            file(QStringLiteral("trellis2"), QStringLiteral("shape_flow_512.gguf"), trellis2Base, QStringLiteral("TRELLIS.2 shape flow (512)")),
+            file(QStringLiteral("trellis2"), QStringLiteral("shape_dec.gguf"), trellis2Base, QStringLiteral("TRELLIS.2 shape decoder")),
+            file(QStringLiteral("trellis2"), QStringLiteral("tex_flow_512.gguf"), trellis2Base, QStringLiteral("TRELLIS.2 texture flow (512)")),
+            file(QStringLiteral("trellis2"), QStringLiteral("tex_dec.gguf"), trellis2Base, QStringLiteral("TRELLIS.2 texture decoder")),
+        }};
     out << ModelSpec{
         QStringLiteral("background-removal"), tr("Background Removal"), tr("Image to 3D"),
         tr("U2Net ONNX model used to remove backgrounds before image-to-3D generation."),

--- a/src/AIModelCatalog_test.cpp
+++ b/src/AIModelCatalog_test.cpp
@@ -1,0 +1,53 @@
+#include <gtest/gtest.h>
+#include <QDir>
+#include <QStandardPaths>
+#include "AIModelCatalog.h"
+#include "ImageTo3D/Trellis2Predictor.h"
+
+// The TRELLIS.2 GGUF weights are downloadable from AI Model Settings
+// (the "QtMeshEditor Models" tab) like every other on-demand model.
+TEST(AIModelCatalogTest, CatalogListsTrellis2GgufWeights)
+{
+    const QVariantList models = AIModelCatalog::instance()->models();
+    QVariantMap t2;
+    for (const QVariant& v : models) {
+        const QVariantMap m = v.toMap();
+        if (m.value("id").toString() == QLatin1String("trellis2-gguf")) {
+            t2 = m;
+            break;
+        }
+    }
+    ASSERT_FALSE(t2.isEmpty()) << "trellis2-gguf missing from the catalog";
+    EXPECT_EQ(t2.value("feature").toString(), QStringLiteral("Image to 3D"));
+    // Not ONNX-gated: trellis.cpp is an external runtime.
+    EXPECT_TRUE(t2.value("available").toBool());
+    const QVariantList files = t2.value("files").toList();
+    ASSERT_EQ(files.size(), 7);   // the full 512-pipeline set
+    // Files land in the directory Trellis2Predictor discovers as a fallback.
+    for (const QVariant& fv : files) {
+        const QString path = fv.toMap().value("path").toString();
+        EXPECT_TRUE(path.contains(QLatin1String("ai_models/trellis2/")))
+            << path.toStdString();
+        EXPECT_TRUE(path.endsWith(QLatin1String(".gguf"))) << path.toStdString();
+    }
+}
+
+TEST(AIModelCatalogTest, PredictorFindsCatalogDownloadedTrellis2Models)
+{
+    // With no explicit models dir and no trellis-cli sibling dir, the
+    // predictor must fall back to the AI Model Settings download location.
+    qputenv("QTMESH_TRELLIS2_CLI", "/nonexistent/trellis-cli-catalog-ut");
+    qunsetenv("QTMESH_TRELLIS2_CLI_MODELS");
+    QStandardPaths::setTestModeEnabled(true);
+    const QString catalogDir =
+        QDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation))
+            .filePath(QStringLiteral("ai_models/trellis2"));
+    ASSERT_TRUE(QDir().mkpath(catalogDir));
+
+    const QString resolved = Trellis2Predictor::trellisCliModelsDir();
+    EXPECT_EQ(QDir(resolved).absolutePath(), QDir(catalogDir).absolutePath());
+
+    QDir(catalogDir).removeRecursively();
+    QStandardPaths::setTestModeEnabled(false);
+    qunsetenv("QTMESH_TRELLIS2_CLI");
+}

--- a/src/AIModelCatalog_test.cpp
+++ b/src/AIModelCatalog_test.cpp
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 #include <QDir>
 #include <QStandardPaths>
+#include <QSettings>
+#include <QVariant>
 #include "AIModelCatalog.h"
 #include "ImageTo3D/Trellis2Predictor.h"
 
@@ -36,9 +38,27 @@ TEST(AIModelCatalogTest, PredictorFindsCatalogDownloadedTrellis2Models)
 {
     // With no explicit models dir and no trellis-cli sibling dir, the
     // predictor must fall back to the AI Model Settings download location.
-    qputenv("QTMESH_TRELLIS2_CLI", "/nonexistent/trellis-cli-catalog-ut");
-    qunsetenv("QTMESH_TRELLIS2_CLI_MODELS");
-    QStandardPaths::setTestModeEnabled(true);
+    // Scoped isolation of every source trellisCliModelsDir() reads: the env
+    // vars, the QSettings key (a developer machine may point it at a real
+    // install), and QStandardPaths test mode.
+    struct Scope {
+        QVariant savedSetting;
+        Scope() {
+            QSettings st;
+            savedSetting = st.value(QStringLiteral("ai/trellis2CliModels"));
+            st.remove(QStringLiteral("ai/trellis2CliModels"));
+            qputenv("QTMESH_TRELLIS2_CLI", "/nonexistent/trellis-cli-catalog-ut");
+            qunsetenv("QTMESH_TRELLIS2_CLI_MODELS");
+            QStandardPaths::setTestModeEnabled(true);
+        }
+        ~Scope() {
+            QStandardPaths::setTestModeEnabled(false);
+            qunsetenv("QTMESH_TRELLIS2_CLI");
+            QSettings st;
+            if (savedSetting.isValid())
+                st.setValue(QStringLiteral("ai/trellis2CliModels"), savedSetting);
+        }
+    } scope;
     const QString catalogDir =
         QDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation))
             .filePath(QStringLiteral("ai_models/trellis2"));
@@ -48,6 +68,4 @@ TEST(AIModelCatalogTest, PredictorFindsCatalogDownloadedTrellis2Models)
     EXPECT_EQ(QDir(resolved).absolutePath(), QDir(catalogDir).absolutePath());
 
     QDir(catalogDir).removeRecursively();
-    QStandardPaths::setTestModeEnabled(false);
-    qunsetenv("QTMESH_TRELLIS2_CLI");
 }

--- a/src/ImageTo3D/Trellis2Predictor.cpp
+++ b/src/ImageTo3D/Trellis2Predictor.cpp
@@ -127,6 +127,18 @@ QString Trellis2Predictor::trellisCliModelsDir()
             dir = QDir(QFileInfo(cli).absolutePath())
                       .filePath(QStringLiteral("models"));
     }
+    if (dir.isEmpty() || !QDir(dir).exists()) {
+        // AI Model Settings download location (AIModelCatalog "trellis2-gguf"):
+        // models fetched from the Settings dialog land here, so a user who
+        // pre-downloaded them only has to install/point at the trellis-cli
+        // binary.
+        const QString catalogDir =
+            QDir(QStandardPaths::writableLocation(
+                     QStandardPaths::AppDataLocation))
+                .filePath(QStringLiteral("ai_models/trellis2"));
+        if (QDir(catalogDir).exists())
+            dir = catalogDir;
+    }
     return (!dir.isEmpty() && QDir(dir).exists()) ? dir : QString();
 }
 

--- a/src/ImageTo3D/Trellis2Predictor.cpp
+++ b/src/ImageTo3D/Trellis2Predictor.cpp
@@ -121,25 +121,42 @@ QString Trellis2Predictor::trellisCliModelsDir()
     QString dir = qEnvironmentVariable(kEnvCliModelsVar);
     if (dir.isEmpty())
         dir = QSettings().value(QLatin1String(kCliModelsSettingsKey)).toString();
-    if (dir.isEmpty()) {
-        const QString cli = trellisCliPath();
-        if (!cli.isEmpty())
-            dir = QDir(QFileInfo(cli).absolutePath())
-                      .filePath(QStringLiteral("models"));
+    // An EXPLICIT dir (env var / QSettings) is authoritative — returned as-is
+    // so error messages point at what the user configured. The IMPLICIT
+    // candidates below are only accepted when they actually hold the
+    // required model set: a bare/partial <cli>/models directory must not
+    // shadow weights downloaded through AI Model Settings.
+    if (!dir.isEmpty())
+        return QDir(dir).exists() ? dir : QString();
+
+    const auto hasRequiredGgufs = [](const QString& d) {
+        const QDir q(d);
+        return q.exists(QStringLiteral("ss_flow.gguf"))
+            && q.exists(QStringLiteral("shape_flow_512.gguf"))
+            && q.exists(QStringLiteral("tex_flow_512.gguf"))
+            && q.exists(QStringLiteral("shape_dec.gguf"))
+            && q.exists(QStringLiteral("tex_dec.gguf"))
+            && q.exists(QStringLiteral("ss_dec.gguf"))
+            && q.exists(QStringLiteral("dinov3.gguf"));
+    };
+
+    const QString cli = trellisCliPath();
+    if (!cli.isEmpty()) {
+        const QString sibling = QDir(QFileInfo(cli).absolutePath())
+                                    .filePath(QStringLiteral("models"));
+        if (hasRequiredGgufs(sibling))
+            return sibling;
     }
-    if (dir.isEmpty() || !QDir(dir).exists()) {
-        // AI Model Settings download location (AIModelCatalog "trellis2-gguf"):
-        // models fetched from the Settings dialog land here, so a user who
-        // pre-downloaded them only has to install/point at the trellis-cli
-        // binary.
-        const QString catalogDir =
-            QDir(QStandardPaths::writableLocation(
-                     QStandardPaths::AppDataLocation))
-                .filePath(QStringLiteral("ai_models/trellis2"));
-        if (QDir(catalogDir).exists())
-            dir = catalogDir;
-    }
-    return (!dir.isEmpty() && QDir(dir).exists()) ? dir : QString();
+    // AI Model Settings download location (AIModelCatalog "trellis2-gguf"):
+    // models fetched from the Settings dialog land here, so a user who
+    // pre-downloaded them only has to install/point at the trellis-cli
+    // binary.
+    const QString catalogDir =
+        QDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation))
+            .filePath(QStringLiteral("ai_models/trellis2"));
+    if (QDir(catalogDir).exists())
+        return catalogDir;
+    return QString();
 }
 
 bool Trellis2Predictor::trellisCliAvailable()


### PR DESCRIPTION
## Summary
- Adds a **TRELLIS.2 (trellis.cpp)** card to AI Model Settings → QtMeshEditor Models: all 7 GGUF weights (~10.4 GB, the full 512-pipeline set) download from [fernandotonon/QtMeshEditor-trellis2-gguf](https://huggingface.co/fernandotonon/QtMeshEditor-trellis2-gguf) into `<AppData>/ai_models/trellis2/` (base URL overridable via `ai/trellis2GgufBaseUrl` / `QTMESH_TRELLIS2_GGUF_BASE_URL`). Not ONNX-gated — trellis.cpp is an external runtime; the card's description points at the trellis-cli install (docs/TRELLIS2.md).
- `Trellis2Predictor::trellisCliModelsDir()` now falls back to that download location (after the env var, QSettings, and the cli-sibling `models/` dir), so weights pre-downloaded from Settings are discovered automatically — installing the trellis-cli binary is the only remaining step.

## Test plan
- [x] `AIModelCatalogTest.CatalogListsTrellis2GgufWeights`: entry present, Image-to-3D feature, available without ONNX, 7 .gguf files landing under `ai_models/trellis2/`
- [x] `AIModelCatalogTest.PredictorFindsCatalogDownloadedTrellis2Models`: with no explicit dir and no cli sibling, the predictor resolves the Settings download directory (QStandardPaths test mode)
- [x] The Settings dialog's model list is a Repeater over the catalog — no QML change needed; Download All includes the new entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Microsoft TRELLIS.2-4B GGUF models for image-to-3D generation.
  * Added seven downloadable model files, including encoders, flow models, decoders, and texture components.
  * Added configurable model hosting with a default download source.

* **Bug Fixes**
  * TRELLIS.2 now discovers models downloaded through AI Model Settings when no explicit model directory is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->