### PR TITLE
feat(trellis2): bundle the trellis.cpp runtime — TRELLIS.2 works out of the box; bump 3.37.3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -970,6 +970,10 @@ jobs:
             if [ -f ./bin/trellis-cli ]; then
               cp ./bin/trellis-cli ./pack-deb/usr/share/qtmesheditor/trellis-cli
               chmod 755 ./pack-deb/usr/share/qtmesheditor/trellis-cli
+              # MIT compliance: the runtime's upstream + vendored notices
+              # must accompany the redistributed binary.
+              cp ./bin/trellis-cli.THIRD_PARTY_LICENSES.txt \
+                 ./pack-deb/usr/share/doc/qtmesheditor/trellis-cli.THIRD_PARTY_LICENSES.txt
             fi
 
             # Create proper launcher script

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -893,6 +893,7 @@ jobs:
             -DCMAKE_CXX_FLAGS="-g" -DCMAKE_C_FLAGS="-g" \
             -DENABLE_STABLE_DIFFUSION=ON \
             -DENABLE_ONNX=ON \
+            -DENABLE_TRELLIS_CPP=ON \
             -DQTMESH_ONNX_GPU=OFF \
             -DENABLE_MOCAP=ON \
             -DENABLE_DRACO=ON \
@@ -964,6 +965,12 @@ jobs:
             cp ./packaging/linux/DEBIAN-postinst ./pack-deb/DEBIAN/postinst
             chmod 755 ./pack-deb/DEBIAN/postinst
             cp ./bin/QtMeshEditor ./pack-deb/usr/share/qtmesheditor/qtmesheditor
+            # Bundled TRELLIS.2 runtime (ENABLE_TRELLIS_CPP) — must sit next
+            # to the editor binary, where Trellis2Predictor probes for it.
+            if [ -f ./bin/trellis-cli ]; then
+              cp ./bin/trellis-cli ./pack-deb/usr/share/qtmesheditor/trellis-cli
+              chmod 755 ./pack-deb/usr/share/qtmesheditor/trellis-cli
+            fi
 
             # Create proper launcher script
             printf '#!/bin/sh\nexport LD_LIBRARY_PATH="/usr/lib/qtmesheditor:${LD_LIBRARY_PATH}"\nexport QT_PLUGIN_PATH="/usr/lib/qtmesheditor/plugins:/usr/share/qtmesheditor:${QT_PLUGIN_PATH}"\nexport QML2_IMPORT_PATH="/usr/share/qtmesheditor/qml:${QML2_IMPORT_PATH}"\n# Ogre requires X11 window handles; force XCB under Wayland\nexport QT_QPA_PLATFORM="${QT_QPA_PLATFORM:-xcb}"\nexec /usr/share/qtmesheditor/qtmesheditor "$@"\n' > ./pack-deb/usr/bin/qtmesheditor
@@ -2109,6 +2116,7 @@ jobs:
             -DCMAKE_CXX_FLAGS="-g" -DCMAKE_C_FLAGS="-g" \
             -DENABLE_STABLE_DIFFUSION=ON \
             -DENABLE_ONNX=ON \
+            -DENABLE_TRELLIS_CPP=ON \
             -DQTMESH_ONNX_GPU=OFF \
             -DENABLE_MOCAP=ON \
             -DENABLE_DRACO=ON \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 3.37.2 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 3.37.3 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")
@@ -295,6 +295,16 @@ if(ENABLE_STABLE_DIFFUSION)
     add_definitions(-DENABLE_STABLE_DIFFUSION)
     message(STATUS "AI texture generation enabled with stable-diffusion.cpp")
 endif()
