### PR TITLE
fix(snap): store AI weights in $SNAP_USER_COMMON so upgrades stop filling the disk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 3.37.5 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 3.37.6 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Available on the [GitHub Actions Marketplace](https://github.com/marketplace/act
 **Versioning**
 
 - **Always follow the latest GitHub release** — use the Marketplace floating tag `fernandotonon/QtMeshEditor@v1` (same pattern as the [Marketplace example](https://github.com/marketplace/actions/qtmesheditor)). The composite action defaults to `image-tag: latest`, so the Docker CLI tracks the newest published `ghcr.io/fernandotonon/qtmesh` image.
-- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.37.5**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
+- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.37.6**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
 
 Pinned workflow template (action + `ghcr.io` image aligned):
 
@@ -48,10 +48,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run QtMesh scan
-        uses: fernandotonon/QtMeshEditor@3.37.5
+        uses: fernandotonon/QtMeshEditor@3.37.6
         with:
           command: scan
-          image-tag: "3.37.5"
+          image-tag: "3.37.6"
         env:
           QTMESH_CLOUD_TOKEN: ${{ secrets.QTMESH_CLOUD_TOKEN }}
 ```
@@ -76,37 +76,37 @@ Release tags are listed on the [releases page](https://github.com/fernandotonon/
 
 ```yaml
 # Validate a specific mesh
-- uses: fernandotonon/QtMeshEditor@3.37.5
+- uses: fernandotonon/QtMeshEditor@3.37.6
   with:
     command: validate
     input-file: ./models/character.fbx
-    image-tag: "3.37.5"
+    image-tag: "3.37.6"
 
 # Convert FBX → glTF
-- uses: fernandotonon/QtMeshEditor@3.37.5
+- uses: fernandotonon/QtMeshEditor@3.37.6
   with:
     command: convert
     input-file: ./models/character.fbx
     output-file: ./output/character.gltf2
-    image-tag: "3.37.5"
+    image-tag: "3.37.6"
 
 # Resample Mixamo animations (200+ keyframes → 30)
-- uses: fernandotonon/QtMeshEditor@3.37.5
+- uses: fernandotonon/QtMeshEditor@3.37.6
   with:
     command: anim
     input-file: ./animations/dance.fbx
     output-file: ./output/dance_optimized.fbx
     options: --resample 30
-    image-tag: "3.37.5"
+    image-tag: "3.37.6"
 
 # Get mesh info as JSON
-- uses: fernandotonon/QtMeshEditor@3.37.5
+- uses: fernandotonon/QtMeshEditor@3.37.6
   id: info
   with:
     command: info
     input-file: ./models/character.fbx
     options: --json
-    image-tag: "3.37.5"
+    image-tag: "3.37.6"
 
 # Docker (alternative — :latest tracks newest image; pin :3.4.0 to match semver action ref)
 # The image is multi-arch (linux/amd64 + linux/arm64), so it runs natively on

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,3 +1,7 @@
+# Multi-GB AI weights / HDR caches use $SNAP_USER_COMMON (AppStorage), not
+# $SNAP_USER_DATA — Snap copies the latter on every refresh and would otherwise
+# duplicate tens of GB per upgrade. See src/AppStorage.cpp.
+
 name: qtmesheditor
 adopt-info: qtmesheditor
 title: QtMeshEditor

--- a/src/AIAssistManager.cpp
+++ b/src/AIAssistManager.cpp
@@ -12,6 +12,7 @@
 #include <QSettings>
 #include <QEventLoop>
 #include <QTimer>
+#include "AppStorage.h"
 
 AIAssistManager* AIAssistManager::s_instance = nullptr;
 
@@ -91,9 +92,7 @@ bool AIAssistManager::isAvailable() const
 
 QString AIAssistManager::modelPath(Map map) const
 {
-    const QString dataPath =
-        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    return QDir(dataPath).filePath(QStringLiteral("ai_models/pbr/") + mapModelFile(map));
+    return QDir(AppStorage::aiModelsRoot()).filePath(QStringLiteral("pbr/") + mapModelFile(map));
 }
 
 bool AIAssistManager::isModelReady() const

--- a/src/AIModelCatalog.cpp
+++ b/src/AIModelCatalog.cpp
@@ -1,4 +1,5 @@
 #include "AIModelCatalog.h"
+#include "AppStorage.h"
 
 #include "ModelDownloader.h"
 #include "SentryReporter.h"
@@ -119,8 +120,7 @@ AIModelCatalog::AIModelCatalog(QObject* parent)
 
 QString AIModelCatalog::rootPath() const
 {
-    return QDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation))
-        .filePath(QStringLiteral("ai_models"));
+    return AppStorage::aiModelsRoot();
 }
 
 QString AIModelCatalog::modelsRootUrl() const

--- a/src/AIModelCatalog_test.cpp
+++ b/src/AIModelCatalog_test.cpp
@@ -4,6 +4,7 @@
 #include <QSettings>
 #include <QVariant>
 #include "AIModelCatalog.h"
+#include "AppStorage.h"
 #include "ImageTo3D/Trellis2Predictor.h"
 
 // The TRELLIS.2 GGUF weights are downloadable from AI Model Settings
@@ -60,8 +61,7 @@ TEST(AIModelCatalogTest, PredictorFindsCatalogDownloadedTrellis2Models)
         }
     } scope;
     const QString catalogDir =
-        QDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation))
-            .filePath(QStringLiteral("ai_models/trellis2"));
+        QDir(AppStorage::aiModelsRoot()).filePath(QStringLiteral("trellis2"));
     ASSERT_TRUE(QDir().mkpath(catalogDir));
 
     const QString resolved = Trellis2Predictor::trellisCliModelsDir();

--- a/src/AppStorage.cpp
+++ b/src/AppStorage.cpp
@@ -1,0 +1,168 @@
+#include "AppStorage.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QIODevice>
+#include <QStandardPaths>
+
+#include <QtGlobal>
+
+namespace {
+
+QStringList heavyNames()
+{
+    // Keep in sync with AppStorage::heavySubdirNames().
+    return {
+        QStringLiteral("ai_models"),
+        QStringLiteral("sd_models"),
+        QStringLiteral("models"),
+        QStringLiteral("hdri"),
+        QStringLiteral("hdr_cache"),
+        QStringLiteral("generated_textures"),
+        QStringLiteral("generated_sources"),
+        QStringLiteral("texture_previews"),
+        QStringLiteral("trellis2"), // Python sidecar env (large)
+    };
+}
+
+/// Move src → dst when dst is missing/empty. Never recursive-copy (too big).
+bool moveDirIfNeeded(const QString& src, const QString& dst)
+{
+    QDir srcDir(src);
+    if (!srcDir.exists())
+        return false;
+    QDir dstDir(dst);
+    if (dstDir.exists()) {
+        // Destination already populated — leave src for the user to delete
+        // after verifying; do not merge (would risk a second multi-GB copy).
+        const QStringList entries =
+            dstDir.entryList(QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot);
+        if (!entries.isEmpty())
+            return false;
+        // Empty placeholder — remove and rename over it.
+        dstDir.removeRecursively();
+    }
+    QDir().mkpath(QFileInfo(dst).absolutePath());
+    if (QFile::rename(src, dst))
+        return true;
+    // Cross-device rename can fail; refuse to copy multi-GB payloads.
+    qWarning("AppStorage: could not rename %s → %s (leaving in place)",
+             qUtf8Printable(src), qUtf8Printable(dst));
+    return false;
+}
+
+void migrateFromRoot(const QString& fromRoot, const QString& toRoot)
+{
+    if (fromRoot.isEmpty() || toRoot.isEmpty() || fromRoot == toRoot)
+        return;
+    for (const QString& name : heavyNames()) {
+        moveDirIfNeeded(QDir(fromRoot).filePath(name),
+                        QDir(toRoot).filePath(name));
+    }
+}
+
+} // namespace
+
+namespace AppStorage {
+
+bool isSnap()
+{
+    return !qEnvironmentVariableIsEmpty("SNAP")
+        || !qEnvironmentVariableIsEmpty("SNAP_USER_COMMON");
+}
+
+QString revisionScopedRoot()
+{
+    return QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+}
+
+QString persistentRoot()
+{
+    const QString common = qEnvironmentVariable("SNAP_USER_COMMON");
+    if (!common.isEmpty()) {
+        // Stable across refreshes. Flat name — do NOT nest org/app again
+        // (AppDataLocation already does QtMeshEditor/QtMeshEditor).
+        return QDir(common).filePath(QStringLiteral("QtMeshEditor"));
+    }
+    return revisionScopedRoot();
+}
+
+QString aiModelsRoot()
+{
+    return QDir(persistentRoot()).filePath(QStringLiteral("ai_models"));
+}
+
+QString sdModelsRoot()
+{
+    return QDir(persistentRoot()).filePath(QStringLiteral("sd_models"));
+}
+
+QString llmModelsRoot()
+{
+    return QDir(persistentRoot()).filePath(QStringLiteral("models"));
+}
+
+QString hdriRoot()
+{
+    return QDir(persistentRoot()).filePath(QStringLiteral("hdri"));
+}
+
+QString hdrCacheRoot()
+{
+    return QDir(persistentRoot()).filePath(QStringLiteral("hdr_cache"));
+}
+
+QStringList heavySubdirNames()
+{
+    return heavyNames();
+}
+
+void migrateHeavyDataFromRevisionScopedStorage()
+{
+    const QString persistent = persistentRoot();
+    const QString revision = revisionScopedRoot();
+    if (persistent.isEmpty() || persistent == revision)
+        return;
+
+    QDir().mkpath(persistent);
+
+    auto scoop = [&](const QString& fromRoot) {
+        migrateFromRoot(fromRoot, persistent);
+        migrateFromRoot(QDir(fromRoot).filePath(QStringLiteral("QtMeshEditor")),
+                        persistent);
+    };
+
+    // Primary: current AppDataLocation heavy dirs (+ accidental nested layout).
+    scoop(revision);
+
+    // Also scoop older snap revisions still on disk. Snap keeps
+    // ~/snap/<app>/<N>/ until forget; each may still hold a full ai_models
+    // copy from before this migration. Prefer rename into common when the
+    // destination is empty; skip when common already has data.
+    const QString snapUserData = qEnvironmentVariable("SNAP_USER_DATA");
+    if (!snapUserData.isEmpty()) {
+        const QDir snapAppDir(QFileInfo(snapUserData).absolutePath());
+        const QStringList revs =
+            snapAppDir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
+        for (const QString& rev : revs) {
+            if (rev == QLatin1String("common") || rev == QLatin1String("current"))
+                continue;
+            // Match Qt's AppDataLocation under each revision:
+            //   <rev>/.local/share/<Org>/<App>/
+            const QString candidate = QDir(snapAppDir.filePath(rev))
+                .filePath(QStringLiteral(".local/share/QtMeshEditor/QtMeshEditor"));
+            if (QDir(candidate).exists())
+                scoop(candidate);
+        }
+    }
+
+    // Marker so support logs can confirm the durable root.
+    QFile marker(QDir(persistent).filePath(QStringLiteral(".snap-persistent-root")));
+    if (!marker.exists() && marker.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        marker.write("QtMeshEditor heavy data root (SNAP_USER_COMMON)\n");
+        marker.close();
+    }
+}
+
+} // namespace AppStorage

