### PR TITLE
feat(anim): trim animations to a time window (dope sheet ✂ / CLI --trim / MCP); bump 3.37.7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ qtmesh anim model.fbx --list                   # list animations
 qtmesh anim model.fbx --list --json            # list animations (JSON)
 qtmesh anim model.fbx --rename "Take 001" "Idle" -o out.fbx  # rename an animation
 qtmesh anim base.fbx --merge walk.fbx run.fbx -o merged.fbx
+qtmesh anim model.fbx --trim --start-time 0.5 --end-time 2.0 --animation "Walk" -o out.fbx  # cut the clip to [0.5s..2s] (boundary poses baked, re-timed to start at 0; GUI: dope-sheet "✂ Trim to range" on the selected keys)
 qtmesh anim model.fbx --resample 30 -o optimized.fbx  # resample to 30 keyframes
 qtmesh anim model.fbx --decimate-step 5 -o lighter.fbx  # keep every 5th keyframe
 qtmesh anim model.fbx --resample 30 --animation "Walk" -o out.fbx  # resample specific animation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 3.37.6 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 3.37.7 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Available on the [GitHub Actions Marketplace](https://github.com/marketplace/act
 **Versioning**
 
 - **Always follow the latest GitHub release** — use the Marketplace floating tag `fernandotonon/QtMeshEditor@v1` (same pattern as the [Marketplace example](https://github.com/marketplace/actions/qtmesheditor)). The composite action defaults to `image-tag: latest`, so the Docker CLI tracks the newest published `ghcr.io/fernandotonon/qtmesh` image.
-- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.37.6**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
+- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.37.7**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
 
 Pinned workflow template (action + `ghcr.io` image aligned):
 
@@ -48,10 +48,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run QtMesh scan
-        uses: fernandotonon/QtMeshEditor@3.37.6
+        uses: fernandotonon/QtMeshEditor@3.37.7
         with:
           command: scan
-          image-tag: "3.37.6"
+          image-tag: "3.37.7"
         env:
           QTMESH_CLOUD_TOKEN: ${{ secrets.QTMESH_CLOUD_TOKEN }}
 ```
@@ -76,37 +76,37 @@ Release tags are listed on the [releases page](https://github.com/fernandotonon/
 
 ```yaml
 # Validate a specific mesh
-- uses: fernandotonon/QtMeshEditor@3.37.6
+- uses: fernandotonon/QtMeshEditor@3.37.7
   with:
     command: validate
     input-file: ./models/character.fbx
-    image-tag: "3.37.6"
+    image-tag: "3.37.7"
 
 # Convert FBX → glTF
-- uses: fernandotonon/QtMeshEditor@3.37.6
+- uses: fernandotonon/QtMeshEditor@3.37.7
   with:
     command: convert
     input-file: ./models/character.fbx
     output-file: ./output/character.gltf2
-    image-tag: "3.37.6"
+    image-tag: "3.37.7"
 
 # Resample Mixamo animations (200+ keyframes → 30)
-- uses: fernandotonon/QtMeshEditor@3.37.6
+- uses: fernandotonon/QtMeshEditor@3.37.7
   with:
     command: anim
     input-file: ./animations/dance.fbx
     output-file: ./output/dance_optimized.fbx
     options: --resample 30
-    image-tag: "3.37.6"
+    image-tag: "3.37.7"
 
 # Get mesh info as JSON
-- uses: fernandotonon/QtMeshEditor@3.37.6
+- uses: fernandotonon/QtMeshEditor@3.37.7
   id: info
   with:
     command: info
     input-file: ./models/character.fbx
     options: --json
-    image-tag: "3.37.6"
+    image-tag: "3.37.7"
 
 # Docker (alternative — :latest tracks newest image; pin :3.4.0 to match semver action ref)
 # The image is multi-arch (linux/amd64 + linux/arm64), so it runs natively on

--- a/qml/AnimationDopeSheet.qml
+++ b/qml/AnimationDopeSheet.qml
@@ -486,6 +486,27 @@ Rectangle {
                     }
                 }
             }
+            // Trim the clip to the selected window: keep [T0..T1], cut the
+            // rest, re-time to start at 0. Undoable (Ctrl+Z restores).
+            Rectangle {
+                id: trimBtn
+                width: trimTxt.implicitWidth + 12; height: 16; radius: 2
+                anchors.verticalCenter: parent.verticalCenter
+                color: trimMa.containsMouse ? AnimationControlController.highlightColor
+                                            : AnimationControlController.headerColor
+                border.color: AnimationControlController.borderColor
+                Text { id: trimTxt; anchors.centerIn: parent
+                       text: "✂ Trim to range"; font.pixelSize: 10
+                       color: AnimationControlController.textColor }
+                MouseArea {
+                    id: trimMa
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: AnimationControlController.trimWindow(
+                                   root.inbetweenT0, root.inbetweenT1)
+                }
+            }
         }
 
         // Result line: which path ran (RMIB model vs spline) + count, or why

--- a/qml/AnimationDopeSheet.qml
+++ b/qml/AnimationDopeSheet.qml
@@ -503,8 +503,15 @@ Rectangle {
                     anchors.fill: parent
                     hoverEnabled: true
                     cursorShape: Qt.PointingHandCursor
-                    onClicked: AnimationControlController.trimWindow(
-                                   root.inbetweenT0, root.inbetweenT1)
+                    onClicked: {
+                        var r = AnimationControlController.trimWindow(
+                                    root.inbetweenT0, root.inbetweenT1)
+                        // The selected keys' times no longer exist after the
+                        // re-time — clear so the range bar doesn't linger with
+                        // stale pre-trim values.
+                        if (r && r.ok)
+                            root.clearSelection()
+                    }
                 }
             }
         }

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -1882,6 +1882,22 @@ QVariantMap AnimationControlController::trimWindow(double t0, double t1)
         return out;
     }
 