+##############################################################
+#  Bundled trellis.cpp runtime — TRELLIS.2 image-to-3D needs no install
+##############################################################
+option(ENABLE_TRELLIS_CPP
+    "Build and bundle the trellis.cpp CLI (TRELLIS.2 runtime) with the editor" OFF)
+if(ENABLE_TRELLIS_CPP)
+    include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/TrellisCpp.cmake)
+    message(STATUS "Bundling trellis.cpp runtime (trellis-cli) with the editor")
+endif()
+
 ##############################################################
 #  ONNX Runtime — AI PBR map synthesis (#404)
 ##############################################################

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Available on the [GitHub Actions Marketplace](https://github.com/marketplace/act
 **Versioning**
 
 - **Always follow the latest GitHub release** — use the Marketplace floating tag `fernandotonon/QtMeshEditor@v1` (same pattern as the [Marketplace example](https://github.com/marketplace/actions/qtmesheditor)). The composite action defaults to `image-tag: latest`, so the Docker CLI tracks the newest published `ghcr.io/fernandotonon/qtmesh` image.
-- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.37.2**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
+- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.37.3**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
 
 Pinned workflow template (action + `ghcr.io` image aligned):
 
@@ -48,10 +48,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run QtMesh scan
-        uses: fernandotonon/QtMeshEditor@3.37.2
+        uses: fernandotonon/QtMeshEditor@3.37.3
         with:
           command: scan
-          image-tag: "3.37.2"
+          image-tag: "3.37.3"
         env:
           QTMESH_CLOUD_TOKEN: ${{ secrets.QTMESH_CLOUD_TOKEN }}
 ```
@@ -76,37 +76,37 @@ Release tags are listed on the [releases page](https://github.com/fernandotonon/
 
 ```yaml
 # Validate a specific mesh
-- uses: fernandotonon/QtMeshEditor@3.37.2
+- uses: fernandotonon/QtMeshEditor@3.37.3
   with:
     command: validate
     input-file: ./models/character.fbx
-    image-tag: "3.37.2"
+    image-tag: "3.37.3"
 
 # Convert FBX → glTF
-- uses: fernandotonon/QtMeshEditor@3.37.2
+- uses: fernandotonon/QtMeshEditor@3.37.3
   with:
     command: convert
     input-file: ./models/character.fbx
     output-file: ./output/character.gltf2
-    image-tag: "3.37.2"
+    image-tag: "3.37.3"
 
 # Resample Mixamo animations (200+ keyframes → 30)
-- uses: fernandotonon/QtMeshEditor@3.37.2
+- uses: fernandotonon/QtMeshEditor@3.37.3
   with:
     command: anim
     input-file: ./animations/dance.fbx
     output-file: ./output/dance_optimized.fbx
     options: --resample 30
-    image-tag: "3.37.2"
+    image-tag: "3.37.3"
 
 # Get mesh info as JSON
-- uses: fernandotonon/QtMeshEditor@3.37.2
+- uses: fernandotonon/QtMeshEditor@3.37.3
   id: info
   with:
     command: info
     input-file: ./models/character.fbx
     options: --json
-    image-tag: "3.37.2"
+    image-tag: "3.37.3"
 
 # Docker (alternative — :latest tracks newest image; pin :3.4.0 to match semver action ref)
 # The image is multi-arch (linux/amd64 + linux/arm64), so it runs natively on

--- a/cmake/ConcatFiles.cmake
+++ b/cmake/ConcatFiles.cmake
@@ -1,0 +1,14 @@
+# Build-time file concatenation (cmake -P): add_custom_command has no shell,
+# so `-E cat ... > out` cannot redirect — this script does it portably.
+#   cmake -DOUT=<path> -DIN=<f1>;<f2>;... -P ConcatFiles.cmake
+if(NOT OUT OR NOT IN)
+    message(FATAL_ERROR "ConcatFiles.cmake: OUT and IN are required")
+endif()
+set(_acc "")
+foreach(_f IN LISTS IN)
+    if(EXISTS "${_f}")
+        file(READ "${_f}" _c)
+        string(APPEND _acc "${_c}\n----------------------------------------\n")
+    endif()
+endforeach()
+file(WRITE "${OUT}" "${_acc}")

--- a/cmake/TrellisCpp.cmake
+++ b/cmake/TrellisCpp.cmake
@@ -45,8 +45,17 @@ set(_trellis_cmake_args
     -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
     -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER})
 if(CMAKE_OSX_ARCHITECTURES)
+    # LIST_SEPARATOR '|' below keeps a multi-arch value ("arm64;x86_64") as
+    # ONE child argument instead of splitting at the semicolon.
+    string(REPLACE ";" "|" _trellis_osx_archs "${CMAKE_OSX_ARCHITECTURES}")
     list(APPEND _trellis_cmake_args
-         -DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES})
+         "-DCMAKE_OSX_ARCHITECTURES=${_trellis_osx_archs}")
+endif()
+if(CMAKE_OSX_DEPLOYMENT_TARGET)
+    # The release build targets macOS 11.0 — the child must match or the
+    # bundled runtime could fail on supported systems.
+    list(APPEND _trellis_cmake_args
+         -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET})
 endif()
 
 ExternalProject_Add(qtmesh_trelliscpp
@@ -56,6 +65,7 @@ ExternalProject_Add(qtmesh_trelliscpp
     PREFIX         "${CMAKE_BINARY_DIR}/_deps/qtmesh_trelliscpp"
     SOURCE_DIR     "${CMAKE_BINARY_DIR}/_deps/qtmesh_trelliscpp-src"
     BINARY_DIR     "${CMAKE_BINARY_DIR}/_deps/qtmesh_trelliscpp-build"
+    LIST_SEPARATOR |
     CMAKE_ARGS     ${_trellis_cmake_args}
     BUILD_COMMAND  ${CMAKE_COMMAND} --build <BINARY_DIR> --target trellis-cli
                    --config Release -j4

--- a/cmake/TrellisCpp.cmake
+++ b/cmake/TrellisCpp.cmake
@@ -1,0 +1,64 @@
+# Bundled trellis.cpp runtime (TRELLIS.2 image-to-3D, MIT code + weights).
+#
+# Builds pwilkin/trellis.cpp's `trellis-cli` as part of the QtMeshEditor build
+# and ships it next to the editor binary, so TRELLIS.2 needs NO separate
+# runtime install — only the GGUF weights, which AI Model Settings downloads
+# into <AppData>/ai_models/trellis2/ (a directory Trellis2Predictor already
+# resolves). Pinned to upstream main AFTER both of our PRs merged (#44 Metal
+# support, #45 --dump-post with the cleaned remesh) — re-audit licenses if the
+# pin moves (docs/trellis2-dependencies.md).
+#
+# Built as an EXTERNAL PROJECT (isolated sub-build), NOT FetchContent:
+# trellis.cpp vendors its own patched ggml fork whose target names collide
+# with the ggml that llama.cpp (ENABLE_LOCAL_LLM) already brings into this
+# build. The sub-build has its own namespace and we only consume the one
+# produced executable.
+#
+# Backends: ggml picks Metal automatically on Apple; everywhere else this
+# builds the CPU backend (slow but functional baseline — GPU builds remain a
+# power-user recompile with -DGGML_VULKAN/CUDA on the trellis.cpp side).
+# TRELLIS_WEBP is forced OFF: QtMeshEditor consumes --dump-post (raw mesh +
+# PBR volume) and does its own baking, so the WebP GLB texture path (and its
+# libwebp FetchContent) is dead weight here.
+
+if(TARGET qtmesh_trelliscpp OR NOT ENABLE_TRELLIS_CPP)
+    return()
+endif()
+
+include(ExternalProject)
+
+set(_trellis_exe_name trellis-cli)
+if(WIN32)
+    set(_trellis_exe_name trellis-cli.exe)
+endif()
+set(QTMESH_TRELLIS_CLI_BINARY
+    "${CMAKE_BINARY_DIR}/_deps/qtmesh_trelliscpp-build/${_trellis_exe_name}"
+    CACHE FILEPATH "Path of the bundled trellis-cli executable" FORCE)
+
+set(_trellis_cmake_args
+    -DCMAKE_BUILD_TYPE=Release
+    -DTRELLIS_WEBP=OFF
+    # Portable CPU code, not -mcpu/-march=native: this binary SHIPS — a
+    # native-tuned CI build would crash on older machines, and Apple clang
+    # rejects -mcpu=native when an explicit target arch is set anyway.
+    -DGGML_NATIVE=OFF
+    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER})
+if(CMAKE_OSX_ARCHITECTURES)
+    list(APPEND _trellis_cmake_args
+         -DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES})
+endif()
+
+ExternalProject_Add(qtmesh_trelliscpp
+    GIT_REPOSITORY https://github.com/pwilkin/trellis.cpp.git
+    GIT_TAG        16f3109e82f3922033bfa62b83c42899678b7b6f
+    GIT_SHALLOW    OFF
+    PREFIX         "${CMAKE_BINARY_DIR}/_deps/qtmesh_trelliscpp"
+    SOURCE_DIR     "${CMAKE_BINARY_DIR}/_deps/qtmesh_trelliscpp-src"
+    BINARY_DIR     "${CMAKE_BINARY_DIR}/_deps/qtmesh_trelliscpp-build"
+    CMAKE_ARGS     ${_trellis_cmake_args}
+    BUILD_COMMAND  ${CMAKE_COMMAND} --build <BINARY_DIR> --target trellis-cli
+                   --config Release -j4
+    INSTALL_COMMAND ""
+    BUILD_BYPRODUCTS "${QTMESH_TRELLIS_CLI_BINARY}"
+    UPDATE_DISCONNECTED ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -829,10 +829,22 @@ if(ENABLE_TRELLIS_CPP AND TARGET qtmesh_trelliscpp)
     # extra runtime setup. Built as an isolated ExternalProject (its vendored
     # ggml fork collides with llama.cpp's ggml targets otherwise).
     add_dependencies(${CMAKE_PROJECT_NAME} qtmesh_trelliscpp)
+    # MIT compliance: redistributing trellis-cli requires shipping the
+    # upstream copyright + permission notices — concatenate trellis.cpp's
+    # LICENSE with its vendored dependencies' notices into ONE file that
+    # travels next to the binary in every package.
+    set(_trellis_src "${CMAKE_BINARY_DIR}/_deps/qtmesh_trelliscpp-src")
+    set(_trellis_lic "${CMAKE_BINARY_DIR}/trellis-cli.THIRD_PARTY_LICENSES.txt")
     add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND}
