### PR TITLE
fix(trellis2): ship trellis-cli with --dump-post (3.37.7)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.24.0)
 cmake_policy(SET CMP0005 NEW)
 cmake_policy(SET CMP0048 NEW) # manages project version
 
-project(QtMeshEditor VERSION 3.37.6 LANGUAGES C CXX)
+project(QtMeshEditor VERSION 3.37.7 LANGUAGES C CXX)
 message(STATUS "Building QtMeshEditor version ${PROJECT_VERSION}")
 
 set(QTMESHEDITOR_VERSION_STRING "\"${PROJECT_VERSION}\"")

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Available on the [GitHub Actions Marketplace](https://github.com/marketplace/act
 **Versioning**
 
 - **Always follow the latest GitHub release** — use the Marketplace floating tag `fernandotonon/QtMeshEditor@v1` (same pattern as the [Marketplace example](https://github.com/marketplace/actions/qtmesheditor)). The composite action defaults to `image-tag: latest`, so the Docker CLI tracks the newest published `ghcr.io/fernandotonon/qtmesh` image.
-- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.37.6**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
+- **Reproducible builds** — pin the action and the container to the same semver as this repository’s `project(QtMeshEditor VERSION …)` in `CMakeLists.txt` (currently **3.37.7**). After bumping the version in CMake, run `./scripts/sync-doc-versions-from-cmake.sh` to refresh the pinned refs in `README.md` and the docs site fallback; CI enforces the match with `./scripts/sync-doc-versions-from-cmake.sh --check`.
 
 Pinned workflow template (action + `ghcr.io` image aligned):
 
@@ -48,10 +48,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run QtMesh scan
-        uses: fernandotonon/QtMeshEditor@3.37.6
+        uses: fernandotonon/QtMeshEditor@3.37.7
         with:
           command: scan
-          image-tag: "3.37.6"
+          image-tag: "3.37.7"
         env:
           QTMESH_CLOUD_TOKEN: ${{ secrets.QTMESH_CLOUD_TOKEN }}
 ```
@@ -76,37 +76,37 @@ Release tags are listed on the [releases page](https://github.com/fernandotonon/
 
 ```yaml
 # Validate a specific mesh
-- uses: fernandotonon/QtMeshEditor@3.37.6
+- uses: fernandotonon/QtMeshEditor@3.37.7
   with:
     command: validate
     input-file: ./models/character.fbx
-    image-tag: "3.37.6"
+    image-tag: "3.37.7"
 
 # Convert FBX → glTF
-- uses: fernandotonon/QtMeshEditor@3.37.6
+- uses: fernandotonon/QtMeshEditor@3.37.7
   with:
     command: convert
     input-file: ./models/character.fbx
     output-file: ./output/character.gltf2
-    image-tag: "3.37.6"
+    image-tag: "3.37.7"
 
 # Resample Mixamo animations (200+ keyframes → 30)
-- uses: fernandotonon/QtMeshEditor@3.37.6
+- uses: fernandotonon/QtMeshEditor@3.37.7
   with:
     command: anim
     input-file: ./animations/dance.fbx
     output-file: ./output/dance_optimized.fbx
     options: --resample 30
-    image-tag: "3.37.6"
+    image-tag: "3.37.7"
 
 # Get mesh info as JSON
-- uses: fernandotonon/QtMeshEditor@3.37.6
+- uses: fernandotonon/QtMeshEditor@3.37.7
   id: info
   with:
     command: info
     input-file: ./models/character.fbx
     options: --json
-    image-tag: "3.37.6"
+    image-tag: "3.37.7"
 
 # Docker (alternative — :latest tracks newest image; pin :3.4.0 to match semver action ref)
 # The image is multi-arch (linux/amd64 + linux/arm64), so it runs natively on

--- a/cmake/TrellisCpp.cmake
+++ b/cmake/TrellisCpp.cmake
@@ -4,9 +4,11 @@
 # and ships it next to the editor binary, so TRELLIS.2 needs NO separate
 # runtime install — only the GGUF weights, which AI Model Settings downloads
 # into <AppData>/ai_models/trellis2/ (a directory Trellis2Predictor already
-# resolves). Pinned to upstream main AFTER both of our PRs merged (#44 Metal
-# support, #45 --dump-post with the cleaned remesh) — re-audit licenses if the
-# pin moves (docs/trellis2-dependencies.md).
+# resolves). MUST include PR #45 (`--dump-post`) — 3.37.6 shipped pin
+# 16f3109e (2026-08-21) which predated that merge and every snap/deb invoke
+# failed with "unknown option: --dump-post". Current pin is upstream main
+# after #44 (Metal) + #45 (dump-post). Re-audit licenses if the pin moves
+# (docs/trellis2-dependencies.md).
 #
 # Built as an EXTERNAL PROJECT (isolated sub-build), NOT FetchContent:
 # trellis.cpp vendors its own patched ggml fork whose target names collide
@@ -70,7 +72,7 @@ endif()
 
 ExternalProject_Add(qtmesh_trelliscpp
     GIT_REPOSITORY https://github.com/pwilkin/trellis.cpp.git
-    GIT_TAG        16f3109e82f3922033bfa62b83c42899678b7b6f
+    GIT_TAG        2516c48b677050c570f47eba2e68dc8a5bc918b0
     GIT_SHALLOW    OFF
     PREFIX         "${CMAKE_BINARY_DIR}/_deps/qtmesh_trelliscpp"
     SOURCE_DIR     "${CMAKE_BINARY_DIR}/_deps/qtmesh_trelliscpp-src"

--- a/docs/TRELLIS2.md
+++ b/docs/TRELLIS2.md
@@ -65,11 +65,14 @@ when both are present:
 | **trellis.cpp** (preferred, **bundled**) | C++/GGML ([pwilkin/trellis.cpp](https://github.com/pwilkin/trellis.cpp)) — CUDA / Vulkan / **Metal** / CPU, no Python, GGUF weights. Built with `ENABLE_TRELLIS_CPP` as a **self-contained** `trellis-cli` (`BUILD_SHARED_LIBS=OFF` so ggml is linked in — shipping only the CLI without `libggml*.so` caused exit 127 on Linux .deb/snap). | Linux + **macOS** release builds (Windows MinGW still OFF pending verification) | Discovery order: env `QTMESH_TRELLIS2_CLI` → QSettings `ai/trellis2Cli` → bundled next to the editor binary → `trellis-cli` on `PATH`. Models: `QTMESH_TRELLIS2_CLI_MODELS` / `ai/trellis2CliModels` / `<AppData>/ai_models/trellis2` (GGUFs from AI Model Settings / [`ilintar/trellis2-gguf`](https://huggingface.co/ilintar/trellis2-gguf)) |
 | Python sidecar | upstream-exact PyTorch/CUDA (`ai/trellis2/`) | Linux + NVIDIA | as below |
 
-QtMeshEditor invokes `trellis-cli --dump-post` (added in the fork): trellis.cpp emits the
-RAW decoded mesh + sparse PBR volume and exits before its own remesh/UV/bake — QtMeshEditor
-keeps the game-ready + native-bake pipeline either way. Presets map to `--res` (fast=512,
-balanced=1024, high=1536); with only the 512 GGUFs installed the backend drops to the 512
-pipeline with a warning. `--mock` runs always route to the Python sidecar.
+QtMeshEditor invokes `trellis-cli --dump-post` (upstream PR
+[#45](https://github.com/pwilkin/trellis.cpp/pull/45); pin must be at/after that merge —
+3.37.6 shipped an older pin and every install failed with `unknown option: --dump-post`):
+trellis.cpp emits the RAW decoded mesh + sparse PBR volume and exits before its own
+remesh/UV/bake — QtMeshEditor keeps the game-ready + native-bake pipeline either way.
+Presets map to `--res` (fast=512, balanced=1024, high=1536); with only the 512 GGUFs
+installed the backend drops to the 512 pipeline with a warning. `--mock` runs always
+route to the Python sidecar.
 
 ## Install (Linux + NVIDIA GPU)
 

--- a/src/ImageTo3D/Trellis2Predictor.cpp
+++ b/src/ImageTo3D/Trellis2Predictor.cpp
@@ -19,6 +19,8 @@
 #include <QTemporaryDir>
 #include "AppStorage.h"
 
+#include <cstdio>
+
 namespace {
 
 constexpr const char* kEnvDirVar     = "QTMESH_TRELLIS2_ENV";
@@ -443,9 +445,12 @@ MeshGenPredictor::Result Trellis2Predictor::predict(
     QProcess proc;
     proc.setProgram(cli);
     proc.setArguments(args);
-    // stderr (backend banner, ggml logs) forwards to ours; stdout carries the
-    // "[k/7]" stage lines we map onto the shared Stage enum.
-    proc.setProcessChannelMode(QProcess::ForwardedErrorChannel);
+    // Separate channels: stdout carries "[k/7]" stage lines; stderr is drained
+    // here so (a) the pipe cannot fill and stall a long run, (b) failures can
+    // surface the real message (e.g. "unknown option: --dump-post") instead of
+    // a useless "see stderr log" when the GUI has nowhere to show Forwarded
+    // stderr. Mirror stderr to our own stderr for CLI/debug visibility.
+    proc.setProcessChannelMode(QProcess::SeparateChannels);
     // Prepend the CLI directory so leftover libggml shared libs next to the
     // bundled binary resolve even when RPATH was stripped (snap/deb private
     // lib dir, macOS SIP, Windows PATH). Static BUILD_SHARED_LIBS=OFF is the
@@ -474,6 +479,15 @@ MeshGenPredictor::Result Trellis2Predictor::predict(
     int lastDone = 0, lastTotal = 2;
     bool cancelled = false;
     QByteArray pending;
+    QByteArray errBuf;
+    auto drainStderr = [&]() {
+        const QByteArray chunk = proc.readAllStandardError();
+        if (chunk.isEmpty())
+            return;
+        errBuf += chunk;
+        fwrite(chunk.constData(), 1, static_cast<size_t>(chunk.size()), stderr);
+        fflush(stderr);
+    };
     auto handleLine = [&](const QByteArray& line) {
         if (line.size() >= 5 && line[0] == '[' && line[2] == '/'
             && line[4] == ']' && line[1] >= '1' && line[1] <= '9') {
@@ -486,6 +500,7 @@ MeshGenPredictor::Result Trellis2Predictor::predict(
     while (proc.state() != QProcess::NotRunning) {
         proc.waitForReadyRead(300);
         pending += proc.readAllStandardOutput();
+        drainStderr();
         int nl;
         while ((nl = pending.indexOf('\n')) >= 0) {
             handleLine(pending.left(nl));
@@ -500,6 +515,8 @@ MeshGenPredictor::Result Trellis2Predictor::predict(
             break;
         }
     }
+    pending += proc.readAllStandardOutput();
+    drainStderr();
     if (cancelled)
         return failResult(QStringLiteral("cancelled"));
     if (proc.exitStatus() != QProcess::NormalExit || proc.exitCode() != 0) {
@@ -511,8 +528,19 @@ MeshGenPredictor::Result Trellis2Predictor::predict(
                 "missing libggml shared library next to the bundled binary). "
                 "Reinstall a build that ships the self-contained trellis.cpp "
                 "runtime."));
+        QString detail = QString::fromLocal8Bit(errBuf).trimmed();
+        detail.replace(QLatin1Char('\n'), QLatin1Char(' '));
+        while (detail.contains(QLatin1String("  ")))
+            detail.replace(QLatin1String("  "), QLatin1String(" "));
+        if (detail.size() > 400)
+            detail = QStringLiteral("…") + detail.right(399);
+        if (!detail.isEmpty())
+            return failResult(QStringLiteral(
+                "trellis2: trellis-cli exited with code %1: %2")
+                                  .arg(proc.exitCode())
+                                  .arg(detail));
         return failResult(QStringLiteral(
-            "trellis2: trellis-cli exited with code %1 (see stderr log).")
+            "trellis2: trellis-cli exited with code %1.")
                               .arg(proc.exitCode()));
     }
     Trellis2Interchange::ReadResult rr =

--- a/src/ImageTo3D/Trellis2Predictor.cpp
+++ b/src/ImageTo3D/Trellis2Predictor.cpp
@@ -485,6 +485,11 @@ MeshGenPredictor::Result Trellis2Predictor::predict(
         if (chunk.isEmpty())
             return;
         errBuf += chunk;
+        // Cap retained stderr so a noisy/long run cannot grow unbounded;
+        // the failure message still takes only a short suffix below.
+        constexpr int kMaxCapturedStderr = 64 * 1024;
+        if (errBuf.size() > kMaxCapturedStderr)
+            errBuf = errBuf.right(kMaxCapturedStderr);
         fwrite(chunk.constData(), 1, static_cast<size_t>(chunk.size()), stderr);
         fflush(stderr);
     };

--- a/website/src/hooks/useQtmeshActionRef.js
+++ b/website/src/hooks/useQtmeshActionRef.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 const QTMESH_RELEASES_LATEST_API = 'https://api.github.com/repos/fernandotonon/QtMeshEditor/releases/latest';
-const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.37.6';
+const QTMESH_ACTION_REF_FALLBACK = 'fernandotonon/QtMeshEditor@3.37.7';
 const CACHE_KEY = 'qtmesh.actionRef.cache.v1';
 const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 


### PR DESCRIPTION
## Summary
- **3.37.6 snap/deb TRELLIS.2 is broken**: bundled `trellis-cli` was pinned to `16f3109` (21 Aug), which predates upstream [pwilkin/trellis.cpp#45](https://github.com/pwilkin/trellis.cpp/pull/45). The app always passes `--dump-post` → exit 1 with `unknown option: --dump-post`.
- Bump the ExternalProject pin to `2516c48` (upstream main after #44 Metal + #45 dump-post).
- Capture/drain `trellis-cli` stderr and include it in the GUI/CLI failure string (no more opaque “see stderr log”).
- Version **3.37.7** + doc version sync.

## Test plan
- [ ] Linux release/CI build produces `trellis-cli --help` listing `--dump-post`
- [ ] After install: `trellis-cli --image … --dump-post /tmp/x.dump --models …` no longer fails at arg parse
- [ ] Snap/deb TRELLIS.2 generation gets past the previous exit-1 failure (models already under `$SNAP_USER_COMMON`)
- [ ] Deliberate CLI failure shows the real stderr text in the error toast/message


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the application to version 3.37.7.
  - Added clearer details to error messages when runtime commands fail.

- **Bug Fixes**
  - Fixed runtime installation failures involving the `--dump-post` option by updating the bundled runtime version.
  - Improved handling of runtime output so failures provide more useful diagnostic information.

- **Documentation**
  - Updated build, CI/CD, and runtime documentation to reference version 3.37.7 and clarify `--dump-post` support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->