### PR TITLE
feat(win): enable ONNX Runtime on the MinGW build — image-to-3D on Windows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -430,6 +430,19 @@ jobs:
             Copy-Item "$mingwBin/libgcc_s_seh-1.dll" "${{github.workspace}}/bin" -ErrorAction SilentlyContinue
             Copy-Item "$mingwBin/libstdc++-6.dll" "${{github.workspace}}/bin" -ErrorAction SilentlyContinue
             Copy-Item "$mingwBin/libwinpthread-1.dll" "${{github.workspace}}/bin" -ErrorAction SilentlyContinue
+            # ONNX Runtime is MSVC-built: app-local deployment of the VC++
+            # runtime it links (vcruntime140*, msvcp140*) so a clean Windows
+            # without the VC redistributable can still start the process.
+            # windows-latest carries the redist copies in System32.
+            $sys32 = "$env:SystemRoot/System32"
+            foreach ($dll in @("vcruntime140.dll","vcruntime140_1.dll","msvcp140.dll","msvcp140_1.dll","msvcp140_2.dll")) {
+              if (Test-Path "$sys32/$dll") {
+                Copy-Item "$sys32/$dll" "${{github.workspace}}/bin" -Force
+                Write-Host "Bundled $dll"
+              } else {
+                Write-Host "NOTE: $dll not found in System32"
+              }
+            }
             Copy-Item "${{github.workspace}}/src/dependencies/zlib1.dll" "${{github.workspace}}/bin/zlib1__.dll" -ErrorAction SilentlyContinue
             Copy-Item "${{github.workspace}}/src/dependencies/zlib1.dll" "${{github.workspace}}/bin/libzlib.dll" -ErrorAction SilentlyContinue
       shell: powershell

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -380,7 +380,7 @@ jobs:
         Write-Host "cmake location: $((Get-Command cmake.exe).Source)"
         gcc --version
         cmake --version