+                -DOUT=${_trellis_lic}
+                "-DIN=${_trellis_src}/LICENSE\;${_trellis_src}/thirdparty/ggml/LICENSE\;${_trellis_src}/thirdparty/fqms/LICENSE.md\;${_trellis_src}/thirdparty/meshoptimizer/LICENSE.md"
+                -P ${CMAKE_SOURCE_DIR}/cmake/ConcatFiles.cmake
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
                 "${QTMESH_TRELLIS_CLI_BINARY}" "$<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>"
-        COMMENT "Copying bundled trellis-cli next to QtMeshEditor")
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "${_trellis_lic}" "$<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>"
+        COMMENT "Copying bundled trellis-cli + license notices next to QtMeshEditor")
 endif()
 
 # Link Sentry if enabled

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -822,6 +822,19 @@ if(ENABLE_ONNX)
     endif()
 endif()
 
+if(ENABLE_TRELLIS_CPP AND TARGET qtmesh_trelliscpp)
+    # Ship the bundled TRELLIS.2 runtime next to the editor binary (macOS:
+    # inside Contents/MacOS). Trellis2Predictor probes this location, and the
+    # GGUF weights come from AI Model Settings — so a fresh install needs no
+    # extra runtime setup. Built as an isolated ExternalProject (its vendored
+    # ggml fork collides with llama.cpp's ggml targets otherwise).
+    add_dependencies(${CMAKE_PROJECT_NAME} qtmesh_trelliscpp)
+    add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "${QTMESH_TRELLIS_CLI_BINARY}" "$<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>"
+        COMMENT "Copying bundled trellis-cli next to QtMeshEditor")
+endif()
+
 # Link Sentry if enabled
 if(ENABLE_SENTRY)
     target_link_libraries(${CMAKE_PROJECT_NAME} sentry)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -845,6 +845,12 @@ if(ENABLE_TRELLIS_CPP AND TARGET qtmesh_trelliscpp)
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
                 "${_trellis_lic}" "$<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>"
         COMMENT "Copying bundled trellis-cli + license notices next to QtMeshEditor")
