### PR TITLE
fix(trellis2): bundle trellis-cli.exe on Windows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -380,10 +380,11 @@ jobs:
         Write-Host "cmake location: $((Get-Command cmake.exe).Source)"
         gcc --version
         cmake --version
-        cmake -S . -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_CXX_FLAGS="-g" -DCMAKE_C_FLAGS="-g" -DQT_QMAKE_EXECUTABLE=qmake -DCMAKE_C_COMPILER="D:/a/QtMeshEditor/Qt/Tools/mingw1310_64/bin/gcc.exe" -DCMAKE_CXX_COMPILER="D:/a/QtMeshEditor/Qt/Tools/mingw1310_64/bin/g++.exe" -DCMAKE_EXE_LINKER_FLAGS=-static -DQt6_DIR=D:/a/QtMeshEditor/Qt/${{env.QT_VERSION}}/mingw_64/lib/cmake/Qt6 -DQT_DIR=D:/a/QtMeshEditor/Qt/${{env.QT_VERSION}}/mingw_64/lib/cmake/Qt6 -DQt6GuiTools_DIR=D:/a/QtMeshEditor/Qt/${{env.QT_VERSION}}/mingw_64/lib/cmake/Qt6GuiTools -DOGRE_DIR=${{github.workspace}}/ogre-build/SDK/CMake/ -DASSIMP_DIR=C:/PROGRA~2/Assimp/lib/cmake/assimp-${{ env.ASSIMP_DIR_VERSION }} -DENABLE_ONNX=ON
-        # ENABLE_TRELLIS_CPP stays OFF on MinGW for now (follow-up). When it
-        # turns on, cmake/TrellisCpp.cmake already forces BUILD_SHARED_LIBS=OFF
-        # and CopyTrellisRuntime.cmake scoops ggml*.dll next to trellis-cli.exe.      shell: powershell
+        cmake -S . -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_CXX_FLAGS="-g" -DCMAKE_C_FLAGS="-g" -DQT_QMAKE_EXECUTABLE=qmake -DCMAKE_C_COMPILER="D:/a/QtMeshEditor/Qt/Tools/mingw1310_64/bin/gcc.exe" -DCMAKE_CXX_COMPILER="D:/a/QtMeshEditor/Qt/Tools/mingw1310_64/bin/g++.exe" -DCMAKE_EXE_LINKER_FLAGS=-static -DQt6_DIR=D:/a/QtMeshEditor/Qt/${{env.QT_VERSION}}/mingw_64/lib/cmake/Qt6 -DQT_DIR=D:/a/QtMeshEditor/Qt/${{env.QT_VERSION}}/mingw_64/lib/cmake/Qt6 -DQt6GuiTools_DIR=D:/a/QtMeshEditor/Qt/${{env.QT_VERSION}}/mingw_64/lib/cmake/Qt6GuiTools -DOGRE_DIR=${{github.workspace}}/ogre-build/SDK/CMake/ -DASSIMP_DIR=C:/PROGRA~2/Assimp/lib/cmake/assimp-${{ env.ASSIMP_DIR_VERSION }} -DENABLE_ONNX=ON -DENABLE_TRELLIS_CPP=ON
+        # ENABLE_TRELLIS_CPP builds the bundled trellis-cli.exe (static MinGW,
+        # OpenMP off, portable AVX baseline — cmake/TrellisCpp.cmake). The
+        # install rules carry it + its license notices into bin/, so the zip
+        # and the installer ship it and the DLL verifier import-walks it.      shell: powershell
 
     - name: Build
       env:
@@ -393,6 +394,19 @@ jobs:
         Write-Host "mingw32-make location: $((Get-Command mingw32-make.exe).Source)"
         mingw32-make --version
         D:/a/QtMeshEditor/Qt/Tools/mingw1310_64/bin/mingw32-make.exe install -j8