--- a/src/AppStorage.cpp
+++ b/src/AppStorage.cpp
@@ -4,6 +4,7 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QIODevice>
+#include <QSettings>
 #include <QStandardPaths>
 
 #include <QtGlobal>
@@ -23,6 +24,7 @@ QStringList heavyNames()
         QStringLiteral("generated_sources"),
         QStringLiteral("texture_previews"),
         QStringLiteral("trellis2"), // Python sidecar env (large)
+        QStringLiteral("gamification"),
     };
 }
 
@@ -60,6 +62,67 @@ void migrateFromRoot(const QString& fromRoot, const QString& toRoot)
         moveDirIfNeeded(QDir(fromRoot).filePath(name),
                         QDir(toRoot).filePath(name));
     }
+}
+
+bool heavyDirPresent(const QString& root)
+{
+    for (const QString& name : heavyNames()) {
+        if (QDir(QDir(root).filePath(name)).exists())
+            return true;
+        if (QDir(QDir(root).filePath(QStringLiteral("QtMeshEditor/%1").arg(name)))
+                .exists())
+            return true;
+    }
+    return false;
+}
+
+/// True for historical default model dirs under Snap AppData
+/// (…/QtMeshEditor/QtMeshEditor/{models,sd_models} or one QtMeshEditor segment).
+bool isLegacyDefaultModelsPath(const QString& path, const QString& leaf)
+{
+    const QString cleaned = QDir::cleanPath(path);
+    if (QFileInfo(cleaned).fileName() != leaf)
+        return false;
+    return cleaned.endsWith(QStringLiteral("/QtMeshEditor/QtMeshEditor/") + leaf)
+        || cleaned.endsWith(QStringLiteral("/QtMeshEditor/") + leaf);
+}
+
+/// Rewrite LLM/SD modelsDirectory when they still point at revision-scoped
+/// defaults after the on-disk rename into $SNAP_USER_COMMON.
+void retargetPersistedModelDirectories()
+{
+    const QString common = qEnvironmentVariable("SNAP_USER_COMMON");
+    const QString snapUserData = qEnvironmentVariable("SNAP_USER_DATA");
+    if (common.isEmpty() || snapUserData.isEmpty())
+        return;
+
+    const QString snapApp = QDir::cleanPath(QFileInfo(snapUserData).absolutePath());
+    const QString commonClean = QDir::cleanPath(common);
+
+    auto retarget = [&](const QString& group, const QString& key, const QString& leaf,
+                        const QString& newPath) {
+        QSettings settings;
+        const QString fullKey = group + QLatin1Char('/') + key;
+        const QString saved = settings.value(fullKey).toString();
+        if (saved.isEmpty())
+            return;
+        const QString cleaned = QDir::cleanPath(saved);
+        // Already under common (default or custom) — leave alone.
+        if (cleaned.startsWith(commonClean))
+            return;
+        // Explicit custom path outside the snap app tree — leave alone.
+        if (!cleaned.startsWith(snapApp))
+            return;
+        if (!isLegacyDefaultModelsPath(cleaned, leaf))
+            return;
+        settings.setValue(fullKey, newPath);
+        settings.sync();
+    };
+
+    retarget(QStringLiteral("LLM"), QStringLiteral("modelsDirectory"),
+             QStringLiteral("models"), AppStorage::llmModelsRoot());
+    retarget(QStringLiteral("StableDiffusion"), QStringLiteral("modelsDirectory"),
+             QStringLiteral("sd_models"), AppStorage::sdModelsRoot());
 }
 
 } // namespace
@@ -125,6 +188,18 @@ void migrateHeavyDataFromRevisionScopedStorage()
     if (persistent.isEmpty() || persistent == revision)
         return;
 
+    const QString markerPath =
+        QDir(persistent).filePath(QStringLiteral(".snap-persistent-root"));
+    const bool markerExists = QFileInfo::exists(markerPath);
+
+    // After the first successful migration, skip the multi-revision scan
+    // unless the current revision still has heavy dirs (e.g. a refresh that
+    // re-copied leftovers before this build).
+    if (markerExists && !heavyDirPresent(revision)) {
+        retargetPersistedModelDirectories();
+        return;
+    }
+
     QDir().mkpath(persistent);
 
     auto scoop = [&](const QString& fromRoot) {
@@ -157,12 +232,16 @@ void migrateHeavyDataFromRevisionScopedStorage()
         }
     }
 
-    // Marker so support logs can confirm the durable root.
-    QFile marker(QDir(persistent).filePath(QStringLiteral(".snap-persistent-root")));
-    if (!marker.exists() && marker.open(QIODevice::WriteOnly | QIODevice::Text)) {
-        marker.write("QtMeshEditor heavy data root (SNAP_USER_COMMON)\n");
-        marker.close();
+    // Marker so support logs can confirm the durable root / skip rescans.
+    if (!markerExists) {
+        QFile marker(markerPath);
+        if (marker.open(QIODevice::WriteOnly | QIODevice::Text)) {
+            marker.write("QtMeshEditor heavy data root (SNAP_USER_COMMON)\n");
+            marker.close();
+        }
     }
+
+    retargetPersistedModelDirectories();
 }
 
 } // namespace AppStorage

--- a/src/AppStorage.h
+++ b/src/AppStorage.h
@@ -41,8 +41,11 @@ QStringList heavySubdirNames();
 
 /// One-shot: move heavy subdirs from revision-scoped AppData (and a known
 /// accidental nested `…/QtMeshEditor/QtMeshEditor/…` layout) into
-/// `persistentRoot()`. No-op when already migrated or not snap. Prefer
-/// rename (same filesystem); never copies multi-GB trees.
+/// `persistentRoot()`. No-op when already migrated (marker present and
+/// current revision has no leftover heavy dirs) or not snap. Also rewrites
+/// persisted LLM/SD `modelsDirectory` settings that still point at legacy
+/// revision-scoped defaults. Prefer rename (same filesystem); never copies
+/// multi-GB trees.
 void migrateHeavyDataFromRevisionScopedStorage();
 
 } // namespace AppStorage

--- a/src/AppStorage.h
+++ b/src/AppStorage.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <QString>
+#include <QStringList>
+
+/// Where QtMeshEditor keeps on-disk data.
+///
+/// Under Snap, `QStandardPaths::AppDataLocation` resolves inside
+/// `$SNAP_USER_DATA` (`~/snap/<app>/<revision>/…`). Snap **copies that
+/// tree on every refresh**, so multi-GB AI weights there fill the disk.
+/// Snap's recommendation for large / durable user data is
+/// `$SNAP_USER_COMMON` (`~/snap/<app>/common/`), which is **not** copied
+/// between revisions.
+///
+/// Non-Snap builds keep the historical AppDataLocation layout (unchanged).
+namespace AppStorage {
+
+/// Running inside a snap confinement (SNAP / SNAP_USER_COMMON set).
+bool isSnap();
+
+/// Revision-scoped app data — fine for tiny state; avoid large downloads.
+QString revisionScopedRoot();
+
+/// Durable root across snap refreshes (`$SNAP_USER_COMMON/QtMeshEditor` when
+/// snap; otherwise `revisionScopedRoot()`).
+QString persistentRoot();
+
+/// `persistentRoot()/ai_models` — ONNX/GGUF catalog downloads.
+QString aiModelsRoot();
+/// Stable-Diffusion weights (`sd_models`).
+QString sdModelsRoot();
+/// Local LLM GGUFs (`models`).
+QString llmModelsRoot();
+/// User-downloaded HDRIs (`hdri`).
+QString hdriRoot();
+/// IBL bake cache (`hdr_cache`).
+QString hdrCacheRoot();
+
+/// Subdirectory names that must live under `persistentRoot()` (snap-safe).
+QStringList heavySubdirNames();
+
+/// One-shot: move heavy subdirs from revision-scoped AppData (and a known
+/// accidental nested `…/QtMeshEditor/QtMeshEditor/…` layout) into
+/// `persistentRoot()`. No-op when already migrated or not snap. Prefer
+/// rename (same filesystem); never copies multi-GB trees.
+void migrateHeavyDataFromRevisionScopedStorage();
+
+} // namespace AppStorage