+    # `make install` (the CI packaging path) must carry the runtime too —
+    # the POST_BUILD copy only reaches the build tree.
+    install(PROGRAMS "${QTMESH_TRELLIS_CLI_BINARY}"
+            DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+    install(FILES "${_trellis_lic}"
+            DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 endif()
 
 # Link Sentry if enabled

--- a/src/ImageTo3D/Trellis2Predictor.cpp
+++ b/src/ImageTo3D/Trellis2Predictor.cpp
@@ -113,6 +113,21 @@ QString Trellis2Predictor::trellisCliPath()
         cli = QSettings().value(QLatin1String(kCliSettingsKey)).toString();
     if (!cli.isEmpty())
         return QFileInfo::exists(cli) ? cli : QString();
+    // Bundled runtime: builds with ENABLE_TRELLIS_CPP ship trellis-cli next
+    // to the editor binary (macOS: inside Contents/MacOS), so a fresh
+    // install needs no runtime setup — only the AI Model Settings weights.
+    if (QCoreApplication::instance()) {
+        const QString bundled = QDir(QCoreApplication::applicationDirPath())
+                                    .filePath(
+#ifdef Q_OS_WIN
+                                        QStringLiteral("trellis-cli.exe")
+#else
+                                        QStringLiteral("trellis-cli")
+#endif
+                                    );
+        if (QFileInfo::exists(bundled))
+            return bundled;
+    }
     return QStandardPaths::findExecutable(QStringLiteral("trellis-cli"));
 }
 
@@ -203,6 +218,14 @@ QString Trellis2Predictor::runtimeDescription()
     case RuntimeKind::None:
         break;
     }