+    // Pre-validate BEFORE pushing: a command that fails inside redo() still
+    // lands on the undo stack as a dead entry (and clears the redo branch).
+    // Same window rules as AnimationMerger::trimAnimation.
+    {
+        const float len =
+            m_selectedSkeleton->getAnimation(m_selectedAnimation)->getLength();
+        const float c0 = std::clamp(static_cast<float>(t0), 0.0f, len);
+        const float c1 = std::clamp(static_cast<float>(t1), 0.0f, len);
+        if (c1 - c0 < 0.01f) {
+            out["error"] = QStringLiteral(
+                "Trim window too small — select at least one frame.");
+            emit inbetweenStatus(out["error"].toString(), true);
+            return out;
+        }
+    }
+
     auto* cmd = new TrimAnimationCommand(m_selectedEntity->getName(),
                                          m_selectedAnimation,
                                          static_cast<float>(t0),

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -1898,6 +1898,14 @@ QVariantMap AnimationControlController::trimWindow(double t0, double t1)
     // refresh (same rationale as inbetweenWindow).
     m_selectedTrack   = nullptr;
     m_currentKeyframe = nullptr;
+    // The timeline exposes m_sliderMaximum, not the Ogre animation — without
+    // this the slider keeps accepting times past the trimmed end. Reset the
+    // loop region too (it may reference cut times).
+    m_sliderMaximum = static_cast<int>(cmd->newLength() * 1000);
+    m_loopStart        = 0.0;
+    m_loopEnd          = cmd->newLength();
+    m_loopRegionActive = false;
+    emit loopRegionChanged();
     setSliderValue(0);
     refreshSliderTicks();
     emit boneRowsChanged();

--- a/src/AnimationControlController.cpp
+++ b/src/AnimationControlController.cpp
@@ -9,6 +9,7 @@
 #include "UndoManager.h"
 #include "commands/MoveKeyframeCommand.h"
 #include "commands/BulkKeyframeCommands.h"
+#include "commands/SkeletonBoneCommands.h"
 #include "commands/SetKeyframeValueCommand.h"
 #include "commands/ResampleCurveCommand.h"
 #include "commands/CurveEditModelChangeCommand.h"
@@ -1868,6 +1869,52 @@ void AnimationControlController::notifyExternalAnimationEdit()
     emit boneRowsChanged();
     emit keyframeTicksChanged();
     emit currentKeyframeChanged();
+}
+
+QVariantMap AnimationControlController::trimWindow(double t0, double t1)
+{
+    QVariantMap out;
+    out["ok"] = false;
+    if (!m_selectedEntity || !m_selectedSkeleton || m_selectedAnimation.empty()
+        || !m_selectedSkeleton->hasAnimation(m_selectedAnimation)) {
+        out["error"] = QStringLiteral("No animation selected.");
+        emit inbetweenStatus(out["error"].toString(), true);
+        return out;
+    }
+
+    auto* cmd = new TrimAnimationCommand(m_selectedEntity->getName(),
+                                         m_selectedAnimation,
+                                         static_cast<float>(t0),
+                                         static_cast<float>(t1));
+    UndoManager::getSingleton()->push(cmd);
+    if (!cmd->applied()) {
+        out["error"] = cmd->error().isEmpty()
+            ? QStringLiteral("Trim failed.") : cmd->error();
+        emit inbetweenStatus(out["error"].toString(), true);
+        return out;
+    }
+
+    // Structural edit — drop cached track/keyframe pointers before the view
+    // refresh (same rationale as inbetweenWindow).
+    m_selectedTrack   = nullptr;
+    m_currentKeyframe = nullptr;
+    setSliderValue(0);
+    refreshSliderTicks();
+    emit boneRowsChanged();
+    emit keyframeTicksChanged();
+    emit currentKeyframeChanged();
+    emit animationLengthChanged();
+    emit animationTreeChanged();
+
+    out["ok"] = true;
+    out["keyframesRemoved"] = cmd->keyframesRemoved();
+    out["newLength"] = cmd->newLength();
+    const QString msg =
+        QStringLiteral("Trimmed to %1s (%2 keyframes cut) — Ctrl+Z restores.")
+            .arg(QString::number(cmd->newLength(), 'f', 2))
+            .arg(cmd->keyframesRemoved());
+    emit inbetweenStatus(msg, false);
+    return out;
 }
 
 QVariantMap AnimationControlController::inbetweenWindow(double t0, double t1,

--- a/src/AnimationControlController.h
+++ b/src/AnimationControlController.h
@@ -330,6 +330,12 @@ public:
     /// error } so the dope-sheet UI can surface a "fell back to spline" note.
     /// Emits inbetweenStatus(message, isError). Not undoable yet — a follow-up
     /// can wrap it in a command (mirrors the resample-curve path).
+    /// Trim the selected animation to the [t0, t1] dope-sheet window — cuts
+    /// everything outside, bakes exact boundary poses, shifts to start at 0.
+    /// UNDOABLE (TrimAnimationCommand snapshots the skeleton). Emits
+    /// inbetweenStatus (the dope sheet's shared status line).
+    Q_INVOKABLE QVariantMap trimWindow(double t0, double t1);
+
     Q_INVOKABLE QVariantMap inbetweenWindow(double t0, double t1,
                                             int gapFrames,
                                             bool noModel = false);

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -379,6 +379,103 @@ int AnimationMerger::resampleAnimation(Ogre::Skeleton* skel,
     return originalMaxKeyframes - targetKeyframes;
 }
 
+AnimationMerger::TrimResult AnimationMerger::trimAnimation(
+    Ogre::Skeleton* skel, const std::string& animName, float t0, float t1)
+{
+    TrimResult res;
+    if (!skel || !skel->hasAnimation(animName)) {
+        res.error = QStringLiteral("Animation not found.");
+        return res;
+    }
+    Ogre::Animation* srcAnim = skel->getAnimation(animName);
+    const float length = srcAnim->getLength();
+    t0 = std::clamp(t0, 0.0f, length);
+    t1 = std::clamp(t1, 0.0f, length);
+    if (t1 - t0 < 0.01f) {
+        res.error = QStringLiteral(
+            "Trim window too small — select at least one frame.");
+        return res;
+    }
+    // No-op window (whole clip) — succeed without touching the tracks.
+    if (t0 <= 1e-4f && t1 >= length - 1e-4f) {
+        res.ok = true;
+        res.newLength = length;
+        return res;
+    }
+
+    // Collect the trimmed keyframe data per track: exact interpolated
+    // boundary poses at t0/t1 plus every original key strictly inside,
+    // all shifted by -t0. Same collect-then-rebuild shape as
+    // resampleAnimation — recreating the animation avoids the
+    // _keyFrameDataChanged stale-cache gotcha entirely.
+    constexpr float kEps = 1e-4f;
+    struct TrackData {
+        unsigned short handle;
+        Ogre::Node* associatedNode;
+        bool useShortestPath;
+        struct KeyframeData {
+            float time;
+            Ogre::Vector3 translate;
+            Ogre::Quaternion rotation;
+            Ogre::Vector3 scale;
+        };
+        std::vector<KeyframeData> keyframes;
+    };
+    std::vector<TrackData> tracks;
+    int kept = 0, original = 0;
+
+    for (const auto& [handle, srcTrack] : srcAnim->_getNodeTrackList()) {
+        TrackData td;
+        td.handle = handle;
+        td.associatedNode = srcTrack->getAssociatedNode();
+        td.useShortestPath = srcTrack->getUseShortestRotationPath();
+        original += static_cast<int>(srcTrack->getNumKeyFrames());
+
+        auto sampleAt = [&](float t, float outTime) {
+            Ogre::TransformKeyFrame kf(nullptr, t);
+            srcTrack->getInterpolatedKeyFrame(srcAnim->_getTimeIndex(t), &kf);
+            td.keyframes.push_back({outTime, kf.getTranslate(),
+                                    kf.getRotation(), kf.getScale()});
+        };
+        sampleAt(t0, 0.0f);
+        for (unsigned short k = 0; k < srcTrack->getNumKeyFrames(); ++k) {
+            const auto* kf = srcTrack->getNodeKeyFrame(k);
+            const float t = kf->getTime();
+            if (t <= t0 + kEps || t >= t1 - kEps)
+                continue;
+            td.keyframes.push_back({t - t0, kf->getTranslate(),
+                                    kf->getRotation(), kf->getScale()});
+        }
+        sampleAt(t1, t1 - t0);
+        kept += static_cast<int>(td.keyframes.size());
+        tracks.push_back(std::move(td));
+    }
+
+    const auto interpMode = srcAnim->getInterpolationMode();
+    const auto rotInterpMode = srcAnim->getRotationInterpolationMode();
+    skel->removeAnimation(animName);
+    Ogre::Animation* newAnim = skel->createAnimation(animName, t1 - t0);
+    newAnim->setInterpolationMode(interpMode);
+    newAnim->setRotationInterpolationMode(rotInterpMode);
+    for (const auto& td : tracks) {
+        auto* newTrack = newAnim->createNodeTrack(td.handle);
+        if (td.associatedNode)
+            newTrack->setAssociatedNode(td.associatedNode);
+        newTrack->setUseShortestRotationPath(td.useShortestPath);
+        for (const auto& kfData : td.keyframes) {
+            auto* kf = newTrack->createNodeKeyFrame(kfData.time);
+            kf->setTranslate(kfData.translate);
+            kf->setRotation(kfData.rotation);
+            kf->setScale(kfData.scale);
+        }
+    }
+
+    res.ok = true;
+    res.keyframesRemoved = std::max(0, original - kept);
+    res.newLength = t1 - t0;
+    return res;
+}
+
 int AnimationMerger::decimateAnimation(Ogre::Skeleton* skel,
                                        const std::string& animName,
                                        int step)

--- a/src/AnimationMerger.cpp
+++ b/src/AnimationMerger.cpp
@@ -453,10 +453,21 @@ AnimationMerger::TrimResult AnimationMerger::trimAnimation(
 
     const auto interpMode = srcAnim->getInterpolationMode();
     const auto rotInterpMode = srcAnim->getRotationInterpolationMode();
+    // Base-keyframe metadata (additive-animation reference) must survive the
+    // recreate — dropping it silently changes how the clip composes.
+    const bool useBaseKf = srcAnim->getUseBaseKeyFrame();
+    const Ogre::String baseKfAnim = srcAnim->getBaseKeyFrameAnimationName();
+    // The base reference time is in the OLD clip's timeline; keep it inside
+    // the trimmed range when it referenced this same clip.
+    float baseKfTime = srcAnim->getBaseKeyFrameTime();
+    if (useBaseKf && (baseKfAnim.empty() || baseKfAnim == animName))
+        baseKfTime = std::clamp(baseKfTime - t0, 0.0f, t1 - t0);
     skel->removeAnimation(animName);
     Ogre::Animation* newAnim = skel->createAnimation(animName, t1 - t0);
     newAnim->setInterpolationMode(interpMode);
     newAnim->setRotationInterpolationMode(rotInterpMode);
+    if (useBaseKf)
+        newAnim->setUseBaseKeyFrame(true, baseKfTime, baseKfAnim);
     for (const auto& td : tracks) {
         auto* newTrack = newAnim->createNodeTrack(td.handle);
         if (td.associatedNode)

--- a/src/AnimationMerger.h
+++ b/src/AnimationMerger.h
@@ -94,6 +94,26 @@ public:
                                  const std::string& animName,
                                  int step);
 
+    /// Result of trimAnimation.
+    struct TrimResult {
+        bool ok = false;
+        QString error;
+        int keyframesRemoved = 0;   ///< keyframes dropped outside the window
+        float newLength = 0.f;      ///< t1 - t0
+    };
+
+    /// TRIM an animation to the [t0, t1] window: keyframes outside are cut,
+    /// exact boundary poses are baked at both ends (interpolated, so the
+    /// motion at the new start/end matches the original at t0/t1), all kept
+    /// keyframes shift by -t0, and the animation length becomes t1 - t0.
+    /// The clip keeps its name; the source keyframes outside the window are
+    /// gone (callers wanting undo should snapshot first — the GUI goes
+    /// through TrimAnimationCommand). Times are clamped to [0, length];
+    /// t1 must exceed t0 by at least ~one frame (0.01s).
+    static TrimResult trimAnimation(Ogre::Skeleton* skel,
+                                    const std::string& animName,
+                                    float t0, float t1);
+
     /// Tolerances for redundant-keyframe detection. A keyframe is "redundant"
     /// when removing it leaves the lerp/slerp from its neighbors within tolerance
     /// of the original value. Defaults are the "Conservative" preset — the

--- a/src/AnimationMerger_test.cpp
+++ b/src/AnimationMerger_test.cpp
@@ -2079,3 +2079,65 @@ TEST_F(AnimationMergerTest, DetectBackwardFacingIgnoresLivePose)
 
     sm->destroyEntity(ent);
 }
+
+// Trim (#dope-sheet trim): cut a clip to [t0,t1] — exact boundary poses,
+// interior keys shifted by -t0, new length t1-t0, outside keys gone.
+TEST_F(AnimationMergerTest, TrimAnimationCutsWindowAndBakesBoundaries)
+{
+    auto skel = createTestSkeleton("trim_skel", {"Root"}, {});
+    auto* anim = skel->createAnimation("clip", 2.0f);
+    auto* trk = anim->createNodeTrack(0, skel->getBone(0));
+    // Linear X translation 0 → 2 over 2s: interpolation is exact, so the
+    // baked boundary poses are analytically checkable.
+    for (int i = 0; i <= 4; ++i) {
+        auto* kf = trk->createNodeKeyFrame(0.5f * i);
+        kf->setTranslate(Ogre::Vector3(0.5f * i, 0, 0));
+    }
+
+    const auto r = AnimationMerger::trimAnimation(skel.get(), "clip", 0.5f, 1.5f);
+    ASSERT_TRUE(r.ok) << r.error.toStdString();
+    EXPECT_FLOAT_EQ(r.newLength, 1.0f);
+
+    Ogre::Animation* trimmed = skel->getAnimation("clip");
+    ASSERT_NE(trimmed, nullptr);
+    EXPECT_FLOAT_EQ(trimmed->getLength(), 1.0f);
+    auto* t = trimmed->getNodeTrack(0);
+    ASSERT_NE(t, nullptr);
+    // keys: boundary@0 (was t=0.5), interior@0.5 (was t=1.0), boundary@1 (was 1.5)
+    ASSERT_EQ(t->getNumKeyFrames(), 3u);
+    EXPECT_NEAR(t->getNodeKeyFrame(0)->getTime(), 0.0f, 1e-4f);
+    EXPECT_NEAR(t->getNodeKeyFrame(0)->getTranslate().x, 0.5f, 1e-4f);
+    EXPECT_NEAR(t->getNodeKeyFrame(1)->getTime(), 0.5f, 1e-4f);
+    EXPECT_NEAR(t->getNodeKeyFrame(1)->getTranslate().x, 1.0f, 1e-4f);
+    EXPECT_NEAR(t->getNodeKeyFrame(2)->getTime(), 1.0f, 1e-4f);
+    EXPECT_NEAR(t->getNodeKeyFrame(2)->getTranslate().x, 1.5f, 1e-4f);
+    EXPECT_EQ(r.keyframesRemoved, 2);   // 5 original → 3 kept
+
+    // Mid-window boundary bake: trim at a non-keyframe time interpolates.
+    auto skel2 = createTestSkeleton("trim_skel2", {"Root"}, {});
+    auto* anim2 = skel2->createAnimation("clip", 2.0f);
+    auto* trk2 = anim2->createNodeTrack(0, skel2->getBone(0));
+    for (int i = 0; i <= 4; ++i) {
+        auto* kf = trk2->createNodeKeyFrame(0.5f * i);
+        kf->setTranslate(Ogre::Vector3(0.5f * i, 0, 0));
+    }
+    const auto r2 = AnimationMerger::trimAnimation(skel2.get(), "clip", 0.25f, 0.75f);
+    ASSERT_TRUE(r2.ok);
+    auto* t2 = skel2->getAnimation("clip")->getNodeTrack(0);
+    ASSERT_EQ(t2->getNumKeyFrames(), 3u);   // bake@0, key@0.25 (was 0.5), bake@0.5
+    EXPECT_NEAR(t2->getNodeKeyFrame(0)->getTranslate().x, 0.25f, 1e-3f);
+    EXPECT_NEAR(t2->getNodeKeyFrame(2)->getTranslate().x, 0.75f, 1e-3f);
+}
+
+TEST_F(AnimationMergerTest, TrimAnimationRejectsBadWindows)
+{
+    auto skel = createTestSkeleton("trim_bad", {"Root"}, {"clip"});
+    // Degenerate window
+    EXPECT_FALSE(AnimationMerger::trimAnimation(skel.get(), "clip", 0.5f, 0.5f).ok);
+    // Unknown animation
+    EXPECT_FALSE(AnimationMerger::trimAnimation(skel.get(), "nope", 0.0f, 1.0f).ok);
+    // Whole-clip window = no-op success
+    const auto r = AnimationMerger::trimAnimation(skel.get(), "clip", 0.0f, 99.0f);
+    EXPECT_TRUE(r.ok);
+    EXPECT_FLOAT_EQ(skel->getAnimation("clip")->getLength(), 1.0f);
+}

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -2453,6 +2453,7 @@ int CLIPipeline::cmdAnim(int argc, char* argv[])
     bool decimateMode = false;
     bool simplifyMode = false;
     bool bakeFpsMode  = false;
+    bool trimMode = false;            // --trim: cut the clip to [start,end]
     bool inbetweenMode = false;       // #409: AI in-betweening
     bool inbetweenNoModel = false;    // --no-model → force spline fallback
     bool dumpCanonicalMode = false;   // #839: rig→canonical clip extraction
@@ -2528,6 +2529,9 @@ int CLIPipeline::cmdAnim(int argc, char* argv[])
             bakeFps = QString(argv[++i]).toInt();
             continue;
         }
