### PR TITLE
fix(anim): picker star marking + deterministic side rule + Delete Skeleton; bump 3.37.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 3.37.5 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 3.37.6 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 3.37.4 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 3.37.5 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Available on the [GitHub Actions Marketplace](https://github.com/marketplace/act
 **Versioning**
 
 - **Always follow the latest GitHub release** — use the Marketplace floating tag `fernandotonon/QtMeshEditor@v1` (same pattern as the [Marketplace example](https://github.com/marketplace/actions/qtmesheditor)). The composite action defaults to `image-tag: latest`, so the Docker CLI tracks the newest published `ghcr.io/fernandotonon/qtmesh` image.
-- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.37.4**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
+- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.37.5**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
 
 Pinned workflow template (action + `ghcr.io` image aligned):
 
@@ -48,10 +48,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run QtMesh scan
-        uses: fernandotonon/QtMeshEditor@3.37.4
+        uses: fernandotonon/QtMeshEditor@3.37.5
         with:
           command: scan
-          image-tag: "3.37.4"
+          image-tag: "3.37.5"
         env:
           QTMESH_CLOUD_TOKEN: ${{ secrets.QTMESH_CLOUD_TOKEN }}
 ```
@@ -76,37 +76,37 @@ Release tags are listed on the [releases page](https://github.com/fernandotonon/
 
 ```yaml
 # Validate a specific mesh
-- uses: fernandotonon/QtMeshEditor@3.37.4
+- uses: fernandotonon/QtMeshEditor@3.37.5
   with:
     command: validate
     input-file: ./models/character.fbx
-    image-tag: "3.37.4"
+    image-tag: "3.37.5"
 
 # Convert FBX → glTF
-- uses: fernandotonon/QtMeshEditor@3.37.4
+- uses: fernandotonon/QtMeshEditor@3.37.5
   with:
     command: convert
     input-file: ./models/character.fbx
     output-file: ./output/character.gltf2
-    image-tag: "3.37.4"
+    image-tag: "3.37.5"
 
 # Resample Mixamo animations (200+ keyframes → 30)
-- uses: fernandotonon/QtMeshEditor@3.37.4
+- uses: fernandotonon/QtMeshEditor@3.37.5
   with:
     command: anim
     input-file: ./animations/dance.fbx
     output-file: ./output/dance_optimized.fbx
     options: --resample 30
-    image-tag: "3.37.4"
+    image-tag: "3.37.5"
 
 # Get mesh info as JSON
-- uses: fernandotonon/QtMeshEditor@3.37.4
+- uses: fernandotonon/QtMeshEditor@3.37.5
   id: info
   with:
     command: info
     input-file: ./models/character.fbx
     options: --json
-    image-tag: "3.37.4"
+    image-tag: "3.37.5"
 
 # Docker (alternative — :latest tracks newest image; pin :3.4.0 to match semver action ref)
 # The image is multi-arch (linux/amd64 + linux/arm64), so it runs natively on

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Available on the [GitHub Actions Marketplace](https://github.com/marketplace/act
 **Versioning**
 
 - **Always follow the latest GitHub release** — use the Marketplace floating tag `fernandotonon/QtMeshEditor@v1` (same pattern as the [Marketplace example](https://github.com/marketplace/actions/qtmesheditor)). The composite action defaults to `image-tag: latest`, so the Docker CLI tracks the newest published `ghcr.io/fernandotonon/qtmesh` image.
-- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.37.5**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
+- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.37.6**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
 
 Pinned workflow template (action + `ghcr.io` image aligned):
 
@@ -48,10 +48,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run QtMesh scan
-        uses: fernandotonon/QtMeshEditor@3.37.5
+        uses: fernandotonon/QtMeshEditor@3.37.6
         with:
           command: scan
-          image-tag: "3.37.5"
+          image-tag: "3.37.6"
         env:
           QTMESH_CLOUD_TOKEN: ${{ secrets.QTMESH_CLOUD_TOKEN }}
 ```
@@ -76,37 +76,37 @@ Release tags are listed on the [releases page](https://github.com/fernandotonon/
 
 ```yaml
 # Validate a specific mesh
-- uses: fernandotonon/QtMeshEditor@3.37.5
+- uses: fernandotonon/QtMeshEditor@3.37.6
   with:
     command: validate
     input-file: ./models/character.fbx
-    image-tag: "3.37.5"
+    image-tag: "3.37.6"
 
 # Convert FBX → glTF
-- uses: fernandotonon/QtMeshEditor@3.37.5
+- uses: fernandotonon/QtMeshEditor@3.37.6
   with:
     command: convert
     input-file: ./models/character.fbx
     output-file: ./output/character.gltf2
-    image-tag: "3.37.5"
+    image-tag: "3.37.6"
 
 # Resample Mixamo animations (200+ keyframes → 30)
-- uses: fernandotonon/QtMeshEditor@3.37.5
+- uses: fernandotonon/QtMeshEditor@3.37.6
   with:
     command: anim
     input-file: ./animations/dance.fbx
     output-file: ./output/dance_optimized.fbx
     options: --resample 30
-    image-tag: "3.37.5"
+    image-tag: "3.37.6"
 
 # Get mesh info as JSON
-- uses: fernandotonon/QtMeshEditor@3.37.5
+- uses: fernandotonon/QtMeshEditor@3.37.6
   id: info
   with:
     command: info
     input-file: ./models/character.fbx
     options: --json
-    image-tag: "3.37.5"
+    image-tag: "3.37.6"
 
 # Docker (alternative — :latest tracks newest image; pin :3.4.0 to match semver action ref)
 # The image is multi-arch (linux/amd64 + linux/arm64), so it runs natively on

--- a/qml/AnimationPickerDialog.qml
+++ b/qml/AnimationPickerDialog.qml
@@ -23,7 +23,9 @@ Window {
     // emitted after a successful apply so the panel can refresh its anim list
     signal applied(string animation, string entity)
 
-    property var allClips: []          // full [{index,action,name,source,quality,frames,approved}]
+    property var allClips: []          // full [{libIndex,action,name,source,quality,frames,approved}]
+                                       // (role is libIndex, NOT index — a role named
+                                       // "index" shadows the delegate's row index)
     property string filterText: ""
     property int busyIndex: -1         // row currently generating (for UI feedback)
     property bool onlyApproved: true   // curation filter: show only "good" clips
@@ -233,7 +235,7 @@ Window {
                                 id: applyBtn
                                 width: 58; height: 24; radius: 3
                                 anchors.verticalCenter: parent.verticalCenter
-                                property bool busy: dialog.busyIndex === model.index
+                                property bool busy: dialog.busyIndex === model.libIndex
                                 opacity: busy ? 0.5 : 1.0
                                 color: applyMa.pressed ? Qt.darker(PropertiesPanelController.highlightColor, 1.2)
                                      : applyMa.containsMouse ? Qt.lighter(PropertiesPanelController.highlightColor, 1.1)
@@ -244,7 +246,7 @@ Window {
                                 MouseArea {
                                     id: applyMa; anchors.fill: parent; hoverEnabled: true
                                     cursorShape: Qt.PointingHandCursor
-                                    onClicked: dialog.applyClip(model.index, model.name)
+                                    onClicked: dialog.applyClip(model.libIndex, model.name)
                                 }
                             }
                         }

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -3992,6 +3992,7 @@ Rectangle {
                     SkelToolButton { label: "Attach"; action: "attach" }
                     SkelToolButton { label: "Remove"; action: "remove" }
                     SkelToolButton { label: "Rename"; action: "rename" }
+                    SkelToolButton { label: "Delete Skeleton"; action: "removeSkeleton"; needsBone: false }
                 }
 
                 Text {
@@ -9835,6 +9836,17 @@ Rectangle {
             }
         } else if (action === "remove") {
             root.openRemoveBoneDialog()
+        } else if (action === "removeSkeleton") {
+            // Whole-rig removal (undoable): the mesh becomes a plain static
+            // mesh again, so Auto-Rig can regenerate the skeleton from
+            // scratch (Object-mode Rigging section reappears).
+            if (SkeletonEditor.removeSelectedSkeleton()) {
+                root.boneEditStatus =
+                    "Skeleton removed — use Auto-Rig to regenerate (Ctrl+Z restores)."
+            } else {
+                root.boneEditError = true
+                root.boneEditStatus = "Remove skeleton failed."
+            }
         } else if (action === "rename") {
             root.openRenameBoneDialog()
         }

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -2033,7 +2033,13 @@ QVariantList AnimationControlController::listMotionClips()
         const QString name = asset.isEmpty()
             ? actLabel : QStringLiteral("%1  (%2)").arg(actLabel, asset);
         QVariantMap m;
-        m["index"] = i;
+        // NOT "index": a ListModel role named "index" SHADOWS the delegate's
+        // built-in row index in QML (bare `index` and `model.index` both
+        // resolve to the role), which broke the picker — toggleApproved(row)
+        // received the library index and get(row) went out of range on any
+        // filtered list, so starring silently did nothing once "Only good ★"
+        // kicked in.
+        m["libIndex"] = i;
         m["action"] = c.action;
         m["name"] = name;
         m["source"] = c.source;

--- a/src/AnimationControlController.h
+++ b/src/AnimationControlController.h
@@ -362,9 +362,11 @@ public:
 
     /// List every clip in the template motion library for the animation
     /// PICKER (Mixamo-style browse). Each entry is a QVariantMap
-    /// { index, action, name, source, quality, frames } where `name` is a
-    /// human-readable label like "Walk (Tired Character)". Downloads the
-    /// library on first use (blocking). Empty list if unavailable.
+    /// { libIndex, action, name, source, quality, frames, approved } where
+    /// `name` is a human-readable label like "Walk (Tired Character)".
+    /// (`libIndex`, NOT `index` — a ListModel role named "index" shadows the
+    /// QML delegate's row index.) Downloads the library on first use
+    /// (blocking). Empty list if unavailable.
     Q_INVOKABLE QVariantList listMotionClips();
     /// Curation (#838 ship-gate): persist whether a library clip (keyed by its
     /// stable `source` string) is user-approved ("good"). The picker's checkbox

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -2053,6 +2053,16 @@ bool AnimationMerger::detectBackwardFacing(Ogre::Entity* entity)
     Ogre::SkeletonInstance* skel = entity->getSkeleton();
     if (!skel) return false;
 
+    // BIND pose, not the live pose: this runs on a rig that may be
+    // mid-animation (a previously applied clip playing or paused), and ankle
+    // positions sampled from an animated pose flip the facing vote from call
+    // to call — which flips trueLeft in the #969 side rule and lands knees/
+    // elbows on the opposite side nondeterministically for the same clip +
+    // model. The render loop re-applies enabled AnimationStates next frame,
+    // and every retarget path downstream resets the skeleton itself anyway.
+    skel->reset(true);
+    skel->_updateTransforms();
+
     // Ankle reference: bones resolving to the canonical foot roles (17/21) —
     // but only those that are actually LOW. Mis-labeled rigs (#969: UniRig
     // A-pose arms named "*Foot_1") put foot-named bones at chest height;

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -2058,10 +2058,16 @@ bool AnimationMerger::detectBackwardFacing(Ogre::Entity* entity)
     // positions sampled from an animated pose flip the facing vote from call
     // to call — which flips trueLeft in the #969 side rule and lands knees/
     // elbows on the opposite side nondeterministically for the same clip +
-    // model. The render loop re-applies enabled AnimationStates next frame,
-    // and every retarget path downstream resets the skeleton itself anyway.
+    // model.
     skel->reset(true);
     skel->_updateTransforms();
+    // Re-arm the live pose: a PLAYING state re-applies next frame on its own,
+    // but a PAUSED enabled state is not dirty and would leave the viewport
+    // stuck in this bind pose if the caller exits early (e.g. the humanoid
+    // gate rejects the rig). _notifyDirty makes the next _updateAnimation
+    // re-apply every enabled state at its current time.
+    if (auto* states = entity->getAllAnimationStates())
+        states->_notifyDirty();
 
     // Ankle reference: bones resolving to the canonical foot roles (17/21) —
     // but only those that are actually LOW. Mis-labeled rigs (#969: UniRig

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -4400,24 +4400,33 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
             rolePos[c] = bonePos[i];
             roleHas[c] = true;
         }
+        // FACING-BLIND world-X score. The canonical channels are WORLD-
+        // anchored: canonical left = world +X (the library extractor's frame,
+        // CMU convention), and the world-frame transport never yaws the
+        // channels to the rig's facing (the root is locked to the standing
+        // pose; yaw180 only steers the raw-delta fallback). So the bones that
+        // must RECEIVE the canonical-left channels are the ones at world +X —
+        // regardless of which way the rig faces. A facing-aware trueLeft here
+        // (the 3.37.x regression) made the fleet-norm Mixamo (+X named-left,
+        // faces +Z) and the UniRig orc (−X named-left, faces −Z) score the
+        // SAME sign and mirrored every asymmetric clip on Mixamo-class rigs.
+        // Empirical matrix (QTMESH_T2M_SIDE_DEBUG, punch-curve correlation):
+        //   Mixamo  rawNamedLeftX +2.36 → no swap (swap mirrors the clip)
+        //   orc     rawNamedLeftX −0.44 → swap    (without it: contorted)
         double side = 0.0;
         for (const auto& pr : kPairs) {
             if (!roleHas[pr[0]] || !roleHas[pr[1]]) continue;
-            side += (rolePos[pr[0]] - rolePos[pr[1]]).dotProduct(trueLeft);
+            side += rolePos[pr[0]].x - rolePos[pr[1]].x;
         }
-        // Swap when the named-left pairs sit at PLUS trueLeft — canonical-
-        // left must end at MINUS trueLeft (anatomical right). Measured after
-        // the de-mirror: Mixamo scores +2.36 (fwd +Z) → swap; the -Z-facing
-        // UniRig orc scores +0.44 against its trueLeft → swap; a rig whose
-        // names mirror its anatomy scores negative → none.
-        constexpr double kExpectedSideSign = -1.0;
         if (qEnvironmentVariableIsSet("QTMESH_T2M_SIDE_DEBUG"))
-            fprintf(stderr, "[t2m] side score %.4f (expected sign %+.0f)\n",
-                    side, kExpectedSideSign);
+            fprintf(stderr,
+                    "[t2m] side score %.4f (facing-blind world-X; swap if "
+                    "negative) yaw180=%d trueLeft=(%.1f,%.1f,%.1f)\n",
+                    side, yaw180 ? 1 : 0, trueLeft.x, trueLeft.y, trueLeft.z);
         const QByteArray forceSwap = qgetenv("QTMESH_T2M_SIDE_SWAP");
         const bool swap = !forceSwap.isEmpty()
             ? (forceSwap != "0")
-            : (side != 0.0 && (side * kExpectedSideSign) < 0.0);
+            : (side < 0.0);
         if (swap) {
             auto mirrorRole = [canonN](int c) {
                 // V1 body pairs: 6..9 ↔ 10..13, 14..17 ↔ 18..21.
@@ -4437,17 +4446,19 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
                     boneToCanon[i] = mirrorRole(boneToCanon[i]);
             res.sideSwapApplied = true;
             fprintf(stderr,
-                    "[t2m] bone naming is mirrored vs anatomy (side score "
-                    "%.3f) — swapped L/R canonical roles to match geometry\n",
+                    "[t2m] named-left bones sit at world -X (side score "
+                    "%.3f) — swapped L/R canonical roles so the world-"
+                    "anchored channels land on the right bones\n",
                     side);
         }
 
         // ---- (b, continued) rescue mis-named arm chains ----------------
         // The stripped chest-height "leg" chains ARE the arms — remap each
         // segment onto the matching arm role, side chosen geometrically in
-        // the POST-swap convention (fleet norm: left roles live at MINUS
-        // trueLeft). Only fills a side whose arm roles are entirely vacant,
-        // so a rig with real (correctly named) arms is never stomped.
+        // the world-anchored channel convention (canonical-left roles belong
+        // to the bones at world +X — same facing-blind frame as the side
+        // score above). Only fills a side whose arm roles are entirely
+        // vacant, so a rig with real (correctly named) arms is never stomped.
         if (!rescue.empty() && hipIdx >= 0) {
             bool armTaken[2] = {false, false};   // 0 = right(7..9), 1 = left(11..13)
             for (int i = 0; i < nBones; ++i) {
@@ -4459,9 +4470,8 @@ AnimationMerger::ApplyMotionResult AnimationMerger::applyMotionClip(
             int rescued = 0;
             for (const Rescue& rc : rescue) {
                 if (rc.seg < 0) continue;
-                const float lat = (bonePos[rc.bone] - bonePos[hipIdx])
-                                      .dotProduct(trueLeft);
-                const int sideIdx = lat < 0.0f ? 1 : 0;   // left roles at -trueLeft
+                const float lat = bonePos[rc.bone].x - bonePos[hipIdx].x;
+                const int sideIdx = lat > 0.0f ? 1 : 0;   // left roles at +X
                 if (armTaken[sideIdx]) continue;
                 boneToCanon[rc.bone] = kArmSeg[sideIdx][rc.seg];
                 ++rescued;

--- a/src/AnimationMerger_test.cpp
+++ b/src/AnimationMerger_test.cpp
@@ -1984,3 +1984,93 @@ TEST_F(AnimationMergerTest, ApplyMotionClipDetectsMirroredSideNaming)
     sm->destroyEntity(anat);
     sm->destroyEntity(mir);
 }
+
+// detectBackwardFacing must be POSE-INDEPENDENT: it feeds yaw180, which feeds
+// the #969 side rule's trueLeft — if it samples the skeleton mid-animation,
+// applying the same clip to the same model gives different knee/elbow sides
+// depending on where the previous clip's playhead happens to be (the field
+// report: "sometimes it flips the knees and elbows, same animation and same
+// model"). The detector must read the BIND pose regardless of the live pose.
+TEST_F(AnimationMergerTest, DetectBackwardFacingIgnoresLivePose)
+{
+    // Rig: hips high, Mixamo-named feet in the lowest quarter.
+    auto skel = Ogre::SkeletonManager::getSingleton().create(
+        "facing_skel", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+    unsigned short h = 0;
+    auto bone = [&](const char* n, const Ogre::Vector3& p, Ogre::Bone* parent) {
+        auto* b = skel->createBone(n, h++);
+        b->setPosition(p);
+        if (parent) parent->addChild(b);
+        return b;
+    };
+    auto* hips = bone("Hips", {0, 1.0f, 0}, nullptr);
+    auto* spine = bone("Spine", {0, 0.3f, 0}, hips);
+    bone("Head", {0, 0.4f, 0}, spine);
+    bone("LeftFoot", {0.15f, -0.9f, 0}, hips);
+    bone("RightFoot", {-0.15f, -0.9f, 0}, hips);
+    skel->setBindingPose();
+
+    // A "live" clip that translates the hips forward — the exact state a
+    // previously applied animation leaves behind. Ankles move to z=0.5 while
+    // the mesh's toe block stays at z=0.2, so a live-pose read sees the toes
+    // BEHIND the ankles and votes backward.
+    auto* anim = skel->createAnimation("pose", 1.0f);
+    auto* trk = anim->createNodeTrack(0, hips);
+    trk->createNodeKeyFrame(0.0f)->setTranslate({0, 0, 0.5f});
+    trk->createNodeKeyFrame(1.0f)->setTranslate({0, 0, 0.5f});
+
+    // Mesh: 20 toe verts forward (+Z) of the bind ankles, in the foot band,
+    // plus a head vert for height.
+    auto mesh = Ogre::MeshManager::getSingleton().createManual(
+        "facing_mesh", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+    auto* sub = mesh->createSubMesh();
+    mesh->sharedVertexData = new Ogre::VertexData();
+    auto* decl = mesh->sharedVertexData->vertexDeclaration;
+    decl->addElement(0, 0, Ogre::VET_FLOAT3, Ogre::VES_POSITION);
+    std::vector<float> verts;
+    for (int i = 0; i < 20; ++i) {
+        verts.push_back(-0.2f + 0.02f * i);   // x spread
+        verts.push_back(0.08f);               // in the foot band (~0.1)
+        verts.push_back(0.2f);                // toes forward of ankle z=0
+    }
+    verts.insert(verts.end(), {0.0f, 1.7f, 0.0f});   // head
+    const size_t nV = verts.size() / 3;
+    auto vbuf = Ogre::HardwareBufferManager::getSingleton().createVertexBuffer(
+        decl->getVertexSize(0), nV, Ogre::HardwareBuffer::HBU_STATIC_WRITE_ONLY);
+    vbuf->writeData(0, verts.size() * sizeof(float), verts.data());
+    mesh->sharedVertexData->vertexBufferBinding->setBinding(0, vbuf);
+    mesh->sharedVertexData->vertexCount = nV;
+    auto ibuf = Ogre::HardwareBufferManager::getSingleton().createIndexBuffer(
+        Ogre::HardwareIndexBuffer::IT_16BIT, 3,
+        Ogre::HardwareBuffer::HBU_STATIC_WRITE_ONLY);
+    uint16_t idx[] = {0, 1, 2};
+    ibuf->writeData(0, sizeof(idx), idx);
+    sub->useSharedVertices = true;
+    sub->indexData->indexBuffer = ibuf;
+    sub->indexData->indexCount = 3;
+    mesh->_notifySkeleton(skel);
+    mesh->_setBounds(Ogre::AxisAlignedBox(-1, -1, -1, 1, 2, 1));
+    mesh->_setBoundingSphereRadius(2.0f);
+    mesh->load();
+
+    auto* sm = Manager::getSingleton()->getSceneMgr();
+    Ogre::Entity* ent = sm->createEntity("facing_ent", mesh);
+    ASSERT_NE(ent, nullptr);
+
+    // Bind pose: toes forward → not backward-facing.
+    EXPECT_FALSE(AnimationMerger::detectBackwardFacing(ent));
+
+    // Pose the LIVE SkeletonInstance as a playing clip would.
+    Ogre::SkeletonInstance* live = ent->getSkeleton();
+    ASSERT_NE(live, nullptr);
+    live->reset(true);
+    live->getAnimation("pose")->apply(live, 0.5f);
+    live->_updateTransforms();
+
+    // The verdict must not change with the live pose.
+    EXPECT_FALSE(AnimationMerger::detectBackwardFacing(ent))
+        << "facing vote flipped with the live pose — the side rule would "
+           "mirror knees/elbows depending on the previous clip's playhead";
+
+    sm->destroyEntity(ent);
+}

--- a/src/AnimationMerger_test.cpp
+++ b/src/AnimationMerger_test.cpp
@@ -1944,11 +1944,12 @@ TEST_F(AnimationMergerTest, ApplyMotionClipDetectsMirroredSideNaming)
     // is ABOUT the check, so re-enable real detection.
     qunsetenv("QTMESH_T2M_SIDE_SWAP");
 
-    // ONE composed permutation: the library's canonical-LEFT channels land
-    // on the ANATOMICAL RIGHT bones (-trueLeft, facing-aware) — recalibrated
-    // in #977 after the import mirror was removed. A rig with anatomically
-    // correct names facing +Z (named-left at +X = +trueLeft) therefore
-    // takes exactly ONE swap...
+    // FACING-BLIND world-anchored rule: the canonical channels are world-
+    // anchored (canonical left = world +X), so named-left bones at +X
+    // already receive the right channels — NO swap. This is the fleet norm
+    // (Mixamo measures rawNamedLeftX +2.36); the 3.37.x facing-aware rule
+    // wrongly swapped it, mirroring every asymmetric clip (verified by
+    // punch-curve correlation: output-right followed source-LEFT).
     Ogre::Entity* anat = build("sideanat", +1.0f);
     ASSERT_NE(anat, nullptr);
     const auto quats = identityClip(3);
@@ -1956,29 +1957,33 @@ TEST_F(AnimationMergerTest, ApplyMotionClipDetectsMirroredSideNaming)
         anat->getSkeleton(), "sideclip", quats, 30, /*worldFrame=*/true,
         srcRestWorld(), false, 8, false, canonRestDirs());
     ASSERT_TRUE(resAnat.ok) << resAnat.error.toStdString();
-    EXPECT_TRUE(resAnat.sideSwapApplied)
-        << "anatomically-named +Z-facing rig takes the single composed swap";
+    EXPECT_FALSE(resAnat.sideSwapApplied)
+        << "named-left at world +X already matches the world-anchored "
+           "channels — swapping would mirror every asymmetric clip";
 
-    // ...while a mirror-named rig (named-left at -X) already has its
-    // named-left on the anatomical right — no permutation.
+    // A rig with named-left at world -X (the UniRig orc class: measured
+    // -0.44, and rendered contorted without the swap) takes the swap.
     Ogre::Entity* mir = build("sidemir", -1.0f);
     ASSERT_NE(mir, nullptr);
     const auto resMir = AnimationMerger::applyMotionClip(
         mir->getSkeleton(), "sideclip", quats, 30, /*worldFrame=*/true,
         srcRestWorld(), false, 8, false, canonRestDirs());
     ASSERT_TRUE(resMir.ok) << resMir.error.toStdString();
-    EXPECT_FALSE(resMir.sideSwapApplied)
-        << "mirror-named rig needs no permutation";
+    EXPECT_TRUE(resMir.sideSwapApplied)
+        << "named-left at world -X needs the swap to receive the "
+           "world-anchored canonical-left channels";
 
-    // Facing-AWARE: yaw180 flips trueLeft, so the same anatomically-named
-    // rig evaluated as backward-facing has its named-left already on the
-    // anatomical right — no swap.
+    // FACING-BLIND: yaw180 must not change the decision — the world-frame
+    // transport never yaws the channels, so the +X rig still takes no swap
+    // when evaluated as backward-facing. (The facing-aware variant of this
+    // rule is exactly what made the swap decision flip with the unstable
+    // facing vote — the 'sometimes flipped knees/elbows' field report.)
     const auto resAnatYaw = AnimationMerger::applyMotionClip(
         anat->getSkeleton(), "sideclip2", quats, 30, /*worldFrame=*/true,
         srcRestWorld(), false, 8, /*yaw180=*/true, canonRestDirs());
     ASSERT_TRUE(resAnatYaw.ok) << resAnatYaw.error.toStdString();
     EXPECT_FALSE(resAnatYaw.sideSwapApplied)
-        << "backward-facing flips trueLeft — no swap for this rig";
+        << "side rule is facing-blind — yaw180 must not flip it";
 
     auto* sm = Manager::getSingleton()->getSceneMgr();
     sm->destroyEntity(anat);

--- a/src/AnimationWidget.cpp
+++ b/src/AnimationWidget.cpp
@@ -131,7 +131,12 @@ bool AnimationWidget::toggleSkeletonDebug(Ogre::Entity* entity, bool show)
 
 bool AnimationWidget::toggleBoneWeights(Ogre::Entity* entity, bool show)
 {
-    if (!entity || !entity->hasSkeleton())
+    if (!entity)
+        return false;
+    // Showing needs a skeleton; HIDING must work without one — after
+    // RemoveSkeletonCommand the entity has no skeleton but its overlay (and
+    // weight-paint session) still exist and must be torn down.
+    if (show && !entity->hasSkeleton())
         return false;
 
     if (show)
@@ -183,8 +188,21 @@ bool AnimationWidget::toggleBoneWeights(Ogre::Entity* entity, bool show)
 
 void AnimationWidget::rebuildSkeletonOverlays(Ogre::Entity* entity)
 {
-    if (!entity || !entity->hasSkeleton())
+    if (!entity)
         return;
+    if (!entity->hasSkeleton()) {
+        // The skeleton was REMOVED (RemoveSkeletonCommand) — any live overlay
+        // for this entity holds pointers into the destroyed SkeletonInstance
+        // and its per-tick update would dereference them. Tear both down;
+        // toggleBoneWeights(false) also exits weight-paint mode (the funnel).
+        toggleBoneWeights(entity, false);
+        if (mShowSkeleton.contains(entity)) {
+            delete mShowSkeleton.value(entity); // NOSONAR — QMap doesn't own
+            mShowSkeleton.remove(entity);
+        }
+        updateSkeletonTable();
+        return;
+    }
 
     if (mShowSkeleton.contains(entity))
         mShowSkeleton.value(entity)->rebuildVisuals();

--- a/src/AnimationWidget.cpp
+++ b/src/AnimationWidget.cpp
@@ -201,6 +201,10 @@ void AnimationWidget::rebuildSkeletonOverlays(Ogre::Entity* entity)
             mShowSkeleton.remove(entity);
         }
         updateSkeletonTable();
+        // The skeletal clips died with the skeleton — rebuild the animation
+        // table too, or the poll timer keeps asking the entity for states
+        // that no longer exist.
+        updateAnimationTable();
         return;
     }
 
@@ -390,6 +394,14 @@ void AnimationWidget::pollAnimationState()
         auto* animNameItem = ui->animTable->item(row, 1);
         if(!animNameItem) continue;
 
+        // Entity::getAnimationState THROWS (ItemIdentityException) when the
+        // state doesn't exist — it never returns null. The table can be
+        // stale (skeleton removed via Delete Skeleton, clip deleted via
+        // MCP), and an Ogre exception escaping this timer slot aborts the
+        // app. Check membership first.
+        Ogre::AnimationStateSet* states = entity->getAllAnimationStates();
+        if(!states || !states->hasAnimationState(animNameItem->text().toStdString()))
+            continue;
         Ogre::AnimationState* animState = entity->getAnimationState(animNameItem->text().toStdString());
         if(!animState) continue;
 
@@ -531,7 +543,14 @@ void AnimationWidget::on_animTable_clicked(const QModelIndex &index) const
     if(!entity)
         return;
 
-    Ogre::AnimationState* animationState = entity->getAnimationState(ui->animTable->item(index.row(),1)->text().toStdString().data());
+    // getAnimationState throws on a missing name (stale table row after a
+    // skeleton removal / clip delete) — membership check first.
+    const std::string animName =
+        ui->animTable->item(index.row(), 1)->text().toStdString();
+    Ogre::AnimationStateSet* stateSet = entity->getAllAnimationStates();
+    if(!stateSet || !stateSet->hasAnimationState(animName))
+        return;
+    Ogre::AnimationState* animationState = entity->getAnimationState(animName);
     if(!animationState)
         return;
 

--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -146,6 +146,7 @@
 #include "PartOpsMesh.h"
 #include "commands/SplitMeshCommand.h"
 #include "commands/ExplodePartsCommand.h"
+#include "commands/SkeletonBoneCommands.h"
 #include "commands/JoinPartsCommand.h"
 #include "commands/TransformCommands.h"
 
@@ -653,6 +654,7 @@ const QMap<QString, MCPServer::ToolHandler>& MCPServer::toolHandlers()
         {QStringLiteral("compute_skin_weights"), &MCPServer::toolComputeSkinWeights},
         {QStringLiteral("set_skinning_display"), &MCPServer::toolSetSkinningDisplay},
         {QStringLiteral("auto_rig"), &MCPServer::toolAutoRig},
+        {QStringLiteral("remove_skeleton"), &MCPServer::toolRemoveSkeleton},
         {QStringLiteral("add_arkit_blendshapes"), &MCPServer::toolAddArkitBlendshapes},
         {QStringLiteral("generate_mesh_texture"), &MCPServer::toolGenerateMeshTexture},
         {QStringLiteral("generate_pbr_maps"), &MCPServer::toolGeneratePbrMaps},
@@ -2438,6 +2440,35 @@ QJsonObject MCPServer::toolAutoRig(const QJsonObject &args)
     j["skinned"] = skinned;
     result["rig"] = j;
     return result;
+}
+
+QJsonObject MCPServer::toolRemoveSkeleton(const QJsonObject &args)
+{
+    Q_UNUSED(args);
+    if (!hasSelectedEntities())
+        return makeErrorResult("No mesh selected. Load a mesh first with load_mesh.");
+    SelectionSet* sel = SelectionSet::getSingleton();
+    const QList<Ogre::Entity*> resolved = sel ? sel->getResolvedEntities()
+                                              : QList<Ogre::Entity*>{};
+    if (resolved.isEmpty() || !resolved.first())
+        return makeErrorResult("No selected entity.");
+    Ogre::Entity* entity = resolved.first();
+    if (!entity->getMesh() || !entity->getMesh()->hasSkeleton())
+        return makeErrorResult("Selected entity has no skeleton.");
+
+    SentryReporter::addBreadcrumb(QStringLiteral("ai.tool_call"),
+        QStringLiteral("remove_skeleton entity=%1")
+            .arg(QString::fromStdString(entity->getName())));
+
+    // Same undoable command the Inspector's "Delete Skeleton" button pushes.
+    auto* cmd = new RemoveSkeletonCommand(entity->getName());
+    UndoManager::getSingleton()->push(cmd);
+    if (!cmd->applied())
+        return makeErrorResult("Remove skeleton failed.");
+    return makeSuccessResult(
+        QStringLiteral("Skeleton removed from '%1' — the mesh is static again "
+                       "(auto_rig can regenerate a rig).")
+            .arg(QString::fromStdString(entity->getName())));
 }
 
 QJsonObject MCPServer::toolAddArkitBlendshapes(const QJsonObject &args)
@@ -10253,6 +10284,20 @@ QJsonArray MCPServer::buildToolsList()
             "joints toward the mesh's medial mass. Best on roughly upright, manifold, "
             "T/A-pose meshes with +Y up. Already-skinned meshes are rejected. Pair "
             "skin:true for a one-click rig+skin.",
+            props
+        );
+    }
+
+    // remove_skeleton
+    {
+        QJsonObject props;
+        appendTool(
+            "remove_skeleton",
+            "Remove the ENTIRE skeleton from the currently selected mesh: clears "
+            "all bone weights and unbinds the rig, turning it back into a plain "
+            "static mesh so auto_rig can regenerate a skeleton from scratch. "
+            "Skeletal animations are removed with the skeleton (morph/pose clips "
+            "survive). Undoable in the GUI session.",
             props
         );
     }

--- a/src/MCPServer.h
+++ b/src/MCPServer.h
@@ -182,6 +182,7 @@ private:
     /// #407: native auto-rig of the selected static mesh (template embedding),
     /// optional skin chain + re-export.
     QJsonObject toolAutoRig(const QJsonObject &args);
+    QJsonObject toolRemoveSkeleton(const QJsonObject &args);
     /// #889: fit the ARKit blendshape template onto the selected face mesh
     /// (NRICP + deformation transfer), attach the 52 ARKit morph targets, and
     /// optionally re-export.

--- a/src/SkeletonEditor.cpp
+++ b/src/SkeletonEditor.cpp
@@ -19,6 +19,8 @@
 #include <OgreSubMesh.h>
 #include <OgreSubEntity.h>
 
+#include <QDataStream>
+#include <QIODevice>
 #include <QSet>
 #include <QStringList>
 #include <QVariantMap>
@@ -1010,6 +1012,77 @@ SkeletonEditor::Result SkeletonEditor::removeBone(Ogre::Entity* entity,
     result.ok = true;
     result.boneName = boneName;
     return result;
+}
+
+QByteArray SkeletonEditor::serializeImportedRestCache(Ogre::Entity* entity)
+{
+    const std::string key = restCacheKey(entity);
+    if (key.empty()) return {};
+    auto& caches = importedRestCaches();
+    const auto it = caches.find(key);
+    if (it == caches.end()) return {};
+
+    QByteArray out;
+    QDataStream s(&out, QIODevice::WriteOnly);
+    s.setVersion(QDataStream::Qt_6_0);
+    const ImportedRestCache& c = it->second;
+    s << static_cast<quint32>(c.bones.size());
+    for (const auto& [name, trs] : c.bones) {
+        s << QByteArray::fromStdString(name)
+          << trs.position.x << trs.position.y << trs.position.z
+          << trs.orientation.w << trs.orientation.x << trs.orientation.y
+          << trs.orientation.z
+          << trs.scale.x << trs.scale.y << trs.scale.z;
+    }
+    s << static_cast<quint32>(c.bindVertexBuffers.size());
+    for (const auto& b : c.bindVertexBuffers) {
+        s << static_cast<qint32>(b.submeshIndex);
+        s << static_cast<quint32>(b.positions.size());
+        for (float f : b.positions) s << f;
+        s << static_cast<quint32>(b.normals.size());
+        for (float f : b.normals) s << f;
+    }
+    return out;
+}
+
+void SkeletonEditor::deserializeImportedRestCache(Ogre::Entity* entity,
+                                                  const QByteArray& data)
+{
+    const std::string key = restCacheKey(entity);
+    if (key.empty() || data.isEmpty()) return;
+
+    QDataStream s(data);
+    s.setVersion(QDataStream::Qt_6_0);
+    ImportedRestCache c;
+    quint32 nBones = 0;
+    s >> nBones;
+    for (quint32 i = 0; i < nBones && s.status() == QDataStream::Ok; ++i) {
+        QByteArray name;
+        RestPoseTRS trs;
+        s >> name >> trs.position.x >> trs.position.y >> trs.position.z
+          >> trs.orientation.w >> trs.orientation.x >> trs.orientation.y
+          >> trs.orientation.z
+          >> trs.scale.x >> trs.scale.y >> trs.scale.z;
+        c.bones.emplace_back(name.toStdString(), trs);
+    }
+    quint32 nBufs = 0;
+    s >> nBufs;
+    for (quint32 i = 0; i < nBufs && s.status() == QDataStream::Ok; ++i) {
+        Snapshot::BindVertexBuffer b;
+        qint32 idx = -1;
+        quint32 n = 0;
+        s >> idx;
+        b.submeshIndex = idx;
+        s >> n;
+        b.positions.resize(n);
+        for (quint32 k = 0; k < n; ++k) s >> b.positions[k];
+        s >> n;
+        b.normals.resize(n);
+        for (quint32 k = 0; k < n; ++k) s >> b.normals[k];
+        c.bindVertexBuffers.push_back(std::move(b));
+    }
+    if (s.status() == QDataStream::Ok)
+        importedRestCaches()[key] = std::move(c);
 }
 
 SkeletonEditor::Result SkeletonEditor::removeSkeleton(Ogre::Entity* entity)

--- a/src/SkeletonEditor.cpp
+++ b/src/SkeletonEditor.cpp
@@ -1039,6 +1039,12 @@ SkeletonEditor::Result SkeletonEditor::removeSkeleton(Ogre::Entity* entity)
         if (sub && !sub->getBoneAssignments().empty())
             sub->clearBoneAssignments();
     }
+    // The imported-rest-pose cache is keyed by mesh name and populated once —
+    // after a re-rig the mesh has a NEW skeleton, and a stale entry holding
+    // the OLD skeleton's bone rests would feed "Reset Rest" wrong transforms
+    // for any bone whose name matches. Drop it with the skeleton (it lazily
+    // repopulates from whatever skeleton exists next).
+    clearImportedRestCache(entity);
     // Empty name = "use no skeleton" (documented Ogre API) — hasSkeleton()
     // turns false, which is exactly what AutoRigController's riggable gate
     // checks. Re-initialise so the entity drops its SkeletonInstance and

--- a/src/SkeletonEditor.cpp
+++ b/src/SkeletonEditor.cpp
@@ -1012,6 +1012,35 @@ SkeletonEditor::Result SkeletonEditor::removeBone(Ogre::Entity* entity,
     return result;
 }
 
+SkeletonEditor::Result SkeletonEditor::removeSkeleton(Ogre::Entity* entity)
+{
+    Result result;
+    if (!entity || !entity->getMesh()) {
+        result.error = QStringLiteral("Invalid entity");
+        return result;
+    }
+    Ogre::Mesh* mesh = entity->getMesh().get();
+    if (!mesh->hasSkeleton()) {
+        result.error = QStringLiteral("Entity has no skeleton");
+        return result;
+    }
+    // Strip every weight first — a skeleton-less mesh must not carry stale
+    // bone assignments (exporters and a later Auto-Rig re-skin both start
+    // from a clean list).
+    mesh->clearBoneAssignments();
+    for (unsigned short si = 0; si < mesh->getNumSubMeshes(); ++si)
+        mesh->getSubMesh(si)->clearBoneAssignments();
+    // Empty name = "use no skeleton" (documented Ogre API) — hasSkeleton()
+    // turns false, which is exactly what AutoRigController's riggable gate
+    // checks. Re-initialise so the entity drops its SkeletonInstance and
+    // rebuilds its AnimationStateSet from the mesh (morph clips survive,
+    // skeletal states go with the skeleton).
+    mesh->setSkeletonName(Ogre::BLANKSTRING);
+    entity->_initialise(true);
+    result.ok = true;
+    return result;
+}
+
 SkeletonEditor::Result SkeletonEditor::renameBone(Ogre::Entity* entity,
                                                     const QString& oldName,
                                                     const QString& newName)
@@ -1860,6 +1889,16 @@ bool SkeletonEditor::removeSelectedBone(bool removeChildren, bool transferWeight
     opts.transferWeightsToParent = transferWeightsToParent;
 
     auto* cmd = new RemoveBoneCommand(entity->getName(), bone, opts);
+    UndoManager::getSingleton()->push(cmd);
+    return cmd->applied();
+}
+
+bool SkeletonEditor::removeSelectedSkeleton()
+{
+    Ogre::Entity* entity = selectedSkinnedEntity();
+    if (!entity) return false;
+
+    auto* cmd = new RemoveSkeletonCommand(entity->getName());
     UndoManager::getSingleton()->push(cmd);
     return cmd->applied();
 }

--- a/src/SkeletonEditor.cpp
+++ b/src/SkeletonEditor.cpp
@@ -1026,10 +1026,19 @@ SkeletonEditor::Result SkeletonEditor::removeSkeleton(Ogre::Entity* entity)
     }
     // Strip every weight first — a skeleton-less mesh must not carry stale
     // bone assignments (exporters and a later Auto-Rig re-skin both start
-    // from a clean list).
-    mesh->clearBoneAssignments();
-    for (unsigned short si = 0; si < mesh->getNumSubMeshes(); ++si)
-        mesh->getSubMesh(si)->clearBoneAssignments();
+    // from a clean list). Only clear where assignments actually exist:
+    // clearBoneAssignments sets the compile-dirty flag, and a SHARED-vertices
+    // submesh has vertexData == nullptr — compiling it later (the undo
+    // restore re-attaches the skeleton and _initAnimationState flushes dirty
+    // submeshes) dereferences that null and crashes. Shared-vertex weights
+    // live on the MESH, which is cleared above.
+    if (!mesh->getBoneAssignments().empty())
+        mesh->clearBoneAssignments();
+    for (unsigned short si = 0; si < mesh->getNumSubMeshes(); ++si) {
+        Ogre::SubMesh* sub = mesh->getSubMesh(si);
+        if (sub && !sub->getBoneAssignments().empty())
+            sub->clearBoneAssignments();
+    }
     // Empty name = "use no skeleton" (documented Ogre API) — hasSkeleton()
     // turns false, which is exactly what AutoRigController's riggable gate
     // checks. Re-initialise so the entity drops its SkeletonInstance and

--- a/src/SkeletonEditor.h
+++ b/src/SkeletonEditor.h
@@ -126,6 +126,14 @@ public:
 
     static Result createBone(Ogre::Entity* entity, const CreateOptions& opts);
     static Result removeBone(Ogre::Entity* entity, const QString& boneName, const RemoveOptions& opts);
+    /// Remove the ENTIRE skeleton from the entity's mesh: clears every bone
+    /// assignment (shared + per-submesh), unbinds the skeleton
+    /// (setSkeletonName("")), and re-initialises the entity. The mesh becomes
+    /// a plain static mesh again — Auto-Rig sees it as riggable, so the user
+    /// can regenerate a rig from scratch. Skeletal animations go with the
+    /// skeleton; mesh-level morph/pose animations are untouched. Undo is a
+    /// full Snapshot restore (RemoveSkeletonCommand).
+    static Result removeSkeleton(Ogre::Entity* entity);
     static Result renameBone(Ogre::Entity* entity, const QString& oldName, const QString& newName);
     static Result duplicateBone(Ogre::Entity* entity, const QString& sourceBoneName);
 
@@ -174,6 +182,7 @@ public:
     /// Push undo commands — used by QML and tests.
     Q_INVOKABLE bool createBoneForSelected(const QString& parentBoneName = {});
     Q_INVOKABLE bool removeSelectedBone(bool removeChildren, bool transferWeightsToParent);
+    Q_INVOKABLE bool removeSelectedSkeleton();
     Q_INVOKABLE bool renameSelectedBone(const QString& newName);
     Q_INVOKABLE bool duplicateSelectedBone();
     Q_INVOKABLE bool reparentSelectedBone(const QString& newParentName, bool keepWorld = true);

--- a/src/SkeletonEditor.h
+++ b/src/SkeletonEditor.h
@@ -179,6 +179,17 @@ public:
 
     static void refreshAfterEdit(const std::string& entityName, const QString& selectBone = {});
 
+    /// Undo plumbing for RemoveSkeletonCommand: the imported-rest-pose cache
+    /// is cleared with the skeleton (a re-rig must not inherit the old rig's
+    /// rests), but an UNDO must bring the ORIGINAL entry back — otherwise the
+    /// cache lazily repopulates from the restored skeleton's current initial
+    /// transforms, and if rest poses were edited before the removal, "Reset
+    /// Rest" would treat the edited rest as the import. Opaque QByteArray so
+    /// the cache type stays internal; empty = no entry existed.
+    static QByteArray serializeImportedRestCache(Ogre::Entity* entity);
+    static void deserializeImportedRestCache(Ogre::Entity* entity,
+                                             const QByteArray& data);
+
     /// Push undo commands — used by QML and tests.
     Q_INVOKABLE bool createBoneForSelected(const QString& parentBoneName = {});
     Q_INVOKABLE bool removeSelectedBone(bool removeChildren, bool transferWeightsToParent);

--- a/src/SkeletonEditor_test.cpp
+++ b/src/SkeletonEditor_test.cpp
@@ -744,3 +744,40 @@ TEST_F(SkeletonEditorTest, RestGhostMeshStaysAtEnableTimePoseAfterBake) {
     EXPECT_TRUE(ghostHost.restGhostShown());
 }
 
+
+TEST_F(SkeletonEditorTest, RemoveSkeletonMakesMeshRiggableAndUndoRestores) {
+    Ogre::Entity* entity = createAnimatedTestEntity("SkelEd_RemoveAll");
+    ASSERT_NE(entity, nullptr);
+    Ogre::Mesh* mesh = entity->getMesh().get();
+    ASSERT_TRUE(mesh->hasSkeleton());
+    const auto before = SkeletonEditor::captureSnapshot(entity);
+    ASSERT_FALSE(before.bones.empty());
+
+    // Remove the ENTIRE skeleton: mesh becomes a plain static mesh (this is
+    // what lets Auto-Rig regenerate a rig — its riggable gate checks
+    // getSkeleton() == nullptr) with no stale weights.
+    const auto result = SkeletonEditor::removeSkeleton(entity);
+    ASSERT_TRUE(result.ok) << result.error.toStdString();
+    EXPECT_FALSE(mesh->hasSkeleton());
+    EXPECT_EQ(mesh->getSkeleton(), nullptr);
+    EXPECT_FALSE(entity->hasSkeleton());
+    EXPECT_TRUE(mesh->getBoneAssignments().empty());
+    for (unsigned short si = 0; si < mesh->getNumSubMeshes(); ++si)
+        EXPECT_TRUE(mesh->getSubMesh(si)->getBoneAssignments().empty());
+
+    // Removing again reports a clean error, not a crash.
+    EXPECT_FALSE(SkeletonEditor::removeSkeleton(entity).ok);
+
+    // Undo path (what RemoveSkeletonCommand::undo runs): the snapshot
+    // restore brings the whole rig back — bones, weights and animations.
+    QString err;
+    ASSERT_TRUE(SkeletonEditor::restoreSnapshot(entity, before, &err))
+        << err.toStdString();
+    mesh = entity->getMesh().get();
+    ASSERT_TRUE(mesh->hasSkeleton());
+    Ogre::SkeletonPtr skel = mesh->getSkeleton();
+    EXPECT_EQ(skel->getNumBones(),
+              static_cast<unsigned short>(before.bones.size()));
+    EXPECT_TRUE(skel->hasAnimation("TestAnim"));
+    EXPECT_TRUE(entity->hasSkeleton());
+}

--- a/src/commands/SkeletonBoneCommands.cpp
+++ b/src/commands/SkeletonBoneCommands.cpp
@@ -1,5 +1,6 @@
 #include "SkeletonBoneCommands.h"
 
+#include "AutoRigController.h"
 #include "Manager.h"
 #include "PropertiesPanelController.h"
 #include "SelectionSet.h"
@@ -117,6 +118,49 @@ void RemoveBoneCommand::undo()
     if (SkeletonEditor::restoreSnapshot(entity, m_before, &err))
         SkeletonEditor::refreshAfterEdit(m_entityName, m_boneName);
     m_applied = false;
+}
+
+RemoveSkeletonCommand::RemoveSkeletonCommand(std::string entityName,
+                                             QUndoCommand* parent)
+    : QUndoCommand(parent)
+    , m_entityName(std::move(entityName))
+{
+    setText(QStringLiteral("Remove skeleton"));
+}
+
+void RemoveSkeletonCommand::redo()
+{
+    Ogre::Entity* entity = resolveEntityByName(m_entityName);
+    if (!entity) return;
+
+    if (m_firstRedo) {
+        m_before = SkeletonEditor::captureSnapshot(entity);
+        m_firstRedo = false;
+    }
+
+    const auto result = SkeletonEditor::removeSkeleton(entity);
+    if (!result.ok) return;
+
+    m_applied = true;
+    SentryReporter::addBreadcrumb(QStringLiteral("scene.skel.remove_skeleton"),
+        QString::fromStdString(m_entityName));
+    SkeletonEditor::refreshAfterEdit(m_entityName);
+    // The mesh just flipped to "riggable" — refresh the Inspector's
+    // Auto-Rig / Skinning section gating.
+    if (auto* rig = AutoRigController::instance())
+        emit rig->selectionChanged();
+}
+
+void RemoveSkeletonCommand::undo()
+{
+    Ogre::Entity* entity = resolveEntityByName(m_entityName);
+    if (!entity) return;
+    QString err;
+    if (SkeletonEditor::restoreSnapshot(entity, m_before, &err))
+        SkeletonEditor::refreshAfterEdit(m_entityName);
+    m_applied = false;
+    if (auto* rig = AutoRigController::instance())
+        emit rig->selectionChanged();
 }
 
 RenameBoneCommand::RenameBoneCommand(std::string entityName,

--- a/src/commands/SkeletonBoneCommands.cpp
+++ b/src/commands/SkeletonBoneCommands.cpp
@@ -135,6 +135,11 @@ void RemoveSkeletonCommand::redo()
 
     if (m_firstRedo) {
         m_before = SkeletonEditor::captureSnapshot(entity);
+        // The imported-rest cache is cleared with the skeleton; capture the
+        // original entry so undo restores it VERBATIM — repopulating lazily
+        // from the restored skeleton would bake any pre-removal rest EDITS
+        // in as the "import".
+        m_restCache = SkeletonEditor::serializeImportedRestCache(entity);
         m_firstRedo = false;
     }
 
@@ -156,8 +161,10 @@ void RemoveSkeletonCommand::undo()
     Ogre::Entity* entity = resolveEntityByName(m_entityName);
     if (!entity) return;
     QString err;
-    if (SkeletonEditor::restoreSnapshot(entity, m_before, &err))
+    if (SkeletonEditor::restoreSnapshot(entity, m_before, &err)) {
+        SkeletonEditor::deserializeImportedRestCache(entity, m_restCache);
         SkeletonEditor::refreshAfterEdit(m_entityName);
+    }
     m_applied = false;
     if (auto* rig = AutoRigController::instance())
         emit rig->selectionChanged();

--- a/src/commands/SkeletonBoneCommands.h
+++ b/src/commands/SkeletonBoneCommands.h
@@ -69,6 +69,7 @@ public:
 private:
     std::string m_entityName;
     SkeletonEditor::Snapshot m_before;
+    QByteArray m_restCache;   ///< imported-rest cache entry, restored on undo
     bool m_applied = false;
     bool m_firstRedo = true;
 };

--- a/src/commands/SkeletonBoneCommands.h
+++ b/src/commands/SkeletonBoneCommands.h
@@ -51,6 +51,28 @@ private:
     bool m_firstRedo = true;
 };
 
+/// Remove the ENTIRE skeleton from an entity's mesh (weights + binding), so
+/// the mesh becomes riggable again and Auto-Rig can regenerate a rig from
+/// scratch. Undo restores the full pre-removal skeleton, animations and
+/// weights from a Snapshot.
+class RemoveSkeletonCommand : public QUndoCommand
+{
+public:
+    explicit RemoveSkeletonCommand(std::string entityName,
+                                   QUndoCommand* parent = nullptr);
+
+    void undo() override;
+    void redo() override;
+
+    bool applied() const { return m_applied; }
+
+private:
+    std::string m_entityName;
+    SkeletonEditor::Snapshot m_before;
+    bool m_applied = false;
+    bool m_firstRedo = true;
+};
+
 class RenameBoneCommand : public QUndoCommand
 {
 public:

--- a/website/src/hooks/useQtmeshActionRef.js
+++ b/website/src/hooks/useQtmeshActionRef.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 const QTMESH_RELEASES_LATEST_API = 'https://api.github.com/repos/fernandotonon/QtMeshEditor/releases/latest';
-const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.37.5';
+const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.37.6';
 const CACHE_KEY = 'qtmesh.actionRef.cache.v1';
 const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 

--- a/website/src/hooks/useQtmeshActionRef.js
+++ b/website/src/hooks/useQtmeshActionRef.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 const QTMESH_RELEASES_LATEST_API = 'https://api.github.com/repos/fernandotonon/QtMeshEditor/releases/latest';
-const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.37.4';
+const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.37.5';
 const CACHE_KEY = 'qtmesh.actionRef.cache.v1';
 const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 


### PR DESCRIPTION
## Two field reports

### 1. "I'm not able to mark the good animations in the template anymore"
The picker's ListModel role was literally named `index` — and in QML a role named `index` **shadows the delegate's built-in row index** (verified standalone: both bare `index` and `model.index` resolve to the role value). `toggleApproved(index)` therefore received the **library** index instead of the row; on any filtered list `listModel.get()` went out of range and the star click silently did nothing.

Why "anymore": with no stars the list is unfiltered and row == library index, so it worked — the moment stars exist, **Only good ★** defaults ON, the list filters, indexes desynchronize, and marking breaks. Fixed by renaming the role to `libIndex` (apply/busy use `model.libIndex`; the row is the context `index` again).

### 2. "Sometimes it flips the knees and elbows to the opposite side, same animation and same model"
`detectBackwardFacing` sampled ankle bone positions from the **live SkeletonInstance without a reset**, while the mesh toe band is bind-pose data. With a previously applied clip playing/paused, the ankles sit wherever the playhead left them → the yaw180 facing vote flips call-to-call → `trueLeft` in the #969 side rule inverts → the entire L/R canonical mapping mirrors. First apply on a fresh rig was correct; re-applies were a coin toss.

Fixed by resetting the skeleton to bind before sampling (same as the side-rule block and `readTargetBindFrame` already do; the render loop re-applies enabled AnimationStates next frame). Audited the rest of the decision chain — this was the only live-pose read.

## Tests
- `AnimationMergerTest.DetectBackwardFacingIgnoresLivePose`: foot-rig + toe-band mesh fixture; poses the live skeleton as a playing clip would and asserts the facing verdict is pose-independent (GL-gated — runs on Linux CI).
- Role-shadowing behavior verified with a standalone QML harness before the fix.

Bumps version to 3.37.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a **Delete Skeleton** action in the Inspector, allowing rigs to be removed from meshes and restored with undo.
  - Added support for removing skeletons through the automation interface.
  - Updated the QtMeshEditor release version to 3.37.6.

- **Bug Fixes**
  - Improved animation clip selection and starring for filtered lists.
  - Made backward-facing detection consistent regardless of the active animation.
  - Corrected mirrored bone-side detection and prevented stale animation data after skeleton or clip removal.

- **Documentation**
  - Updated reproducible-build instructions and workflow examples for version 3.37.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->