+    // With a bundled trellis-cli (ENABLE_TRELLIS_CPP builds) the only
+    // missing piece is the weights — say exactly that instead of asking the
+    // user to install a runtime they already have.
+    if (!trellisCliPath().isEmpty())
+        return QStringLiteral(
+            "TRELLIS.2 models not downloaded yet. Open AI Model Settings → "
+            "QtMeshEditor Models and download 'TRELLIS.2 (trellis.cpp)' "
+            "(plus 'TRELLIS.2 cascade' for the Balanced/High presets).");
     return QStringLiteral(
         "TRELLIS.2 runtime not installed. Either build trellis.cpp and point "
         "QTMESH_TRELLIS2_CLI / QSettings ai/trellis2Cli at trellis-cli (with "

--- a/src/ImageTo3D/Trellis2Predictor.cpp
+++ b/src/ImageTo3D/Trellis2Predictor.cpp
@@ -116,17 +116,30 @@ QString Trellis2Predictor::trellisCliPath()
     // Bundled runtime: builds with ENABLE_TRELLIS_CPP ship trellis-cli next
     // to the editor binary (macOS: inside Contents/MacOS), so a fresh
     // install needs no runtime setup — only the AI Model Settings weights.
+    // Probe BOTH the application dir and the dir of the RESOLVED executable:
+    // the Homebrew install launches through a /opt/homebrew/bin symlink,
+    // where applicationDirPath() is the symlink's directory while the
+    // bundled runtime sits beside the real binary inside the .app (the same
+    // trap main.cpp's fixBundlePathsForSymlinkLaunch documents for Qt
+    // plugins — and CLI mode returns before that workaround even runs).
     if (QCoreApplication::instance()) {
-        const QString bundled = QDir(QCoreApplication::applicationDirPath())
-                                    .filePath(
+        const QString exeName =
 #ifdef Q_OS_WIN
-                                        QStringLiteral("trellis-cli.exe")
+            QStringLiteral("trellis-cli.exe");
 #else
-                                        QStringLiteral("trellis-cli")
+            QStringLiteral("trellis-cli");
 #endif
-                                    );
-        if (QFileInfo::exists(bundled))
-            return bundled;
+        QStringList dirs{QCoreApplication::applicationDirPath()};
+        const QString realExe =
+            QFileInfo(QCoreApplication::applicationFilePath())
+                .canonicalFilePath();
+        if (!realExe.isEmpty())
+            dirs << QFileInfo(realExe).absolutePath();
+        for (const QString& d : dirs) {
+            const QString bundled = QDir(d).filePath(exeName);
+            if (QFileInfo::exists(bundled))
+                return bundled;
+        }
     }
     return QStandardPaths::findExecutable(QStringLiteral("trellis-cli"));
 }