+        // Trim: keep only [--start-time, --end-time] of the animation (cut
+        // the lead-in/tail; exact boundary poses baked; re-timed to start 0).
+        if (arg == "--trim") { trimMode = true; continue; }
         if (arg == "--in-between") { inbetweenMode = true; continue; }
         if (arg == "--gap-frames" && i + 1 < argc) {
             inbetweenGapFrames = QString(argv[++i]).toInt();
@@ -3070,8 +3074,8 @@ int CLIPipeline::cmdAnim(int argc, char* argv[])
 
     if (!listMode && !renameMode && !mergeMode && !resampleMode && !decimateMode
         && !simplifyMode && !analyzeMode && !bakeFpsMode && !inbetweenMode
-        && !dumpCanonicalMode) {
-        err() << "Error: Specify --list, --rename, --merge, --resample, --decimate-step, --simplify, --bake-fps, --in-between, --generate, or --analyze." << Qt::endl;
+        && !trimMode && !dumpCanonicalMode) {
+        err() << "Error: Specify --list, --rename, --merge, --resample, --decimate-step, --trim, --simplify, --bake-fps, --in-between, --generate, or --analyze." << Qt::endl;
         err() << "Usage: qtmesh anim <file> --list [--json]" << Qt::endl;
         err() << "       qtmesh anim <file> --analyze [--json]" << Qt::endl;
         err() << "       qtmesh anim <file> --rename <old> <new> [-o <output>]" << Qt::endl;
@@ -3093,7 +3097,7 @@ int CLIPipeline::cmdAnim(int argc, char* argv[])
     }
 
     if ((renameMode || mergeMode || resampleMode || decimateMode || simplifyMode
-         || bakeFpsMode || inbetweenMode) && outputPath.isEmpty()) {
+         || bakeFpsMode || inbetweenMode || trimMode) && outputPath.isEmpty()) {
         outputPath = filePath;  // overwrite in place
     }
 