+      shell: powershell
+
+    - name: Verify bundled trellis-cli.exe
+      run: |
+        if (-not (Test-Path "${{github.workspace}}/bin/trellis-cli.exe")) {
+            Write-Error "ENABLE_TRELLIS_CPP=ON but bin/trellis-cli.exe is missing"
+            exit 1
+        }
+        if (-not (Test-Path "${{github.workspace}}/bin/trellis-cli.THIRD_PARTY_LICENSES.txt")) {
+            Write-Error "trellis-cli license notices missing from bin/"
+            exit 1
+        }
+        Write-Host "bundled trellis-cli.exe present: $((Get-Item "${{github.workspace}}/bin/trellis-cli.exe").Length) bytes"
       shell: powershell
 
     - name: Upload debug symbols to Sentry

--- a/cmake/PatchTrellisMinGW.cmake
+++ b/cmake/PatchTrellisMinGW.cmake
@@ -1,0 +1,42 @@
+# Idempotent source patch for the bundled trellis.cpp checkout (run as the
+# ExternalProject PATCH_COMMAND, all platforms — it no-ops where the pattern
+# is already guarded).
+#
+# Qt's MinGW 13.1 toolchain ships mingw-w64 headers that predate the Windows 11
+# thread-power-throttling API: THREAD_POWER_THROTTLING_STATE and friends are
+# missing (only the PROCESS_* variants exist), so trellis.cpp's vendored
+# ggml-cpu.c fails to compile even though the block is _WIN32_WINNT-guarded.
+# The block is a perf-only opt-out (keeps Win11 from parking cores) — extend
+# its guard so header sets without the API simply skip it, exactly what the
+# code already does for pre-8 Windows targets.
+#
+# Usage: cmake -DSRC=<trellis src dir> -P PatchTrellisMinGW.cmake
+if(NOT SRC)
+    message(FATAL_ERROR "PatchTrellisMinGW.cmake: pass -DSRC=<source dir>")
+endif()
+
+set(_file "${SRC}/thirdparty/ggml/src/ggml-cpu/ggml-cpu.c")
+if(NOT EXISTS "${_file}")
+    message(FATAL_ERROR "PatchTrellisMinGW.cmake: ${_file} not found — did the pin move?")
+endif()
+
+file(READ "${_file}" _content)
+set(_old "#if _WIN32_WINNT >= 0x0602\n        THREAD_POWER_THROTTLING_STATE t;")
+set(_new "#if _WIN32_WINNT >= 0x0602 && defined(THREAD_POWER_THROTTLING_CURRENT_VERSION)\n        THREAD_POWER_THROTTLING_STATE t;")
+
+string(FIND "${_content}" "${_new}" _already)
+if(NOT _already EQUAL -1)
+    message(STATUS "trellis.cpp MinGW throttling guard already applied")
+    return()
+endif()
+
+string(FIND "${_content}" "${_old}" _found)
+if(_found EQUAL -1)
+    message(FATAL_ERROR "PatchTrellisMinGW.cmake: expected pattern not found in "
+                        "ggml-cpu.c — the pin moved; re-check whether upstream "
+                        "fixed the MinGW guard and drop this patch if so.")
+endif()
+
+string(REPLACE "${_old}" "${_new}" _content "${_content}")
+file(WRITE "${_file}" "${_content}")
+message(STATUS "trellis.cpp: applied MinGW thread-power-throttling guard")