--- a/website/src/hooks/useQtmeshActionRef.js
+++ b/website/src/hooks/useQtmeshActionRef.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 const QTMESH_RELEASES_LATEST_API = 'https://api.github.com/repos/fernandotonon/QtMeshEditor/releases/latest';
-const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.37.2';
+const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.37.3';
 const CACHE_KEY = 'qtmesh.actionRef.cache.v1';
 const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 


### PR DESCRIPTION
## Summary
Fresh installations said **'TRELLIS.2 runtime not installed'** and required users to build/install trellis.cpp themselves. The runtime is MIT and <1 MB, so this builds it as part of QtMeshEditor and ships it next to the editor binary — combined with the AI Model Settings weight downloads, **a fresh install needs no extra setup**.

- `cmake/TrellisCpp.cmake` (`ENABLE_TRELLIS_CPP`, ON for release Linux/macOS CI): builds `trellis-cli` pinned to upstream `pwilkin/trellis.cpp` main (both our upstreamed PRs — Metal #44, `--dump-post` #45 — are in). Built as an **isolated ExternalProject** (its vendored patched-ggml collides with llama.cpp's ggml targets), with `GGML_NATIVE=OFF` (shipping binaries must be portable; Apple clang also rejects `-mcpu=native` under an explicit arch) and `TRELLIS_WEBP=OFF` (we consume `--dump-post` and bake natively).
- Backends: **Metal automatically on Apple**; portable CPU baseline elsewhere (GPU = power-user recompile).
- `Trellis2Predictor` probes the bundled location (applicationDirPath) after env/QSettings; with a bundled CLI the 'not installed' message becomes 'download the models in AI Model Settings'.
- Packaging: macOS `.app` carries it in `Contents/MacOS` (the signing loop already signs every bundle executable); the Linux `.deb` ships it beside the editor binary. **Windows stays OFF** pending MinGW verification (follow-up).
- Version **3.37.3**.

## Test plan
- [x] Local macOS: ExternalProject builds, `trellis-cli` lands in the .app and executes (Metal)
- [ ] CI: build-linux (amd64+arm64) and build-macos with the flag ON — first CI builds of the bundled runtime
- [ ] .deb/.dmg content check via the release pipeline on the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TRELLIS.2 support can now be bundled with the application, reducing the need for separate runtime setup.
  * The app detects a bundled TRELLIS.2 runtime before searching system locations.
  * When the runtime is available but model weights are missing, guidance now directs users to AI Model Settings.

* **Documentation**
  * Updated build instructions, workflow examples, container references, and action versions to 3.37.3.

* **Chores**
  * Updated the application version to 3.37.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->