### PR TITLE
fix(trellis2): background rescue no longer keeps shadows/vignettes; bump 3.37.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 3.37.3 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 3.37.4 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Available on the [GitHub Actions Marketplace](https://github.com/marketplace/act
 **Versioning**
 
 - **Always follow the latest GitHub release** — use the Marketplace floating tag `fernandotonon/QtMeshEditor@v1` (same pattern as the [Marketplace example](https://github.com/marketplace/actions/qtmesheditor)). The composite action defaults to `image-tag: latest`, so the Docker CLI tracks the newest published `ghcr.io/fernandotonon/qtmesh` image.
-- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.37.3**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
+- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.37.4**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
 
 Pinned workflow template (action + `ghcr.io` image aligned):
 
@@ -48,10 +48,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run QtMesh scan
-        uses: fernandotonon/QtMeshEditor@3.37.3
+        uses: fernandotonon/QtMeshEditor@3.37.4
         with:
           command: scan
-          image-tag: "3.37.3"
+          image-tag: "3.37.4"
         env:
           QTMESH_CLOUD_TOKEN: ${{ secrets.QTMESH_CLOUD_TOKEN }}
 ```
@@ -76,37 +76,37 @@ Release tags are listed on the [releases page](https://github.com/fernandotonon/
 
 ```yaml
 # Validate a specific mesh
-- uses: fernandotonon/QtMeshEditor@3.37.3
+- uses: fernandotonon/QtMeshEditor@3.37.4
   with:
     command: validate
     input-file: ./models/character.fbx
-    image-tag: "3.37.3"
+    image-tag: "3.37.4"
 
 # Convert FBX → glTF
-- uses: fernandotonon/QtMeshEditor@3.37.3
+- uses: fernandotonon/QtMeshEditor@3.37.4
   with:
     command: convert
     input-file: ./models/character.fbx
     output-file: ./output/character.gltf2
-    image-tag: "3.37.3"
+    image-tag: "3.37.4"
 
 # Resample Mixamo animations (200+ keyframes → 30)
-- uses: fernandotonon/QtMeshEditor@3.37.3
+- uses: fernandotonon/QtMeshEditor@3.37.4
   with:
     command: anim
     input-file: ./animations/dance.fbx
     output-file: ./output/dance_optimized.fbx
     options: --resample 30
-    image-tag: "3.37.3"
+    image-tag: "3.37.4"
 
 # Get mesh info as JSON
-- uses: fernandotonon/QtMeshEditor@3.37.3
+- uses: fernandotonon/QtMeshEditor@3.37.4
   id: info
   with:
     command: info
     input-file: ./models/character.fbx
     options: --json
-    image-tag: "3.37.3"
+    image-tag: "3.37.4"
 
 # Docker (alternative — :latest tracks newest image; pin :3.4.0 to match semver action ref)
 # The image is multi-arch (linux/amd64 + linux/arm64), so it runs natively on

--- a/src/ImageTo3D/BackgroundRemover.cpp
+++ b/src/ImageTo3D/BackgroundRemover.cpp
@@ -378,6 +378,8 @@ void BackgroundRemover::applyUniformBackgroundRescue(const QImage& image,
     // Distance threshold above the background's own noise floor.
     const double thr = std::max(28.0, 6.0 * std::sqrt(std::max(0.0, maxVar)));
     const double bgSum = bg[0] + bg[1] + bg[2];
+    const double bgChroma = std::max({bg[0], bg[1], bg[2]})
+                          - std::min({bg[0], bg[1], bg[2]});
     const size_t total = static_cast<size_t>(W) * static_cast<size_t>(H);
 
     // Pass 1 — candidates: clearly different from the background color, and
@@ -401,15 +403,25 @@ void BackgroundRemover::applyUniformBackgroundRescue(const QImage& image,
             if (d <= thr)
                 continue;
             const double s = r + g + b;
-            if (s > 1.0 && bgSum > 1.0) {
-                const double k = bgSum / s;
-                if (k > 0.7 && k < 3.5) {
-                    const double d2 = std::abs(r * k - bg[0])
-                                    + std::abs(g * k - bg[1])
-                                    + std::abs(b * k - bg[2]);
-                    if (d2 <= thr)
-                        continue;   // shading of the backdrop, not geometry
-                }
+            const double k = (s > 1.0 && bgSum > 1.0) ? bgSum / s : 1e9;
+            if (k > 0.7 && k < 3.5) {
+                const double d2 = std::abs(r * k - bg[0])
+                                + std::abs(g * k - bg[1])
+                                + std::abs(b * k - bg[2]);
+                if (d2 <= thr)
+                    continue;   // shading of the backdrop, not geometry
+            } else if (bgChroma < 24.0) {
+                // Outside the proportional window the luminance-scaled
+                // comparison is meaningless (clipped shadows; noise blown up
+                // by a huge k), but a deep/clipped shadow on an ACHROMATIC
+                // backdrop is itself achromatic — still shading. Genuinely
+                // dark geometry is left to the saliency net (solid dark
+                // masses are salient; the rescue exists for the chromatic
+                // thin appendages saliency misses).
+                const double pixChroma = std::max({r, g, b})
+                                       - std::min({r, g, b});
+                if (pixChroma < 24.0)
+                    continue;
             }
             cand[i] = 1;
         }

--- a/src/ImageTo3D/BackgroundRemover.cpp
+++ b/src/ImageTo3D/BackgroundRemover.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <vector>
 
 #ifdef ENABLE_ONNX
@@ -226,81 +227,13 @@ BackgroundRemover::Result BackgroundRemover::removeBackground(const QImage& imag
             }
         }
 
-        // --- Uniform-background color rescue (#978) ------------------------
+        // --- Uniform-background color rescue (#978, tightened) --------------
         // U²-Net's 320² saliency reliably finds the subject's mass but can
         // MISS thin appendages — a T-pose goblin lost a whole arm to the
         // matte, and the 3D generation faithfully reproduced the amputation.
-        // Character sheets/renders overwhelmingly sit on a near-uniform
-        // background, which gives an independent, resolution-exact signal:
-        // when the four corner patches agree on a background color, any
-        // pixel whose color clearly differs from it is foreground — OR that
-        // mask into the saliency alpha so a saliency miss can never clip
-        // real geometry. Busy backgrounds (corners disagree) skip the
-        // rescue entirely and behave exactly as before.
-        {
-            const QImage src32 = image.convertToFormat(QImage::Format_RGB32);
-            auto patchStats = [&](int px, int py, double m[3], double& var) {
-                double sum[3] = {0, 0, 0}, sq[3] = {0, 0, 0};
-                int n = 0;
-                px = std::max(0, px);
-                py = std::max(0, py);
-                for (int y = py; y < py + 24 && y < H; ++y) {
-                    const QRgb* line =
-                        reinterpret_cast<const QRgb*>(src32.constScanLine(y));
-                    for (int x = px; x < px + 24 && x < W; ++x) {
-                        const double c[3] = {double(qRed(line[x])),
-                                             double(qGreen(line[x])),
-                                             double(qBlue(line[x]))};
-                        for (int k = 0; k < 3; ++k) {
-                            sum[k] += c[k];
-                            sq[k] += c[k] * c[k];
-                        }
-                        ++n;
-                    }
-                }
-                var = 0;
-                for (int k = 0; k < 3; ++k) {
-                    m[k] = sum[k] / std::max(1, n);
-                    var += sq[k] / std::max(1, n) - m[k] * m[k];
-                }
-            };
-            double c0[3], c1[3], c2[3], c3[3], v0, v1, v2, v3;
-            // Clamp the patch origins: an image under 24px would otherwise
-            // hand negative coordinates to constScanLine/line[x].
-            const int px1 = std::max(0, W - 24);
-            const int py1 = std::max(0, H - 24);
-            patchStats(0, 0, c0, v0);
-            patchStats(px1, 0, c1, v1);
-            patchStats(0, py1, c2, v2);
-            patchStats(px1, py1, c3, v3);
-            double bg[3], spread = 0;
-            for (int k = 0; k < 3; ++k) {
-                bg[k] = (c0[k] + c1[k] + c2[k] + c3[k]) / 4.0;
-                const double mx = std::max({c0[k], c1[k], c2[k], c3[k]});
-                const double mn = std::min({c0[k], c1[k], c2[k], c3[k]});
-                spread = std::max(spread, mx - mn);
-            }
-            const double maxVar = std::max({v0, v1, v2, v3});
-            if (spread < 12.0 && maxVar < 90.0) {
-                // Distance threshold above the background's own noise floor.
-                const double thr =
-                    std::max(28.0, 6.0 * std::sqrt(std::max(0.0, maxVar)));
-                for (int y = 0; y < H; ++y) {
-                    const QRgb* line =
-                        reinterpret_cast<const QRgb*>(src32.constScanLine(y));
-                    for (int x = 0; x < W; ++x) {
-                        float& a = alpha[static_cast<size_t>(y) * W + x];
-                        if (a >= 1.0f)
-                            continue;
-                        const double d = std::abs(qRed(line[x]) - bg[0])
-                                       + std::abs(qGreen(line[x]) - bg[1])
-                                       + std::abs(qBlue(line[x]) - bg[2]);
-                        if (d > thr)
-                            a = 1.0f;
-                    }
-                }
-            }
-        }
+        // See applyUniformBackgroundRescue for the chroma + connectivity
+        // rules that keep shadows/vignettes/watermarks out of the matte.
+        applyUniformBackgroundRescue(image, alpha);
 
         for (int y = 0; y < H; ++y) {
             for (int x = 0; x < W; ++x) {
@@ -384,3 +317,158 @@ BackgroundRemover::Result BackgroundRemover::removeBackground(const QImage& imag
 }
 
 #endif // ENABLE_ONNX
+
+// Compiled in every build (the header declares it unconditionally and the
+// unit tests exercise it without ONNX).
+void BackgroundRemover::applyUniformBackgroundRescue(const QImage& image,
+                                                     std::vector<float>& alpha)
+{
+    const int W = image.width(), H = image.height();
+    if (W <= 0 || H <= 0
+        || alpha.size() != static_cast<size_t>(W) * static_cast<size_t>(H))
+        return;
+
+    const QImage src32 = image.convertToFormat(QImage::Format_RGB32);
+    auto patchStats = [&](int px, int py, double m[3], double& var) {
+        double sum[3] = {0, 0, 0}, sq[3] = {0, 0, 0};
+        int n = 0;
+        // Clamp the patch origins: an image under 24px would otherwise hand
+        // negative coordinates to constScanLine/line[x].
+        px = std::max(0, px);
+        py = std::max(0, py);
+        for (int y = py; y < py + 24 && y < H; ++y) {
+            const QRgb* line =
+                reinterpret_cast<const QRgb*>(src32.constScanLine(y));
+            for (int x = px; x < px + 24 && x < W; ++x) {
+                const double c[3] = {double(qRed(line[x])),
+                                     double(qGreen(line[x])),
+                                     double(qBlue(line[x]))};
+                for (int k = 0; k < 3; ++k) {
+                    sum[k] += c[k];
+                    sq[k] += c[k] * c[k];
+                }
+                ++n;
+            }
+        }
+        var = 0;
+        for (int k = 0; k < 3; ++k) {
+            m[k] = sum[k] / std::max(1, n);
+            var += sq[k] / std::max(1, n) - m[k] * m[k];
+        }
+    };
+    double c0[3], c1[3], c2[3], c3[3], v0, v1, v2, v3;
+    const int px1 = std::max(0, W - 24);
+    const int py1 = std::max(0, H - 24);
+    patchStats(0, 0, c0, v0);
+    patchStats(px1, 0, c1, v1);
+    patchStats(0, py1, c2, v2);
+    patchStats(px1, py1, c3, v3);
+    double bg[3], spread = 0;
+    for (int k = 0; k < 3; ++k) {
+        bg[k] = (c0[k] + c1[k] + c2[k] + c3[k]) / 4.0;
+        const double mx = std::max({c0[k], c1[k], c2[k], c3[k]});
+        const double mn = std::min({c0[k], c1[k], c2[k], c3[k]});
+        spread = std::max(spread, mx - mn);
+    }
+    const double maxVar = std::max({v0, v1, v2, v3});
+    // Busy background (corners disagree) → no reliable bg color → no rescue.
+    if (!(spread < 12.0 && maxVar < 90.0))
+        return;
+
+    // Distance threshold above the background's own noise floor.
+    const double thr = std::max(28.0, 6.0 * std::sqrt(std::max(0.0, maxVar)));
+    const double bgSum = bg[0] + bg[1] + bg[2];
+    const size_t total = static_cast<size_t>(W) * static_cast<size_t>(H);
+
+    // Pass 1 — candidates: clearly different from the background color, and
+    // NOT a brightness-only (shading) change. Drop shadows, vignettes and
+    // lighting falloff keep the backdrop's CHROMA at a different luminance;
+    // scaling the pixel to the background's luminance collapses those back
+    // onto the background color, while real geometry keeps a chroma distance.
+    // The scale range covers modest brightening (spill) through deep shadow;
+    // a genuinely dark object (k above the cap) stays a candidate.
+    std::vector<uint8_t> cand(total, 0);
+    for (int y = 0; y < H; ++y) {
+        const QRgb* line = reinterpret_cast<const QRgb*>(src32.constScanLine(y));
+        for (int x = 0; x < W; ++x) {
+            const size_t i = static_cast<size_t>(y) * W + x;
+            if (alpha[i] >= 1.0f)
+                continue;
+            const double r = qRed(line[x]), g = qGreen(line[x]),
+                         b = qBlue(line[x]);
+            const double d = std::abs(r - bg[0]) + std::abs(g - bg[1])
+                           + std::abs(b - bg[2]);
+            if (d <= thr)
+                continue;
+            const double s = r + g + b;
+            if (s > 1.0 && bgSum > 1.0) {
+                const double k = bgSum / s;
+                if (k > 0.7 && k < 3.5) {
+                    const double d2 = std::abs(r * k - bg[0])
+                                    + std::abs(g * k - bg[1])
+                                    + std::abs(b * k - bg[2]);
+                    if (d2 <= thr)
+                        continue;   // shading of the backdrop, not geometry
+                }
+            }
+            cand[i] = 1;
+        }
+    }
+
+    // Pass 2 — connectivity: keep only candidate regions attached to the
+    // existing U²-Net foreground. A saliency-missed limb touches the body; a
+    // watermark, prop shadow or backdrop gradient blob does not. Seeds are
+    // candidates 8-adjacent to a foreground pixel; flood over candidates.
+    std::vector<uint8_t> keep(total, 0);
+    std::vector<size_t> stack;
+    stack.reserve(1024);
+    auto foregroundAt = [&](int x, int y) {
+        return x >= 0 && x < W && y >= 0 && y < H
+               && alpha[static_cast<size_t>(y) * W + x] >= 0.5f;
+    };
+    for (int y = 0; y < H; ++y) {
+        for (int x = 0; x < W; ++x) {
+            const size_t i = static_cast<size_t>(y) * W + x;
+            if (!cand[i] || keep[i])
+                continue;
+            bool seed = false;
+            for (int dy = -1; dy <= 1 && !seed; ++dy)
+                for (int dx = -1; dx <= 1 && !seed; ++dx)
+                    seed = (dx || dy) && foregroundAt(x + dx, y + dy);
+            if (!seed)
+                continue;
+            keep[i] = 1;
+            stack.push_back(i);
+            while (!stack.empty()) {
+                const size_t j = stack.back();
+                stack.pop_back();
+                const int jx = int(j % W), jy = int(j / W);
+                for (int dy = -1; dy <= 1; ++dy)
+                    for (int dx = -1; dx <= 1; ++dx) {
+                        const int nx = jx + dx, ny = jy + dy;
+                        if (nx < 0 || nx >= W || ny < 0 || ny >= H)
+                            continue;
+                        const size_t n = static_cast<size_t>(ny) * W + nx;
+                        if (cand[n] && !keep[n]) {
+                            keep[n] = 1;
+                            stack.push_back(n);
+                        }
+                    }
+            }
+        }
+    }
+
+    // Safety valve: a rescue that floods the frame is a misfire (the gate
+    // passed on agreeing corners but the "background" wasn't uniform after
+    // all) — keep the saliency matte untouched rather than hand the 3D
+    // generation a backdrop slab.
+    size_t rescued = 0;
+    for (size_t i = 0; i < total; ++i)
+        rescued += keep[i];
+    if (rescued > total * 3 / 10)
+        return;
+
+    for (size_t i = 0; i < total; ++i)
+        if (keep[i])
+            alpha[i] = 1.0f;
+}

--- a/src/ImageTo3D/BackgroundRemover.h
+++ b/src/ImageTo3D/BackgroundRemover.h
@@ -3,6 +3,7 @@
 
 #include <QImage>
 #include <QString>
+#include <vector>
 
 // AI background removal (epic #764 support): segment the foreground object out of
 // a photo so image-to-3D (TripoSR) sees a clean, isolated subject. TripoSR is
@@ -80,6 +81,20 @@ public:
     static Result removeBackground(const QImage& image,
                                    const QString& modelPath,
                                    const Options& opts = {});
+
+    // Uniform-background thin-appendage rescue (#978): OR into `alpha` pixels
+    // that clearly differ from the corner-agreed background color. Tightened
+    // after 3.37.3 field reports (backdrop slabs + washed-out bakes): a pixel
+    // must differ in CHROMA — a brightness-only change (drop shadow, vignette,
+    // lighting falloff on the backdrop) stays background — and its rescue
+    // region must be CONNECTED to the existing U²-Net foreground (a
+    // saliency-missed arm touches the body; a watermark or backdrop gradient
+    // does not). Skips busy backgrounds (corner patches disagree) and aborts
+    // when the rescue would flood the frame. `alpha` is the row-major
+    // [width*height] foreground matte in [0,1]. Pure (QImage + alpha in/out),
+    // public so it unit-tests headless.
+    static void applyUniformBackgroundRescue(const QImage& image,
+                                             std::vector<float>& alpha);
 };
 
 #endif // BACKGROUND_REMOVER_H

--- a/src/ImageTo3D/BackgroundRemover_test.cpp
+++ b/src/ImageTo3D/BackgroundRemover_test.cpp
@@ -69,3 +69,105 @@ TEST(BackgroundRemoverTest, SegmentsWhenModelPresentElseFallsBack)
         EXPECT_EQ(r.image.size(), img.size());   // original passed through
     }
 }
+
+// --- Uniform-background rescue (pure, model-free) --------------------------
+// The fixture: a white 200×200 backdrop with a blue "body" the saliency
+// already found (alpha=1). The rescue must recover geometry the saliency
+// missed WITHOUT re-mattering the backdrop (3.37.3 field reports: kept
+// shadows/vignettes became flat slabs and washed the bakes out bright).
+
+namespace {
+
+struct RescueFixture {
+    static constexpr int W = 200, H = 200;
+    QImage img{W, H, QImage::Format_RGB32};
+    std::vector<float> alpha;
+
+    RescueFixture()
+    {
+        img.fill(qRgb(255, 255, 255));
+        alpha.assign(size_t(W) * H, 0.0f);
+        // Body: blue rect, already matted as foreground.
+        for (int y = 80; y <= 160; ++y)
+            for (int x = 30; x <= 90; ++x) {
+                img.setPixel(x, y, qRgb(40, 60, 200));
+                alpha[size_t(y) * W + x] = 1.0f;
+            }
+    }
+    float a(int x, int y) const { return alpha[size_t(y) * W + x]; }
+};
+
+} // namespace
+
+TEST(BackgroundRemoverTest, RescueRecoversLimbConnectedToSubject)
+{
+    RescueFixture f;
+    // A thin blue "arm" the saliency missed, attached to the body.
+    for (int y = 100; y <= 110; ++y)
+        for (int x = 91; x <= 170; ++x)
+            f.img.setPixel(x, y, qRgb(40, 60, 200));
+
+    BackgroundRemover::applyUniformBackgroundRescue(f.img, f.alpha);
+    EXPECT_EQ(f.a(160, 105), 1.0f);   // arm tip rescued
+    EXPECT_EQ(f.a(120, 105), 1.0f);   // arm middle rescued
+    EXPECT_EQ(f.a(180, 30), 0.0f);    // plain backdrop untouched
+}
+
+TEST(BackgroundRemoverTest, RescueIgnoresDropShadow)
+{
+    RescueFixture f;
+    // A gray drop shadow touching the body's feet: same chroma as the white
+    // backdrop, darker — the old rescue kept it and TRELLIS grew a slab.
+    for (int y = 161; y <= 185; ++y)
+        for (int x = 20; x <= 110; ++x)
+            f.img.setPixel(x, y, qRgb(170, 170, 170));
+
+    BackgroundRemover::applyUniformBackgroundRescue(f.img, f.alpha);
+    EXPECT_EQ(f.a(60, 175), 0.0f);    // shadow stays background
+    EXPECT_EQ(f.a(105, 170), 0.0f);
+}
+
+TEST(BackgroundRemoverTest, RescueIgnoresDisconnectedBlob)
+{
+    RescueFixture f;
+    // A strongly-colored watermark/logo far from the subject: chroma passes,
+    // but it is not connected to the saliency foreground.
+    for (int y = 15; y <= 40; ++y)
+        for (int x = 150; x <= 190; ++x)
+            f.img.setPixel(x, y, qRgb(200, 40, 40));
+
+    BackgroundRemover::applyUniformBackgroundRescue(f.img, f.alpha);
+    EXPECT_EQ(f.a(170, 25), 0.0f);    // disconnected blob dropped
+}
+
+TEST(BackgroundRemoverTest, RescueAbortsWhenItWouldFloodTheFrame)
+{
+    RescueFixture f;
+    // Corners agree (white — the panel stays clear of all four 24px corner
+    // patches) but the "background" isn't uniform after all: a huge colored
+    // panel touches the body. Rescuing it would hand the 3D generation a
+    // backdrop slab — the safety valve must bail out instead.
+    for (int y = 30; y <= 165; ++y)
+        for (int x = 91; x <= 190; ++x)
+            f.img.setPixel(x, y, qRgb(80, 160, 90));
+
+    BackgroundRemover::applyUniformBackgroundRescue(f.img, f.alpha);
+    EXPECT_EQ(f.a(150, 120), 0.0f);   // panel not rescued
+    EXPECT_EQ(f.a(60, 120), 1.0f);    // body untouched
+}
+
+TEST(BackgroundRemoverTest, RescueSkipsBusyBackground)
+{
+    RescueFixture f;
+    // Make the corners disagree — no reliable background color, no rescue.
+    for (int y = 0; y < 30; ++y)
+        for (int x = 0; x < 30; ++x)
+            f.img.setPixel(x, y, qRgb(200, 30, 30));
+    // A missed limb that WOULD be rescued on a uniform backdrop.
+    for (int y = 100; y <= 110; ++y)
+        for (int x = 91; x <= 170; ++x)
+            f.img.setPixel(x, y, qRgb(40, 60, 200));
+
+    BackgroundRemover::applyUniformBackgroundRescue(f.img, f.alpha);
+    EXPECT_EQ(f.a(160, 105), 0.0f);   // gate closed → alpha untouched
+}

--- a/src/ImageTo3D/BackgroundRemover_test.cpp
+++ b/src/ImageTo3D/BackgroundRemover_test.cpp
@@ -118,13 +118,34 @@ TEST(BackgroundRemoverTest, RescueIgnoresDropShadow)
     RescueFixture f;
     // A gray drop shadow touching the body's feet: same chroma as the white
     // backdrop, darker — the old rescue kept it and TRELLIS grew a slab.
-    for (int y = 161; y <= 185; ++y)
-        for (int x = 20; x <= 110; ++x)
+    for (int y = 161; y <= 175; ++y)
+        for (int x = 30; x <= 105; ++x)
             f.img.setPixel(x, y, qRgb(170, 170, 170));
 
     BackgroundRemover::applyUniformBackgroundRescue(f.img, f.alpha);
     EXPECT_EQ(f.a(60, 175), 0.0f);    // shadow stays background
     EXPECT_EQ(f.a(105, 170), 0.0f);
+}
+
+TEST(BackgroundRemoverTest, RescueIgnoresDeepClippedShadow)
+{
+    RescueFixture f;
+    // A deep, near-clipped shadow (below the proportional-shading window,
+    // k >= 3.5) touching the body: achromatic on an achromatic backdrop is
+    // still shading, however dark. Dark GEOMETRY on a white backdrop is the
+    // saliency net's job — solid dark masses are salient.
+    for (int y = 161; y <= 175; ++y)
+        for (int x = 30; x <= 105; ++x)
+            f.img.setPixel(x, y, qRgb(45, 45, 45));
+
+    BackgroundRemover::applyUniformBackgroundRescue(f.img, f.alpha);
+    EXPECT_EQ(f.a(60, 175), 0.0f);    // deep shadow stays background
+    // A CHROMATIC dark limb at the same depth is still rescued.
+    for (int y = 100; y <= 110; ++y)
+        for (int x = 91; x <= 170; ++x)
+            f.img.setPixel(x, y, qRgb(20, 25, 90));
+    BackgroundRemover::applyUniformBackgroundRescue(f.img, f.alpha);
+    EXPECT_EQ(f.a(160, 105), 1.0f);
 }
 
 TEST(BackgroundRemoverTest, RescueIgnoresDisconnectedBlob)

--- a/website/src/hooks/useQtmeshActionRef.js
+++ b/website/src/hooks/useQtmeshActionRef.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 const QTMESH_RELEASES_LATEST_API = 'https://api.github.com/repos/fernandotonon/QtMeshEditor/releases/latest';
-const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.37.3';
+const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.37.4';
 const CACHE_KEY = 'qtmesh.actionRef.cache.v1';
 const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 


### PR DESCRIPTION
## Problem (3.37.3 field reports)
Generated models came out **very bright** and often grew a **flat block**. Root cause: the #978 uniform-background rescue re-matted the whole frame against the corner-patch color — any pixel differing by ~28 RGB units was marked foreground. Drop shadows, vignettes, and backdrop gradients all exceed that, so the backdrop was kept: TRELLIS.2 reconstructed it as a slab, and its bright pixels bled into the texture bake (bbox crop also collapsed to the whole frame, shrinking the subject's token share).

## Fix
The rescue is tightened to its actual purpose — recovering thin appendages the U²-Net saliency missed:
- **Shading rejection**: a pixel that is a brightness-scaled version of the background color (shadow / vignette / lighting falloff) stays background; only a chroma difference marks geometry.
- **Connectivity**: rescue regions must be 8-connected to the existing U²-Net foreground (a missed arm touches the body; a watermark or gradient blob does not).
- **Safety valve**: a rescue that would flood >30% of the frame bails out entirely.

Extracted as `BackgroundRemover::applyUniformBackgroundRescue` (pure, compiled in every build) + 5 headless unit tests (limb rescued / shadow ignored / disconnected blob ignored / flood aborts / busy background skips).

## Verification
- All `BackgroundRemoverTest` cases pass locally.
- End-to-end on the T-pose goblin (the image that originally lost an arm, on a noisy gray vignetted backdrop): generated with **both arms, no backdrop slab, normal colors** (fast preset, bundled trellis-cli, Metal).

Bumps version to 3.37.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved background removal to recover connected foreground details, such as thin limbs, on uniform backgrounds.
  * Better ignores shadows, disconnected objects, busy backgrounds, and overly large regions that could cause incorrect results.

* **Documentation**
  * Updated reproducible-build guidance and action examples to version 3.37.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->