### PR TITLE
fix(#995): decal/projection wrote an all-white layer on non-square textures

### DIFF
--- a/src/PaintLayerStack.cpp
+++ b/src/PaintLayerStack.cpp
@@ -165,8 +165,34 @@ int PaintLayerStack::addFromBuffer(const TexturePaintBuffer& src,
     }
     const int w = width();
     const int h = height();
-    if (src.width() != w || src.height() != h)
-        L.buffer.resize(w, h);
+    if (src.width() != w || src.height() != h) {
+        // RESCALE, never bare resize(): TexturePaintBuffer::resize fills the
+        // buffer with 0xFF (opaque WHITE) and drops the content, so a caller
+        // that handed us a differently-sized buffer — e.g. a decal projected
+        // at square resolution onto a NON-SQUARE texture — got a blank white
+        // layer instead of its pixels. Nearest-neighbour keeps this
+        // dependency-free and preserves hard alpha edges (decals/stencils).
+        TexturePaintBuffer scaled;
+        scaled.resize(w, h);
+        if (w > 0 && h > 0 && src.width() > 0 && src.height() > 0) {
+            const auto& s = src.data();
+            auto& d = scaled.data();
+            for (int y = 0; y < h; ++y) {
+                const int sy = std::min(src.height() - 1,
+                                        y * src.height() / h);
+                for (int x = 0; x < w; ++x) {
+                    const int sx = std::min(src.width() - 1,
+                                            x * src.width() / w);
+                    const size_t si =
+                        (static_cast<size_t>(sy) * src.width() + sx) * 4u;
+                    const size_t di = (static_cast<size_t>(y) * w + x) * 4u;
+                    if (si + 3 < s.size() && di + 3 < d.size())
+                        std::memcpy(&d[di], &s[si], 4);
+                }
+            }
+        }
+        L.buffer = std::move(scaled);
+    }
     m_layers.push_back(std::move(L));
     m_activeIndex = layerCount() - 1;
     return m_activeIndex;

--- a/src/PaintLayerStack.cpp
+++ b/src/PaintLayerStack.cpp
@@ -22,9 +22,16 @@ void copyBuffer(const TexturePaintBuffer& src, TexturePaintBuffer& dst)
 TexturePaintBuffer rescaleNearest(const TexturePaintBuffer& src, int w, int h)
 {
     TexturePaintBuffer scaled;
+    if (w <= 0 || h <= 0) return scaled;
     scaled.resize(w, h);
-    if (w <= 0 || h <= 0 || src.width() <= 0 || src.height() <= 0)
+    // resize() leaves the buffer OPAQUE WHITE, so a degenerate source must be
+    // cleared to transparent — returning it as-is would reintroduce exactly
+    // the blank-white layer this helper exists to prevent.
+    if (src.width() <= 0 || src.height() <= 0) {
+        scaled.clear(Ogre::ColourValue(0.0f, 0.0f, 0.0f, 0.0f));
+        scaled.clearDirty();
         return scaled;
+    }
 
     const auto& s = src.data();
     auto& d = scaled.data();

--- a/src/PaintLayerStack.cpp
+++ b/src/PaintLayerStack.cpp
@@ -15,6 +15,34 @@ void copyBuffer(const TexturePaintBuffer& src, TexturePaintBuffer& dst)
     dst.clearDirty();
 }
 
+/// Nearest-neighbour rescale of `src` into a new w*h buffer.
+/// Deliberately NOT TexturePaintBuffer::resize, which fills with 0xFF
+/// (opaque white) and discards the content. Nearest-neighbour keeps this
+/// dependency-free and preserves hard alpha edges (decals / stencils).
+TexturePaintBuffer rescaleNearest(const TexturePaintBuffer& src, int w, int h)
+{
+    TexturePaintBuffer scaled;
+    scaled.resize(w, h);
+    if (w <= 0 || h <= 0 || src.width() <= 0 || src.height() <= 0)
+        return scaled;
+
+    const auto& s = src.data();
+    auto& d = scaled.data();
+    for (int y = 0; y < h; ++y) {
+        const int sy = std::min(src.height() - 1, y * src.height() / h);
+        const size_t srcRow = static_cast<size_t>(sy) * src.width();
+        const size_t dstRow = static_cast<size_t>(y) * w;
+        for (int x = 0; x < w; ++x) {
+            const int sx = std::min(src.width() - 1, x * src.width() / w);
+            const size_t si = (srcRow + sx) * 4u;
+            const size_t di = (dstRow + x) * 4u;
+            if (si + 3 < s.size() && di + 3 < d.size())
+                std::memcpy(&d[di], &s[si], 4);
+        }
+    }
+    return scaled;
+}
+
 } // namespace
 
 int PaintLayerStack::width() const
@@ -165,34 +193,12 @@ int PaintLayerStack::addFromBuffer(const TexturePaintBuffer& src,
     }
     const int w = width();
     const int h = height();
