### PR TITLE
feat(#991): weld co-located duplicate vertices — fix animation tearing on generated meshes

### DIFF
--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -10744,6 +10744,25 @@ Rectangle {
                 }
             }
 
+            // Weld Duplicate Vertices — merges byte-identical co-located
+            // vertices (index remap; UV seams kept) and unifies skin weights
+            // across seam twins so animation can't tear the mesh apart.
+            // Undoable. Shown when validation found something to weld.
+            Rectangle {
+                width: parent.width - 16; height: 28; radius: 3
+                visible: MeshValidator.hasWeldableVertices
+                color: weldMouse.pressed ? Qt.darker("#50b070", 1.2)
+                     : weldMouse.containsMouse ? Qt.lighter("#50b070", 1.2)
+                     : "#50b070"
+                Text { anchors.centerIn: parent
+                       text: "Weld Duplicate Vertices (fix animation tearing)"
+                       color: "white"; font.pixelSize: 11 }
+                MouseArea {
+                    id: weldMouse; anchors.fill: parent; hoverEnabled: true
+                    onClicked: MeshValidator.weldDuplicateVertices()
+                }
+            }
+
             // Fix feedback
             Text {
                 id: fixFeedback

--- a/qml/PropertiesPanel.qml
+++ b/qml/PropertiesPanel.qml
@@ -10750,7 +10750,10 @@ Rectangle {
             // Undoable. Shown when validation found something to weld.
             Rectangle {
                 width: parent.width - 16; height: 28; radius: 3
-                visible: MeshValidator.hasWeldableVertices
+                // `validated` too: the weld flag reflects the LAST validation,
+                // so without it the button would survive a selection change
+                // and weld a mesh that was never analyzed.
+                visible: MeshValidator.validated && MeshValidator.hasWeldableVertices
                 color: weldMouse.pressed ? Qt.darker("#50b070", 1.2)
                      : weldMouse.containsMouse ? Qt.lighter("#50b070", 1.2)
                      : "#50b070"

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -2130,13 +2130,22 @@ int CLIPipeline::cmdFix(int argc, char* argv[])
 
     // Weld co-located vertices (index remap of byte-identical duplicates +
     // unified skin weights across seam twins — the animation-tearing fix).
-    int weldedRefs = 0, weightsUnified = 0;
+    int weldedRefs = 0, weightsUnified = 0, weldFailures = 0;
     if (opts.weldVertices) {
         for (Ogre::Entity* entity : entities) {
             const MeshWeldOps::Report r = MeshWeldOps::apply(entity);
             if (r.ok) {
                 weldedRefs += r.weldedVertices;
                 weightsUnified += r.weightsUnified;
+            } else {
+                // Never let a failure read as "nothing needed welding" — the
+                // MCP tool surfaces rep.error, so the CLI must too.
+                ++weldFailures;
+                err() << "Warning: weld skipped for '"
+                      << QString::fromStdString(entity->getName()) << "': "
+                      << (r.error.isEmpty() ? QStringLiteral("unknown error")
+                                            : r.error)
+                      << Qt::endl;
             }
         }
     }
@@ -2169,10 +2178,14 @@ int CLIPipeline::cmdFix(int argc, char* argv[])
         if (opts.mergeMaterials) extras << "merge-materials";
         if (opts.weldVertices) extras << "weld-vertices";
         report += QString("  Extra: %1\n").arg(extras.join(", "));
-        if (opts.weldVertices)
+        if (opts.weldVertices) {
             report += QString("  Weld: %1 index reference(s) remapped, "
                               "%2 seam vertex weight(s) unified\n")
                           .arg(weldedRefs).arg(weightsUnified);
+            if (weldFailures > 0)
+                report += QString("        (%1 mesh(es) could not be welded — "
+                                  "see warnings above)\n").arg(weldFailures);
+        }
     }
 
     if (vertsBefore > 0) {

--- a/src/CLIPipeline.cpp
+++ b/src/CLIPipeline.cpp
@@ -6,6 +6,7 @@
 #include "ColorPaletteLibrary.h"
 #include "BrushPresetLibrary.h"
 #include "BrushAssetLibrary.h"
+#include "MeshWeldOps.h"
 #include "CloudCLIPipeline.h"
 #include "GamificationManager.h"
 #include "Manager.h"
@@ -784,6 +785,7 @@ void CLIPipeline::printUsage()
         "\n"
         "Fix flags:\n"
         "  --remove-degenerates  Remove degenerate triangles\n"
+        "  --weld-vertices       Weld co-located duplicate vertices + unify seam skin weights\n"
         "  --merge-materials     Remove redundant materials\n"
         "  --all                 Apply all extra fixes\n"
         "  (no flags)            Standard import/export (joins vertices, smooths normals, optimizes)\n"
@@ -2040,6 +2042,7 @@ int CLIPipeline::cmdFix(int argc, char* argv[])
         }
         if (arg == "--remove-degenerates") { opts.removeDegenerates = true; continue; }
         if (arg == "--merge-materials") { opts.mergeMaterials = true; continue; }
+        if (arg == "--weld-vertices") { opts.weldVertices = true; continue; }
         if (arg == "--all") { allFlag = true; continue; }
         if (!arg.startsWith("-") && inputPath.isEmpty()) {
             inputPath = arg;
@@ -2049,7 +2052,7 @@ int CLIPipeline::cmdFix(int argc, char* argv[])
 
     if (inputPath.isEmpty()) {
         err() << "Error: Missing required arguments." << Qt::endl;
-        err() << "Usage: qtmesh fix <file> [-o <output>] [--remove-degenerates] [--merge-materials] [--all]" << Qt::endl;
+        err() << "Usage: qtmesh fix <file> [-o <output>] [--remove-degenerates] [--merge-materials] [--weld-vertices] [--all]" << Qt::endl;
         return 2;
     }
 
@@ -2066,6 +2069,7 @@ int CLIPipeline::cmdFix(int argc, char* argv[])
     if (allFlag) {
         opts.removeDegenerates = true;
         opts.mergeMaterials = true;
+        opts.weldVertices = true;
     }
 
     QFileInfo outFi(outputPath);
@@ -2111,6 +2115,7 @@ int CLIPipeline::cmdFix(int argc, char* argv[])
     QStringList fixFlags;
     if (opts.removeDegenerates) fixFlags << "remove-degenerates";
     if (opts.mergeMaterials) fixFlags << "merge-materials";
+    if (opts.weldVertices) fixFlags << "weld-vertices";
     SentryReporter::addBreadcrumb("cli.fix", QString("Fix .%1 -> .%2%3")
         .arg(fi.suffix(), outFi.suffix(),
              fixFlags.isEmpty() ? "" : " [" + fixFlags.join(", ") + "]"));
@@ -2121,6 +2126,19 @@ int CLIPipeline::cmdFix(int argc, char* argv[])
         SentryReporter::captureMessage(QString("CLI fix: import failed (.%1)").arg(fi.suffix()), "error");
         err() << "Error: Failed to load file: " << inputPath << Qt::endl;
         return 1;
+    }
+
+    // Weld co-located vertices (index remap of byte-identical duplicates +
+    // unified skin weights across seam twins — the animation-tearing fix).
+    int weldedRefs = 0, weightsUnified = 0;
+    if (opts.weldVertices) {
+        for (Ogre::Entity* entity : entities) {
+            const MeshWeldOps::Report r = MeshWeldOps::apply(entity);
+            if (r.ok) {
+                weldedRefs += r.weldedVertices;
+                weightsUnified += r.weightsUnified;
+            }
+        }
     }
 
     // Gather "after" counts from Ogre entities
@@ -2149,7 +2167,12 @@ int CLIPipeline::cmdFix(int argc, char* argv[])
         QStringList extras;
         if (opts.removeDegenerates) extras << "remove-degenerates";
         if (opts.mergeMaterials) extras << "merge-materials";
+        if (opts.weldVertices) extras << "weld-vertices";
         report += QString("  Extra: %1\n").arg(extras.join(", "));
+        if (opts.weldVertices)
+            report += QString("  Weld: %1 index reference(s) remapped, "
+                              "%2 seam vertex weight(s) unified\n")
+                          .arg(weldedRefs).arg(weightsUnified);
     }
 
     if (vertsBefore > 0) {

--- a/src/CLIPipeline.h
+++ b/src/CLIPipeline.h
@@ -43,9 +43,10 @@ struct MeshInfo {
 struct FixOptions {
     bool removeDegenerates = false;
     bool mergeMaterials = false;
+    bool weldVertices = false;   // post-import: MeshWeldOps::apply per entity
 
     bool anySet() const {
-        return removeDegenerates || mergeMaterials;
+        return removeDegenerates || mergeMaterials || weldVertices;
     }
 
     unsigned int toAssimpFlags() const {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -100,6 +100,7 @@ commands/SplitMeshCommand.cpp
 commands/ExplodePartsCommand.cpp
 commands/JoinPartsCommand.cpp
 commands/SkeletonBoneCommands.cpp
+commands/WeldVerticesCommand.cpp
 commands/UVEditCommand.cpp
 commands/UvSeamCommands.cpp
 UvSeamData.cpp
@@ -231,6 +232,7 @@ VertexCacheOptimizer.cpp
 MeshDecimator.cpp
 MeshDecimatorController.cpp
 MeshValidator.cpp
+MeshWeldOps.cpp
 AIChatManager.cpp
 AIModelCatalog.cpp
 AppStorage.cpp
@@ -419,6 +421,7 @@ MeshDecimator.h
 MeshDecimatorController.h
 PartOpsController.h
 MeshValidator.h
+MeshWeldOps.h
 AIChatManager.h
 AIModelCatalog.h
 WelcomeScreenController.h

--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -1,4 +1,6 @@
 #include "MCPServer.h"
+#include "MeshWeldOps.h"
+#include "commands/WeldVerticesCommand.h"
 #include "mainwindow.h"
 #include "GamificationManager.h"
 #include "Manager.h"
@@ -743,6 +745,7 @@ const QMap<QString, MCPServer::ToolHandler>& MCPServer::toolHandlers()
         {QStringLiteral("pack_atlas"), &MCPServer::toolPackAtlas},
         {QStringLiteral("apply_atlas"), &MCPServer::toolApplyAtlas},
         {QStringLiteral("optimize_mesh"), &MCPServer::toolOptimizeMesh},
+        {QStringLiteral("weld_vertices"), &MCPServer::toolWeldVertices},
         {QStringLiteral("generate_isometric_sprites"), &MCPServer::toolGenerateIsometricSprites},
         {QStringLiteral("bake_vat"), &MCPServer::toolBakeVat},
         {QStringLiteral("list_morph_targets"), &MCPServer::toolListMorphTargets},
@@ -885,6 +888,7 @@ QJsonObject MCPServer::callTool(const QString &name, const QJsonObject &args)
             {QStringLiteral("decimate_mesh"), QStringLiteral("decimate_lod")},
             {QStringLiteral("generate_lods"), QStringLiteral("decimate_lod")},
             {QStringLiteral("optimize_mesh"), QStringLiteral("decimate_lod")},
+            {QStringLiteral("weld_vertices"), QStringLiteral("decimate_lod")},
             {QStringLiteral("auto_uv_unwrap"), QStringLiteral("uv_unwrap")},
             {QStringLiteral("uv_unwrap_selection"), QStringLiteral("uv_unwrap")},
             {QStringLiteral("uv_project"), QStringLiteral("uv_unwrap")},
@@ -941,7 +945,7 @@ QJsonObject MCPServer::callTool(const QString &name, const QJsonObject &args)
         QStringLiteral("delete_entity"), QStringLiteral("create_light"), QStringLiteral("delete_light"),
         QStringLiteral("set_light_property"), QStringLiteral("apply_light_rig"), QStringLiteral("duplicate_entity"),
         QStringLiteral("group_nodes"), QStringLiteral("ungroup_node"), QStringLiteral("reparent_node"),
-        QStringLiteral("apply_atlas"), QStringLiteral("optimize_mesh"), QStringLiteral("bake_vat"),
+        QStringLiteral("apply_atlas"), QStringLiteral("optimize_mesh"), QStringLiteral("weld_vertices"), QStringLiteral("bake_vat"),
         QStringLiteral("set_morph_weight"), QStringLiteral("import_alembic"), QStringLiteral("set_node_keyframe"),
         QStringLiteral("apply_pose"), QStringLiteral("delete_pose"), QStringLiteral("mirror_pose"),
         QStringLiteral("load_pose_library")
@@ -5609,6 +5613,99 @@ double resolveMcpReduction(const QJsonObject& args,
 // NOSONAR(cpp:S5817) — ToolHandler is a non-const member-fn pointer (matching
 // every other tool method in this class); marking just this one const would
 // break the registry signature in MCPServer.h.
+QJsonObject MCPServer::toolWeldVertices(const QJsonObject &args)
+{
+    // Args:
+    //   entity_name (string, optional) — target entity; defaults to the
+    //                                    selection, else the only mesh entity
+    //   epsilon (double, optional)     — position tolerance; <=0/absent = auto
+    //   dry_run (bool, default false)  — analyze only, no mutation
+    try {
+        Manager* mgr = Manager::getSingletonPtr();
+        if (!mgr) return makeErrorResult("Error: Manager not available");
+
+        Ogre::Entity* target = nullptr;
+        const QString entityName = args.value("entity_name").toString();
+        if (!entityName.isEmpty()) {
+            target = findEntityByName(entityName);
+            if (!target)
+                return makeErrorResult(
+                    QString("Entity '%1' not found.").arg(entityName));
+        } else {
+            const SelectionSet* sel = SelectionSet::getSingleton();
+            const QList<Ogre::Entity*> selected =
+                sel ? sel->getResolvedEntities() : QList<Ogre::Entity*>{};
+            if (!selected.isEmpty()) {
+                target = selected.first();
+            } else {
+                // Fall back to the only mesh entity in the scene.
+                for (Ogre::Entity* ent : mgr->getEntities()) {
+                    if (!ent || ent->getMovableType() != "Entity") continue;
+                    if (target)
+                        return makeErrorResult(
+                            "Multiple entities in scene — pass entity_name or "
+                            "select one first.");
+                    target = ent;
+                }
+                if (!target)
+                    return makeErrorResult("No mesh entity in the scene.");
+            }
+        }
+
+        const float epsilon =
+            static_cast<float>(args.value("epsilon").toDouble(0.0));
+        const bool dryRun = args.value("dry_run").toBool(false);
+
+        SentryReporter::addBreadcrumb("ai.tool_call", "weld_vertices");
+
+        MeshWeldOps::Report rep;
+        if (dryRun) {
+            rep = MeshWeldOps::analyze(target, epsilon);
+            if (!rep.ok)
+                return makeErrorResult(
+                    QString("Analysis failed: %1").arg(rep.error));
+        } else {
+            auto* cmd = new WeldVerticesCommand(target->getName());
+            UndoManager::getSingleton()->push(cmd);
+            rep = cmd->report();
+            if (!rep.ok)
+                return makeErrorResult(
+                    QString("Weld failed: %1").arg(rep.error));
+        }
+
+        QJsonObject result = makeSuccessResult(
+            dryRun
+                ? QString("Analysis of '%1': %2 co-located vertex(es) in %3 "
+                          "cluster(s); %4 byte-identical duplicate(s) weldable; "
+                          "%5 cluster(s) with mismatched skin weights.")
+                      .arg(QString::fromStdString(target->getName()))
+                      .arg(rep.duplicateVertices)
+                      .arg(rep.duplicateClusters)
+                      .arg(rep.weldableVertices)
+                      .arg(rep.weightMismatchClusters)
+                : QString("Welded '%1': %2 index reference(s) remapped, %3 "
+                          "seam vertex(es) got unified skin weights. Undoable "
+                          "(Ctrl+Z).")
+                      .arg(QString::fromStdString(target->getName()))
+                      .arg(rep.weldedVertices)
+                      .arg(rep.weightsUnified));
+        QJsonObject weld;
+        weld["entity"] = QString::fromStdString(target->getName());
+        weld["dry_run"] = dryRun;
+        weld["duplicate_vertices"] = rep.duplicateVertices;
+        weld["duplicate_clusters"] = rep.duplicateClusters;
+        weld["weldable_vertices"] = rep.weldableVertices;
+        weld["weight_mismatch_clusters"] = rep.weightMismatchClusters;
+        weld["welded_references"] = rep.weldedVertices;
+        weld["weights_unified"] = rep.weightsUnified;
+        weld["skinned"] = rep.skinned;
+        result["weld"] = weld;
+        return result;
+    } catch (const std::exception &e) {
+        return makeErrorResult(QString("Error welding vertices: %1").arg(e.what()));
+    }
+}
+
 QJsonObject MCPServer::toolDecimateMesh(const QJsonObject &args)
 {
     // Args (one wins, in priority order):
@@ -11109,6 +11206,29 @@ QJsonArray MCPServer::buildToolsList()
             "selected via `algo` (default `ogre`). The response includes a human-readable "
             "summary in 'content' and a structured 'decimation' object with per-submesh "
             "and total triangle counts before / after.",
+            props
+        );
+    }
+
+    // weld_vertices
+    {
+        QJsonObject props;
+        props["entity_name"] = QJsonObject{
+            {"type", "string"},
+            {"description", "Target entity name. Omit to use the current selection (or the only mesh entity in the scene)."}};
+        props["epsilon"] = QJsonObject{
+            {"type", "number"},
+            {"description", "Position tolerance for co-location. Omit/<=0 for auto (1e-5 x bounding-box diagonal)."}};
+        props["dry_run"] = QJsonObject{
+            {"type", "boolean"},
+            {"description", "Analyze only — report duplicate/weldable counts without mutating (default false)."}};
+        appendTool(
+            "weld_vertices",
+            "Weld co-located duplicate vertices: remaps indices of byte-identical duplicates "
+            "to one representative (UV seams are preserved) and unifies skin weights across "
+            "remaining co-located seam twins so animation cannot tear the triangles apart. "
+            "The fix for generated/baked meshes whose surface visibly splits when animated. "
+            "Undoable (Ctrl+Z).",
             props
         );
     }

--- a/src/MCPServer.cpp
+++ b/src/MCPServer.cpp
@@ -5665,7 +5665,7 @@ QJsonObject MCPServer::toolWeldVertices(const QJsonObject &args)
                 return makeErrorResult(
                     QString("Analysis failed: %1").arg(rep.error));
         } else {
-            auto* cmd = new WeldVerticesCommand(target->getName());
+            auto* cmd = new WeldVerticesCommand(target->getName(), epsilon);
             UndoManager::getSingleton()->push(cmd);
             rep = cmd->report();
             if (!rep.ok)

--- a/src/MCPServer.h
+++ b/src/MCPServer.h
@@ -297,6 +297,10 @@ private:
     /// optimizations end-to-end on a single asset and writes the result.
     /// Per-stage applied/summary report on success.
     QJsonObject toolOptimizeMesh(const QJsonObject &args);
+    // Weld co-located duplicate vertices + unify seam skin weights on a live
+    // scene entity (undoable via WeldVerticesCommand). Fix for "triangles
+    // separate when animating" on generated/baked meshes.
+    QJsonObject toolWeldVertices(const QJsonObject &args);
     /// #724: 8-direction isometric animated sprite grid export (file-in / file-out).
     QJsonObject toolGenerateIsometricSprites(const QJsonObject &args);
     /// Phase VAT slice 4: bake a skeletal animation to a Vertex

--- a/src/MeshValidator.cpp
+++ b/src/MeshValidator.cpp
@@ -320,6 +320,12 @@ void MeshValidator::doValidate()
     // triangles visibly tear apart during animation (generated/baked meshes
     // hit this constantly). Plain duplicates are only an info row — UV-seam
     // twins are legitimate on every textured mesh.
+    // NB: weld rows carry fixable=false on purpose — `fixable` warnings feed
+    // the red "Fix All (re-import with cleanup)" button, whose OBJ round-trip
+    // drops the skeleton and does NOT unify weights. The weld rows have their
+    // own dedicated fix (the 'Weld Duplicate Vertices' button, gated on
+    // `weldable`), so routing them into Fix All would direct the user to a
+    // destructive action that cannot fix the reported problem.
     if (totalWeightMismatch > 0) {
         QVariantMap issue;
         issue["type"] = "warning";
@@ -329,7 +335,7 @@ void MeshValidator::doValidate()
             "Duplicate Vertices' to unify them.")
                                    .arg(totalWeightMismatch);
         issue["count"] = totalWeightMismatch;
-        issue["fixable"] = true;
+        issue["fixable"] = false;
         issue["weldable"] = true;
         m_issues.append(issue);
     } else if (totalWeldable > 0) {
@@ -341,7 +347,7 @@ void MeshValidator::doValidate()
                                    .arg(totalWeldable)
                                    .arg(totalDupClusters);
         issue["count"] = totalWeldable;
-        issue["fixable"] = true;
+        issue["fixable"] = false;
         issue["weldable"] = true;
         m_issues.append(issue);
     } else {

--- a/src/MeshValidator.cpp
+++ b/src/MeshValidator.cpp
@@ -1,4 +1,7 @@
 #include "MeshValidator.h"
+#include "MeshWeldOps.h"
+#include "commands/WeldVerticesCommand.h"
+#include "UndoManager.h"
 #include "Manager.h"
 #include "SelectionSet.h"
 #include "MeshImporterExporter.h"
@@ -163,6 +166,7 @@ void MeshValidator::doValidate()
     m_issues.clear();
     m_validated = false;
     m_cacheOptimizationAvailable = false;
+    m_weldAvailable = false;
 
     const QList<Ogre::Entity*> targets = validationTargetEntities();
     if (targets.isEmpty()) {
@@ -178,10 +182,27 @@ void MeshValidator::doValidate()
     int totalSubmeshes = 0;
     int meshesWithUVs = 0;
     int meshesWithoutUVs = 0;
+    int totalDupVertices = 0;
+    int totalDupClusters = 0;
+    int totalWeldable = 0;
+    int totalWeightMismatch = 0;
 
     for (Ogre::Entity* entity : targets) {
         Ogre::MeshPtr mesh = entity->getMesh();
         if (!mesh) continue;
+
+        // Co-located-vertex analysis (weld candidates + animation-tear risk).
+        // Runs BEFORE this loop's own buffer locks — MeshWeldOps locks the
+        // vertex buffers itself and Ogre throws on a double lock.
+        {
+            const MeshWeldOps::Report weld = MeshWeldOps::analyze(entity);
+            if (weld.ok) {
+                totalDupVertices    += weld.duplicateVertices;
+                totalDupClusters    += weld.duplicateClusters;
+                totalWeldable       += weld.weldableVertices;
+                totalWeightMismatch += weld.weightMismatchClusters;
+            }
+        }
 
         for (unsigned si = 0; si < mesh->getNumSubMeshes(); ++si) {
             Ogre::SubMesh* sub = mesh->getSubMesh(si);
@@ -292,6 +313,49 @@ void MeshValidator::doValidate()
     // This way the user always sees what was actually analyzed rather than a
     // bare "No issues found." that hides the scope of the validation.
     QLocale locale;
+
+    // 0. Geometry — co-located (duplicate) vertices. The dangerous case is a
+    // SKINNED mesh whose co-located twins carry different bone weights: the
+    // triangles visibly tear apart during animation (generated/baked meshes
+    // hit this constantly). Plain duplicates are only an info row — UV-seam
+    // twins are legitimate on every textured mesh.
+    if (totalWeightMismatch > 0) {
+        QVariantMap issue;
+        issue["type"] = "warning";
+        issue["description"] = QString(
+            "Geometry: %1 co-located vertex cluster(s) with MISMATCHED skin "
+            "weights — triangles tear apart when animated. Use 'Weld "
+            "Duplicate Vertices' to unify them.")
+                                   .arg(totalWeightMismatch);
+        issue["count"] = totalWeightMismatch;
+        issue["fixable"] = true;
+        issue["weldable"] = true;
+        m_issues.append(issue);
+    } else if (totalWeldable > 0) {
+        QVariantMap issue;
+        issue["type"] = "info";
+        issue["description"] = QString(
+            "Geometry: %1 fully-identical duplicate vertex(es) across %2 "
+            "co-located cluster(s) — weldable (UV seams are kept).")
+                                   .arg(totalWeldable)
+                                   .arg(totalDupClusters);
+        issue["count"] = totalWeldable;
+        issue["fixable"] = true;
+        issue["weldable"] = true;
+        m_issues.append(issue);
+    } else {
+        QVariantMap issue;
+        issue["type"] = "ok";
+        issue["description"] = totalDupVertices > 0
+            ? QString("Geometry: %1 co-located vertex(es) are UV/attribute "
+                      "seams (legitimate) — weights consistent, nothing to weld")
+                  .arg(totalDupVertices)
+            : QStringLiteral("Geometry: no duplicated vertex positions");
+        issue["count"] = 0;
+        issue["fixable"] = false;
+        m_issues.append(issue);
+    }
+    m_weldAvailable = (totalWeldable > 0 || totalWeightMismatch > 0);
 
     // 1. Geometry — degenerate triangles
     if (totalDegenerates > 0) {
@@ -592,5 +656,33 @@ void MeshValidator::optimizeVertexCache()
     }
 
     // Refresh the checklist — the row should flip to "already optimal".
+    validate();
+}
+
+void MeshValidator::weldDuplicateVertices()
+{
+    const QList<Ogre::Entity*> targets = validationTargetEntities();
+    if (targets.isEmpty()) {
+        emit error(tr("Select a mesh first."));
+        return;
+    }
+    int refs = 0, unified = 0, applied = 0;
+    for (Ogre::Entity* entity : targets) {
+        auto* cmd = new WeldVerticesCommand(entity->getName());
+        UndoManager::getSingleton()->push(cmd);
+        if (cmd->applied()) {
+            ++applied;
+            refs    += cmd->report().weldedVertices;
+            unified += cmd->report().weightsUnified;
+        }
+    }
+    if (applied == 0) {
+        emit fixApplied(tr("Nothing to weld — no duplicate vertices found."));
+    } else {
+        emit fixApplied(tr("Welded duplicates on %1 mesh(es): %2 index "
+                           "reference(s) remapped, %3 seam vertex(es) got "
+                           "unified skin weights. Ctrl+Z reverts.")
+                            .arg(applied).arg(refs).arg(unified));
+    }
     validate();
 }

--- a/src/MeshValidator.cpp
+++ b/src/MeshValidator.cpp
@@ -61,6 +61,7 @@ MeshValidator::MeshValidator() : QObject(nullptr)
         m_issues.clear();
         m_validated = false;
         m_cacheOptimizationAvailable = false;
+        m_weldAvailable = false;
         // The previous Optimize Geometry result was about the
         // previously-selected entity — drop it so it doesn't leak
         // into the new selection's report.
@@ -666,10 +667,17 @@ void MeshValidator::weldDuplicateVertices()
         emit error(tr("Select a mesh first."));
         return;
     }
+    // One undo step for the whole selection: child commands under a single
+    // parent, pushed once (QUndoCommand runs children's redo/undo in order).
+    auto* macro = new QUndoCommand(
+        QObject::tr("Weld duplicate vertices (%1 mesh(es))").arg(targets.size()));
+    std::vector<WeldVerticesCommand*> cmds;
+    cmds.reserve(static_cast<size_t>(targets.size()));
+    for (Ogre::Entity* entity : targets)
+        cmds.push_back(new WeldVerticesCommand(entity->getName(), 0.0f, macro));
+    UndoManager::getSingleton()->push(macro);
     int refs = 0, unified = 0, applied = 0;
-    for (Ogre::Entity* entity : targets) {
-        auto* cmd = new WeldVerticesCommand(entity->getName());
-        UndoManager::getSingleton()->push(cmd);
+    for (WeldVerticesCommand* cmd : cmds) {
         if (cmd->applied()) {
             ++applied;
             refs    += cmd->report().weldedVertices;

--- a/src/MeshValidator.h
+++ b/src/MeshValidator.h
@@ -16,6 +16,10 @@ class MeshValidator : public QObject, public Ogre::FrameListener
     Q_PROPERTY(QVariantList issues READ issues NOTIFY issuesChanged)
     Q_PROPERTY(bool hasFixableIssues READ hasFixableIssues NOTIFY issuesChanged)
     Q_PROPERTY(bool hasCacheOptimization READ hasCacheOptimization NOTIFY issuesChanged)
+    // Co-located-vertex weld available (duplicates to merge and/or skinned
+    // seam twins with mismatched weights to unify) — gates the "Weld
+    // Duplicate Vertices" button.
+    Q_PROPERTY(bool hasWeldableVertices READ hasWeldableVertices NOTIFY issuesChanged)
     Q_PROPERTY(bool validated READ validated NOTIFY issuesChanged)
     Q_PROPERTY(bool validating READ validating NOTIFY validatingChanged)
 
@@ -28,6 +32,7 @@ public:
     QVariantList issues() const { return m_issues; }
     bool hasFixableIssues() const;
     bool hasCacheOptimization() const { return m_cacheOptimizationAvailable; }
+    bool hasWeldableVertices() const { return m_weldAvailable; }
     bool validated() const { return m_validated; }
     bool validating() const { return m_pendingValidate; }
 
@@ -39,6 +44,11 @@ public:
     // on every selected entity. Mutates Ogre's index buffers — does NOT
     // touch the source file. Re-runs validate() to refresh the report.
     Q_INVOKABLE void optimizeVertexCache();
+    // Weld duplicate vertices on every selected entity (undoable): remaps
+    // indices of byte-identical duplicates to one representative and unifies
+    // skin weights across the remaining co-located twins so animation cannot
+    // tear them apart. UV seams are preserved. Re-runs validate() after.
+    Q_INVOKABLE void weldDuplicateVertices();
 
     // Run validation synchronously (GL context must be current — safe from MCP/CLI context
     // and from inside the Ogre render loop; use validate() from QML to defer automatically).
@@ -65,6 +75,7 @@ private:
     bool m_validated = false;
     bool m_pendingValidate = false;
     bool m_cacheOptimizationAvailable = false;
+    bool m_weldAvailable = false;
     Ogre::Root* m_registeredRoot = nullptr; // which Root we are listening on
     // Persists the last "Optimize Geometry" outcome so the
     // validation list keeps showing it after the auto-revalidate

--- a/src/MeshWeldOps.cpp
+++ b/src/MeshWeldOps.cpp
@@ -211,12 +211,22 @@ MeshWeldOps::Report MeshWeldOps::run(Ogre::Entity* entity, float epsilon,
                 differ = weightsDiffer(weights[verts[0]], weights[verts[i]]);
             if (differ) {
                 ++rep.weightMismatchClusters;
-                for (size_t i = 1; i < verts.size(); ++i)
-                    if (weightsDiffer(weights[verts[0]], weights[verts[i]]))
-                        unifyTargets.push_back(verts[i]);
-                // Representative = verts[0]; remember the source for each.
-                for (size_t i = 1; i < verts.size(); ++i)
-                    weights[verts[i]] = weights[verts[0]];
+                // Representative = the member with the largest total weight,
+                // never an unweighted one — copying an EMPTY map onto a twin
+                // that carries valid assignments would delete real skinning
+                // data instead of repairing the seam.
+                int repIdx = verts[0];
+                float repSum = -1.0f;
+                for (int v : verts) {
+                    float sum = 0.0f;
+                    for (const auto& [bone, w] : weights[v]) sum += w;
+                    if (sum > repSum) { repSum = sum; repIdx = v; }
+                }
+                for (int v : verts)
+                    if (v != repIdx && weightsDiffer(weights[repIdx], weights[v]))
+                        unifyTargets.push_back(v);
+                for (int v : verts)
+                    weights[v] = weights[repIdx];
             }
         }
     }

--- a/src/MeshWeldOps.cpp
+++ b/src/MeshWeldOps.cpp
@@ -149,17 +149,22 @@ MeshWeldOps::Report MeshWeldOps::run(Ogre::Entity* entity, float epsilon,
     std::vector<WeightMap> weights(static_cast<size_t>(total));
     if (rep.skinned) {
         auto collect = [&](const Ogre::Mesh::VertexBoneAssignmentList& list,
-                           int base) {
-            for (const auto& [vi, vba] : list)
-                weights[base + vba.vertexIndex][vba.boneIndex] += vba.weight;
+                           const Owner& ow) {
+            // vba.vertexIndex is OWNER-LOCAL; a stale/malformed importer
+            // assignment can exceed the owner's vertex count — indexing
+            // `weights` with it unchecked would write past the end.
+            for (const auto& [vi, vba] : list) {
+                if (vba.vertexIndex >= ow.vd->vertexCount) continue;
+                weights[ow.base + vba.vertexIndex][vba.boneIndex] += vba.weight;
+            }
         };
         for (const Owner& ow : owners) {
             if (ow.submeshIndex < 0)
-                collect(mesh->getBoneAssignments(), ow.base);
+                collect(mesh->getBoneAssignments(), ow);
             else
                 collect(mesh->getSubMesh(
                             static_cast<unsigned short>(ow.submeshIndex))
-                            ->getBoneAssignments(), ow.base);
+                            ->getBoneAssignments(), ow);
         }
     }
 

--- a/src/MeshWeldOps.cpp
+++ b/src/MeshWeldOps.cpp
@@ -1,0 +1,300 @@
+#include "MeshWeldOps.h"
+
+#include <QByteArray>
+
+#include <OgreEntity.h>
+#include <OgreMesh.h>
+#include <OgreSubMesh.h>
+#include <OgreHardwareBufferManager.h>
+
+#include <cmath>
+#include <cstring>
+#include <map>
+#include <unordered_map>
+#include <vector>
+
+namespace {
+
+// One vertex-data owner: the mesh's shared block (submeshIndex -1) or a
+// non-shared submesh. Global vertex ids are owner base + local index —
+// the same convention SkinEvaluate::extract uses.
+struct Owner {
+    int submeshIndex = -1;               // -1 = shared
+    Ogre::VertexData* vd = nullptr;
+    int base = 0;                        // global index of local vertex 0
+};
+
+struct QuantKey {
+    long long x, y, z;
+    bool operator<(const QuantKey& o) const {
+        if (x != o.x) return x < o.x;
+        if (y != o.y) return y < o.y;
+        return z < o.z;
+    }
+};
+
+// Full-record byte signature of one vertex (every element from every bound
+// buffer, in declaration order). Byte-identical signature = true duplicate.
+QByteArray vertexSignature(Ogre::VertexData* vd,
+                           const std::vector<const unsigned char*>& locked,
+                           size_t v)
+{
+    QByteArray sig;
+    const auto& elems = vd->vertexDeclaration->getElements();
+    for (const auto& el : elems) {
+        const unsigned char* buf = locked[el.getSource()];
+        if (!buf) continue;
+        const size_t stride =
+            vd->vertexBufferBinding->getBuffer(el.getSource())->getVertexSize();
+        sig.append(reinterpret_cast<const char*>(
+                       buf + v * stride + el.getOffset()),
+                   static_cast<int>(el.getSize()));
+    }
+    return sig;
+}
+
+} // namespace
+
+MeshWeldOps::Report MeshWeldOps::analyze(Ogre::Entity* entity, float epsilon)
+{
+    return run(entity, epsilon, /*mutate=*/false);
+}
+
+MeshWeldOps::Report MeshWeldOps::apply(Ogre::Entity* entity, float epsilon)
+{
+    return run(entity, epsilon, /*mutate=*/true);
+}
+
+MeshWeldOps::Report MeshWeldOps::run(Ogre::Entity* entity, float epsilon,
+                                     bool mutate)
+{
+    Report rep;
+    if (!entity || !entity->getMesh()) {
+        rep.error = QStringLiteral("No entity/mesh");
+        return rep;
+    }
+    Ogre::MeshPtr mesh = entity->getMesh();
+    rep.skinned = mesh->hasSkeleton();
+
+    if (epsilon <= 0.0f) {
+        const Ogre::Vector3 size = mesh->getBounds().getSize();
+        epsilon = std::max(1e-9f, 1e-5f * size.length());
+    }
+
+    // ---- gather owners --------------------------------------------------
+    std::vector<Owner> owners;
+    int total = 0;
+    if (mesh->sharedVertexData) {
+        owners.push_back({-1, mesh->sharedVertexData, total});
+        total += static_cast<int>(mesh->sharedVertexData->vertexCount);
+    }
+    for (unsigned short si = 0; si < mesh->getNumSubMeshes(); ++si) {
+        Ogre::SubMesh* sub = mesh->getSubMesh(si);
+        if (sub && !sub->useSharedVertices && sub->vertexData) {
+            owners.push_back({si, sub->vertexData, total});
+            total += static_cast<int>(sub->vertexData->vertexCount);
+        }
+    }
+    if (total == 0) {
+        rep.error = QStringLiteral("Mesh has no vertex data");
+        return rep;
+    }
+
+    // ---- read positions + signatures (global indexing) -------------------
+    std::vector<Ogre::Vector3> positions(static_cast<size_t>(total));
+    std::vector<QByteArray> signatures(static_cast<size_t>(total));
+    for (const Owner& ow : owners) {
+        const auto* posElem = ow.vd->vertexDeclaration->findElementBySemantic(
+            Ogre::VES_POSITION);
+        if (!posElem) continue;
+        // Lock every distinct source buffer once.
+        const size_t nSrc = ow.vd->vertexBufferBinding->getBufferCount();
+        std::vector<const unsigned char*> locked(
+            ow.vd->vertexBufferBinding->getLastBoundIndex() + 1, nullptr);
+        std::vector<Ogre::HardwareVertexBufferSharedPtr> bufs;
+        (void)nSrc;
+        for (const auto& [src, buf] : ow.vd->vertexBufferBinding->getBindings()) {
+            bufs.push_back(buf);
+            locked[src] = static_cast<const unsigned char*>(
+                buf->lock(Ogre::HardwareBuffer::HBL_READ_ONLY));
+        }
+        const size_t posStride =
+            ow.vd->vertexBufferBinding->getBuffer(posElem->getSource())
+                ->getVertexSize();
+        const unsigned char* posBuf = locked[posElem->getSource()];
+        for (size_t v = 0; v < ow.vd->vertexCount; ++v) {
+            const float* p;
+            posElem->baseVertexPointerToElement(
+                const_cast<unsigned char*>(posBuf + v * posStride),
+                const_cast<float**>(&p));
+            positions[ow.base + v] = Ogre::Vector3(p[0], p[1], p[2]);
+            signatures[ow.base + v] = vertexSignature(ow.vd, locked, v);
+        }
+        for (auto& b : bufs) b->unlock();
+    }
+
+    // ---- cluster by quantized position (global, across owners) -----------
+    std::map<QuantKey, std::vector<int>> clusters;
+    for (int v = 0; v < total; ++v) {
+        const Ogre::Vector3& p = positions[static_cast<size_t>(v)];
+        clusters[{static_cast<long long>(std::llround(p.x / epsilon)),
+                  static_cast<long long>(std::llround(p.y / epsilon)),
+                  static_cast<long long>(std::llround(p.z / epsilon))}]
+            .push_back(v);
+    }
+
+    // ---- current skin weights per global vertex ---------------------------
+    // Owner-local assignment lists; vba.vertexIndex is OWNER-LOCAL.
+    using WeightMap = std::map<unsigned short, float>;
+    std::vector<WeightMap> weights(static_cast<size_t>(total));
+    if (rep.skinned) {
+        auto collect = [&](const Ogre::Mesh::VertexBoneAssignmentList& list,
+                           int base) {
+            for (const auto& [vi, vba] : list)
+                weights[base + vba.vertexIndex][vba.boneIndex] += vba.weight;
+        };
+        for (const Owner& ow : owners) {
+            if (ow.submeshIndex < 0)
+                collect(mesh->getBoneAssignments(), ow.base);
+            else
+                collect(mesh->getSubMesh(
+                            static_cast<unsigned short>(ow.submeshIndex))
+                            ->getBoneAssignments(), ow.base);
+        }
+    }
+
+    auto weightsDiffer = [](const WeightMap& a, const WeightMap& b) {
+        if (a.size() != b.size()) return true;
+        auto ia = a.begin();
+        auto ib = b.begin();
+        for (; ia != a.end(); ++ia, ++ib) {
+            if (ia->first != ib->first) return true;
+            if (std::fabs(ia->second - ib->second) > 1e-4f) return true;
+        }
+        return false;
+    };
+
+    // ---- analyze clusters -------------------------------------------------
+    // weldRemap: OWNER-LOCAL index remap per owner (only within one owner —
+    // index buffers can only reference their own vertex data).
+    std::unordered_map<int, int> globalRemap;   // global dup -> global rep
+    std::vector<int> unifyTargets;              // globals needing weight rewrite
+    for (auto& [key, verts] : clusters) {
+        if (verts.size() < 2) continue;
+        ++rep.duplicateClusters;
+        rep.duplicateVertices += static_cast<int>(verts.size());
+
+        // Weld: byte-identical twins within the SAME owner collapse onto the
+        // first such twin.
+        auto ownerOf = [&](int g) {
+            for (size_t i = owners.size(); i-- > 0;)
+                if (g >= owners[i].base) return static_cast<int>(i);
+            return 0;
+        };
+        for (size_t i = 0; i < verts.size(); ++i) {
+            for (size_t j = 0; j < i; ++j) {
+                if (ownerOf(verts[i]) != ownerOf(verts[j])) continue;
+                if (signatures[verts[i]] == signatures[verts[j]]
+                    && !globalRemap.count(verts[i])
+                    && !globalRemap.count(verts[j])) {
+                    globalRemap[verts[i]] = verts[j];
+                    ++rep.weldableVertices;
+                    break;
+                }
+            }
+        }
+
+        // Weight mismatch across the cluster?
+        if (rep.skinned) {
+            bool differ = false;
+            for (size_t i = 1; i < verts.size() && !differ; ++i)
+                differ = weightsDiffer(weights[verts[0]], weights[verts[i]]);
+            if (differ) {
+                ++rep.weightMismatchClusters;
+                for (size_t i = 1; i < verts.size(); ++i)
+                    if (weightsDiffer(weights[verts[0]], weights[verts[i]]))
+                        unifyTargets.push_back(verts[i]);
+                // Representative = verts[0]; remember the source for each.
+                for (size_t i = 1; i < verts.size(); ++i)
+                    weights[verts[i]] = weights[verts[0]];
+            }
+        }
+    }
+
+    if (!mutate) {
+        rep.ok = true;
+        return rep;
+    }
+
+    // ---- apply: index remap (weld) ---------------------------------------
+    if (!globalRemap.empty()) {
+        for (unsigned short si = 0; si < mesh->getNumSubMeshes(); ++si) {
+            Ogre::SubMesh* sub = mesh->getSubMesh(si);
+            if (!sub || !sub->indexData || !sub->indexData->indexBuffer)
+                continue;
+            // Which owner does this submesh's index buffer reference?
+            int base = -1;
+            if (sub->useSharedVertices) {
+                for (const Owner& ow : owners)
+                    if (ow.submeshIndex == -1) base = ow.base;
+            } else {
+                for (const Owner& ow : owners)
+                    if (ow.submeshIndex == si) base = ow.base;
+            }
+            if (base < 0) continue;
+
+            Ogre::IndexData* id = sub->indexData;
+            const bool use16 = (id->indexBuffer->getType()
+                                == Ogre::HardwareIndexBuffer::IT_16BIT);
+            void* idata = id->indexBuffer->lock(
+                Ogre::HardwareBuffer::HBL_NORMAL);
+            auto* idx16 = static_cast<uint16_t*>(idata);
+            auto* idx32 = static_cast<uint32_t*>(idata);
+            for (size_t k = 0; k < id->indexCount; ++k) {
+                const size_t pos = id->indexStart + k;
+                const int global = base + static_cast<int>(
+                    use16 ? idx16[pos] : idx32[pos]);
+                const auto it = globalRemap.find(global);
+                if (it == globalRemap.end()) continue;
+                const int local = it->second - base;
+                if (use16) idx16[pos] = static_cast<uint16_t>(local);
+                else       idx32[pos] = static_cast<uint32_t>(local);
+                ++rep.weldedVertices;
+            }
+            id->indexBuffer->unlock();
+        }
+    }
+
+    // ---- apply: unified skin weights --------------------------------------
+    if (rep.skinned && !unifyTargets.empty()) {
+        rep.weightsUnified = static_cast<int>(unifyTargets.size());
+        // Rewrite the owner assignment lists in place from the (already
+        // unified) `weights` array — the SkinWeightController write path:
+        // clear + add + _compileBoneAssignments per owner, NO _initialise
+        // (swapping VertexData under a live SkeletonInstance shatters the
+        // on-screen mesh).
+        for (const Owner& ow : owners) {
+            const int count = static_cast<int>(ow.vd->vertexCount);
+            if (ow.submeshIndex < 0) {
+                mesh->clearBoneAssignments();
+                for (int v = 0; v < count; ++v)
+                    for (const auto& [bone, w] : weights[ow.base + v])
+                        mesh->addBoneAssignment(
+                            {static_cast<unsigned>(v), bone, w});
+                mesh->_compileBoneAssignments();
+            } else {
+                Ogre::SubMesh* sub = mesh->getSubMesh(
+                    static_cast<unsigned short>(ow.submeshIndex));
+                sub->clearBoneAssignments();
+                for (int v = 0; v < count; ++v)
+                    for (const auto& [bone, w] : weights[ow.base + v])
+                        sub->addBoneAssignment(
+                            {static_cast<unsigned>(v), bone, w});
+                sub->_compileBoneAssignments();
+            }
+        }
+    }
+
+    rep.ok = true;
+    return rep;
+}

--- a/src/MeshWeldOps.h
+++ b/src/MeshWeldOps.h
@@ -1,0 +1,51 @@
+#ifndef MESH_WELD_OPS_H
+#define MESH_WELD_OPS_H
+
+#include <QString>
+
+namespace Ogre { class Entity; }
+
+// Co-located-vertex analysis + weld (validation flow, degenerate-triangles
+// pattern). Generated/baked meshes routinely carry vertices that share a
+// POSITION but are not connected: xatlas UV-seam splits, marching-cubes
+// bakes, imported duplicates. Statically they render fine — but once the
+// mesh is SKINNED, twins with mismatched bone weights move apart and the
+// triangles visibly tear during animation.
+//
+// Two complementary fixes, applied together by apply():
+//   1. WELD identical duplicates — vertices whose ENTIRE vertex record
+//      (position + normal + UV + every other attribute) is byte-identical
+//      are true duplicates; their indices are remapped to one
+//      representative. UV seams survive (seam twins differ in UV, so they
+//      are never welded). Orphaned vertices stay in the buffer (no
+//      compaction — index remap only, cheap and non-destructive).
+//   2. UNIFY skin weights across the remaining co-located twins — same
+//      position ⇒ same bone assignments (the representative's), so
+//      animation can never separate them. This is the fix for the
+//      "triangles separate when animating" report; UVs/normals untouched.
+//
+// analyze() runs the same walk without mutating, for the validator rows.
+// NOT safe to call while the entity's vertex buffers are locked elsewhere.
+class MeshWeldOps {
+public:
+    struct Report {
+        int duplicateVertices = 0;       ///< vertices sharing a position with ≥1 other
+        int duplicateClusters = 0;       ///< distinct co-located position clusters
+        int weldableVertices = 0;        ///< byte-identical duplicates (weld candidates)
+        int weightMismatchClusters = 0;  ///< clusters whose members' weights differ
+        int weldedVertices = 0;          ///< apply(): indices remapped away
+        int weightsUnified = 0;          ///< apply(): vertices whose assignments were rewritten
+        bool skinned = false;
+        QString error;
+        bool ok = false;
+    };
+
+    /// epsilon <= 0 → auto: 1e-5 × bounding-box diagonal.
+    static Report analyze(Ogre::Entity* entity, float epsilon = 0.0f);
+    static Report apply(Ogre::Entity* entity, float epsilon = 0.0f);
+
+private:
+    static Report run(Ogre::Entity* entity, float epsilon, bool mutate);
+};
+
+#endif // MESH_WELD_OPS_H

--- a/src/MeshWeldOps_test.cpp
+++ b/src/MeshWeldOps_test.cpp
@@ -113,8 +113,8 @@ class MeshWeldOpsTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        if (!tryInitOgre()) GTEST_SKIP() << "Ogre init unavailable";
-        if (!canLoadMeshFiles()) GTEST_SKIP() << "no GL context";
+        ASSERT_TRUE(tryInitOgre()) << "Ogre init failed — invalid test environment";
+        if (!canLoadMeshFiles()) GTEST_SKIP() << "no GL context (macOS local run)";
     }
 };
 

--- a/src/MeshWeldOps_test.cpp
+++ b/src/MeshWeldOps_test.cpp
@@ -1,0 +1,209 @@
+#include "MeshWeldOps.h"
+#include "TestHelpers.h"
+#include "Manager.h"
+
+#include <gtest/gtest.h>
+
+#include <Ogre.h>
+
+#include <string>
+
+// Tests for the co-located-vertex weld (validation flow). GL-gated —
+// building the fixture mesh needs hardware buffers, so the suite skips
+// when the environment cannot create a render system (macOS local runs;
+// Linux CI under Xvfb runs it).
+
+namespace {
+
+std::string uniqueWeldName(const char* prefix)
+{
+    static int counter = 0;
+    return std::string(prefix) + std::to_string(++counter);
+}
+
+// Two triangles that SHOULD share an edge but were exported disconnected
+// (the generated-mesh case):
+//   v0 (0,0,0) uv(0,0)              tri A = 0,1,2
+//   v1 (1,0,0) uv(1,0)
+//   v2 (0,1,0) uv(0,1)
+//   v3 (1,0,0) uv(1,0)   byte-identical twin of v1  → weldable
+//   v4 (0,1,0) uv(.9,.9) co-located with v2, different UV → seam twin
+//   v5 (1,1,0) uv(1,1)              tri B = 3,4,5
+// Skinned: everything on bone 1 except v4, which gets bone 0 — the
+// weight-mismatch cluster that tears during animation.
+Ogre::Entity* createWeldFixtureEntity(const std::string& name, bool skinned)
+{
+    auto mesh = Ogre::MeshManager::getSingleton().createManual(
+        name + "_mesh", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+
+    auto* sub = mesh->createSubMesh();
+    mesh->sharedVertexData = new Ogre::VertexData();
+    auto* decl = mesh->sharedVertexData->vertexDeclaration;
+    decl->addElement(0, 0, Ogre::VET_FLOAT3, Ogre::VES_POSITION);
+    decl->addElement(0, sizeof(float) * 3, Ogre::VET_FLOAT2,
+                     Ogre::VES_TEXTURE_COORDINATES, 0);
+
+    const float verts[6 * 5] = {
+        0, 0, 0,  0.0f, 0.0f,
+        1, 0, 0,  1.0f, 0.0f,
+        0, 1, 0,  0.0f, 1.0f,
+        1, 0, 0,  1.0f, 0.0f,   // v3 = byte-identical twin of v1
+        0, 1, 0,  0.9f, 0.9f,   // v4 = co-located with v2, different UV
+        1, 1, 0,  1.0f, 1.0f,
+    };
+    auto vbuf = Ogre::HardwareBufferManager::getSingleton().createVertexBuffer(
+        decl->getVertexSize(0), 6, Ogre::HardwareBuffer::HBU_STATIC_WRITE_ONLY);
+    vbuf->writeData(0, sizeof(verts), verts);
+    mesh->sharedVertexData->vertexBufferBinding->setBinding(0, vbuf);
+    mesh->sharedVertexData->vertexCount = 6;
+
+    auto ibuf = Ogre::HardwareBufferManager::getSingleton().createIndexBuffer(
+        Ogre::HardwareIndexBuffer::IT_16BIT, 6,
+        Ogre::HardwareBuffer::HBU_STATIC_WRITE_ONLY);
+    const Ogre::uint16 idx[6] = { 0, 1, 2, 3, 4, 5 };
+    ibuf->writeData(0, sizeof(idx), idx);
+    sub->useSharedVertices = true;
+    sub->indexData->indexBuffer = ibuf;
+    sub->indexData->indexCount = 6;
+
+    if (skinned) {
+        auto skel = Ogre::SkeletonManager::getSingleton().create(
+            name + "_skel",
+            Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+        auto* root = skel->createBone("Root", 0);
+        root->setPosition(Ogre::Vector3(0, 0, 0));
+        auto* child = skel->createBone("Child", 1);
+        child->setPosition(Ogre::Vector3(0, 1, 0));
+        root->addChild(child);
+        skel->setBindingPose();
+
+        Ogre::VertexBoneAssignment vba;
+        vba.weight = 1.0f;
+        for (unsigned v = 0; v < 6; ++v) {
+            vba.vertexIndex = v;
+            vba.boneIndex = (v == 4) ? 0 : 1;   // v4 mismatches its twin v2
+            mesh->addBoneAssignment(vba);
+        }
+        mesh->_notifySkeleton(skel);
+    }
+
+    mesh->_setBounds(Ogre::AxisAlignedBox(-1, -1, -1, 2, 2, 2));
+    mesh->_setBoundingSphereRadius(3.0f);
+    mesh->load();
+
+    auto* sm = Manager::getSingleton()->getSceneMgr();
+    return sm->createEntity(name + "_ent", mesh);
+}
+
+std::vector<Ogre::uint16> readIndices(Ogre::Entity* entity)
+{
+    Ogre::SubMesh* sub = entity->getMesh()->getSubMesh(0);
+    const auto& buf = sub->indexData->indexBuffer;
+    std::vector<Ogre::uint16> out(sub->indexData->indexCount);
+    buf->readData(0, out.size() * sizeof(Ogre::uint16), out.data());
+    return out;
+}
+
+} // namespace
+
+class MeshWeldOpsTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        if (!tryInitOgre()) GTEST_SKIP() << "Ogre init unavailable";
+        if (!canLoadMeshFiles()) GTEST_SKIP() << "no GL context";
+    }
+};
+
+TEST_F(MeshWeldOpsTest, AnalyzeReportsClustersWeldablesAndWeightMismatch)
+{
+    Ogre::Entity* ent =
+        createWeldFixtureEntity(uniqueWeldName("weldAnalyze"), /*skinned=*/true);
+    ASSERT_NE(ent, nullptr);
+
+    const MeshWeldOps::Report rep = MeshWeldOps::analyze(ent);
+    ASSERT_TRUE(rep.ok) << rep.error.toStdString();
+    EXPECT_TRUE(rep.skinned);
+    EXPECT_EQ(rep.duplicateClusters, 2);        // {v1,v3} and {v2,v4}
+    EXPECT_EQ(rep.duplicateVertices, 4);
+    EXPECT_EQ(rep.weldableVertices, 1);         // only v3 is byte-identical
+    EXPECT_EQ(rep.weightMismatchClusters, 1);   // {v2,v4} weights differ
+    // analyze() must not mutate.
+    EXPECT_EQ(rep.weldedVertices, 0);
+    EXPECT_EQ(rep.weightsUnified, 0);
+    const auto idx = readIndices(ent);
+    EXPECT_EQ(idx[3], 3) << "analyze must leave the index buffer untouched";
+}
+
+TEST_F(MeshWeldOpsTest, ApplyWeldsIdenticalTwinAndUnifiesSeamWeights)
+{
+    Ogre::Entity* ent =
+        createWeldFixtureEntity(uniqueWeldName("weldApply"), /*skinned=*/true);
+    ASSERT_NE(ent, nullptr);
+    Ogre::MeshPtr mesh = ent->getMesh();
+
+    const MeshWeldOps::Report rep = MeshWeldOps::apply(ent);
+    ASSERT_TRUE(rep.ok) << rep.error.toStdString();
+    EXPECT_EQ(rep.weldedVertices, 1);   // one index reference (v3 in tri B)
+    EXPECT_EQ(rep.weightsUnified, 1);   // v4 rewritten to v2's weights
+
+    // Index buffer: tri B's first corner now references v1.
+    const auto idx = readIndices(ent);
+    EXPECT_EQ(idx[3], 1);
+    // Seam twin v4 keeps its own index (different UV — never welded).
+    EXPECT_EQ(idx[4], 4);
+
+    // v4's weights now match v2's (bone 1).
+    bool foundV4 = false;
+    for (const auto& [vi, vba] : mesh->getBoneAssignments()) {
+        if (vba.vertexIndex == 4) {
+            foundV4 = true;
+            EXPECT_EQ(vba.boneIndex, 1);
+            EXPECT_NEAR(vba.weight, 1.0f, 1e-5f);
+        }
+    }
+    EXPECT_TRUE(foundV4);
+
+    // Re-analyzing the fixed mesh reports nothing left to fix.
+    const MeshWeldOps::Report again = MeshWeldOps::analyze(ent);
+    ASSERT_TRUE(again.ok);
+    EXPECT_EQ(again.weightMismatchClusters, 0);
+}
+
+TEST_F(MeshWeldOpsTest, UnskinnedMeshWeldsWithoutWeightWork)
+{
+    Ogre::Entity* ent = createWeldFixtureEntity(uniqueWeldName("weldStatic"),
+                                                /*skinned=*/false);
+    ASSERT_NE(ent, nullptr);
+
+    const MeshWeldOps::Report rep = MeshWeldOps::apply(ent);
+    ASSERT_TRUE(rep.ok) << rep.error.toStdString();
+    EXPECT_FALSE(rep.skinned);
+    EXPECT_EQ(rep.weldedVertices, 1);
+    EXPECT_EQ(rep.weightsUnified, 0);
+    EXPECT_EQ(rep.weightMismatchClusters, 0);
+}
+
+TEST_F(MeshWeldOpsTest, CleanMeshReportsNothing)
+{
+    Ogre::MeshPtr mesh =
+        createInMemoryTriangleMesh(uniqueWeldName("weldClean"));
+    ASSERT_TRUE(mesh);
+    auto* sm = Manager::getSingleton()->getSceneMgr();
+    Ogre::Entity* ent =
+        sm->createEntity(uniqueWeldName("weldCleanEnt"), mesh);
+
+    const MeshWeldOps::Report rep = MeshWeldOps::analyze(ent);
+    ASSERT_TRUE(rep.ok) << rep.error.toStdString();
+    EXPECT_EQ(rep.duplicateClusters, 0);
+    EXPECT_EQ(rep.weldableVertices, 0);
+    EXPECT_EQ(rep.weightMismatchClusters, 0);
+}
+
+TEST_F(MeshWeldOpsTest, NullEntityFailsGracefully)
+{
+    const MeshWeldOps::Report rep = MeshWeldOps::analyze(nullptr);
+    EXPECT_FALSE(rep.ok);
+    EXPECT_FALSE(rep.error.isEmpty());
+}

--- a/src/MeshWeldOps_test.cpp
+++ b/src/MeshWeldOps_test.cpp
@@ -31,7 +31,8 @@ std::string uniqueWeldName(const char* prefix)
 //   v5 (1,1,0) uv(1,1)              tri B = 3,4,5
 // Skinned: everything on bone 1 except v4, which gets bone 0 — the
 // weight-mismatch cluster that tears during animation.
-Ogre::Entity* createWeldFixtureEntity(const std::string& name, bool skinned)
+Ogre::Entity* createWeldFixtureEntity(const std::string& name, bool skinned,
+                                      bool unweightedV2 = false)
 {
     auto mesh = Ogre::MeshManager::getSingleton().createManual(
         name + "_mesh", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
@@ -80,6 +81,7 @@ Ogre::Entity* createWeldFixtureEntity(const std::string& name, bool skinned)
         Ogre::VertexBoneAssignment vba;
         vba.weight = 1.0f;
         for (unsigned v = 0; v < 6; ++v) {
+            if (unweightedV2 && v == 2) continue;   // v2 has NO assignments
             vba.vertexIndex = v;
             vba.boneIndex = (v == 4) ? 0 : 1;   // v4 mismatches its twin v2
             mesh->addBoneAssignment(vba);
@@ -206,4 +208,27 @@ TEST_F(MeshWeldOpsTest, NullEntityFailsGracefully)
     const MeshWeldOps::Report rep = MeshWeldOps::analyze(nullptr);
     EXPECT_FALSE(rep.ok);
     EXPECT_FALSE(rep.error.isEmpty());
+}
+
+TEST_F(MeshWeldOpsTest, UnweightedClusterMemberNeverBecomesTheRepresentative)
+{
+    // v2 carries NO assignments while its co-located twin v4 is weighted to
+    // bone 0. The representative must be the WEIGHTED member — copying the
+    // empty map would delete valid skinning data instead of repairing it.
+    Ogre::Entity* ent = createWeldFixtureEntity(
+        uniqueWeldName("weldEmptyRep"), /*skinned=*/true, /*unweightedV2=*/true);
+    ASSERT_NE(ent, nullptr);
+
+    const MeshWeldOps::Report rep = MeshWeldOps::apply(ent);
+    ASSERT_TRUE(rep.ok) << rep.error.toStdString();
+    EXPECT_GE(rep.weightsUnified, 1);
+
+    // v2 gained v4's weights (bone 0); v4 kept them.
+    float w2 = -1.0f, w4 = -1.0f;
+    for (const auto& [vi, vba] : ent->getMesh()->getBoneAssignments()) {
+        if (vba.vertexIndex == 2 && vba.boneIndex == 0) w2 = vba.weight;
+        if (vba.vertexIndex == 4 && vba.boneIndex == 0) w4 = vba.weight;
+    }
+    EXPECT_NEAR(w2, 1.0f, 1e-5f) << "the unweighted twin must ADOPT weights";
+    EXPECT_NEAR(w4, 1.0f, 1e-5f) << "the weighted twin must keep its weights";
 }

--- a/src/SkinWeights.cpp
+++ b/src/SkinWeights.cpp
@@ -584,13 +584,16 @@ SkinWeights::JobResult SkinWeights::runJob(const ComputeJob& job,
         SkinWeightsPost::laplacianSmooth(
             res.weights, adjacency, opts.smoothIterations, res.locked);
     }
-    SkinWeightsPost::pruneAndRenormalize(res.weights,
-                                         opts.maxInfluencesPerVertex);
     // Co-located (UV-seam twin) vertices must end up with IDENTICAL weights
     // or animation tears the seam apart — smoothing runs on the adjacency
-    // graph, which does not connect duplicated seam vertices, so unify last.
+    // graph, which does not connect duplicated seam vertices. Unify BEFORE
+    // the prune pass: a union of two bone sets can exceed
+    // maxInfluencesPerVertex, and pruning identical rows keeps them
+    // identical, so the cap holds and the rows stay unified.
     SkinWeightsPost::unifyCoLocated(res.weights, job.positions,
                                     /*epsilon=*/0.0f, res.locked);
+    SkinWeightsPost::pruneAndRenormalize(res.weights,
+                                         opts.maxInfluencesPerVertex);
 
     if (!res.info.allowedBones.empty()) {
         const double f = SkinWeightsPost::bleedFraction(res.weights,

--- a/src/SkinWeights.cpp
+++ b/src/SkinWeights.cpp
@@ -586,6 +586,11 @@ SkinWeights::JobResult SkinWeights::runJob(const ComputeJob& job,
     }
     SkinWeightsPost::pruneAndRenormalize(res.weights,
                                          opts.maxInfluencesPerVertex);
+    // Co-located (UV-seam twin) vertices must end up with IDENTICAL weights
+    // or animation tears the seam apart — smoothing runs on the adjacency
+    // graph, which does not connect duplicated seam vertices, so unify last.
+    SkinWeightsPost::unifyCoLocated(res.weights, job.positions,
+                                    /*epsilon=*/0.0f, res.locked);
 
     if (!res.info.allowedBones.empty()) {
         const double f = SkinWeightsPost::bleedFraction(res.weights,

--- a/src/SkinWeightsPost.cpp
+++ b/src/SkinWeightsPost.cpp
@@ -1,6 +1,7 @@
 #include "SkinWeightsPost.h"
 
 #include <algorithm>
+#include <map>
 #include <cmath>
 #include <utility>
 
@@ -181,4 +182,100 @@ double SkinWeightsPost::bleedFraction(
     }
     if (total == 0) return -1.0;
     return double(bleeding) / double(total);
+}
+
+int SkinWeightsPost::unifyCoLocated(
+    std::vector<SkinWeights::VertexWeights>& weights,
+    const std::vector<float>& positions,
+    float epsilon,
+    const std::vector<std::uint8_t>& locked)
+{
+    const std::size_t n = weights.size();
+    if (n == 0 || positions.size() < n * 3) return 0;
+
+    if (epsilon <= 0.0f) {
+        float mn[3] = { positions[0], positions[1], positions[2] };
+        float mx[3] = { positions[0], positions[1], positions[2] };
+        for (std::size_t v = 1; v < n; ++v)
+            for (int a = 0; a < 3; ++a) {
+                mn[a] = std::min(mn[a], positions[v * 3 + a]);
+                mx[a] = std::max(mx[a], positions[v * 3 + a]);
+            }
+        const float dx = mx[0] - mn[0], dy = mx[1] - mn[1], dz = mx[2] - mn[2];
+        epsilon = std::max(1e-9f,
+                           1e-5f * std::sqrt(dx * dx + dy * dy + dz * dz));
+    }
+
+    // Quantized-position clustering (same scheme as MeshWeldOps).
+    struct Key {
+        long long x, y, z;
+        bool operator<(const Key& o) const {
+            if (x != o.x) return x < o.x;
+            if (y != o.y) return y < o.y;
+            return z < o.z;
+        }
+    };
+    std::map<Key, std::vector<int>> clusters;
+    for (std::size_t v = 0; v < n; ++v)
+        clusters[{ (long long)std::llround(positions[v * 3 + 0] / epsilon),
+                   (long long)std::llround(positions[v * 3 + 1] / epsilon),
+                   (long long)std::llround(positions[v * 3 + 2] / epsilon) }]
+            .push_back(int(v));
+
+    auto isLocked = [&](int v) {
+        return !locked.empty() && std::size_t(v) < locked.size() && locked[v];
+    };
+    auto sameWeights = [](const SkinWeights::VertexWeights& a,
+                          const SkinWeights::VertexWeights& b) {
+        if (a.count != b.count) return false;
+        for (int i = 0; i < a.count; ++i)
+            if (a.boneIndices[i] != b.boneIndices[i]
+                || std::fabs(a.weights[i] - b.weights[i]) > 1e-6)
+                return false;
+        return true;
+    };
+
+    int changed = 0;
+    for (auto& [key, verts] : clusters) {
+        if (verts.size() < 2) continue;
+
+        // A locked member dominates: everyone unlocked copies it.
+        int lockedRep = -1;
+        for (int v : verts)
+            if (isLocked(v)) { lockedRep = v; break; }
+
+        SkinWeights::VertexWeights target;
+        if (lockedRep >= 0) {
+            target = weights[lockedRep];
+        } else {
+            // Entry-wise average over the cluster, renormalized.
+            std::map<int, double> acc;
+            for (int v : verts)
+                for (int i = 0; i < weights[v].count; ++i)
+                    acc[weights[v].boneIndices[i]] +=
+                        weights[v].weights[i] / double(verts.size());
+            // Keep the top 8 by weight.
+            std::vector<std::pair<int, double>> rows(acc.begin(), acc.end());
+            std::sort(rows.begin(), rows.end(),
+                      [](const auto& a, const auto& b) {
+                          return a.second > b.second;
+                      });
+            if (rows.size() > 8) rows.resize(8);
+            double sum = 0;
+            for (const auto& r : rows) sum += r.second;
+            target = {};
+            for (const auto& r : rows) {
+                target.boneIndices[target.count] = r.first;
+                target.weights[target.count] = sum > 0 ? r.second / sum : 0.0;
+                ++target.count;
+            }
+        }
+        for (int v : verts) {
+            if (isLocked(v)) continue;
+            if (sameWeights(weights[v], target)) continue;
+            weights[v] = target;
+            ++changed;
+        }
+    }
+    return changed;
 }

--- a/src/SkinWeightsPost.h
+++ b/src/SkinWeightsPost.h
@@ -58,6 +58,23 @@ public:
     // empty allowed set (no geodesic data for them).
     static double bleedFraction(const std::vector<SkinWeights::VertexWeights>& weights,
                                 const std::vector<std::vector<int>>& allowedBones);
+
+    // Unify weights across co-located vertices (same quantized position).
+    // Generated/baked meshes carry UV-seam twins: same position, different
+    // vertex records. If the skinner leaves them with (even slightly)
+    // different weights, animation pulls them apart and the surface tears
+    // along the seam. Each cluster of vertices within `epsilon` of one
+    // another gets ONE weight set — the entry-wise average of its members
+    // (renormalized) — so co-located vertices can never separate. Locked
+    // (merge-mode) vertices keep their weights and instead dominate their
+    // cluster: if a cluster contains locked members, the unlocked members
+    // copy the first locked member's weights. Returns the number of
+    // vertices whose weights changed. `positions` = xyz triples;
+    // epsilon <= 0 → auto: 1e-5 × bounding-box diagonal.
+    static int unifyCoLocated(std::vector<SkinWeights::VertexWeights>& weights,
+                              const std::vector<float>& positions,
+                              float epsilon = 0.0f,
+                              const std::vector<std::uint8_t>& locked = {});
 };
 
 #endif // SKIN_WEIGHTS_POST_H

--- a/src/SkinWeightsPost_test.cpp
+++ b/src/SkinWeightsPost_test.cpp
@@ -317,3 +317,29 @@ TEST(SkinWeightsPostTest, UnifyCoLocatedHandlesDegenerateInput)
     positions = {1.0f};
     EXPECT_EQ(SkinWeightsPost::unifyCoLocated(weights, positions), 0);
 }
+
+TEST(SkinWeightsPostTest, UnifyThenPruneKeepsRowsIdenticalAndCapped)
+{
+    // Two co-located rows with disjoint 3-bone sets: the unified union has 6
+    // influences, above a caller cap of 4. The computeAndApply pipeline runs
+    // unify BEFORE pruneAndRenormalize — pruning identical rows must keep
+    // them identical AND enforce the cap (review P1 on #992).
+    std::vector<SkinWeights::VertexWeights> weights = {
+        makeVW({{0, 0.5}, {1, 0.3}, {2, 0.2}}),
+        makeVW({{3, 0.5}, {4, 0.3}, {5, 0.2}}),
+    };
+    const std::vector<float> positions = {
+        1.0f, 1.0f, 1.0f,
+        1.0f, 1.0f, 1.0f,
+    };
+    SkinWeightsPost::unifyCoLocated(weights, positions);
+    EXPECT_EQ(weights[0].count, 6);
+    SkinWeightsPost::pruneAndRenormalize(weights, 4);
+    EXPECT_LE(weights[0].count, 4);
+    EXPECT_EQ(weights[0].count, weights[1].count);
+    for (int i = 0; i < weights[0].count; ++i) {
+        EXPECT_EQ(weights[0].boneIndices[i], weights[1].boneIndices[i]);
+        EXPECT_NEAR(weights[0].weights[i], weights[1].weights[i], 1e-9);
+    }
+    EXPECT_NEAR(rowSum(weights[0]), 1.0, 1e-9);
+}

--- a/src/SkinWeightsPost_test.cpp
+++ b/src/SkinWeightsPost_test.cpp
@@ -226,3 +226,94 @@ TEST(SkinWeightsPostTest, BleedFractionReturnsMinusOneWhenUncomputable)
     const std::vector<std::vector<int>> allowed = { {} };
     EXPECT_DOUBLE_EQ(SkinWeightsPost::bleedFraction(w, allowed), -1.0);
 }
+
+// ─── unifyCoLocated ──────────────────────────────────────────────────────────
+
+TEST(SkinWeightsPostTest, UnifyCoLocatedAveragesClusterWeights)
+{
+    // Two vertices at the SAME position with different weights (a UV-seam
+    // twin pair), one far-away vertex untouched.
+    std::vector<SkinWeights::VertexWeights> weights = {
+        makeVW({{0, 1.0}}),
+        makeVW({{0, 0.5}, {1, 0.5}}),
+        makeVW({{2, 1.0}}),
+    };
+    const std::vector<float> positions = {
+        1.0f, 2.0f, 3.0f,
+        1.0f, 2.0f, 3.0f,
+        9.0f, 9.0f, 9.0f,
+    };
+    const int changed = SkinWeightsPost::unifyCoLocated(weights, positions);
+    EXPECT_EQ(changed, 2);
+
+    // Both twins now identical: average = bone0 0.75, bone1 0.25.
+    EXPECT_NEAR(weightOnBone(weights[0], 0), 0.75, 1e-9);
+    EXPECT_NEAR(weightOnBone(weights[0], 1), 0.25, 1e-9);
+    EXPECT_NEAR(weightOnBone(weights[1], 0), 0.75, 1e-9);
+    EXPECT_NEAR(weightOnBone(weights[1], 1), 0.25, 1e-9);
+    EXPECT_NEAR(rowSum(weights[0]), 1.0, 1e-9);
+    // Far vertex untouched.
+    EXPECT_NEAR(weightOnBone(weights[2], 2), 1.0, 1e-9);
+}
+
+TEST(SkinWeightsPostTest, UnifyCoLocatedIsANoOpWhenWeightsAlreadyMatch)
+{
+    std::vector<SkinWeights::VertexWeights> weights = {
+        makeVW({{0, 0.5}, {1, 0.5}}),
+        makeVW({{0, 0.5}, {1, 0.5}}),
+    };
+    const std::vector<float> positions = {
+        1.0f, 1.0f, 1.0f,
+        1.0f, 1.0f, 1.0f,
+    };
+    EXPECT_EQ(SkinWeightsPost::unifyCoLocated(weights, positions), 0);
+}
+
+TEST(SkinWeightsPostTest, UnifyCoLocatedLockedMemberDominates)
+{
+    std::vector<SkinWeights::VertexWeights> weights = {
+        makeVW({{0, 1.0}}),               // free
+        makeVW({{1, 1.0}}),               // LOCKED (manual weights)
+    };
+    const std::vector<float> positions = {
+        2.0f, 2.0f, 2.0f,
+        2.0f, 2.0f, 2.0f,
+    };
+    const std::vector<std::uint8_t> locked = {0, 1};
+    const int changed = SkinWeightsPost::unifyCoLocated(weights, positions,
+                                                        0.0f, locked);
+    EXPECT_EQ(changed, 1);
+    // The free twin copied the locked one; the locked one is untouched.
+    EXPECT_NEAR(weightOnBone(weights[0], 1), 1.0, 1e-9);
+    EXPECT_EQ(weights[0].count, 1);
+    EXPECT_NEAR(weightOnBone(weights[1], 1), 1.0, 1e-9);
+}
+
+TEST(SkinWeightsPostTest, UnifyCoLocatedRespectsEpsilon)
+{
+    std::vector<SkinWeights::VertexWeights> weights = {
+        makeVW({{0, 1.0}}),
+        makeVW({{1, 1.0}}),
+    };
+    // 0.3 apart — clustered only when epsilon is large enough.
+    std::vector<float> positions = {
+        0.0f, 0.0f, 0.0f,
+        0.3f, 0.0f, 0.0f,
+    };
+    auto w1 = weights;
+    EXPECT_EQ(SkinWeightsPost::unifyCoLocated(w1, positions, 0.001f), 0);
+    auto w2 = weights;
+    EXPECT_GT(SkinWeightsPost::unifyCoLocated(w2, positions, 1.0f), 0);
+}
+
+TEST(SkinWeightsPostTest, UnifyCoLocatedHandlesDegenerateInput)
+{
+    std::vector<SkinWeights::VertexWeights> weights;
+    std::vector<float> positions;
+    EXPECT_EQ(SkinWeightsPost::unifyCoLocated(weights, positions), 0);
+
+    // Positions shorter than weights → refuse rather than read OOB.
+    weights.push_back(makeVW({{0, 1.0}}));
+    positions = {1.0f};
+    EXPECT_EQ(SkinWeightsPost::unifyCoLocated(weights, positions), 0);
+}

--- a/src/commands/WeldVerticesCommand.cpp
+++ b/src/commands/WeldVerticesCommand.cpp
@@ -1,0 +1,109 @@
+#include "WeldVerticesCommand.h"
+
+#include "../Manager.h"
+#include "../SentryReporter.h"
+
+#include <OgreEntity.h>
+#include <OgreSubMesh.h>
+
+namespace {
+Ogre::Entity* weldResolveEntity(const std::string& name)
+{
+    auto* mgr = Manager::getSingletonPtr();
+    if (!mgr) return nullptr;
+    for (Ogre::Entity* ent : mgr->getEntities()) {
+        if (!ent || ent->getMovableType() != "Entity") continue;
+        if (ent->getName() == name) return ent;
+    }
+    return nullptr;
+}
+} // namespace
+
+WeldVerticesCommand::WeldVerticesCommand(std::string entityName,
+                                         QUndoCommand* parent)
+    : QUndoCommand(parent)
+    , m_entityName(std::move(entityName))
+{
+    setText(QStringLiteral("Weld duplicate vertices"));
+}
+
+void WeldVerticesCommand::redo()
+{
+    Ogre::Entity* entity = weldResolveEntity(m_entityName);
+    if (!entity || !entity->getMesh()) return;
+    Ogre::MeshPtr mesh = entity->getMesh();
+
+    if (m_firstRedo) {
+        m_firstRedo = false;
+        // Snapshot index buffers + assignment lists for undo.
+        for (unsigned short si = 0; si < mesh->getNumSubMeshes(); ++si) {
+            Ogre::SubMesh* sub = mesh->getSubMesh(si);
+            if (sub && sub->indexData && sub->indexData->indexBuffer) {
+                IndexSnapshot snap;
+                snap.submesh = si;
+                const auto& buf = sub->indexData->indexBuffer;
+                snap.bytes.resize(static_cast<int>(buf->getSizeInBytes()));
+                buf->readData(0, buf->getSizeInBytes(), snap.bytes.data());
+                m_indexSnaps.push_back(std::move(snap));
+            }
+            if (sub && !sub->useSharedVertices) {
+                AssignSnapshot as;
+                as.submesh = si;
+                for (const auto& [vi, vba] : sub->getBoneAssignments())
+                    as.list.push_back(vba);
+                m_assignSnaps.push_back(std::move(as));
+            }
+        }
+        AssignSnapshot shared;
+        shared.submesh = -1;
+        for (const auto& [vi, vba] : mesh->getBoneAssignments())
+            shared.list.push_back(vba);
+        m_assignSnaps.push_back(std::move(shared));
+    }
+
+    m_report = MeshWeldOps::apply(entity);
+    m_applied = m_report.ok
+                && (m_report.weldedVertices > 0 || m_report.weightsUnified > 0);
+    SentryReporter::addBreadcrumb(QStringLiteral("mesh.weld"),
+        QStringLiteral("%1: %2 refs remapped, %3 weights unified")
+            .arg(QString::fromStdString(m_entityName))
+            .arg(m_report.weldedVertices)
+            .arg(m_report.weightsUnified));
+}
+
+void WeldVerticesCommand::undo()
+{
+    Ogre::Entity* entity = weldResolveEntity(m_entityName);
+    if (!entity || !entity->getMesh()) return;
+    Ogre::MeshPtr mesh = entity->getMesh();
+
+    for (const IndexSnapshot& snap : m_indexSnaps) {
+        if (snap.submesh >= mesh->getNumSubMeshes()) continue;
+        Ogre::SubMesh* sub = mesh->getSubMesh(snap.submesh);
+        if (!sub || !sub->indexData || !sub->indexData->indexBuffer) continue;
+        const auto& buf = sub->indexData->indexBuffer;
+        if (static_cast<int>(buf->getSizeInBytes()) != snap.bytes.size())
+            continue;
+        buf->writeData(0, buf->getSizeInBytes(), snap.bytes.constData(), true);
+    }
+
+    if (mesh->hasSkeleton()) {
+        for (const AssignSnapshot& as : m_assignSnaps) {
+            if (as.submesh < 0) {
+                mesh->clearBoneAssignments();
+                for (const auto& vba : as.list)
+                    mesh->addBoneAssignment(vba);
+                if (mesh->sharedVertexData)
+                    mesh->_compileBoneAssignments();
+            } else if (as.submesh < mesh->getNumSubMeshes()) {
+                Ogre::SubMesh* sub = mesh->getSubMesh(
+                    static_cast<unsigned short>(as.submesh));
+                sub->clearBoneAssignments();
+                for (const auto& vba : as.list)
+                    sub->addBoneAssignment(vba);
+                sub->_compileBoneAssignments();
+            }
+        }
+    }
+    m_applied = false;
+}

--- a/src/commands/WeldVerticesCommand.cpp
+++ b/src/commands/WeldVerticesCommand.cpp
@@ -20,9 +20,11 @@ Ogre::Entity* weldResolveEntity(const std::string& name)
 } // namespace
 
 WeldVerticesCommand::WeldVerticesCommand(std::string entityName,
+                                         float epsilon,
                                          QUndoCommand* parent)
     : QUndoCommand(parent)
     , m_entityName(std::move(entityName))
+    , m_epsilon(epsilon)
 {
     setText(QStringLiteral("Weld duplicate vertices"));
 }
@@ -61,7 +63,7 @@ void WeldVerticesCommand::redo()
         m_assignSnaps.push_back(std::move(shared));
     }
 
-    m_report = MeshWeldOps::apply(entity);
+    m_report = MeshWeldOps::apply(entity, m_epsilon);
     m_applied = m_report.ok
                 && (m_report.weldedVertices > 0 || m_report.weightsUnified > 0);
     SentryReporter::addBreadcrumb(QStringLiteral("mesh.weld"),

--- a/src/commands/WeldVerticesCommand.h
+++ b/src/commands/WeldVerticesCommand.h
@@ -1,0 +1,50 @@
+#ifndef WELD_VERTICES_COMMAND_H
+#define WELD_VERTICES_COMMAND_H
+
+#include <QUndoCommand>
+#include <QByteArray>
+#include <QString>
+
+#include "../MeshWeldOps.h"
+
+#include <OgreMesh.h>
+
+#include <string>
+#include <vector>
+
+// Undoable "Weld duplicate vertices" (validation flow): index-remap weld of
+// byte-identical duplicates + skin-weight unification across co-located
+// twins (MeshWeldOps::apply). Undo restores the snapshotted index buffers
+// and bone-assignment lists (recompiled in place — no Entity::_initialise,
+// which would swap VertexData under the live SkeletonInstance).
+class WeldVerticesCommand : public QUndoCommand
+{
+public:
+    explicit WeldVerticesCommand(std::string entityName,
+                                 QUndoCommand* parent = nullptr);
+
+    void undo() override;
+    void redo() override;
+
+    bool applied() const { return m_applied; }
+    MeshWeldOps::Report report() const { return m_report; }
+
+private:
+    struct IndexSnapshot {
+        unsigned short submesh = 0;
+        QByteArray bytes;          // full index buffer contents
+    };
+    struct AssignSnapshot {
+        int submesh = -1;          // -1 = mesh-level (shared)
+        std::vector<Ogre::VertexBoneAssignment> list;
+    };
+
+    std::string m_entityName;
+    std::vector<IndexSnapshot> m_indexSnaps;
+    std::vector<AssignSnapshot> m_assignSnaps;
+    MeshWeldOps::Report m_report;
+    bool m_applied = false;
+    bool m_firstRedo = true;
+};
+
+#endif // WELD_VERTICES_COMMAND_H

--- a/src/commands/WeldVerticesCommand.h
+++ b/src/commands/WeldVerticesCommand.h
@@ -21,6 +21,7 @@ class WeldVerticesCommand : public QUndoCommand
 {
 public:
     explicit WeldVerticesCommand(std::string entityName,
+                                 float epsilon = 0.0f,
                                  QUndoCommand* parent = nullptr);
 
     void undo() override;
@@ -40,6 +41,7 @@ private:
     };
 
     std::string m_entityName;
+    float m_epsilon = 0.0f;      // <=0 = auto (1e-5 x bbox diagonal)
     std::vector<IndexSnapshot> m_indexSnaps;
     std::vector<AssignSnapshot> m_assignSnaps;
     MeshWeldOps::Report m_report;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -269,6 +269,8 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/UvProject.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/UvPipeline.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/MeshValidator.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/MeshWeldOps.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/commands/WeldVerticesCommand.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AIChatManager.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AIModelCatalog.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppStorage.cpp


### PR DESCRIPTION
Closes #991

Generated models (image-to-3D bakes, some imports) often carry vertices that sit on the same position but are not connected. Statically fine — but once skinned, the co-located twins can carry **different bone weights**, so the triangles visibly separate during animation.

## What this adds (mirrors the degenerate-triangles flow)

- **MeshWeldOps** (new): `analyze`/`apply`. Clusters vertices by quantized position (auto eps = 1e-5 × bbox diagonal). **Weld** remaps indices of byte-identical duplicates to one representative (full vertex-record signature, so UV seams are never welded; no buffer compaction). **Unify** rewrites skin weights across the remaining co-located twins so animation can never pull them apart — the actual fix for the tearing.
- **WeldVerticesCommand** (new): undoable — snapshots index buffers + bone-assignment lists on first redo; undo restores and recompiles in place (no `Entity::_initialise`, which would swap VertexData under the live SkeletonInstance).
- **MeshValidator**: new checklist rows — *warning* when co-located clusters have mismatched skin weights, *info* for benign weldable duplicates, *ok* otherwise — plus a **'Weld Duplicate Vertices'** button in the Inspector validation section (`hasWeldableVertices` gated).
- **SkinWeightsPost::unifyCoLocated** (pure-data): post-pass in `SkinWeights::computeAndApply` so every skinning algorithm leaves co-located vertices with identical weights (locked/merge-mode vertices dominate their cluster). Root-cause prevention for future auto-skins.
- **CLI**: `qtmesh fix --weld-vertices` (also included in `--all`).
- **MCP**: `weld_vertices` tool (`entity_name`/`epsilon`/`dry_run`; undoable).

## Verification

- **Real asset (TRELLIS-generated, rigged goblin)**: CLI `fix --weld-vertices` → *0 index refs remapped* (Assimp's JoinIdenticalVertices already merged exact dupes on import), **5230 seam vertex weights unified** across 3252 mismatched clusters. Welded mesh re-renders and animates with continuous surfaces.
- **MCP cycle**: dry-run reports 3252 mismatch clusters → apply unifies 5230 → re-analysis reports **0** remaining.
- **Tests**: `MeshWeldOps_test` (GL-gated: analyze counts, weld+unify, seam-twin preservation, unskinned, clean-mesh, null-entity), `SkinWeightsPostTest` unifyCoLocated cases (average, locked-dominates, epsilon, degenerate input) — 16/16 pure-data tests pass locally; GL suites run on Linux CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added mesh validation for duplicate vertices and skin-weight mismatches.
  - Added an undoable “Weld Duplicate Vertices” action while preserving UV seams.
  - Added vertex-welding support to command-line fixes and MCP tools.
  - Added command-line painting tools for asset listing, baking, layer inspection, and stencil projection.
  - Added live texture-painting tools through the MCP interface.
  - Skin-weight processing now unifies weights for co-located vertices.

- **Bug Fixes**
  - The weld action now appears only after mesh validation has completed.

- **Tests**
  - Added coverage for vertex welding and skin-weight unification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->