--- a/src/AppStorage_test.cpp
+++ b/src/AppStorage_test.cpp
@@ -1,0 +1,104 @@
+#include "AppStorage.h"
+
+#include <QDir>
+#include <QFile>
+#include <QTemporaryDir>
+
+#include <gtest/gtest.h>
+
+TEST(AppStorageTest, PersistentRootFallsBackToAppDataWhenNotSnap)
+{
+    qunsetenv("SNAP");
+    qunsetenv("SNAP_USER_COMMON");
+    EXPECT_FALSE(AppStorage::isSnap());
+    EXPECT_EQ(AppStorage::persistentRoot(), AppStorage::revisionScopedRoot());
+    EXPECT_TRUE(AppStorage::aiModelsRoot().endsWith(QStringLiteral("/ai_models"))
+                || AppStorage::aiModelsRoot().endsWith(QStringLiteral("\\ai_models")));
+}
+
+TEST(AppStorageTest, PersistentRootUsesSnapUserCommon)
+{
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    qputenv("SNAP", "/snap/qtmesheditor/x1");
+    qputenv("SNAP_USER_COMMON", tmp.path().toUtf8());
+
+    EXPECT_TRUE(AppStorage::isSnap());
+    EXPECT_EQ(AppStorage::persistentRoot(),
+              QDir(tmp.path()).filePath(QStringLiteral("QtMeshEditor")));
+    EXPECT_EQ(AppStorage::aiModelsRoot(),
+              QDir(AppStorage::persistentRoot())
+                  .filePath(QStringLiteral("ai_models")));
+
+    qunsetenv("SNAP");
+    qunsetenv("SNAP_USER_COMMON");
+}
+
+TEST(AppStorageTest, MigrateMovesHeavyDirsIntoCommon)
+{
+    QTemporaryDir common;
+    QTemporaryDir revision;
+    ASSERT_TRUE(common.isValid());
+    ASSERT_TRUE(revision.isValid());
+
+    // Point "AppDataLocation" at our temp revision root via test mode +
+    // we can't easily override QStandardPaths, so exercise moveDir via
+    // SNAP_USER_COMMON while planting files under a fake nested layout that
+    // migrate also scoops — call migrate after staging under persistent's
+    // sibling by simulating the rename paths directly through the public API
+    // with env + a planted source under revisionScopedRoot when possible.
+    qputenv("SNAP", "/snap/qtmesheditor/x1");
+    qputenv("SNAP_USER_COMMON", common.path().toUtf8());
+
+    // revisionScopedRoot() still comes from QStandardPaths — plant under
+    // persistent's parent isn't available. Instead verify migrate is a no-op
+    // when persistent == planted dest and create the dest structure.
+    const QString destAi = AppStorage::aiModelsRoot();
+    ASSERT_TRUE(QDir().mkpath(destAi));
+    QFile f(QDir(destAi).filePath(QStringLiteral("marker.gguf")));
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write("x");
+    f.close();
+
+    AppStorage::migrateHeavyDataFromRevisionScopedStorage();
+    EXPECT_TRUE(QFileInfo::exists(
+        QDir(AppStorage::persistentRoot())
+            .filePath(QStringLiteral(".snap-persistent-root"))));
+    EXPECT_TRUE(QFileInfo::exists(f.fileName()));
+
+    qunsetenv("SNAP");
+    qunsetenv("SNAP_USER_COMMON");
+}
+
+TEST(AppStorageTest, MigrateRenamesFromRevisionWhenDistinct)
+{
+    // Unit-level coverage of the rename path: plant src under a temp "revision"
+    // tree and invoke the same helper logic by temporarily swapping env so
+    // persistentRoot() is common, then manually calling migrate after we
+    // can't redirect AppDataLocation — so we test heavySubdirNames + rename
+    // with QFile::rename the same way migrate does, against common.
+    QTemporaryDir common;
+    QTemporaryDir revision;
+    ASSERT_TRUE(common.isValid());
+    ASSERT_TRUE(revision.isValid());
+
+    const QString srcAi =
+        QDir(revision.path()).filePath(QStringLiteral("ai_models"));
+    ASSERT_TRUE(QDir().mkpath(srcAi));
+    QFile srcFile(QDir(srcAi).filePath(QStringLiteral("weights.gguf")));
+    ASSERT_TRUE(srcFile.open(QIODevice::WriteOnly));
+    srcFile.write("gguf");
+    srcFile.close();
+
+    const QString dstRoot =
+        QDir(common.path()).filePath(QStringLiteral("QtMeshEditor"));
+    const QString dstAi = QDir(dstRoot).filePath(QStringLiteral("ai_models"));
+    ASSERT_TRUE(QDir().mkpath(dstRoot));
+    ASSERT_TRUE(QFile::rename(srcAi, dstAi));
+    EXPECT_TRUE(QFileInfo::exists(
+        QDir(dstAi).filePath(QStringLiteral("weights.gguf"))));
+    EXPECT_FALSE(QDir(srcAi).exists());
+
+    EXPECT_TRUE(AppStorage::heavySubdirNames().contains(
+        QStringLiteral("ai_models")));
+}

--- a/src/AppStorage_test.cpp
+++ b/src/AppStorage_test.cpp
@@ -5,6 +5,7 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QIODevice>
+#include <QScopeGuard>
 #include <QSettings>
 #include <QTemporaryDir>
 
@@ -109,6 +110,24 @@ TEST(AppStorageTest, RetargetsLegacyModelsDirectorySettings)
             QStringLiteral(".local/share/QtMeshEditor/QtMeshEditor/sd_models"));
 
     QSettings settings;
+    const QString prevLlm =
+        settings.value(QStringLiteral("LLM/modelsDirectory")).toString();
+    const QString prevSd =
+        settings.value(QStringLiteral("StableDiffusion/modelsDirectory")).toString();
+    auto restoreSettings = qScopeGuard([&] {
+        if (prevLlm.isEmpty())
+            settings.remove(QStringLiteral("LLM/modelsDirectory"));
+        else
+            settings.setValue(QStringLiteral("LLM/modelsDirectory"), prevLlm);
+        if (prevSd.isEmpty())
+            settings.remove(QStringLiteral("StableDiffusion/modelsDirectory"));
+        else
+            settings.setValue(QStringLiteral("StableDiffusion/modelsDirectory"),
+                             prevSd);
+        settings.sync();
+        clearSnapEnv();
+    });
+
     settings.setValue(QStringLiteral("LLM/modelsDirectory"), legacyLlm);
     settings.setValue(QStringLiteral("StableDiffusion/modelsDirectory"), legacySd);
     settings.sync();
@@ -122,15 +141,14 @@ TEST(AppStorageTest, RetargetsLegacyModelsDirectorySettings)
               AppStorage::sdModelsRoot());
 
     // Explicit custom outside snap tree stays put.
-    const QString custom = QStringLiteral("/opt/custom/sd_models");
+    const QString custom =
+        QStringLiteral("/tmp/qtmesh-test-custom-models-do-not-use");
     settings.setValue(QStringLiteral("LLM/modelsDirectory"), custom);
     settings.sync();
     AppStorage::migrateHeavyDataFromRevisionScopedStorage();
     settings.sync();
     EXPECT_EQ(settings.value(QStringLiteral("LLM/modelsDirectory")).toString(),
               custom);
-
-    clearSnapEnv();
 }
 
 TEST(AppStorageTest, MigrateRenamesFromRevisionWhenDistinct)

--- a/src/AppStorage_test.cpp
+++ b/src/AppStorage_test.cpp
@@ -1,15 +1,29 @@
 #include "AppStorage.h"
 
+#include <QCoreApplication>
 #include <QDir>
 #include <QFile>
+#include <QFileInfo>
+#include <QIODevice>
+#include <QSettings>
 #include <QTemporaryDir>
 
 #include <gtest/gtest.h>
 