@@ -3409,6 +3413,56 @@ int CLIPipeline::cmdAnim(int argc, char* argv[])
     }
 
     // Resample mode
+    // Trim mode: cut the animation to the [--start-time, --end-time] window.
+    if (trimMode) {
+        if (animationFilter.isEmpty() && skel->getNumAnimations() > 1) {
+            err() << "Error: --trim on a multi-animation file needs "
+                     "--animation <name>." << Qt::endl;
+            return 2;
+        }
+        std::string trimAnim = animationFilter.isEmpty()
+            ? skel->getAnimation(static_cast<unsigned short>(0))->getName()
+            : animationFilter.toStdString();
+        if (!skel->hasAnimation(trimAnim)) {
+            err() << "Error: Animation not found: "
+                  << QString::fromStdString(trimAnim) << Qt::endl;
+            return 1;
+        }
+        const float len = skel->getAnimation(trimAnim)->getLength();
+        const float t0 = inbetweenStart >= 0.0f ? inbetweenStart : 0.0f;
+        const float t1 = inbetweenEnd >= 0.0f ? inbetweenEnd : len;
+        SentryReporter::addBreadcrumb("cli.anim",
+            QString("Trim anim=%1 [%2..%3]")
+                .arg(QString::fromStdString(trimAnim)).arg(t0).arg(t1));
+        const auto r = AnimationMerger::trimAnimation(skel.get(), trimAnim, t0, t1);
+        if (!r.ok) {
+            err() << "Error: " << r.error << Qt::endl;
+            return 1;
+        }
+        QFileInfo outFi(outputPath);
+        if (isAnimOnlyInput) {
+            QString exportErr;
+            if (!exportAnimOnly(skel, outFi.absoluteFilePath(), &exportErr)) {
+                err() << "Error: Export failed: " << exportErr << Qt::endl;
+                return 1;
+            }
+        } else {
+            entity->refreshAvailableAnimationState();
+            auto* node = entity->getParentSceneNode();
+            if (MeshImporterExporter::exporter(node, outFi.absoluteFilePath(),
+                                               formatForExtension(outputPath)) != 0) {
+                err() << "Error: Export failed." << Qt::endl;
+                return 1;
+            }
+        }
+        cliWrite(QString("Trimmed '%1' to [%2s..%3s] → %4s (%5 keyframes cut)\nOutput: %6\n")
+            .arg(QString::fromStdString(trimAnim))
+            .arg(t0, 0, 'f', 2).arg(t1, 0, 'f', 2)
+            .arg(r.newLength, 0, 'f', 2).arg(r.keyframesRemoved)
+            .arg(outFi.fileName()));
+        return 0;
+    }
+
     if (resampleMode) {
         if (resampleCount < 2) {
             err() << "Error: --resample requires N >= 2." << Qt::endl;

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -3415,6 +3415,10 @@ int CLIPipeline::cmdAnim(int argc, char* argv[])
     // Resample mode
     // Trim mode: cut the animation to the [--start-time, --end-time] window.
     if (trimMode) {
+        if (skel->getNumAnimations() == 0) {
+            err() << "Error: File has no skeletal animations to trim." << Qt::endl;
+            return 1;
+        }
         if (animationFilter.isEmpty() && skel->getNumAnimations() > 1) {
             err() << "Error: --trim on a multi-animation file needs "
                      "--animation <name>." << Qt::endl;

--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -655,6 +655,7 @@ const QMap<QString, MCPServer::ToolHandler>& MCPServer::toolHandlers()
         {QStringLiteral("set_skinning_display"), &MCPServer::toolSetSkinningDisplay},
         {QStringLiteral("auto_rig"), &MCPServer::toolAutoRig},
         {QStringLiteral("remove_skeleton"), &MCPServer::toolRemoveSkeleton},
+        {QStringLiteral("trim_animation"), &MCPServer::toolTrimAnimation},
         {QStringLiteral("add_arkit_blendshapes"), &MCPServer::toolAddArkitBlendshapes},
         {QStringLiteral("generate_mesh_texture"), &MCPServer::toolGenerateMeshTexture},
         {QStringLiteral("generate_pbr_maps"), &MCPServer::toolGeneratePbrMaps},
@@ -4380,6 +4381,64 @@ QJsonObject MCPServer::toolBakeAnimationFps(const QJsonObject &args)
     } catch (std::exception& e) {
         return makeErrorResult(QString("Error: %1").arg(e.what()));
     }
+}
+
+QJsonObject MCPServer::toolTrimAnimation(const QJsonObject &args)
+{
+    Manager* mgr = Manager::getSingletonPtr();
+    if (!mgr)
+        return makeErrorResult("Error: Manager not available");
+
+    QString entityName = args["entity_name"].toString();
+    Ogre::Entity* entity = nullptr;
+    const QList<Ogre::Entity*> allEntities = mgr->getEntities();
+    if (!entityName.isEmpty()) {
+        for (auto* ent : allEntities)
+            if (ent && QString::fromStdString(ent->getName()) == entityName) { entity = ent; break; }
+        if (!entity)
+            return makeErrorResult(QString("Error: Entity '%1' not found").arg(entityName));
+    } else {
+        for (auto* ent : allEntities)
+            if (ent && ent->hasSkeleton()) { entity = ent; break; }
+    }
+    if (!entity || !entity->hasSkeleton())
+        return makeErrorResult("Error: No entity with skeleton found");
+    Ogre::SkeletonPtr skel = entity->getMesh()->getSkeleton();
+    if (!skel)
+        return makeErrorResult("Error: No skeleton found");
+
+    QString animName = args["animation_name"].toString();
+    if (animName.isEmpty()) {
+        if (skel->getNumAnimations() == 0)
+            return makeErrorResult("Error: Skeleton has no animations");
+        animName = QString::fromStdString(skel->getAnimation(0)->getName());
+    } else if (!skel->hasAnimation(animName.toStdString())) {
+        return makeErrorResult(QString("Error: Animation '%1' not found").arg(animName));
+    }
+    const float clipLen = skel->getAnimation(animName.toStdString())->getLength();
+    const float t0 = static_cast<float>(args.value("start_time").toDouble(0.0));
+    const float t1 = args.contains("end_time")
+        ? static_cast<float>(args.value("end_time").toDouble(clipLen)) : clipLen;
+
+    SentryReporter::addBreadcrumb(QStringLiteral("ai.tool_call"),
+        QStringLiteral("trim_animation %1 [%2..%3]").arg(animName).arg(t0).arg(t1));
+
+    // Same undoable command the dope sheet's Trim button pushes.
+    auto* cmd = new TrimAnimationCommand(entity->getName(),
+                                         animName.toStdString(), t0, t1);
+    UndoManager::getSingleton()->push(cmd);
+    if (!cmd->applied())
+        return makeErrorResult(cmd->error().isEmpty()
+            ? QStringLiteral("Trim failed.") : cmd->error());
+
+    QJsonObject result = makeSuccessResult(
+        QStringLiteral("Trimmed '%1' to %2s (%3 keyframes cut).")
+            .arg(animName)
+            .arg(QString::number(cmd->newLength(), 'f', 2))
+            .arg(cmd->keyframesRemoved()));
+    result["new_length"] = cmd->newLength();
+    result["keyframes_removed"] = cmd->keyframesRemoved();
+    return result;
 }
 
 QJsonObject MCPServer::toolMotionInBetween(const QJsonObject &args)
@@ -10284,6 +10343,27 @@ QJsonArray MCPServer::buildToolsList()
             "joints toward the mesh's medial mass. Best on roughly upright, manifold, "
             "T/A-pose meshes with +Y up. Already-skinned meshes are rejected. Pair "
             "skin:true for a one-click rig+skin.",
+            props
+        );
+    }
+
+    // trim_animation
+    {
+        QJsonObject props;
+        props["animation_name"] = QJsonObject{{"type", "string"},
+            {"description", "Animation to trim (default: the first one)."}};
+        props["start_time"] = QJsonObject{{"type", "number"},
+            {"description", "Window start in seconds (default 0)."}};
+        props["end_time"] = QJsonObject{{"type", "number"},
+            {"description", "Window end in seconds (default: clip length)."}};
+        props["entity_name"] = QJsonObject{{"type", "string"},
+            {"description", "Target entity (default: first skinned entity)."}};
+        appendTool(
+            "trim_animation",
+            "TRIM a skeletal animation to a [start_time, end_time] window: cuts "
+            "the lead-in and tail, bakes exact boundary poses at both ends, and "
+            "re-times the clip to start at 0. Undoable in the GUI session. Use "
+            "when only an interval of a clip is good.",
             props
         );
     }

