### PR TITLE
fix(trellis2): license-notices concat wrote 0 bytes on Windows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -402,8 +402,9 @@ jobs:
             Write-Error "ENABLE_TRELLIS_CPP=ON but bin/trellis-cli.exe is missing"
             exit 1
         }
-        if (-not (Test-Path "${{github.workspace}}/bin/trellis-cli.THIRD_PARTY_LICENSES.txt")) {
-            Write-Error "trellis-cli license notices missing from bin/"
+        $lic = "${{github.workspace}}/bin/trellis-cli.THIRD_PARTY_LICENSES.txt"
+        if (-not (Test-Path $lic) -or (Get-Item $lic).Length -eq 0) {
+            Write-Error "trellis-cli license notices missing or EMPTY in bin/ (the 3.38.0 zip shipped a 0-byte file)"
             exit 1
         }
         Write-Host "bundled trellis-cli.exe present: $((Get-Item "${{github.workspace}}/bin/trellis-cli.exe").Length) bytes"

--- a/cmake/ConcatFiles.cmake
+++ b/cmake/ConcatFiles.cmake
@@ -1,14 +1,29 @@
 # Build-time file concatenation (cmake -P): add_custom_command has no shell,
 # so `-E cat ... > out` cannot redirect — this script does it portably.
-#   cmake -DOUT=<path> -DIN=<f1>;<f2>;... -P ConcatFiles.cmake
+#   cmake -DOUT=<path> "-DIN=<f1>|<f2>|..." -P ConcatFiles.cmake
+# The separator is '|', NOT ';' — an escaped semicolon list survives POSIX
+# shells (which strip the backslash) but reaches CMake as one giant literal
+# "a\;b\;c" path under Windows cmd, so every EXISTS failed and the 3.38.0
+# Windows zip shipped a 0-byte trellis-cli.THIRD_PARTY_LICENSES.txt.
 if(NOT OUT OR NOT IN)
     message(FATAL_ERROR "ConcatFiles.cmake: OUT and IN are required")
 endif()
+string(REPLACE "|" ";" _in_list "${IN}")
 set(_acc "")
-foreach(_f IN LISTS IN)
+set(_missing "")
+foreach(_f IN LISTS _in_list)
     if(EXISTS "${_f}")
         file(READ "${_f}" _c)
         string(APPEND _acc "${_c}\n----------------------------------------\n")
+    else()
+        list(APPEND _missing "${_f}")
     endif()
 endforeach()
+if(_acc STREQUAL "")
+    message(FATAL_ERROR "ConcatFiles.cmake: NO input files existed — would "
+                        "write an empty ${OUT}. Missing: ${_missing}")
+endif()
+if(_missing)
+    message(WARNING "ConcatFiles.cmake: skipped missing inputs: ${_missing}")
+endif()
 file(WRITE "${OUT}" "${_acc}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -840,7 +840,7 @@ if(ENABLE_TRELLIS_CPP AND TARGET qtmesh_trelliscpp)
     add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
         COMMAND ${CMAKE_COMMAND}
                 -DOUT=${_trellis_lic}
-                "-DIN=${_trellis_src}/LICENSE\;${_trellis_src}/thirdparty/ggml/LICENSE\;${_trellis_src}/thirdparty/fqms/LICENSE.md\;${_trellis_src}/thirdparty/meshoptimizer/LICENSE.md"
+                "-DIN=${_trellis_src}/LICENSE|${_trellis_src}/thirdparty/ggml/LICENSE|${_trellis_src}/thirdparty/fqms/LICENSE.md|${_trellis_src}/thirdparty/meshoptimizer/LICENSE.md"
                 -P ${CMAKE_SOURCE_DIR}/cmake/ConcatFiles.cmake
         COMMAND ${CMAKE_COMMAND}
                 -DDEST=$<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -848,7 +848,11 @@ if(ENABLE_TRELLIS_CPP AND TARGET qtmesh_trelliscpp)
                 -DBUILD_DIR=${_trellis_build}
                 -DLIC=${_trellis_lic}
                 -P ${CMAKE_SOURCE_DIR}/cmake/CopyTrellisRuntime.cmake
-        COMMENT "Copying bundled trellis-cli (+ ggml libs) next to QtMeshEditor")
+        COMMENT "Copying bundled trellis-cli (+ ggml libs) next to QtMeshEditor"
+        # VERBATIM is what keeps the '|' separators inside -DIN as literal
+        # argument characters — without it the recipe shell can parse the
+        # unquoted command line and treat '|' as a pipe.
+        VERBATIM)
     # `make install` (the CI packaging path) must carry the runtime too —
     # the POST_BUILD copy only reaches the build tree. install(CODE) reuses
     # the same scoop so any leftover libggml*.so land beside the CLI AND get


### PR DESCRIPTION
## Problem
The 3.38.0 Windows zip ships `trellis-cli.exe` correctly, but `trellis-cli.THIRD_PARTY_LICENSES.txt` is **0 bytes**. The concat inputs were an escaped-semicolon list: POSIX shells strip the backslash (macOS/Linux fine), Windows cmd passes `\;` through literally — CMake saw one giant nonexistent path and wrote an empty file.

## Fix
- `ConcatFiles.cmake` takes a `|`-separated input list (shell-proof everywhere), **fails the build** when no input exists (an empty notices file must never ship silently again), and warns on partially-missing inputs.
- The Windows CI verify step now requires the notices file to be **non-empty**.

## Verification
Local: real pinned-checkout inputs → 4482-byte notices file; all-missing inputs → hard configure error. The decisive check is this PR's build-windows job producing a non-empty notices file.

No version bump — rides the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of bundled third-party license notices on Windows, including detection of empty license files.
  - License bundle generation now warns when source files are missing and fails instead of producing an empty output when no valid files are available.
  - Improved handling of multiple license-file inputs across build environments, including Windows shell usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->