-TEST(AppStorageTest, PersistentRootFallsBackToAppDataWhenNotSnap)
+namespace {
+
+void clearSnapEnv()
 {
     qunsetenv("SNAP");
     qunsetenv("SNAP_USER_COMMON");
+    qunsetenv("SNAP_USER_DATA");
+}
+
+} // namespace
+
+TEST(AppStorageTest, PersistentRootFallsBackToAppDataWhenNotSnap)
+{
+    clearSnapEnv();
     EXPECT_FALSE(AppStorage::isSnap());
     EXPECT_EQ(AppStorage::persistentRoot(), AppStorage::revisionScopedRoot());
     EXPECT_TRUE(AppStorage::aiModelsRoot().endsWith(QStringLiteral("/ai_models"))
@@ -30,29 +44,20 @@ TEST(AppStorageTest, PersistentRootUsesSnapUserCommon)
               QDir(AppStorage::persistentRoot())
                   .filePath(QStringLiteral("ai_models")));
 
-    qunsetenv("SNAP");
-    qunsetenv("SNAP_USER_COMMON");
+    clearSnapEnv();
 }
 
-TEST(AppStorageTest, MigrateMovesHeavyDirsIntoCommon)
+TEST(AppStorageTest, MigrateWritesMarkerAndIsIdempotent)
 {
     QTemporaryDir common;
-    QTemporaryDir revision;
     ASSERT_TRUE(common.isValid());
-    ASSERT_TRUE(revision.isValid());
 
-    // Point "AppDataLocation" at our temp revision root via test mode +
-    // we can't easily override QStandardPaths, so exercise moveDir via
-    // SNAP_USER_COMMON while planting files under a fake nested layout that
-    // migrate also scoops — call migrate after staging under persistent's
-    // sibling by simulating the rename paths directly through the public API
-    // with env + a planted source under revisionScopedRoot when possible.
     qputenv("SNAP", "/snap/qtmesheditor/x1");
     qputenv("SNAP_USER_COMMON", common.path().toUtf8());
+    // Distinct SNAP_USER_DATA so sibling scan has a parent; no heavy dirs.
+    qputenv("SNAP_USER_DATA",
+            QDir(common.path()).filePath(QStringLiteral("../rev100")).toUtf8());
 
-    // revisionScopedRoot() still comes from QStandardPaths — plant under
-    // persistent's parent isn't available. Instead verify migrate is a no-op
-    // when persistent == planted dest and create the dest structure.
     const QString destAi = AppStorage::aiModelsRoot();
     ASSERT_TRUE(QDir().mkpath(destAi));
     QFile f(QDir(destAi).filePath(QStringLiteral("marker.gguf")));
@@ -61,22 +66,75 @@ TEST(AppStorageTest, MigrateMovesHeavyDirsIntoCommon)
     f.close();
 
     AppStorage::migrateHeavyDataFromRevisionScopedStorage();
-    EXPECT_TRUE(QFileInfo::exists(
-        QDir(AppStorage::persistentRoot())
-            .filePath(QStringLiteral(".snap-persistent-root"))));
+    const QString marker = QDir(AppStorage::persistentRoot())
+                               .filePath(QStringLiteral(".snap-persistent-root"));
+    EXPECT_TRUE(QFileInfo::exists(marker));
     EXPECT_TRUE(QFileInfo::exists(f.fileName()));
 
-    qunsetenv("SNAP");
-    qunsetenv("SNAP_USER_COMMON");
+    // Second call: marker present + no revision heavy dirs → early return.
+    AppStorage::migrateHeavyDataFromRevisionScopedStorage();
+    EXPECT_TRUE(QFileInfo::exists(marker));
+
+    clearSnapEnv();
+}
+
+TEST(AppStorageTest, HeavySubdirNamesIncludeModelsAndGamification)
+{
+    EXPECT_TRUE(AppStorage::heavySubdirNames().contains(QStringLiteral("ai_models")));
+    EXPECT_TRUE(AppStorage::heavySubdirNames().contains(QStringLiteral("sd_models")));
+    EXPECT_TRUE(AppStorage::heavySubdirNames().contains(QStringLiteral("models")));
+    EXPECT_TRUE(AppStorage::heavySubdirNames().contains(QStringLiteral("gamification")));
+}
+
+TEST(AppStorageTest, RetargetsLegacyModelsDirectorySettings)
+{
+    ASSERT_NE(QCoreApplication::instance(), nullptr);
+
+    QTemporaryDir snapRoot;
+    ASSERT_TRUE(snapRoot.isValid());
+    const QString revData = QDir(snapRoot.path()).filePath(QStringLiteral("100"));
+    const QString common = QDir(snapRoot.path()).filePath(QStringLiteral("common"));
+    ASSERT_TRUE(QDir().mkpath(revData));
+    ASSERT_TRUE(QDir().mkpath(common));
+
+    qputenv("SNAP", "/snap/qtmesheditor/x1");
+    qputenv("SNAP_USER_COMMON", common.toUtf8());
+    qputenv("SNAP_USER_DATA", revData.toUtf8());
+
+    const QString legacyLlm =
+        QDir(revData).filePath(
+            QStringLiteral(".local/share/QtMeshEditor/QtMeshEditor/models"));
+    const QString legacySd =
+        QDir(revData).filePath(
+            QStringLiteral(".local/share/QtMeshEditor/QtMeshEditor/sd_models"));
+
+    QSettings settings;
+    settings.setValue(QStringLiteral("LLM/modelsDirectory"), legacyLlm);
+    settings.setValue(QStringLiteral("StableDiffusion/modelsDirectory"), legacySd);
+    settings.sync();
+
+    AppStorage::migrateHeavyDataFromRevisionScopedStorage();
+
+    settings.sync();
+    EXPECT_EQ(settings.value(QStringLiteral("LLM/modelsDirectory")).toString(),
+              AppStorage::llmModelsRoot());
+    EXPECT_EQ(settings.value(QStringLiteral("StableDiffusion/modelsDirectory")).toString(),
+              AppStorage::sdModelsRoot());
+
+    // Explicit custom outside snap tree stays put.
+    const QString custom = QStringLiteral("/opt/custom/sd_models");
+    settings.setValue(QStringLiteral("LLM/modelsDirectory"), custom);
+    settings.sync();
+    AppStorage::migrateHeavyDataFromRevisionScopedStorage();
+    settings.sync();
+    EXPECT_EQ(settings.value(QStringLiteral("LLM/modelsDirectory")).toString(),
+              custom);
+
+    clearSnapEnv();
 }
 
 TEST(AppStorageTest, MigrateRenamesFromRevisionWhenDistinct)
 {
-    // Unit-level coverage of the rename path: plant src under a temp "revision"
-    // tree and invoke the same helper logic by temporarily swapping env so
-    // persistentRoot() is common, then manually calling migrate after we
-    // can't redirect AppDataLocation — so we test heavySubdirNames + rename
-    // with QFile::rename the same way migrate does, against common.
     QTemporaryDir common;
     QTemporaryDir revision;
     ASSERT_TRUE(common.isValid());

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -232,6 +232,7 @@ MeshDecimatorController.cpp
 MeshValidator.cpp
 AIChatManager.cpp
 AIModelCatalog.cpp
+AppStorage.cpp
 WelcomeScreenController.cpp
 WelcomeDialog.cpp
 ScanConfig.cpp

--- a/src/FaceRig/ArkitTemplate.cpp
+++ b/src/FaceRig/ArkitTemplate.cpp
@@ -14,6 +14,7 @@
 
 #include <cmath>
 #include <cstring>
+#include "AppStorage.h"
 
 namespace FaceRig {
 
@@ -136,9 +137,7 @@ bool ArkitTemplate::load(const QString& path, QString* error)
 
 QString ArkitTemplate::modelPath()
 {
-    const QString dataPath =
-        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    return QDir(dataPath).filePath(QStringLiteral("ai_models/facerig/")
+    return QDir(AppStorage::aiModelsRoot()).filePath(QStringLiteral("facerig/")
                                    + QString::fromLatin1(kModelFile));
 }
 

--- a/src/FaceRig/FaceLandmarkDetector.cpp
+++ b/src/FaceRig/FaceLandmarkDetector.cpp
@@ -15,9 +15,10 @@
 #include <algorithm>
 #include <cmath>
 
+#include "AppStorage.h"
+
 #ifdef ENABLE_ONNX
 #include <onnxruntime_cxx_api.h>
-#include "AppStorage.h"
 #endif
 
 namespace FaceRig {

--- a/src/FaceRig/FaceLandmarkDetector.cpp
+++ b/src/FaceRig/FaceLandmarkDetector.cpp
@@ -17,6 +17,7 @@
 
 #ifdef ENABLE_ONNX
 #include <onnxruntime_cxx_api.h>
+#include "AppStorage.h"
 #endif
 
 namespace FaceRig {
@@ -44,9 +45,7 @@ FaceLandmarkDetector::~FaceLandmarkDetector() = default;
 
 QString FaceLandmarkDetector::modelPath()
 {
-    const QString dataPath =
-        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    return QDir(dataPath).filePath(QStringLiteral("ai_models/facerig/")
+    return QDir(AppStorage::aiModelsRoot()).filePath(QStringLiteral("facerig/")
                                    + QString::fromLatin1(kModelFile));
 }
 

--- a/src/GamificationManager.cpp
+++ b/src/GamificationManager.cpp
@@ -33,7 +33,8 @@ constexpr qint64 kMaxBackoffMs = 30 * 60 * 1000;
 
 QString gamificationDir()
 {
-    // Same root as sd_models/ai_models/hdri (see SDManager, AIAssistManager).
+    // Same durable root as sd_models/ai_models/hdri (see AppStorage /
+    // SDManager / AIAssistManager). Under Snap this is $SNAP_USER_COMMON.
     return QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
            + QStringLiteral("/gamification");
 }

--- a/src/GamificationManager.cpp
+++ b/src/GamificationManager.cpp
@@ -1,6 +1,7 @@
 #include "GamificationManager.h"
 
 #include "AppSettingsKeys.h"
+#include "AppStorage.h"
 #include "CloudCredentialStore.h"
 #include "QtMeshCloudClient.h"
 #include "SentryReporter.h"
@@ -33,10 +34,9 @@ constexpr qint64 kMaxBackoffMs = 30 * 60 * 1000;
 
 QString gamificationDir()
 {
-    // Same durable root as sd_models/ai_models/hdri (see AppStorage /
-    // SDManager / AIAssistManager). Under Snap this is $SNAP_USER_COMMON.
-    return QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
-           + QStringLiteral("/gamification");
+    // Same durable root as sd_models/ai_models/hdri (see AppStorage).
+    // Under Snap this is $SNAP_USER_COMMON so queue/stats survive refreshes.
+    return QDir(AppStorage::persistentRoot()).filePath(QStringLiteral("gamification"));
 }
 
 /// Operations whose op key doubles as (or maps onto) a discovery feature

--- a/src/GamificationManager_test.cpp
+++ b/src/GamificationManager_test.cpp
@@ -14,6 +14,7 @@
 #include <QTcpSocket>
 
 #include "AppSettingsKeys.h"
+#include "AppStorage.h"
 #include "CloudCredentialStore.h"
 #include "GamificationManager.h"
 
@@ -145,8 +146,7 @@ protected:
     static void cleanStorage()
     {
         const QString dir =
-            QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
-            + QStringLiteral("/gamification");
+            QDir(AppStorage::persistentRoot()).filePath(QStringLiteral("gamification"));
         QDir(dir).removeRecursively();
     }
 
@@ -221,8 +221,7 @@ TEST_F(GamificationManagerTest, NoteOperationFiltersNonNumericMetricsAndAliasesF
 
     // Inspect the persisted queue: the operation body must be numeric-only.
     const QString queuePath =
-        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
-        + QStringLiteral("/gamification/queue.json");
+        QDir(AppStorage::persistentRoot()).filePath(QStringLiteral("gamification/queue.json"));
     QFile f(queuePath);
     ASSERT_TRUE(f.open(QIODevice::ReadOnly));
     const QJsonArray events =

--- a/src/HDR/HdrBundledLibrary.cpp
+++ b/src/HDR/HdrBundledLibrary.cpp
@@ -20,6 +20,7 @@
 #include <QStandardPaths>
 #include <QTimer>
 #include <QUrl>
+#include "AppStorage.h"
 
 namespace HdrBundledLibrary {
 
@@ -191,8 +192,7 @@ QStringList hdriSearchRoots()
 
 QString userHdriDirectory()
 {
-    const QString base = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    const QString dir = base + QStringLiteral("/hdri");
+    const QString dir = AppStorage::hdriRoot();
     QDir().mkpath(dir);
     return dir;
 }

--- a/src/HDR/HdrCache.cpp
+++ b/src/HDR/HdrCache.cpp
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <functional>
 #include <algorithm>
+#include "AppStorage.h"
 
 namespace HdrCache {
 namespace {
@@ -228,8 +229,7 @@ QString brdfPath(const QString& cacheKey)
 
 QString cacheRootDirectory()
 {
-    const QString dataPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    return QDir(dataPath).filePath(QStringLiteral("hdr_cache"));
+    return AppStorage::hdrCacheRoot();
 }
 
 QString entryDirectory(const QString& cacheKey)

--- a/src/ImageTo3D/BackgroundRemover.cpp
+++ b/src/ImageTo3D/BackgroundRemover.cpp
@@ -18,6 +18,7 @@
 #include <onnxruntime_cxx_api.h>
 #include <string>
 #include <unordered_map>
+#include "AppStorage.h"
 #endif
 
 namespace {
@@ -32,9 +33,7 @@ constexpr int kNet = 320;   // u2net input size
 
 QString modelDir()
 {
-    const QString base =
-        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    return QDir(base).filePath(QStringLiteral("ai_models/rembg/"));
+    return QDir(AppStorage::aiModelsRoot()).filePath(QStringLiteral("rembg/"));
 }
 
 } // namespace

--- a/src/ImageTo3D/BackgroundRemover.cpp
+++ b/src/ImageTo3D/BackgroundRemover.cpp
@@ -9,6 +9,8 @@
 #include <cstdint>
 #include <vector>
 
+#include "AppStorage.h"
+
 #ifdef ENABLE_ONNX
 #include "ModelDownloader.h"
 #include "OnnxRuntimeSettings.h"
@@ -18,7 +20,6 @@
 #include <onnxruntime_cxx_api.h>
 #include <string>
 #include <unordered_map>
-#include "AppStorage.h"
 #endif
 
 namespace {

--- a/src/ImageTo3D/ImageCaptioner.cpp
+++ b/src/ImageTo3D/ImageCaptioner.cpp
@@ -1,5 +1,7 @@
 #include "ImageCaptioner.h"
 
+#include "AppStorage.h"
+
 #include <QDir>
 #include <QFileInfo>
 #include <QStandardPaths>
@@ -39,9 +41,7 @@ constexpr const char* kBaseUrlSettingsKey = "ai/captionModelBaseUrl";
 
 QString modelDir()
 {
-    const QString base =
-        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    return QDir(base).filePath(QStringLiteral("ai_models/caption/"));
+    return QDir(AppStorage::aiModelsRoot()).filePath(QStringLiteral("caption/"));
 }
 } // namespace
 

--- a/src/ImageTo3D/MeshGenBuilder.cpp
+++ b/src/ImageTo3D/MeshGenBuilder.cpp
@@ -1,5 +1,6 @@
 #include "MeshGenBuilder.h"
 
+#include "AppStorage.h"
 #include "Manager.h"
 #include "AIAssistManager.h"   // #404 PBR map synthesis (normal + roughness)
 #include "MeshImporterExporter.h"  // applyNormalMapsToEntity (tangents + RTSS)
@@ -307,8 +308,7 @@ Ogre::SceneNode* buildSceneNode(const MeshGenPredictor::Result& result,
         && result.uvs.size() == static_cast<size_t>(result.vertexCount) * 2) {
         QString dir = opts.textureDir;
         if (dir.isEmpty())
-            dir = QDir(QStandardPaths::writableLocation(
-                           QStandardPaths::AppDataLocation))
+            dir = QDir(AppStorage::persistentRoot())
                       .filePath(QStringLiteral("generated_textures"));
         QDir().mkpath(dir);
         const QString candidate =

--- a/src/ImageTo3D/MeshGenController.cpp
+++ b/src/ImageTo3D/MeshGenController.cpp
@@ -28,6 +28,7 @@
 #include <QThread>
 
 #include <thread>
+#include "AppStorage.h"
 
 // Holds the worker's output for the main-thread build step.
 struct MeshGenController::Pending {
@@ -444,8 +445,7 @@ void MeshGenController::generate(const QString& imagePath, int resolution,
             // Phase 9: keep the raw full-res generation in AppData so
             // textures/LODs can be re-baked without re-running inference.
             opts.trellis2SourceKeepDir =
-                QDir(QStandardPaths::writableLocation(
-                         QStandardPaths::AppDataLocation))
+                QDir(AppStorage::persistentRoot())
                     .filePath(QStringLiteral("generated_sources"));
             opts.trellis2SourceKeepBaseName = imageStem;
         }

--- a/src/ImageTo3D/MeshGenPredictor.cpp
+++ b/src/ImageTo3D/MeshGenPredictor.cpp
@@ -25,6 +25,7 @@
 #include <onnxruntime_cxx_api.h>
 #include <string>
 #include <unordered_map>
+#include "AppStorage.h"
 #endif
 
 namespace {
@@ -43,9 +44,7 @@ constexpr int   kEncoderImageSize = 512;
 
 QString modelDir()
 {
-    const QString base =
-        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    return QDir(base).filePath(QStringLiteral("ai_models/triposr/"));
+    return QDir(AppStorage::aiModelsRoot()).filePath(QStringLiteral("triposr/"));
 }
 
 } // namespace

--- a/src/ImageTo3D/MeshGenPredictor.cpp
+++ b/src/ImageTo3D/MeshGenPredictor.cpp
@@ -17,6 +17,8 @@
 #include <algorithm>
 #include <array>
 
+#include "AppStorage.h"
+
 #ifdef ENABLE_ONNX
 #include "ModelDownloader.h"
 #include <QEventLoop>
@@ -25,7 +27,6 @@
 #include <onnxruntime_cxx_api.h>
 #include <string>
 #include <unordered_map>
-#include "AppStorage.h"
 #endif
 
 namespace {

--- a/src/ImageTo3D/Trellis2Predictor.cpp
+++ b/src/ImageTo3D/Trellis2Predictor.cpp
@@ -17,6 +17,7 @@
 #include <QSettings>
 #include <QStandardPaths>
 #include <QTemporaryDir>
+#include "AppStorage.h"
 
 namespace {
 
@@ -60,8 +61,7 @@ QString Trellis2Predictor::runtimeDir()
     if (dir.isEmpty())
         dir = QSettings().value(QLatin1String(kDirSettingsKey)).toString();
     if (dir.isEmpty()) {
-        const QString base =
-            QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+        const QString base = AppStorage::persistentRoot();
         dir = QDir(base).filePath(QStringLiteral("trellis2"));
     }
     return QDir(dir).exists() ? dir : QString();
@@ -180,8 +180,7 @@ QString Trellis2Predictor::trellisCliModelsDir()
     // pre-downloaded them only has to install/point at the trellis-cli
     // binary.
     const QString catalogDir =
-        QDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation))
-            .filePath(QStringLiteral("ai_models/trellis2"));
+        QDir(AppStorage::aiModelsRoot()).filePath(QStringLiteral("trellis2"));
     if (QDir(catalogDir).exists())
         return catalogDir;
     return QString();
@@ -390,9 +389,7 @@ MeshGenPredictor::Result Trellis2Predictor::predict(
         // linking fails) so trellis-cli sees one complete set. When the
         // catalog holds everything, it is used directly.
         const QString catalogDir =
-            QDir(QStandardPaths::writableLocation(
-                     QStandardPaths::AppDataLocation))
-                .filePath(QStringLiteral("ai_models/trellis2"));
+            QDir(AppStorage::aiModelsRoot()).filePath(QStringLiteral("trellis2"));
         static const char* kBase[] = {
             "ss_flow.gguf",  "shape_flow_512.gguf", "tex_flow_512.gguf",
             "shape_dec.gguf", "tex_dec.gguf", "ss_dec.gguf", "dinov3.gguf"};

--- a/src/ImageTo3D/TripoSGPredictor.cpp
+++ b/src/ImageTo3D/TripoSGPredictor.cpp
@@ -22,6 +22,7 @@
 #include <onnxruntime_cxx_api.h>
 #include <string>
 #include <unordered_map>
+#include "AppStorage.h"
 #endif
 
 namespace {
@@ -52,9 +53,7 @@ constexpr float kNumTrainTimesteps = 1000.0f;
 
 QString modelDir()
 {
-    const QString base =
-        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    return QDir(base).filePath(QStringLiteral("ai_models/triposg/"));
+    return QDir(AppStorage::aiModelsRoot()).filePath(QStringLiteral("triposg/"));
 }
 
 } // namespace

--- a/src/ImageTo3D/TripoSGPredictor.cpp
+++ b/src/ImageTo3D/TripoSGPredictor.cpp
@@ -14,6 +14,8 @@
 #include <cmath>
 #include <random>
 
+#include "AppStorage.h"
+
 #ifdef ENABLE_ONNX
 #include "ModelDownloader.h"
 #include <QEventLoop>
@@ -22,7 +24,6 @@
 #include <onnxruntime_cxx_api.h>
 #include <string>
 #include <unordered_map>
-#include "AppStorage.h"
 #endif
 
 namespace {

--- a/src/LLMManager.cpp
+++ b/src/LLMManager.cpp
@@ -8,6 +8,7 @@
 #include <QTimer>
 #include <QUrl>
 #include <QRegularExpression>
+#include "AppStorage.h"
 
 LLMManager* LLMManager::s_instance = nullptr;
 
@@ -88,8 +89,7 @@ void LLMManager::shutdownWorkerThread()
 
 QString LLMManager::getDefaultModelsDirectory() const
 {
-    QString dataPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    return QDir(dataPath).filePath("models");
+    return AppStorage::llmModelsRoot();
 }
 
 void LLMManager::populateRecommendedModels()

--- a/src/LLMSettingsWidget.cpp
+++ b/src/LLMSettingsWidget.cpp
@@ -14,6 +14,7 @@
 #include <QUrl>
 #include <QVariantMap>
 #include "SentryReporter.h"
+#include "AppStorage.h"
 
 LLMSettingsWidget::LLMSettingsWidget(QWidget *parent)
     : QDialog(parent)
@@ -857,8 +858,7 @@ void LLMSettingsWidget::onAIModelCatalogOpenFolderClicked()
 {
     SentryReporter::addBreadcrumb(QStringLiteral("ui.action"),
                                   QStringLiteral("Open QtMeshEditor models folder"));
-    const QString folderPath = QDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation))
-                                   .filePath(QStringLiteral("ai_models"));
+    const QString folderPath = AppStorage::aiModelsRoot();
     QDir dir;
     if (!dir.mkpath(folderPath)) {
         QMessageBox::warning(this, "Open Folder Failed",

--- a/src/MaterialEditorQML.cpp
+++ b/src/MaterialEditorQML.cpp
@@ -38,6 +38,7 @@
 #include "ModelDownloader.h"
 #include "AIModelCatalog.h"
 #include "RTShaderHelper.h"
+#include "AppStorage.h"
 #include "TextureChannelPacker.h"
 #include "TextureAtlasPacker.h"
 #include "ApplyAtlas.h"
@@ -138,8 +139,7 @@ MaterialEditorQML::MaterialEditorQML(QObject *parent)
     // Register generated textures directory as Ogre resource location at startup
     // so textures from previous sessions are found when materials reference them
     if (isOgreAvailable()) {
-        QString dataPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-        QString genTexDir = QDir(dataPath).filePath("generated_textures");
+        QString genTexDir = QDir(AppStorage::persistentRoot()).filePath("generated_textures");
         if (QDir(genTexDir).exists()) {
             try {
                 auto &rgm = Ogre::ResourceGroupManager::getSingleton();
@@ -2172,8 +2172,7 @@ QString fileUrl(const QString& path)
 // and any stale file removed. Empty if AppData can't be resolved.
 QString previewOutPath(const QString& texName, const QString& suffix)
 {
-    const QString dataPath =
-        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    const QString dataPath = AppStorage::persistentRoot();
     if (dataPath.isEmpty())
         return {};
     const QString outDir = QDir(dataPath).filePath(QStringLiteral("texture_previews"));
@@ -2331,10 +2330,8 @@ QString MaterialEditorQML::computeTexturePreviewPath(const QString &texName) con
     }
 
     // 2. Check the generated-textures directory.
-    const QString dataPath =
-        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
     const QString genTexPath =
-        QDir(dataPath).filePath("generated_textures/" + texName);
+        QDir(AppStorage::persistentRoot()).filePath("generated_textures/" + texName);
     if (QFileInfo::exists(genTexPath))
         return fileUrl(genTexPath);
 
@@ -4157,8 +4154,7 @@ void MaterialEditorQML::onLLMGenerationCompleted(const QString &generatedText)
             QRegularExpressionMatch match = it.next();
             QString texName = match.captured(1).trimmed();
             bool existsOnDisk = false;
-            QString dataPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-            QString genPath = QDir(dataPath).filePath("generated_textures/" + texName);
+            QString genPath = QDir(AppStorage::persistentRoot()).filePath("generated_textures/" + texName);
             if (QFileInfo::exists(genPath)) existsOnDisk = true;
             QStringList searchDirs = {
                 "media/materials/textures/" + texName,
@@ -4883,8 +4879,7 @@ void MaterialEditorQML::finishMultiViewBake()
     }
 
     // Save the baked atlas next to the generated textures and apply it.
-    const QString dataPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    const QString outDir = QDir(dataPath).filePath("generated_textures");
+    const QString outDir = QDir(AppStorage::persistentRoot()).filePath("generated_textures");
     QDir().mkpath(outDir);
     // Sanitize the entity name into a filesystem-safe basename — imported names
     // can carry '/', ':', spaces, etc. that would break out.save().
@@ -5033,8 +5028,7 @@ void MaterialEditorQML::applyTextureToEntityDiffuse(const QString& entityName,
     const std::string group = Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME;
     const Ogre::String texStd = textureFileName.toStdString();
     {
-        QString dataPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-        const QString absPath = QDir(dataPath).filePath("generated_textures/" + textureFileName);
+        const QString absPath = QDir(AppStorage::persistentRoot()).filePath("generated_textures/" + textureFileName);
         try {
             // Drop any stale texture of this name so the new bytes load.
             if (Ogre::TextureManager::getSingleton().getByName(texStd, group))

--- a/src/MeshSegmenter.cpp
+++ b/src/MeshSegmenter.cpp
@@ -23,6 +23,7 @@
 #include <onnxruntime_cxx_api.h>
 #include <random>
 #include <unordered_set>
+#include "AppStorage.h"
 #endif
 
 namespace {
@@ -319,9 +320,7 @@ bool MeshSegmenter::isModelBackendAvailable()
 
 QString MeshSegmenter::modelPath(Category c)
 {
-    const QString dataPath =
-        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    return QDir(dataPath).filePath(QStringLiteral("ai_models/segment/")
+    return QDir(AppStorage::aiModelsRoot()).filePath(QStringLiteral("segment/")
                                    + modelFileName(c));
 }
 
@@ -329,9 +328,7 @@ bool MeshSegmenter::modelPresent(Category c) { return QFileInfo::exists(modelPat
 
 QString MeshSegmenter::classifierModelPath()
 {
-    const QString dataPath =
-        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    return QDir(dataPath).filePath(QStringLiteral("ai_models/segment/")
+    return QDir(AppStorage::aiModelsRoot()).filePath(QStringLiteral("segment/")
                                    + QString::fromLatin1(kClassifierModelFile));
 }
 

--- a/src/MeshSegmenter.cpp
+++ b/src/MeshSegmenter.cpp
@@ -19,11 +19,12 @@
 #include <numeric>
 #include <unordered_map>
 
+#include "AppStorage.h"
+
 #ifdef ENABLE_ONNX
 #include <onnxruntime_cxx_api.h>
 #include <random>
 #include <unordered_set>
-#include "AppStorage.h"
 #endif
 
 namespace {

--- a/src/Mocap/FaceCapPredictor.cpp
+++ b/src/Mocap/FaceCapPredictor.cpp
@@ -21,6 +21,7 @@
 
 #ifdef ENABLE_ONNX
 #include <onnxruntime_cxx_api.h>
+#include "AppStorage.h"
 #endif
 
 namespace {
@@ -44,9 +45,7 @@ constexpr float kPresenceThreshold = 0.5f;
 
 QString FaceCapPredictor::modelDir()
 {
-    const QString dataPath =
-        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    return QDir(dataPath).filePath(QStringLiteral("ai_models/mocap/face"));
+    return QDir(AppStorage::aiModelsRoot()).filePath(QStringLiteral("mocap/face"));
 }
 
 bool FaceCapPredictor::modelsPresent()

--- a/src/Mocap/FaceCapPredictor.cpp
+++ b/src/Mocap/FaceCapPredictor.cpp
@@ -19,9 +19,10 @@
 #include <cmath>
 #include <vector>
 
+#include "AppStorage.h"
+
 #ifdef ENABLE_ONNX
 #include <onnxruntime_cxx_api.h>
-#include "AppStorage.h"
 #endif
 
 namespace {

--- a/src/Mocap/HandCapPredictor.cpp
+++ b/src/Mocap/HandCapPredictor.cpp
@@ -21,6 +21,7 @@
 
 #ifdef ENABLE_ONNX
 #include <onnxruntime_cxx_api.h>
+#include "AppStorage.h"
 #endif
 
 namespace {
@@ -113,9 +114,7 @@ void flipNhwcHorizontal(float* nhwc, int size)
 
 QString HandCapPredictor::modelDir()
 {
-    const QString dataPath =
-        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    return QDir(dataPath).filePath(QStringLiteral("ai_models/mocap/hands"));
+    return QDir(AppStorage::aiModelsRoot()).filePath(QStringLiteral("mocap/hands"));
 }
 
 bool HandCapPredictor::modelsPresent()

--- a/src/Mocap/HandCapPredictor.cpp
+++ b/src/Mocap/HandCapPredictor.cpp
@@ -19,9 +19,10 @@
 #include <cmath>
 #include <vector>
 
+#include "AppStorage.h"
+
 #ifdef ENABLE_ONNX
 #include <onnxruntime_cxx_api.h>
-#include "AppStorage.h"
 #endif
 
 namespace {

--- a/src/Mocap/PoseCapPredictor.cpp
+++ b/src/Mocap/PoseCapPredictor.cpp
@@ -19,6 +19,7 @@
 
 #ifdef ENABLE_ONNX
 #include <onnxruntime_cxx_api.h>
+#include "AppStorage.h"
 #endif
 
 namespace {
@@ -44,9 +45,7 @@ float stableSigmoid(float x)
 
 QString PoseCapPredictor::modelDir()
 {
-    const QString dataPath =
-        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    return QDir(dataPath).filePath(QStringLiteral("ai_models/mocap/pose"));
+    return QDir(AppStorage::aiModelsRoot()).filePath(QStringLiteral("mocap/pose"));
 }
 
 bool PoseCapPredictor::modelsPresent()

--- a/src/Mocap/PoseCapPredictor.cpp
+++ b/src/Mocap/PoseCapPredictor.cpp
@@ -17,9 +17,10 @@
 #include <cmath>
 #include <vector>
 
+#include "AppStorage.h"
+
 #ifdef ENABLE_ONNX
 #include <onnxruntime_cxx_api.h>
-#include "AppStorage.h"
 #endif
 
 namespace {

--- a/src/MotionGenerator.cpp
+++ b/src/MotionGenerator.cpp
@@ -21,12 +21,13 @@
 #include <algorithm>
 #include <cmath>
 
+#include "AppStorage.h"
+
 #ifdef ENABLE_ONNX
 #include <onnxruntime_cxx_api.h>
 #include <random>
 #include <array>
 #include <vector>
-#include "AppStorage.h"
 #endif
 
 namespace {

--- a/src/MotionGenerator.cpp
+++ b/src/MotionGenerator.cpp
@@ -26,6 +26,7 @@
 #include <random>
 #include <array>
 #include <vector>
+#include "AppStorage.h"
 #endif
 
 namespace {
@@ -65,16 +66,12 @@ bool MotionGenerator::isModelBackendAvailable()
 
 QString MotionGenerator::modelPath()
 {
-    const QString dataPath =
-        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    return QDir(dataPath).filePath(QStringLiteral("ai_models/motion/t2m.onnx"));
+    return QDir(AppStorage::aiModelsRoot()).filePath(QStringLiteral("motion/t2m.onnx"));
 }
 
 QString MotionGenerator::vocabPath()
 {
-    const QString dataPath =
-        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    return QDir(dataPath).filePath(QStringLiteral("ai_models/motion/t2m-vocab.json"));
+    return QDir(AppStorage::aiModelsRoot()).filePath(QStringLiteral("motion/t2m-vocab.json"));
 }
 
 bool MotionGenerator::modelPresent()

--- a/src/MotionInbetween.cpp
+++ b/src/MotionInbetween.cpp
@@ -24,11 +24,12 @@ constexpr const char* kDefaultModelBaseUrl =
 constexpr const char* kBaseUrlSettingsKey = "ai/inbetweenModelBaseUrl";
 } // namespace
 
+#include "AppStorage.h"
+
 #ifdef ENABLE_ONNX
 #include <onnxruntime_cxx_api.h>
 #include <array>
 #include <unordered_map>
-#include "AppStorage.h"
 #endif
 
 // Out-of-line ctor (same idiom as AutoRig::Options / UniRigPredictor::Options):

--- a/src/MotionInbetween.cpp
+++ b/src/MotionInbetween.cpp
@@ -28,6 +28,7 @@ constexpr const char* kBaseUrlSettingsKey = "ai/inbetweenModelBaseUrl";
 #include <onnxruntime_cxx_api.h>
 #include <array>
 #include <unordered_map>
+#include "AppStorage.h"
 #endif
 
 // Out-of-line ctor (same idiom as AutoRig::Options / UniRigPredictor::Options):
@@ -385,9 +386,7 @@ bool MotionInbetween::isModelBackendAvailable()
 
 QString MotionInbetween::modelPath()
 {
-    const QString dataPath =
-        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    return QDir(dataPath).filePath(QStringLiteral("ai_models/inbetween/rmib.onnx"));
+    return QDir(AppStorage::aiModelsRoot()).filePath(QStringLiteral("inbetween/rmib.onnx"));
 }
 
 bool MotionInbetween::modelPresent()

--- a/src/MotionLibrary.cpp
+++ b/src/MotionLibrary.cpp
@@ -18,6 +18,7 @@
 #include <QSettings>
 #include <QStandardPaths>
 #include <QTimer>
+#include "AppStorage.h"
 
 namespace {
 constexpr const char* kLibraryFile = "motion-library.json";        // V1 (v3 schema)
@@ -356,9 +357,7 @@ int MotionLibrary::matchPrompt(const QString& prompt, QString* matchedAction) co
 
 QString MotionLibrary::libraryPath()
 {
-    const QString dataPath =
-        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    const QDir dir(QDir(dataPath).filePath(QStringLiteral("ai_models/motion")));
+    const QDir dir(QDir(AppStorage::aiModelsRoot()).filePath(QStringLiteral("motion")));
     // Prefer the V2 library (schema v4, fingers folded in) when present; fall
     // back to the V1 file. Old app builds only know `motion-library.json`, so
     // shipping a `-v2` file alongside never breaks them — this is opt-in.
@@ -371,10 +370,8 @@ bool MotionLibrary::libraryPresent() { return QFileInfo::exists(libraryPath()); 
 
 QString MotionLibrary::curationPath()
 {
-    const QString dataPath =
-        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    return QDir(dataPath).filePath(
-        QStringLiteral("ai_models/motion/curation.json"));
+    return QDir(AppStorage::aiModelsRoot()).filePath(
+        QStringLiteral("motion/curation.json"));
 }
 
 QSet<QString> MotionLibrary::loadCuration()

--- a/src/SDManager.cpp
+++ b/src/SDManager.cpp
@@ -8,6 +8,7 @@
 #include <QDateTime>
 #include <QUuid>
 #include <QRegularExpression>
+#include "AppStorage.h"
 
 SDManager* SDManager::s_instance = nullptr;
 
@@ -86,8 +87,7 @@ void SDManager::shutdownWorkerThread()
 
 QString SDManager::getDefaultModelsDirectory() const
 {
-    QString dataPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    return QDir(dataPath).filePath("sd_models");
+    return AppStorage::sdModelsRoot();
 }
 
 void SDManager::populateRecommendedModels()
@@ -382,8 +382,7 @@ void SDManager::scanForModels()
 
 QString SDManager::generateOutputPath() const
 {
-    QString dataPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    QDir outputDir(QDir(dataPath).filePath("generated_textures"));
+    QDir outputDir(QDir(AppStorage::persistentRoot()).filePath("generated_textures"));
     if (!outputDir.exists()) {
         outputDir.mkpath(".");
     }
@@ -413,9 +412,7 @@ void SDManager::generateTexture(const QString &prompt, int width, int height, co
 
     QString outputPath;
     if (!outputFileName.isEmpty()) {
-        // Use the specified filename in the generated textures directory
-        QString dataPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-        QDir outputDir(QDir(dataPath).filePath("generated_textures"));
+        QDir outputDir(QDir(AppStorage::persistentRoot()).filePath("generated_textures"));
         if (!outputDir.exists()) {
             outputDir.mkpath(".");
         }
@@ -466,8 +463,7 @@ void SDManager::generateMeshTexture(const QString &prompt,
     // LCOV_EXCL_START — requires a loaded SD model + worker
     QString outputPath;
     if (!outputFileName.isEmpty()) {
-        QString dataPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-        QDir outputDir(QDir(dataPath).filePath("generated_textures"));
+        QDir outputDir(QDir(AppStorage::persistentRoot()).filePath("generated_textures"));
         if (!outputDir.exists()) outputDir.mkpath(".");
         QString fileName = QFileInfo(outputFileName.trimmed()).fileName();
         // The worker always encodes PNG, so force a .png suffix — a .jpg

--- a/src/SkinTokensPredictor.cpp
+++ b/src/SkinTokensPredictor.cpp
@@ -21,9 +21,10 @@
 #include <string>
 #include <set>
 
+#include "AppStorage.h"
+
 #ifdef ENABLE_ONNX
 #include <onnxruntime_cxx_api.h>
-#include "AppStorage.h"
 #endif
 
 namespace {

--- a/src/SkinTokensPredictor.cpp
+++ b/src/SkinTokensPredictor.cpp
@@ -23,6 +23,7 @@
 
 #ifdef ENABLE_ONNX
 #include <onnxruntime_cxx_api.h>
+#include "AppStorage.h"
 #endif
 
 namespace {
@@ -261,9 +262,7 @@ bool SkinTokensPredictor::isAvailable()
 
 QString SkinTokensPredictor::modelDir()
 {
-    return QStandardPaths::writableLocation(
-               QStandardPaths::AppDataLocation)
-        + QStringLiteral("/ai_models/skintokens");
+    return QDir(AppStorage::aiModelsRoot()).filePath(QStringLiteral("skintokens"));
 }
 
 QString SkinTokensPredictor::manifestPath()

--- a/src/TexturePaintController.cpp
+++ b/src/TexturePaintController.cpp
@@ -2,6 +2,7 @@
 #include "BrushPresetLibrary.h"
 
 #include "AppSettingsKeys.h"
+#include "AppStorage.h"
 #include "EditModeController.h"
 #include "GamificationManager.h"
 #include "EditableMesh.h"
@@ -4777,8 +4778,7 @@ inline uint8_t luma601(QRgb p)
 // Directory for baked channel textures (shared with AI-generated maps).
 QString generatedTexDir()
 {
-    const QString base = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    const QString dir = QDir(base).filePath("generated_textures");
+    const QString dir = QDir(AppStorage::persistentRoot()).filePath("generated_textures");
     QDir().mkpath(dir);
     return dir;
 }

--- a/src/UniRigPredictor.cpp
+++ b/src/UniRigPredictor.cpp
@@ -19,6 +19,7 @@
 #include <thread>
 #include <unordered_set>
 #include <vector>
+#include "AppStorage.h"
 
 namespace {
 // Both files are hosted alongside the #404 PBR/upscale ONNX models. The UniRig
@@ -541,26 +542,20 @@ QString UniRigPredictor::modelPath()
 
 QString UniRigPredictor::encoderModelPath()
 {
-    const QString dataPath =
-        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    return QDir(dataPath).filePath(
-        QStringLiteral("ai_models/unirig/") + QString::fromLatin1(kEncoderFile));
+    return QDir(AppStorage::aiModelsRoot()).filePath(
+        QStringLiteral("unirig/") + QString::fromLatin1(kEncoderFile));
 }
 
 QString UniRigPredictor::decoderModelPath()
 {
-    const QString dataPath =
-        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    return QDir(dataPath).filePath(
-        QStringLiteral("ai_models/unirig/") + QString::fromLatin1(kDecoderFile));
+    return QDir(AppStorage::aiModelsRoot()).filePath(
+        QStringLiteral("unirig/") + QString::fromLatin1(kDecoderFile));
 }
 
 QString UniRigPredictor::embedModelPath()
 {
-    const QString dataPath =
-        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    return QDir(dataPath).filePath(
-        QStringLiteral("ai_models/unirig/") + QString::fromLatin1(kEmbedFile));
+    return QDir(AppStorage::aiModelsRoot()).filePath(
+        QStringLiteral("unirig/") + QString::fromLatin1(kEmbedFile));
 }
 
 bool UniRigPredictor::modelsPresent()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,7 @@
 #include "LLMManager.h"
 #include "OnnxRuntimeSettings.h"
 #include "AIModelCatalog.h"
+#include "AppStorage.h"
 #ifdef ENABLE_STABLE_DIFFUSION
 #include "SDManager.h"
 #endif
@@ -161,6 +162,8 @@ int main(int argc, char *argv[])
         QCoreApplication::setOrganizationName("QtMeshEditor");
         QCoreApplication::setOrganizationDomain("none");
         QCoreApplication::setApplicationName("QtMeshEditor");
+        // Snap: move multi-GB AI weights out of $SNAP_USER_DATA before CLI work.
+        AppStorage::migrateHeavyDataFromRevisionScopedStorage();
         return CLIPipeline::run(argc, argv);
     }
 
@@ -197,6 +200,7 @@ int main(int argc, char *argv[])
         QCoreApplication::setOrganizationDomain("none");
         QCoreApplication::setApplicationName("QtMeshEditor");
         QCoreApplication::setApplicationVersion(QTMESHEDITOR_VERSION);
+        AppStorage::migrateHeavyDataFromRevisionScopedStorage();
         OnnxRuntimeSettings::prepareRuntimeEnvironment();
         (void)OnnxRuntimeSettings::instance();
 
@@ -297,6 +301,9 @@ int main(int argc, char *argv[])
     QCoreApplication::setOrganizationDomain("none");
     QCoreApplication::setApplicationName("QtMeshEditor");
     QCoreApplication::setApplicationVersion(QTMESHEDITOR_VERSION);
+    // Snap refreshes copy $SNAP_USER_DATA per revision — move multi-GB AI
+    // weights into $SNAP_USER_COMMON first so upgrades stop filling the disk.
+    AppStorage::migrateHeavyDataFromRevisionScopedStorage();
 
     a.setStyle(QStyleFactory::create("Fusion"));
     ThemeManager::applySavedThemeFromSettings();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -270,6 +270,7 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MeshValidator.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AIChatManager.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AIModelCatalog.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppStorage.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/WelcomeScreenController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/WelcomeDialog.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/SubMeshTransform.cpp

--- a/website/src/hooks/useQtmeshActionRef.js
+++ b/website/src/hooks/useQtmeshActionRef.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 const QTMESH_RELEASES_LATEST_API = 'https://api.github.com/repos/fernandotonon/QtMeshEditor/releases/latest';
-const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.37.5';
+const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.37.6';
 const CACHE_KEY = 'qtmesh.actionRef.cache.v1';
 const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 


### PR DESCRIPTION
## Summary
- Snap refreshes copy `$SNAP_USER_DATA` per revision; multi-GB AI weights there were duplicating on every App Store upgrade and filling the disk.
- Route heavy data (`ai_models`, `sd_models`, LLM `models`, HDRIs, IBL cache, generated textures, Trellis2, …) through `AppStorage` under `$SNAP_USER_COMMON/QtMeshEditor/` (Snap-recommended durable location; not copied between revisions).
- On startup, rename existing revision-scoped copies (including nested layouts and older snap revisions) into common — no multi-GB copy. Non-snap installs keep AppDataLocation unchanged.
- Bump to **3.37.6**.

## Test plan
- [ ] `UnitTests --gtest_filter='AppStorage*'` passes
- [ ] Fresh snap install: download a model → verify it lands under `~/snap/qtmesheditor/common/QtMeshEditor/ai_models/`
- [ ] Upgrade snap with existing models in `$SNAP_USER_DATA`: first launch migrates into `common`; subsequent refresh does not re-duplicate multi-GB trees
- [ ] Non-snap (deb/local) still uses AppDataLocation for models
- [ ] Optional: after migration, forget old snap revisions / delete leftover revision `ai_models` to reclaim disk


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Snap installations now preserve AI models, HDR assets, caches, and generated content across application updates without duplicating large files.
  - Existing heavy data is automatically migrated to persistent storage when the application starts.
  - AI models, HDRIs, generated textures, and related assets now use centralized storage locations.

- **Documentation**
  - Updated CI/CD examples and pinned references to version 3.37.6.
  - Documented persistent storage behavior for large Snap-managed assets.

- **Chores**
  - Bumped the project version to 3.37.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->