--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -4389,6 +4389,17 @@ QJsonObject MCPServer::toolTrimAnimation(const QJsonObject &args)
     if (!mgr)
         return makeErrorResult("Error: Manager not available");
 
+    // Strict arg typing: a present-but-mistyped field must error, not fall
+    // back to a default that silently trims the wrong window.
+    if (args.contains("entity_name") && !args["entity_name"].isString())
+        return makeErrorResult("Error: 'entity_name' must be a string.");
+    if (args.contains("animation_name") && !args["animation_name"].isString())
+        return makeErrorResult("Error: 'animation_name' must be a string.");
+    if (args.contains("start_time") && !args["start_time"].isDouble())
+        return makeErrorResult("Error: 'start_time' must be a number.");
+    if (args.contains("end_time") && !args["end_time"].isDouble())
+        return makeErrorResult("Error: 'end_time' must be a number.");
+
     QString entityName = args["entity_name"].toString();
     Ogre::Entity* entity = nullptr;
     const QList<Ogre::Entity*> allEntities = mgr->getEntities();
@@ -4419,6 +4430,15 @@ QJsonObject MCPServer::toolTrimAnimation(const QJsonObject &args)
     const float t0 = static_cast<float>(args.value("start_time").toDouble(0.0));
     const float t1 = args.contains("end_time")
         ? static_cast<float>(args.value("end_time").toDouble(clipLen)) : clipLen;