-        cmake -S . -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_CXX_FLAGS="-g" -DCMAKE_C_FLAGS="-g" -DQT_QMAKE_EXECUTABLE=qmake -DCMAKE_C_COMPILER="D:/a/QtMeshEditor/Qt/Tools/mingw1310_64/bin/gcc.exe" -DCMAKE_CXX_COMPILER="D:/a/QtMeshEditor/Qt/Tools/mingw1310_64/bin/g++.exe" -DCMAKE_EXE_LINKER_FLAGS=-static -DQt6_DIR=D:/a/QtMeshEditor/Qt/${{env.QT_VERSION}}/mingw_64/lib/cmake/Qt6 -DQT_DIR=D:/a/QtMeshEditor/Qt/${{env.QT_VERSION}}/mingw_64/lib/cmake/Qt6 -DQt6GuiTools_DIR=D:/a/QtMeshEditor/Qt/${{env.QT_VERSION}}/mingw_64/lib/cmake/Qt6GuiTools -DOGRE_DIR=${{github.workspace}}/ogre-build/SDK/CMake/ -DASSIMP_DIR=C:/PROGRA~2/Assimp/lib/cmake/assimp-${{ env.ASSIMP_DIR_VERSION }}
+        cmake -S . -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_CXX_FLAGS="-g" -DCMAKE_C_FLAGS="-g" -DQT_QMAKE_EXECUTABLE=qmake -DCMAKE_C_COMPILER="D:/a/QtMeshEditor/Qt/Tools/mingw1310_64/bin/gcc.exe" -DCMAKE_CXX_COMPILER="D:/a/QtMeshEditor/Qt/Tools/mingw1310_64/bin/g++.exe" -DCMAKE_EXE_LINKER_FLAGS=-static -DQt6_DIR=D:/a/QtMeshEditor/Qt/${{env.QT_VERSION}}/mingw_64/lib/cmake/Qt6 -DQT_DIR=D:/a/QtMeshEditor/Qt/${{env.QT_VERSION}}/mingw_64/lib/cmake/Qt6 -DQt6GuiTools_DIR=D:/a/QtMeshEditor/Qt/${{env.QT_VERSION}}/mingw_64/lib/cmake/Qt6GuiTools -DOGRE_DIR=${{github.workspace}}/ogre-build/SDK/CMake/ -DASSIMP_DIR=C:/PROGRA~2/Assimp/lib/cmake/assimp-${{ env.ASSIMP_DIR_VERSION }} -DENABLE_ONNX=ON
       shell: powershell
 
     - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 3.36.1 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 3.37.0 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Available on the [GitHub Actions Marketplace](https://github.com/marketplace/act
 **Versioning**
 
 - **Always follow the latest GitHub release** — use the Marketplace floating tag `fernandotonon/QtMeshEditor@v1` (same pattern as the [Marketplace example](https://github.com/marketplace/actions/qtmesheditor)). The composite action defaults to `image-tag: latest`, so the Docker CLI tracks the newest published `ghcr.io/fernandotonon/qtmesh` image.
-- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.36.1**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
+- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.37.0**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
 
 Pinned workflow template (action + `ghcr.io` image aligned):
 
@@ -48,10 +48,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run QtMesh scan
-        uses: fernandotonon/QtMeshEditor@3.36.1
+        uses: fernandotonon/QtMeshEditor@3.37.0
         with:
           command: scan
-          image-tag: "3.36.1"
+          image-tag: "3.37.0"
         env:
           QTMESH_CLOUD_TOKEN: ${{ secrets.QTMESH_CLOUD_TOKEN }}
 ```
@@ -76,37 +76,37 @@ Release tags are listed on the [releases page](https://github.com/fernandotonon/
 
 ```yaml
 # Validate a specific mesh
-- uses: fernandotonon/QtMeshEditor@3.36.1
+- uses: fernandotonon/QtMeshEditor@3.37.0
   with:
     command: validate
     input-file: ./models/character.fbx
-    image-tag: "3.36.1"
+    image-tag: "3.37.0"
 
 # Convert FBX → glTF
-- uses: fernandotonon/QtMeshEditor@3.36.1
+- uses: fernandotonon/QtMeshEditor@3.37.0
   with:
     command: convert
     input-file: ./models/character.fbx
     output-file: ./output/character.gltf2
-    image-tag: "3.36.1"
+    image-tag: "3.37.0"
 
 # Resample Mixamo animations (200+ keyframes → 30)
-- uses: fernandotonon/QtMeshEditor@3.36.1
+- uses: fernandotonon/QtMeshEditor@3.37.0
   with:
     command: anim
     input-file: ./animations/dance.fbx
     output-file: ./output/dance_optimized.fbx
     options: --resample 30
-    image-tag: "3.36.1"
+    image-tag: "3.37.0"
 
 # Get mesh info as JSON
-- uses: fernandotonon/QtMeshEditor@3.36.1
+- uses: fernandotonon/QtMeshEditor@3.37.0
   id: info
   with:
     command: info
     input-file: ./models/character.fbx
     options: --json
-    image-tag: "3.36.1"
+    image-tag: "3.37.0"
 
 # Docker (alternative — :latest tracks newest image; pin :3.4.0 to match semver action ref)
 # The image is multi-arch (linux/amd64 + linux/arm64), so it runs natively on

--- a/cmake/OnnxRuntime.cmake
+++ b/cmake/OnnxRuntime.cmake
@@ -12,8 +12,13 @@
 # Linux x64 GPU: pass -DQTMESH_ONNX_GPU=ON (auto-defaults ON when nvidia-smi is
 # found outside CI) to fetch onnxruntime-linux-x64-gpu-*.tgz. The CUDA provider
 # .so must ship next to the binary AND cuDNN 9 + CUDA 12 must be on the system.
-# Windows MinGW is intentionally NOT wired here — the official Windows archive is
-# MSVC-built and won't link under MinGW.
+# Windows (MSVC and MinGW) uses the official win-x64 archive. The DLL exports a
+# plain C ABI (x64: no stdcall decoration), so MinGW links it too — via the
+# shipped onnxruntime.lib import library, which GNU binutils reads (short-
+# import-archive format). NB the import library, NOT the DLL directly: the CI
+# link runs with -static, and GNU ld refuses raw dynamic objects in static
+# mode while import libraries are ordinary archives (the same way the Qt
+# .dll.a import libs link there).
 
 if(TARGET qtmesh_onnx)
     return()
@@ -62,7 +67,7 @@ elseif(UNIX)
         endif()
     endif()
     set(_ort_libname "libonnxruntime.so.${QTMESH_ONNX_VERSION}")
-elseif(WIN32 AND NOT MINGW)
+elseif(WIN32)
     if(QTMESH_ONNX_GPU)
         message(WARNING "QTMESH_ONNX_GPU: Windows GPU package not wired in CMake yet; using CPU ONNX Runtime")
         set(QTMESH_ONNX_GPU OFF CACHE BOOL "" FORCE)
@@ -112,10 +117,15 @@ set_target_properties(qtmesh_onnx PROPERTIES
     IMPORTED_LOCATION "${QTMESH_ONNX_RUNTIME_LIB}"
     INTERFACE_INCLUDE_DIRECTORIES "${QTMESH_ONNX_INCLUDE_DIR}")
 if(WIN32)
+    # Both toolchains use the shipped import library (see the header comment:
+    # under -static, GNU ld accepts archives but refuses raw DLLs).
     file(GLOB _ort_implib "${QTMESH_ONNX_ROOT}/lib/onnxruntime.lib")
     if(_ort_implib)
         list(GET _ort_implib 0 _ort_implib0)
         set_target_properties(qtmesh_onnx PROPERTIES IMPORTED_IMPLIB "${_ort_implib0}")
+    elseif(MINGW)
+        message(FATAL_ERROR "ENABLE_ONNX: onnxruntime.lib missing from the win-x64 "
+                            "archive — MinGW needs the import library to link.")
     endif()
 endif()
 

--- a/cmake/OnnxRuntime.cmake
+++ b/cmake/OnnxRuntime.cmake
@@ -117,6 +117,14 @@ set_target_properties(qtmesh_onnx PROPERTIES
     IMPORTED_LOCATION "${QTMESH_ONNX_RUNTIME_LIB}"
     INTERFACE_INCLUDE_DIRECTORIES "${QTMESH_ONNX_INCLUDE_DIR}")
 if(WIN32)
+    if(MINGW)
+        # MinGW-w64's sal.h lags the newer MSVC source annotations ORT's
+        # header uses (_Frees_ptr_opt_ & co) — force-include a shim that
+        # no-op defines only what the real sal.h did not provide.
+        set_property(TARGET qtmesh_onnx APPEND PROPERTY
+            INTERFACE_COMPILE_OPTIONS
+            "SHELL:-include ${CMAKE_CURRENT_LIST_DIR}/onnx_mingw_sal_shim.h")
+    endif()
     # Both toolchains use the shipped import library (see the header comment:
     # under -static, GNU ld accepts archives but refuses raw DLLs).
     file(GLOB _ort_implib "${QTMESH_ONNX_ROOT}/lib/onnxruntime.lib")

--- a/cmake/onnx_mingw_sal_shim.h
+++ b/cmake/onnx_mingw_sal_shim.h
@@ -1,0 +1,87 @@
+/* MinGW SAL shim for the MSVC-built ONNX Runtime headers (force-included via
+ * cmake/OnnxRuntime.cmake, MinGW only).
+ *
+ * onnxruntime_c_api.h annotates its API with MSVC SAL macros. MinGW-w64's
+ * sal.h covers the classic set but lags the newer annotations (the 13.1
+ * toolchain lacks _Frees_ptr_opt_, which ORT 1.20 uses) — every gap is a
+ * hard compile error. Include the real sal.h first, then no-op define ONLY
+ * whatever it did not provide, covering the full annotation inventory the
+ * ORT header actually uses (grep _[A-Z][a-z] over onnxruntime_c_api.h). */
+#ifndef QTMESH_ONNX_MINGW_SAL_SHIM_H
+#define QTMESH_ONNX_MINGW_SAL_SHIM_H
+
+#if defined(__MINGW32__) || defined(__MINGW64__)
+#include <sal.h>
+
+#ifndef _Frees_ptr_opt_
+#define _Frees_ptr_opt_
+#endif
+#ifndef _Check_return_
+#define _Check_return_
+#endif
+#ifndef _In_
+#define _In_
+#endif
+#ifndef _In_opt_
+#define _In_opt_
+#endif
+#ifndef _In_opt_z_
+#define _In_opt_z_
+#endif
+#ifndef _In_z_
+#define _In_z_
+#endif
+#ifndef _In_reads_
+#define _In_reads_(s)
+#endif
+#ifndef _Inout_
+#define _Inout_
+#endif
+#ifndef _Inout_opt_
+#define _Inout_opt_
+#endif
+#ifndef _Inout_updates_
+#define _Inout_updates_(s)
+#endif
+#ifndef _Inout_updates_all_
+#define _Inout_updates_all_(s)
+#endif
+#ifndef _Out_
+#define _Out_
+#endif
+#ifndef _Out_opt_
+#define _Out_opt_
+#endif
+#ifndef _Out_writes_
+#define _Out_writes_(s)
+#endif
+#ifndef _Out_writes_all_
+#define _Out_writes_all_(s)
+#endif
+#ifndef _Out_writes_bytes_all_
+#define _Out_writes_bytes_all_(s)
+#endif
+#ifndef _Outptr_
+#define _Outptr_
+#endif
+#ifndef _Outptr_result_buffer_maybenull_
+#define _Outptr_result_buffer_maybenull_(s)
+#endif
+#ifndef _Outptr_result_maybenull_
+#define _Outptr_result_maybenull_
+#endif
+#ifndef _Ret_maybenull_
+#define _Ret_maybenull_
+#endif
+#ifndef _Ret_notnull_
+#define _Ret_notnull_
+#endif
+#ifndef _Return_type_success_
+#define _Return_type_success_(e)
+#endif
+#ifndef _Success_
+#define _Success_(e)
+#endif
+
+#endif /* __MINGW32__ || __MINGW64__ */
+#endif /* QTMESH_ONNX_MINGW_SAL_SHIM_H */

--- a/scripts/verify-windows-package-dlls.ps1
+++ b/scripts/verify-windows-package-dlls.ps1
@@ -26,7 +26,10 @@ if (-not (Test-Path $BinDir)) {
 $BinDir = (Resolve-Path $BinDir).Path
 
 # Windows loader / MinGW runtimes that are expected from System32 or need not be bundled.
-$SystemDllPattern = '^(?i)(api-ms-.*|ext-ms-.*|kernel32|kernelbase|user32|gdi32|advapi32|shell32|ole32|comdlg32|ws2_32|winmm|imm32|oleaut32|setupapi|version|msvcrt|ucrtbase|vcruntime.*|dbghelp|crypt32|secur32|bcrypt|ntdll|msvcp.*|d3d.*|dxgi|opengl32|glu32|wtsapi32|userenv|netapi32|iphlpapi|shlwapi|comctl32|uxtheme|dwmapi|propsys|windowscodecs|hid|setupapi|winspool|mpr|powrprof|cfgmgr32|devobj|wintrust|imagehlp|mswsock|dnsapi|rsaenh|bcryptprimitives|profapi)\.dll$'
+# NB vcruntime*/msvcp* are NOT in this list: since ONNX Runtime (MSVC-built)
+# ships in the package, the VC++ runtime must be bundled app-local — a clean
+# Windows has no VC redistributable and the process would fail at startup.
+$SystemDllPattern = '^(?i)(api-ms-.*|ext-ms-.*|kernel32|kernelbase|user32|gdi32|advapi32|shell32|ole32|comdlg32|ws2_32|winmm|imm32|oleaut32|setupapi|version|msvcrt|ucrtbase|dbghelp|crypt32|secur32|bcrypt|ntdll|d3d.*|dxgi|opengl32|glu32|wtsapi32|userenv|netapi32|iphlpapi|shlwapi|comctl32|uxtheme|dwmapi|propsys|windowscodecs|hid|setupapi|winspool|mpr|powrprof|cfgmgr32|devobj|wintrust|imagehlp|mswsock|dnsapi|rsaenh|bcryptprimitives|profapi)\.dll$'
 
 function Test-IsSystemDll([string]$Name) {
     return $Name -match $SystemDllPattern

--- a/website/src/hooks/useQtmeshActionRef.js
+++ b/website/src/hooks/useQtmeshActionRef.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 const QTMESH_RELEASES_LATEST_API = 'https://api.github.com/repos/fernandotonon/QtMeshEditor/releases/latest';
-const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.36.1';
+const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.37.0';
 const CACHE_KEY = 'qtmesh.actionRef.cache.v1';
 const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 


### PR DESCRIPTION
## Summary
Windows shipped with `ENABLE_ONNX=OFF` since #404 ('the official ONNX Runtime archive is MSVC-built and won't link under MinGW'), hiding **Image-to-3D and every ONNX AI feature** (PBR synth, upscaler, segmentation, background removal, UniRig, SkinTokens, in-betweening) on Windows. The blocker dissolves on inspection:

- `onnxruntime.dll` exports a **plain C ABI** (x64 — no stdcall decoration), and GNU binutils reads the shipped `onnxruntime.lib` (short-import-archive format), so MinGW links the official win-x64 archive as-is. The import library specifically — not the DLL directly — because the CI link runs with `-static`, where GNU ld accepts archives but refuses raw dynamic objects (exactly how Qt's `.dll.a` import libs already link there).
- Every `Ort::Session` open site has carried `#ifdef _WIN32` wide-path (`ORTCHAR_T`) branches from day one — zero consumer changes.
- The existing generic POST_BUILD copy already globs `onnxruntime.dll` + `onnxruntime_providers_*.dll` into `bin/`, which the zip/Inno installer package; the zip **CLI smoke test** in CI exercises the DLL load.

## Test plan
- [x] macOS build unaffected (only WIN32 branches touched)
- [ ] **build-windows CI is the validation** — first MinGW link of ORT; if the short-import-lib link fails, the fallback is a gendef/dlltool-generated import lib (follow-up commit on this PR)
- [ ] Zip smoke test proves the DLL ships and loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows MinGW build support for ONNX Runtime.
  * Windows packages now include required Visual C++ runtime libraries for improved compatibility on clean systems.

* **Bug Fixes**
  * Updated package validation to correctly check bundled Visual C++ runtime DLLs.

* **Documentation**
  * Updated build instructions, workflow examples, and action references for version 3.37.0.

* **Release**
  * Updated the project version to 3.37.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->