### PR TITLE
fix(trellis2): sRGB colors, chip-free bakes, thin-limb-safe matte, cascade presets

### DIFF
--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -2000,7 +2000,11 @@ Rectangle {
                     id: mgT2Preset
                     width: 190
                     enabled: !MeshGenController.busy
-                    model: ["Fast (512)", "Balanced (default)", "High (1536, more VRAM)"]
+                    // Balanced/High run the 1024/1536 cascade pipelines and
+                    // need the "TRELLIS.2 cascade" weights from AI Model
+                    // Settings; without them the generation falls back to 512
+                    // (thin structures can vanish) and says so in the status.
+                    model: ["Fast (512)", "Balanced (1024 cascade, default)", "High (1536 cascade, more VRAM)"]
                     currentIndex: 1
                     readonly property var presetValues: ["fast", "balanced", "high"]
                     property string presetValue: presetValues[currentIndex]

--- a/src/AIModelCatalog.cpp
+++ b/src/AIModelCatalog.cpp
@@ -258,6 +258,19 @@ QList<AIModelCatalog::ModelSpec> AIModelCatalog::specs() const
             file(QStringLiteral("trellis2"), QStringLiteral("tex_dec.gguf"), trellis2Base, QStringLiteral("TRELLIS.2 texture decoder")),
         }};
     out << ModelSpec{
+        QStringLiteral("trellis2-cascade-gguf"), tr("TRELLIS.2 cascade (1024/1536)"), tr("Image to 3D"),
+        tr("Optional high-resolution cascade weights for TRELLIS.2's Balanced and "
+           "High presets (1024/1536 pipelines). Without them those presets fall "
+           "back to the 512 pipeline, where thin structures (arms, straps) can "
+           "vanish at the sparse-structure stage. Requires the base TRELLIS.2 "
+           "weights and the trellis.cpp runtime."),
+        QStringLiteral("~5.2 GB"), QString(),
+        true,
+        {
+            file(QStringLiteral("trellis2"), QStringLiteral("shape_flow_1024.gguf"), trellis2Base, QStringLiteral("TRELLIS.2 shape flow (1024 cascade)")),
+            file(QStringLiteral("trellis2"), QStringLiteral("tex_flow_1024.gguf"), trellis2Base, QStringLiteral("TRELLIS.2 texture flow (1024 cascade)")),
+        }};
+    out << ModelSpec{
         QStringLiteral("background-removal"), tr("Background Removal"), tr("Image to 3D"),
         tr("U2Net ONNX model used to remove backgrounds before image-to-3D generation."),
         QStringLiteral("~170 MB"), onnxAvailable ? QString() : tr("Requires an ONNX-enabled build"),

--- a/src/ImageTo3D/BackgroundRemover.cpp
+++ b/src/ImageTo3D/BackgroundRemover.cpp
@@ -223,6 +223,82 @@ BackgroundRemover::Result BackgroundRemover::removeBackground(const QImage& imag
                     a = (a >= opts.threshold) ? 1.0f : 0.0f;
                 }
                 alpha[static_cast<size_t>(y) * W + x] = a;
+            }
+        }
+
+        // --- Uniform-background color rescue (#978) ------------------------
+        // U²-Net's 320² saliency reliably finds the subject's mass but can
+        // MISS thin appendages — a T-pose goblin lost a whole arm to the
+        // matte, and the 3D generation faithfully reproduced the amputation.
+        // Character sheets/renders overwhelmingly sit on a near-uniform
+        // background, which gives an independent, resolution-exact signal:
+        // when the four corner patches agree on a background color, any
+        // pixel whose color clearly differs from it is foreground — OR that
+        // mask into the saliency alpha so a saliency miss can never clip
+        // real geometry. Busy backgrounds (corners disagree) skip the
+        // rescue entirely and behave exactly as before.
+        {
+            const QImage src32 = image.convertToFormat(QImage::Format_RGB32);
+            auto patchStats = [&](int px, int py, double m[3], double& var) {
+                double sum[3] = {0, 0, 0}, sq[3] = {0, 0, 0};
+                int n = 0;
+                for (int y = py; y < py + 24 && y < H; ++y) {
+                    const QRgb* line =
+                        reinterpret_cast<const QRgb*>(src32.constScanLine(y));
+                    for (int x = px; x < px + 24 && x < W; ++x) {
+                        const double c[3] = {double(qRed(line[x])),
+                                             double(qGreen(line[x])),
+                                             double(qBlue(line[x]))};
+                        for (int k = 0; k < 3; ++k) {
+                            sum[k] += c[k];
+                            sq[k] += c[k] * c[k];
+                        }
+                        ++n;
+                    }
+                }
+                var = 0;
+                for (int k = 0; k < 3; ++k) {
+                    m[k] = sum[k] / std::max(1, n);
+                    var += sq[k] / std::max(1, n) - m[k] * m[k];
+                }
+            };
+            double c0[3], c1[3], c2[3], c3[3], v0, v1, v2, v3;
+            patchStats(0, 0, c0, v0);
+            patchStats(W - 24, 0, c1, v1);
+            patchStats(0, H - 24, c2, v2);
+            patchStats(W - 24, H - 24, c3, v3);
+            double bg[3], spread = 0;
+            for (int k = 0; k < 3; ++k) {
+                bg[k] = (c0[k] + c1[k] + c2[k] + c3[k]) / 4.0;
+                const double mx = std::max({c0[k], c1[k], c2[k], c3[k]});
+                const double mn = std::min({c0[k], c1[k], c2[k], c3[k]});
+                spread = std::max(spread, mx - mn);
+            }
+            const double maxVar = std::max({v0, v1, v2, v3});
+            if (spread < 12.0 && maxVar < 90.0) {
+                // Distance threshold above the background's own noise floor.
+                const double thr =
+                    std::max(28.0, 6.0 * std::sqrt(std::max(0.0, maxVar)));
+                for (int y = 0; y < H; ++y) {
+                    const QRgb* line =
+                        reinterpret_cast<const QRgb*>(src32.constScanLine(y));
+                    for (int x = 0; x < W; ++x) {
+                        float& a = alpha[static_cast<size_t>(y) * W + x];
+                        if (a >= 1.0f)
+                            continue;
+                        const double d = std::abs(qRed(line[x]) - bg[0])
+                                       + std::abs(qGreen(line[x]) - bg[1])
+                                       + std::abs(qBlue(line[x]) - bg[2]);
+                        if (d > thr)
+                            a = 1.0f;
+                    }
+                }
+            }
+        }
+
+        for (int y = 0; y < H; ++y) {
+            for (int x = 0; x < W; ++x) {
+                const float a = alpha[static_cast<size_t>(y) * W + x];
                 if (a > 0.5f) {
                     ++kept;
                     bx0 = std::min(bx0, x); by0 = std::min(by0, y);

--- a/src/ImageTo3D/BackgroundRemover.cpp
+++ b/src/ImageTo3D/BackgroundRemover.cpp
@@ -242,6 +242,8 @@ BackgroundRemover::Result BackgroundRemover::removeBackground(const QImage& imag
             auto patchStats = [&](int px, int py, double m[3], double& var) {
                 double sum[3] = {0, 0, 0}, sq[3] = {0, 0, 0};
                 int n = 0;
+                px = std::max(0, px);
+                py = std::max(0, py);
                 for (int y = py; y < py + 24 && y < H; ++y) {
                     const QRgb* line =
                         reinterpret_cast<const QRgb*>(src32.constScanLine(y));
@@ -263,10 +265,14 @@ BackgroundRemover::Result BackgroundRemover::removeBackground(const QImage& imag
                 }
             };
             double c0[3], c1[3], c2[3], c3[3], v0, v1, v2, v3;
+            // Clamp the patch origins: an image under 24px would otherwise
+            // hand negative coordinates to constScanLine/line[x].
+            const int px1 = std::max(0, W - 24);
+            const int py1 = std::max(0, H - 24);
             patchStats(0, 0, c0, v0);
-            patchStats(W - 24, 0, c1, v1);
-            patchStats(0, H - 24, c2, v2);
-            patchStats(W - 24, H - 24, c3, v3);
+            patchStats(px1, 0, c1, v1);
+            patchStats(0, py1, c2, v2);
+            patchStats(px1, py1, c3, v3);
             double bg[3], spread = 0;
             for (int k = 0; k < 3; ++k) {
                 bg[k] = (c0[k] + c1[k] + c2[k] + c3[k]) / 4.0;

--- a/src/ImageTo3D/Trellis2Bake.cpp
+++ b/src/ImageTo3D/Trellis2Bake.cpp
@@ -1360,6 +1360,12 @@ BakeResult bake(const std::vector<float>& targetPositions,
                             float nts[3] = {dot3(Ns, T), dot3(Ns, B),
                                             dot3(Ns, Nt)};
                             normalize3(nts);
+                            // A detail normal can never point INTO the
+                            // surface: negative tangent-space z texels (a
+                            // few % on dense noisy sources) render as dark
+                            // glints under lighting. Clamp and renormalize.
+                            if (nts[2] < 0.05f) nts[2] = 0.05f;
+                            normalize3(nts);
                             for (int k = 0; k < 3; ++k)
                                 accN[k] += nts[k];
                         }
@@ -1727,6 +1733,10 @@ NormalBakeResult bakeDetailNormal(const std::vector<float>& targetPositions,
                 }
                 float nts[3] = {dot3(Ns, T), dot3(Ns, B), dot3(Ns, Nt)};
                 normalize3(nts);
+                // Detail normals never point INTO the surface — clamp the
+                // few inverted-z texels dense noisy sources produce (they
+                // render as dark glints) and renormalize.
+                if (nts[2] < 0.05f) { nts[2] = 0.05f; normalize3(nts); }
                 uchar* np = normal.scanLine(y) + static_cast<size_t>(x) * 3;
                 np[0] = toByte(nts[0] * 0.5f + 0.5f);
                 np[1] = toByte(nts[1] * 0.5f + 0.5f);

--- a/src/ImageTo3D/Trellis2Bake.cpp
+++ b/src/ImageTo3D/Trellis2Bake.cpp
@@ -277,8 +277,17 @@ public:
 
     // Closest point on the whole surface. Returns triangle index (or -1 for
     // an empty mesh) and fills the closest point + barycentrics.
-    int closest(const float p[3], float outPoint[3], float outBary[3]) const
+    int closest(const float p[3], float outPoint[3], float outBary[3],
+                const float* towardNormal = nullptr) const
     {
+        // towardNormal (optional): reject candidate triangles whose face
+        // normal opposes it (dot < -0.2). The bake queries the DENSE source
+        // from a SIMPLIFIED surface point; on detailed regions the plain
+        // nearest triangle can belong to a different nearby surface (the
+        // back of an ear, the inside of a mouth) whose color then lands as
+        // a dark chip exactly where the model is most detailed. Filtering
+        // by facing keeps the sample on "our" side; the caller falls back
+        // to the unfiltered query when nothing on-side is found.
         if (m_triCount == 0)
             return -1;
         const int cx = cellIndex(p[0], 0);
@@ -300,6 +309,16 @@ public:
                 const float* a = &(*m_positions)[idx[0] * 3];
                 const float* b = &(*m_positions)[idx[1] * 3];
                 const float* c = &(*m_positions)[idx[2] * 3];
+                if (towardNormal) {
+                    float e1[3], e2[3], fn[3];
+                    sub3(b, a, e1);
+                    sub3(c, a, e2);
+                    cross3(e1, e2, fn);
+                    const float l = len3(fn);
+                    if (l > 1e-20f
+                        && dot3(fn, towardNormal) < -0.2f * l)
+                        continue;
+                }
                 float cp[3], bc[3];
                 closestPointOnTriangle(a, b, c, p, cp, bc);
                 float dvec[3];
@@ -1312,7 +1331,9 @@ BakeResult bake(const std::vector<float>& targetPositions,
                         normalize3(Nt);
 
                         float S[3], sb[3];
-                        const int sTri = grid.closest(P, S, sb);
+                        int sTri = grid.closest(P, S, sb, Nt);
+                        if (sTri < 0)
+                            sTri = grid.closest(P, S, sb);
                         float attr[6];
                         if (!volume.sample(sTri >= 0 ? S : P, attr))
                             continue;   // no opaque voxel within reach —
@@ -1482,50 +1503,84 @@ BakeResult bake(const std::vector<float>& targetPositions,
         covered.swap(next);
     }
 
-    // Mip-safe background: the dilation ring (a few texels) disappears at
-    // higher mip levels, and on heavily-charted meshes (a simplified TRELLIS
-    // dual grid produces thousands of small charts) the neutral background
-    // then bleeds through as bright seam networks at render time. Fill ALL
-    // remaining background with the mesh's average baked colour so every mip
-    // level samples plausible values.
+    // Mip-safe fill: after the exact gutter dilation above, fill EVERY
+    // remaining uncovered texel — inter-chart background AND interior holes
+    // (failed samples) — with its NEAREST covered texel's values via a
+    // jump-flood pass. The previous global-average flood was the source of
+    // the "dark chip" flecks on detailed models: a heavily-charted simplify
+    // (thousands of tiny charts) mixes bright skin and dark leather, so the
+    // average is mud, and both mip bleed at chart borders and any interior
+    // fill landed muddy chips onto bright surfaces. Nearest-texel fill makes
+    // every empty texel extend its closest chart instead.
     {
-        double sum[5] = {0, 0, 0, 0, 0};
-        size_t n = 0;
-        for (int y = 0; y < H; ++y) {
-            const uchar* bcRow = bcBits + static_cast<size_t>(y) * bcBpl;
-            const uchar* roRow = roBits + static_cast<size_t>(y) * roBpl;
-            const uchar* meRow = meBits + static_cast<size_t>(y) * meBpl;
+        constexpr int32_t kNoSeed = -1;
+        std::vector<int32_t> seed(static_cast<size_t>(W) * H, kNoSeed);
+        for (int y = 0; y < H; ++y)
             for (int x = 0; x < W; ++x) {
-                if (!covered[static_cast<size_t>(y) * W + x])
-                    continue;
-                sum[0] += bcRow[x * 4 + 0];
-                sum[1] += bcRow[x * 4 + 1];
-                sum[2] += bcRow[x * 4 + 2];
-                sum[3] += roRow[x];
-                sum[4] += meRow[x];
-                ++n;
+                const size_t lin = static_cast<size_t>(y) * W + x;
+                if (covered[lin])
+                    seed[lin] = static_cast<int32_t>(lin);
+            }
+        auto better = [&](int32_t cand, int x, int y, int32_t cur) {
+            if (cand == kNoSeed) return false;
+            const int cx = cand % W, cy = cand / W;
+            const long long dcx = cx - x, dcy = cy - y;
+            const long long dc = dcx * dcx + dcy * dcy;
+            if (cur == kNoSeed) return true;
+            const int ux = cur % W, uy = cur / W;
+            const long long dux = ux - x, duy = uy - y;
+            return dc < dux * dux + duy * duy;
+        };
+        int step = 1;
+        while (step < std::max(W, H)) step <<= 1;
+        for (; step >= 1; step >>= 1) {
+            for (int y = 0; y < H; ++y) {
+                for (int x = 0; x < W; ++x) {
+                    const size_t lin = static_cast<size_t>(y) * W + x;
+                    int32_t best = seed[lin];
+                    for (int dy = -1; dy <= 1; ++dy) {
+                        const int ny = y + dy * step;
+                        if (ny < 0 || ny >= H) continue;
+                        for (int dx = -1; dx <= 1; ++dx) {
+                            const int nx = x + dx * step;
+                            if (nx < 0 || nx >= W) continue;
+                            const int32_t cand =
+                                seed[static_cast<size_t>(ny) * W + nx];
+                            if (better(cand, x, y, best))
+                                best = cand;
+                        }
+                    }
+                    seed[lin] = best;
+                }
             }
         }
-        if (n > 0) {
-            const uchar avg[5] = {
-                static_cast<uchar>(sum[0] / n + 0.5),
-                static_cast<uchar>(sum[1] / n + 0.5),
-                static_cast<uchar>(sum[2] / n + 0.5),
-                static_cast<uchar>(sum[3] / n + 0.5),
-                static_cast<uchar>(sum[4] / n + 0.5)};
-            for (int y = 0; y < H; ++y) {
-                uchar* bcRow = bcBits + static_cast<size_t>(y) * bcBpl;
-                uchar* roRow = roBits + static_cast<size_t>(y) * roBpl;
-                uchar* meRow = meBits + static_cast<size_t>(y) * meBpl;
-                for (int x = 0; x < W; ++x) {
-                    if (covered[static_cast<size_t>(y) * W + x])
-                        continue;
-                    bcRow[x * 4 + 0] = avg[0];
-                    bcRow[x * 4 + 1] = avg[1];
-                    bcRow[x * 4 + 2] = avg[2];
-                    bcRow[x * 4 + 3] = 255;
-                    roRow[x] = avg[3];
-                    meRow[x] = avg[4];
+        for (int y = 0; y < H; ++y) {
+            uchar* bcRow = bcBits + static_cast<size_t>(y) * bcBpl;
+            uchar* roRow = roBits + static_cast<size_t>(y) * roBpl;
+            uchar* meRow = meBits + static_cast<size_t>(y) * meBpl;
+            for (int x = 0; x < W; ++x) {
+                const size_t lin = static_cast<size_t>(y) * W + x;
+                if (covered[lin])
+                    continue;
+                const int32_t src = seed[lin];
+                if (src == kNoSeed)
+                    continue;   // fully empty atlas (no covered texels)
+                const int sx = src % W, sy = src / W;
+                const uchar* sbc = bcBits + static_cast<size_t>(sy) * bcBpl
+                                 + static_cast<size_t>(sx) * 4;
+                bcRow[x * 4 + 0] = sbc[0];
+                bcRow[x * 4 + 1] = sbc[1];
+                bcRow[x * 4 + 2] = sbc[2];
+                bcRow[x * 4 + 3] = 255;
+                roRow[x] = (roBits + static_cast<size_t>(sy) * roBpl)[sx];
+                meRow[x] = (meBits + static_cast<size_t>(sy) * meBpl)[sx];
+                if (noBits) {
+                    uchar* nRow = noBits + static_cast<size_t>(y) * noBpl;
+                    const uchar* snr = noBits + static_cast<size_t>(sy) * noBpl
+                                     + static_cast<size_t>(sx) * 3;
+                    nRow[x * 3 + 0] = snr[0];
+                    nRow[x * 3 + 1] = snr[1];
+                    nRow[x * 3 + 2] = snr[2];
                 }
             }
         }
@@ -1719,7 +1774,9 @@ NormalBakeResult bakeDetailNormal(const std::vector<float>& targetPositions,
                     B[k] *= wsign;
 
                 float S[3], sb[3];
-                const int sTri = grid.closest(P, S, sb);
+                int sTri = grid.closest(P, S, sb, Nt);
+                if (sTri < 0)
+                    sTri = grid.closest(P, S, sb);
                 float Ns[3];
                 if (sTri >= 0) {
                     const uint32_t* sidx = &sourceIndices[sTri * 3];

--- a/src/ImageTo3D/Trellis2Interchange.cpp
+++ b/src/ImageTo3D/Trellis2Interchange.cpp
@@ -102,6 +102,13 @@ const uint8_t* checkedBlob(const QByteArray& blob, qint64 blobBase,
 
 } // namespace
 
+// IEC 61966-2-1 linear -> sRGB transfer.
+static float linearToSrgb(float v)
+{
+    return v <= 0.0031308f ? v * 12.92f
+                           : 1.055f * std::pow(v, 1.0f / 2.4f) - 0.055f;
+}
+
 ReadResult read(const QString& path)
 {
     ReadResult r;
@@ -263,6 +270,23 @@ ReadResult read(const QString& path)
     if (d.vertexCount <= 0 || d.triangleCount <= 0) {
         r.error = QStringLiteral("empty mesh");
         return r;
+    }
+    // LEGACY color space: qtm3d files written before the sRGB stamp hold
+    // LINEAR base-color lanes (both the trellis.cpp dump path and the
+    // Python sidecar wrote the model's raw linear output). Convert them on
+    // load so old preserved sources re-bake with correct brightness; files
+    // stamped "srgb" are already display-ready.
+    if (d.meta.value(QStringLiteral("colorSpace")).toString()
+            != QLatin1String("srgb")
+        && !d.voxelAttrs.empty()) {
+        for (size_t i = 0; i < d.voxelAttrs.size(); ++i) {
+            if (i % 6 >= 3)
+                continue;
+            const float lin = d.voxelAttrs[i] / 255.0f;
+            d.voxelAttrs[i] = static_cast<uint8_t>(
+                linearToSrgb(lin) * 255.0f + 0.5f);
+        }
+        d.meta.insert(QStringLiteral("colorSpace"), QStringLiteral("srgb"));
     }
     r.ok = true;
     return r;
@@ -461,13 +485,26 @@ ReadResult readTrellisCppDump(const QString& path)
             const float v = ap[i];
             // NaN fails both comparisons and float->u8 of NaN is UB —
             // treat non-finite lanes as 0.
-            const float cl = !std::isfinite(v) ? 0.0f
+            float cl = !std::isfinite(v) ? 0.0f
                 : (v < 0.0f ? 0.0f : (v > 1.0f ? 1.0f : v));
+            // trellis.cpp emits LINEAR-light colors (no gamma anywhere in
+            // its pipeline — verified against the source). Encode the BASE
+            // COLOR channels (lanes 0..2 of the 6-lane layout) to sRGB
+            // before quantizing, or every texture bakes murky-dark (a
+            // bright-green goblin measured mean luminance 0.096 raw vs a
+            // plausible 0.32 in sRGB). Metallic/roughness/alpha stay linear
+            // by definition.
+            if (i % 6 < 3)
+                cl = linearToSrgb(cl);
             d.voxelAttrs[i] = static_cast<uint8_t>(cl * 255.0f + 0.5f);
         }
     }
     d.meta.insert(QStringLiteral("generator"), QStringLiteral("trellis.cpp"));
     d.meta.insert(QStringLiteral("resolution"), res);
+    // Stamp the color space so a re-bake of this preserved source doesn't
+    // convert twice; qtm3d files WITHOUT the stamp predate the conversion
+    // and hold linear values (read() converts those on load).
+    d.meta.insert(QStringLiteral("colorSpace"), QStringLiteral("srgb"));
     r.ok = true;
     return r;
 }

--- a/src/ImageTo3D/Trellis2Interchange.cpp
+++ b/src/ImageTo3D/Trellis2Interchange.cpp
@@ -345,6 +345,12 @@ bool write(const QString& path, const Data& data, QString* error)
     }
 
     QJsonObject meta = data.meta;
+    // In-memory Data is display-ready (sRGB) by contract — the legacy-linear
+    // interpretation applies only to FILES from pre-conversion builds.
+    // Stamp unlabeled data so a write()/read() round trip is lossless
+    // instead of gamma-converting fresh bytes as if they were legacy.
+    if (!meta.contains(QStringLiteral("colorSpace")))
+        meta.insert(QStringLiteral("colorSpace"), QStringLiteral("srgb"));
     meta.insert(QStringLiteral("resolution"), data.resolution);
     meta.insert(QStringLiteral("voxelSize"), static_cast<double>(data.voxelSize));
     meta.insert(QStringLiteral("origin"),

--- a/src/ImageTo3D/Trellis2Predictor.cpp
+++ b/src/ImageTo3D/Trellis2Predictor.cpp
@@ -337,31 +337,61 @@ MeshGenPredictor::Result Trellis2Predictor::predict(
     else if (presetName == QLatin1String("high"))
         res = 1536;
     QString models2 = models;
-    if (res > 512
-        && !QDir(models2).exists(QStringLiteral("shape_flow_1024.gguf"))) {
+    const auto hasCascade = [](const QString& d) {
+        // BOTH cascade files, always — launching trellis-cli at 1024/1536
+        // with only one of them (e.g. a cancelled two-file download) fails
+        // mid-run instead of falling back.
+        const QDir q(d);
+        return q.exists(QStringLiteral("shape_flow_1024.gguf"))
+            && q.exists(QStringLiteral("tex_flow_1024.gguf"));
+    };
+    if (res > 512 && !hasCascade(models2)) {
         // The resolved dir (often the trellis-cli sibling with the 512 set)
         // has no cascade weights — but the AI Model Settings download
-        // location may: prefer it when it holds the FULL set including the
-        // cascade, so downloading "TRELLIS.2 cascade" in Settings lights up
-        // the Balanced/High presets without touching the cli install.
+        // location may. The cascade card downloads ONLY the two 1024 files,
+        // so the common layout is base set beside trellis-cli + cascade in
+        // the catalog dir: merge them into a temp dir of links (copies when
+        // linking fails) so trellis-cli sees one complete set. When the
+        // catalog holds everything, it is used directly.
         const QString catalogDir =
             QDir(QStandardPaths::writableLocation(
                      QStandardPaths::AppDataLocation))
                 .filePath(QStringLiteral("ai_models/trellis2"));
-        const QDir cd(catalogDir);
-        const bool catalogHasAll =
-            cd.exists(QStringLiteral("shape_flow_1024.gguf"))
-            && cd.exists(QStringLiteral("tex_flow_1024.gguf"))
-            && cd.exists(QStringLiteral("ss_flow.gguf"))
-            && cd.exists(QStringLiteral("shape_flow_512.gguf"))
-            && cd.exists(QStringLiteral("tex_flow_512.gguf"))
-            && cd.exists(QStringLiteral("shape_dec.gguf"))
-            && cd.exists(QStringLiteral("tex_dec.gguf"))
-            && cd.exists(QStringLiteral("ss_dec.gguf"))
-            && cd.exists(QStringLiteral("dinov3.gguf"));
-        if (catalogHasAll) {
-            models2 = catalogDir;
-        } else {
+        static const char* kBase[] = {
+            "ss_flow.gguf",  "shape_flow_512.gguf", "tex_flow_512.gguf",
+            "shape_dec.gguf", "tex_dec.gguf", "ss_dec.gguf", "dinov3.gguf"};
+        const auto hasBase = [&](const QString& d) {
+            const QDir q(d);
+            for (const char* f : kBase)
+                if (!q.exists(QLatin1String(f)))
+                    return false;
+            return true;
+        };
+        if (hasCascade(catalogDir)) {
+            if (hasBase(catalogDir)) {
+                models2 = catalogDir;
+            } else if (hasBase(models2)) {
+                const QString merged =
+                    QDir(tmp.path()).filePath(QStringLiteral("models"));
+                QDir().mkpath(merged);
+                bool mergedOk = true;
+                const auto place = [&](const QString& srcDir, const char* f) {
+                    const QString src = QDir(srcDir).filePath(QLatin1String(f));
+                    const QString dst = QDir(merged).filePath(QLatin1String(f));
+                    if (QFile::link(src, dst) || QFile::copy(src, dst))
+                        return true;
+                    mergedOk = false;
+                    return false;
+                };
+                for (const char* f : kBase)
+                    place(models2, f);
+                place(catalogDir, "shape_flow_1024.gguf");
+                place(catalogDir, "tex_flow_1024.gguf");
+                if (mergedOk)
+                    models2 = merged;
+            }
+        }
+        if (!hasCascade(models2)) {
             if (!warning.isEmpty())
                 warning += QStringLiteral(" ");
             warning += QStringLiteral(

--- a/src/ImageTo3D/Trellis2Predictor.cpp
+++ b/src/ImageTo3D/Trellis2Predictor.cpp
@@ -336,18 +336,45 @@ MeshGenPredictor::Result Trellis2Predictor::predict(
         res = 512;
     else if (presetName == QLatin1String("high"))
         res = 1536;
+    QString models2 = models;
     if (res > 512
-        && !QDir(models).exists(QStringLiteral("shape_flow_1024.gguf"))) {
-        if (!warning.isEmpty())
-            warning += QStringLiteral(" ");
-        warning += QStringLiteral(
-            "trellis.cpp models dir has no 1024-cascade weights — using the "
-            "512 pipeline.");
-        res = 512;
+        && !QDir(models2).exists(QStringLiteral("shape_flow_1024.gguf"))) {
+        // The resolved dir (often the trellis-cli sibling with the 512 set)
+        // has no cascade weights — but the AI Model Settings download
+        // location may: prefer it when it holds the FULL set including the
+        // cascade, so downloading "TRELLIS.2 cascade" in Settings lights up
+        // the Balanced/High presets without touching the cli install.
+        const QString catalogDir =
+            QDir(QStandardPaths::writableLocation(
+                     QStandardPaths::AppDataLocation))
+                .filePath(QStringLiteral("ai_models/trellis2"));
+        const QDir cd(catalogDir);
+        const bool catalogHasAll =
+            cd.exists(QStringLiteral("shape_flow_1024.gguf"))
+            && cd.exists(QStringLiteral("tex_flow_1024.gguf"))
+            && cd.exists(QStringLiteral("ss_flow.gguf"))
+            && cd.exists(QStringLiteral("shape_flow_512.gguf"))
+            && cd.exists(QStringLiteral("tex_flow_512.gguf"))
+            && cd.exists(QStringLiteral("shape_dec.gguf"))
+            && cd.exists(QStringLiteral("tex_dec.gguf"))
+            && cd.exists(QStringLiteral("ss_dec.gguf"))
+            && cd.exists(QStringLiteral("dinov3.gguf"));
+        if (catalogHasAll) {
+            models2 = catalogDir;
+        } else {
+            if (!warning.isEmpty())
+                warning += QStringLiteral(" ");
+            warning += QStringLiteral(
+                "the '%1' preset needs the 1024-cascade weights, which are "
+                "not installed — using the 512 pipeline (thin structures may "
+                "be lost). Download 'TRELLIS.2 cascade' in AI Model Settings "
+                "to enable it.").arg(presetName);
+            res = 512;
+        }
     }
     QStringList args{QStringLiteral("--image"),     inputPng,
                      QStringLiteral("--dump-post"), outDump,
-                     QStringLiteral("--models"),    models,
+                     QStringLiteral("--models"),    models2,
                      QStringLiteral("--res"),       QString::number(res),
                      QStringLiteral("--seed"),      QString::number(opts.seed)};
     QProcess proc;


### PR DESCRIPTION
## Summary
Diagnosed and fixed the full set of TRELLIS.2 quality issues reported on real generations (goblin assets), user-verified working:

**Murky/dark textures** — trellis.cpp emits **linear-light** colors (no gamma anywhere in its source); the dump reader now encodes base-color lanes to sRGB (`meta colorSpace=srgb`), legacy `.qtm3d` files convert on load, and `write()` stamps unlabeled in-memory data so round trips are lossless.

**Dark chip-shaped flecks on detailed models** — two mechanisms in the bake:
- the seam/hole fill used the *global average* color (mud on mixed bright/dark models) → replaced with a **jump-flood nearest-texel fill** on every channel including the normal map;
- the closest-point sampler could snap to a **different nearby surface** (back of an ear, inside the mouth) where the simplified mesh deviates → sampling is now **facing-filtered** with an unfiltered fallback.
Also: inverted-z texels clamped in detail-normal bakes.

**Missing limbs** — two mechanisms:
- Balanced/High presets silently ran the 512 pipeline → **TRELLIS.2 cascade (1024/1536)** card in AI Model Settings (both files now hosted on the HF gguf repo); the preset resolver merges a CLI-local base set with catalog-downloaded cascade files (temp link dir), requires BOTH cascade files, and the fallback warning says exactly what to download. Quality presets name their resolutions (1536 reuses the 1024 cascade weights — no extra download).
- **U²-Net's matte amputated thin limbs** (proven by a perfect-matte A/B: both arms returned) → uniform-background color rescue in `BackgroundRemover` (4-corner agreement gate; color-distance mask OR'd into the alpha; busy backgrounds unaffected), with review-hardened bounds for tiny images.

## Test plan
- [x] User-verified in the GUI: complete two-armed generations, bright correct colors, chip-free close-ups
- [x] E2E through the real --remove-bg path at 1024: complete T-pose goblin
- [x] Perfect-matte A/B isolated the matte; close-up renders verified the chip fixes
- [x] 48+ unit tests green (interchange legacy conversion, bake, catalog); review findings (5) all addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)