+    // Pre-validate BEFORE pushing — a redo() failure would leave a dead undo
+    // entry on the stack (and clear the redo branch).
+    {
+        const float c0 = std::clamp(t0, 0.0f, clipLen);
+        const float c1 = std::clamp(t1, 0.0f, clipLen);
+        if (c1 - c0 < 0.01f)
+            return makeErrorResult(
+                "Error: Trim window too small — select at least one frame.");
+    }
 
     SentryReporter::addBreadcrumb(QStringLiteral("ai.tool_call"),
         QStringLiteral("trim_animation %1 [%2..%3]").arg(animName).arg(t0).arg(t1));

--- a/src/MCPServer.h
+++ b/src/MCPServer.h
@@ -183,6 +183,7 @@ private:
     /// optional skin chain + re-export.
     QJsonObject toolAutoRig(const QJsonObject &args);
     QJsonObject toolRemoveSkeleton(const QJsonObject &args);
+    QJsonObject toolTrimAnimation(const QJsonObject &args);
     /// #889: fit the ARKit blendshape template onto the selected face mesh
     /// (NRICP + deformation transfer), attach the 52 ARKit morph targets, and
     /// optionally re-export.

--- a/src/commands/SkeletonBoneCommands.cpp
+++ b/src/commands/SkeletonBoneCommands.cpp
@@ -1,5 +1,6 @@
 #include "SkeletonBoneCommands.h"
 