--- a/cmake/TrellisCpp.cmake
+++ b/cmake/TrellisCpp.cmake
@@ -64,7 +64,8 @@ set(_trellis_cmake_args
 # INS_ENB=ON (AVX2+FMA+F16C+BMI2) — Haswell+. 3.37.7 snap SIGILL'd
 # (vfmadd213ss / exit 4) on Ivy Bridge (AVX+F16C, no FMA). Pin an
 # AVX+SSE4.2 baseline without FMA/AVX2/F16C/BMI2 so Sandy Bridge+.
-if(UNIX AND NOT APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64")
+# Applies to Windows x86_64 too — the same shipping-binary rule.
+if(NOT APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64")
     list(APPEND _trellis_cmake_args
          -DGGML_SSE42=ON
          -DGGML_AVX=ON
@@ -72,6 +73,21 @@ if(UNIX AND NOT APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64")
          -DGGML_FMA=OFF
          -DGGML_F16C=OFF
          -DGGML_BMI2=OFF)
+endif()
+# Windows (MinGW): self-contained trellis-cli.exe. -static folds the MinGW
+# runtimes (libgcc/libstdc++/winpthread) into the exe so the package's
+# transitive-import verifier sees only system DLLs; GGML_OPENMP=OFF avoids a
+# libgomp dependency (ggml falls back to its own thread pool). CPU backend
+# for now — Vulkan needs the SDK on the runner + a driver-provided
+# vulkan-1.dll on user machines (tracked follow-up).
+if(WIN32)
+    list(APPEND _trellis_cmake_args
+         "-DCMAKE_EXE_LINKER_FLAGS=-static"
+         -DGGML_OPENMP=OFF)
+    if(CMAKE_MAKE_PROGRAM)
+        list(APPEND _trellis_cmake_args
+             "-DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}")
+    endif()
 endif()
 # Linux: Vulkan GPU backend (runtime dep: libvulkan1). Falls back to CPU
 # when no suitable device is present.

--- a/cmake/TrellisCpp.cmake
+++ b/cmake/TrellisCpp.cmake
@@ -116,6 +116,10 @@ ExternalProject_Add(qtmesh_trelliscpp
     SOURCE_DIR     "${CMAKE_BINARY_DIR}/_deps/qtmesh_trelliscpp-src"
     BINARY_DIR     "${CMAKE_BINARY_DIR}/_deps/qtmesh_trelliscpp-build"
     LIST_SEPARATOR |
+    # MinGW header compat (see cmake/PatchTrellisMinGW.cmake) — idempotent,
+    # runs on every platform, errors loudly if the pin moves past the pattern.
+    PATCH_COMMAND  ${CMAKE_COMMAND} -DSRC=<SOURCE_DIR>
+                   -P ${CMAKE_CURRENT_LIST_DIR}/PatchTrellisMinGW.cmake
     CMAKE_ARGS     ${_trellis_cmake_args}
     BUILD_COMMAND  ${CMAKE_COMMAND} --build <BINARY_DIR> --target trellis-cli
                    --config Release -j4


### PR DESCRIPTION
## Problem
Windows users still get **"TRELLIS.2 runtime not installed…"** — the 3.37.3 bundling covered macOS + Linux and deferred MinGW.

## Fix
- `build-windows` enables `-DENABLE_TRELLIS_CPP=ON` + a loud post-install check that `bin/trellis-cli.exe` and its license notices landed (mirrors the Linux check).
- The trellis.cpp child build on Windows: **`-static`** (MinGW runtimes folded into the exe — the package's transitive-import verifier then sees only system DLLs), **`GGML_OPENMP=OFF`** (no libgomp dep; ggml's own thread pool), `CMAKE_MAKE_PROGRAM` forwarded, and the **portable AVX/no-FMA x86_64 baseline** now applies to Windows too (same shipping rule that fixed the Ivy Bridge SIGILL on Linux).
- CPU backend for now; **Vulkan on Windows is a tracked follow-up** (needs the SDK on the runner + driver-provided vulkan-1.dll on user machines — the verifier would flag that import today).

Everything downstream was already Windows-ready: `Trellis2Predictor` probes `trellis-cli.exe` next to the app, `install(PROGRAMS)` carries it into `bin/` (zip + installer), `CopyTrellisRuntime` scoops any `ggml*.dll`.

## Verification
MinGW cross-verification isn't possible locally — the critical validation is this PR's **build-windows** job: first-ever MinGW build of the bundled runtime + the new existence check + the DLL verifier import-walking `trellis-cli.exe`. Watching it.

No version bump here (PR #988 holds 3.38.0); this rides the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)