-    if (src.width() != w || src.height() != h) {
-        // RESCALE, never bare resize(): TexturePaintBuffer::resize fills the
-        // buffer with 0xFF (opaque WHITE) and drops the content, so a caller
-        // that handed us a differently-sized buffer — e.g. a decal projected
-        // at square resolution onto a NON-SQUARE texture — got a blank white
-        // layer instead of its pixels. Nearest-neighbour keeps this
-        // dependency-free and preserves hard alpha edges (decals/stencils).
-        TexturePaintBuffer scaled;
-        scaled.resize(w, h);
-        if (w > 0 && h > 0 && src.width() > 0 && src.height() > 0) {
-            const auto& s = src.data();
-            auto& d = scaled.data();
-            for (int y = 0; y < h; ++y) {
-                const int sy = std::min(src.height() - 1,
-                                        y * src.height() / h);
-                for (int x = 0; x < w; ++x) {
-                    const int sx = std::min(src.width() - 1,
-                                            x * src.width() / w);
-                    const size_t si =
-                        (static_cast<size_t>(sy) * src.width() + sx) * 4u;
-                    const size_t di = (static_cast<size_t>(y) * w + x) * 4u;
-                    if (si + 3 < s.size() && di + 3 < d.size())
-                        std::memcpy(&d[di], &s[si], 4);
-                }
-            }
-        }
-        L.buffer = std::move(scaled);
-    }
+    // RESCALE a mismatched buffer, never bare resize(): resize fills with
+    // 0xFF (opaque WHITE) and drops the content, so a caller that handed us a
+    // differently-sized buffer — e.g. a decal projected at square resolution
+    // onto a NON-SQUARE texture — got a blank white layer instead of pixels.
+    if (src.width() != w || src.height() != h)
+        L.buffer = rescaleNearest(src, w, h);
     m_layers.push_back(std::move(L));
     m_activeIndex = layerCount() - 1;
     return m_activeIndex;

--- a/src/PaintLayerStack_test.cpp
+++ b/src/PaintLayerStack_test.cpp
@@ -275,3 +275,49 @@ TEST(PaintLayerStackTest, ResizeAllKeepsEveryLayerInStep) {
         EXPECT_EQ(s.layer(i).buffer.height(), 8) << "layer " << i;
     }
 }
+
+// --- mismatched-size layers (the all-white decal bug) -----------------------
+
+TEST(PaintLayerStackTest, AddFromBufferRescalesInsteadOfBlankingToWhite) {
+    // TexturePaintBuffer::resize() fills with 0xFF (opaque white) and drops the
+    // content. addFromBuffer used to call it on any size mismatch, so a decal
+    // projected at a different resolution than the stack committed as a blank
+    // WHITE layer instead of its pixels. It must RESCALE the content instead.
+    PaintLayerStack s = seeded();
+
+    // A differently-sized, fully opaque BLUE source.
+    TexturePaintBuffer src(kW * 2, kH * 3);
+    for (size_t i = 0; i + 3 < src.data().size(); i += 4) {
+        src.data()[i + 0] = 0;   src.data()[i + 1] = 0;
+        src.data()[i + 2] = 255; src.data()[i + 3] = 255;
+    }
+
+    const int idx = s.addFromBuffer(src, QStringLiteral("Decal"),
+                                    PaintLayerStack::LayerType::Generated);
+    ASSERT_GE(idx, 0);
+    EXPECT_EQ(s.layer(idx).buffer.width(), kW);
+    EXPECT_EQ(s.layer(idx).buffer.height(), kH);
+
+    const Px p = firstPixel(s);
+    EXPECT_EQ(p.b, 255) << "the layer must keep its BLUE content";
+    EXPECT_EQ(p.r, 0)   << "white (255,255,255) here means the content was "
+                           "discarded by a bare resize()";
+    EXPECT_EQ(p.g, 0);
+}
+
+TEST(PaintLayerStackTest, AddFromBufferPreservesTransparencyWhenRescaling) {
+    // A decal is mostly transparent outside its footprint; rescaling must not
+    // turn those texels opaque (a bare resize made them opaque white).
+    PaintLayerStack s = seeded();
+    TexturePaintBuffer src(kW * 2, kH * 2);   // all zeroes = fully transparent
+    for (auto& b : src.data()) b = 0;
+
+    const int idx = s.addFromBuffer(src, QStringLiteral("Empty decal"),
+                                    PaintLayerStack::LayerType::Generated);
+    ASSERT_GE(idx, 0);
+    EXPECT_EQ(s.layer(idx).buffer.pixel(0, 0).a, 0.0f)
+        << "transparent source texels must stay transparent";
+    // The red base must still show through the transparent layer.
+    const Px p = firstPixel(s);
+    EXPECT_EQ(p.r, 255);
+}

--- a/src/PaintLayerStack_test.cpp
+++ b/src/PaintLayerStack_test.cpp
@@ -321,3 +321,22 @@ TEST(PaintLayerStackTest, AddFromBufferPreservesTransparencyWhenRescaling) {
     const Px p = firstPixel(s);
     EXPECT_EQ(p.r, 255);
 }