+#include "AnimationMerger.h"
 #include "AutoRigController.h"
 #include "Manager.h"
 #include "PropertiesPanelController.h"
@@ -168,6 +169,68 @@ void RemoveSkeletonCommand::undo()
     m_applied = false;
     if (auto* rig = AutoRigController::instance())
         emit rig->selectionChanged();
+}
+
+TrimAnimationCommand::TrimAnimationCommand(std::string entityName,
+                                           std::string animName,
+                                           float t0, float t1,
+                                           QUndoCommand* parent)
+    : QUndoCommand(parent)
+    , m_entityName(std::move(entityName))
+    , m_animName(std::move(animName))
+    , m_t0(t0)
+    , m_t1(t1)
+{
+    setText(QStringLiteral("Trim animation"));
+}
+
+void TrimAnimationCommand::redo()
+{
+    Ogre::Entity* entity = resolveEntityByName(m_entityName);
+    if (!entity || !entity->getMesh() || !entity->getMesh()->hasSkeleton()) {
+        m_error = QStringLiteral("Entity has no skeleton.");
+        return;
+    }
+    // Master skeleton — the resource exports read; the entity's
+    // SkeletonInstance shares its animation list.
+    Ogre::Skeleton* master = entity->getMesh()->getSkeleton().get();
+    if (!master || !master->hasAnimation(m_animName)) {
+        m_error = QStringLiteral("Animation not found on the skeleton.");
+        return;
+    }
+
+    if (m_firstRedo) {
+        m_before = SkeletonEditor::captureSnapshot(entity);
+        m_firstRedo = false;
+    }
+
+    const auto r = AnimationMerger::trimAnimation(master, m_animName,
+                                                  m_t0, m_t1);
+    if (!r.ok) {
+        m_error = r.error;
+        return;
+    }
+    m_keyframesRemoved = r.keyframesRemoved;
+    m_newLength = r.newLength;
+    m_applied = true;
+    // The entity's AnimationState still carries the OLD length — rebuild the
+    // state set so the timeline/slider sees the trimmed clip.
+    entity->refreshAvailableAnimationState();
+    SentryReporter::addBreadcrumb(QStringLiteral("scene.anim.trim"),
+        QStringLiteral("%1 [%2..%3] -%4 keys")
+            .arg(QString::fromStdString(m_animName))
+            .arg(m_t0).arg(m_t1).arg(m_keyframesRemoved));
+    SkeletonEditor::refreshAfterEdit(m_entityName);
+}
+
+void TrimAnimationCommand::undo()
+{
+    Ogre::Entity* entity = resolveEntityByName(m_entityName);
+    if (!entity) return;
+    QString err;
+    if (SkeletonEditor::restoreSnapshot(entity, m_before, &err))
+        SkeletonEditor::refreshAfterEdit(m_entityName);
+    m_applied = false;
 }
 
 RenameBoneCommand::RenameBoneCommand(std::string entityName,

--- a/src/commands/SkeletonBoneCommands.h
+++ b/src/commands/SkeletonBoneCommands.h
@@ -74,6 +74,37 @@ private:
     bool m_firstRedo = true;
 };
 