+
+TEST(PaintLayerStackTest, AddFromBufferWithAnEmptySourceIsTransparentNotWhite) {
+    // A degenerate (zero-sized) source must not become an opaque white layer:
+    // TexturePaintBuffer::resize fills with 0xFF, so the rescale path has to
+    // clear it explicitly. Regression guard for the same white-out class.
+    PaintLayerStack s = seeded();
+    const TexturePaintBuffer empty;           // 0x0
+    const int idx = s.addFromBuffer(empty, QStringLiteral("Empty"),
+                                    PaintLayerStack::LayerType::Generated);
+    ASSERT_GE(idx, 0);
+    EXPECT_EQ(s.layer(idx).buffer.width(), kW);
+    EXPECT_EQ(s.layer(idx).buffer.height(), kH);
+    EXPECT_EQ(s.layer(idx).buffer.pixel(0, 0).a, 0.0f)
+        << "an empty source must yield a TRANSPARENT layer, not white";
+    // The red base must still show through.
+    const Px p = firstPixel(s);
+    EXPECT_EQ(p.r, 255);
+    EXPECT_EQ(p.g, 0);
+}

--- a/src/ProjectionPainter.cpp
+++ b/src/ProjectionPainter.cpp
@@ -106,10 +106,17 @@ ProjectionPainter::Report ProjectionPainter::project(
     if (tris.empty()) { rep.error = "no triangles"; return rep; }
     if (source.isNull()) { rep.error = "empty source image"; return rep; }
 
-    const int res = opts.resolution > 0 ? opts.resolution
-                                        : std::max(out.width(), out.height());
-    if (res <= 0) { rep.error = "invalid resolution"; return rep; }
-    out.resize(res, res);
+    // Width and height are tracked SEPARATELY: a NON-SQUARE texture (an
+    // AI-generated diffuse is routinely e.g. 2504x2526) gave a square output
+    // here, and PaintLayerStack::addFromBuffer then resize()d the mismatched
+    // layer to the stack size — which fills with opaque WHITE and discards
+    // every projected texel, so the decal committed as an all-white layer.
+    // opts.resolution (when set) is a SQUARE request; otherwise keep the
+    // caller's buffer aspect.
+    const int outW = opts.resolution > 0 ? opts.resolution : out.width();
+    const int outH = opts.resolution > 0 ? opts.resolution : out.height();
+    if (outW <= 0 || outH <= 0) { rep.error = "invalid resolution"; return rep; }
+    out.resize(outW, outH);
     out.clear(Ogre::ColourValue(0, 0, 0, 0));   // new-layer buffer starts transparent
 
     for (const Triangle& t : tris) {
@@ -127,15 +134,16 @@ ProjectionPainter::Report ProjectionPainter::project(
         const Projected pc = projectToViewportUV(t.p[2], view.viewProj);
         if (pa.behind || pb.behind || pc.behind) continue;
 
-        // UV0 -> pixel space (top-left origin).
+        // UV0 -> pixel space (top-left origin); each axis scales by its own
+        // extent so a non-square target isn't skewed.
         auto toPix = [&](const Ogre::Vector2& uv) {
-            return Ogre::Vector2(uv.x * res, uv.y * res);
+            return Ogre::Vector2(uv.x * outW, uv.y * outH);
         };
         const Ogre::Vector2 A = toPix(t.uv[0]), B = toPix(t.uv[1]), C = toPix(t.uv[2]);
         int x0 = std::max(0, static_cast<int>(std::floor(std::min({A.x, B.x, C.x}))));
-        int x1 = std::min(res - 1, static_cast<int>(std::ceil(std::max({A.x, B.x, C.x}))));
+        int x1 = std::min(outW - 1, static_cast<int>(std::ceil(std::max({A.x, B.x, C.x}))));
         int y0 = std::max(0, static_cast<int>(std::floor(std::min({A.y, B.y, C.y}))));
-        int y1 = std::min(res - 1, static_cast<int>(std::ceil(std::max({A.y, B.y, C.y}))));
+        int y1 = std::min(outH - 1, static_cast<int>(std::ceil(std::max({A.y, B.y, C.y}))));
         const float denom = (B.y - C.y) * (A.x - C.x) + (C.x - B.x) * (A.y - C.y);
         if (std::abs(denom) < 1e-9f) continue;
         const float invDen = 1.0f / denom;
@@ -186,14 +194,19 @@ int ProjectionPainter::projectDab(
     const Ogre::ColourValue& brushColor, float strength,
     TexturePaintBuffer& out, const Options& opts, const OcclusionMap* occ)
 {
-    if (tris.empty() || out.width() <= 0) return 0;
-    const int res = std::max(out.width(), out.height());
+    if (tris.empty() || out.width() <= 0 || out.height() <= 0) return 0;
+    // Per-axis extents — see project(): a non-square target must not be
+    // squashed onto a single square `res`.
+    const int outW = out.width();
+    const int outH = out.height();
     const bool haveStencil = !stencil.isNull();
     int touched = 0;
 
-    // Brush footprint in pixel space (round falloff).
-    const float rPix = brushRadiusUv * res;
-    const float cxPix = brushUv.x * res, cyPix = brushUv.y * res;
+    // Brush footprint in pixel space (round falloff). The radius is a UV
+    // fraction; on a non-square texture use the smaller axis so the dab stays
+    // circular in UV space rather than stretching along the longer one.
+    const float rPix = brushRadiusUv * std::min(outW, outH);
+    const float cxPix = brushUv.x * outW, cyPix = brushUv.y * outH;
 
     for (const Triangle& t : tris) {
         Ogre::Vector3 nrm = t.normal;
@@ -210,14 +223,14 @@ int ProjectionPainter::projectDab(
         if (pa.behind || pb.behind || pc.behind) continue;
 
         auto toPix = [&](const Ogre::Vector2& uv) {
-            return Ogre::Vector2(uv.x * res, uv.y * res);
+            return Ogre::Vector2(uv.x * outW, uv.y * outH);
         };
         const Ogre::Vector2 A = toPix(t.uv[0]), B = toPix(t.uv[1]), C = toPix(t.uv[2]);
         // Clamp the scanned box to the brush footprint (perf: only near the dab).
         int x0 = std::max(0, static_cast<int>(std::floor(std::max(std::min({A.x, B.x, C.x}), cxPix - rPix))));
-        int x1 = std::min(res - 1, static_cast<int>(std::ceil(std::min(std::max({A.x, B.x, C.x}), cxPix + rPix))));
+        int x1 = std::min(outW - 1, static_cast<int>(std::ceil(std::min(std::max({A.x, B.x, C.x}), cxPix + rPix))));
         int y0 = std::max(0, static_cast<int>(std::floor(std::max(std::min({A.y, B.y, C.y}), cyPix - rPix))));
-        int y1 = std::min(res - 1, static_cast<int>(std::ceil(std::min(std::max({A.y, B.y, C.y}), cyPix + rPix))));
+        int y1 = std::min(outH - 1, static_cast<int>(std::ceil(std::min(std::max({A.y, B.y, C.y}), cyPix + rPix))));
         const float denom = (B.y - C.y) * (A.x - C.x) + (C.x - B.x) * (A.y - C.y);
         if (std::abs(denom) < 1e-9f) continue;
         const float invDen = 1.0f / denom;

--- a/src/ProjectionPainter.cpp
+++ b/src/ProjectionPainter.cpp
@@ -116,6 +116,8 @@ ProjectionPainter::Report ProjectionPainter::project(
     const int outW = opts.resolution > 0 ? opts.resolution : out.width();
     const int outH = opts.resolution > 0 ? opts.resolution : out.height();
     if (outW <= 0 || outH <= 0) { rep.error = "invalid resolution"; return rep; }
+    const float outWf = static_cast<float>(outW);
+    const float outHf = static_cast<float>(outH);
     out.resize(outW, outH);
     out.clear(Ogre::ColourValue(0, 0, 0, 0));   // new-layer buffer starts transparent
 
@@ -137,7 +139,7 @@ ProjectionPainter::Report ProjectionPainter::project(
         // UV0 -> pixel space (top-left origin); each axis scales by its own
         // extent so a non-square target isn't skewed.
         auto toPix = [&](const Ogre::Vector2& uv) {
-            return Ogre::Vector2(uv.x * outW, uv.y * outH);
+            return Ogre::Vector2(uv.x * outWf, uv.y * outHf);
         };
         const Ogre::Vector2 A = toPix(t.uv[0]), B = toPix(t.uv[1]), C = toPix(t.uv[2]);
         int x0 = std::max(0, static_cast<int>(std::floor(std::min({A.x, B.x, C.x}))));
@@ -207,11 +209,14 @@ int ProjectionPainter::projectDab(
     // per-axis pixel radius and take the falloff from NORMALISED distances,
     // matching TexturePaintBuffer::paintBrush. (Using one radius off the
     // smaller axis shrank the dab in UV terms along the longer axis.)
-    const float rPixX = brushRadiusUv * outW;
-    const float rPixY = brushRadiusUv * outH;
+    const float outWf = static_cast<float>(outW);
+    const float outHf = static_cast<float>(outH);
+    const float rPixX = brushRadiusUv * outWf;
+    const float rPixY = brushRadiusUv * outHf;
     const float invRx = 1.0f / std::max(rPixX, 1e-6f);
     const float invRy = 1.0f / std::max(rPixY, 1e-6f);
-    const float cxPix = brushUv.x * outW, cyPix = brushUv.y * outH;
+    const float cxPix = brushUv.x * outWf;
+    const float cyPix = brushUv.y * outHf;
 
     for (const Triangle& t : tris) {
         Ogre::Vector3 nrm = t.normal;
@@ -228,7 +233,7 @@ int ProjectionPainter::projectDab(
         if (pa.behind || pb.behind || pc.behind) continue;
 
         auto toPix = [&](const Ogre::Vector2& uv) {
-            return Ogre::Vector2(uv.x * outW, uv.y * outH);
+            return Ogre::Vector2(uv.x * outWf, uv.y * outHf);
         };
         const Ogre::Vector2 A = toPix(t.uv[0]), B = toPix(t.uv[1]), C = toPix(t.uv[2]);
         // Clamp the scanned box to the brush footprint (perf: only near the dab).
@@ -240,37 +245,47 @@ int ProjectionPainter::projectDab(
         if (std::abs(denom) < 1e-9f) continue;
         const float invDen = 1.0f / denom;
 
+        // One texel of the dab; returns true when it painted. Factored out so
+        // the scan stays two loops deep (the occlusion test would otherwise
+        // nest a 4th level).
+        auto paintTexel = [&](int px, int py) {
+            const float fx = px + 0.5f;
+            const float fy = py + 0.5f;
+            // Round brush falloff in NORMALISED (per-axis) distance, so the
+            // dab is a circle in UV space on any aspect ratio.
+            const float nx = (fx - cxPix) * invRx;
+            const float ny = (fy - cyPix) * invRy;
+            const float dr = std::hypot(nx, ny);
+            if (rPixX <= 0.0f || rPixY <= 0.0f || dr > 1.0f) return false;
+            const float fall = 1.0f - dr;
+
+            const float l0 = ((B.y - C.y) * (fx - C.x) + (C.x - B.x) * (fy - C.y)) * invDen;
+            const float l1 = ((C.y - A.y) * (fx - C.x) + (A.x - C.x) * (fy - C.y)) * invDen;
+            const float l2 = 1.0f - l0 - l1;
+            const float eps = -1e-4f;
+            if (l0 < eps || l1 < eps || l2 < eps) return false;
+
+            const Ogre::Vector2 suv = pa.uv * l0 + pb.uv * l1 + pc.uv * l2;
+            if (suv.x < 0.0f || suv.x > 1.0f || suv.y < 0.0f || suv.y > 1.0f)
+                return false;
+
+            const bool wantDepth = occ && (opts.useOcclusion || opts.depthLimit > 0.0f);
+            if (wantDepth) {
+                const Ogre::Vector3 wp = t.p[0] * l0 + t.p[1] * l1 + t.p[2] * l2;
+                if (classifyDepth(wp, *occ, opts.depthLimit, opts.useOcclusion) != 0)
+                    return false;
+            }
+
+            const float stencilA = haveStencil ? sampleImage(stencil, suv).a : 1.0f;
+            const float a = facing * stencilA * fall * strength;
+            if (a <= 0.0f) return false;
+            compositeOver(out, px, py, brushColor, a);
+            return true;
+        };
+
         for (int py = y0; py <= y1; ++py) {
             for (int px = x0; px <= x1; ++px) {
-                const float fx = px + 0.5f, fy = py + 0.5f;
-                // Round brush falloff in NORMALISED (per-axis) distance, so
-                // the dab is a circle in UV space on any aspect ratio.
-                const float nx = (fx - cxPix) * invRx;
-                const float ny = (fy - cyPix) * invRy;
-                const float dr = std::hypot(nx, ny);
-                if (rPixX <= 0.0f || rPixY <= 0.0f || dr > 1.0f) continue;
-                const float fall = 1.0f - dr;
-
-                const float l0 = ((B.y - C.y) * (fx - C.x) + (C.x - B.x) * (fy - C.y)) * invDen;
-                const float l1 = ((C.y - A.y) * (fx - C.x) + (A.x - C.x) * (fy - C.y)) * invDen;
-                const float l2 = 1.0f - l0 - l1;
-                const float eps = -1e-4f;
-                if (l0 < eps || l1 < eps || l2 < eps) continue;
-
-                const Ogre::Vector2 suv = pa.uv * l0 + pb.uv * l1 + pc.uv * l2;
-                if (suv.x < 0.0f || suv.x > 1.0f || suv.y < 0.0f || suv.y > 1.0f) continue;
-
-                if (occ && (opts.useOcclusion || opts.depthLimit > 0.0f)) {
-                    const Ogre::Vector3 wp = t.p[0] * l0 + t.p[1] * l1 + t.p[2] * l2;
-                    const int cls = classifyDepth(wp, *occ, opts.depthLimit, opts.useOcclusion);
-                    if (cls != 0) continue;
-                }
-
-                const float stencilA = haveStencil ? sampleImage(stencil, suv).a : 1.0f;
-                const float a = facing * stencilA * fall * strength;
-                if (a <= 0.0f) continue;
-                compositeOver(out, px, py, brushColor, a);
-                ++touched;
+                if (paintTexel(px, py)) ++touched;
             }
         }
     }

--- a/src/ProjectionPainter.cpp
+++ b/src/ProjectionPainter.cpp
@@ -202,10 +202,15 @@ int ProjectionPainter::projectDab(
     const bool haveStencil = !stencil.isNull();
     int touched = 0;
 
-    // Brush footprint in pixel space (round falloff). The radius is a UV
-    // fraction; on a non-square texture use the smaller axis so the dab stays
-    // circular in UV space rather than stretching along the longer one.
-    const float rPix = brushRadiusUv * std::min(outW, outH);
+    // Brush footprint in pixel space (round falloff). brushRadiusUv is a UV
+    // radius, so it must span that same fraction on BOTH axes — derive a
+    // per-axis pixel radius and take the falloff from NORMALISED distances,
+    // matching TexturePaintBuffer::paintBrush. (Using one radius off the
+    // smaller axis shrank the dab in UV terms along the longer axis.)
+    const float rPixX = brushRadiusUv * outW;
+    const float rPixY = brushRadiusUv * outH;
+    const float invRx = 1.0f / std::max(rPixX, 1e-6f);
+    const float invRy = 1.0f / std::max(rPixY, 1e-6f);
     const float cxPix = brushUv.x * outW, cyPix = brushUv.y * outH;
 
     for (const Triangle& t : tris) {
@@ -227,10 +232,10 @@ int ProjectionPainter::projectDab(
         };
         const Ogre::Vector2 A = toPix(t.uv[0]), B = toPix(t.uv[1]), C = toPix(t.uv[2]);
         // Clamp the scanned box to the brush footprint (perf: only near the dab).
-        int x0 = std::max(0, static_cast<int>(std::floor(std::max(std::min({A.x, B.x, C.x}), cxPix - rPix))));
-        int x1 = std::min(outW - 1, static_cast<int>(std::ceil(std::min(std::max({A.x, B.x, C.x}), cxPix + rPix))));
-        int y0 = std::max(0, static_cast<int>(std::floor(std::max(std::min({A.y, B.y, C.y}), cyPix - rPix))));
-        int y1 = std::min(outH - 1, static_cast<int>(std::ceil(std::min(std::max({A.y, B.y, C.y}), cyPix + rPix))));
+        int x0 = std::max(0, static_cast<int>(std::floor(std::max(std::min({A.x, B.x, C.x}), cxPix - rPixX))));
+        int x1 = std::min(outW - 1, static_cast<int>(std::ceil(std::min(std::max({A.x, B.x, C.x}), cxPix + rPixX))));
+        int y0 = std::max(0, static_cast<int>(std::floor(std::max(std::min({A.y, B.y, C.y}), cyPix - rPixY))));
+        int y1 = std::min(outH - 1, static_cast<int>(std::ceil(std::min(std::max({A.y, B.y, C.y}), cyPix + rPixY))));
         const float denom = (B.y - C.y) * (A.x - C.x) + (C.x - B.x) * (A.y - C.y);
         if (std::abs(denom) < 1e-9f) continue;
         const float invDen = 1.0f / denom;
@@ -238,10 +243,13 @@ int ProjectionPainter::projectDab(
         for (int py = y0; py <= y1; ++py) {
             for (int px = x0; px <= x1; ++px) {
                 const float fx = px + 0.5f, fy = py + 0.5f;
-                // Round brush falloff.
-                const float dr = std::hypot(fx - cxPix, fy - cyPix);
-                if (rPix <= 0.0f || dr > rPix) continue;
-                const float fall = 1.0f - (dr / rPix);
+                // Round brush falloff in NORMALISED (per-axis) distance, so
+                // the dab is a circle in UV space on any aspect ratio.
+                const float nx = (fx - cxPix) * invRx;
+                const float ny = (fy - cyPix) * invRy;
+                const float dr = std::hypot(nx, ny);
+                if (rPixX <= 0.0f || rPixY <= 0.0f || dr > 1.0f) continue;
+                const float fall = 1.0f - dr;
 
                 const float l0 = ((B.y - C.y) * (fx - C.x) + (C.x - B.x) * (fy - C.y)) * invDen;
                 const float l1 = ((C.y - A.y) * (fx - C.x) + (A.x - C.x) * (fy - C.y)) * invDen;

--- a/src/ProjectionPainter_test.cpp
+++ b/src/ProjectionPainter_test.cpp
@@ -246,3 +246,60 @@ TEST(ProjectionPainterTest, DabPaintsWithinFootprintAndAccumulates) {
                                   Ogre::ColourValue(0, 0, 1, 1), 0.5f, out, opts);
     EXPECT_GT(out.pixel(32, 32).a, aAfter1);
 }
+
+// --- non-square targets (the "decal commits as an all-white layer" bug) -----
+
+TEST(ProjectionPainterTest, NonSquareTargetKeepsItsAspect) {
+    // A generated diffuse is routinely non-square (e.g. 2504x2526). The
+    // projection must fill the caller's buffer at ITS size — a square output
+    // gets resize()d downstream, which fills opaque white and drops the decal.
+    auto tris = frontQuad(0.0f, /*faceCamera*/true);
+    ProjectionPainter::View v{ orthoViewProj(), Ogre::Vector3(0, 0, -1),
+                               Ogre::Vector3(0, 0, 5) };
+    TexturePaintBuffer out; out.resize(64, 96);
+    ProjectionPainter::Options opts;    // resolution left 0 = keep buffer size
+    opts.backfaceCull = true;
+    auto rep = ProjectionPainter::project(tris, v, solid(32, Qt::red), out, opts);
+    ASSERT_TRUE(rep.ok) << rep.error.toStdString();
+    EXPECT_EQ(out.width(), 64);
+    EXPECT_EQ(out.height(), 96) << "a square output would be resized to white "
+                                   "by PaintLayerStack::addFromBuffer";
+    EXPECT_GT(rep.texelsWritten, 0);
+    // The quad covers UV [0..1] on both axes, so the full height is painted:
+    // a square-projected result would leave the bottom third untouched.
+    EXPECT_GT(out.pixel(32, 90).a, 0.5f)
+        << "bottom rows must be covered on a non-square target";
+    EXPECT_GT(out.pixel(32, 48).r, 0.5f);
+}
+
+TEST(ProjectionPainterTest, ExplicitSquareResolutionStillHonoured) {
+    // opts.resolution is a square request — keep that contract for callers
+    // (e.g. bakes) that deliberately ask for a fixed square size.
+    auto tris = frontQuad(0.0f, /*faceCamera*/true);
+    ProjectionPainter::View v{ orthoViewProj(), Ogre::Vector3(0, 0, -1),
+                               Ogre::Vector3(0, 0, 5) };
+    TexturePaintBuffer out; out.resize(10, 200);
+    ProjectionPainter::Options opts; opts.resolution = 48;
+    auto rep = ProjectionPainter::project(tris, v, solid(32, Qt::red), out, opts);
+    ASSERT_TRUE(rep.ok) << rep.error.toStdString();
+    EXPECT_EQ(out.width(), 48);
+    EXPECT_EQ(out.height(), 48);
+}
+
+TEST(ProjectionPainterTest, DabOnNonSquareTargetStaysInBounds) {
+    auto tris = frontQuad(0.0f, /*faceCamera*/true);
+    ProjectionPainter::View v{ orthoViewProj(), Ogre::Vector3(0, 0, -1),
+                               Ogre::Vector3(0, 0, 5) };
+    TexturePaintBuffer out; out.resize(64, 96);
+    out.clear(Ogre::ColourValue(0, 0, 0, 0));
+    ProjectionPainter::Options opts;
+    const int n = ProjectionPainter::projectDab(
+        tris, v, QImage(), Ogre::Vector2(0.5f, 0.5f), 0.25f,
+        Ogre::ColourValue(1, 0, 0, 1), 1.0f, out, opts);
+    EXPECT_GT(n, 0);
+    EXPECT_EQ(out.width(), 64);
+    EXPECT_EQ(out.height(), 96);
+    // Centre of a v=0.5 dab lands at y = 0.5*96 = 48, not 0.5*64 = 32.
+    EXPECT_GT(out.pixel(32, 48).a, 0.5f) << "dab must centre on the V axis "
+                                            "scaled by HEIGHT";
+}

--- a/src/ProjectionPainter_test.cpp
+++ b/src/ProjectionPainter_test.cpp
@@ -302,4 +302,16 @@ TEST(ProjectionPainterTest, DabOnNonSquareTargetStaysInBounds) {
     // Centre of a v=0.5 dab lands at y = 0.5*96 = 48, not 0.5*64 = 32.
     EXPECT_GT(out.pixel(32, 48).a, 0.5f) << "dab must centre on the V axis "
                                             "scaled by HEIGHT";
+
+    // brushRadiusUv is a UV radius, so the footprint must span that same
+    // fraction on BOTH axes: 0.25 * 96 = 24 px vertically (a radius taken
+    // from the smaller axis would only reach 16 px and stop short).
+    auto painted = [&](int x, int y) { return out.pixel(x, y).a > 0.01f; };
+    EXPECT_TRUE(painted(32, 48 + 20)) << "vertical footprint must reach "
+                                         "0.25 UV (~24px), not 0.25*width";
+    EXPECT_TRUE(painted(32, 48 - 20));
+    EXPECT_FALSE(painted(32, 48 + 30)) << "and must stop at the UV radius";
+    // Horizontal radius is 0.25 * 64 = 16 px.
+    EXPECT_TRUE(painted(32 + 13, 48));
+    EXPECT_FALSE(painted(32 + 20, 48));
 }

--- a/src/TexturePaintController.cpp
+++ b/src/TexturePaintController.cpp
@@ -867,7 +867,10 @@ bool TexturePaintController::buildOcclusionForView(const ProjectionPainter::View
 ProjectionPainter::Options TexturePaintController::projectionOptions() const
 {
     ProjectionPainter::Options opts;
-    opts.resolution = m_buffer.width() > 0 ? m_buffer.width() : 1024;
+    // resolution stays 0 = "keep the target buffer's own size". Setting it to
+    // the width forced a SQUARE output, which on a non-square texture made
+    // PaintLayerStack::addFromBuffer resize (→ opaque white) the committed
+    // layer. Callers size their scratch buffer from the session instead.
     opts.backfaceCull = m_projBackfaceCull;
     opts.useOcclusion = m_projUseOcclusion;
     // depthLimit is a fraction of the bounds radius → world units.
@@ -933,7 +936,9 @@ bool TexturePaintController::projectPhotoWithView(const QImage& src,
     opts.useOcclusion = m_haveProjOcc;   // photo always occludes when we have a map
 
     TexturePaintBuffer scratch;
-    scratch.resize(opts.resolution, opts.resolution);
+    const int sw = m_buffer.width() > 0 ? m_buffer.width() : 1024;
+    const int sh = m_buffer.height() > 0 ? m_buffer.height() : sw;
+    scratch.resize(sw, sh);
     const auto rep = ProjectionPainter::project(
         m_projTris, v, src, scratch, opts, m_haveProjOcc ? &m_projOcc : nullptr);
     if (!rep.ok || rep.texelsWritten == 0) return false;
@@ -1257,12 +1262,18 @@ bool TexturePaintController::commitDecal()
     ProjectionPainter::OcclusionMap occ;
     const bool haveOcc = buildOcclusionForView(ci.view, occ);
     ProjectionPainter::Options opts;
-    opts.resolution = m_buffer.width() > 0 ? m_buffer.width() : 1024;
+    // Leave opts.resolution at 0 (= keep the scratch buffer's own size): the
+    // session buffer matches the model's texture, which is NOT necessarily
+    // square. Forcing a square scratch made PaintLayerStack::addFromBuffer
+    // resize the mismatched layer, which fills opaque WHITE and drops every
+    // projected texel — the "decal commits as an all-white layer" bug.
     opts.backfaceCull = true;
     opts.useOcclusion = haveOcc;
 
     TexturePaintBuffer scratch;
-    scratch.resize(opts.resolution, opts.resolution);
+    const int sw = m_buffer.width() > 0 ? m_buffer.width() : 1024;
+    const int sh = m_buffer.height() > 0 ? m_buffer.height() : sw;
+    scratch.resize(sw, sh);
     const auto rep = ProjectionPainter::project(
         m_projTris, ci.view, ci.source, scratch, opts, haveOcc ? &occ : nullptr);
     const bool ok = rep.ok && rep.texelsWritten > 0
@@ -5360,6 +5371,26 @@ QString TexturePaintController::bakeVertexLayerToTextureLayer(int resolution,
     const int painted = VertexColorBaker::bake(mesh, scratch, opts);
     if (painted <= 0)
         return tr("The mesh has no vertex colours to bake, or no UV0 to bake into.");
+
+    // VertexColorBaker is square-only, but the layer stack follows the model's
+    // texture, which may not be. addFromBuffer would then resize() the layer —
+    // which fills opaque WHITE and drops the bake — so rescale to the stack's
+    // aspect here instead.
+    if (m_layerStack.layerCount() > 0
+        && (scratch.width() != m_layerStack.width()
+            || scratch.height() != m_layerStack.height())) {
+        QImage img(scratch.width(), scratch.height(), QImage::Format_RGBA8888);
+        std::memcpy(img.bits(), scratch.data().data(),
+                    static_cast<size_t>(scratch.width()) * scratch.height() * 4);
+        const QImage scaled = img.scaled(m_layerStack.width(), m_layerStack.height(),
+                                         Qt::IgnoreAspectRatio,
+                                         Qt::SmoothTransformation)
+                                  .convertToFormat(QImage::Format_RGBA8888);
+        TexturePaintBuffer resized(scaled.width(), scaled.height());
+        std::memcpy(resized.data().data(), scaled.constBits(),
+                    static_cast<size_t>(scaled.width()) * scaled.height() * 4);
+        scratch = std::move(resized);
+    }
 
     const int idx = m_layerStack.addFromBuffer(
         scratch, tr("Vertex colour bake"), PaintLayerStack::LayerType::Generated);


### PR DESCRIPTION
Closes #995

Placing a decal on a model whose texture is **not square** produced a blank white layer. A sibling model with a square texture worked fine — that difference is the whole bug.

**Confirmed fixed by the reporter on the original model.**

## Root cause

1. The paint session buffer matches the model's texture, so it is non-square (the reported model: **2504×2526**).
2. `commitDecal` built a **square** scratch (`resize(width, width)`), and `ProjectionPainter::project` was square-only throughout (one `res`, `out.resize(res,res)`, UV scaled by `res` on both axes).
3. `PaintLayerStack::addFromBuffer` saw the mismatch and called `TexturePaintBuffer::resize` — which is `m_pixels.assign(n, 0xFF)`, i.e. **opaque white**, discarding every projected texel.

So the decal was computed correctly, then thrown away and replaced with white.

## Changes

- **`ProjectionPainter`** — `project`/`projectDab` track width and height separately. `opts.resolution` keeps its "square request" contract when set; otherwise the caller's buffer aspect is preserved. UV→pixel scales each axis by its own extent (no skew).
- **`projectDab` radius** (review round) — `brushRadiusUv` is a **UV** radius, so it now uses separate X/Y pixel radii with falloff from **normalised** per-axis distances, matching `TexturePaintBuffer::paintBrush`. The first cut derived one radius from the smaller axis, which compressed the dab in UV terms along the longer one (0.25 → 0.167 UV on a 64×96 target).
- **`TexturePaintController`** — `commitDecal` and `projectPhotoWithView` size their scratch from the session buffer (w *and* h); `projectionOptions` no longer forces a square resolution from the width alone.
- **Vertex-colour layer bake** — `VertexColorBaker` is square-only by design, so its result is rescaled to the stack aspect instead of handing `addFromBuffer` a mismatched buffer. (Same latent defect; would have hit the same models.)
- **`PaintLayerStack::addFromBuffer`** — **rescales** a mismatched buffer (nearest-neighbour, alpha-preserving) rather than blanking it, so no future caller can reintroduce this class of bug.

## Verification

End-to-end on the reported asset via `qtmesh paint --apply-stencil`:

| | painted texture | pure-white pixels |
|---|---|---|
| before | 2504×2526 | **100.0%** |
| after | 2504×2526 | **0.0%** (decal present, real skin/clothing tones) |

The square-textured sibling model is unchanged (2048×2048, 0% white) — no regression.

Every new test was confirmed to **fail against the pre-fix code** with the reported symptom, including the strengthened dab test against the smaller-axis first cut. 66 tests pass across `ProjectionPainterTest` / `PaintLayerStackTest` / `DecalSessionTest` / `SkinWeightsPostTest`.

Rebased onto master after #992 merged; the weld feature and this fix touch different files (no conflicts), and both were re-verified together on the real assets after the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved painted pixels and transparency when importing content into layers with different dimensions.
  - Fixed projection, photo projection, decals, and vertex-color baking on non-square textures.
  - Prevented projected or baked content from being replaced by opaque white areas.
  - Maintained correct aspect ratios and circular dab shapes across rectangular targets.
  - Ensured explicit square output settings continue to produce square results.
- **Tests**
  - Added coverage for non-square projections, dab placement, layer compositing, transparency, and rescaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->