+/// Trim a skeletal animation to a [t0, t1] window (dope-sheet "Trim").
+/// Redo runs AnimationMerger::trimAnimation on the mesh's MASTER skeleton
+/// (so exports carry the cut); undo restores the full pre-trim snapshot.
+class TrimAnimationCommand : public QUndoCommand
+{
+public:
+    TrimAnimationCommand(std::string entityName,
+                         std::string animName,
+                         float t0, float t1,
+                         QUndoCommand* parent = nullptr);
+
+    void undo() override;
+    void redo() override;
+
+    bool applied() const { return m_applied; }
+    QString error() const { return m_error; }
+    int keyframesRemoved() const { return m_keyframesRemoved; }
+    float newLength() const { return m_newLength; }
+
+private:
+    std::string m_entityName;
+    std::string m_animName;
+    float m_t0 = 0.f, m_t1 = 0.f;
+    SkeletonEditor::Snapshot m_before;
+    QString m_error;
+    int m_keyframesRemoved = 0;
+    float m_newLength = 0.f;
+    bool m_applied = false;
+    bool m_firstRedo = true;
+};
+
 class RenameBoneCommand : public QUndoCommand
 {
 public:

--- a/website/src/hooks/useQtmeshActionRef.js
+++ b/website/src/hooks/useQtmeshActionRef.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 const QTMESH_RELEASES_LATEST_API = 'https://api.github.com/repos/fernandotonon/QtMeshEditor/releases/latest';
-const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.37.6';
+const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.37.7';
 const CACHE_KEY = 'qtmesh.actionRef.cache.v1';
 const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 


### PR DESCRIPTION
## What
Cut off the beginning and end of an animation and keep the good interval (field request: many library/imported clips are only usable in a sub-range).

- **Core** `AnimationMerger::trimAnimation`: original keys inside the window survive, exact interpolated boundary poses are baked at both ends, the clip re-times to start at 0 with length t1−t0. Collect-then-recreate (the resample pattern) — no stale keyframe caches.
- **Dope sheet**: box-select keyframes spanning the good interval → **✂ Trim to range** (in the same window bar as the AI in-between control). Fully **undoable** (skeleton-snapshot command); the status line reports the new length + a Ctrl+Z hint.
- **CLI**: `qtmesh anim model.fbx --trim --start-time 0.5 --end-time 2.0 [--animation NAME] -o out.fbx` (times clamp to the clip).
- **MCP**: `trim_animation` — same undoable command path.
- Unit tests for the boundary-bake math (analytic linear channel), mid-window interpolation, bad windows, whole-window no-op.

## Verification
Rumba `mixamo.com` 2.367s → `--trim 1.0..3.0` → **1.367s** (end clamped to clip length), 1126 keyframes cut, output `--list` round-trips the new duration.

Bumps version to 3.37.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added animation trimming in the dope sheet, with boundary poses baked and results retimed from zero.
  * Added undo/redo support for trimming via Ctrl+Z.
  * Added `qtmesh anim --trim` for command-line exports.
  * Added animation trimming through the MCP tool.
  * Added a documented example for trimming the “Walk” animation.

* **Bug Fixes**
  * Improved validation and error reporting for invalid ranges and missing animations.
  * Preserved additive animation settings when trimming clips.

* **Documentation**
  * Updated project and CI/CD references to version 3.37.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->